### PR TITLE
feat(trails): migrate RB-2/RB-5 to v1.1 (P8)

### DIFF
--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -227,7 +227,7 @@ steps:
     intent: Observe the settled task status and route only its typed receipt token.
     command:
       adapter: shell
-      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in done) echo done;; timeout|silence-timeout) echo timeout;; needs-finalize|no-deliverable) echo attention;; failed|crashed) echo failed;; rate-limited) echo rate-limited;; cancelled|dry-run) echo aborted;; *) echo unknown-status;; esac']
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in done) echo done;; timeout) echo timeout;; needs_finalize|no_deliverable) echo attention;; failed|crashed) echo failed;; rate_limited) echo rate-limited;; cancelled|dry_run) echo aborted;; *) echo unknown-status;; esac']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
       timeout_seconds: 30
       mutation_class: observe

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -1,43 +1,16 @@
-# RB-2 — dispatch loop (T2 DRAFT, extraction from drive-epic SKILL steps 3/4/4a + the
-# infra driver's dispatch-brief checklist and settle discipline). Part of #5885.
-#
-# DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
-# certification waits for T1.4/5.
-#
-# Anti-pattern guard (the #5860 r1 lessons, tightened across the #5915 r1-r3 sealed
-# reviews): every command is a real, currently runnable repo command whose OUTPUT
-# SHAPE was captured live (2026-07-27/28 infra session); every MECHANICAL step is
-# single-signal (transition derivable from its own predicate's vocabulary; multi-
-# signal branchings are split); where proof is impossible the trail FAILS CLOSED and
-# says so. Live-lookup tables (width, lane-routing) are procedures by design: their
-# steps' predicates prove the table's INPUTS were captured, and the SEAT records the
-# applied decision as a receipt line — an auditable write obligation, not a machine
-# derivation (stated per the r3 review).
-#
-# RETRY MODEL (r3/r4 findings): trailspec.v1 has no cross-step variable rebinding,
-# so a re-fire ends THIS invocation at `refired_new_invocation` after dispatching the
-# -retry worker. What the predicate PROVES is only that the retry worker is running;
-# binding a fresh RB-2 invocation to the -retry id is an ORCHESTRATION-LAYER
-# OBLIGATION declared here (the runner that starts trails must start one per live
-# dispatch id) — when honored, a second failure hits the -retry suffix gate FIRST
-# (before any cleanup) and stops with the table's exact code. Declared, not
-# machine-proven: a v1.1 invocation-binding form is the proposed fix.
-#
-# kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — settle
-# waiting is a summon whose documentation-predicate covers arming ONE Monitor
-# settle-loop and idling on its event (a Monitor arm is a harness action with no repo
-# command to predicate on — encoding it as mechanical was the r3 finding). SCHEMA
-# NOTE for v1.1 (proposal, operator/advisor call — not built): per-transition
-# evidence predicates + an invocation-parameter rebinding form would let the retry
-# arc and multi-signal branchings collapse back into fewer steps.
-schema_version: trailspec.v1
+# RB-2 dispatch loop. TrailSpec v1.1 keeps every action receipt-bound: dispatches
+# and cleanup are mutations, while decisions and settlement are re-observations.
+schema_version: trailspec.v1.1
 trail_id: rb2-dispatch-loop
-version: "0.7.0"
-title: RB2 Dispatch loop — brief, dispatch, settle, finalize
-seats:
-  - grok-daily
-  - glm-trial
-  - judgment
+version: "1.0.0"
+title: RB2 Dispatch loop — brief, dispatch, bounded settlement, and recovery
+seats: [grok, glm-local, kimi]
+parameters:
+  handoff_agent: string
+  lane: string
+  task_id: string
+  brief_path: string
+  overlap_reason: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-concurrency-conflict
@@ -52,436 +25,363 @@ terminal_outcomes:
 steps:
   - step_id: drain_slot_inbox
     intent: >-
-      Mandatory inbox-drain substep (drive-epic 4a pattern): surface pending slot
-      deliveries before firing new work. Live output shape: "<agent> inbox:" then
-      "pending: N (oldest ...)". NOTE (live-verified in the #5915 r1 review): show is
-      not a pure read — it expires stale deliveries via an UPDATE; a read-only DB
-      fails loudly here, which is a precondition failure, not a skip.
-    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
-    evidence_predicate:
-      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
-      success_pattern: 'pending:\s+0'
+      Refresh this seat's inbox receipt. The bridge may expire stale deliveries, so
+      this is an honest local write; the next step alone interprets the receipt.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for "$HANDOFF_AGENT" show "$HANDOFF_AGENT" > "batch_state/rb2-inbox-$HANDOFF_AGENT.txt" 2>&1 && echo inbox-receipt-written || echo inbox-refresh-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      empty: disk_floor_check
-      pending_deliveries: drain_once
-      db_not_writable: STOP-precondition-failed
-    kind: mechanical
+      inbox_receipt_written: {target: observe_slot_inbox, evidence: {predicate_id: inbox-receipt-written, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-receipt-written}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      inbox_refresh_failed: {target: STOP-precondition-failed, evidence: {predicate_id: inbox-refresh-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-refresh-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_slot_inbox
+    intent: Observe only the immutable inbox receipt written by drain_slot_inbox.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'P=$(awk "/pending:/{print \$2}" "batch_state/rb2-inbox-$HANDOFF_AGENT.txt" 2>/dev/null); case "$P" in 0) echo empty;; "") echo inbox-unreadable;; *[!0-9]*) echo inbox-unreadable;; *) echo pending-deliveries;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      empty: {target: disk_floor_check, evidence: {predicate_id: inbox-empty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: empty}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      pending_deliveries: {target: drain_once, evidence: {predicate_id: inbox-pending, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pending-deliveries}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      inbox_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: inbox-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-unreadable}]}}
     blocked_on: null
 
   - step_id: drain_once
-    intent: >-
-      Run the thread-coalesced inbox worker exactly once, then re-check.
-      Still-pending after one drain needs handling this trail cannot do mechanically.
-    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} run {handoff_agent}
-    evidence_predicate:
-      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
-      success_pattern: 'pending:\s+0'
+    intent: Apply the bridge's one-shot inbox worker; re-observation remains separate.
+    command:
+      adapter: shell
+      argv: [.venv/bin/python, scripts/ai_agent_bridge/__main__.py, inbox, --for, "{handoff_agent}", run, "{handoff_agent}"]
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 60
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      drained: disk_floor_check
-      still_pending: STOP-manual-intervention
-    kind: mechanical
+      drained: {target: drain_slot_inbox, evidence: {predicate_id: drain-worker-complete, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      drain_failed: {target: STOP-manual-intervention, evidence: {predicate_id: drain-worker-failed, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 1}]}}
     blocked_on: null
 
   - step_id: disk_floor_check
-    intent: >-
-      The width table's dominant clause ("DISK WINS every conflict") checked alone:
-      free space on / must clear the floor for at least one dispatch worktree
-      (~0.5 GB each; floor 10G for estate headroom — live probe shape: a bare avail
-      field like "184G"). Below the floor no quota argument can widen; reaping
-      finished worktrees is the recovery.
-    command: df -h / | awk 'NR==2 {print $4}'
-    evidence_predicate:
-      command: df -h / | awk 'NR==2 {print $4}'
-      success_pattern: '^([1-9][0-9]|[0-9]{3,})[GT]i?$'
+    intent: Observe whether the available root filesystem capacity satisfies the 10G dispatch floor.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'A=$(df -Pk / | awk "NR==2 {print \$4}"); case "$A" in ""|*[!0-9]*) echo disk-unreadable;; *) [ "$A" -ge 10485760 ] && echo floor-cleared || echo below-floor;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      floor_cleared: width_weigh
-      below_floor: parked_no_capacity
-    kind: mechanical
+      floor_cleared: {target: observe_width_decision, evidence: {predicate_id: disk-floor-cleared, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: floor-cleared}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      below_floor: {target: parked_no_capacity, evidence: {predicate_id: disk-below-floor, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: below-floor}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      disk_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: disk-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: disk-unreadable}]}}
     blocked_on: null
 
-  - step_id: width_weigh
+  - step_id: observe_width_decision
     intent: >-
-      Width is a LIVE-LOOKUP table: the weighing of per-lane pace stage + reserve
-      against in-flight load is the table's procedure. This step's machine obligation
-      is input completeness — the ANDed predicate proves each input class (codexbar
-      pace rows, disk, worktree footprint) is present so the lookup never runs blind.
-      The SEAT then appends the applied decision to the same receipt as a line
-      "decision: capacity_ok|no_capacity — <one-line basis>" — an auditable write
-      obligation (r3 review: the decision must be recorded, and it is recorded BY THE
-      SEAT applying the table, not derived by this predicate).
-    command: sh -c 'R=batch_state/rb2-width-receipt.txt; codexbar usage --json > "$R" 2>&1; df -h / >> "$R"; du -sh .worktrees >> "$R"; cat "$R"'
-    evidence_predicate:
-      command: sh -c 'R=batch_state/rb2-width-receipt.txt; grep -q -e "provider" "$R" && grep -q -e "%" "$R" && grep -q -e ".worktrees" "$R" && echo all-inputs-present'
-      success_pattern: '^all-inputs-present$'
+      Former live-lookup judgment. Observe a separately authored width receipt; no
+      command invents capacity approval. Missing or malformed evidence stops.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'R="batch_state/rb2-width-$TASK_ID.receipt"; test -s "$R" || { echo width-receipt-missing; exit 0; }; V=$(awk -F= "/^outcome=/{print \$2}" "$R"); case "$V" in capacity_ok) echo capacity-ok;; no_capacity) echo no-capacity;; *) echo width-receipt-invalid;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      capacity_ok: route_lane
-      no_capacity: parked_no_capacity
-      receipt_incomplete: STOP-precondition-failed
-    kind: table-lookup
-    table: width
+      capacity_ok: {target: observe_lane_decision, evidence: {predicate_id: width-capacity-ok, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: capacity-ok}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      no_capacity: {target: parked_no_capacity, evidence: {predicate_id: width-no-capacity, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-capacity}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      width_receipt_missing: {target: STOP-manual-intervention, evidence: {predicate_id: width-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: width-receipt-missing}]}}
+      width_receipt_invalid: {target: STOP-manual-intervention, evidence: {predicate_id: width-receipt-invalid, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: width-receipt-invalid}]}}
     blocked_on: null
 
-  - step_id: route_lane
-    intent: >-
-      Lane-routing is a LIVE-LOOKUP table applied to the served routing SSOT. The
-      step fetches the document to a receipt (offline fallback: the shared rules
-      file — same content); the predicate proves the receipt is the real assignment
-      document (live first heading: "Per-Task Model Assignment"). The resolved lane
-      is recorded in the brief the next step authors — the auditable resolution
-      artifact. check-model capability confirmation exists only for agy/kimi today
-      (live CLI --agent choices); other lanes rely on the routing doc + fallback
-      substitutions. No sanctioned lane for the family is a hard stop.
-    command: sh -c 'curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown" -o batch_state/rb2-rules-receipt.md || cp agents_extensions/shared/rules/model-assignment.md batch_state/rb2-rules-receipt.md'
-    evidence_predicate:
-      command: grep -c -e "Per-Task Model Assignment" -e "model-assignment" batch_state/rb2-rules-receipt.md
-      success_pattern: '^[1-9][0-9]*$'
+  - step_id: observe_lane_decision
+    intent: Observe the routing receipt bound to the requested lane before authoring or dispatching.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'R="batch_state/rb2-lane-$TASK_ID.receipt"; test -s "$R" || { echo lane-receipt-missing; exit 0; }; grep -Fxq "lane=$LANE" "$R" && echo lane-resolved || echo lane-receipt-invalid']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}", LANE: "{lane}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      lane_resolved: author_brief
-      no_sanctioned_lane: STOP-precondition-failed
-      rules_unreadable: STOP-precondition-failed
-    kind: table-lookup
-    table: lane-routing
+      lane_resolved: {target: author_brief, evidence: {predicate_id: lane-receipt-matches, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: lane-resolved}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      lane_receipt_missing: {target: STOP-manual-intervention, evidence: {predicate_id: lane-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: lane-receipt-missing}]}}
+      lane_receipt_invalid: {target: STOP-manual-intervention, evidence: {predicate_id: lane-receipt-invalid, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: lane-receipt-invalid}]}}
     blocked_on: null
 
   - step_id: author_brief
     intent: >-
-      Judgment authors the brief AND the research-registry classification together —
-      the same cognitive act. Registry duty: pass dimensions explicitly derivable
-      from the issue text, omit the rest (pointer-free is legal and deliberate; never
-      invent; never infer from provider/agent name). The resolved lane from
-      route_lane is recorded here. Brief conventions: numbered steps, worktree-only,
-      #M-4 evidence preamble, tests + mutation checks, hard exclusions, no auto-merge
-      by worker, one-line finalize comment on the tracking issue. Step 0 lives here:
-      sibling search by ISSUE REFERENCE (gh pr list --state all --search "<issue-nr>"
-      — live shape: JSON array, [] clear) + issue timeline; residual-scope judgment
-      on any hit. No explicit acceptance criteria → failed precondition, never a
-      guessed brief.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe a non-empty external brief receipt; authoring
+      and research classification happen outside this trail and cannot be fabricated.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'test -s "$BRIEF_PATH" && echo brief-receipt-present || echo brief-receipt-missing']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", BRIEF_PATH: "{brief_path}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      brief_written_and_classified: dispatch_worker
-      siblings_change_scope: STOP-manual-intervention
-      no_clear_spec: STOP-precondition-failed
-    kind: summon
+      brief_receipt_present: {target: dispatch_worker, evidence: {predicate_id: brief-receipt-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: brief-receipt-present}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      brief_receipt_missing: {target: STOP-manual-intervention, evidence: {predicate_id: brief-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: brief-receipt-missing}]}}
     blocked_on: null
 
   - step_id: dispatch_worker
