### PR TITLE
fix(review): trust the npm user-prefix codex install root (#5978)

### DIFF
--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -1716,6 +1716,11 @@ def resolve_trusted_reviewer_executable(
             [
                 home / ".hermes" / "node" / "lib" / "node_modules" / "@openai" / "codex",
                 home / ".local" / "share" / "codex",
+                # npm user-prefix install (`npm i -g` with prefix ~/.local): the
+                # #5950 CLI rollback reinstalled codex here, and the seat died
+                # with trusted_reviewer_not_found until this root was trusted
+                # (#5978). Package-scoped, same trust level as the hermes root.
+                home / ".local" / "lib" / "node_modules" / "@openai" / "codex",
             ]
         )
     elif engine_key == "claude":

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -3693,3 +3693,31 @@ class TestExecRootAcceptsSentinel:
         )
         with pytest.raises(isolation.ReviewIsolationError, match="marker_invalid"):
             self._validate(root, tmp_path)
+
+
+def test_codex_npm_user_prefix_install_is_a_trusted_reviewer_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#5978: the #5950 CLI rollback reinstalled codex under the npm user prefix
+    (~/.local/lib/node_modules/@openai/codex); the trust list only knew the
+    hermes root and ~/.local/share/codex, so the reviewer seat died at checkout
+    with trusted_reviewer_not_found:codex despite a healthy install."""
+    home = tmp_path / "home"
+    package_bin = home / ".local" / "lib" / "node_modules" / "@openai" / "codex" / "bin"
+    package_bin.mkdir(parents=True)
+    real = package_bin / "codex.js"
+    real.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    real.chmod(0o755)
+    launcher_dir = home / ".local" / "bin"
+    launcher_dir.mkdir(parents=True)
+    launcher = launcher_dir / "codex"
+    launcher.symlink_to(
+        Path("..") / "lib" / "node_modules" / "@openai" / "codex" / "bin" / "codex.js"
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+    resolved = resolve_trusted_reviewer_executable(
+        "codex", reject_roots=(tmp_path / "repo",)
+    )
+
+    assert resolved == real.resolve()


### PR DESCRIPTION
## Summary
- The #5950 CLI rollback reinstalled codex under the npm user prefix (`~/.local/lib/node_modules/@openai/codex`); the trusted-reviewer allowed roots only knew the hermes root and `~/.local/share/codex`, so the codex reviewer seat died at checkout with `trusted_reviewer_not_found:codex` despite a healthy install (measured: `~/.local/bin/codex` → `../lib/node_modules/@openai/codex/bin/codex.js`).
- Adds the package-scoped npm user-prefix root — same trust level as the existing hermes package root, no broadening beyond the `@openai/codex` package directory.

## Evidence
My run: `tests/test_review_isolation.py` 105 passed. Mutation-proven: removing the new root fails exactly `test_codex_npm_user_prefix_install_is_a_trusted_reviewer_root` (fake-home end-to-end resolution).

Closes #5978

🤖 Generated with [Claude Code](https://claude.com/claude-code)