### PR TITLE
fix(runtime): pass P6 rail-approval env through the agent sanitizer

### DIFF
--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -38,6 +38,13 @@ _SAFE_NAME_ALLOWLIST = {
     "AGENT_NO_MERGE",
     "HOME",
     "LANG",
+    # P6 rail-approval context (#5885): opaque receipt/task identifiers, not
+    # credentials. The worker-side write hook re-fetches and verifies the
+    # receipt externally; without these names a dispatched worker can never
+    # perform an approved rail write (delegate.py sets them, this filter
+    # silently dropped them — burned 2026-07-29).
+    "LEARN_UK_RAIL_APPROVAL_RECEIPT",
+    "LEARN_UK_RAIL_TASK_ID",
     "LOGNAME",
     "PATH",
     "TMPDIR",

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -65,6 +65,12 @@ _SAFE_VALUE_NAME_ALLOWLIST = {
     "TMPDIR",
     "LU_RUNTIME_TMP_BASE_ROOT",
     "LU_RUNTIME_TMP_ROOT",
+    # Same trap as the tmp lease controls: a rail dispatch task id such as
+    # ``task-4956`` contains the substring ``sk-`` and would be stripped by the
+    # value redactor even though its NAME is allowlisted (glm review FR-001 on
+    # #5997, escalated: ``task-`` ids are the common case, not a hypothetical).
+    "LEARN_UK_RAIL_APPROVAL_RECEIPT",
+    "LEARN_UK_RAIL_TASK_ID",
 }
 
 _PROVIDER_SECRET_ALLOWLIST = {

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -452,3 +452,29 @@ def test_runner_gemini_subprocess_does_not_get_gh_token(tmp_path):
 
     assert outcome.returncode == 0
     assert outcome.parse.ok is True
+
+
+def test_build_agent_env_passes_rail_approval_context_to_workers():
+    """P6 rail receipts (#5885): delegate.py exports these two names for an
+    approved rail dispatch; the worker-side write hook needs them to resolve
+    the receipt. The sanitizer silently dropping them meant no dispatched
+    worker could ever perform an approved rail write (burned 2026-07-29)."""
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "LEARN_UK_RAIL_APPROVAL_RECEIPT": "rail-approval-753c6b55268844d581e16fdba41487af",
+            "LEARN_UK_RAIL_TASK_ID": "rail-p8-rb2-rb5",
+            "LEARN_UK_UNRELATED": "drop-me",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(provider="codex")
+
+    assert env["LEARN_UK_RAIL_APPROVAL_RECEIPT"] == (
+        "rail-approval-753c6b55268844d581e16fdba41487af"
+    )
+    assert env["LEARN_UK_RAIL_TASK_ID"] == "rail-p8-rb2-rb5"
+    # Only the two exact rail names are admitted — no blanket LEARN_UK_ prefix.
+    assert "LEARN_UK_UNRELATED" not in env

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -465,7 +465,10 @@ def test_build_agent_env_passes_rail_approval_context_to_workers():
             "PATH": "/usr/bin",
             "HOME": "/Users/example",
             "LEARN_UK_RAIL_APPROVAL_RECEIPT": "rail-approval-753c6b55268844d581e16fdba41487af",
-            "LEARN_UK_RAIL_TASK_ID": "rail-p8-rb2-rb5",
+            # Deliberately contains the substring ``sk-`` (as any ``task-…`` id
+            # does): must survive the value-pattern redactor, not just the name
+            # filter (glm review FR-001 on #5997).
+            "LEARN_UK_RAIL_TASK_ID": "task-4956",
             "LEARN_UK_UNRELATED": "drop-me",
         },
         clear=True,
@@ -475,6 +478,6 @@ def test_build_agent_env_passes_rail_approval_context_to_workers():
     assert env["LEARN_UK_RAIL_APPROVAL_RECEIPT"] == (
         "rail-approval-753c6b55268844d581e16fdba41487af"
     )
-    assert env["LEARN_UK_RAIL_TASK_ID"] == "rail-p8-rb2-rb5"
+    assert env["LEARN_UK_RAIL_TASK_ID"] == "task-4956"
     # Only the two exact rail names are admitted — no blanket LEARN_UK_ prefix.
     assert "LEARN_UK_UNRELATED" not in env


### PR DESCRIPTION
## Summary
- `delegate.py` exports `LEARN_UK_RAIL_APPROVAL_RECEIPT` / `LEARN_UK_RAIL_TASK_ID` for an approved rail dispatch, but `build_agent_env`'s allowlist silently dropped both names (its prefix list has `LU_`, these are `LEARN_UK_`). Net effect: no dispatched worker could ever perform an approved rail write — both P8/P9 trail-migration dispatches today stopped honestly at 'receipt env missing' with clean worktrees.
- Admits exactly the two names — deliberately NO blanket `LEARN_UK_` prefix; values are opaque receipt/task identifiers, and the worker-side write hook still re-fetches and verifies the receipt externally (the env is a locator, not authority).

## Evidence
Worker result of the blocked dispatch (task `rail-p8-rb2-rb5`, 2026-07-29 11:14Z):
```text
--- rail receipt present ---
MISSING
```
My run: `tests/test_agent_runtime_env_sanitize.py` 12 passed. Mutation-proven: reverting the allowlist addition fails exactly `test_build_agent_env_passes_rail_approval_context_to_workers` (1 failed, 11 passed).

Refs #5885

🤖 Generated with [Claude Code](https://claude.com/claude-code)