### PR TITLE
feat(opsec): gate public identifiers and cloze answers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,16 @@ jobs:
         run: .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
       - name: Gate scrubbed public identifiers and teacher-cloze answers
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            .venv/bin/python scripts/audit/lint_opsec_leaks.py \
+              "${PR_BASE_SHA}...${PR_HEAD_SHA}" --public-identifiers
+          else
+            .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
+          fi
           .venv/bin/python scripts/audit/check_teacher_cloze_content.py
 
       - name: Check locked modules are not published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,11 @@ jobs:
       - name: Check internal IDs are not published
         run: .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
+      - name: Gate scrubbed public identifiers and teacher-cloze answers
+        run: |
+          .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
+          .venv/bin/python scripts/audit/check_teacher_cloze_content.py
+
       - name: Check locked modules are not published
         run: .venv/bin/python scripts/audit/check_locked_module_not_published.py --changed-vs-base origin/main
 

--- a/scripts/audit/check_teacher_cloze_content.py
+++ b/scripts/audit/check_teacher_cloze_content.py
@@ -78,15 +78,15 @@ def _is_non_linguistic(value: str) -> bool:
 
 
 def _validate_answer_value(value: Any) -> str | None:
-    """Return a reason when a learner answer is an English descriptor, not a form."""
+    """Return a reason for invalid input or multiple ASCII words in an answer."""
     if not isinstance(value, str) or not value.strip():
         return "must be a non-empty string"
     if _is_non_linguistic(value):
         return None
-    if _CYRILLIC_LETTER_RE.search(value):
-        return None
     if len(_ASCII_WORD_RE.findall(value)) >= 2:
         return "must not be an English multi-word descriptive phrase"
+    if _CYRILLIC_LETTER_RE.search(value):
+        return None
     return None
 
 

--- a/scripts/audit/check_teacher_cloze_content.py
+++ b/scripts/audit/check_teacher_cloze_content.py
@@ -78,7 +78,7 @@ def _is_non_linguistic(value: str) -> bool:
 
 
 def _validate_answer_value(value: Any) -> str | None:
-    """Return a reason for invalid input or multiple ASCII words in an answer."""
+    """Return a reason unless an answer is non-linguistic or contains Cyrillic."""
     if not isinstance(value, str) or not value.strip():
         return "must be a non-empty string"
     if _is_non_linguistic(value):
@@ -87,7 +87,7 @@ def _validate_answer_value(value: Any) -> str | None:
         return "must not be an English multi-word descriptive phrase"
     if _CYRILLIC_LETTER_RE.search(value):
         return None
