### PR TITLE
fix(git): run full hygiene every four hours

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -1,7 +1,7 @@
 # Worktree cleanup
 
-This runbook covers immediate post-merge cleanup and the local macOS safety
-backstop for both Learn Ukrainian repositories.
+This runbook covers immediate post-merge cleanup and the local macOS Git
+hygiene backstop for both Learn Ukrainian repositories.
 
 ## Safety contract
 
@@ -68,12 +68,25 @@ Apply:
 .venv/bin/python scripts/orchestration/scheduled_worktree_cleanup.py --apply
 ```
 
-Each run fetches and prunes `origin`, probes process working directories, runs
-the exact-merged-PR reaper for both repository roots, reports orphaned worktree
-directories, and writes an immutable JSON receipt under:
+Each run performs the following in both repository roots:
+
+1. fetches `origin` and prunes deleted remote refs;
+2. prunes stale Git worktree registrations;
+3. removes clean, inactive worktrees that have exact finalized-PR or settled
+   dispatch evidence, plus old detached worktrees already contained by
+   `origin/main`;
+4. deletes local branches whose upstream is gone only when their exact head is
+   proven merged or is already an ancestor of `origin/main`;
+5. preserves and reports unproven gone branches and orphaned worktree
+   directories;
+6. runs `git gc --auto`;
+7. writes an immutable JSON receipt.
+
+Dirty worktrees, open PRs, active/non-terminal tasks, checked-out branches, and
+unmerged branch heads remain untouched.
 
 ```text
-~/.codex/worktree-cleanup/receipts/v1/
+~/.codex/worktree-cleanup/receipts/v2/
 ```
 
 An unavailable fetch or process-activity probe blocks apply for that
@@ -87,7 +100,7 @@ Render the plist without writing system configuration:
 .venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py render
 ```
 
-The job runs at load and every 15 minutes. It uses the public checkout's exact
+The job runs at load and every 4 hours. It uses the public checkout's exact
 `.venv/bin/python`, passes both repository roots explicitly, and persists logs
 under:
 

--- a/scripts/orchestration/install_worktree_cleanup_launchd.py
+++ b/scripts/orchestration/install_worktree_cleanup_launchd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the dual-repository worktree cleanup LaunchAgent on macOS."""
+"""Install the dual-repository Git hygiene LaunchAgent on macOS."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from scripts.orchestration import scheduled_worktree_cleanup
 
 LABEL = "com.learn-ukrainian.worktree-cleanup"
-DEFAULT_INTERVAL_MINUTES = 15
+DEFAULT_INTERVAL_MINUTES = 240
 LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 
@@ -67,7 +67,7 @@ def build_plist(
             "--repo-root",
             str(private_repo),
             "--receipt-dir",
-            str(runtime / "receipts" / "v1"),
+            str(runtime / "receipts" / "v2"),
         ],
         "RunAtLoad": True,
         "StandardErrorPath": str(runtime / "logs" / "stderr.log"),
@@ -173,7 +173,7 @@ def install(
         runtime,
         runtime / "logs",
         runtime / "receipts",
-        runtime / "receipts" / "v1",
+        runtime / "receipts" / "v2",
     ):
         directory.mkdir(parents=True, exist_ok=True, mode=0o700)
         os.chmod(directory, 0o700)

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -63,6 +63,7 @@ class ReapResult:
     dirty: bool | None
     pr: dict[str, Any] | None = None
     error: str | None = None
+    branch_pruned: bool = False
 
 
 def sanitized_git_env() -> dict[str, str]:
@@ -544,14 +545,32 @@ def _remove_worktree(repo_root: Path, info: WorktreeInfo) -> str | None:
     return None
 
 
-def _prune_branch(repo_root: Path, branch: str | None, force: bool = False) -> str | None:
+def _prune_branch(
+    repo_root: Path,
+    branch: str | None,
+    force: bool = False,
+    expected_head: str | None = None,
+) -> str | None:
     if not branch:
         return None