-    intent: >-
-      Fire the dispatch, teeing all output to the per-task log later steps triage.
-      This step's OWN signal is the task state file: present with status
-      spawning|running means dispatched. Absent task file routes to log triage — the
-      log, not this predicate, discriminates refusal from spawn error.
-    command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee batch_state/rb2-dispatch-{task_id}.log'
-    evidence_predicate:
-      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(spawning|running)$'
+    intent: Dispatch exactly once; a separate observation reads the task state receipt.
+    command:
+      adapter: shell
+      argv: [.venv/bin/python, scripts/delegate.py, dispatch, --agent, "{lane}", --task-id, "{task_id}", --prompt-file, "{brief_path}", --worktree, --mode, danger]
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 120
+      mutation_class: remote-mutation
+      outcome_decoder: {source: stdout-token}
     transitions:
-      dispatched: await_settle
-      no_task_file: triage_dispatch_log
-    kind: mechanical
+      dispatched: {target: observe_dispatch_state, evidence: {predicate_id: dispatch-command-complete, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      dispatch_failed: {target: STOP-unrecoverable-error, evidence: {predicate_id: dispatch-command-failed, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 1}]}}
     blocked_on: null
 
-  - step_id: triage_dispatch_log
-    intent: >-
-      Single-signal log triage: the teed dispatch log either contains a write-path
-      REFUSE or it does not. REFUSE present routes to the benign-refusal proof;
-      REFUSE absent with no task file is a spawn error.
-    command: grep -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
-    evidence_predicate:
-      command: grep -c -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
-      success_pattern: '^[0-9]+$'
+  - step_id: observe_dispatch_state
+    intent: Re-observe the task state written by dispatch; no predicate executes a dispatch command.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in spawning|running) echo dispatched;; "") grep -Fq "No actual path overlap was found" "batch_state/rb2-dispatch-$TASK_ID.log" 2>/dev/null && echo overlap-refused || echo task-receipt-missing;; *) echo dispatch-not-running;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      refuse_present: triage_refusal
-      refuse_absent_spawn_error: STOP-unrecoverable-error
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: triage_refusal
-    intent: >-
-      FAIL-CLOSED refusal semantics (no claim to prove an actual overlap — that
-      shape has never been live-captured): the ONLY refusal proven benign is the
-      disjointness-proof gap whose live-captured text is "No actual path overlap was
-      found". That exact phrase routes to judgment for an override decision; every
-      other refusal text is treated as a real concurrency conflict BY DESIGN.
-    command: grep -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
-    evidence_predicate:
-      command: grep -c -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
-      success_pattern: '^[0-9]+$'
-    transitions:
-      provably_benign: approve_override
-      not_provably_benign: STOP-concurrency-conflict
-    kind: mechanical
+      dispatched: {target: await_settle, evidence: {predicate_id: dispatch-state-running, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: dispatched}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      overlap_refused: {target: approve_override, evidence: {predicate_id: dispatch-overlap-refused, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: overlap-refused}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      task_receipt_missing: {target: STOP-unrecoverable-error, evidence: {predicate_id: dispatch-state-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: task-receipt-missing}]}}
+      dispatch_not_running: {target: finalize_settle, evidence: {predicate_id: dispatch-state-terminal, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: dispatch-not-running}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: approve_override
     intent: >-
-      Judgment reviews the refusal text and the undeclared writer it names, and
-      writes the override reason (who the writer is, why the write surfaces are
-      disjoint). A weak seat never self-approves an ownership override.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe the external override receipt naming the task and
+      reason; absence or a mismatch stops rather than fabricating an approval.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'R="batch_state/rb2-overlap-$TASK_ID.receipt"; test -s "$R" || { echo override-receipt-missing; exit 0; }; grep -Fxq "task_id=$TASK_ID" "$R" && grep -Fxq "reason=$OVERLAP_REASON" "$R" && echo override-approved || echo override-receipt-invalid']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}", OVERLAP_REASON: "{overlap_reason}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      override_approved: override_dispatch
-      override_denied: STOP-concurrency-conflict
-    kind: summon
+      override_approved: {target: override_dispatch, evidence: {predicate_id: override-receipt-approved, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-approved}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      override_receipt_missing: {target: STOP-concurrency-conflict, evidence: {predicate_id: override-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-receipt-missing}]}}
+      override_receipt_invalid: {target: STOP-concurrency-conflict, evidence: {predicate_id: override-receipt-invalid, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-receipt-invalid}]}}
     blocked_on: null
 
   - step_id: override_dispatch
-    intent: >-
-      Re-run the identical dispatch with the approved --allow-path-overlap reason.
-      Admitted shapes (live-captured): "would-refuse recorded (override); admitted
-      under refuse" or "admitted; paths disjoint". A second refusal is a hard stop.
-    command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} --allow-path-overlap "{overlap_reason}" 2>&1 | tee batch_state/rb2-dispatch-{task_id}-override.log'
-    evidence_predicate:
-      command: grep -c -e "admitted under refuse" -e "admitted; paths disjoint" batch_state/rb2-dispatch-{task_id}-override.log
-      success_pattern: '^[1-9]'
+    intent: Dispatch once with an externally observed overlap approval; success is re-observed separately.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger --allow-path-overlap "$OVERLAP_REASON" && echo override-dispatch-issued || echo override-dispatch-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}", BRIEF_PATH: "{brief_path}", OVERLAP_REASON: "{overlap_reason}"}
+      timeout_seconds: 120
+      mutation_class: remote-mutation
+      outcome_decoder: {source: stdout-token}
     transitions:
-      dispatched: await_settle
-      refused_again: STOP-concurrency-conflict
-    kind: mechanical
+      override_dispatch_issued: {target: observe_override_dispatch, evidence: {predicate_id: override-dispatch-issued, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-dispatch-issued}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      override_dispatch_failed: {target: STOP-concurrency-conflict, evidence: {predicate_id: override-dispatch-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-dispatch-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_override_dispatch
+    intent: Re-observe the task state after the approved override mutation.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in spawning|running) echo override-running;; *) echo override-state-missing;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      override_running: {target: await_settle, evidence: {predicate_id: override-state-running, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-running}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      override_state_missing: {target: STOP-concurrency-conflict, evidence: {predicate_id: override-state-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: override-state-missing}]}}
     blocked_on: null
 
   - step_id: await_settle
     intent: >-
-      Settle wait (kind-wait header note): the seat arms ONE Monitor settle-loop
-      over the task status file — the file is truth (the active-list API can omit
-      live tasks); poll cadence 60-90s; emit exactly once when status leaves
-      {spawning, running, ""} — then idles on the settle event, whose payload is the
-      terminal status string the next step routes. Arming a Monitor is a harness
-      action with no repo command to predicate on, which is why this whole
-      arm-and-wait is ONE summon with a documentation-predicate (r3 finding: a
-      mechanical arm step had no derivable evidence). Never keyword-grep worker logs
-      as completion; never poll with scheduled wakeups. A watch that outlives its
-      Monitor (session end, watcher reaped) is re-armed, not forgotten.
-    command: null
-    evidence_predicate: null
+      Former wait/summon. A bounded observation may prove a terminal task receipt;
+      an active task stops because TrailSpec v1.1 has no approved wait primitive.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in spawning|running|"") echo settlement-pending;; *) echo settlement-observed;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      settle_event: finalize_settle
-      watcher_lost: await_settle
-    kind: summon
+      settlement_observed: {target: finalize_settle, evidence: {predicate_id: settlement-terminal-observed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: settlement-observed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      settlement_pending: {target: STOP-manual-intervention, evidence: {predicate_id: settlement-wait-unavailable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: settlement-pending}]}}
     blocked_on: null
 
   - step_id: finalize_settle
-    intent: >-
-      Route the terminal status through the settle-status table — every row mapped
-      with the table's own dispositions: done and both timeout flavors go to the
-      success-path deliverable check (an open PR satisfies the table's "gh pr list"
-      check before any worktree digging); the attention states needs_finalize and
-      no_deliverable go to the ATTENTION-path deliverable check whose no-PR branch is
-      finalize-BY-HAND (the table's words — never an automatic retry; #5855-class
-      false negatives are disproven by checking the branch first); failed/crashed go
-      to failure-evidence reading then cleanup then the bounded re-fire;
-      rate_limited reroutes per fallback substitutions (the seat NOTES the substitution in the brief/receipt — a write obligation); cancelled/dry_run are
-      terminal-not-success; a spurious settle with status still spawning/running
-      re-enters the wait; anything else is unknown.
-    command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-    evidence_predicate:
-      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable|spawning|running)$'
+    intent: Observe the settled task status and route only its typed receipt token.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); case "$S" in done) echo done;; timeout|silence-timeout) echo timeout;; needs-finalize|no-deliverable) echo attention;; failed|crashed) echo failed;; rate-limited) echo rate-limited;; cancelled|dry-run) echo aborted;; *) echo unknown-status;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      done: verify_deliverable_success
-      timeout: verify_deliverable_timeout
-      silence_timeout: verify_deliverable_timeout
-      needs_finalize: verify_deliverable_attention
-      no_deliverable: verify_deliverable_attention
-      failed: retry_suffix_gate
-      crashed: retry_suffix_gate
-      rate_limited: route_lane
-      cancelled: aborted
-      dry_run: aborted
-      still_spawning_or_running: await_settle
-      unknown_status: STOP-unknown
-    kind: table-lookup
-    table: settle-status
+      done: {target: verify_deliverable_success, evidence: {predicate_id: settle-done, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: done}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      timeout: {target: verify_deliverable_timeout, evidence: {predicate_id: settle-timeout, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: timeout}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      attention: {target: verify_deliverable_attention, evidence: {predicate_id: settle-attention, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: attention}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      failed: {target: retry_suffix_gate, evidence: {predicate_id: settle-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: failed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      rate_limited: {target: STOP-manual-intervention, evidence: {predicate_id: settle-rate-limited, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: rate-limited}]}}
+      aborted: {target: aborted, evidence: {predicate_id: settle-aborted, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: aborted}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      unknown_status: {target: STOP-unknown, evidence: {predicate_id: settle-unknown, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: unknown-status}]}}
     blocked_on: null
 
   - step_id: verify_deliverable_success
-    intent: >-
-      Success/timeout path: an open PR for the dispatch branch is the deliverable
-      receipt (live shape: JSON array with a number field; [] means none). Reading
-      the produced CONTENT before the review gate is RB-3's entry. No PR routes to
-      the commits-ahead check (silent-exit class), which may end in the bounded
-      re-fire.
-    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
-    evidence_predicate:
-      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
-      success_pattern: '"number"'
+    intent: Observe whether the dispatched branch has an open PR deliverable.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      pr_open: handed_to_pr_lifecycle
-      no_pr_for_branch: commits_ahead_check
-    kind: mechanical
+      pr_open: {target: handed_to_pr_lifecycle, evidence: {predicate_id: success-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      no_pr: {target: commits_ahead_check, evidence: {predicate_id: success-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: verify_deliverable_timeout
-    intent: >-
-      Timeout path (timeout / silence-timeout): the same PR receipt check. An open
-      PR is finalize-BY-HAND (a died-at-deadline worker's deliverable needs eyes).
-      No PR routes into the commits-ahead/dirty-tree chain, whose clean-and-empty
-      outcome reaches the bounded failed/crashed retry — the table's disposition for
-      a deliverable-less timeout ("treat as the failed|crashed rows").
-    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
-    evidence_predicate:
-      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
-      success_pattern: '"number"'
+    intent: Observe the timeout deliverable; an open PR requires human finalization.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      pr_open: STOP-manual-intervention
-      no_pr_for_branch: commits_ahead_check
-    kind: mechanical
+      pr_open: {target: STOP-manual-intervention, evidence: {predicate_id: timeout-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}]}}
+      no_pr: {target: commits_ahead_check, evidence: {predicate_id: timeout-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: verify_deliverable_attention
-    intent: >-
-      Attention path (timeout flavors + needs_finalize / no_deliverable): the same
-      PR check, but the table's disposition here is finalize BY HAND — an OPEN PR
-      also routes to judgment (a died worker's deliverable needs eyes before RB-3's
-      babysit could auto-merge it), and a missing PR runs the commit-verification
-      PROBE — recorded evidence for the human, never a route into the automatic
-      retry chain (three live #5855-class false negatives this session all had real
-      deliverables the status missed).
-    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
-    evidence_predicate:
-      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
-      success_pattern: '"number"'
+    intent: Observe the attention-path deliverable; this path never automatically retries.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      pr_open: STOP-manual-intervention
-      no_pr_for_branch: attention_absence_probe
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: attention_absence_probe
-    intent: >-
-      The table's commit-verification for attention states, with the table's
-      disposition kept intact: run the commits-beyond-base probe (base bound inline
-      from worktree_base_sha) and RECORD its result into the attention receipt — then
-      finalize BY HAND regardless of the count (r5 finding: the attention path must
-      never reach the automatic retry chain; the probe informs the human, it does not
-      route). The single transition to the stop is deliberate: verification is an
-      evidence obligation here, not a branch point.
-    command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD | tee batch_state/rb2-attention-{task_id}.txt'
-    evidence_predicate:
-      command: test -s batch_state/rb2-attention-{task_id}.txt && echo probe-recorded
-      success_pattern: '^probe-recorded$'
-    transitions:
-      probe_recorded: STOP-manual-intervention
-    kind: mechanical
+      pr_open: {target: STOP-manual-intervention, evidence: {predicate_id: attention-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}]}}
+      no_pr: {target: STOP-manual-intervention, evidence: {predicate_id: attention-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}]}}
     blocked_on: null
 
   - step_id: commits_ahead_check
-    intent: >-
-      Single-signal: count commits the dispatch worktree carries beyond its recorded
-      base, read from the task file's worktree_base_sha field (live-verified key) —
-      no unbound placeholders. Non-zero means finished-but-unpushed work — judgment
-      finalize, never a blind refire over real work. Zero falls through to the
-      dirty-tree check.
-    command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD'
-    evidence_predicate:
-      command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD'
-      success_pattern: '^[0-9]+$'
+    intent: Observe the worktree's commits beyond its recorded base before any cleanup.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'B=$(jq -r ".worktree_base_sha // empty" "batch_state/tasks/$TASK_ID.json" 2>/dev/null); W=".worktrees/dispatch/$LANE/$TASK_ID"; test -n "$B" && test -d "$W" || { echo worktree-unreadable; exit 0; }; N=$(git -C "$W" rev-list --count "$B"..HEAD 2>/dev/null); case "$N" in 0) echo no-commits;; ""|*[!0-9]*) echo worktree-unreadable;; *) echo commits-present;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      commits_present: STOP-manual-intervention
-      no_commits: dirty_tree_check
-    kind: mechanical
+      no_commits: {target: dirty_tree_check, evidence: {predicate_id: commits-none, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-commits}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      commits_present: {target: STOP-manual-intervention, evidence: {predicate_id: commits-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: commits-present}]}}
+      worktree_unreadable: {target: STOP-unrecoverable-error, evidence: {predicate_id: commits-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-unreadable}]}}
     blocked_on: null
 
   - step_id: dirty_tree_check
