### PR TITLE
fix(guards): stdlib-only rail path classification + BSD sed -i '' parsing (#5992)

### DIFF
--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -50,8 +50,11 @@ Coverage limitations (documented, by design)
   enforcement layer is #4445/#4446/#4449 instead. See
   ``docs/runbooks/codex-hooks.md``.
 
-The hook fails **open**: any parse/import/git error exits 0 (allow). It is a
-safety net, not a chokepoint — physical isolation is the real guarantee.
+The primary-checkout containment layer fails **open**: any
+parse/import/git error there exits 0 (allow). The separate P6 rail layer fails
+**closed** whenever it sees a write target or path-scoped git intent it cannot
+classify. Physical isolation remains the primary-checkout guarantee; P6
+authorization is intentionally a chokepoint for control-rail mutations.
 
 Emergency override (explicit operator only): set
 ``LEARN_UK_ALLOW_PRIMARY_GIT_WRITE=1`` to skip the git-mediated primary block
@@ -67,6 +70,7 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 # ---------------------------------------------------------------------------
 # shared containment predicate (issue #4444) — imported, never re-derived
@@ -117,7 +121,7 @@ def _load_rail_path_guard():
     return None
 
 
-def _git_output(cwd: str, *args: str) -> str | None:
+def _git_output(cwd: str, *args: str) -> Optional[str]:  # noqa: UP045 - Python 3.9 parser
     try:
         completed = subprocess.run(
             ["git", "-C", cwd, *args],
@@ -138,8 +142,10 @@ def _rail_write_decision(raw_targets: list[str], *, cwd: str):
     """Classify hook write targets through the one P6 decision module."""
     try:
         rail_guard = _load_rail_path_guard()
-    except Exception:
-        return None, "rail_path_guard_unavailable"
+    except Exception as exc:
+        return None, (
+            f"rail_path_guard_unavailable:{type(exc).__name__}: {exc}"
+        )
     if rail_guard is None:
         return None, "rail_path_guard_unavailable"
     receipt_id = os.environ.get("LEARN_UK_RAIL_APPROVAL_RECEIPT")
@@ -567,6 +573,10 @@ def _inplace_edit_targets(segment: list[str], cmd_index: int) -> list[str]:
             if tok in ("-e", "-f"):
                 skip_next = True
             continue
+        # BSD sed's ``-i ''`` has an empty backup suffix. It is neither a
+        # script nor a file, and must not consume the real inline script.
+        if tok == "":
+            continue
         # Positional token.
         if not has_explicit_script and not first_positional_seen:
             first_positional_seen = True  # inline script (no -e); never a file
@@ -601,14 +611,16 @@ def bash_write_targets(command: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _git_global_prefix(args: list[str]) -> tuple[str | None, list[str]]:
+def _git_global_prefix(
+    args: list[str],
+) -> tuple[Optional[str], list[str]]:  # noqa: UP045 - Python 3.9 parser
     """Strip git global options; return optional ``-C`` path and remaining args.
 
     Handles ``-C <path>``, ``-C<path>``, and common no-arg globals (``-c`` is
     two-token). Unknown long options with ``=`` are skipped; bare long options
     that take a value are not fully modeled — fail-open if we cannot parse.
     """
-    c_path: str | None = None
+    c_path: Optional[str] = None  # noqa: UP045 - Python 3.9 parser
     i = 0
     n = len(args)
     while i < n:
@@ -920,7 +932,7 @@ def expand_shell_target(
     target: str,
     assignments: dict[str, str],
     *,
-    ambiguous: set[str] | None = None,
+    ambiguous: Optional[set[str]] = None,  # noqa: UP045 - Python 3.9 parser
 ) -> str:
     """Expand a pure ``$VAR`` / ``${VAR}`` write target when assignment is known.
 
@@ -956,8 +968,6 @@ def main() -> int:
     if not tool_name:
         return 0
 
-    wc = _load_containment()
-
     tool_input = _tool_input(payload)
     cwd = _payload_cwd(payload)
     command = ""
@@ -969,6 +979,32 @@ def main() -> int:
         raw_targets = bash_write_targets(command)
     else:
         raw_targets = write_tool_targets(tool_input)
+
+    # A supported interpreter is required to import the shared rail classifier
+    # (it uses Python 3.11 stdlib features). Under an older interpreter we
+    # cannot classify a write without duplicating that classifier, so deny
+    # writes and path-scoped git mutations before attempting the import.
+    git_intents: list[dict[str, object]] = []
+    if tool_name == "Bash" and command:
+        try:
+            git_intents = bash_git_write_intents(command)
+        except Exception:  # pragma: no cover - parser failure must not bypass P6
+            sys.stderr.write(
+                "BLOCKED by rail-path guard: cannot inspect git-mediated write targets; "
+                "failing closed.\n"
+            )
+            return 2
+    has_path_scoped_git_intent = any(
+        not intent.get("allowlisted") and bool(intent.get("paths"))
+        for intent in git_intents
+    )
+    if sys.version_info < (3, 11) and (raw_targets or has_path_scoped_git_intent):
+        sys.stderr.write(
+            "BLOCKED by rail-path guard: "
+            f"rail_path_guard_python_too_old:{sys.version_info.major}.{sys.version_info.minor}; "
+            "failing closed.\n"
+        )
+        return 2
 
     # P6 rail protection applies in every registered worktree, not only the
     # primary checkout.  It intentionally runs before the older primary-only
@@ -1010,44 +1046,43 @@ def main() -> int:
     # they need their own rail pass. This executes for every path-scoped intent
     # before the primary-containment branch below decides whether the worktree
     # is the protected primary or an isolated dispatch tree.
-    git_intents: list[dict[str, object]] = []
-    if tool_name == "Bash" and command:
-        try:
-            git_intents = bash_git_write_intents(command)
-            for intent in git_intents:
-                if intent.get("allowlisted"):
-                    continue
-                paths = list(intent.get("paths") or [])
-                if not paths:
-                    # Pathless whole-tree mutators (apply/am/stash pop|apply)
-                    # cannot be enumerated in this fast hook for a non-primary
-                    # worktree. The residual is covered by the CI rail-path job
-                    # + merge guard diff of actual changed files; never treat
-                    # this deliberate non-enumeration as an implicit rail allow.
-                    continue
-                git_cwd = _effective_git_cwd(intent, cwd)
-                rail_decision, rail_error = _rail_write_decision(paths, cwd=str(git_cwd))
-                if rail_error is not None or rail_decision is None:
-                    sys.stderr.write(
-                        "BLOCKED by rail-path guard: shared decision module is unreadable "
-                        f"({rail_error or 'unknown error'}); failing closed.\n"
-                    )
-                    return 2
-                if not rail_decision.allowed:
-                    paths_text = ", ".join(rail_decision.rail_paths) or "(unreadable path)"
-                    sys.stderr.write(
-                        "BLOCKED by rail-path guard: git-mediated rail mutation requires a current, "
-                        "externally verified approval receipt.\n"
-                        f"  reason: {rail_decision.reason}\n"
-                        f"  rail paths: {paths_text}\n"
-                    )
-                    return 2
-        except Exception:  # pragma: no cover - parser/OS failure must not bypass P6
-            sys.stderr.write(
-                "BLOCKED by rail-path guard: cannot inspect git-mediated write targets; "
-                "failing closed.\n"
-            )
-            return 2
+    try:
+        for intent in git_intents:
+            if intent.get("allowlisted"):
+                continue
+            paths = list(intent.get("paths") or [])
+            if not paths:
+                # Pathless whole-tree mutators (apply/am/stash pop|apply)
+                # cannot be enumerated in this fast hook for a non-primary
+                # worktree. The residual is covered by the CI rail-path job
+                # + merge guard diff of actual changed files; never treat
+                # this deliberate non-enumeration as an implicit rail allow.
+                continue
+            git_cwd = _effective_git_cwd(intent, cwd)
+            rail_decision, rail_error = _rail_write_decision(paths, cwd=str(git_cwd))
+            if rail_error is not None or rail_decision is None:
+                sys.stderr.write(
+                    "BLOCKED by rail-path guard: shared decision module is unreadable "
+                    f"({rail_error or 'unknown error'}); failing closed.\n"
+                )
+                return 2
+            if not rail_decision.allowed:
+                paths_text = ", ".join(rail_decision.rail_paths) or "(unreadable path)"
+                sys.stderr.write(
+                    "BLOCKED by rail-path guard: git-mediated rail mutation requires a current, "
+                    "externally verified approval receipt.\n"
+                    f"  reason: {rail_decision.reason}\n"
+                    f"  rail paths: {paths_text}\n"
+                )
+                return 2
+    except Exception:  # pragma: no cover - parser/OS failure must not bypass P6
+        sys.stderr.write(
+            "BLOCKED by rail-path guard: cannot inspect git-mediated write targets; "
+            "failing closed.\n"
+        )
+        return 2
+
+    wc = _load_containment()
 
     if wc is None:
         return 0  # P6 ran above; the older primary-only predicate is unavailable.

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -25,8 +25,6 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
 
-from jsonschema import Draft202012Validator, FormatChecker
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 RAIL_APPROVAL_RECEIPT_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json"
@@ -166,6 +164,10 @@ class RailApprovalReceiptError(ValueError):
     """A receipt could not prove authorization for a rail mutation."""
 
 
+class RailApprovalValidatorUnavailableError(RailApprovalReceiptError):
+    """The optional schema validator is unavailable for receipt authorization."""
+
+
 class RailApprovalReceiptStore(Protocol):
     """A provisioned external receipt source, never a caller-controlled file."""
 
@@ -284,6 +286,12 @@ def _validator() -> Draft202012Validator:
     global _RECEIPT_VALIDATOR
     if _RECEIPT_VALIDATOR is not None:
         return _RECEIPT_VALIDATOR
+    try:
+        from jsonschema import Draft202012Validator, FormatChecker
+    except ImportError as exc:
+        raise RailApprovalValidatorUnavailableError(
+            "rail approval receipt validator is unavailable"
+        ) from exc
     try:
         schema = json.loads(RAIL_APPROVAL_RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -577,6 +585,8 @@ def _receipt_authorizes(
     """Return a refusal reason, or ``None`` only for a current path binding."""
     try:
         payload = validate_rail_approval_receipt_data(receipt.payload)
+    except RailApprovalValidatorUnavailableError:
+        return "rail_approval_validator_unavailable"
     except RailApprovalReceiptError:
         return "invalid_rail_approval_receipt"
     if payload["issuer"] not in APPROVED_ISSUERS:
@@ -677,6 +687,12 @@ def decide_rail_path_mutation_with_production_receipt(
         return preliminary
     try:
         receipt = (resolver or build_production_rail_approval_receipt_resolver()).fetch(receipt_id)
+    except RailApprovalValidatorUnavailableError:
+        return RailPathDecision(
+            RailPathDecisionKind.DENY,
+            "rail_approval_validator_unavailable",
+            preliminary.rail_paths,
+        )
     except RailApprovalReceiptError as exc:
         reason = (
             "expired_rail_approval_receipt"

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -23,6 +23,7 @@ import importlib.util
 import json
 import os
 import subprocess
+from collections import namedtuple
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,7 @@ _GIT_ENV = {
     "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
     "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_COMMON_DIR",
 }
+_RAIL_ENV = {"LEARN_UK_RAIL_APPROVAL_RECEIPT", "LEARN_UK_RAIL_TASK_ID"}
 
 
 def _load_hook():
@@ -76,6 +78,8 @@ hook = _load_hook()
         ("sudo tee /etc/hosts", ["/etc/hosts"]),
         # In-place editors — script excluded, files kept.
         ('sed -i "s/x/y/" real.py', ["real.py"]),
+        ("sed -i '' 's/a/b/' f", ["f"]),
+        ("sed -i '' f", []),
         ('sed -i.bak -e "s/a/b/" f1 f2', ["f1", "f2"]),
         ('perl -pi -e "s/x/y/" z.txt', ["z.txt"]),
         # Leading env assignment before the command word.
@@ -154,7 +158,7 @@ def test_write_tool_targets_apply_patch_move():
 
 
 def _clean_env() -> dict[str, str]:
-    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
+    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV | _RAIL_ENV}
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -243,6 +247,104 @@ def test_read_only_bash_allowed(repo: Path):
         payload = {"tool_name": "Bash", "cwd": str(repo), "tool_input": {"command": command}}
         result = _run(repo, payload)
         assert result.returncode == 0, f"{command!r}: {result.stderr}"
+
+
+def test_read_only_bash_redirect_is_allowed_when_jsonschema_is_masked(
+    repo: Path, tmp_path: Path
+) -> None:
+    """#5992: loading the path classifier must not require receipt validation."""
+    poison = tmp_path / "poison"
+    poison.mkdir()
+    (poison / "jsonschema.py").write_text(
+        "raise ImportError('jsonschema deliberately masked')\n", encoding="utf-8"
+    )
+    env = _clean_env()
+    env["PYTHONPATH"] = str(poison)
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "git status 2>/dev/null"},
+    }
+
+    result = subprocess.run(
+        [_python(), str(HOOK_PATH)],
+        input=json.dumps(payload),
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_old_python_denies_write_targets_and_path_scoped_git_before_classifier_load(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Python <3.11 cannot import the classifier, so P6 refuses classified writes."""
+    VersionInfo = namedtuple("VersionInfo", "major minor micro releaselevel serial")
+    monkeypatch.setattr(hook.sys, "version_info", VersionInfo(3, 9, 6, "final", 0))
+    monkeypatch.setattr(
+        hook,
+        "_load_rail_path_guard",
+        lambda: (_ for _ in ()).throw(AssertionError("must not load classifier")),
+    )
+
+    for command in ("echo x > /tmp/target", "git add docs/notes.md"):
+        monkeypatch.setattr(
+            hook,
+            "_read_payload",
+            lambda command=command: {
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            },
+        )
+
+        assert hook.main() == 2
+        assert "rail_path_guard_python_too_old:3.9" in capsys.readouterr().err
+
+
+def test_old_python_leaves_read_only_commands_untouched(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No write target or path-scoped git intent leaves the old hook behavior intact."""
+    VersionInfo = namedtuple("VersionInfo", "major minor micro releaselevel serial")
+    monkeypatch.setattr(hook.sys, "version_info", VersionInfo(3, 9, 6, "final", 0))
+    monkeypatch.setattr(
+        hook,
+        "_read_payload",
+        lambda: {"tool_name": "Bash", "tool_input": {"command": "git status"}},
+    )
+    monkeypatch.setattr(hook, "_load_containment", lambda: None)
+    monkeypatch.setattr(
+        hook,
+        "_load_rail_path_guard",
+        lambda: (_ for _ in ()).throw(AssertionError("must not load classifier")),
+    )
+
+    assert hook.main() == 0
+
+
+def test_rail_classifier_load_failure_reports_underlying_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A real loader failure gives the next incident its actual cause (#5992)."""
+    monkeypatch.setattr(
+        hook,
+        "_read_payload",
+        lambda: {"tool_name": "Bash", "tool_input": {"command": "echo x > /tmp/target"}},
+    )
+
+    def fail_load():
+        raise RuntimeError("forced rail loader failure")
+
+    monkeypatch.setattr(hook, "_load_rail_path_guard", fail_load)
+
+    assert hook.main() == 2
+    stderr = capsys.readouterr().err
+    assert "RuntimeError: forced rail loader failure" in stderr
 
 
 def test_bash_tool_input_workdir_controls_relative_write_resolution(repo: Path):

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -172,7 +173,11 @@ print(json.dumps({{'non_rail': non_rail.reason, 'rail': rail.reason}}))
 """
     env = os.environ.copy()
     env["PYTHONPATH"] = str(poison)
-    python = Path(__file__).resolve().parents[1] / ".venv/bin/python"
+    # Mirror tests/test_guard_primary_checkout_write.py's `_python()` fallback:
+    # a missing venv must not turn this test into a low-signal FileNotFoundError
+    # (sealed review F001 on #6001).
+    venv_python = Path(__file__).resolve().parents[1] / ".venv/bin/python"
+    python = venv_python if venv_python.exists() else Path(sys.executable)
 
     result = subprocess.run(
         [str(python), "-c", script],

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -130,6 +132,79 @@ def test_non_rail_paths_are_unaffected_without_receipt() -> None:
     assert decision.allowed is True
     assert decision.reason == "non_rail_paths"
     assert decision.rail_paths == ()
+
+
+def test_path_classification_imports_without_jsonschema_but_receipt_validation_denies(
+    tmp_path: Path,
+) -> None:
+    """#5992: only receipt validation, not path classification, needs jsonschema."""
+    poison = tmp_path / "poison"
+    poison.mkdir()
+    (poison / "jsonschema.py").write_text(
+        "raise ImportError('jsonschema deliberately masked')\n", encoding="utf-8"
+    )
+    receipt = _receipt()
+    script = f"""
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+spec = importlib.util.spec_from_file_location('masked_rail_guard', {str(Path(__file__).resolve().parents[1] / 'scripts/orchestration/rail_path_guard.py')!r})
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+class Store:
+    source_id = 'test-api'
+    source_kind = 'api'
+    def fetch_rail_approval_receipt(self, receipt_id):
+        return {receipt!r}
+
+resolver = module.ApprovedRailApprovalReceiptResolver(Store(), now=lambda: module.datetime(2026, 7, 28, tzinfo=module.UTC))
+non_rail = module.decide_rail_path_mutation_with_production_receipt(
+    task_id='not-used', candidate_paths=('docs/notes.md',), head_sha={'a' * 40!r}, receipt_id=None
+)
+rail = module.decide_rail_path_mutation_with_production_receipt(
+    task_id={TASK!r}, candidate_paths=({OWNED_RAIL_PATH!r},), head_sha={'a' * 40!r}, receipt_id={RECEIPT_ID!r}, resolver=resolver
+)
+print(json.dumps({{'non_rail': non_rail.reason, 'rail': rail.reason}}))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(poison)
+    python = Path(__file__).resolve().parents[1] / ".venv/bin/python"
+
+    result = subprocess.run(
+        [str(python), "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "non_rail": "non_rail_paths",
+        "rail": "rail_approval_validator_unavailable",
+    }
+
+
+def test_direct_receipt_authorization_maps_missing_validator_to_its_own_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct receipt callers must not misreport a missing validator as invalid."""
+    receipt = _direct_payload_receipt()
+
+    def unavailable():
+        raise guard.RailApprovalValidatorUnavailableError("validator unavailable")
+
+    monkeypatch.setattr(guard, "_validator", unavailable)
+
+    decision = _decide(OWNED_RAIL_PATH, receipt=receipt)
+
+    assert decision.allowed is False
+    assert decision.reason == "rail_approval_validator_unavailable"
 
 
 def test_rail_path_without_receipt_is_refused() -> None:


### PR DESCRIPTION
Closes #5992

## Root cause

`rail_path_guard.py` imported `jsonschema` at module scope, so the checkout-write hook could not classify paths when its host interpreter lacked that optional validator. A redirect such as `2>/dev/null` therefore reached the fail-closed rail path and blocked an otherwise read-only command. The hook also treated BSD `sed -i ''`'s empty backup suffix as its inline script.

This change makes path classification stdlib-only, maps unavailable receipt validation to `rail_approval_validator_unavailable`, enforces the documented Python 3.11 rail-classifier floor before loading it, reports loader exception type and message, and handles the BSD empty suffix.

## Raw verification evidence

```text
$ .venv/bin/python -m pytest tests/test_guard_primary_checkout_write.py tests/test_rail_path_guard.py tests/test_rail_approval.py -q
======================== 136 passed, 1 warning in 5.19s ========================

$ .venv/bin/python -m ruff check scripts/orchestration/rail_path_guard.py agents_extensions/shared/hooks/guard-primary-checkout-write.py tests/test_guard_primary_checkout_write.py tests/test_rail_path_guard.py
All checks passed!

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  9199eb5887  PASS  X-Agent: codex/rail-5992-guard-fix

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.

$ .venv/bin/python scripts/audit/lint_opsec_leaks.py
🔒 Checking 4 files for OPSEC leaks (mode: git diff (origin/main..HEAD))...
✅ OPSEC check passed. Zero leaks detected.
```

## Mutation checks (expected failures)

```text
$ [temporarily re-add module-level jsonschema import] && .venv/bin/python -m pytest tests/test_rail_path_guard.py::test_path_classification_imports_without_jsonschema_but_receipt_validation_denies tests/test_guard_primary_checkout_write.py::test_read_only_bash_redirect_is_allowed_when_jsonschema_is_masked -q
============================== 2 failed in 0.30s ==============================
mutation_exit=1

$ [temporarily remove BSD empty-suffix handling] && .venv/bin/python -m pytest tests/test_guard_primary_checkout_write.py::test_bash_write_targets -q
========================= 2 failed, 17 passed in 0.14s =========================
mutation_exit=1
```

Rail merge approval pending: advisor issues the `pr-<N>` receipt and the receipt trailer body trailer is added after review; the rail CI check stays red until then — expected.

Rail-Approval-Receipt: rail-approval-bf028f23d4a04a43b90959a5d9b9ac27