+    if expected_head is None:
+        flag = "-D" if force else "-d"
+        proc = _run(["git", "branch", flag, "--", branch], cwd=repo_root)
+        return None if proc.returncode == 0 else _format_failure(proc)
+
+    current = _run(
+        ["git", "rev-parse", "--verify", f"refs/heads/{branch}"],
+        cwd=repo_root,
+    )
+    if (
+        current.returncode != 0
+        or (current.stdout or "").strip() != expected_head
+    ):
+        return "branch HEAD changed during cleanup"
+
     flag = "-D" if force else "-d"
-    proc = _run(["git", "branch", flag, branch], cwd=repo_root)
-    if proc.returncode != 0:
-        return _format_failure(proc)
-    return None
+    deleted = _run(["git", "branch", flag, "--", branch], cwd=repo_root)
+    return None if deleted.returncode == 0 else _format_failure(deleted)
 
 
 def _reap_qualified_worktree(
@@ -656,13 +675,20 @@ def _reap_qualified_worktree(
         )
 
     branch_prune_error = None
+    branch_pruned = False
     if (
         prune_merged_branches
         and pr_state is not None
         and pr_state.state == "MERGED"
         and pr_state.head_sha == current_head
     ):
-        branch_prune_error = _prune_branch(repo_root, info.branch, force=True)
+        branch_prune_error = _prune_branch(
+            repo_root,
+            info.branch,
+            force=True,
+            expected_head=current_head,
+        )
+        branch_pruned = branch_prune_error is None
 
     if branch_prune_error is not None:
         return ReapResult(
@@ -682,6 +708,7 @@ def _reap_qualified_worktree(
         reason=reason,
         dirty=dirty,
         pr=_pr_dict(pr_state),
+        branch_pruned=branch_pruned,
     )
 
 
@@ -726,6 +753,21 @@ def reap_worktrees(
                         branch=info.branch,
                         action="skipped",
                         reason="outside repo .worktrees/",
+                        dirty=None,
+                    )
+                )
+                continue
+
+            if not info.path.is_dir():
+                results.append(
+                    ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason=(
+                            "registered worktree path is missing; "
+                            "run git worktree prune"
+                        ),
                         dirty=None,
                     )
                 )

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Run fail-closed worktree cleanup for an explicit repository set.
+"""Run fail-closed Git hygiene for an explicit repository set.
 
-The scheduled runner fetches remote state, requires the macOS process-CWD
-probe in apply mode, delegates eligibility and deletion to the canonical
-reaper, and writes an immutable JSON receipt for every run. Orphaned
-``.worktrees/**`` directories are reported but never deleted.
+The scheduled runner prunes remote refs and stale worktree registrations,
+requires the macOS process-CWD probe in apply mode, delegates safe worktree
+removal to the canonical reaper, deletes only provably merged local branches,
+runs automatic Git maintenance, and writes an immutable JSON receipt.
+Orphaned ``.worktrees/**`` directories are reported but never deleted.
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import json
 import os
@@ -27,8 +29,8 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts.orchestration import reap_worktrees
 
-SCHEMA_VERSION = "scheduled-worktree-cleanup.v1"
-DEFAULT_INTERVAL_MINUTES = 15
+SCHEMA_VERSION = "scheduled-git-hygiene.v2"
+DEFAULT_INTERVAL_MINUTES = 240
 
 
 def default_public_repo() -> Path:
@@ -62,6 +64,227 @@ def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
 def _failure(proc: subprocess.CompletedProcess[str]) -> str:
     detail = (proc.stderr or proc.stdout or "").strip()
     return detail.splitlines()[-1] if detail else f"exit {proc.returncode}"
+
+
+class _GitHygieneLock:
+    def __init__(self, repo_root: Path) -> None:
+        common_git_dir = reap_worktrees._common_git_dir(repo_root)
+        self.path = common_git_dir / "scheduled-git-hygiene.lock"
+        self.handle: Any = None
+
+    def __enter__(self) -> None:
+        self.handle = self.path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self.handle.close()
+            raise RuntimeError(
+                f"another scheduled Git hygiene run holds {self.path}"
+            ) from exc
+
+    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+        if self.handle is not None:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+            self.handle.close()
+
+
+def _worktree_prune(repo_root: Path, *, apply: bool) -> dict[str, Any]:
+    args = ["worktree", "prune", "--expire", "now", "--verbose"]
+    if not apply:
+        args.insert(2, "--dry-run")
+    proc = _run_git(repo_root, *args)
+    detail = (proc.stdout or proc.stderr or "").strip()
+    return {
+        "action": "pruned" if apply else "would_prune",
+        "detail": detail or None,
+        "ok": proc.returncode == 0,
+    }
+
+
+def _checked_out_branches(repo_root: Path) -> set[str]:
+    return {
+        item.branch
+        for item in reap_worktrees.list_git_worktrees(repo_root)
+        if item.branch is not None
+    }
+
+
+def _gone_local_branches(repo_root: Path) -> list[tuple[str, str]]:
+    proc = _run_git(
+        repo_root,
+        "for-each-ref",
+        "refs/heads",
+        "--format=%(refname:short)%09%(objectname)%09%(upstream)",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"cannot list local branches: {_failure(proc)}")
+    gone: list[tuple[str, str]] = []
+    for line in (proc.stdout or "").splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        branch, head_sha, upstream = parts
+        if branch in {"main", "master"} or not upstream.startswith(
+            "refs/remotes/origin/"
+        ):
+            continue
+        exists = _run_git(repo_root, "show-ref", "--verify", "--quiet", upstream)
+        if exists.returncode == 1:
+            gone.append((branch, head_sha))
+        elif exists.returncode != 0:
+            raise RuntimeError(
+                f"cannot verify upstream for {branch}: {_failure(exists)}"
+            )
+    return gone
+
+
+def _branch_is_origin_main_ancestor(repo_root: Path, head_sha: str) -> bool:
+    proc = _run_git(
+        repo_root,
+        "merge-base",
+        "--is-ancestor",
+        head_sha,
+        "origin/main",
+    )
+    return proc.returncode == 0
+
+
+def _delete_local_branch(
+    repo_root: Path,
+    *,
+    branch: str,
+    expected_head: str,
+) -> str | None:
+    current = _run_git(
+        repo_root,
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+    )
+    if current.returncode != 0 or (current.stdout or "").strip() != expected_head:
+        return "branch HEAD changed during cleanup"
+    if branch in _checked_out_branches(repo_root):
+        return "branch became checked out during cleanup"
+    return reap_worktrees._prune_branch(
+        repo_root,
+        branch,
+        force=True,
+        expected_head=expected_head,
+    )
+
+
+def cleanup_gone_local_branches(
+    repo_root: Path,
+    *,
+    apply: bool,
+) -> list[dict[str, Any]]:
+    """Delete gone-upstream branches only with exact merged or ancestry proof."""
+    checked_out = _checked_out_branches(repo_root)
+    results: list[dict[str, Any]] = []
+    for branch, head_sha in _gone_local_branches(repo_root):
+        if branch in checked_out:
+            results.append(
+                {
+                    "action": "skipped",
+                    "branch": branch,
+                    "head_sha": head_sha,
+                    "reason": "upstream gone but branch is checked out",
+                }
+            )
+            continue
+
+        prs, pr_error = reap_worktrees._query_pr_states(repo_root, branch)
+        if pr_error is not None:
+            results.append(
+                {
+                    "action": "error",
+                    "branch": branch,
+                    "head_sha": head_sha,
+                    "reason": "upstream gone but PR state could not be verified",
+                    "error": pr_error,
+                }
+            )
+            continue
+        open_pr = next((pr for pr in prs if pr.state == "OPEN"), None)
+        exact_merged = next(
+            (
+                pr
+                for pr in prs
+                if pr.state == "MERGED" and pr.head_sha == head_sha
+            ),
+            None,
+        )
+        if open_pr is not None:
+            results.append(
+                {
+                    "action": "skipped",
+                    "branch": branch,
+                    "head_sha": head_sha,
+                    "reason": f"upstream gone but PR #{open_pr.number} is OPEN",
+                }
+            )
+            continue
+
+        origin_main_ancestor = False
+        if exact_merged is not None:
+            reason = f"upstream gone; exact head of MERGED PR #{exact_merged.number}"
+        else:
+            origin_main_ancestor = _branch_is_origin_main_ancestor(
+                repo_root,
+                head_sha,
+            )
+        if exact_merged is None and origin_main_ancestor:
+            reason = "upstream gone; branch HEAD is an ancestor of origin/main"
+        elif exact_merged is None:
+            results.append(
+                {
+                    "action": "skipped",
+                    "branch": branch,
+                    "head_sha": head_sha,
+                    "reason": (
+                        "upstream gone but no exact merged-PR or "
+                        "origin/main ancestry evidence"
+                    ),
+                }
+            )
+            continue
+        if not apply:
+            results.append(
+                {
+                    "action": "would_delete",
+                    "branch": branch,
+                    "head_sha": head_sha,
+                    "reason": reason,
+                }
+            )
+            continue
+
+        error = _delete_local_branch(
+            repo_root,
+            branch=branch,
+            expected_head=head_sha,
+        )
+        results.append(
+            {
+                "action": "error" if error else "deleted",
+                "branch": branch,
+                "head_sha": head_sha,
+                "reason": reason,
+                "error": error,
+            }
+        )
+    return results
+
+
+def _git_maintenance(repo_root: Path, *, apply: bool) -> dict[str, Any]:
+    if not apply:
+        return {"action": "would_run", "ok": True, "detail": "git gc --auto"}
+    proc = _run_git(repo_root, "gc", "--auto")
+    return {
+        "action": "ran",
+        "ok": proc.returncode == 0,
+        "detail": None if proc.returncode == 0 else _failure(proc),
+    }
 
 
 def _registered_paths(repo_root: Path) -> set[Path]:
@@ -116,15 +339,22 @@ def find_orphaned_worktree_directories(repo_root: Path) -> list[dict[str, Any]]:
     return sorted(orphans, key=lambda item: item["path"])
 
 
-def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
-    result: dict[str, Any] = {
+def _empty_repo_result(repo_root: Path) -> dict[str, Any]:
+    return {
         "repo_root": str(repo_root),
         "fetch": None,
+        "worktree_prune": None,
         "activity_probe": None,
         "results": [],
+        "branches": [],
+        "maintenance": None,
         "orphans": [],
         "errors": [],
     }
+
+
+def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
+    result = _empty_repo_result(repo_root)
     if not (repo_root / ".git").exists():
         result["errors"].append("repository .git metadata is missing")
         return result
@@ -136,6 +366,12 @@ def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
     }
     if fetch.returncode != 0:
         result["errors"].append("fetch failed; cleanup skipped")
+        return result
+
+    worktree_prune = _worktree_prune(repo_root, apply=apply)
+    result["worktree_prune"] = worktree_prune
+    if not worktree_prune["ok"]:
+        result["errors"].append("worktree prune failed; cleanup skipped")
         return result
 
     live_cwds = reap_worktrees._live_cwd_paths(repo_root)
@@ -155,7 +391,7 @@ def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
             prune_merged_branches=True,
             safe_only=True,
             live_cwds=live_cwds,
-            merged_pr_only=True,
+            merged_pr_only=False,
         )
         result["results"] = [asdict(row) for row in rows]
         result["errors"].extend(
@@ -163,10 +399,35 @@ def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
             for row in rows
             if row.action == "error"
         )
+        branches = cleanup_gone_local_branches(repo_root, apply=apply)
+        result["branches"] = branches
+        result["errors"].extend(
+            f"{row['branch']}: {row.get('error') or row['reason']}"
+            for row in branches
+            if row["action"] == "error"
+        )
         result["orphans"] = find_orphaned_worktree_directories(repo_root)
+        maintenance = _git_maintenance(repo_root, apply=apply)
+        result["maintenance"] = maintenance
+        if not maintenance["ok"]:
+            result["errors"].append(
+                f"git maintenance failed: {maintenance['detail']}"
+            )
     except RuntimeError as exc:
         result["errors"].append(str(exc))
     return result
+
+
+def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
+    if not (repo_root / ".git").exists():
+        return _repo_result_unlocked(repo_root, apply=apply)
+    try:
+        with _GitHygieneLock(repo_root):
+            return _repo_result_unlocked(repo_root, apply=apply)
+    except RuntimeError as exc:
+        result = _empty_repo_result(repo_root)
+        result["errors"].append(str(exc))
+        return result
 
 
 def build_receipt(
@@ -185,6 +446,17 @@ def build_receipt(
     )
     errors = sum(len(repository["errors"]) for repository in repositories)
     orphans = sum(len(repository["orphans"]) for repository in repositories)
+    branches_deleted = sum(
+        1
+        for repository in repositories
+        for row in repository["branches"]
+        if row["action"] == "deleted"
+    ) + sum(
+        1
+        for repository in repositories
+        for row in repository["results"]
+        if row.get("branch_pruned") is True
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "observed_at": timestamp,
@@ -192,6 +464,7 @@ def build_receipt(
         "summary": {
             "repositories": len(repositories),
             "removed": removed,
+            "branches_deleted": branches_deleted,
             "orphans_reported": orphans,
             "errors": errors,
         },
@@ -254,7 +527,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--receipt-dir",
         type=Path,
-        default=default_state_dir() / "receipts" / "v1",
+        default=default_state_dir() / "receipts" / "v2",
     )
     parser.set_defaults(
         default_repo_roots=[public_repo, default_private_repo(public_repo)]

--- a/tests/orchestration/test_install_worktree_cleanup_launchd.py
+++ b/tests/orchestration/test_install_worktree_cleanup_launchd.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from scripts.orchestration import install_worktree_cleanup_launchd as launchd
 
 
-def test_rendered_plist_runs_both_repositories_every_fifteen_minutes(
+def test_rendered_plist_runs_both_repositories_every_four_hours(
     tmp_path: Path,
 ) -> None:
     public = tmp_path / "public"
@@ -19,12 +19,12 @@ def test_rendered_plist_runs_both_repositories_every_fifteen_minutes(
             public_repo=public,
             private_repo=private,
             home=home,
-            interval_minutes=15,
+            interval_minutes=240,
         )
     )
 
     assert payload["Label"] == launchd.LABEL
-    assert payload["StartInterval"] == 900
+    assert payload["StartInterval"] == 14_400
     assert payload["RunAtLoad"] is True
     assert payload["ProgramArguments"] == [
         str(public / ".venv" / "bin" / "python"),
@@ -35,7 +35,7 @@ def test_rendered_plist_runs_both_repositories_every_fifteen_minutes(
         "--repo-root",
         str(private),
         "--receipt-dir",
-        str(home / ".codex" / "worktree-cleanup" / "receipts" / "v1"),
+        str(home / ".codex" / "worktree-cleanup" / "receipts" / "v2"),
     ]
     assert "/opt/homebrew/bin" in payload["EnvironmentVariables"]["PATH"]
 
@@ -160,7 +160,7 @@ def test_uninstall_preserves_receipts(tmp_path: Path, monkeypatch) -> None:
     destination = launchd.plist_path(home)
     destination.parent.mkdir(parents=True)
     destination.write_text("plist", encoding="utf-8")
-    receipt = launchd.state_dir(home) / "receipts" / "v1" / "receipt.json"
+    receipt = launchd.state_dir(home) / "receipts" / "v2" / "receipt.json"
     receipt.parent.mkdir(parents=True)
     receipt.write_text("{}", encoding="utf-8")
 

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -484,6 +485,7 @@ def test_squash_merge_branch_force_delete(
 
     result = result_for(results, worktree_path)
     assert result.action == "removed"
+    assert result.branch_pruned is True
     assert not worktree_path.exists()
 
     # Check that the branch was indeed deleted
@@ -495,6 +497,26 @@ def test_squash_merge_branch_force_delete(
         timeout=30,
     )
     assert "codex/squash-merged" not in proc.stdout
+
+
+def test_prune_branch_refuses_branch_checked_out_in_another_worktree(
+    tmp_path: Path,
+) -> None:
+    repo = init_repo(tmp_path)
+    branch = "codex/checked-out-during-prune"
+    worktree = add_worktree(repo, branch)
+    expected_head = git(repo, "rev-parse", branch)
+
+    error = rw._prune_branch(
+        repo,
+        branch,
+        force=True,
+        expected_head=expected_head,
+    )
+
+    assert error is not None
+    assert git(repo, "rev-parse", branch) == expected_head
+    assert git(worktree, "branch", "--show-current") == branch
 
 
 def test_open_pr_matching_origin_is_not_reaped(
@@ -671,6 +693,28 @@ def test_reaper_lock_rejects_concurrent_cleanup(
                 live_cwds=set(),
             )
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def test_missing_registered_worktree_is_reported_not_crashed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/missing-registration")
+    shutil.rmtree(worktree)
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+        ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert result.reason == "registered worktree path is missing; run git worktree prune"
 
 
 def test_merged_flag_does_not_remove_settled_dispatch_without_merged_pr(

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from dataclasses import replace
 from pathlib import Path
@@ -131,6 +132,268 @@ def test_lock_contention_marks_repository_run_failed(
     assert result["errors"] == ["cleanup lock held"]
 
 
+def test_stale_worktree_registration_is_pruned_before_reaping(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/stale-registration"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "stale-registration"
+    _git(repo, "worktree", "add", "-b", branch, str(worktree), "main")
+    shutil.rmtree(worktree)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_live_cwd_paths",
+        lambda _repo: set(),
+    )
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["errors"] == []
+    assert result["worktree_prune"]["ok"] is True
+    registered = cleanup.reap_worktrees.list_git_worktrees(repo)
+    assert all(item.path != worktree for item in registered)
+
+
+def _gone_branch(repo: Path, branch: str) -> str:
+    _git(repo, "branch", branch, "main")
+    _git(repo, "push", "origin", branch)
+    _git(repo, "branch", "--set-upstream-to", f"origin/{branch}", branch)
+    head_sha = _git(repo, "rev-parse", branch)
+    _git(repo, "push", "origin", "--delete", branch)
+    return head_sha
+
+
+def test_exact_merged_gone_branch_is_deleted(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/merged-gone"
+    head_sha = _gone_branch(repo, branch)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_query_pr_states",
+        lambda _repo, candidate: (
+            [
+                cleanup.reap_worktrees.PullRequestState(
+                    number=42,
+                    state="MERGED",
+                    head_sha=head_sha,
+                )
+            ]
+            if candidate == branch
+            else [],
+            None,
+        ),
+    )
+
+    dry_run = cleanup.cleanup_gone_local_branches(repo, apply=False)
+    applied = cleanup.cleanup_gone_local_branches(repo, apply=True)
+
+    assert dry_run == [
+        {
+            "action": "would_delete",
+            "branch": branch,
+            "head_sha": head_sha,
+            "reason": "upstream gone; exact head of MERGED PR #42",
+        }
+    ]
+    assert applied[0]["action"] == "deleted"
+    assert _git(repo, "branch", "--list", branch) == ""
+
+
+def test_unproven_gone_branch_is_preserved(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    _git(repo, "checkout", "-b", "source-work")
+    (repo / "local.txt").write_text("not merged\n", encoding="utf-8")
+    _git(repo, "add", "local.txt")
+    _git(repo, "commit", "-m", "local only")
+    _git(repo, "checkout", "main")
+    branch = "codex/unproven-gone"
+    _git(repo, "branch", branch, "source-work")
+    _git(repo, "push", "origin", branch)
+    _git(repo, "branch", "--set-upstream-to", f"origin/{branch}", branch)
+    _git(repo, "push", "origin", "--delete", branch)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_query_pr_states",
+        lambda _repo, _branch: ([], None),
+    )
+
+    result = cleanup.cleanup_gone_local_branches(repo, apply=True)
+
+    row = next(item for item in result if item["branch"] == branch)
+    assert row["action"] == "skipped"
+    assert "no exact merged-PR" in row["reason"]
+    assert _git(repo, "branch", "--list", branch) != ""
+
+
+def test_pr_query_failure_preserves_branch_and_reports_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/pr-query-failed"
+    _gone_branch(repo, branch)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_query_pr_states",
+        lambda _repo, _branch: ([], "gh pr list failed: offline"),
+    )
+
+    result = cleanup.cleanup_gone_local_branches(repo, apply=True)
+
+    assert result == [
+        {
+            "action": "error",
+            "branch": branch,
+            "head_sha": _git(repo, "rev-parse", branch),
+            "reason": "upstream gone but PR state could not be verified",
+            "error": "gh pr list failed: offline",
+        }
+    ]
+    assert _git(repo, "branch", "--list", branch) != ""
+
+
+def test_open_pr_preserves_gone_branch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/open-pr"
+    head_sha = _gone_branch(repo, branch)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_query_pr_states",
+        lambda _repo, _branch: (
+            [
+                cleanup.reap_worktrees.PullRequestState(
+                    number=99,
+                    state="OPEN",
+                    head_sha=head_sha,
+                )
+            ],
+            None,
+        ),
+    )
+
+    result = cleanup.cleanup_gone_local_branches(repo, apply=True)
+
+    assert result[0]["action"] == "skipped"
+    assert result[0]["reason"] == "upstream gone but PR #99 is OPEN"
+    assert _git(repo, "branch", "--list", branch) != ""
+
+
+def test_checked_out_branch_is_not_deleted(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/checked-out"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "checked-out"
+    _git(repo, "worktree", "add", "-b", branch, str(worktree), "main")
+    expected_head = _git(repo, "rev-parse", branch)
+
+    error = cleanup._delete_local_branch(
+        repo,
+        branch=branch,
+        expected_head=expected_head,
+    )
+
+    assert error is not None
+    assert _git(repo, "branch", "--list", branch) != ""
+    assert _git(worktree, "branch", "--show-current") == branch
+
+
+def test_origin_main_ancestor_with_gone_upstream_is_deleted(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "codex/ancestor-gone"
+    _git(repo, "checkout", "-b", branch)
+    (repo / "merged.txt").write_text("merged remotely\n", encoding="utf-8")
+    _git(repo, "add", "merged.txt")
+    _git(repo, "commit", "-m", "merged branch commit")
+    _git(repo, "push", "-u", "origin", branch)
+    branch_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "push", "origin", f"{branch}:main")
+    _git(repo, "checkout", "main")
+    assert _git(repo, "rev-parse", "HEAD") != branch_head
+    _git(repo, "push", "origin", "--delete", branch)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_query_pr_states",
+        lambda _repo, _branch: ([], None),
+    )
+
+    result = cleanup.cleanup_gone_local_branches(repo, apply=True)
+
+    assert result[0]["action"] == "deleted"
+    assert "ancestor of origin/main" in result[0]["reason"]
+    assert _git(repo, "branch", "--list", branch) == ""
+
+
+def test_repository_run_fails_closed_when_hygiene_lock_is_held(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+
+    with cleanup._GitHygieneLock(repo):
+        result = cleanup._repo_result(repo, apply=False)
+
+    assert result["fetch"] is None
+    assert result["errors"] == [
+        f"another scheduled Git hygiene run holds "
+        f"{repo / '.git' / 'scheduled-git-hygiene.lock'}"
+    ]
+
+
+def test_worktree_prune_failure_stops_repository_run(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(
+        cleanup,
+        "_worktree_prune",
+        lambda _repo, *, apply: {
+            "action": "pruned",
+            "detail": "cannot prune",
+            "ok": False,
+        },
+    )
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["results"] == []
+    assert result["branches"] == []
+    assert result["maintenance"] is None
+    assert result["errors"] == ["worktree prune failed; cleanup skipped"]
+
+
+def test_lock_contention_is_aggregated_in_receipt(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+
+    with cleanup._GitHygieneLock(repo):
+        receipt = cleanup.build_receipt(
+            [repo],
+            apply=True,
+            observed_at="2026-07-29T10:00:00Z",
+        )
+
+    assert receipt["schema_version"] == "scheduled-git-hygiene.v2"
+    assert receipt["summary"]["errors"] == 1
+    assert "another scheduled Git hygiene run holds" in (
+        receipt["repositories"][0]["errors"][0]
+    )
+
+
 def test_receipt_aggregates_both_repositories(tmp_path: Path, monkeypatch) -> None:
     public = tmp_path / "public"
     private = tmp_path / "private"
@@ -143,7 +406,11 @@ def test_receipt_aggregates_both_repositories(tmp_path: Path, monkeypatch) -> No
             "results": [
                 {
                     "action": "removed" if repo_root == public else "skipped",
+                    "branch_pruned": repo_root == public,
                 }
+            ],
+            "branches": [
+                {"action": "deleted"} if repo_root == public else {"action": "skipped"}
             ],
             "orphans": [{"path": "orphan"}] if repo_root == private else [],
             "errors": [],
@@ -161,10 +428,35 @@ def test_receipt_aggregates_both_repositories(tmp_path: Path, monkeypatch) -> No
     assert receipt["summary"] == {
         "repositories": 2,
         "removed": 1,
+        "branches_deleted": 2,
         "orphans_reported": 1,
         "errors": 0,
     }
     assert receipt["mode"] == "apply"
+
+
+def test_git_maintenance_failure_is_reported(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(cleanup.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    monkeypatch.setattr(cleanup.reap_worktrees, "reap_worktrees", lambda **_kwargs: [])
+    monkeypatch.setattr(cleanup, "cleanup_gone_local_branches", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
+    monkeypatch.setattr(
+        cleanup,
+        "_git_maintenance",
+        lambda _repo, *, apply: {
+            "action": "ran",
+            "ok": False,
+            "detail": "gc failed",
+        },
+    )
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["errors"] == ["git maintenance failed: gc failed"]
 
 
 def test_receipt_write_is_atomic_and_private(tmp_path: Path) -> None:
@@ -176,7 +468,7 @@ def test_receipt_write_is_atomic_and_private(tmp_path: Path) -> None:
         "repositories": [],
     }
 
-    receipt_dir = tmp_path / "state" / "receipts" / "v1"
+    receipt_dir = tmp_path / "state" / "receipts" / "v2"
     path = cleanup.write_receipt(receipt, receipt_dir)
 
     assert json.loads(path.read_text(encoding="utf-8")) == receipt


### PR DESCRIPTION
## Summary

- replace the worktree-only 15-minute backstop with full Git hygiene every 4 hours
- fetch/prune refs, prune stale registrations, safely reap inactive worktrees, clean proven gone branches, and run git gc --auto in both repositories
- fail closed on missing PR evidence, live/dirty/open state, lock contention, and process-CWD probe failure
- emit scheduled-git-hygiene.v2 receipts under receipts/v2

## Verification

- ruff: passed
- focused/regression pytest: 54 passed
- rendered LaunchAgent plist: plutil passed with StartInterval 14400
- real two-repository apply: zero errors; two settled worktrees removed; live/open/dirty/unproven state preserved
- independent cross-family review: Gemini 3.6 Flash High PASS, no findings
- canonical review verifier: clean

Refs #4956