### PR TITLE
fix(dispatch): bind rail admission and worktree creation to one immutable base SHA

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1136,6 +1136,7 @@ def _rail_path_admission_error(
     mode: str,
     owned_paths: Sequence[str] | None,
     receipt_id: str | None = None,
+    head_sha: str | None = None,
 ) -> str | None:
     """Return a P6 refusal before write-path ownership creates any state.
 
@@ -1154,23 +1155,25 @@ def _rail_path_admission_error(
             decide_rail_path_mutation_with_production_receipt,
         )
 
-    try:
-        head_sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=_REPO_ROOT,
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return f"❌ rail-path admission refused: cannot read current HEAD ({type(exc).__name__})"
-    if head_sha.returncode != 0:
-        return "❌ rail-path admission refused: cannot read current HEAD"
+    if head_sha is None:
+        try:
+            head_sha_proc = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=_REPO_ROOT,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return f"❌ rail-path admission refused: cannot read current HEAD ({type(exc).__name__})"
+        if head_sha_proc.returncode != 0:
+            return "❌ rail-path admission refused: cannot read current HEAD"
+        head_sha = head_sha_proc.stdout.strip()
     decision = decide_rail_path_mutation_with_production_receipt(
         task_id=task_id,
         candidate_paths=owned_paths or (),
-        head_sha=head_sha.stdout.strip(),
+        head_sha=head_sha,
         receipt_id=receipt_id,
     )
     if decision.allowed:
@@ -1192,6 +1195,32 @@ def _rail_path_admission_advisory(
     if mode in _WRITE_CAPABLE_MODES and not owned_paths:
         return RAIL_ADMISSION_NO_PATH_ADVISORY
     return None
+
+
+def _dispatch_is_receipt_bound(
+    *,
+    receipt_id: str | None,
+    owned_paths: Sequence[str] | None,
+) -> bool:
+    """Whether pre-admission worktree reuse must remain immutable.
+
+    A production receipt binds a precise worktree base, so its dispatch must
+    never rebase an existing checkout before rail admission. The same rule
+    applies to an explicitly declared rail path even before a receipt is
+    supplied: malformed candidates fail closed here and receive their precise
+    refusal from the admission guard later.
+    """
+    if receipt_id is not None:
+        return True
+    try:
+        from scripts.orchestration.rail_path_guard import rail_paths_from_candidates
+    except ImportError:  # pragma: no cover - flat script path
+        from orchestration.rail_path_guard import rail_paths_from_candidates  # type: ignore
+
+    try:
+        return bool(rail_paths_from_candidates(owned_paths or ()))
+    except ValueError:
+        return True
 
 
 def _with_rail_admission_state(
@@ -2429,6 +2458,64 @@ def _apply_dispatch_sparse_checkout(
     return telemetry
 
 
+def _resolve_worktree_base_sha(
+    *,
+    agent: str,
+    task_id: str,
+    raw_path: str,
+    base: str,
+    branch: str | None,
+    allow_rebase: bool = True,
+) -> str:
+    """Resolve one immutable base SHA before rail admission or creation.
+
+    A dispatch receipt and its worker must bind the same checkout state. This
+    helper performs moving-ref validation first, then returns the SHA passed to
+    both rail admission and :func:`_ensure_worktree`. The latter must not
+    fetch, rebase, or dereference a branch again when the SHA is supplied.
+    """
+    worktree_path = _normalize_worktree_path(raw_path)
+    requested_branch = _validate_branch_reuse_name(branch) if branch else None
+
+    if worktree_path.exists():
+        if not worktree_path.is_dir():
+            raise ValueError(f"worktree path exists but is not a directory: {worktree_path}")
+        _validate_existing_worktree(
+            path=worktree_path,
+            expected_branch=requested_branch or _derive_worktree_branch(agent, task_id),
+            base=requested_branch or base,
+            # Receipt-bound dispatches must leave a reused worktree untouched
+            # until admission succeeds. Ordinary follow-ups retain the
+            # established auto-rebase behavior.
+            allow_rebase=allow_rebase,
+        )
+        resolved = _resolve_sha(worktree_path)
+        if resolved is None:
+            raise RuntimeError(f"could not resolve HEAD for existing worktree {worktree_path}")
+        return resolved
+
+    if requested_branch:
+        _fetch_existing_branch(requested_branch)
+        return _require_local_branch_is_ancestor_of_origin(requested_branch)
+
+    origin_ref = _origin_base_ref(base)
+    if _fetch_base(base):
+        resolved = _resolve_sha(_REPO_ROOT, origin_ref)
+        if resolved is not None:
+            return resolved
+
+    branch_name = _base_branch_name(base)
+    raise RuntimeError(
+        f"could not fetch origin/{branch_name} and {origin_ref} is "
+        f"unresolvable — refusing to branch from possibly-stale local "
+        f"{branch_name}. Check connectivity and that "
+        "`git remote get-url origin` points at the canonical remote "
+        "(github.com:learn-ukrainian/learn-ukrainian.github.io), then "
+        f"run `git fetch origin {branch_name}` and retry the dispatch. "
+        "Do NOT use the primary checkout as a freshness source."
+    )
+
+
 def _ensure_worktree(
     *,
     agent: str,
@@ -2436,6 +2523,7 @@ def _ensure_worktree(
     raw_path: str,
     base: str = "main",
     branch: str | None = None,
+    resolved_base_sha: str | None = None,
     dry_run: bool = False,
     full_checkout: bool = False,
     sparse_include: Sequence[str] = (),
@@ -2465,8 +2553,9 @@ def _ensure_worktree(
     }
 
     if requested_branch:
-        _fetch_existing_branch(requested_branch)
-        _require_local_branch_is_ancestor_of_origin(requested_branch)
+        if resolved_base_sha is None:
+            _fetch_existing_branch(requested_branch)
+            _require_local_branch_is_ancestor_of_origin(requested_branch)
         occupied_paths = _branch_worktree_paths(requested_branch)
         elsewhere = [path for path in occupied_paths if path != worktree_path]
         if elsewhere:
@@ -2497,19 +2586,28 @@ def _ensure_worktree(
         if not worktree_path.is_dir():
             raise ValueError(f"worktree path exists but is not a directory: {worktree_path}")
         telemetry["reused"] = True
-        telemetry["rebased"] = _validate_existing_worktree(
-            path=worktree_path,
-            expected_branch=worktree_branch,
-            # For --branch reuse the staleness/fast-forward reference is the
-            # requested branch ITSELF (origin/<branch>), never origin/main: a
-            # follow-up worktree for an existing PR is almost always behind
-            # main (main moved since the PR branched), and validating against
-            # main would spuriously fail the dry-run or rebase a PR branch
-            # onto main as a validation side effect. (review-4905-grok)
-            base=requested_branch or base,
-            allow_rebase=not dry_run,
-        )
-        telemetry["base_sha"] = _resolve_sha(worktree_path)
+        if resolved_base_sha is None:
+            telemetry["rebased"] = _validate_existing_worktree(
+                path=worktree_path,
+                expected_branch=worktree_branch,
+                # For --branch reuse the staleness/fast-forward reference is the
+                # requested branch ITSELF (origin/<branch>), never origin/main: a
+                # follow-up worktree for an existing PR is almost always behind
+                # main (main moved since the PR branched), and validating against
+                # main would spuriously fail the dry-run or rebase a PR branch
+                # onto main as a validation side effect. (review-4905-grok)
+                base=requested_branch or base,
+                allow_rebase=not dry_run,
+            )
+        actual_sha = _resolve_sha(worktree_path)
+        if actual_sha is None:
+            raise RuntimeError(f"could not resolve HEAD for existing worktree {worktree_path}")
+        if resolved_base_sha is not None and actual_sha != resolved_base_sha:
+            raise WorktreeStaleBase(
+                "existing worktree HEAD changed after immutable-base resolution; "
+                f"expected {resolved_base_sha}, found {actual_sha}. Refusing worker spawn."
+            )
+        telemetry["base_sha"] = actual_sha
         if dry_run:
             return worktree_path, worktree_branch, telemetry
         # Reused worktrees may predate this provisioning hook; the helper is
@@ -2535,7 +2633,9 @@ def _ensure_worktree(
     # origin-prefixed ``base`` (``--base origin/main``, the mandated form)
     # fetches ``main`` and branches from ``origin/main`` — not the
     # unresolvable ``origin/origin/main``.
-    if requested_branch:
+    if resolved_base_sha is not None:
+        worktree_base_ref = resolved_base_sha
+    elif requested_branch:
         # Attach directly to the fetched PR/follow-up branch.  Never branch
         # from origin/main here: that was the follow-up-dispatch footgun.
         worktree_base_ref = requested_branch
@@ -2563,7 +2663,7 @@ def _ensure_worktree(
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
     add_command = ["git", "worktree", "add"]
-    if requested_branch:
+    if requested_branch and resolved_base_sha is None:
         # ``-B`` intentionally resets a behind local tracking ref to the SHA
         # fetched from origin. _require_local_branch_is_ancestor_of_origin()
         # already refused any local-only commits, and branch holders were
@@ -2577,6 +2677,10 @@ def _ensure_worktree(
                 f"origin/{requested_branch}",
             ]
         )
+    elif requested_branch:
+        # The branch was resolved before rail admission. Reset only to that
+        # immutable commit, never a ref that might move before creation.
+        add_command.extend(["-B", requested_branch, str(worktree_path), worktree_base_ref])
     else:
         add_command.extend(["-b", worktree_branch, str(worktree_path), worktree_base_ref])
     proc = subprocess.run(
@@ -2589,13 +2693,38 @@ def _ensure_worktree(
     if proc.returncode != 0:
         stderr = (proc.stderr or proc.stdout or "git worktree add failed").strip()
         raise RuntimeError(stderr)
+    actual_sha = _resolve_sha(worktree_path)
+    if actual_sha is None:
+        raise RuntimeError(f"could not resolve HEAD for created worktree {worktree_path}")
+    if resolved_base_sha is not None and actual_sha != resolved_base_sha:
+        raise WorktreeStaleBase(
+            "created worktree HEAD differs from immutable base; "
+            f"expected {resolved_base_sha}, found {actual_sha}. Refusing worker spawn."
+        )
+    telemetry["base_sha"] = actual_sha
+    if requested_branch and resolved_base_sha is not None:
+        # `git worktree add -B <branch> <path> <sha>` does not configure an
+        # upstream. Restore the tracking contract the non-SHA branch path
+        # gets from `--track`, after verifying the immutable checkout and
+        # before any provisioning or worker side effect.
+        upstream_proc = subprocess.run(
+            ["git", "branch", "--set-upstream-to", f"origin/{requested_branch}", requested_branch],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if upstream_proc.returncode != 0:
+            detail = (upstream_proc.stderr or upstream_proc.stdout or "git branch failed").strip()
+            raise RuntimeError(
+                f"could not configure upstream origin/{requested_branch} for {worktree_path}: {detail}"
+            )
     _provision_data_symlinks(worktree_path, _REPO_ROOT)
     telemetry["sparse"] = _apply_dispatch_sparse_checkout(
         worktree_path,
         full_checkout=full_checkout,
         sparse_include=sparse_include,
     )
-    telemetry["base_sha"] = _resolve_sha(worktree_path)
     return worktree_path, worktree_branch, telemetry
 
 
@@ -3571,83 +3700,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             )
             return 2
 
-    # P6 rail-path admission runs before the ownership ledger. A refusal must
-    # leave no task-state, worktree, branch, or claim residue for a rail write.
-    rail_admission_advisory = _rail_path_admission_advisory(
-        mode=str(args.mode),
-        owned_paths=getattr(args, "research_owned_path", None),
-    )
-    if rail_admission_advisory is not None:
-        print(rail_admission_advisory, file=sys.stderr)
-    rail_admission_error = _rail_path_admission_error(
-        task_id=task_id,
-        mode=str(args.mode),
-        owned_paths=getattr(args, "research_owned_path", None),
-        receipt_id=getattr(args, "rail_approval_receipt", None),
-    )
-    if rail_admission_error:
-        print(rail_admission_error, file=sys.stderr)
-        return 2
-
-    # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
-    # Runs before task-state write / worktree / branch side effects so a refuse
-    # leaves no residue. Read-only modes are exempt inside the helper.
-    # Dry-run must leave zero residue (same contract as tmp-lease reap) — skip
-    # the shared ownership ledger entirely (Claude CF #5649 r11).
-    if not bool(getattr(args, "dry_run", False)):
-        try:
-            from scripts.guardrails.delegate_ownership import (
-                GuardMode,
-                admit_write_paths,
-                env_guard_mode,
-            )
-        except ImportError:  # pragma: no cover - flat script path
-            from guardrails.delegate_ownership import (  # type: ignore
-                GuardMode,
-                admit_write_paths,
-                env_guard_mode,
-            )
-
-        guard_mode = env_guard_mode()
-        try:
-            ownership = admit_write_paths(
-                task_id=task_id,
-                mode=str(args.mode),
-                owned_paths=getattr(args, "research_owned_path", None),
-                allow_path_overlap=getattr(args, "allow_path_overlap", None),
-                pid=os.getpid(),
-                guard_mode=guard_mode,
-            )
-        except Exception as own_exc:
-            # WARN (opt-in via DELEGATE_OWNERSHIP_MODE=warn): never crash on ledger I/O.
-            # REFUSE (default after #5645): fail closed so conflicts cannot proceed.
-            print(
-                f"⚠️  write-path ownership: ledger error: {own_exc}",
-                file=sys.stderr,
-            )
-            if guard_mode == GuardMode.REFUSE:
-                print(
-                    f"❌ write-path ownership refused (ledger error) for task_id={task_id!r}",
-                    file=sys.stderr,
-                )
-                return 2
-        else:
-            if ownership.would_refuse or ownership.override_reason:
-                # Only report a conflict count when there ARE conflicts: an
-                # unprovable-disjointness refusal has none, and printing
-                # "conflicts=0" next to it reads as a guard bug (#5340-adjacent).
-                suffix = f" (conflicts={len(ownership.conflicts)})" if ownership.conflicts else ""
-                print(
-                    f"⚠️  write-path ownership: {ownership.reason}{suffix}",
-                    file=sys.stderr,
-                )
-            if not ownership.admitted:
-                print(
-                    f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
-                    file=sys.stderr,
-                )
-                return 2
-
     # Resolve prompt: literal --prompt, or - for stdin, or --prompt-file.
     if args.prompt_file:
         prompt = Path(args.prompt_file).read_text()
@@ -3713,6 +3765,113 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"❌ invalid --output-schema: {exc}", file=sys.stderr)
         return 2
 
+    # Resolve once before rail admission. Fetching or rebasing after receipt
+    # validation could detach the worker's actual HEAD from the approved base.
+    # Only a receipt-bound rail dispatch forbids the established reuse-rebase
+    # behavior during this pre-resolution step.
+    resolved_worktree_base_sha: str | None = None
+    resolved_worktree_raw: str | None = None
+    receipt_bound_dispatch = _dispatch_is_receipt_bound(
+        receipt_id=getattr(args, "rail_approval_receipt", None),
+        owned_paths=getattr(args, "research_owned_path", None),
+    )
+    if worktree_arg:
+        resolved_worktree_raw = (
+            str(_auto_worktree_path(dispatch_agent, task_id))
+            if worktree_arg == "auto"
+            else worktree_arg
+        )
+        try:
+            resolved_worktree_base_sha = _resolve_worktree_base_sha(
+                agent=dispatch_agent,
+                task_id=task_id,
+                raw_path=resolved_worktree_raw,
+                base=getattr(args, "base", None) or "main",
+                branch=requested_branch,
+                allow_rebase=not bool(getattr(args, "dry_run", False)) and not receipt_bound_dispatch,
+            )
+        except (ValueError, RuntimeError) as exc:
+            print(f"❌ failed to resolve immutable worktree base for {task_id!r}: {exc}", file=sys.stderr)
+            return 1
+
+    # P6 rail-path admission runs before the ownership ledger. A refusal must
+    # leave no task-state, worktree, branch, or claim residue for a rail write.
+    rail_admission_advisory = _rail_path_admission_advisory(
+        mode=str(args.mode),
+        owned_paths=getattr(args, "research_owned_path", None),
+    )
+    if rail_admission_advisory is not None:
+        print(rail_admission_advisory, file=sys.stderr)
+    rail_admission_error = _rail_path_admission_error(
+        task_id=task_id,
+        mode=str(args.mode),
+        owned_paths=getattr(args, "research_owned_path", None),
+        receipt_id=getattr(args, "rail_approval_receipt", None),
+        head_sha=resolved_worktree_base_sha,
+    )
+    if rail_admission_error:
+        print(rail_admission_error, file=sys.stderr)
+        return 2
+
+    # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
+    # Runs before task-state write / worktree / branch side effects so a refuse
+    # leaves no residue. Read-only modes are exempt inside the helper.
+    # Dry-run must leave zero residue (same contract as tmp-lease reap) — skip
+    # the shared ownership ledger entirely (Claude CF #5649 r11).
+    if not bool(getattr(args, "dry_run", False)):
+        try:
+            from scripts.guardrails.delegate_ownership import (
+                GuardMode,
+                admit_write_paths,
+                env_guard_mode,
+            )
+        except ImportError:  # pragma: no cover - flat script path
+            from guardrails.delegate_ownership import (  # type: ignore
+                GuardMode,
+                admit_write_paths,
+                env_guard_mode,
+            )
+
+        guard_mode = env_guard_mode()
+        try:
+            ownership = admit_write_paths(
+                task_id=task_id,
+                mode=str(args.mode),
+                owned_paths=getattr(args, "research_owned_path", None),
+                allow_path_overlap=getattr(args, "allow_path_overlap", None),
+                pid=os.getpid(),
+                guard_mode=guard_mode,
+            )
+        except Exception as own_exc:
+            # WARN (opt-in via DELEGATE_OWNERSHIP_MODE=warn): never crash on ledger I/O.
+            # REFUSE (default after #5645): fail closed so conflicts cannot proceed.
+            print(
+                f"⚠️  write-path ownership: ledger error: {own_exc}",
+                file=sys.stderr,
+            )
+            if guard_mode == GuardMode.REFUSE:
+                print(
+                    f"❌ write-path ownership refused (ledger error) for task_id={task_id!r}",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            if ownership.would_refuse or ownership.override_reason:
+                # Only report a conflict count when there ARE conflicts: an
+                # unprovable-disjointness refusal has none, and printing
+                # "conflicts=0" next to it reads as a guard bug (#5340-adjacent).
+                suffix = f" (conflicts={len(ownership.conflicts)})" if ownership.conflicts else ""
+                print(
+                    f"⚠️  write-path ownership: {ownership.reason}{suffix}",
+                    file=sys.stderr,
+                )
+            if not ownership.admitted:
+                print(
+                    f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
+                    file=sys.stderr,
+                )
+                return 2
+
     if getattr(args, "dry_run", False):
         dry_run_worktree: Path | None = None
         dry_run_branch: str | None = None
@@ -3731,6 +3890,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                     raw_path=resolved_raw,
                     base=getattr(args, "base", None) or "main",
                     branch=requested_branch,
+                    resolved_base_sha=resolved_worktree_base_sha,
                     dry_run=True,
                     full_checkout=full_checkout,
                     sparse_include=sparse_include,
@@ -3848,6 +4008,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 raw_path=resolved_raw,
                 base=getattr(args, "base", None) or "main",
                 branch=requested_branch,
+                resolved_base_sha=resolved_worktree_base_sha,
                 full_checkout=full_checkout,
                 sparse_include=sparse_include,
             )

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2873,10 +2873,10 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, tmp_path, monke
     # At minimum: git fetch + git rev-parse --verify + git worktree add + git rev-parse HEAD.
     assert any(c[:3] == ["git", "worktree", "add"] for c in calls)
     assert any(c[:2] == ["git", "fetch"] for c in calls)
-    # Fix 1: the worktree add MUST branch from origin/main, not local main.
+    # Rail admission and worktree creation share one immutable resolved SHA.
     add_cmd = next(c for c in calls if c[:3] == ["git", "worktree", "add"])
-    assert add_cmd[-1] == "origin/main", (
-        f"worktree must be created from origin/main, got base={add_cmd[-1]!r}"
+    assert add_cmd[-1] == "deadbeef", (
+        f"worktree must be created from the resolved SHA, got base={add_cmd[-1]!r}"
     )
     captured = capsys.readouterr()
     assert "issue-1383-smoke" in captured.out
@@ -2912,11 +2912,10 @@ def test_fetch_base_plain_branch_unchanged(monkeypatch):
     assert fetch_cmd == ["git", "fetch", "origin", "main"]
 
 
-def test_dispatch_origin_prefixed_base_branches_from_remote_ref(
+def test_dispatch_origin_prefixed_base_resolves_remote_ref_to_immutable_sha(
     tmp_tasks_dir, tmp_path, monkeypatch, capsys
 ):
-    """base="origin/main" must produce `worktree add ... origin/main`,
-    never the unresolvable `origin/origin/main`."""
+    """base="origin/main" must fetch that ref and create from its SHA."""
     import argparse
 
     class _FakeStdin:
@@ -2953,8 +2952,8 @@ def test_dispatch_origin_prefixed_base_branches_from_remote_ref(
     fetch_cmd = next(c for c in calls if c[:2] == ["git", "fetch"])
     assert fetch_cmd == ["git", "fetch", "origin", "main"]
     add_cmd = next(c for c in calls if c[:3] == ["git", "worktree", "add"])
-    assert add_cmd[-1] == "origin/main", (
-        f"worktree must be created from origin/main, got base={add_cmd[-1]!r}"
+    assert add_cmd[-1] == "feedc0de", (
+        f"worktree must use the resolved SHA, got base={add_cmd[-1]!r}"
     )
 
 

--- a/tests/test_delegate_rail_path_admission.py
+++ b/tests/test_delegate_rail_path_admission.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
@@ -13,6 +16,129 @@ import delegate
 
 from scripts.orchestration import rail_approval
 from scripts.orchestration import rail_path_guard as guard
+
+RAIL_PATH = "agents_extensions/shared/hooks/guard-pr-merge.py"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    # The agent-runtime Git shim rejects pushes to `main` when its
+    # AGENT_NO_MERGE guard is inherited. These fixtures push disposable
+    # scratch repos and must not inherit that ambient policy.
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.pop("AGENT_NO_MERGE", None)
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True, env=environment
+    ).stdout.strip()
+
+
+def _make_remote_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    """Return a primary clone whose HEAD lags the canonical origin/main."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    primary = tmp_path / "primary"
+    subprocess.run(["git", "clone", str(origin), str(primary)], check=True, capture_output=True)
+    _git(primary, "config", "user.email", "test@example.com")
+    _git(primary, "config", "user.name", "Test")
+    (primary / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+    (primary / "tracked.txt").write_text("initial\n", encoding="utf-8")
+    _git(primary, "add", ".gitignore", "tracked.txt")
+    _git(primary, "commit", "-m", "initial")
+    _git(primary, "branch", "-M", "main")
+    _git(primary, "push", "-u", "origin", "main")
+    old_sha = _git(primary, "rev-parse", "HEAD")
+
+    writer = tmp_path / "writer"
+    subprocess.run(["git", "clone", str(origin), str(writer)], check=True, capture_output=True)
+    _git(writer, "config", "user.email", "test@example.com")
+    _git(writer, "config", "user.name", "Test")
+    _git(writer, "checkout", "main")
+    (writer / "tracked.txt").write_text("remote advance\n", encoding="utf-8")
+    _git(writer, "commit", "-am", "remote advance")
+    _git(writer, "push", "origin", "main")
+    return primary, writer, old_sha, _git(writer, "rev-parse", "HEAD")
+
+
+class _FakeStdin:
+    def write(self, _data: bytes) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeWorker:
+    pid = 424242
+    stdin = _FakeStdin()
+
+
+def _patch_worker_spawn(monkeypatch) -> list[list[str]]:
+    """Record workers while retaining the real subprocess path for git."""
+    spawned: list[list[str]] = []
+    real_popen = delegate.subprocess.Popen
+
+    def fake_popen(cmd, *args, **kwargs):
+        if cmd and str(cmd[0]) == "git":
+            return real_popen(cmd, *args, **kwargs)
+        spawned.append(list(cmd))
+        return _FakeWorker()
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+    return spawned
+
+
+def _worker_spawns(spawned: list[list[str]]) -> list[list[str]]:
+    """Exclude the dispatch telemetry CLI-version probe from worker evidence."""
+    return [command for command in spawned if "_worker" in command]
+
+
+def _dispatch_args(
+    *,
+    task_id: str,
+    worktree: Path,
+    receipt_id: str | None = None,
+    branch: str | None = None,
+    owned_paths: tuple[str, ...] = (RAIL_PATH,),
+):
+    command = [
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        task_id,
+        "--prompt",
+        "fixture",
+        "--mode",
+        "workspace-write",
+        "--worktree",
+        str(worktree),
+    ]
+    for owned_path in owned_paths:
+        command.extend(["--research-owned-path", owned_path])
+    if receipt_id:
+        command.extend(["--rail-approval-receipt", receipt_id])
+    if branch:
+        command.extend(["--branch", branch])
+    return delegate.build_parser().parse_args(command)
+
+
+def _prepare_dispatch_fixture(monkeypatch, tmp_path: Path, primary: Path) -> None:
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(delegate, "_warn_if_monitor_api_unreachable", lambda: None)
+    monkeypatch.setattr(delegate, "_check_capacity_hint", lambda *_args, **_kwargs: None)
+    for key in tuple(os.environ):
+        if key.startswith(("GIT_", "PRE_COMMIT")):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _receipt(task_id: str, head_sha: str) -> dict[str, object]:
+    return rail_approval.create_rail_approval_receipt(
+        task_id=task_id,
+        head_sha=head_sha,
+        owned_paths=[RAIL_PATH],
+        issuer="operator",
+        ttl_hours=1,
+    )
 
 
 def test_dispatch_admission_refuses_rail_claim_before_ownership_ledger() -> None:
@@ -132,3 +258,292 @@ def test_dispatch_admission_refetches_a_valid_production_receipt(
     )
 
     assert error is None
+
+
+def test_dispatch_fresh_worktree_admits_receipt_bound_to_fetched_origin_tip(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """cmd_dispatch admits the fetched origin/main SHA, not primary HEAD."""
+    primary, _writer, primary_sha, origin_sha = _make_remote_fixture(tmp_path)
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "rail-fresh-origin-tip"
+    receipt = _receipt(task_id, origin_sha)
+    monkeypatch.setattr(guard, "_monitor_api_get", lambda _path: (200, json.dumps(receipt), {}))
+
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+    assert (
+        delegate.cmd_dispatch(
+            _dispatch_args(task_id=task_id, worktree=worktree, receipt_id=receipt["receipt_id"])
+        )
+        == 0
+    )
+
+    assert primary_sha != origin_sha
+    assert _git(worktree, "rev-parse", "HEAD") == origin_sha
+    assert len(_worker_spawns(spawned)) == 1
+
+
+def test_dispatch_branch_admits_receipt_bound_to_branch_tip_not_primary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Follow-up admission binds the fetched branch tip despite a different primary."""
+    primary, writer, primary_sha, _origin_sha = _make_remote_fixture(tmp_path)
+    branch = "codex/rail-follow-up"
+    _git(writer, "checkout", "-b", branch)
+    (writer / "branch.txt").write_text("branch tip\n", encoding="utf-8")
+    _git(writer, "add", "branch.txt")
+    _git(writer, "commit", "-m", "branch tip")
+    _git(writer, "push", "-u", "origin", branch)
+    branch_sha = _git(writer, "rev-parse", "HEAD")
+
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "rail-branch-tip"
+    receipt = _receipt(task_id, branch_sha)
+    monkeypatch.setattr(guard, "_monitor_api_get", lambda _path: (200, json.dumps(receipt), {}))
+
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+    assert (
+        delegate.cmd_dispatch(
+            _dispatch_args(
+                task_id=task_id,
+                worktree=worktree,
+                receipt_id=receipt["receipt_id"],
+                branch=branch,
+            )
+        )
+        == 0
+    )
+
+    assert primary_sha != branch_sha
+    assert _git(worktree, "rev-parse", "HEAD") == branch_sha
+    assert _git(worktree, "rev-parse", "--abbrev-ref", "@{upstream}") == f"origin/{branch}"
+    assert len(_worker_spawns(spawned)) == 1
+
+
+def test_dispatch_refuses_receipt_bound_to_wrong_base_before_worker_spawn(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    primary, _writer, primary_sha, _origin_sha = _make_remote_fixture(tmp_path)
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "rail-wrong-base"
+    receipt = _receipt(task_id, primary_sha)
+    monkeypatch.setattr(guard, "_monitor_api_get", lambda _path: (200, json.dumps(receipt), {}))
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+
+    assert (
+        delegate.cmd_dispatch(
+            _dispatch_args(task_id=task_id, worktree=worktree, receipt_id=receipt["receipt_id"])
+        )
+        == 2
+    )
+
+    assert "rail_approval_head_mismatch" in capsys.readouterr().err
+    assert _worker_spawns(spawned) == []
+    assert not worktree.exists()
+
+
+def test_dispatch_refuses_worker_spawn_when_created_head_differs_from_resolved_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Post-create verification fails before sparse provisioning or Popen."""
+    calls: list[list[str]] = []
+    resolved_sha = "a" * 40
+    created_sha = "b" * 40
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"]:
+            ref = cmd[-1]
+            if ref == "origin/main" or "--verify" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, resolved_sha, "")
+            return subprocess.CompletedProcess(cmd, 0, created_sha, "")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(delegate, "_resolve_write_cwd_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_resolve_dirty_primary_checkout_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_resolve_primary_integrity_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_warn_if_monitor_api_unreachable", lambda: None)
+    monkeypatch.setattr(delegate, "_check_capacity_hint", lambda *_args, **_kwargs: None)
+    spawned = _patch_worker_spawn(monkeypatch)
+    worktree = tmp_path / "worktree"
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "head-verify",
+            "--prompt",
+            "fixture",
+            "--mode",
+            "workspace-write",
+            "--worktree",
+            str(worktree),
+        ]
+    )
+
+    assert delegate.cmd_dispatch(args) == 1
+
+    assert _worker_spawns(spawned) == []
+    assert not any(cmd[:2] == ["git", "sparse-checkout"] for cmd in calls)
+
+
+def test_reused_stale_worktree_refuses_without_rebase_before_admission(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Receipt rejection cannot be preceded by a reuse-rebase side effect."""
+    worktree = tmp_path / "existing"
+    worktree.mkdir()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "rev-parse"]:
+            if "--abbrev-ref" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "codex/stale\n", "")
+            return subprocess.CompletedProcess(cmd, 0, "a" * 40, "")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "fetch"] or "--verify" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-list"]:
+            return subprocess.CompletedProcess(cmd, 0, "1\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeStaleBase):
+        delegate._resolve_worktree_base_sha(
+            agent="codex",
+            task_id="stale",
+            raw_path=str(worktree),
+            base="main",
+            branch=None,
+            allow_rebase=False,
+        )
+
+    assert not any(cmd[:2] == ["git", "rebase"] for cmd in calls)
+
+
+def test_worktree_creation_uses_resolved_sha_after_remote_ref_moves(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A remote push after resolution cannot change the created worktree base."""
+    primary, writer, _primary_sha, initial_origin_sha = _make_remote_fixture(tmp_path)
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / "frozen-base"
+    resolved_sha = delegate._resolve_worktree_base_sha(
+        agent="codex",
+        task_id="frozen-base",
+        raw_path=str(worktree),
+        base="main",
+        branch=None,
+    )
+    assert resolved_sha == initial_origin_sha
+
+    _git(writer, "checkout", "main")
+    (writer / "tracked.txt").write_text("moves again\n", encoding="utf-8")
+    _git(writer, "commit", "-am", "move remote after resolution")
+    _git(writer, "push", "origin", "main")
+    moved_sha = _git(writer, "rev-parse", "HEAD")
+
+    created, _branch, telemetry = delegate._ensure_worktree(
+        agent="codex",
+        task_id="frozen-base",
+        raw_path=str(worktree),
+        base="main",
+        resolved_base_sha=resolved_sha,
+    )
+
+    assert moved_sha != resolved_sha
+    assert _git(created, "rev-parse", "HEAD") == resolved_sha
+    assert telemetry["base_sha"] == resolved_sha
+
+
+def test_dispatch_branch_occupancy_refuses_with_pre_resolved_sha(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """cmd_dispatch reaches the unconditional #5340 occupancy guard."""
+    primary, writer, _primary_sha, _origin_sha = _make_remote_fixture(tmp_path)
+    branch = "codex/occupied-follow-up"
+    _git(writer, "checkout", "-b", branch)
+    _git(writer, "push", "-u", "origin", branch)
+    branch_sha = _git(writer, "rev-parse", "HEAD")
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "rail-occupied-branch"
+    receipt = _receipt(task_id, branch_sha)
+    monkeypatch.setattr(guard, "_monitor_api_get", lambda _path: (200, json.dumps(receipt), {}))
+    occupied = tmp_path / "occupied"
+    occupied.mkdir()
+    monkeypatch.setattr(delegate, "_branch_worktree_paths", lambda _branch: [occupied])
+    monkeypatch.setattr(delegate, "_release_stale_branch_holders", lambda **_kwargs: [])
+
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+    assert (
+        delegate.cmd_dispatch(
+            _dispatch_args(
+                task_id=task_id,
+                worktree=worktree,
+                receipt_id=receipt["receipt_id"],
+                branch=branch,
+            )
+        )
+        == 1
+    )
+
+    assert _worker_spawns(spawned) == []
+    assert not worktree.exists()
+
+
+def test_dispatch_reused_stale_worktree_without_receipt_rebases_and_dispatches(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Ordinary reused worktrees retain the pre-receipt auto-rebase behavior."""
+    primary, _writer, primary_sha, origin_sha = _make_remote_fixture(tmp_path)
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "reuse-no-receipt"
+    branch = f"codex/{task_id}"
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+    worktree.parent.mkdir(parents=True)
+    _git(primary, "worktree", "add", "-b", branch, str(worktree), primary_sha)
+
+    assert delegate.cmd_dispatch(
+        _dispatch_args(task_id=task_id, worktree=worktree, owned_paths=())
+    ) == 0
+
+    assert _git(worktree, "rev-parse", "HEAD") == origin_sha
+    assert len(_worker_spawns(spawned)) == 1
+
+
+def test_dispatch_receipt_bound_stale_reuse_refuses_without_rebase_or_spawn(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A receipt-bound stale reuse fails before admission can mutate its HEAD."""
+    primary, _writer, primary_sha, origin_sha = _make_remote_fixture(tmp_path)
+    _prepare_dispatch_fixture(monkeypatch, tmp_path, primary)
+    spawned = _patch_worker_spawn(monkeypatch)
+    task_id = "reuse-receipt-bound"
+    branch = f"codex/{task_id}"
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / task_id
+    worktree.parent.mkdir(parents=True)
+    _git(primary, "worktree", "add", "-b", branch, str(worktree), primary_sha)
+    receipt = _receipt(task_id, origin_sha)
+    monkeypatch.setattr(guard, "_monitor_api_get", lambda _path: (200, json.dumps(receipt), {}))
+
+    assert delegate.cmd_dispatch(
+        _dispatch_args(task_id=task_id, worktree=worktree, receipt_id=receipt["receipt_id"])
+    ) == 1
+
+    assert _git(worktree, "rev-parse", "HEAD") == primary_sha
+    assert _worker_spawns(spawned) == []


### PR DESCRIPTION
Refs #5885

## Summary

- Resolves one immutable dispatch base SHA and passes it to both receipt admission and worktree preparation.
- Creates and verifies new worktrees at that SHA before provisioning; receipt-bound stale reuse now refuses untouched, while ordinary reuse retains auto-rebase.
- Keeps pre-resolved branch occupancy checks unconditional and restores `origin/<branch>` tracking after SHA-based branch creation.

## Verification evidence

```text
$ .venv/bin/python -m ruff check scripts/delegate.py tests/test_delegate.py tests/test_delegate_rail_path_admission.py
All checks passed!

$ .venv/bin/python -m pytest -q tests/test_delegate.py tests/test_delegate_rail_path_admission.py tests/api/test_release_snapshot.py
collected 215 items
215 passed in 23.59s

$ .venv/bin/python scripts/audit/lint_opsec_leaks.py --staged
🔒 Checking 3 files for OPSEC leaks (mode: staged git index (:path))...
✅ OPSEC check passed. Zero leaks detected.

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  1a68d214ae  PASS  X-Agent: codex/fix-rail-admission-base-sha

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Mutation checks

```text
$ [temporarily remove `head_sha=resolved_worktree_base_sha`] && .venv/bin/python -m pytest -q tests/test_delegate_rail_path_admission.py::test_dispatch_fresh_worktree_admits_receipt_bound_to_fetched_origin_tip tests/test_delegate_rail_path_admission.py::test_dispatch_branch_admits_receipt_bound_to_branch_tip_not_primary
collected 2 items
FF
rail_approval_head_mismatch

$ [temporarily nest the requested-branch occupancy block under `resolved_base_sha is None`] && .venv/bin/python -m pytest -q tests/test_delegate_rail_path_admission.py::test_dispatch_branch_occupancy_refuses_with_pre_resolved_sha
collected 1 item
F
AssertionError: assert 0 == 1
```

No auto-merge requested.

Rail-Approval-Receipt: rail-approval-d956425f2c8044119651405e800f874b
