### PR TITLE
fix(guards): merge-hook receipt fetch — repo-root sys.path + package-free client load (#5885)

### DIFF
--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -942,6 +942,8 @@ def _load_rail_path_guard():
         candidate = parent / "scripts" / "orchestration" / "rail_path_guard.py"
         if not candidate.is_file():
             continue
+        if str(parent) not in sys.path:
+            sys.path.insert(0, str(parent))
         spec = importlib.util.spec_from_file_location("rail_path_guard", candidate)
         if spec is None or spec.loader is None:
             return None

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -16,8 +16,11 @@ enforcement layer uses the same schema and binding rules.
 
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import re
+import sys
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -178,9 +181,23 @@ class RailApprovalReceiptStore(Protocol):
 
 def _monitor_api_get(path: str) -> tuple[int, str, Mapping[str, str]]:
     """Use the established Monitor client rather than a caller-chosen URL."""
-    from scripts.ai_agent_bridge.monitor_client import MonitorClient
 
-    return MonitorClient()._get(path)
+    bridge_dir = PROJECT_ROOT / "scripts" / "ai_agent_bridge"
+    package_name = "_rail_path_guard_monitor_client"
+    package_spec = importlib.machinery.ModuleSpec(package_name, loader=None, is_package=True)
+    package_spec.submodule_search_locations = [str(bridge_dir)]
+    package = importlib.util.module_from_spec(package_spec)
+    sys.modules[package_name] = package
+
+    client_name = f"{package_name}.monitor_client"
+    client_spec = importlib.util.spec_from_file_location(client_name, bridge_dir / "monitor_client.py")
+    if client_spec is None or client_spec.loader is None:
+        raise ImportError("could not load the Monitor client")
+    client_module = importlib.util.module_from_spec(client_spec)
+    sys.modules[client_name] = client_module
+    client_spec.loader.exec_module(client_module)
+
+    return client_module.MonitorClient()._get(path)
 
 
 class MonitorRailApprovalReceiptStore:

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -289,6 +289,67 @@ def test_pr_ref_requires_explicit_selector():
     assert guard._pr_ref(["5", "--squash"]) == "5"
 
 
+def test_hook_loader_reaches_default_receipt_store_from_outside_repo(tmp_path) -> None:
+    """The deployed hook must bootstrap its source root before loading the guard."""
+    receipt = {
+        "schema_version": "rail-approval-receipt.v1",
+        "receipt_id": _RECEIPT_ID,
+        "issuer": "advisor",
+        "issued_at": "2026-07-28T00:00:00Z",
+        "expires_at": "2099-07-30T00:00:00Z",
+        "action": "rail-path-mutation",
+        "task_id": "pr-5",
+        "head_sha": "a" * 40,
+        "owned_paths": ["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    }
+    script = f'''\
+import importlib.util
+import json
+import sys
+import urllib.request
+n=0
+repo_root = {str(REPO_ROOT)!r}
+sys.path[:] = [entry for entry in sys.path if entry != repo_root]
+spec = importlib.util.spec_from_file_location("guard_pr_merge_subprocess", {str(HOOK_PATH)!r})
+hook = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = hook
+spec.loader.exec_module(hook)
+rail_guard = hook._load_rail_path_guard()
+assert rail_guard is not None
+assert sys.path[0] == {str(REPO_ROOT)!r}
+class Response:
+    status = 200
+    headers = {{}}
+    def read(self):
+        return {json.dumps(json.dumps(receipt))}.encode("utf-8")
+    def __enter__(self):
+        return self
+    def __exit__(self, *_args):
+        return False
+def urlopen(request, timeout):
+    global n
+    n += 1
+    assert request.full_url.endswith("/api/rail-approvals/{_RECEIPT_ID}")
+    return Response()
+urllib.request.urlopen = urlopen
+store = rail_guard.MonitorRailApprovalReceiptStore()
+assert store.fetch_rail_approval_receipt({_RECEIPT_ID!r})["receipt_id"] == {_RECEIPT_ID!r}
+assert n == 1
+print("store-layer-reached")
+'''
+
+    result = subprocess.run(
+        [str(REPO_ROOT / ".venv" / "bin" / "python"), "-c", script],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "store-layer-reached"
+
+
 # --- main() decision (fail-closed) -----------------------------------------
 
 

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
+import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -222,6 +225,35 @@ def test_unreadable_receipt_store_fails_closed() -> None:
 
     with pytest.raises(guard.RailApprovalReceiptError, match="could not re-fetch"):
         resolver.fetch(RECEIPT_ID)
+
+
+def test_default_monitor_fetch_does_not_import_bridge_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The by-file client load preserves its relative import without bridge startup."""
+    package_name = "scripts.ai_agent_bridge"
+    monkeypatch.setitem(sys.modules, package_name, types.ModuleType(package_name))
+    monkeypatch.delitem(sys.modules, f"{package_name}.monitor_client", raising=False)
+
+    class Response:
+        status = 200
+
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def read(self) -> bytes:
+            return json.dumps(_receipt()).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> bool:
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+
+    receipt = guard.MonitorRailApprovalReceiptStore().fetch_rail_approval_receipt(RECEIPT_ID)
+
+    assert receipt["receipt_id"] == RECEIPT_ID
+    assert f"{package_name}.monitor_client" not in sys.modules
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Root causes

`guard-pr-merge.py:_load_rail_path_guard()` spec-loaded `rail_path_guard.py` without putting the discovered repository root on `sys.path`. Its default Monitor fetch then reached `_monitor_cache`'s `from scripts.common.repo_root import resolve_repo_root` without a resolvable `scripts` package.

`rail_path_guard._monitor_api_get()` also previously imported `MonitorClient` through `scripts.ai_agent_bridge`. That executes the bridge package `__init__`, which eagerly imports the agent-runtime tree before receipt retrieval.

This PR inserts the found root at `sys.path[0]` before executing the rail guard. It loads `monitor_client.py` by file path under the private `_rail_path_guard_monitor_client` synthetic package namespace, so its relative cache import still works while `scripts.ai_agent_bridge.__init__` never runs. Fetch failures remain fail-closed through the existing per-cause receipt error path; no allow path was added.

## Residual non-stdlib fetch dependencies

- `from . import _monitor_cache as cache`
- Transitively `from scripts.common.repo_root import resolve_repo_root`

No third-party dependency exists in the fetch subtree.

## Evidence (#M-4)

All commands ran from `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/rail-merge-hook-fetch`.

`sed -n '938,956p' agents_extensions/shared/hooks/guard-pr-merge.py` after the change:

```text
if str(parent) not in sys.path:
    sys.path.insert(0, str(parent))
spec = importlib.util.spec_from_file_location("rail_path_guard", candidate)
```

`sed -n '15,45p' scripts/ai_agent_bridge/monitor_client.py` showed:

```text
This is a pure-stdlib module — no httpx / requests dependency.
from . import _monitor_cache as cache
```

`sed -n '1,110p' scripts/ai_agent_bridge/_monitor_cache.py` showed the transitive project import:

```text
from scripts.common.repo_root import resolve_repo_root
```

`sed -n '1,120p' scripts/ai_agent_bridge/__init__.py` showed its eager re-exports, including:

```text
from ._broker import (...)
from ._claude import ask_claude, process_for_claude
from ._cli import interactive_mode, main, process_all_claude, process_all_gemini
from ._codex import ask_codex, process_all_codex, process_for_codex
```

```text
$ .venv/bin/python -m pytest tests/test_guard_pr_merge.py tests/test_rail_path_guard.py tests/test_rail_approval.py -q
242 passed, 1 warning in 2.02s

$ .venv/bin/ruff check agents_extensions/shared/hooks/guard-pr-merge.py scripts/orchestration/rail_path_guard.py tests/test_guard_pr_merge.py tests/test_rail_path_guard.py
All checks passed!

$ git diff --check
(exit 0; no output)

$ .venv/bin/python scripts/audit/lint_opsec_leaks.py --staged
Checking 4 files for OPSEC leaks (mode: staged git index (:path))...
OPSEC check passed. Zero leaks detected.

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:
8e2c4aedaa  PASS  X-Agent: codex/rail-merge-hook-fetch
All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Mutation evidence:

```text
$ .venv/bin/python -m pytest tests/test_guard_pr_merge.py::test_hook_loader_reaches_default_receipt_store_from_outside_repo -q
1 failed in 0.28s
```

This was run with the `sys.path.insert(0, str(parent))` mutation removed. Restored implementation passes and reaches the stubbed store layer from an outside-repository cwd.

```text
$ .venv/bin/python -m pytest tests/test_rail_path_guard.py::test_default_monitor_fetch_does_not_import_bridge_package -q
1 failed in 0.17s
```

This was run with the former `from scripts.ai_agent_bridge.monitor_client import MonitorClient` import restored. The poisoned bridge package prevents that import; restored implementation passes using the synthetic package.


This PR is the one advisor-ruled out-of-harness arming exception (Sol reply 6171 ruling b): after review + receipt + green CI the OPERATOR arms it directly; no agent may bypass the merge guard for it.

Refs #5885

Rail-Approval-Receipt: rail-approval-f3c74d6bebd641d39edddf13be3a7c9e