-    intent: >-
-      Single-signal: count dirty entries in the dispatch worktree. Non-zero means
-      uncommitted work — judgment finalize (never delete uncommitted work). Zero
-      means provably no deliverable anywhere → the failure-evidence read precedes
-      the bounded re-fire.
-    command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
-    evidence_predicate:
-      command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
-      success_pattern: '^[0-9]+$'
+    intent: Observe the failed worktree's dirty state; uncommitted work is never removed.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'W=".worktrees/dispatch/$LANE/$TASK_ID"; test -d "$W" || { echo worktree-unreadable; exit 0; }; git -C "$W" status --porcelain | grep -q . && echo dirty-entries-present || echo clean-and-empty']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      dirty_entries_present: STOP-manual-intervention
-      clean_and_empty: read_failure_evidence
-    kind: mechanical
+      clean_and_empty: {target: retry_suffix_gate, evidence: {predicate_id: worktree-clean-empty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: clean-and-empty}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      dirty_entries_present: {target: STOP-manual-intervention, evidence: {predicate_id: worktree-dirty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: dirty-entries-present}]}}
+      worktree_unreadable: {target: STOP-unrecoverable-error, evidence: {predicate_id: worktree-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-unreadable}]}}
     blocked_on: null
 
   - step_id: retry_suffix_gate
-    intent: >-
-      FIRST-MATCH gate for failed/crashed (r4 finding: the stop must precede any
-      cleanup): a task id already carrying -retry has consumed its single re-fire —
-      stop immediately with the table's exact code, PRESERVING the failed retry's
-      worktree and logs for forensics. Only a first-attempt id proceeds to
-      failure-evidence reading and cleanup.
-    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
-    evidence_predicate:
-      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
-      success_pattern: '^(already-retried|first-attempt)$'
+    intent: Observe the bounded retry suffix before cleanup; retries are preserved for forensics.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'case "$TASK_ID" in *-retry) echo already-retried;; *) echo first-attempt;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      first_attempt: read_failure_evidence
-      already_retried: STOP-unrecoverable-error
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: read_failure_evidence
-    intent: >-
-      The settle-status row's action verbatim: read stderr_excerpt AND the logs.
-      Both the task file's stderr_excerpt field (live-verified key) and the teed
-      dispatch log are concatenated into the failure receipt, preserving the cause
-      for the -retry brief and audit. An empty excerpt is still evidence.
-    command: sh -c '{ jq -r ".stderr_excerpt // \"(no stderr recorded)\"" batch_state/tasks/{task_id}.json; echo "--- dispatch log tail ---"; tail -40 batch_state/rb2-dispatch-{task_id}.log 2>/dev/null || echo "(no dispatch log)"; } | tee batch_state/rb2-failure-{task_id}.txt'
-    evidence_predicate:
-      command: test -s batch_state/rb2-failure-{task_id}.txt && echo evidence-recorded
-      success_pattern: '^evidence-recorded$'
-    transitions:
-      evidence_recorded: cleanup_failed_worktree
-      task_file_unreadable: STOP-unrecoverable-error
-    kind: mechanical
+      first_attempt: {target: cleanup_failed_worktree, evidence: {predicate_id: retry-first-attempt, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: first-attempt}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      already_retried: {target: STOP-unrecoverable-error, evidence: {predicate_id: retry-already-consumed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: already-retried}]}}
     blocked_on: null
 
   - step_id: cleanup_failed_worktree
     intent: >-
-      The settle-status row's action verbatim, ENFORCED (r5 finding: no swallowed
-      branch-delete): remove the worktree, then delete the never-merged branch with
-      -D — failures are not suppressed, and the predicate proves BOTH absences
-      (worktree gone from the registry AND no branch ref remains). A harness whose
-      write guard blocks manual branch -D fails this step honestly into
-      STOP-manual-intervention — a dangling branch is never accepted as cleaned.
-    command: sh -c 'git worktree remove --force .worktrees/dispatch/{lane}/{task_id} && git branch -D {lane}/{task_id}'
-    evidence_predicate:
-      command: sh -c '(git worktree list | grep -q -e "dispatch/{lane}/{task_id}") && exit 1; (git branch --list "{lane}/{task_id}" | grep -q .) && exit 1; echo fully-cleaned'
-      success_pattern: '^fully-cleaned$'
+      Remove only a clean, proven-unmerged worktree without force. Branch deletion is
+      deliberately omitted: a failed branch remains for forensics and approved cleanup.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'git worktree remove ".worktrees/dispatch/$LANE/$TASK_ID" && echo worktree-removed || echo removal-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 60
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      cleaned: retry_gate
-      removal_failed: STOP-manual-intervention
-    kind: mechanical
+      worktree_removed: {target: observe_cleanup, evidence: {predicate_id: cleanup-command-complete, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-removed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      removal_failed: {target: STOP-manual-intervention, evidence: {predicate_id: cleanup-command-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: removal-failed}]}}
     blocked_on: null
 
-  - step_id: retry_gate
-    intent: >-
-      Defense-in-depth suffix re-check on the re-fire path (the authoritative
-      first-match gate is retry_suffix_gate, which runs BEFORE any cleanup): a task
-      id already carrying -retry stops as STOP-unrecoverable-error (the table's
-      exact code). Otherwise the retry id <task_id>-retry is recorded to a receipt
-      for the re-fire step.
-    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo "{task_id}-retry" > batch_state/rb2-retry-{task_id}.txt; cat batch_state/rb2-retry-{task_id}.txt ;; esac'
-    evidence_predicate:
-      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) cat batch_state/rb2-retry-{task_id}.txt ;; esac'
-      success_pattern: '^(already-retried|.+-retry)$'
+  - step_id: observe_cleanup
+    intent: Re-observe only that the worktree is absent; the branch receipt remains available for forensics.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'git worktree list --porcelain | grep -Fq ".worktrees/dispatch/$LANE/$TASK_ID" && echo worktree-still-present || echo worktree-absent']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      retry_id_recorded: dispatch_retry
-      already_retried: STOP-unrecoverable-error
-    kind: mechanical
+      worktree_absent: {target: dispatch_retry, evidence: {predicate_id: cleanup-observed-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-absent}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      worktree_still_present: {target: STOP-manual-intervention, evidence: {predicate_id: cleanup-observed-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-still-present}]}}
     blocked_on: null
 
   - step_id: dispatch_retry
-    intent: >-
-      Fire ONCE under the recorded -retry id (read from the receipt), same brief and
-      lane, teeing to the retry log — then this invocation ENDS at the terminal
-      refired_new_invocation. trailspec.v1 cannot rebind {task_id} mid-trail (r3
-      finding), so the -retry task is owned by a NEW invocation of this same trail
-      whose {task_id} IS the -retry id: its settle, verification, and retry gate all
-      address the right task, and its retry_gate stops on the -retry suffix —
-      bounded without rebinding.
-    command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id "$RID" --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee "batch_state/rb2-dispatch-$RID.log"'
-    evidence_predicate:
-      command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); jq -r ".status // \"\"" "batch_state/tasks/$RID.json"'
-      success_pattern: '^(spawning|running)$'
+    intent: Dispatch one new invocation under the bounded retry task id.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID-retry" --prompt-file "$BRIEF_PATH" --worktree --mode danger && echo retry-dispatch-issued || echo retry-dispatch-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}", BRIEF_PATH: "{brief_path}"}
+      timeout_seconds: 120
+      mutation_class: remote-mutation
+      outcome_decoder: {source: stdout-token}
     transitions:
-      retry_dispatched: refired_new_invocation
-      retry_spawn_failed: STOP-unrecoverable-error
-    kind: mechanical
+      retry_dispatch_issued: {target: observe_retry_dispatch, evidence: {predicate_id: retry-dispatch-issued, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: retry-dispatch-issued}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      retry_dispatch_failed: {target: STOP-unrecoverable-error, evidence: {predicate_id: retry-dispatch-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: retry-dispatch-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_retry_dispatch
+    intent: Re-observe the retry task receipt instead of claiming dispatch success from the mutation output.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'S=$(jq -r ".status // empty" "batch_state/tasks/$TASK_ID-retry.json" 2>/dev/null); case "$S" in spawning|running) echo retry-running;; *) echo retry-receipt-missing;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", TASK_ID: "{task_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      retry_running: {target: refired_new_invocation, evidence: {predicate_id: retry-state-running, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: retry-running}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      retry_receipt_missing: {target: STOP-unrecoverable-error, evidence: {predicate_id: retry-state-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: retry-receipt-missing}]}}
     blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -138,14 +138,14 @@ steps:
       overlap refusal is re-observed; every other nonzero result remains a failure.
     command:
       adapter: shell
-      argv: [bash, -c, 'mkdir -p batch_state || exit 1; LOG="batch_state/rb2-dispatch-$TASK_ID.log"; .venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger 2>&1 | tee "$LOG" >&2; PIPE_STATUSES=("${PIPESTATUS[@]}"); DISPATCH_STATUS="${PIPE_STATUSES[0]}"; TEE_STATUS="${PIPE_STATUSES[1]}"; if [ "$TEE_STATUS" -ne 0 ]; then exit "$TEE_STATUS"; fi; if [ "$DISPATCH_STATUS" -eq 0 ]; then echo dispatched; exit 0; fi; if grep -Fq "No actual path overlap was found" "$LOG"; then echo dispatched; exit 0; fi; exit "$DISPATCH_STATUS"']
+      argv: [bash, -c, 'mkdir -p batch_state; MKDIR_STATUS=$?; if [ "$MKDIR_STATUS" -ne 0 ]; then echo dispatch-failed; exit "$MKDIR_STATUS"; fi; LOG="batch_state/rb2-dispatch-$TASK_ID.log"; .venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger 2>&1 | tee "$LOG" >&2; PIPE_STATUSES=("${PIPESTATUS[@]}"); DISPATCH_STATUS="${PIPE_STATUSES[0]}"; TEE_STATUS="${PIPE_STATUSES[1]}"; if [ "$TEE_STATUS" -ne 0 ]; then echo dispatch-failed; exit "$TEE_STATUS"; fi; if [ "$DISPATCH_STATUS" -eq 0 ]; then echo dispatched; exit 0; fi; if grep -Fq "No actual path overlap was found" "$LOG"; then echo dispatched; exit 0; fi; echo dispatch-failed; exit "$DISPATCH_STATUS"']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}", BRIEF_PATH: "{brief_path}"}
       timeout_seconds: 120
       mutation_class: remote-mutation
       outcome_decoder: {source: stdout-token}
     transitions:
       dispatched: {target: observe_dispatch_state, evidence: {predicate_id: dispatch-command-complete, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 0}]}}
-      dispatch_failed: {target: STOP-unrecoverable-error, evidence: {predicate_id: dispatch-command-failed, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 1}]}}
+      dispatch_failed: {target: STOP-unrecoverable-error, evidence: {predicate_id: dispatch-command-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: dispatch-failed}]}}
     blocked_on: null
 
   - step_id: observe_dispatch_state
@@ -250,7 +250,7 @@ steps:
     intent: Observe whether the dispatched branch has an open PR deliverable.
     command:
       adapter: shell
-      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      argv: [sh, -c, 'PR_JSON=$(gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3) || { echo deliverable-check-failed; exit 0; }; PR_COUNT=$(printf "%s" "$PR_JSON" | jq -e "if type == \"array\" then length else error(\"expected PR array\") end") || { echo deliverable-check-failed; exit 0; }; case "$PR_COUNT" in 0) echo no-pr;; *[!0-9]*|"") echo deliverable-check-failed;; *) echo pr-open;; esac']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
       timeout_seconds: 30
       mutation_class: observe
