### PR TITLE
test(lexicon): guard intake decisions default

### DIFF
--- a/scripts/lexicon/promote_teacher_lesson_intake.py
+++ b/scripts/lexicon/promote_teacher_lesson_intake.py
@@ -92,6 +92,7 @@ from scripts.lexicon.grow_lexicon_from_content import build_payload, build_skele
 from scripts.lexicon.lemma_normalization import strip_acute_stress
 from scripts.verification.vesum import verify_words
 
+# Keep this committed ledger path until #5995 ships its coordinated ledger scrub and rename.
 DEFAULT_FULL_DECISIONS = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/2026-07-23-alona-full-document-intake.yaml"

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "53f14aa890c0915cedd730c6ca60596572b330472825fe1788f5e4189fb06002",
+  "fingerprint": "58e977847ba6fb99805e2249039618e99253aeb93d43cc589c3d601a64134d48",
   "inputs": {
     "lexicon_code": [
       {
@@ -180,7 +180,7 @@
       },
       {
         "path": "scripts/lexicon/promote_teacher_lesson_intake.py",
-        "sha256": "99eb174d108a18087bc6a895bb81e35de11078dcfc6e899b1c512edd7977a306"
+        "sha256": "81ad1a9103594abee149199a5eecd6dd0a88f5538facdcc424057defddc071f7"
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",

--- a/tests/test_promote_teacher_lesson_intake.py
+++ b/tests/test_promote_teacher_lesson_intake.py
@@ -1,0 +1,17 @@
+"""Regression coverage for teacher-lesson intake promotion defaults."""
+
+from pathlib import Path
+
+from scripts.lexicon.promote_teacher_lesson_intake import DEFAULT_FULL_DECISIONS, PROJECT_ROOT
+
+
+def test_default_full_decisions_is_a_committed_repository_file() -> None:
+    relative_path = DEFAULT_FULL_DECISIONS.relative_to(PROJECT_ROOT)
+
+    assert relative_path == (
+        Path("data")
+        / "lexicon"
+        / "source-inventory-review-decisions"
+        / "2026-07-23-alona-full-document-intake.yaml"
+    )
+    assert DEFAULT_FULL_DECISIONS.is_file()


### PR DESCRIPTION
## Summary

- document that #5995 owns the coordinated ledger scrub and path rename
- assert the default full-decisions ledger path is exact and committed
- refresh the required lexicon code fingerprint

## Verification

- `.venv/bin/pytest -q tests/test_promote_teacher_lesson_intake.py tests/test_private_teacher_lesson_full_intake.py`
- `.venv/bin/ruff check scripts/lexicon/promote_teacher_lesson_intake.py tests/test_promote_teacher_lesson_intake.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No ledger content was renamed or rewritten. Auto-merge is intentionally not enabled.