-    return None
+    return "must include Ukrainian content in Cyrillic"
 
 
 def validate_teacher_cloze_content(

--- a/scripts/audit/check_teacher_cloze_content.py
+++ b/scripts/audit/check_teacher_cloze_content.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail closed when a shipped teacher-cloze answer is not Ukrainian content."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CLOZE_REL_PATH = Path("site/src/data/lexicon-teacher-cloze.json")
+OVERRIDES_REL_PATH = Path("site/src/data/lexicon-teacher-cloze-overrides.json")
+
+_CYRILLIC_LETTER_RE = re.compile(r"[\u0400-\u04ff]")
+_ASCII_WORD_RE = re.compile(r"[A-Za-z]+")
+_LETTER_RE = re.compile(r"[^\W\d_]", re.UNICODE)
+
+
+def _load_json_object(path: Path, label: str) -> tuple[dict[str, Any] | None, list[str]]:
+    """Load a JSON object, returning a user-actionable failure instead of crashing."""
+    if not path.is_file():
+        return None, [f"{label} is missing: {path}"]
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"{label} is invalid JSON: {path}: {exc.msg}"]
+    if not isinstance(value, dict):
+        return None, [f"{label} must contain a JSON object: {path}"]
+    return value, []
+
+
+def _load_excluded_cloze_ids(path: Path, known_ids: set[str]) -> tuple[set[str], list[str]]:
+    """Load optional exclusions and reject malformed or stale sidecars."""
+    if not path.exists():
+        return set(), []
+
+    payload, errors = _load_json_object(path, "teacher-cloze overrides")
+    if payload is None:
+        return set(), errors
+
+    excluded_ids = payload.get("excludedClozeIds")
+    if not isinstance(excluded_ids, list) or not all(
+        isinstance(cloze_id, str) and cloze_id for cloze_id in excluded_ids
+    ):
+        return set(), [f"teacher-cloze overrides require a non-empty-string excludedClozeIds list: {path}"]
+
+    duplicates = sorted({cloze_id for cloze_id in excluded_ids if excluded_ids.count(cloze_id) > 1})
+    if duplicates:
+        errors.append(f"teacher-cloze overrides duplicate excludedClozeIds: {duplicates}")
+
+    unknown = sorted(set(excluded_ids) - known_ids)
+    if unknown:
+        errors.append(f"teacher-cloze overrides reference unknown cloze IDs: {unknown}")
+    return set(excluded_ids), errors
+
+
+def _answer_fields(card: dict[str, Any]) -> Iterable[tuple[str, Any]]:
+    """Yield the Ukrainian fields which can become learner-visible answers."""
+    for field in ("lemmaId", "lemma", "form"):
+        yield field, card.get(field)
+
+    options = card.get("options")
+    if not isinstance(options, list):
+        return
+    for option_index, option in enumerate(options):
+        if not isinstance(option, dict) or option.get("kind") != "answer":
+            continue
+        for field in ("lemmaId", "label"):
+            yield f"options[{option_index}].{field}", option.get(field)
+
+
+def _is_non_linguistic(value: str) -> bool:
+    """Allow a numeric/symbol cloze answer; those are not word-form claims."""
+    return not _LETTER_RE.search(value)
+
+
+def _validate_answer_value(value: Any) -> str | None:
+    """Return a reason when a learner answer is an English descriptor, not a form."""
+    if not isinstance(value, str) or not value.strip():
+        return "must be a non-empty string"
+    if _is_non_linguistic(value):
+        return None
+    if _CYRILLIC_LETTER_RE.search(value):
+        return None
+    if len(_ASCII_WORD_RE.findall(value)) >= 2:
+        return "must not be an English multi-word descriptive phrase"
+    return None
+
+
+def validate_teacher_cloze_content(
+    cloze_path: Path,
+    overrides_path: Path,
+) -> list[str]:
+    """Validate effective teacher-cloze answers after optional exclusions apply."""
+    payload, errors = _load_json_object(cloze_path, "teacher-cloze data")
+    if payload is None:
+        return errors
+
+    cards = payload.get("cloze")
+    if not isinstance(cards, list):
+        return [*errors, f"teacher-cloze data requires a cloze list: {cloze_path}"]
+
+    card_ids: set[str] = set()
+    for index, card in enumerate(cards):
+        if not isinstance(card, dict) or not isinstance(card.get("clozeId"), str) or not card["clozeId"]:
+            errors.append(f"teacher-cloze card {index} requires a non-empty string clozeId")
+            continue
+        if card["clozeId"] in card_ids:
+            errors.append(f"teacher-cloze data duplicates clozeId: {card['clozeId']}")
+        card_ids.add(card["clozeId"])
+
+    excluded_ids, override_errors = _load_excluded_cloze_ids(overrides_path, card_ids)
+    errors.extend(override_errors)
+
+    for index, card in enumerate(cards):
+        if not isinstance(card, dict):
+            errors.append(f"teacher-cloze card {index} must be an object")
+            continue
+        cloze_id = card.get("clozeId")
+        if not isinstance(cloze_id, str) or cloze_id in excluded_ids:
+            continue
+        for field, value in _answer_fields(card):
+            reason = _validate_answer_value(value)
+            if reason:
+                errors.append(f"teacher-cloze {cloze_id} {field}: {reason}; got {value!r}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the teacher-cloze content gate from the repository root or a fixture root."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="Repository root (default: current repository)")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    errors = validate_teacher_cloze_content(root / CLOZE_REL_PATH, root / OVERRIDES_REL_PATH)
+    if errors:
+        print("Teacher cloze content gate failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Teacher cloze content gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/lint_opsec_leaks.py
+++ b/scripts/audit/lint_opsec_leaks.py
@@ -58,17 +58,20 @@ _FORBIDDEN_PATTERNS = [
     (re.compile(r"passwordless\s+SSH", re.IGNORECASE), "Raw SSH auth method disclosure"),
 ]
 
-# Personal identifiers scrubbed from public learner-facing content.  Keep the
-# canonical Latin spelling and its Ukrainian rendering together: either form
-# is a leak when it appears as a standalone token in a shipped data, component,
-# or documentation file.
+# Personal identifiers scrubbed from public learner-facing content.  Match the
+# name stems rather than only their nominative forms: Ukrainian declension can
+# produce Альони, Альоні, Альону, Альоною, or Альоно.  The leading word boundary
+# prevents an embedded substring such as батальона from being treated as a name.
 _SCRUBBED_PERSONAL_IDENTIFIER_TOKENS = ("alona", "альона")
 _PERSONAL_IDENTIFIER_PATTERNS = tuple(
     (
         token,
-        re.compile(rf"(?<!\w){re.escape(token)}(?!\w)", re.IGNORECASE),
+        re.compile(
+            rf"(?<!\w){re.escape(stem)}\w*\b",
+            re.IGNORECASE,
+        ),
     )
-    for token in _SCRUBBED_PERSONAL_IDENTIFIER_TOKENS
+    for token, stem in (("alona", "alona"), ("альона", "альон"))
 )
 
 # This is deliberately exact rather than a broad directory exemption.  Tests
@@ -77,8 +80,10 @@ _PERSONAL_IDENTIFIER_PATTERNS = tuple(
 _PERSONAL_IDENTIFIER_PATH_ALLOWLIST: frozenset[str] = frozenset()
 
 _PUBLIC_PERSONAL_IDENTIFIER_ROOTS = (
-    Path("site/src/data"),
-    Path("site/src/components"),
+    # All files that may be shipped by the static site, including pages, their
+    # supporting source, and already-built public assets.
+    Path("site/src"),
+    Path("site/public"),
     Path("docs"),
 )
 

--- a/scripts/audit/lint_opsec_leaks.py
+++ b/scripts/audit/lint_opsec_leaks.py
@@ -255,23 +255,29 @@ def get_diff_range_head(diff_range: str) -> str:
     return "HEAD"
 
 
-def get_files_to_check(diff_range: str | None = None, staged_only: bool = False, scan_all: bool = False) -> tuple[list[str], str, str]:
+def get_files_to_check(
+    diff_range: str | None = None,
+    staged_only: bool = False,
+    scan_all: bool = False,
+    *,
+    apply_infrastructure_skips: bool = True,
+) -> tuple[list[str], str, str]:
     """Return tuple of (list_of_relative_path_strings, mode_description, rev_target)."""
     if scan_all:
         cmd = ["git", "ls-files", "-z"]
         paths = run_git_nul_separated(cmd)
-        return filter_rel_paths(paths), "all tracked files (--all)", "HEAD"
+        return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), "all tracked files (--all)", "HEAD"
 
     if staged_only:
         cmd = ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMRT"]
         paths = run_git_nul_separated(cmd)
-        return filter_rel_paths(paths), "staged git index (:path)", ""
+        return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), "staged git index (:path)", ""
 
     if diff_range:
         rev_target = get_diff_range_head(diff_range)
         cmd = ["git", "diff", "-z", "--name-only", "--diff-filter=ACMRT", diff_range]
         paths = run_git_nul_separated(cmd)