@@ -258,13 +258,14 @@ steps:
     transitions:
       pr_open: {target: handed_to_pr_lifecycle, evidence: {predicate_id: success-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
       no_pr: {target: commits_ahead_check, evidence: {predicate_id: success-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      deliverable_check_failed: {target: STOP-precondition-failed, evidence: {predicate_id: success-deliverable-check-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: deliverable-check-failed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: verify_deliverable_timeout
     intent: Observe the timeout deliverable; an open PR requires human finalization.
     command:
       adapter: shell
-      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      argv: [sh, -c, 'PR_JSON=$(gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3) || { echo deliverable-check-failed; exit 0; }; PR_COUNT=$(printf "%s" "$PR_JSON" | jq -e "if type == \"array\" then length else error(\"expected PR array\") end") || { echo deliverable-check-failed; exit 0; }; case "$PR_COUNT" in 0) echo no-pr;; *[!0-9]*|"") echo deliverable-check-failed;; *) echo pr-open;; esac']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
       timeout_seconds: 30
       mutation_class: observe
@@ -272,13 +273,14 @@ steps:
     transitions:
       pr_open: {target: STOP-manual-intervention, evidence: {predicate_id: timeout-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}]}}
       no_pr: {target: commits_ahead_check, evidence: {predicate_id: timeout-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      deliverable_check_failed: {target: STOP-precondition-failed, evidence: {predicate_id: timeout-deliverable-check-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: deliverable-check-failed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: verify_deliverable_attention
     intent: Observe the attention-path deliverable; this path never automatically retries.
     command:
       adapter: shell
-      argv: [sh, -c, 'gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3 | jq -e "length > 0" >/dev/null 2>&1 && echo pr-open || echo no-pr']
+      argv: [sh, -c, 'PR_JSON=$(gh pr list --state open --head "$LANE/$TASK_ID" --json number --limit 3) || { echo deliverable-check-failed; exit 0; }; PR_COUNT=$(printf "%s" "$PR_JSON" | jq -e "if type == \"array\" then length else error(\"expected PR array\") end") || { echo deliverable-check-failed; exit 0; }; case "$PR_COUNT" in 0) echo no-pr;; *[!0-9]*|"") echo deliverable-check-failed;; *) echo pr-open;; esac']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}"}
       timeout_seconds: 30
       mutation_class: observe
@@ -286,6 +288,7 @@ steps:
     transitions:
       pr_open: {target: STOP-manual-intervention, evidence: {predicate_id: attention-pr-open, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pr-open}]}}
       no_pr: {target: STOP-manual-intervention, evidence: {predicate_id: attention-pr-absent, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: no-pr}]}}
+      deliverable_check_failed: {target: STOP-precondition-failed, evidence: {predicate_id: attention-deliverable-check-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: deliverable-check-failed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
     blocked_on: null
 
   - step_id: commits_ahead_check

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -133,11 +133,13 @@ steps:
     blocked_on: null
 
   - step_id: dispatch_worker
-    intent: Dispatch exactly once; a separate observation reads the task state receipt.
+    intent: >-
+      Dispatch exactly once while retaining combined output. Only the recorded benign
+      overlap refusal is re-observed; every other nonzero result remains a failure.
     command:
       adapter: shell
-      argv: [.venv/bin/python, scripts/delegate.py, dispatch, --agent, "{lane}", --task-id, "{task_id}", --prompt-file, "{brief_path}", --worktree, --mode, danger]
-      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      argv: [bash, -c, 'mkdir -p batch_state || exit 1; LOG="batch_state/rb2-dispatch-$TASK_ID.log"; .venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger 2>&1 | tee "$LOG" >&2; PIPE_STATUSES=("${PIPESTATUS[@]}"); DISPATCH_STATUS="${PIPE_STATUSES[0]}"; TEE_STATUS="${PIPE_STATUSES[1]}"; if [ "$TEE_STATUS" -ne 0 ]; then exit "$TEE_STATUS"; fi; if [ "$DISPATCH_STATUS" -eq 0 ]; then echo dispatched; exit 0; fi; if grep -Fq "No actual path overlap was found" "$LOG"; then echo dispatched; exit 0; fi; exit "$DISPATCH_STATUS"']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}", BRIEF_PATH: "{brief_path}"}
       timeout_seconds: 120
       mutation_class: remote-mutation
       outcome_decoder: {source: stdout-token}
@@ -180,10 +182,12 @@ steps:
     blocked_on: null
 
   - step_id: override_dispatch
-    intent: Dispatch once with an externally observed overlap approval; success is re-observed separately.
+    intent: >-
+      Dispatch once with an externally observed overlap approval and retain combined
+      output; success is re-observed separately.
     command:
       adapter: shell
-      argv: [sh, -c, '.venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger --allow-path-overlap "$OVERLAP_REASON" && echo override-dispatch-issued || echo override-dispatch-failed']
+      argv: [bash, -c, 'mkdir -p batch_state || exit 1; LOG="batch_state/rb2-override-dispatch-$TASK_ID.log"; .venv/bin/python scripts/delegate.py dispatch --agent "$LANE" --task-id "$TASK_ID" --prompt-file "$BRIEF_PATH" --worktree --mode danger --allow-path-overlap "$OVERLAP_REASON" 2>&1 | tee "$LOG" >&2; PIPE_STATUSES=("${PIPESTATUS[@]}"); DISPATCH_STATUS="${PIPE_STATUSES[0]}"; TEE_STATUS="${PIPE_STATUSES[1]}"; if [ "$TEE_STATUS" -ne 0 ]; then exit "$TEE_STATUS"; fi; if [ "$DISPATCH_STATUS" -eq 0 ]; then echo override-dispatch-issued; exit 0; fi; echo override-dispatch-failed; exit "$DISPATCH_STATUS"']
       environment: {TRAIL_INVOCATION_ID: "{invocation_id}", LANE: "{lane}", TASK_ID: "{task_id}", BRIEF_PATH: "{brief_path}", OVERLAP_REASON: "{overlap_reason}"}
       timeout_seconds: 120
       mutation_class: remote-mutation

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -1,44 +1,13 @@
-# RB-5 — session close (T2 DRAFT, extraction from drive-epic SKILL §8/§8a + the
-# handoff-completeness decision table + the machine-checked handoff-readiness
-# predicate #3138 + the #M-10a close sweep). Part of #5885.
-#
-# DRAFT STATUS: authored against today's substrate; certification waits for T1.4/5.
-# Two pieces are deliberately NOT drafted as steps (RB-4 r3/r4 precedent — never ship
-# unreachable speculative machinery):
-# - The runner-backed receipt-chain closure gate (design v2: "no receipt chain → no
-#   close"). No trail runner emits StepReceipt rows yet, so a chain-validation step
-#   could never pass; it ships WITH the trail runner. Today's close is receipt-backed
-#   by this trail's OWN tee'd receipts (readiness + worktree snapshots).
-# - The fenced lease release. The hardened SessionEnd hook owns it (T1.2, #5896,
-#   deployed): identity-fenced, symlink-refusing, fires on process exit. A driver
-#   command for it would be invented machinery.
-#
-# Fleet-comms: the file handoff stays authoritative in EVERY plane mode (mode today:
-# shadow); nothing in this trail flips cutovers or retires file handoffs.
-#
-# Anti-pattern guard (RB-2 v0.7.0 discipline): every command is a real, currently
-# runnable repo command whose OUTPUT SHAPE was captured live (2026-07-28 infra
-# session): handoff_ready --json check vocabulary ok|red|unknown with [status,
-# detail] pairs; inbox "pending: N (oldest ...)"; `git rev-list --count
-# origin/main..main` bare integer; `git worktree list --porcelain` worktree/HEAD/
-# branch triplets. Every MECHANICAL step is single-signal; the compound readiness
-# JSON is captured ONCE and split into per-field single-signal compares (the RB-4
-# probe→compare pattern).
-#
-# Live-captured hazard this trail encodes: the readiness predicate's in-flight
-# counter is repo-GLOBAL — on 2026-07-28 it flagged two dispatches that both
-# belonged to OTHER lanes (concurrent multi-lane operation is the norm). Per-lane
-# attribution is mechanically impossible until runner-emitted step receipts exist,
-# so a non-zero count routes to judgment, never to a guess and never to a silent
-# proceed.
-schema_version: trailspec.v1
+# RB-5 session close. The terminal step is observation only; TrailExecutor.close()
+# is the sole closure gate and re-observes the complete receipt chain.
+schema_version: trailspec.v1.1
 trail_id: rb5-session-close
-version: "0.1.6"
-title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
-seats:
-  - grok-daily
-  - glm-trial
-  - judgment
+version: "1.0.0"
+title: RB5 Session close — receipt observations and closure-gate handoff
+seats: [grok, glm-local, kimi]
+parameters:
+  handoff_agent: string
+  handoff_file: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-manual-intervention
@@ -48,279 +17,275 @@ terminal_outcomes:
   - back_to_dispatch_loop
 steps:
   - step_id: assert_primary_checkout
-    intent: >-
-      FAIL-CLOSED entry assertion (r6 finding): every relative path in this trail
-      (.venv, batch_state) and every checkout-dependent signal (readiness tree,
-      the ahead count) assumes the PRIMARY main checkout — an assumption v0.1.5
-      narrated but never enforced, so a run from a clean feature worktree could
-      close over that worktree's own unpushed state while inspecting an
-      unrelated main ref. Discriminator (live-verified both directions
-      2026-07-28): in the primary checkout git-dir equals git-common-dir; in a
-      linked worktree they differ. The primary must also BE on main (layout A);
-      anything else stops before a single receipt is written.
-    command: sh -c 'G=$(git rev-parse --git-dir 2>/dev/null); C=$(git rev-parse --git-common-dir 2>/dev/null); B=$(git symbolic-ref --short -q HEAD); if [ -z "$G" ] || [ -z "$C" ]; then echo not-primary-checkout; elif [ "$G" != "$C" ]; then echo not-primary-checkout; elif [ "$B" != "main" ]; then echo primary-off-main; else echo primary-confirmed; fi'
-    evidence_predicate:
-      command: sh -c 'G=$(git rev-parse --git-dir 2>/dev/null); C=$(git rev-parse --git-common-dir 2>/dev/null); B=$(git symbolic-ref --short -q HEAD); if [ -z "$G" ] || [ -z "$C" ]; then echo not-primary-checkout; elif [ "$G" != "$C" ]; then echo not-primary-checkout; elif [ "$B" != "main" ]; then echo primary-off-main; else echo primary-confirmed; fi'
-      success_pattern: '^(primary-confirmed|not-primary-checkout|primary-off-main)$'
+    intent: Observe the primary main checkout before any close receipt is written.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'G=$(git rev-parse --git-dir 2>/dev/null); C=$(git rev-parse --git-common-dir 2>/dev/null); B=$(git symbolic-ref --short -q HEAD); if [ -z "$G" ] || [ -z "$C" ] || [ "$G" != "$C" ]; then echo not-primary-checkout; elif [ "$B" = main ]; then echo primary-confirmed; else echo primary-off-main; fi']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      primary_confirmed: drain_slot_inbox
-      not_primary_checkout: STOP-precondition-failed
-      primary_off_main: STOP-precondition-failed
-    kind: mechanical
+      primary_confirmed: {target: drain_slot_inbox, evidence: {predicate_id: primary-confirmed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: primary-confirmed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      not_primary_checkout: {target: STOP-precondition-failed, evidence: {predicate_id: primary-not-primary, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: not-primary-checkout}]}}
+      primary_off_main: {target: STOP-precondition-failed, evidence: {predicate_id: primary-off-main, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: primary-off-main}]}}
     blocked_on: null
 
   - step_id: drain_slot_inbox
-    intent: >-
-      OPENING live-driver inbox drain (drive-epic 8a pattern): surface every
-      pending slot delivery before the close sequence starts. The 8a
-      "immediately before handoff" guarantee is NOT this step's — deliveries can
-      arrive during the readiness and sweep interval (r2 finding), so
-      final_inbox_recheck re-proves pending: 0 right before the handoff gate.
-      Live output shape: "<agent> inbox:" then "pending: N (oldest ...)". NOTE
-      (live-verified in the #5915 r1 review): show is not a pure read — it expires
-      stale deliveries via an UPDATE; a read-only DB fails loudly here, which is a
-      precondition failure, not a skip. The wrapper normalizes output + exit
-      status into exactly the three transition tokens (r3 finding: raw bridge
-      output plus a boolean predicate cannot discriminate pending-work from a
-      broken DB).
-    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-{handoff_agent}.txt || { echo db-not-writable; exit 0; }; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
-    evidence_predicate:
-      command: sh -c 'OUT=$(cat batch_state/rb5-inbox-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
-      success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
+    intent: Refresh an inbox receipt; bridge expiry behavior makes this a local write.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for "$HANDOFF_AGENT" show "$HANDOFF_AGENT" > "batch_state/rb5-inbox-$HANDOFF_AGENT.txt" 2>&1 && echo inbox-receipt-written || echo inbox-refresh-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      empty: readiness_snapshot
-      pending_deliveries: apply_deliveries
-      db_not_writable: STOP-precondition-failed
-    kind: mechanical
+      inbox_receipt_written: {target: observe_slot_inbox, evidence: {predicate_id: close-inbox-receipt-written, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-receipt-written}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      inbox_refresh_failed: {target: STOP-precondition-failed, evidence: {predicate_id: close-inbox-refresh-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-refresh-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_slot_inbox
+    intent: Observe the inbox receipt and stop rather than pretending to consume deliveries.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'P=$(awk "/pending:/{print \$2}" "batch_state/rb5-inbox-$HANDOFF_AGENT.txt" 2>/dev/null); case "$P" in 0) echo empty;; "") echo inbox-unreadable;; *[!0-9]*) echo inbox-unreadable;; *) echo pending-deliveries;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      empty: {target: readiness_snapshot, evidence: {predicate_id: close-inbox-empty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: empty}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      pending_deliveries: {target: apply_deliveries, evidence: {predicate_id: close-inbox-pending, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pending-deliveries}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      inbox_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: close-inbox-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-unreadable}]}}
     blocked_on: null
 
   - step_id: apply_deliveries
     intent: >-
-      The 8a contract is live-driver consumption, not worker acknowledgement
-      ("never claim the handoff is complete because a one-shot worker acknowledged
-      it"): judgment READS each pending delivery, APPLIES it (an action taken, a
-      queue item updated, or an unresolved request recorded in the handoff), then
-      acks with `ack --consumed-by-live-driver <id> ...` (flag live-verified to
-      exist — a #5886 review claim to the contrary was refuted by probe). Control
-      returns to the drain step to re-prove pending: 0.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe an externally written delivery-consumption
+      receipt; a missing receipt stops and this trail never fabricates an acknowledgement.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'test -s "batch_state/rb5-deliveries-consumed-$HANDOFF_AGENT.receipt" && echo deliveries-consumed || echo deliveries-unresolved']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      deliveries_consumed: drain_slot_inbox
-      cannot_apply: STOP-manual-intervention
-    kind: summon
+      deliveries_consumed: {target: drain_slot_inbox, evidence: {predicate_id: deliveries-receipt-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: deliveries-consumed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      deliveries_unresolved: {target: STOP-manual-intervention, evidence: {predicate_id: deliveries-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: deliveries-unresolved}]}}
     blocked_on: null
 
   - step_id: readiness_snapshot
-    intent: >-
-      Capture the machine-checked handoff-readiness predicate (#3138) ONCE into a
-      receipt; later steps split it into single-signal compares. Live shape
-      (2026-07-28): JSON with branch/pr/ready and checks.{tree_clean, no_inflight,
-      branch_pushed, pr_checks_green}, each a [status, detail] pair with status
-      vocabulary ok|red|unknown. The predicate is run, never asserted in prose
-      (#M-4); its compound `ready` boolean is deliberately NOT the signal here —
-      pr_checks_green is legitimately `unknown` at close when no PR is open, and
-      branch_pushed conflates behind-origin (benign) with ahead-of-origin (a real
-      stop) — the split steps read the fields this trail can act on soundly.
-    command: sh -c '.venv/bin/python -m scripts.orchestration.handoff_ready --json | tee batch_state/rb5-ready-{handoff_agent}.json'
-    evidence_predicate:
-      command: sh -c 'jq -e ".checks | has(\"tree_clean\")" batch_state/rb5-ready-{handoff_agent}.json >/dev/null 2>&1 && echo snapshot-recorded || echo predicate-unavailable'
-      success_pattern: '^(snapshot-recorded|predicate-unavailable)$'
+    intent: Capture handoff readiness once; later steps observe its immutable receipt.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python -m scripts.orchestration.handoff_ready --json > "batch_state/rb5-ready-$HANDOFF_AGENT.json" 2>/dev/null && echo readiness-recorded || echo readiness-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      snapshot_recorded: tree_clean_check
-      predicate_unavailable: STOP-precondition-failed
-    kind: mechanical
+      readiness_recorded: {target: tree_clean_check, evidence: {predicate_id: readiness-snapshot-written, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: readiness-recorded}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      readiness_failed: {target: STOP-precondition-failed, evidence: {predicate_id: readiness-snapshot-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: readiness-failed}]}}
     blocked_on: null
 
   - step_id: tree_clean_check
-    intent: >-
-      Single-signal read of checks.tree_clean from the recorded receipt. A dirty
-      tree at close is never auto-resolved — uncommitted work is never deleted and
-      never blind-committed (#M-10 class); it is judgment's to place, so the trail
-      stops.
-    command: sh -c 'V=$(jq -r ".checks.tree_clean[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo tree-clean;; red) echo tree-dirty;; *) echo receipt-unreadable;; esac'
-    evidence_predicate:
-      command: sh -c 'V=$(jq -r ".checks.tree_clean[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo tree-clean;; red) echo tree-dirty;; *) echo receipt-unreadable;; esac'
-      success_pattern: '^(tree-clean|tree-dirty|receipt-unreadable)$'
+    intent: Observe the recorded tree-clean field; dirty work is never altered by this trail.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'V=$(jq -r ".checks.tree_clean[0] // empty" "batch_state/rb5-ready-$HANDOFF_AGENT.json" 2>/dev/null); case "$V" in ok) echo tree-clean;; red) echo tree-dirty;; *) echo receipt-unreadable;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      tree_clean: inflight_check
-      tree_dirty: STOP-manual-intervention
-      receipt_unreadable: STOP-precondition-failed
-    kind: mechanical
+      tree_clean: {target: inflight_check, evidence: {predicate_id: tree-clean, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: tree-clean}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      tree_dirty: {target: STOP-manual-intervention, evidence: {predicate_id: tree-dirty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: tree-dirty}]}}
+      receipt_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: tree-receipt-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: receipt-unreadable}]}}
     blocked_on: null
 
   - step_id: inflight_check
-    intent: >-
-      Single-signal read of checks.no_inflight from the recorded receipt. The
-      counter is repo-GLOBAL (live-captured 2026-07-28: it flagged two dispatches
-      that were both OTHER lanes' live work), so a non-zero count is an attribution
-      question this trail cannot answer mechanically — it routes to judgment,
-      never to a guess and never past the close.
-    command: sh -c 'V=$(jq -r ".checks.no_inflight[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo in-flight-none;; red) echo in-flight-present;; *) echo receipt-unreadable;; esac'
-    evidence_predicate:
-      command: sh -c 'V=$(jq -r ".checks.no_inflight[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo in-flight-none;; red) echo in-flight-present;; *) echo receipt-unreadable;; esac'
-      success_pattern: '^(in-flight-none|in-flight-present|receipt-unreadable)$'
+    intent: Observe the global in-flight receipt; attribution remains an explicit stop boundary.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'V=$(jq -r ".checks.no_inflight[0] // empty" "batch_state/rb5-ready-$HANDOFF_AGENT.json" 2>/dev/null); case "$V" in ok) echo in-flight-none;; red) echo in-flight-present;; *) echo receipt-unreadable;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      in_flight_none: primary_ahead_check
-      in_flight_present: resolve_inflight
-      receipt_unreadable: STOP-precondition-failed
-    kind: mechanical
+      in_flight_none: {target: fetch_primary_state, evidence: {predicate_id: inflight-none, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: in-flight-none}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      in_flight_present: {target: resolve_inflight, evidence: {predicate_id: inflight-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: in-flight-present}]}}
+      receipt_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: inflight-receipt-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: receipt-unreadable}]}}
     blocked_on: null
 
   - step_id: resolve_inflight
     intent: >-
