### PR TITLE
feat(ci): head-SHA workflow concurrency (P12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ name: CI
 # path-filtered required check. Every required job below is unconditional.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   # PRs cancel their own stale runs. `main` and `merge_group` must never
   # cancel themselves — that was why 14 of the last 30 `main` runs were
   # cancelled and 0 succeeded.

--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -1,7 +1,7 @@
 name: Content CI
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -9,7 +9,7 @@ name: Hygiene (advisory)
 # change is a non-event, not a silent regression.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,7 +7,7 @@ name: Security Audit (advisory)
 # only once the existing backlog is drained, or branch protection would wedge.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,7 +10,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 # triage plan — some checkouts legitimately need credentials.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/tests/test_workflow_head_concurrency.py
+++ b/tests/test_workflow_head_concurrency.py
@@ -1,0 +1,36 @@
+"""Guard PR workflow concurrency against ref-keyed TOCTOU cancellation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HEAD_SHA_GROUP = "${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}"
+_WORKFLOW_EXPECTATIONS = {
+    ".github/workflows/ci.yml": "${{ github.event_name == 'pull_request' }}",
+    ".github/workflows/content-ci.yml": True,
+    ".github/workflows/hygiene.yml": True,
+    ".github/workflows/security-audit.yml": True,
+    ".github/workflows/zizmor.yml": True,
+}
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_cancellation"),
+    _WORKFLOW_EXPECTATIONS.items(),
+)
+def test_workflow_concurrency_is_head_sha_keyed_and_preserves_cancellation(
+    relative_path: str,
+    expected_cancellation: bool | str,
+) -> None:
+    """Each scoped workflow isolates PR runs by immutable head and keeps its policy."""
+    workflow_path = _REPO_ROOT / relative_path
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    assert workflow["concurrency"] == {
+        "group": _HEAD_SHA_GROUP,
+        "cancel-in-progress": expected_cancellation,
+    }


### PR DESCRIPTION
## Summary

- Replaces ref/head-ref concurrency keys in the five scoped PR workflows with `${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}`.
- Keeps each workflow's existing `cancel-in-progress` value: PR-only expression in `ci.yml`; `true` in the other four workflows.
- Adds hermetic static coverage that pins both the head-SHA/fallback group and cancellation policy per workflow.

For pull-request events, a superseded and a live head SHA now have different concurrency groups. Therefore rerunning the superseded head cannot cancel the live head's run through that group. The `github.ref` fallback retains a group for non-PR events.

Automatic reruns remain disabled until the live two-head proof passes.

## Evidence

```text
$ .venv/bin/python -m pytest tests/test_workflow_head_concurrency.py -v
collecting ... collected 5 items
... PASSED [100%]
============================== 5 passed in 0.11s ===============================

$ actionlint .github/workflows/ci.yml .github/workflows/content-ci.yml .github/workflows/hygiene.yml .github/workflows/security-audit.yml .github/workflows/zizmor.yml
actionlint_exit=0

$ .venv/bin/python -m ruff check tests/test_workflow_head_concurrency.py
All checks passed!

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  e02a93eb16  PASS  X-Agent: codex/rail-p12-head-concurrency

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.

$ .venv/bin/python scripts/audit/lint_opsec_leaks.py
🔒 Checking 6 files for OPSEC leaks (mode: git diff (origin/main..HEAD))...
✅ OPSEC check passed. Zero leaks detected.
```

## Mutation check

Temporarily reverting only `.github/workflows/ci.yml` to `${{ github.workflow }}-${{ github.ref }}` produced this raw focused-test result before restoring the approved expression:

```text
$ .venv/bin/python -m pytest tests/test_workflow_head_concurrency.py -v
collecting ... collected 5 items
tests/test_workflow_head_concurrency.py::test_workflow_concurrency_is_head_sha_keyed_and_preserves_cancellation[.github/workflows/ci.yml-${{ github.event_name == 'pull_request' }}] FAILED [ 20%]
...
========================= 1 failed, 4 passed in 0.13s ==========================
mutation_exit=1
```

## Rail merge approval

The advisor issues the `pr-<N>` receipt; the rail CI check stays red until the receipt trailer is added — expected. No auto-merge is armed.

Refs #5885

Rail-Approval-Receipt: rail-approval-0b8ac5f547f040b1a74df9fe5e046270
