### PR TITLE
fix(practice): admit VESUM-verified canonical lemma

### DIFF
--- a/scripts/audit/lexeme_filter.py
+++ b/scripts/audit/lexeme_filter.py
@@ -125,6 +125,11 @@ def is_practice_eligible(entry: dict[str, Any]) -> bool:
     # form-of relation; provenance alone would incorrectly remove that lemma.
     if entry.get("form_of"):
         return False
+    # A ``built_vocabulary_form`` row is an alias route by construction.  Do
+    # not let a malformed row with a missing relation become drillable merely
+    # because it otherwise has a valid-looking lexeme shape.
+    if entry.get("primary_source") == "built_vocabulary_form":
+        return False
     if entry.get("primary_source") == SURZHYK_SOURCE:
         return False
     if not is_surface_admitted(entry, SURFACE_PRACTICE):

--- a/scripts/audit/lexeme_filter.py
+++ b/scripts/audit/lexeme_filter.py
@@ -30,8 +30,9 @@ from typing import Any
 # pos value the manifest carries for Latin/Ukrainian grammar metaterms.
 GRAMMAR_TERM_POS = "grammar term"
 
-# Inflected / normalized duplicates of a canonical lemma (e.g. "Іване" voc. of "Іван",
-# "автобусом" instr. of "автобус"). Not study headwords — the #3450 class.
+# Source labels used by inflected / normalized duplicate routes (e.g. "Іване" voc. of
+# "Іван", "автобусом" instr. of "автобус"). Their ``form_of`` relationship, rather
+# than this shared provenance label alone, identifies them as non-study headwords.
 DERIVED_FORM_SOURCES = frozenset(
     {
         "built_vocabulary_form",
@@ -119,7 +120,10 @@ def is_practice_eligible(entry: dict[str, Any]) -> bool:
         return False
     if not _has_text(entry.get("gloss")):
         return False
-    if entry.get("primary_source") in DERIVED_FORM_SOURCES:
+    # ``built_vocabulary_normalized`` can also produce a canonical lemma from
+    # an inflected source surface. Exclude only entries that retain an actual
+    # form-of relation; provenance alone would incorrectly remove that lemma.
+    if entry.get("form_of"):
         return False
     if entry.get("primary_source") == SURZHYK_SOURCE:
         return False

--- a/scripts/audit/lexeme_filter.py
+++ b/scripts/audit/lexeme_filter.py
@@ -30,9 +30,10 @@ from typing import Any
 # pos value the manifest carries for Latin/Ukrainian grammar metaterms.
 GRAMMAR_TERM_POS = "grammar term"
 
-# Source labels used by inflected / normalized duplicate routes (e.g. "Іване" voc. of
-# "Іван", "автобусом" instr. of "автобус"). Their ``form_of`` relationship, rather
-# than this shared provenance label alone, identifies them as non-study headwords.
+# Source labels emitted while resolving inflected / normalized vocabulary (e.g. "Іване"
+# voc. of "Іван", "автобусом" instr. of "автобус"). They are used by consumers that
+# need to treat every derived source conservatively, but are *not* a practice-exclusion
+# list: normalization/canonicalization may produce a legitimate canonical lemma.
 DERIVED_FORM_SOURCES = frozenset(
     {
         "built_vocabulary_form",
@@ -120,14 +121,15 @@ def is_practice_eligible(entry: dict[str, Any]) -> bool:
         return False
     if not _has_text(entry.get("gloss")):
         return False
-    # ``built_vocabulary_normalized`` can also produce a canonical lemma from
-    # an inflected source surface. Exclude only entries that retain an actual
-    # form-of relation; provenance alone would incorrectly remove that lemma.
+    # Three-way policy for form-derived provenance:
+    # 1. Any actual ``form_of`` relation is an alias/form row, so exclude it.
+    # 2. ``built_vocabulary_form`` is an alias route by construction, including
+    #    malformed rows that have lost that relation, so exclude it.
+    # 3. ``built_vocabulary_normalized`` and ``built_vocabulary_canonicalized``
+    #    without ``form_of`` can be canonical lemmas, so admit them when the
+    #    remaining practice checks pass.
     if entry.get("form_of"):
         return False
-    # A ``built_vocabulary_form`` row is an alias route by construction.  Do
-    # not let a malformed row with a missing relation become drillable merely
-    # because it otherwise has a valid-looking lexeme shape.
     if entry.get("primary_source") == "built_vocabulary_form":
         return False
     if entry.get("primary_source") == SURZHYK_SOURCE:

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -371,7 +371,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.fill_existing_glosses:
         assert manifest is not None
         result = fill_missing_manifest_glosses(rows, manifest, args.target_lemma)
-        wrote_manifest = bool(args.write and result.applied)
+        if args.write and result.applied:
+            assert args.manifest is not None
+            _write_json(args.manifest, manifest)
+            wrote_manifest = True
         print(
             "Seed gloss fill: "
             f"applied={len(result.applied)} skipped_existing={len(result.skipped_existing)}"
@@ -379,14 +382,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.fill_existing_pos:
         assert manifest is not None
         pos_result = fill_missing_manifest_pos(manifest, args.target_lemma)
-        wrote_manifest = wrote_manifest or bool(args.write and pos_result.applied)
+        if args.write and pos_result.applied:
+            assert args.manifest is not None
+            _write_json(args.manifest, manifest)
+            wrote_manifest = True
         print(
             "VESUM POS fill: "
             f"applied={len(pos_result.applied)} skipped_existing={len(pos_result.skipped_existing)}"
         )
-    if args.write and wrote_manifest:
-        assert args.manifest is not None and manifest is not None
-        _write_json(args.manifest, manifest)
     if args.fill_existing_glosses or args.fill_existing_pos:
         print(f"Manifest written={str(wrote_manifest).lower()}")
     if args.public_seed_out:

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -220,9 +220,9 @@ def fill_missing_manifest_pos(
 ) -> PosFillResult:
     """Fill selected blank Atlas POS fields from their VESUM lemma analyses.
 
-    This repair is deliberately target-scoped: the supplied curated seed admits
-    practice examples, while VESUM alone supplies the grammatical category.
-    Existing POS values are preserved rather than overwritten.
+    This repair is deliberately target-scoped: only explicitly named lemmas
+    may have their POS auto-filled from VESUM. Existing POS values are
+    preserved rather than overwritten.
     """
     entries = manifest.get("entries")
     if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -349,9 +349,9 @@ def main(argv: list[str] | None = None) -> int:
         "--target-lemma",
         action="append",
         default=[],
-        help="Lemma permitted for --fill-existing-glosses; repeat for every reviewed target.",
+        help="Lemma permitted for an explicit fill repair; repeat for every reviewed target.",
     )
-    parser.add_argument("--write", action="store_true", help="Write a manifest changed by --fill-existing-glosses.")
+    parser.add_argument("--write", action="store_true", help="Write a manifest changed by an explicit fill repair.")
     args = parser.parse_args(argv)
     rows = read_public_seed(args.input) if args.input.suffix == ".json" else normalize_rows(_read_jsonl(args.input))
     if args.write and not (args.fill_existing_glosses or args.fill_existing_pos):

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -241,18 +241,26 @@ def fill_missing_manifest_pos(
     if missing_manifest:
         raise ValueError(f"target lemmas missing from Atlas manifest: {', '.join(missing_manifest)}")
 
+    resolved_pos: dict[str, str] = {}
+    for key in sorted(targets):
+        entry = manifest_entries[key]
+        lemma = _text(entry.get("lemma"))
+        if _text(entry.get("pos")):
+            continue
+        pos = _vesum_pos(lemma)
+        if not pos:
+            raise ValueError(f"target lemma has no VESUM POS: {lemma}")
+        resolved_pos[key] = pos
+
     applied: list[str] = []
     skipped_existing: list[str] = []
     for key in sorted(targets):
         entry = manifest_entries[key]
         lemma = _text(entry.get("lemma"))
-        if _text(entry.get("pos")):
+        if key not in resolved_pos:
             skipped_existing.append(lemma)
             continue
-        pos = _vesum_pos(lemma)
-        if not pos:
-            raise ValueError(f"target lemma has no VESUM POS: {lemma}")
-        entry["pos"] = pos
+        entry["pos"] = resolved_pos[key]
         applied.append(lemma)
     return PosFillResult(applied=tuple(applied), skipped_existing=tuple(skipped_existing))
 

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -329,7 +329,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", type=Path, required=True, help="Raw v5 JSONL or public v5 seed JSON")
+    parser.add_argument("--input", type=Path, help="Raw v5 JSONL or public v5 seed JSON")
     parser.add_argument("--public-seed-out", type=Path)
     parser.add_argument("--manifest", type=Path)
     parser.add_argument("--candidates-out", type=Path)
@@ -353,7 +353,23 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--write", action="store_true", help="Write a manifest changed by an explicit fill repair.")
     args = parser.parse_args(argv)
-    rows = read_public_seed(args.input) if args.input.suffix == ".json" else normalize_rows(_read_jsonl(args.input))
+    needs_seed_rows = bool(
+        args.fill_existing_glosses
+        or args.public_seed_out
+        or args.candidates_out
+        or args.practice_seed_out
+        or args.report_out
+    )
+    if args.input is None:
+        if needs_seed_rows:
+            parser.error("--input is required for seed-derived output or --fill-existing-glosses")
+        rows: list[dict[str, Any]] = []
+    else:
+        rows = (
+            read_public_seed(args.input)
+            if args.input.suffix == ".json"
+            else normalize_rows(_read_jsonl(args.input))
+        )
     if args.write and not (args.fill_existing_glosses or args.fill_existing_pos):
         parser.error("--write requires --fill-existing-glosses or --fill-existing-pos")
 

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -39,6 +39,14 @@ class GlossFillResult:
     skipped_existing: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class PosFillResult:
+    """Result of applying an explicit VESUM-backed POS repair."""
+
+    applied: tuple[str, ...]
+    skipped_existing: tuple[str, ...]
+
+
 def _text(value: object) -> str:
     return str(value or "").strip()
 
@@ -206,6 +214,49 @@ def _clean_seed_gloss(gloss: str) -> str:
     return _ASPECT_NOTE_RE.sub("", gloss).strip()
 
 
+def fill_missing_manifest_pos(
+    manifest: dict[str, Any],
+    target_lemmas: Iterable[str],
+) -> PosFillResult:
+    """Fill selected blank Atlas POS fields from their VESUM lemma analyses.
+
+    This repair is deliberately target-scoped: the supplied curated seed admits
+    practice examples, while VESUM alone supplies the grammatical category.
+    Existing POS values are preserved rather than overwritten.
+    """
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
+        raise ValueError("manifest entries must be objects")
+
+    targets = {_lemma_key(_text(lemma)) for lemma in target_lemmas if _text(lemma)}
+    if not targets:
+        raise ValueError("at least one target lemma is required")
+
+    manifest_entries = {
+        _lemma_key(_text(entry.get("lemma"))): entry
+        for entry in entries
+        if _text(entry.get("lemma"))
+    }
+    missing_manifest = sorted(targets - set(manifest_entries))
+    if missing_manifest:
+        raise ValueError(f"target lemmas missing from Atlas manifest: {', '.join(missing_manifest)}")
+
+    applied: list[str] = []
+    skipped_existing: list[str] = []
+    for key in sorted(targets):
+        entry = manifest_entries[key]
+        lemma = _text(entry.get("lemma"))
+        if _text(entry.get("pos")):
+            skipped_existing.append(lemma)
+            continue
+        pos = _vesum_pos(lemma)
+        if not pos:
+            raise ValueError(f"target lemma has no VESUM POS: {lemma}")
+        entry["pos"] = pos
+        applied.append(lemma)
+    return PosFillResult(applied=tuple(applied), skipped_existing=tuple(skipped_existing))
+
+
 def _cefr(entry: dict[str, Any]) -> tuple[str, str] | None:
     enrichment = entry.get("enrichment")
     value = enrichment.get("cefr") if isinstance(enrichment, dict) else None
@@ -290,6 +341,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Fill explicit blank manifest glosses from the curated seed English.",
     )
     parser.add_argument(
+        "--fill-existing-pos",
+        action="store_true",
+        help="Fill explicit blank manifest POS fields from VESUM lemma analyses.",
+    )
+    parser.add_argument(
         "--target-lemma",
         action="append",
         default=[],
@@ -298,24 +354,41 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--write", action="store_true", help="Write a manifest changed by --fill-existing-glosses.")
     args = parser.parse_args(argv)
     rows = read_public_seed(args.input) if args.input.suffix == ".json" else normalize_rows(_read_jsonl(args.input))
-    if args.write and not args.fill_existing_glosses:
-        parser.error("--write requires --fill-existing-glosses")
-    if args.fill_existing_glosses:
+    if args.write and not (args.fill_existing_glosses or args.fill_existing_pos):
+        parser.error("--write requires --fill-existing-glosses or --fill-existing-pos")
+
+    manifest: dict[str, Any] | None = None
+    if args.fill_existing_glosses or args.fill_existing_pos:
         if not args.manifest:
-            parser.error("--fill-existing-glosses requires --manifest")
+            parser.error("--fill-existing-glosses/--fill-existing-pos requires --manifest")
         if not args.target_lemma:
-            parser.error("--fill-existing-glosses requires at least one --target-lemma")
+            parser.error("--fill-existing-glosses/--fill-existing-pos requires at least one --target-lemma")
         manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
         if not isinstance(manifest, dict):
             raise ValueError(f"manifest must contain an object: {args.manifest}")
+
+    wrote_manifest = False
+    if args.fill_existing_glosses:
+        assert manifest is not None
         result = fill_missing_manifest_glosses(rows, manifest, args.target_lemma)
-        if args.write and result.applied:
-            _write_json(args.manifest, manifest)
+        wrote_manifest = bool(args.write and result.applied)
         print(
             "Seed gloss fill: "
-            f"applied={len(result.applied)} skipped_existing={len(result.skipped_existing)} "
-            f"written={str(bool(args.write and result.applied)).lower()}"
+            f"applied={len(result.applied)} skipped_existing={len(result.skipped_existing)}"
         )
+    if args.fill_existing_pos:
+        assert manifest is not None
+        pos_result = fill_missing_manifest_pos(manifest, args.target_lemma)
+        wrote_manifest = wrote_manifest or bool(args.write and pos_result.applied)
+        print(
+            "VESUM POS fill: "
+            f"applied={len(pos_result.applied)} skipped_existing={len(pos_result.skipped_existing)}"
+        )
+    if args.write and wrote_manifest:
+        assert args.manifest is not None and manifest is not None
+        _write_json(args.manifest, manifest)
+    if args.fill_existing_glosses or args.fill_existing_pos:
+        print(f"Manifest written={str(wrote_manifest).lower()}")
     if args.public_seed_out:
         write_public_seed(rows, args.public_seed_out)
     if args.candidates_out:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "6b2f9e7e52a0ea8cdf66a604b3f591f656684caa5a4f0ed912b7b10d7d8c4fff",
+  "fingerprint": "53f14aa890c0915cedd730c6ca60596572b330472825fe1788f5e4189fb06002",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "79ecb6c46ade461b2a10d42ceca876b395efd7f5b9703d8b17719571dc18691f"
+        "sha256": "756f7d122704364dd51cc8af27e94da4acbbe4df52019f55f7a22da486cef447"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "b2923a993e8a58b47ea5984dc8b601da0814f46515e9429744c220250c0f4f02",
+  "fingerprint": "da6df6a3618330b9cde2ae04236f584c8304164f273e3ba000099a962b997b74",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "5d022151300d9f0626a504f470707fcc757c105648d5581db330ee350af9be88"
+        "sha256": "c3007dd8168aebe443dab427167428878e7f8b7c31b44128db75736fdd839770"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "69477980200fd35a039fcb7eb35bd7402e70b849749fda2e4cb4e2022b2a012a",
+  "fingerprint": "b2923a993e8a58b47ea5984dc8b601da0814f46515e9429744c220250c0f4f02",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "139d82a831e07b173a67544b1578683606f602a39d8505c017f1be65ccafb358"
+        "sha256": "5d022151300d9f0626a504f470707fcc757c105648d5581db330ee350af9be88"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "9e70badb5df86737aac46f698dce85fede73e68fc1c7e90619002547c8f55d6c",
+  "fingerprint": "6b2f9e7e52a0ea8cdf66a604b3f591f656684caa5a4f0ed912b7b10d7d8c4fff",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "1a1f6db678d69f788820ec90c724d0951a7e85383445b265a1e933f0c1ceb4c6"
+        "sha256": "79ecb6c46ade461b2a10d42ceca876b395efd7f5b9703d8b17719571dc18691f"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "da6df6a3618330b9cde2ae04236f584c8304164f273e3ba000099a962b997b74",
+  "fingerprint": "9e70badb5df86737aac46f698dce85fede73e68fc1c7e90619002547c8f55d6c",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "c3007dd8168aebe443dab427167428878e7f8b7c31b44128db75736fdd839770"
+        "sha256": "1a1f6db678d69f788820ec90c724d0951a7e85383445b265a1e933f0c1ceb4c6"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "e21a9fc99528aae2ca527e6d696a20c30a1da4e91a6d869dfa99ba21470ab485",
+  "fingerprint": "69477980200fd35a039fcb7eb35bd7402e70b849749fda2e4cb4e2022b2a012a",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "e305c7ddcf7c460245869f9d36a11ba5678d074170966796ba86540cbbeb879a"
+        "sha256": "139d82a831e07b173a67544b1578683606f602a39d8505c017f1be65ccafb358"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -158,6 +158,24 @@ def test_fill_missing_manifest_pos_rejects_unverified_target(monkeypatch) -> Non
         admission.fill_missing_manifest_pos(manifest, ["помішувати"])
 
 
+def test_fill_missing_manifest_pos_does_not_mutate_when_later_target_is_unverified(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {"lemma": "помішувати", "pos": None},
+            {"lemma": "шукати", "pos": None},
+        ]
+    }
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: "verb" if lemma == "помішувати" else None)
+
+    with pytest.raises(ValueError, match="no VESUM POS: шукати"):
+        admission.fill_missing_manifest_pos(manifest, ["помішувати", "шукати"])
+
+    assert manifest["entries"] == [
+        {"lemma": "помішувати", "pos": None},
+        {"lemma": "шукати", "pos": None},
+    ]
+
+
 def test_main_fills_pos_without_input_seed(tmp_path: Path, monkeypatch) -> None:
     manifest_path = _manifest(
         tmp_path / "manifest.json",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -158,6 +158,48 @@ def test_fill_missing_manifest_pos_rejects_unverified_target(monkeypatch) -> Non
         admission.fill_missing_manifest_pos(manifest, ["помішувати"])
 
 
+def test_main_persists_gloss_fill_before_later_pos_fill_failure(tmp_path: Path, monkeypatch) -> None:
+    input_path = tmp_path / "seed.jsonl"
+    input_path.write_text(
+        "\n".join(
+            (
+                json.dumps({"lemma": "лоток", "gloss": "tray"}),
+                json.dumps({"lemma": "невідоме", "gloss": "unknown"}),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_path = _manifest(
+        tmp_path / "manifest.json",
+        [
+            {"lemma": "лоток", "gloss": None, "pos": "noun"},
+            {"lemma": "невідоме", "gloss": "unknown", "pos": None},
+        ],
+    )
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: None)
+
+    with pytest.raises(ValueError, match="target lemma has no VESUM POS: невідоме"):
+        admission.main(
+            [
+                "--input",
+                str(input_path),
+                "--manifest",
+                str(manifest_path),
+                "--fill-existing-glosses",
+                "--fill-existing-pos",
+                "--target-lemma",
+                "лоток",
+                "--target-lemma",
+                "невідоме",
+                "--write",
+            ]
+        )
+
+    persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert persisted["entries"][0]["gloss"] == "tray"
+
+
 def test_write_json_uses_shared_atomic_write_helper(tmp_path: Path, monkeypatch) -> None:
     output = tmp_path / "nested" / "seed.json"
     observed: dict[str, object] = {}

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -125,6 +125,39 @@ def test_fill_missing_manifest_glosses_rejects_missing_target_seed() -> None:
         admission.fill_missing_manifest_glosses([], manifest, ["лоток"])
 
 
+def test_fill_missing_manifest_pos_uses_vesum_for_explicit_blank_target(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {"lemma": "помішувати", "pos": None},
+            {"lemma": "обставини", "pos": "noun:pl"},
+        ]
+    }
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: "verb" if lemma == "помішувати" else None)
+
+    result = admission.fill_missing_manifest_pos(manifest, ["помішувати"])
+
+    assert result == admission.PosFillResult(applied=("помішувати",), skipped_existing=())
+    assert manifest["entries"][0]["pos"] == "verb"
+    assert manifest["entries"][1]["pos"] == "noun:pl"
+
+
+def test_fill_missing_manifest_pos_preserves_existing_pos(monkeypatch) -> None:
+    manifest = {"entries": [{"lemma": "обставини", "pos": "noun:pl"}]}
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: pytest.fail(f"unexpected VESUM lookup: {lemma}"))
+
+    result = admission.fill_missing_manifest_pos(manifest, ["обставини"])
+
+    assert result == admission.PosFillResult(applied=(), skipped_existing=("обставини",))
+
+
+def test_fill_missing_manifest_pos_rejects_unverified_target(monkeypatch) -> None:
+    manifest = {"entries": [{"lemma": "помішувати", "pos": None}]}
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: None)
+
+    with pytest.raises(ValueError, match="no VESUM POS"):
+        admission.fill_missing_manifest_pos(manifest, ["помішувати"])
+
+
 def test_write_json_uses_shared_atomic_write_helper(tmp_path: Path, monkeypatch) -> None:
     output = tmp_path / "nested" / "seed.json"
     observed: dict[str, object] = {}

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -158,6 +158,29 @@ def test_fill_missing_manifest_pos_rejects_unverified_target(monkeypatch) -> Non
         admission.fill_missing_manifest_pos(manifest, ["помішувати"])
 
 
+def test_main_fills_pos_without_input_seed(tmp_path: Path, monkeypatch) -> None:
+    manifest_path = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "помішувати", "pos": None}],
+    )
+    monkeypatch.setattr(admission, "_vesum_pos", lambda lemma: "verb" if lemma == "помішувати" else None)
+
+    result = admission.main(
+        [
+            "--manifest",
+            str(manifest_path),
+            "--fill-existing-pos",
+            "--target-lemma",
+            "помішувати",
+            "--write",
+        ]
+    )
+
+    assert result == 0
+    persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert persisted["entries"][0]["pos"] == "verb"
+
+
 def test_main_persists_gloss_fill_before_later_pos_fill_failure(tmp_path: Path, monkeypatch) -> None:
     input_path = tmp_path / "seed.jsonl"
     input_path.write_text(

--- a/tests/test_lexeme_filter.py
+++ b/tests/test_lexeme_filter.py
@@ -5,8 +5,9 @@ Pure inline fixtures (no 39 MB manifest needed): the predicate is data-shape log
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.audit.lexeme_filter import (
-    DERIVED_FORM_SOURCES,
     GRAMMAR_TERM_POS,
     SURFACE_CLOZE,
     SURFACE_DAILY,
@@ -82,33 +83,56 @@ def test_practice_rejects_surzhyk_to_avoid():
     assert is_practice_eligible(_noun(primary_source=SURZHYK_SOURCE)) is False
 
 
-def test_practice_rejects_derived_forms():
-    for src in DERIVED_FORM_SOURCES:
-        assert is_practice_eligible(
-            _noun(primary_source=src, form_of={"lemma": "хліб", "url_slug": "khlib"})
-        ) is False
+@pytest.mark.parametrize(
+    ("primary_source", "form_of", "expected"),
+    [
+        pytest.param(
+            "built_vocabulary_normalized",
+            {"lemma": "хліб", "url_slug": "khlib"},
+            False,
+            id="form-of-set-normalized",
+        ),
+        pytest.param(
+            "built_vocabulary_canonicalized",
+            {"lemma": "хліб", "url_slug": "khlib"},
+            False,
+            id="form-of-set-canonicalized",
+        ),
+        pytest.param(
+            "built_vocabulary_form",
+            {"lemma": "хліб", "url_slug": "khlib"},
+            False,
+            id="form-of-set-form-source",
+        ),
+        pytest.param(
+            "built_vocabulary_form",
+            None,
+            False,
+            id="form-source-without-form-of",
+        ),
+        pytest.param(
+            "built_vocabulary_normalized",
+            None,
+            True,
+            id="normalized-canonical-lemma-without-form-of",
+        ),
+        pytest.param(
+            "built_vocabulary_canonicalized",
+            None,
+            True,
+            id="canonicalized-canonical-lemma-without-form-of",
+        ),
+    ],
+)
+def test_practice_derived_source_form_of_policy_matrix(
+    primary_source: str, form_of: dict[str, str] | None, expected: bool
+) -> None:
+    """Only aliases and built form rows are excluded from otherwise-valid cards."""
+    entry = _noun(primary_source=primary_source)
+    if form_of is not None:
+        entry["form_of"] = form_of
 
-
-def test_practice_keeps_canonical_lemma_normalized_from_an_inflected_surface():
-    entry = _noun(primary_source="built_vocabulary_normalized")
-
-    assert is_practice_eligible(entry) is True
-
-
-def test_practice_keeps_canonicalized_headword_without_form_of():
-    # VESUM canonicalization creates a real headword, not an alias route. Its source
-    # label must not exclude it when it has no actual form_of relationship.
-    entry = _noun(primary_source="built_vocabulary_canonicalized")
-
-    assert is_practice_eligible(entry) is True
-
-
-def test_practice_rejects_form_source_missing_its_form_of_relation():
-    # The builder must pair this provenance with ``form_of``. A malformed row
-    # must remain excluded rather than becoming a study-card candidate.
-    entry = _noun(primary_source="built_vocabulary_form")
-
-    assert is_practice_eligible(entry) is False
+    assert is_practice_eligible(entry) is expected
 
 
 def test_practice_rejects_glossless():

--- a/tests/test_lexeme_filter.py
+++ b/tests/test_lexeme_filter.py
@@ -95,6 +95,23 @@ def test_practice_keeps_canonical_lemma_normalized_from_an_inflected_surface():
     assert is_practice_eligible(entry) is True
 
 
+def test_practice_keeps_canonicalized_headword_without_form_of():
+    # VESUM canonicalization creates a real headword, not an alias route. Its source
+    # label must not exclude it when it has no actual form_of relationship.
+    entry = _noun(primary_source="built_vocabulary_canonicalized")
+
+    assert is_practice_eligible(entry) is True
+
+
+def test_practice_uses_form_of_not_form_source_for_exclusion():
+    # The manifest builder emits built_vocabulary_form only alongside form_of (covered
+    # in test_lexicon_build_manifest.py). This synthetic entry locks the predicate's
+    # deliberate contract: the relationship, not provenance, determines exclusion.
+    entry = _noun(primary_source="built_vocabulary_form")
+
+    assert is_practice_eligible(entry) is True
+
+
 def test_practice_rejects_glossless():
     assert is_practice_eligible(_noun(gloss=None)) is False
 

--- a/tests/test_lexeme_filter.py
+++ b/tests/test_lexeme_filter.py
@@ -103,13 +103,12 @@ def test_practice_keeps_canonicalized_headword_without_form_of():
     assert is_practice_eligible(entry) is True
 
 
-def test_practice_uses_form_of_not_form_source_for_exclusion():
-    # The manifest builder emits built_vocabulary_form only alongside form_of (covered
-    # in test_lexicon_build_manifest.py). This synthetic entry locks the predicate's
-    # deliberate contract: the relationship, not provenance, determines exclusion.
+def test_practice_rejects_form_source_missing_its_form_of_relation():
+    # The builder must pair this provenance with ``form_of``. A malformed row
+    # must remain excluded rather than becoming a study-card candidate.
     entry = _noun(primary_source="built_vocabulary_form")
 
-    assert is_practice_eligible(entry) is True
+    assert is_practice_eligible(entry) is False
 
 
 def test_practice_rejects_glossless():

--- a/tests/test_lexeme_filter.py
+++ b/tests/test_lexeme_filter.py
@@ -84,7 +84,15 @@ def test_practice_rejects_surzhyk_to_avoid():
 
 def test_practice_rejects_derived_forms():
     for src in DERIVED_FORM_SOURCES:
-        assert is_practice_eligible(_noun(primary_source=src)) is False
+        assert is_practice_eligible(
+            _noun(primary_source=src, form_of={"lemma": "хліб", "url_slug": "khlib"})
+        ) is False
+
+
+def test_practice_keeps_canonical_lemma_normalized_from_an_inflected_surface():
+    entry = _noun(primary_source="built_vocabulary_normalized")
+
+    assert is_practice_eligible(entry) is True
 
 
 def test_practice_rejects_glossless():


### PR DESCRIPTION
## Summary

- adds an explicit, target-scoped VESUM repair for blank top-level POS fields
- keeps actual `form_of` entries out of practice while admitting canonical lemmas normalized from source surfaces
- restores the seeded local practice result: `помішувати` is indexed; derived `обставини` remains excluded

## Verification

- `.venv/bin/python -m pytest tests/test_lexeme_filter.py tests/test_curated_seed_atlas_admission.py tests/test_generate_practice_deck.py -q` (78 passed)
- `.venv/bin/ruff check scripts/audit/lexeme_filter.py scripts/lexicon/curated_seed_atlas_admission.py tests/test_lexeme_filter.py tests/test_curated_seed_atlas_admission.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- local ignored proof: `batch_state/tasks/teacher-pos-residual-r4.proof.json` — 673/674 unique teacher seed lemmas are in the practice index; only the derived form remains excluded

No auto-merge requested.