-      Judgment attributes each non-terminal batch_state/tasks/<id>.json row (the
-      task FILE is truth; the active-list API can omit live tasks — #5207). A live
-      dispatch of THIS seat's own means the session is not closable: the settle
-      obligation belongs to the dispatch loop, so the trail hands back. Rows all
-      confirmed other-lane (cwd/brief/epic evidence, never provider name alone)
-      proceed. Anything unattributable stops.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe a signed attribution receipt; absent or
+      ambiguous attribution stops instead of classifying other lanes from memory.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'R="batch_state/rb5-inflight-attribution-$HANDOFF_AGENT.receipt"; test -s "$R" || { echo attribution-missing; exit 0; }; V=$(awk -F= "/^outcome=/{print \$2}" "$R"); case "$V" in own_dispatch_live) echo own-dispatch-live;; all_other_lane) echo all-other-lane;; *) echo attribution-ambiguous;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      own_dispatch_live: back_to_dispatch_loop
-      all_other_lane: primary_ahead_check
-      ownership_ambiguous: STOP-manual-intervention
-    kind: summon
-    blocked_on: "per-lane in-flight attribution needs runner-emitted step receipts (#5885)"
+      own_dispatch_live: {target: back_to_dispatch_loop, evidence: {predicate_id: inflight-own-dispatch, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: own-dispatch-live}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      all_other_lane: {target: fetch_primary_state, evidence: {predicate_id: inflight-other-lane, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: all-other-lane}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      attribution_missing: {target: STOP-manual-intervention, evidence: {predicate_id: inflight-attribution-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: attribution-missing}]}}
+      attribution_ambiguous: {target: STOP-manual-intervention, evidence: {predicate_id: inflight-attribution-ambiguous, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: attribution-ambiguous}]}}
+    blocked_on: null
+
+  - step_id: fetch_primary_state
+    intent: Refresh origin/main before the separate ahead-count observation.
+    command:
+      adapter: shell
+      argv: [git, fetch, origin, --quiet]
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 60
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      fetched: {target: primary_ahead_check, evidence: {predicate_id: primary-fetch-complete, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      fetch_failed: {target: STOP-precondition-failed, evidence: {predicate_id: primary-fetch-failed, clauses: [{source: command_receipt, field: exit_code, op: eq, value: 1}]}}
+    blocked_on: null
 
   - step_id: primary_ahead_check
-    intent: >-
-      Unpushed local commits on the primary checkout at close violate the PRs-only
-      discipline and would strand work invisible to every other machine — that is
-      the stop this step exists for. Behind-origin is BENIGN at close (other lanes
-      merge continuously; live-captured 2026-07-28: origin/main moved ahead of a
-      freshly-fetched local within the same session). The readiness predicate's
-      branch_pushed field conflates the two directions, so this step counts only
-      the ahead direction (live shape: bare integer, "0" when clean). FAILS
-      CLOSED (r1 finding): a failed fetch means the remote state could not be
-      verified, so the count is unavailable — a stale tracking ref must never
-      read as primary-clean. Counts origin/main..HEAD — HEAD IS main here, the
-      entry assertion guarantees it (r6: counting the main ref from an arbitrary
-      checkout inspected the wrong subject).
-    command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..HEAD 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
-    evidence_predicate:
-      command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..HEAD 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
-      success_pattern: '^(primary-clean|primary-ahead|count-unavailable)$'
+    intent: Observe only the refreshed origin/main..HEAD ahead count.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'N=$(git rev-list --count origin/main..HEAD 2>/dev/null); case "$N" in 0) echo primary-clean;; ""|*[!0-9]*) echo count-unavailable;; *) echo primary-ahead;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      primary_clean: worktree_receipt
-      primary_ahead: STOP-manual-intervention
-      count_unavailable: STOP-precondition-failed
-    kind: mechanical
+      primary_clean: {target: worktree_receipt, evidence: {predicate_id: primary-ahead-none, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: primary-clean}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      primary_ahead: {target: STOP-manual-intervention, evidence: {predicate_id: primary-ahead-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: primary-ahead}]}}
+      count_unavailable: {target: STOP-precondition-failed, evidence: {predicate_id: primary-count-unavailable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: count-unavailable}]}}
     blocked_on: null
 
   - step_id: worktree_receipt
-    intent: >-
-      Record the worktree estate into a receipt and read ONE signal from it: the
-      worktree count (live shape: "worktree <path>" / "HEAD <sha>" / "branch <ref>"
-      triplets, blank-line separated). Exactly one worktree (the primary) proceeds;
-      more routes the recorded receipt to the sweep judgment — the #M-10a close
-      sweep is disposition-per-worktree work this trail cannot do mechanically
-      (merged-clean vs uncommitted vs other-lane-live all look alike to a count).
-      The command emits the transition vocabulary itself (sibling sweep of the r1
-      fail-closed class: a bare count narrates the branching instead of enforcing
-      it, and a failed listing must not read as any worktree state).
-    command: sh -c 'git worktree list --porcelain > batch_state/rb5-worktrees-{handoff_agent}.txt 2>/dev/null || { echo receipt-unwritable; exit 0; }; N=$(grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt); case "$N" in 1) echo primary-only;; 0) echo receipt-unwritable;; *) echo extra-worktrees;; esac'
-    evidence_predicate:
-      command: sh -c 'N=$(grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt 2>/dev/null); case "$N" in 1) echo primary-only;; ""|0) echo receipt-unwritable;; *) echo extra-worktrees;; esac'
-      success_pattern: '^(primary-only|extra-worktrees|receipt-unwritable)$'
+    intent: Capture a worktree receipt before the sweep decision is re-observed.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'git worktree list --porcelain > "batch_state/rb5-worktrees-$HANDOFF_AGENT.txt" 2>/dev/null && echo worktree-receipt-written || echo worktree-receipt-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      primary_only: final_inbox_recheck
-      extra_worktrees: sweep_judgment
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
+      worktree_receipt_written: {target: observe_worktree_count, evidence: {predicate_id: worktree-receipt-written, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-receipt-written}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      worktree_receipt_failed: {target: STOP-precondition-failed, evidence: {predicate_id: worktree-receipt-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: worktree-receipt-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_worktree_count
+    intent: Observe worktree count from the recorded receipt; no sweep happens in this step.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'N=$(grep -c "^worktree " "batch_state/rb5-worktrees-$HANDOFF_AGENT.txt" 2>/dev/null); case "$N" in 1) echo primary-only;; 0) echo receipt-unreadable;; *) echo extra-worktrees;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      primary_only: {target: final_inbox_recheck, evidence: {predicate_id: worktree-primary-only, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: primary-only}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      extra_worktrees: {target: sweep_judgment, evidence: {predicate_id: worktree-extra, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: extra-worktrees}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      receipt_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: worktree-receipt-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: receipt-unreadable}]}}
     blocked_on: null
 
   - step_id: sweep_judgment
     intent: >-
-      Judgment applies the close-sweep rules to the recorded worktree receipt:
-      OWN worktrees that are merged and clean are reaped (worktree removal BEFORE
-      local-branch cleanup); uncommitted work is NEVER deleted (#M-10); other
-      lanes' worktrees are hands-off and get LISTED in the handoff instead
-      (live-captured 2026-07-28: 8 of 9 extra worktrees were other lanes' active
-      work — a mass sweep would have killed live dispatches). Own uncommitted
-      work found at close stops the trail — placing it is not a close-time call.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe a completed external sweep receipt; this trail
+      does not delete another lane's worktree or manufacture a sweep-success token.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'R="batch_state/rb5-sweep-$HANDOFF_AGENT.receipt"; test -s "$R" || { echo sweep-receipt-missing; exit 0; }; V=$(awk -F= "/^outcome=/{print \$2}" "$R"); case "$V" in sweep_applied) echo sweep-observed;; own_uncommitted_work) echo own-uncommitted-work;; *) echo sweep-receipt-invalid;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      sweep_applied: final_inbox_recheck
-      own_uncommitted_work: STOP-manual-intervention
-    kind: summon
+      sweep_observed: {target: final_inbox_recheck, evidence: {predicate_id: sweep-receipt-applied, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: sweep-observed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      own_uncommitted_work: {target: STOP-manual-intervention, evidence: {predicate_id: sweep-own-uncommitted, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: own-uncommitted-work}]}}
+      sweep_receipt_missing: {target: STOP-manual-intervention, evidence: {predicate_id: sweep-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: sweep-receipt-missing}]}}
+      sweep_receipt_invalid: {target: STOP-manual-intervention, evidence: {predicate_id: sweep-receipt-invalid, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: sweep-receipt-invalid}]}}
     blocked_on: null
 
   - step_id: final_inbox_recheck