-        return filter_rel_paths(paths), f"git diff ({diff_range})", rev_target
+        return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), f"git diff ({diff_range})", rev_target
 
     # Sol F004 / Fable F007: Explicit pre-push ref environment check
     pre_push_local = os.environ.get("PRE_PUSH_LOCAL_REF") or os.environ.get("PRE_COMMIT_TO_REF", "")
@@ -280,13 +286,13 @@ def get_files_to_check(diff_range: str | None = None, staged_only: bool = False,
         range_spec = f"{pre_push_remote}..{pre_push_local}"
         cmd = ["git", "diff", "-z", "--name-only", "--diff-filter=ACMRT", range_spec]
         paths = run_git_nul_separated(cmd)
-        return filter_rel_paths(paths), f"pre-push range ({range_spec})", pre_push_local
+        return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), f"pre-push range ({range_spec})", pre_push_local
 
     # Default logic: staged > feature branch diff > HEAD~1..HEAD
     cmd_staged = ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMRT"]
     staged_paths = run_git_nul_separated(cmd_staged)
     if staged_paths:
-        return filter_rel_paths(staged_paths), "staged git index (:path)", ""
+        return filter_rel_paths(staged_paths, apply_infrastructure_skips=apply_infrastructure_skips), "staged git index (:path)", ""
 
     # Feature branch diff mode
     try:
@@ -296,28 +302,31 @@ def get_files_to_check(diff_range: str | None = None, staged_only: bool = False,
             cmd = ["git", "diff", "-z", "--name-only", "--diff-filter=ACMRT", "origin/main..HEAD"]
             paths = run_git_nul_separated(cmd)
             if paths:
-                return filter_rel_paths(paths), "git diff (origin/main..HEAD)", "HEAD"
+                return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), "git diff (origin/main..HEAD)", "HEAD"
     except Exception:
         pass
 
     # Default commit range check for push/local
     cmd = ["git", "diff", "-z", "--name-only", "--diff-filter=ACMRT", "HEAD~1..HEAD"]
     paths = run_git_nul_separated(cmd)
-    return filter_rel_paths(paths), "recent commit (HEAD~1..HEAD)", "HEAD"
+    return filter_rel_paths(paths, apply_infrastructure_skips=apply_infrastructure_skips), "recent commit (HEAD~1..HEAD)", "HEAD"
 
 
-def filter_rel_paths(paths: list[str]) -> list[str]:
-    """Filter relative path strings by extension and skip patterns (F001: preserve scripts/audit/ via filter_rel_paths)."""
+def filter_rel_paths(
+    paths: list[str], *, apply_infrastructure_skips: bool = True
+) -> list[str]:
+    """Filter paths by extension and, for infrastructure scans, skip patterns."""
     valid_paths: list[str] = []
     for rel_str in paths:
         path_obj = Path(rel_str)
         if path_obj.suffix.lower() in _SKIP_EXTENSIONS:
             continue
         normalized = rel_str.replace("\\", "/")
-        if normalized.startswith("scripts/audit/"):
-            valid_paths.append(rel_str)
-            continue
-        if any(sub in normalized for sub in _SKIP_PATH_SUBSTRINGS):
+        if (
+            apply_infrastructure_skips
+            and not normalized.startswith("scripts/audit/")
+            and any(sub in normalized for sub in _SKIP_PATH_SUBSTRINGS)
+        ):
             continue
         valid_paths.append(rel_str)
     return valid_paths
@@ -358,7 +367,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.public_identifiers:
             if args.diff_range:
-                changed_paths, diff_mode, rev_target = get_files_to_check(args.diff_range)
+                changed_paths, diff_mode, rev_target = get_files_to_check(
+                    args.diff_range, apply_infrastructure_skips=False
+                )
                 rel_paths = [
                     path for path in changed_paths if is_public_personal_identifier_path(path)
                 ]

--- a/scripts/audit/lint_opsec_leaks.py
+++ b/scripts/audit/lint_opsec_leaks.py
@@ -247,6 +247,14 @@ def run_git_nul_separated(cmd: list[str]) -> list[str]:
     return decoded
 
 