-    intent: >-
-      The 8a contract enforced at the RIGHT moment (r2 finding): deliveries that
-      arrived during the readiness and sweep interval must be consumed before the
-      handoff is written or declared — an empty inbox observed at the START of
-      the close is not an empty inbox NOW. Only pending: 0 HERE may proceed to
-      the handoff gate; a late delivery routes to judgment consumption and the
-      close re-verifies from the top (the delivery may have changed the world
-      the readiness receipts described). Same normalized three-token wrapper as
-      the opening drain (r3 finding).
-    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-final-{handoff_agent}.txt || { echo db-not-writable; exit 0; }; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
-    evidence_predicate:
-      command: sh -c 'OUT=$(cat batch_state/rb5-inbox-final-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
-      success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
+    intent: Refresh the final inbox receipt before observing its contents again.
+    command:
+      adapter: shell
+      argv: [sh, -c, '.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for "$HANDOFF_AGENT" show "$HANDOFF_AGENT" > "batch_state/rb5-inbox-final-$HANDOFF_AGENT.txt" 2>&1 && echo final-inbox-receipt-written || echo final-inbox-refresh-failed']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder: {source: stdout-token}
     transitions:
-      empty: write_handoff
-      pending_deliveries: apply_deliveries
-      db_not_writable: STOP-precondition-failed
-    kind: mechanical
+      final_inbox_receipt_written: {target: observe_final_inbox, evidence: {predicate_id: final-inbox-receipt-written, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: final-inbox-receipt-written}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      final_inbox_refresh_failed: {target: STOP-precondition-failed, evidence: {predicate_id: final-inbox-refresh-failed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: final-inbox-refresh-failed}]}}
+    blocked_on: null
+
+  - step_id: observe_final_inbox
+    intent: Observe the final inbox receipt; late deliveries return to explicit consumption evidence.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'P=$(awk "/pending:/{print \$2}" "batch_state/rb5-inbox-final-$HANDOFF_AGENT.txt" 2>/dev/null); case "$P" in 0) echo empty;; "") echo inbox-unreadable;; *[!0-9]*) echo inbox-unreadable;; *) echo pending-deliveries;; esac']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
+    transitions:
+      empty: {target: write_handoff, evidence: {predicate_id: final-inbox-empty, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: empty}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      pending_deliveries: {target: apply_deliveries, evidence: {predicate_id: final-inbox-pending, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: pending-deliveries}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      inbox_unreadable: {target: STOP-precondition-failed, evidence: {predicate_id: final-inbox-unreadable, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: inbox-unreadable}]}}
     blocked_on: null
 
   - step_id: write_handoff
     intent: >-
-      Judgment WRITES the current-session handoff block (r3 finding: a gate that
-      only tests pre-existing non-emptiness would accept a stale handoff and a
-      fresh session would always stop — the write must be an explicit step).
-      Content comes from the handoff-completeness table rows, reconstructed from
-      tool output and THIS trail's receipts (readiness + worktrees + inbox),
-      never from memory; the 40KB archive rule applies before appending. Currency
-      of the written block is judgment's obligation here until the runner-backed
-      receipt chain can prove it mechanically.
-    command: null
-    evidence_predicate: null
+      Former judgment/summon. Observe the externally authored current-session handoff
+      receipt; no command in this trail writes or asserts handoff completeness.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'test -s "$HANDOFF_FILE" && echo handoff-receipt-present || echo handoff-receipt-missing']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_FILE: "{handoff_file}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      handoff_written: handoff_gate
-      cannot_reconstruct: STOP-manual-intervention
-    kind: summon
+      handoff_receipt_present: {target: handoff_gate, evidence: {predicate_id: handoff-receipt-present, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: handoff-receipt-present}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      handoff_receipt_missing: {target: STOP-manual-intervention, evidence: {predicate_id: handoff-receipt-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: handoff-receipt-missing}]}}
     blocked_on: null
 
   - step_id: handoff_gate
-    intent: >-
-      The handoff-completeness table is the content contract (every row
-      reconstructed from tool output, never memory; IN-FLIGHT with watcher ids;
-      NEXT ACTION ordered list; operator-pending items; the 40KB archive rule).
-      Prose completeness is not machine-checkable until the closure-gate
-      integration lands, so the mechanical signal here is presence+non-empty of
-      the seat's handoff file only — the seat applies the table rows to the file
-      it just wrote, and the receipt records that the gate was consulted.
-    command: sh -c 'test -s {handoff_file} && echo handoff-present || echo handoff-absent'
-    evidence_predicate:
-      command: sh -c 'test -s {handoff_file} && echo handoff-present || echo handoff-absent'
-      success_pattern: '^(handoff-present|handoff-absent)$'
+    intent: Observe the handoff receipt size boundary before the terminal closure observation.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'test -s "$HANDOFF_FILE" || { echo handoff-missing; exit 0; }; N=$(wc -c < "$HANDOFF_FILE"); [ "$N" -le 40960 ] && echo handoff-gate-passed || echo handoff-too-large']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_FILE: "{handoff_file}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      handoff_present: close_declaration
-      handoff_absent: STOP-manual-intervention
-    kind: table-lookup
-    table: handoff-completeness
-    blocked_on: "runner-backed closure-gate integration (receipt-chain validation ships with the trail runner; lease-release hooks landed with T1.2 #5896)"
+      handoff_gate_passed: {target: close_declaration, evidence: {predicate_id: handoff-gate-passed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: handoff-gate-passed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      handoff_missing: {target: STOP-manual-intervention, evidence: {predicate_id: handoff-gate-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: handoff-missing}]}}
+      handoff_too_large: {target: STOP-manual-intervention, evidence: {predicate_id: handoff-gate-too-large, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: handoff-too-large}]}}
+    blocked_on: null
 
   - step_id: close_declaration
     intent: >-
-      The close is declared only over this trail's own receipts — both snapshot
-      files must exist and be non-empty, so "closed clean" is receipt-backed
-      rather than asserted. The fenced lease release is NOT commanded here: the
-      hardened SessionEnd hook (T1.2, #5896) owns it on process exit. When the
-      trail runner lands, the receipt-chain closure gate supersedes this step's
-      two-file check with full-chain validation.
-    command: sh -c 'test -s batch_state/rb5-ready-{handoff_agent}.json && test -s batch_state/rb5-worktrees-{handoff_agent}.txt && echo receipts-complete || echo receipts-missing'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb5-ready-{handoff_agent}.json && test -s batch_state/rb5-worktrees-{handoff_agent}.txt && echo receipts-complete || echo receipts-missing'
-      success_pattern: '^(receipts-complete|receipts-missing)$'
+      Terminal observation only. It proves required local receipts exist; it does not
+      invoke close or release leases. TrailExecutor.close() is the sole closure gate.
+    command:
+      adapter: shell
+      argv: [sh, -c, 'test -s "batch_state/rb5-ready-$HANDOFF_AGENT.json" && test -s "batch_state/rb5-worktrees-$HANDOFF_AGENT.txt" && test -s "$HANDOFF_FILE" && echo closure-inputs-observed || echo closure-inputs-missing']
+      environment: {TRAIL_INVOCATION_ID: "{invocation_id}", HANDOFF_AGENT: "{handoff_agent}", HANDOFF_FILE: "{handoff_file}"}
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder: {source: stdout-token}
     transitions:
-      receipts_complete: closed_handoff_written
-      receipts_missing: STOP-precondition-failed
-    kind: mechanical
+      closure_inputs_observed: {target: closed_handoff_written, evidence: {predicate_id: closure-inputs-observed, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: closure-inputs-observed}, {source: command_receipt, field: exit_code, op: eq, value: 0}]}}
+      closure_inputs_missing: {target: STOP-precondition-failed, evidence: {predicate_id: closure-inputs-missing, clauses: [{source: command_receipt, field: actor_outcome, op: eq, value: closure-inputs-missing}]}}
     blocked_on: null

--- a/tests/trails/test_rb2_rb5_v11.py
+++ b/tests/trails/test_rb2_rb5_v11.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import copy
+import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -171,6 +173,110 @@ def test_former_judgment_and_summon_nodes_are_observe_or_stop() -> None:
                 transition["target"].startswith("STOP-")
                 for transition in step["transitions"].values()
             )