+def get_diff_range_head(diff_range: str) -> str:
+    """Return the revision containing files at the right side of a git range."""
+    for separator in ("...", ".."):
+        if separator in diff_range:
+            return diff_range.rsplit(separator, 1)[1]
+    return "HEAD"
+
+
 def get_files_to_check(diff_range: str | None = None, staged_only: bool = False, scan_all: bool = False) -> tuple[list[str], str, str]:
     """Return tuple of (list_of_relative_path_strings, mode_description, rev_target)."""
     if scan_all:
@@ -260,7 +268,7 @@ def get_files_to_check(diff_range: str | None = None, staged_only: bool = False,
         return filter_rel_paths(paths), "staged git index (:path)", ""
 
     if diff_range:
-        rev_target = diff_range.split("..")[-1] if ".." in diff_range else "HEAD"
+        rev_target = get_diff_range_head(diff_range)
         cmd = ["git", "diff", "-z", "--name-only", "--diff-filter=ACMRT", diff_range]
         paths = run_git_nul_separated(cmd)
         return filter_rel_paths(paths), f"git diff ({diff_range})", rev_target
@@ -324,32 +332,41 @@ def get_public_personal_identifier_paths(revision: str = "") -> list[str]:
     return [path for path in paths if is_public_personal_identifier_path(path)]
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Lint repository for OPSEC leaks.")
-    parser.add_argument("diff_range", nargs="?", help="Git diff range (e.g. origin/main..HEAD)")
+    parser.add_argument("diff_range", nargs="?", help="Git diff range (e.g. origin/main...HEAD)")
     parser.add_argument("--staged", action="store_true", help="Inspect staged git index blobs")
     parser.add_argument("--all", action="store_true", help="Explicitly scan all tracked files in repo")
     parser.add_argument(
         "--public-identifiers",
         action="store_true",
-        help="Scan all learner-facing files for scrubbed personal identifiers only",
+        help="Scan learner-facing files for scrubbed personal identifiers only",
     )
     parser.add_argument(
         "--revision",
         help="Read --public-identifiers files from this git revision instead of HEAD",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    if args.public_identifiers and (args.diff_range or args.staged or args.all):
-        parser.error("--public-identifiers cannot be combined with a diff range, --staged, or --all")
+    if args.public_identifiers and (args.staged or args.all):
+        parser.error("--public-identifiers cannot be combined with --staged or --all")
     if args.revision and not args.public_identifiers:
         parser.error("--revision requires --public-identifiers")
+    if args.revision and args.diff_range:
+        parser.error("--revision cannot be combined with a diff range")
 
     try:
         if args.public_identifiers:
-            rel_paths = get_public_personal_identifier_paths(args.revision or "HEAD")
-            mode_str = "all tracked learner-facing files (--public-identifiers)"
-            rev_target = args.revision or "HEAD"
+            if args.diff_range:
+                changed_paths, diff_mode, rev_target = get_files_to_check(args.diff_range)
+                rel_paths = [
+                    path for path in changed_paths if is_public_personal_identifier_path(path)
+                ]
+                mode_str = f"changed learner-facing files (--public-identifiers; {diff_mode})"
+            else:
+                rel_paths = get_public_personal_identifier_paths(args.revision or "HEAD")
+                mode_str = "all tracked learner-facing files (--public-identifiers)"
+                rev_target = args.revision or "HEAD"
         else:
             rel_paths, mode_str, rev_target = get_files_to_check(args.diff_range, staged_only=args.staged, scan_all=args.all)
     except Exception as exc:
@@ -369,10 +386,14 @@ def main() -> int:
         if content is None:
             disk_path = REPO_ROOT / rel_path
             if not disk_path.is_file():
+                print(f"💥 Fail-closed unreadable selected file: {rel_path}", file=sys.stderr)
+                total_findings += 1
                 continue
             try:
                 content = disk_path.read_text(encoding="utf-8", errors="ignore")
-            except Exception:
+            except OSError as exc:
+                print(f"💥 Fail-closed unreadable selected file: {rel_path}: {exc}", file=sys.stderr)
+                total_findings += 1
                 continue
 
         findings = check_content(

--- a/scripts/audit/lint_opsec_leaks.py
+++ b/scripts/audit/lint_opsec_leaks.py
@@ -23,6 +23,7 @@ import os
 import re
 import subprocess
 import sys
+import unicodedata
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -56,6 +57,30 @@ _FORBIDDEN_PATTERNS = [
     (re.compile(r"-----BEGIN\s+(?:[A-Z0-9_-]+\s+)?PRIVATE\s+KEY-----", re.IGNORECASE), "Private Key Header (PKCS#1/PKCS#8/OpenSSH/RSA/EC/DSA/Encrypted)"),
     (re.compile(r"passwordless\s+SSH", re.IGNORECASE), "Raw SSH auth method disclosure"),
 ]
+
+# Personal identifiers scrubbed from public learner-facing content.  Keep the
+# canonical Latin spelling and its Ukrainian rendering together: either form
+# is a leak when it appears as a standalone token in a shipped data, component,
+# or documentation file.
+_SCRUBBED_PERSONAL_IDENTIFIER_TOKENS = ("alona", "альона")
+_PERSONAL_IDENTIFIER_PATTERNS = tuple(
+    (
+        token,
+        re.compile(rf"(?<!\w){re.escape(token)}(?!\w)", re.IGNORECASE),
+    )
+    for token in _SCRUBBED_PERSONAL_IDENTIFIER_TOKENS
+)
+
+# This is deliberately exact rather than a broad directory exemption.  Tests
+# exercise the detector directly, so no public learner-facing file is allowed
+# to carry a regression marker.
+_PERSONAL_IDENTIFIER_PATH_ALLOWLIST: frozenset[str] = frozenset()
+
+_PUBLIC_PERSONAL_IDENTIFIER_ROOTS = (
+    Path("site/src/data"),
+    Path("site/src/components"),
+    Path("docs"),
+)
 
 # File extensions to skip (strictly binary / generated / virtual environment files)
 _SKIP_EXTENSIONS = {
@@ -112,12 +137,43 @@ def is_section_citation(line: str, filename: str, p0: int, p1: int, p2: int, p3:
     return False
 
 
-def check_content(content: str, filename: str) -> list[tuple[int, str, str]]:
+def is_public_personal_identifier_path(filename: str) -> bool:
+    """Return whether a path is a learner-facing tree protected from name leaks."""
+    normalized = Path(filename.replace("\\", "/"))
+    return any(normalized.is_relative_to(root) for root in _PUBLIC_PERSONAL_IDENTIFIER_ROOTS)
+
+
+def check_personal_identifiers(content: str, filename: str) -> list[tuple[int, str, str]]:
+    """Return scrubbed personal-name findings in public learner-facing content only."""
+    normalized_filename = filename.replace("\\", "/")
+    if (
+        normalized_filename in _PERSONAL_IDENTIFIER_PATH_ALLOWLIST
+        or not is_public_personal_identifier_path(normalized_filename)
+    ):
+        return []
+
+    findings: list[tuple[int, str, str]] = []
+    for line_number, line in enumerate(unicodedata.normalize("NFC", content).splitlines(), 1):
+        for token, pattern in _PERSONAL_IDENTIFIER_PATTERNS:
+            if pattern.search(line):
+                findings.append((line_number, token, "Scrubbed personal identifier"))
+    return findings
+
+
+def check_content(
+    content: str,
+    filename: str,
+    *,
+    include_infrastructure: bool = True,
+) -> list[tuple[int, str, str]]:
     """Scan string content line by line for OPSEC leaks.
 
     Returns list of (line_num, match_str, description).
     """
     findings: list[tuple[int, str, str]] = []
+    if not include_infrastructure:
+        return check_personal_identifiers(content, filename)
+
     lines = content.splitlines()
 
     is_linter_itself = filename.replace("\\", "/").endswith("lint_opsec_leaks.py")
@@ -158,7 +214,7 @@ def check_content(content: str, filename: str) -> list[tuple[int, str, str]]:
             if pattern.search(line):
                 findings.append((idx, line.strip(), desc))
 
-    return findings
+    return findings + check_personal_identifiers(content, filename)
 
 
 def get_git_content(rel_path: str, rev: str = "") -> str | None:
@@ -259,15 +315,43 @@ def filter_rel_paths(paths: list[str]) -> list[str]:
     return valid_paths
 
 
+def get_public_personal_identifier_paths(revision: str = "") -> list[str]:
+    """Return all tracked learner-facing files that must be free of scrubbed names."""
+    command = ["git", "ls-files", "-z"]
+    if revision:
+        command = ["git", "ls-tree", "-rz", "--name-only", revision]
+    paths = run_git_nul_separated(command)
+    return [path for path in paths if is_public_personal_identifier_path(path)]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Lint repository for OPSEC leaks.")
     parser.add_argument("diff_range", nargs="?", help="Git diff range (e.g. origin/main..HEAD)")
     parser.add_argument("--staged", action="store_true", help="Inspect staged git index blobs")
     parser.add_argument("--all", action="store_true", help="Explicitly scan all tracked files in repo")
+    parser.add_argument(
+        "--public-identifiers",
+        action="store_true",
+        help="Scan all learner-facing files for scrubbed personal identifiers only",
+    )
+    parser.add_argument(
+        "--revision",
+        help="Read --public-identifiers files from this git revision instead of HEAD",
+    )
     args = parser.parse_args()
 
+    if args.public_identifiers and (args.diff_range or args.staged or args.all):
+        parser.error("--public-identifiers cannot be combined with a diff range, --staged, or --all")
+    if args.revision and not args.public_identifiers:
+        parser.error("--revision requires --public-identifiers")
+
     try:
-        rel_paths, mode_str, rev_target = get_files_to_check(args.diff_range, staged_only=args.staged, scan_all=args.all)
+        if args.public_identifiers:
+            rel_paths = get_public_personal_identifier_paths(args.revision or "HEAD")
+            mode_str = "all tracked learner-facing files (--public-identifiers)"
+            rev_target = args.revision or "HEAD"
+        else:
+            rel_paths, mode_str, rev_target = get_files_to_check(args.diff_range, staged_only=args.staged, scan_all=args.all)
     except Exception as exc:
         print(f"💥 Fail-closed git error: {exc}", file=sys.stderr)
         return 1
@@ -291,7 +375,11 @@ def main() -> int:
             except Exception:
                 continue
 
-        findings = check_content(content, rel_path)
+        findings = check_content(
+            content,
+            rel_path,
+            include_infrastructure=not args.public_identifiers,
+        )
 
         if findings:
             total_findings += len(findings)
@@ -301,7 +389,7 @@ def main() -> int:
 
     if total_findings > 0:
         print(f"\n💥 Total OPSEC leaks found: {total_findings}")
-        print("Please remove raw infrastructure IPs, host keys, and auth details before submitting!")
+        print("Please remove OPSEC-sensitive infrastructure details and scrubbed identifiers before submitting!")
         return 1
 
     print("✅ OPSEC check passed. Zero leaks detected.")

--- a/site/src/data/lexicon-teacher-cloze-overrides.json
+++ b/site/src/data/lexicon-teacher-cloze-overrides.json
@@ -1,5 +1,9 @@
 {
   "excludedClozeIds": [
-    "teacher_cloze_3150"
+    "teacher_cloze_192",
+    "teacher_cloze_512",
+    "teacher_cloze_515",
+    "teacher_cloze_3150",
+    "teacher_cloze_4574"
   ]
 }

--- a/site/src/data/lexicon-teacher-cloze-overrides.json
+++ b/site/src/data/lexicon-teacher-cloze-overrides.json
@@ -1,0 +1,5 @@
+{
+  "excludedClozeIds": [
+    "teacher_cloze_3150"
+  ]
+}

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -71,6 +71,39 @@ def test_scrubbed_personal_identifier_is_not_checked_in_private_code_or_as_subst
     assert substring_findings == []
 
 
+def test_scrubbed_personal_identifier_matches_ukrainian_declensions_and_latin_stem():
+    forms = ("Альона", "Альони", "Альоні", "Альону", "Альоною", "Альоно", "Alona")
+
+    findings = check_content("\n".join(forms), "site/src/pages/index.astro")
+
+    assert findings == [
+        (1, "альона", "Scrubbed personal identifier"),
+        (2, "альона", "Scrubbed personal identifier"),
+        (3, "альона", "Scrubbed personal identifier"),
+        (4, "альона", "Scrubbed personal identifier"),
+        (5, "альона", "Scrubbed personal identifier"),
+        (6, "альона", "Scrubbed personal identifier"),
+        (7, "alona", "Scrubbed personal identifier"),
+    ]
+
+
+def test_scrubbed_personal_identifier_stem_does_not_match_embedded_words():
+    findings = check_content(
+        "value = 'malonated'; noun = 'батальона'",
+        "docs/safety.md",
+    )
+
+    assert findings == []
+
+
+def test_scrubbed_personal_identifier_scans_site_source_and_public_assets():
+    source_findings = check_content("const owner = 'Alona'", "site/src/lib/owner.ts")
+    asset_findings = check_content("Альони", "site/public/lexicon/owner.json")
+
+    assert source_findings == [(1, "alona", "Scrubbed personal identifier")]
+    assert asset_findings == [(1, "альона", "Scrubbed personal identifier")]
+
+
 def test_public_identifier_pr_mode_scans_only_changed_public_paths(monkeypatch):
     changed_public_path = "site/src/data/changed.json"
     unchanged_public_path = "docs/unchanged.md"

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -48,3 +48,23 @@ def test_public_ip_flagged_even_with_low_octet_numbers_unless_heading():
     content_heading = "### 4.1.3.1 Section Heading"
     findings_heading = check_content(content_heading, "doc.py")
     assert len(findings_heading) == 0
+
+
+def test_scrubbed_personal_identifier_is_blocked_in_public_content():
+    findings = check_content(
+        "export const source = 'Alona';\nconst sourceUk = 'АЛЬОНА';",
+        "site/src/components/LexiconPractice.tsx",
+    )
+
+    assert findings == [
+        (1, "alona", "Scrubbed personal identifier"),
+        (2, "альона", "Scrubbed personal identifier"),
+    ]
+
+
+def test_scrubbed_personal_identifier_is_not_checked_in_private_code_or_as_substring():
+    code_findings = check_content("owner = 'Alona'", "scripts/private_import.py")
+    substring_findings = check_content("value = 'malonated'", "docs/safety.md")
+
+    assert code_findings == []
+    assert substring_findings == []

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -79,7 +79,7 @@ def test_public_identifier_pr_mode_scans_only_changed_public_paths(monkeypatch):
     monkeypatch.setattr(
         opsec_linter,
         "get_files_to_check",
-        lambda diff_range: ([changed_public_path, "scripts/private_import.py"], "git diff", "pr-head"),
+        lambda diff_range, **kwargs: ([changed_public_path, "scripts/private_import.py"], "git diff", "pr-head"),
     )
 
     def get_content(path: str, rev: str) -> str:
@@ -101,11 +101,38 @@ def test_public_identifier_pr_mode_rejects_a_leak_in_a_changed_public_path(monke
     monkeypatch.setattr(
         opsec_linter,
         "get_files_to_check",
-        lambda diff_range: ([changed_public_path], "git diff", "pr-head"),
+        lambda diff_range, **kwargs: ([changed_public_path], "git diff", "pr-head"),
     )
     monkeypatch.setattr(opsec_linter, "get_git_content", lambda path, rev: marker)
 
     assert opsec_linter.main(["base...pr-head", "--public-identifiers"]) == 1
+
+
+def test_public_identifier_pr_mode_scans_public_path_with_infrastructure_skip_substring(monkeypatch):
+    changed_public_path = "docs/references/external/changed.md"
+    marker = opsec_linter._SCRUBBED_PERSONAL_IDENTIFIER_TOKENS[0]
+    scanned_paths: list[str] = []
+
+    monkeypatch.setattr(opsec_linter, "run_git_nul_separated", lambda cmd: [changed_public_path])
+
+    def get_content(path: str, rev: str) -> str:
+        scanned_paths.append(path)
+        assert rev == "pr-head"
+        return marker
+
+    monkeypatch.setattr(opsec_linter, "get_git_content", get_content)
+
+    assert opsec_linter.main(["base...pr-head", "--public-identifiers"]) == 1
+    assert scanned_paths == [changed_public_path]
+
+
+def test_infrastructure_path_filter_keeps_its_skip_list():
+    skipped_path = "docs/references/external/private.md"
+
+    assert opsec_linter.filter_rel_paths([skipped_path]) == []
+    assert opsec_linter.filter_rel_paths(
+        [skipped_path], apply_infrastructure_skips=False
+    ) == [skipped_path]
 
 
 def test_public_identifier_full_tree_mode_scans_every_public_path(monkeypatch):

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts/audit"))
 
+import lint_opsec_leaks as opsec_linter
 from lint_opsec_leaks import check_content
 
 
@@ -68,3 +69,67 @@ def test_scrubbed_personal_identifier_is_not_checked_in_private_code_or_as_subst
 
     assert code_findings == []
     assert substring_findings == []
+
+
+def test_public_identifier_pr_mode_scans_only_changed_public_paths(monkeypatch):
+    changed_public_path = "site/src/data/changed.json"
+    unchanged_public_path = "docs/unchanged.md"
+    scanned_paths: list[str] = []
+
+    monkeypatch.setattr(
+        opsec_linter,
+        "get_files_to_check",
+        lambda diff_range: ([changed_public_path, "scripts/private_import.py"], "git diff", "pr-head"),
+    )
+
+    def get_content(path: str, rev: str) -> str:
+        scanned_paths.append(path)
+        assert rev == "pr-head"
+        return "clean content"
+
+    monkeypatch.setattr(opsec_linter, "get_git_content", get_content)
+
+    assert opsec_linter.main(["base...pr-head", "--public-identifiers"]) == 0
+    assert scanned_paths == [changed_public_path]
+    assert unchanged_public_path not in scanned_paths
+
+
+def test_public_identifier_pr_mode_rejects_a_leak_in_a_changed_public_path(monkeypatch):
+    changed_public_path = "docs/changed.md"
+    marker = opsec_linter._SCRUBBED_PERSONAL_IDENTIFIER_TOKENS[0]
+
+    monkeypatch.setattr(
+        opsec_linter,
+        "get_files_to_check",
+        lambda diff_range: ([changed_public_path], "git diff", "pr-head"),
+    )
+    monkeypatch.setattr(opsec_linter, "get_git_content", lambda path, rev: marker)
+
+    assert opsec_linter.main(["base...pr-head", "--public-identifiers"]) == 1
+
+
+def test_public_identifier_full_tree_mode_scans_every_public_path(monkeypatch):
+    public_paths = ["site/src/data/a.json", "docs/b.md"]
+    scanned_paths: list[str] = []
+
+    monkeypatch.setattr(opsec_linter, "get_public_personal_identifier_paths", lambda revision: public_paths)
+
+    def get_content(path: str, rev: str) -> str:
+        scanned_paths.append(path)
+        assert rev == "HEAD"
+        return "clean content"
+
+    monkeypatch.setattr(opsec_linter, "get_git_content", get_content)
+
+    assert opsec_linter.main(["--public-identifiers"]) == 0
+    assert scanned_paths == public_paths
+
+
+def test_symmetric_diff_uses_its_head_for_blob_reads(monkeypatch):
+    monkeypatch.setattr(opsec_linter, "run_git_nul_separated", lambda cmd: ["site/src/data/a.json"])
+
+    paths, mode, revision = opsec_linter.get_files_to_check("base-sha...head-sha")
+
+    assert paths == ["site/src/data/a.json"]
+    assert mode == "git diff (base-sha...head-sha)"
+    assert revision == "head-sha"

--- a/tests/test_teacher_cloze_content_gate.py
+++ b/tests/test_teacher_cloze_content_gate.py
@@ -50,6 +50,19 @@ def test_rejects_english_multiword_teacher_answer(tmp_path: Path) -> None:
     ]
 
 
+def test_rejects_multiword_english_answer_with_cyrillic_text(tmp_path: Path) -> None:
+    card = _valid_card()
+    card["lemma"] = "curated private урок"
+    cloze_path, overrides_path = _write_gate_files(tmp_path, [card])
+
+    errors = validate_teacher_cloze_content(cloze_path, overrides_path)
+
+    assert errors == [
+        "teacher-cloze teacher_cloze_1 lemma: must not be an English multi-word descriptive phrase; "
+        "got 'curated private урок'"
+    ]
+
+
 def test_excluded_card_is_removed_before_answer_validation(tmp_path: Path) -> None:
     excluded = _valid_card("teacher_cloze_2")
     excluded["form"] = "curated private teacher lesson"

--- a/tests/test_teacher_cloze_content_gate.py
+++ b/tests/test_teacher_cloze_content_gate.py
@@ -50,6 +50,19 @@ def test_rejects_english_multiword_teacher_answer(tmp_path: Path) -> None:
     ]
 
 
+def test_rejects_single_word_english_teacher_answer(tmp_path: Path) -> None:
+    card = _valid_card()
+    card["lemma"] = "lesson"
+    cloze_path, overrides_path = _write_gate_files(tmp_path, [card])
+
+    errors = validate_teacher_cloze_content(cloze_path, overrides_path)
+
+    assert errors == [
+        "teacher-cloze teacher_cloze_1 lemma: must include Ukrainian content in Cyrillic; "
+        "got 'lesson'"
+    ]
+
+
 def test_rejects_multiword_english_answer_with_cyrillic_text(tmp_path: Path) -> None:
     card = _valid_card()
     card["lemma"] = "curated private урок"

--- a/tests/test_teacher_cloze_content_gate.py
+++ b/tests/test_teacher_cloze_content_gate.py
@@ -1,0 +1,77 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts/audit"))
+
+from check_teacher_cloze_content import validate_teacher_cloze_content
+
+
+def _write_gate_files(tmp_path: Path, cards: list[dict], overrides: dict | None = None) -> tuple[Path, Path]:
+    data_dir = tmp_path / "site/src/data"
+    data_dir.mkdir(parents=True)
+    cloze_path = data_dir / "lexicon-teacher-cloze.json"
+    overrides_path = data_dir / "lexicon-teacher-cloze-overrides.json"
+    cloze_path.write_text(json.dumps({"cloze": cards}, ensure_ascii=False), encoding="utf-8")
+    if overrides is not None:
+        overrides_path.write_text(json.dumps(overrides), encoding="utf-8")
+    return cloze_path, overrides_path
+
+
+def _valid_card(cloze_id: str = "teacher_cloze_1") -> dict:
+    return {
+        "clozeId": cloze_id,
+        "lemmaId": "читати",
+        "lemma": "читати",
+        "form": "читаю",
+        "options": [
+            {"kind": "answer", "lemmaId": "читати", "label": "читаю"},
+            {"kind": "distractor", "lemmaId": "писати", "label": "пишу"},
+        ],
+    }
+
+
+def test_accepts_ukrainian_targets_without_optional_overrides(tmp_path: Path) -> None:
+    cloze_path, overrides_path = _write_gate_files(tmp_path, [_valid_card()])
+
+    assert validate_teacher_cloze_content(cloze_path, overrides_path) == []
+
+
+def test_rejects_english_multiword_teacher_answer(tmp_path: Path) -> None:
+    card = _valid_card()
+    card["lemma"] = "curated private teacher lesson"
+    cloze_path, overrides_path = _write_gate_files(tmp_path, [card])
+
+    errors = validate_teacher_cloze_content(cloze_path, overrides_path)
+
+    assert errors == [
+        "teacher-cloze teacher_cloze_1 lemma: must not be an English multi-word descriptive phrase; "
+        "got 'curated private teacher lesson'"
+    ]
+
+
+def test_excluded_card_is_removed_before_answer_validation(tmp_path: Path) -> None:
+    excluded = _valid_card("teacher_cloze_2")
+    excluded["form"] = "curated private teacher lesson"
+    cloze_path, overrides_path = _write_gate_files(
+        tmp_path,
+        [_valid_card(), excluded],
+        {"excludedClozeIds": ["teacher_cloze_2"]},
+    )
+
+    assert validate_teacher_cloze_content(cloze_path, overrides_path) == []
+
+
+def test_rejects_stale_or_malformed_override_ids(tmp_path: Path) -> None:
+    cloze_path, overrides_path = _write_gate_files(
+        tmp_path,
+        [_valid_card()],
+        {"excludedClozeIds": ["teacher_cloze_missing", "teacher_cloze_missing"]},
+    )
+
+    errors = validate_teacher_cloze_content(cloze_path, overrides_path)
+
+    assert errors == [
+        "teacher-cloze overrides duplicate excludedClozeIds: ['teacher_cloze_missing']",
+        "teacher-cloze overrides reference unknown cloze IDs: ['teacher_cloze_missing']",
+    ]


### PR DESCRIPTION
## Summary
- add a deterministic full-tree gate for scrubbed identifiers in public data, components, and documentation
- validate effective teacher-cloze answer fields and sidecar exclusions
- run both gates in the required Contracts job

## Verification
- `.venv/bin/python -m pytest tests/test_opsec_linter.py tests/test_teacher_cloze_content_gate.py -q` (11 passed)
- `.venv/bin/python -m ruff check scripts/audit/lint_opsec_leaks.py scripts/audit/check_teacher_cloze_content.py tests/test_opsec_linter.py tests/test_teacher_cloze_content_gate.py`
- `.venv/bin/python scripts/audit/check_teacher_cloze_content.py`
- `.venv/bin/python scripts/audit/check_teacher_cloze_content.py --root /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/opsec-5987-cloze-sidecar-cf`

## Blocking evidence
A dry run against #5987 head reports 10 remaining scrubbed-identifier occurrences in `site/src/data/lexicon-teacher-cloze.json`; its sidecar makes the effective teacher-cloze gate pass, but it does not remove the raw shipped-data leak. This PR intentionally makes that gap CI-visible.

No auto-merge requested.

Rail-Approval-Receipt: rail-approval-dbef927780cc483d86e748d6e57a0f11