+
+
+def _rb2_step(spec: dict[str, Any], step_id: str) -> dict[str, Any]:
+    return next(step for step in spec["steps"] if step["step_id"] == step_id)
+
+
+def _run_rb2_shell_step(
+    step: dict[str, Any], tmp_path: Path, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        step["command"]["argv"],
+        cwd=tmp_path,
+        env={**os.environ, **environment},
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _write_fake_delegate(tmp_path: Path) -> None:
+    fake_python = tmp_path / ".venv/bin/python"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$FAKE_DISPATCH_OUTPUT\"\nexit \"$FAKE_DISPATCH_EXIT\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+
+def test_rb2_benign_overlap_refusal_reaches_approval_or_concurrency_stop(
+    tmp_path: Path,
+) -> None:
+    """A logged benign refusal reaches approval; missing or denied approval stops safely."""
+    spec = _load(RB2_PATH)
+    dispatch = _rb2_step(spec, "dispatch_worker")
+    observe_dispatch = _rb2_step(spec, "observe_dispatch_state")
+    approve_override = _rb2_step(spec, "approve_override")
+    _write_fake_delegate(tmp_path)
+    environment = {
+        "TASK_ID": "overlap-task",
+        "LANE": "grok",
+        "BRIEF_PATH": "brief.md",
+        "OVERLAP_REASON": "approved-reason",
+        "FAKE_DISPATCH_OUTPUT": "No actual path overlap was found",
+        "FAKE_DISPATCH_EXIT": "1",
+    }
+
+    benign_refusal = _run_rb2_shell_step(dispatch, tmp_path, environment)
+
+    assert benign_refusal.returncode == 0
+    assert benign_refusal.stdout == "dispatched\n"
+    assert (
+        tmp_path / "batch_state/rb2-dispatch-overlap-task.log"
+    ).read_text(encoding="utf-8") == "No actual path overlap was found\n"
+    observed_refusal = _run_rb2_shell_step(observe_dispatch, tmp_path, environment)
+    assert observed_refusal.stdout == "overlap-refused\n"
+    assert observe_dispatch["transitions"]["overlap_refused"]["target"] == "approve_override"
+
+    missing_approval = _run_rb2_shell_step(approve_override, tmp_path, environment)
+    assert missing_approval.stdout == "override-receipt-missing\n"
+    assert (
+        approve_override["transitions"]["override_receipt_missing"]["target"]
+        == "STOP-concurrency-conflict"
+    )
+    receipt = tmp_path / "batch_state/rb2-overlap-overlap-task.receipt"
+    receipt.write_text("task_id=overlap-task\nreason=denied\n", encoding="utf-8")
+    denied_approval = _run_rb2_shell_step(approve_override, tmp_path, environment)
+    assert denied_approval.stdout == "override-receipt-invalid\n"
+    assert (
+        approve_override["transitions"]["override_receipt_invalid"]["target"]
+        == "STOP-concurrency-conflict"
+    )
+
+
+def test_rb2_dispatch_wrappers_log_combined_output_without_masking_failures(
+    tmp_path: Path,
+) -> None:
+    """Both wrappers retain output, and non-benign delegate failures preserve their status."""
+    spec = _load(RB2_PATH)
+    dispatch = _rb2_step(spec, "dispatch_worker")
+    override = _rb2_step(spec, "override_dispatch")
+    _write_fake_delegate(tmp_path)
+    environment = {
+        "TASK_ID": "failed-task",
+        "LANE": "grok",
+        "BRIEF_PATH": "brief.md",
+        "OVERLAP_REASON": "approved-reason",
+        "FAKE_DISPATCH_OUTPUT": "ordinary failure",
+        "FAKE_DISPATCH_EXIT": "17",
+    }
+
+    failed_dispatch = _run_rb2_shell_step(dispatch, tmp_path, environment)
+    failed_override = _run_rb2_shell_step(override, tmp_path, environment)
+
+    assert failed_dispatch.returncode == 17
+    assert failed_dispatch.stdout == ""
+    assert failed_override.returncode == 17
+    assert failed_override.stdout == "override-dispatch-failed\n"
+    assert (tmp_path / "batch_state/rb2-dispatch-failed-task.log").read_text(
+        encoding="utf-8"
+    ) == "ordinary failure\n"
+    assert (tmp_path / "batch_state/rb2-override-dispatch-failed-task.log").read_text(
+        encoding="utf-8"
+    ) == "ordinary failure\n"
 
 
 class _TerminalSource:

--- a/tests/trails/test_rb2_rb5_v11.py
+++ b/tests/trails/test_rb2_rb5_v11.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from scripts.orchestration.trails.closure import TrailClosureGate
-from scripts.orchestration.trails.executor import TrailExecutor
+from scripts.orchestration.trails.executor import DefaultReceiptPredicateEvaluator, TrailExecutor
 from scripts.orchestration.trails.models import CommandExecution, ExitClass
 from scripts.orchestration.trails.store import TrailStore
 from scripts.orchestration.validate_trailspec import PROJECT_ROOT, validate_trailspec
@@ -192,6 +192,14 @@ def _run_rb2_shell_step(
     )
 
 
+def _matching_transition_labels(
+    step: dict[str, Any], *, actor_outcome: str, exit_code: int
+) -> list[str]:
+    return DefaultReceiptPredicateEvaluator().matching_labels(
+        step, {"actor_outcome": actor_outcome, "exit_code": exit_code}
+    )
+
+
 def _write_fake_delegate(tmp_path: Path) -> None:
     fake_python = tmp_path / ".venv/bin/python"
     fake_python.parent.mkdir(parents=True)
@@ -200,6 +208,43 @@ def _write_fake_delegate(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     fake_python.chmod(0o755)
+
+
+def _write_fake_gh(tmp_path: Path) -> Path:
+    fake_gh = tmp_path / "bin/gh"
+    fake_gh.parent.mkdir(parents=True)
+    fake_gh.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$FAKE_GH_OUTPUT\"\nexit \"$FAKE_GH_EXIT\"\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    return fake_gh.parent
+
+
+def _write_fake_tee(tmp_path: Path) -> Path:
+    fake_tee = tmp_path / "bin/tee"
+    fake_tee.parent.mkdir(parents=True)
+    fake_tee.write_text(
+        "#!/bin/sh\nexit \"$FAKE_TEE_EXIT\"\n",
+        encoding="utf-8",
+    )
+    fake_tee.chmod(0o755)
+    return fake_tee.parent
+
+
+def _assert_dispatch_failure_routes_by_token(spec: dict[str, Any]) -> None:
+    dispatch = _rb2_step(spec, "dispatch_worker")
+    assert dispatch["transitions"]["dispatch_failed"]["evidence"]["clauses"] == [
+        {
+            "source": "command_receipt",
+            "field": "actor_outcome",
+            "op": "eq",
+            "value": "dispatch-failed",
+        }
+    ]
+    assert _matching_transition_labels(
+        dispatch, actor_outcome="dispatch-failed", exit_code=17
+    ) == ["dispatch_failed"]
 
 
 def test_rb2_benign_overlap_refusal_reaches_approval_or_concurrency_stop(
@@ -247,10 +292,10 @@ def test_rb2_benign_overlap_refusal_reaches_approval_or_concurrency_stop(
     )
 
 
-def test_rb2_dispatch_wrappers_log_combined_output_without_masking_failures(
+def test_rb2_dispatch_wrappers_log_combined_output_and_route_failure_tokens(
     tmp_path: Path,
 ) -> None:
-    """Both wrappers retain output, and non-benign delegate failures preserve their status."""
+    """Both wrappers retain output, and dispatch failure selects its token transition."""
     spec = _load(RB2_PATH)
     dispatch = _rb2_step(spec, "dispatch_worker")
     override = _rb2_step(spec, "override_dispatch")
@@ -268,7 +313,10 @@ def test_rb2_dispatch_wrappers_log_combined_output_without_masking_failures(
     failed_override = _run_rb2_shell_step(override, tmp_path, environment)
 
     assert failed_dispatch.returncode == 17
-    assert failed_dispatch.stdout == ""
+    assert failed_dispatch.stdout == "dispatch-failed\n"
+    assert _matching_transition_labels(
+        dispatch, actor_outcome=failed_dispatch.stdout.strip(), exit_code=failed_dispatch.returncode
+    ) == ["dispatch_failed"]
     assert failed_override.returncode == 17
     assert failed_override.stdout == "override-dispatch-failed\n"
     assert (tmp_path / "batch_state/rb2-dispatch-failed-task.log").read_text(
@@ -277,6 +325,102 @@ def test_rb2_dispatch_wrappers_log_combined_output_without_masking_failures(
     assert (tmp_path / "batch_state/rb2-override-dispatch-failed-task.log").read_text(
         encoding="utf-8"
     ) == "ordinary failure\n"
+
+
+def test_rb2_dispatch_emits_failure_token_for_setup_and_tee_errors(tmp_path: Path) -> None:
+    """Setup and log-capture failures preserve status and select dispatch_failed."""
+    spec = _load(RB2_PATH)
+    dispatch = _rb2_step(spec, "dispatch_worker")
+    environment = {
+        "TASK_ID": "setup-task",
+        "LANE": "grok",
+        "BRIEF_PATH": "brief.md",
+        "FAKE_DISPATCH_OUTPUT": "success",
+        "FAKE_DISPATCH_EXIT": "0",
+    }
+
+    (tmp_path / "batch_state").write_text("not a directory\n", encoding="utf-8")
+    setup_failure = _run_rb2_shell_step(dispatch, tmp_path, environment)
+    assert setup_failure.returncode == 1
+    assert setup_failure.stdout == "dispatch-failed\n"
+    assert _matching_transition_labels(
+        dispatch, actor_outcome=setup_failure.stdout.strip(), exit_code=setup_failure.returncode
+    ) == ["dispatch_failed"]
+
+    tee_tmp_path = tmp_path / "tee-failure"
+    tee_tmp_path.mkdir()
+    _write_fake_delegate(tee_tmp_path)
+    fake_bin = _write_fake_tee(tee_tmp_path)
+    tee_failure = _run_rb2_shell_step(
+        dispatch,
+        tee_tmp_path,
+        {**environment, "PATH": f"{fake_bin}:{os.environ['PATH']}", "FAKE_TEE_EXIT": "2"},
+    )
+    assert tee_failure.returncode == 2
+    assert tee_failure.stdout == "dispatch-failed\n"
+    assert _matching_transition_labels(
+        dispatch, actor_outcome=tee_failure.stdout.strip(), exit_code=tee_failure.returncode
+    ) == ["dispatch_failed"]
+
+
+def test_rb2_dispatch_failure_token_pin_rejects_the_old_exit_code_predicate() -> None:
+    """Mutation check: reintroducing exit-code 1 makes the status-17 pin fail."""
+    spec = _load(RB2_PATH)
+    _assert_dispatch_failure_routes_by_token(spec)
+
+    mutated = copy.deepcopy(spec)
+    mutated_dispatch = _rb2_step(mutated, "dispatch_worker")
+    mutated_dispatch["transitions"]["dispatch_failed"]["evidence"]["clauses"].append(
+        {"source": "command_receipt", "field": "exit_code", "op": "eq", "value": 1}
+    )
+
+    mutated_selection = _matching_transition_labels(
+        mutated_dispatch, actor_outcome="dispatch-failed", exit_code=17
+    )
+    assert mutated_selection == []
+    with pytest.raises(AssertionError):
+        assert mutated_selection == ["dispatch_failed"]
+
+
+@pytest.mark.parametrize(
+    ("gh_output", "gh_exit", "expected_outcome"),
+    [
+        ("network unavailable", "1", "deliverable-check-failed"),
+        ("[]", "0", "no-pr"),
+        ("not JSON", "0", "deliverable-check-failed"),
+    ],
+)
+def test_rb2_deliverable_probes_distinguish_pr_absence_from_check_failures(
+    tmp_path: Path, gh_output: str, gh_exit: str, expected_outcome: str
+) -> None:
+    """All settle paths fail closed unless gh returns validated JSON with no PRs."""
+    spec = _load(RB2_PATH)
+    fake_bin = _write_fake_gh(tmp_path)
+    environment = {
+        "TASK_ID": "deliverable-task",
+        "LANE": "grok",
+        "FAKE_GH_OUTPUT": gh_output,
+        "FAKE_GH_EXIT": gh_exit,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    }
+
+    for step_id in (
+        "verify_deliverable_success",
+        "verify_deliverable_timeout",
+        "verify_deliverable_attention",
+    ):
+        step = _rb2_step(spec, step_id)
+        result = _run_rb2_shell_step(step, tmp_path, environment)
+
+        assert result.returncode == 0
+        assert result.stdout == f"{expected_outcome}\n"
+        selected = _matching_transition_labels(
+            step, actor_outcome=result.stdout.strip(), exit_code=result.returncode
+        )
+        expected_label = expected_outcome.replace("-", "_")
+        assert selected == [expected_label]
+        if expected_outcome == "deliverable-check-failed":
+            assert step["transitions"][expected_label]["target"] == "STOP-precondition-failed"
 
 
 class _TerminalSource:

--- a/tests/trails/test_rb2_rb5_v11.py
+++ b/tests/trails/test_rb2_rb5_v11.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,19 @@ from scripts.orchestration.validate_trailspec import PROJECT_ROOT, validate_trai
 
 RB2_PATH = PROJECT_ROOT / "scripts/config/trails/rb2-dispatch-loop.trail.yaml"
 RB5_PATH = PROJECT_ROOT / "scripts/config/trails/rb5-session-close.trail.yaml"
+
+# Mirrors scripts.delegate._RUNTIME_TMP_TERMINAL_STATUSES, the dispatch task-status vocabulary.
+DELEGATE_TERMINAL_STATUSES = {
+    "done",
+    "timeout",
+    "needs_finalize",
+    "no_deliverable",
+    "failed",
+    "crashed",
+    "rate_limited",
+    "cancelled",
+    "dry_run",
+}
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -60,6 +74,21 @@ def test_each_transition_has_one_receipt_only_predicate(path: Path) -> None:
             assert evidence["clauses"]
             assert {clause["source"] for clause in evidence["clauses"]} == {"command_receipt"}
         assert len(predicate_ids) == len(set(predicate_ids))
+
+
+def test_finalize_settle_matches_delegate_terminal_status_vocabulary() -> None:
+    """The status case arms accept delegate.py's underscore-form terminal states."""
+    spec = _load(RB2_PATH)
+    finalize_settle = next(step for step in spec["steps"] if step["step_id"] == "finalize_settle")
+    command = finalize_settle["command"]["argv"][2]
+    matched_statuses = {
+        status
+        for case_arm in re.findall(r'(?:case "\$S" in|;;)\s*([^)]*)\)\s*echo', command)
+        for status in case_arm.split("|")
+        if status != "*"
+    }
+
+    assert matched_statuses == DELEGATE_TERMINAL_STATUSES
 
 
 def _assert_rb2_cleanup_is_non_force(spec: dict[str, Any]) -> None:

--- a/tests/trails/test_rb2_rb5_v11.py
+++ b/tests/trails/test_rb2_rb5_v11.py
@@ -1,0 +1,312 @@
+"""Contract tests for the RB-2/RB-5 TrailSpec v1.1 migrations."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.orchestration.trails.closure import TrailClosureGate
+from scripts.orchestration.trails.executor import TrailExecutor
+from scripts.orchestration.trails.models import CommandExecution, ExitClass
+from scripts.orchestration.trails.store import TrailStore
+from scripts.orchestration.validate_trailspec import PROJECT_ROOT, validate_trailspec
+
+RB2_PATH = PROJECT_ROOT / "scripts/config/trails/rb2-dispatch-loop.trail.yaml"
+RB5_PATH = PROJECT_ROOT / "scripts/config/trails/rb5-session-close.trail.yaml"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _commands(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step["command"] for step in spec["steps"]]
+
+
+@pytest.mark.parametrize(
+    ("path", "trail_id", "steps"),
+    [(RB2_PATH, "rb2-dispatch-loop", 24), (RB5_PATH, "rb5-session-close", 18)],
+)
+def test_migrated_trails_validate_v11(path: Path, trail_id: str, steps: int) -> None:
+    """Each migration is execution-eligible and has the expected v1.1 identity."""
+    result = validate_trailspec(spec_path=path)
+    assert result["ok"] is True
+    assert result["spec"]["trail_id"] == trail_id
+    assert result["spec"]["version"] == "1.0.0"
+    assert result["spec"]["steps_count"] == steps
+    assert result["spec"]["execution_eligible"] is True
+    assert len(result["spec"]["trail_hash"]) == 64
+
+
+@pytest.mark.parametrize("path", [RB2_PATH, RB5_PATH])
+def test_every_command_binds_the_runner_invocation(path: Path) -> None:
+    """All commands receive the durable invocation ID through their environment."""
+    for command in _commands(_load(path)):
+        assert command["environment"]["TRAIL_INVOCATION_ID"] == "{invocation_id}"
+
+
+@pytest.mark.parametrize("path", [RB2_PATH, RB5_PATH])
+def test_each_transition_has_one_receipt_only_predicate(path: Path) -> None:
+    """Every transition identifies one distinct predicate over its command receipt."""
+    for step in _load(path)["steps"]:
+        predicate_ids = []
+        for transition in step["transitions"].values():
+            evidence = transition["evidence"]
+            predicate_ids.append(evidence["predicate_id"])
+            assert evidence["clauses"]
+            assert {clause["source"] for clause in evidence["clauses"]} == {"command_receipt"}
+        assert len(predicate_ids) == len(set(predicate_ids))
+
+
+def _assert_rb2_cleanup_is_non_force(spec: dict[str, Any]) -> None:
+    command = next(
+        step["command"] for step in spec["steps"] if step["step_id"] == "cleanup_failed_worktree"
+    )
+    argv = command["argv"]
+    assert "--force" not in argv
+    assert "-D" not in argv
+    assert "--force" not in " ".join(argv)
+    assert " branch -D " not in f" {' '.join(argv)} "
+    assert command["mutation_class"] == "local-write"
+
+
+def test_rb2_cleanup_never_force_deletes_or_removes_the_branch() -> None:
+    """Cleanup is non-force worktree removal; failed branches remain for forensics."""
+    spec = _load(RB2_PATH)
+    _assert_rb2_cleanup_is_non_force(spec)
+    cleanup = next(step for step in spec["steps"] if step["step_id"] == "cleanup_failed_worktree")
+    assert cleanup["transitions"]["worktree_removed"]["target"] == "observe_cleanup"
+    assert cleanup["command"]["argv"][:2] == ["sh", "-c"]
+
+
+def test_negative_rb2_readding_force_fails_only_the_cleanup_guard() -> None:
+    """Mutation check: reintroducing force removal trips the dedicated cleanup guard."""
+    spec = _load(RB2_PATH)
+    cleanup = next(step for step in spec["steps"] if step["step_id"] == "cleanup_failed_worktree")
+    cleanup["command"]["argv"][2] = cleanup["command"]["argv"][2].replace(
+        "git worktree remove", "git worktree remove --force"
+    )
+    with pytest.raises(AssertionError):
+        _assert_rb2_cleanup_is_non_force(spec)
+
+
+def test_mutations_always_have_a_distinct_reobservation_step() -> None:
+    """Mutating commands never claim state themselves; a different observe step follows."""
+    checks = {
+        RB2_PATH: {
+            "drain_slot_inbox": "observe_slot_inbox",
+            "dispatch_worker": "observe_dispatch_state",
+            "override_dispatch": "observe_override_dispatch",
+            "cleanup_failed_worktree": "observe_cleanup",
+            "dispatch_retry": "observe_retry_dispatch",
+        },
+        RB5_PATH: {
+            "drain_slot_inbox": "observe_slot_inbox",
+            "readiness_snapshot": "tree_clean_check",
+            "fetch_primary_state": "primary_ahead_check",
+            "worktree_receipt": "observe_worktree_count",
+            "final_inbox_recheck": "observe_final_inbox",
+        },
+    }
+    for path, pairs in checks.items():
+        steps = {step["step_id"]: step for step in _load(path)["steps"]}
+        for mutation_id, observe_id in pairs.items():
+            mutation = steps[mutation_id]
+            assert mutation["command"]["mutation_class"] in {"local-write", "remote-mutation"}
+            assert observe_id != mutation_id
+            assert steps[observe_id]["command"]["mutation_class"] == "observe"
+            assert observe_id in {
+                transition["target"] for transition in mutation["transitions"].values()
+            }
+
+
+def test_former_judgment_and_summon_nodes_are_observe_or_stop() -> None:
+    """Former human/judgment nodes only accept a receipt observation or route to STOP."""
+    former_judgment_nodes = {
+        RB2_PATH: {"author_brief", "approve_override", "await_settle"},
+        RB5_PATH: {"apply_deliveries", "resolve_inflight", "sweep_judgment", "write_handoff"},
+    }
+    for path, step_ids in former_judgment_nodes.items():
+        steps = {step["step_id"]: step for step in _load(path)["steps"]}
+        for step_id in step_ids:
+            step = steps[step_id]
+            assert step["command"]["mutation_class"] == "observe"
+            command_text = " ".join(step["command"]["argv"])
+            assert "echo approved" not in command_text
+            assert "echo written" not in command_text
+            assert any(
+                transition["target"].startswith("STOP-")
+                for transition in step["transitions"].values()
+            )
+
+
+class _TerminalSource:
+    source_id = "fleet-bridge"
+    source_kind = "bridge"
+
+    def __init__(self, *, lease_current: bool = True) -> None:
+        self.lease_current = lease_current
+        self.calls = 0
+
+    def reobserve_terminal(
+        self,
+        *,
+        run: Any,
+        terminal_command_receipt: dict[str, Any],
+        terminal_step_receipt: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls += 1
+        return {
+            "observation_id": "rb5-close-observation",
+            "observed_at": "2026-07-29T00:00:00Z",
+            "run_id": run.run_id,
+            "trail_id": run.trail_id,
+            "trail_hash": run.trail_hash,
+            "terminal_outcome": run.terminal_outcome,
+            "lease_id": "lease-rb5",
+            "lease_generation": 1,
+            "fencing_token": "fence-rb5",
+            "pr_head": None,
+            "lease_current": self.lease_current,
+            "terminal_observed": True,
+        }
+
+
+class _InvalidTerminalAuthority(_TerminalSource):
+    """A provisioned source that returns unusable closure authority evidence."""
+
+    def reobserve_terminal(
+        self,
+        *,
+        run: Any,
+        terminal_command_receipt: dict[str, Any],
+        terminal_step_receipt: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls += 1
+        return {"observation_id": "invalid-authority"}
+
+
+def _rb5_terminal_fixture() -> dict[str, Any]:
+    """Use RB-5's actual terminal observation with a direct test entry point."""
+    spec = _load(RB5_PATH)
+    terminal = copy.deepcopy(next(step for step in spec["steps"] if step["step_id"] == "close_declaration"))
+    terminal["transitions"] = {
+        "closure_inputs_observed": {
+            **terminal["transitions"]["closure_inputs_observed"],
+            "target": "closed_handoff_written",
+        }
+    }
+    return {
+        **{key: copy.deepcopy(spec[key]) for key in ("schema_version", "trail_id", "version", "title", "seats", "parameters", "stop_codes", "terminal_outcomes")},
+        "steps": [terminal],
+    }
+
+
+def _rb5_executor(tmp_path: Path, source: _TerminalSource) -> TrailExecutor:
+    seats = tmp_path / "fleet.yaml"
+    seats.write_text(
+        yaml.safe_dump(
+            {"endpoints": [{"name": name, "state": "live"} for name in _load(RB5_PATH)["seats"]]}
+        ),
+        encoding="utf-8",
+    )
+    store = TrailStore(tmp_path / "runs.sqlite3", tmp_path / "receipts")
+    return TrailExecutor(
+        store,
+        project_root=tmp_path,
+        seat_registry_path=seats,
+        command_runner=lambda command, cwd: CommandExecution(0, "closure-inputs-observed", ""),
+        closure_gate=TrailClosureGate(store, source),
+    )
+
+
+def _terminal_rb5_run(executor: TrailExecutor, tmp_path: Path) -> str:
+    path = tmp_path / "rb5-terminal.trail.yaml"
+    path.write_text(yaml.safe_dump(_rb5_terminal_fixture(), sort_keys=False), encoding="utf-8")
+    begun = executor.begin(
+        trail_path=path,
+        seat="grok",
+        task_family="infra-orchestration",
+        params={"handoff_agent": "grok", "handoff_file": "handoff.md"},
+    )
+    assert begun.run_id is not None
+    terminal = executor.step(run_id=begun.run_id, expected_step="close_declaration")
+    assert terminal.outcome == "terminal"
+    return begun.run_id
+
+
+def test_rb5_terminal_step_delegates_closure_to_executor_close(tmp_path: Path) -> None:
+    """RB-5's terminal observation does not close; TrailExecutor.close performs closure."""
+    source = _TerminalSource()
+    executor = _rb5_executor(tmp_path, source)
+    run_id = _terminal_rb5_run(executor, tmp_path)
+
+    before = executor.store.get_run(run_id)
+    closed = executor.close(run_id=run_id)
+
+    assert before.closure_state == "open"
+    assert closed.exit_class == ExitClass.OK
+    assert closed.outcome == "closed"
+    assert source.calls == 1
+
+
+def test_rb5_close_refuses_invalid_chain_without_reobservation(tmp_path: Path) -> None:
+    """A malformed receipt projection parks RB-5 closure before terminal re-observation."""
+    source = _TerminalSource()
+    executor = _rb5_executor(tmp_path, source)
+    run_id = _terminal_rb5_run(executor, tmp_path)
+    invocation = executor.store.list_invocations(run_id)[0]
+    projection = executor.store.projection_path(
+        run_id=run_id, filename=f"command-000000-{invocation['invocation_id']}.json"
+    )
+    projection.write_text("{}\n", encoding="utf-8")
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.outcome == "closure_parked"
+    assert source.calls == 0
+
+
+def test_rb5_close_parks_a_stale_lease(tmp_path: Path) -> None:
+    """Closure re-observation rejects stale lease evidence for this RB-5 terminal."""
+    source = _TerminalSource(lease_current=False)
+    executor = _rb5_executor(tmp_path, source)
+    run_id = _terminal_rb5_run(executor, tmp_path)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.outcome == "closure_parked"
+    assert executor.store.get_run(run_id).closure_state == "parked"
+
+
+def test_rb5_close_requires_a_provisioned_closure_authority(tmp_path: Path) -> None:
+    """Without a closure re-observer, local receipts cannot authorize close."""
+    source = _TerminalSource()
+    executor = _rb5_executor(tmp_path, source)
+    run_id = _terminal_rb5_run(executor, tmp_path)
+    executor.closure_gate = None
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.INVALID
+    assert result.outcome == "closure_unavailable"
+    assert source.calls == 0
+
+
+def test_rb5_close_parks_invalid_closure_authority_evidence(tmp_path: Path) -> None:
+    """Malformed re-observed closure authority evidence cannot close the RB-5 run."""
+    source = _InvalidTerminalAuthority()
+    executor = _rb5_executor(tmp_path, source)
+    run_id = _terminal_rb5_run(executor, tmp_path)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.outcome == "closure_parked"
+    assert executor.store.get_run(run_id).closure_state == "parked"


### PR DESCRIPTION
Refs #5885

## Summary

- Migrates the two authorized RB-2/RB-5 rail trails to `trailspec.v1.1`, with receipt-bound observation, separated mutations/re-observation, non-force RB-2 cleanup, and an RB-5 terminal observation owned by `TrailExecutor.close()`.
- Adds hermetic migration coverage for schema/invocation/predicate contracts, no-force cleanup, observation honesty, mutation splitting, and RB-5 closure refusal cases.

## Deferred — spec gap (T2.1)

RB-2 settlement is a bounded observation: `settlement-pending` routes to `STOP-manual-intervention`. TrailSpec v1.1 has no approved wait primitive, so this trail does not encode a polling loop or a fabricated wait success.

## Evidence

Command:
```sh
.venv/bin/python -m scripts.orchestration.validate_trailspec --spec scripts/config/trails/rb2-dispatch-loop.trail.yaml --tables scripts/config/trails/decision-tables.v1.yaml
```
Raw output:
```text
TrailSpec valid: id='rb2-dispatch-loop' version='1.0.0' steps=24 hash=0ff09073cc830ada730de150be88dea5986d21c0f2773a51243293d16f0da1d5 execution_eligible=True
```

Command:
```sh
.venv/bin/python -m scripts.orchestration.validate_trailspec --spec scripts/config/trails/rb5-session-close.trail.yaml --tables scripts/config/trails/decision-tables.v1.yaml
```
Raw output:
```text
TrailSpec valid: id='rb5-session-close' version='1.0.0' steps=18 hash=2419e502cb6ec1a6039be8f39f7739b64ac7e3591bcfb7eb6bd0b172913026e8 execution_eligible=True
```

Command:
```sh
.venv/bin/python -m pytest tests/trails/test_rb2_rb5_v11.py tests/trails/test_rb1_rb6_v11.py tests/test_validate_trailspec.py -q
```
Raw output:
```text
collected 97 items
97 passed in 2.12s
```

Command:
```sh
.venv/bin/python -m ruff check tests/trails/test_rb2_rb5_v11.py
```
Raw output:
```text
All checks passed!
```

Mutation command:
```sh
.venv/bin/python -m pytest tests/trails/test_rb2_rb5_v11.py -q
```
Raw output after temporarily re-adding `--force` to RB-2 cleanup, before restoring the approved content:
```text
collected 15 items
FAILED tests/trails/test_rb2_rb5_v11.py::test_rb2_cleanup_never_force_deletes_or_removes_the_branch
1 failed, 14 passed in 0.84s
```

Rail merge approval pending: operator issues the pr-<N> receipt and adds the receipt trailer body trailer after review; the rail CI check stays red until then — expected.

Rail-Approval-Receipt: rail-approval-ae01bea8b8ee4111ae48869371c2619d
