### PR TITLE
docs(ua-eval): publish contamination policy in English and ban hybrid prose

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,6 +136,18 @@ repos:
         files: ^site/src/content/docs/.*\.mdx$
         stages: [pre-commit]
 
+      - id: check-ua-eval-public-doc-language
+        name: check public UA-eval English document language
+        entry: >-
+          bash scripts/pre_commit/project_python.sh
+          scripts/audit/check_ua_eval_public_doc_language.py --files
+        language: system
+        files: >-
+          (?x)^docs/projects/ua-eval-harness/
+          (DATA_CARD\.en|README|REPRODUCING|THIRD_PARTY_NOTICES|
+          contamination-policy)\.md$
+        stages: [pre-commit]
+
       - id: check-mdx-forward-parity
         name: check forward MDX parity
         entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_mdx_forward_parity.py --files

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -216,7 +216,7 @@ offline:
 .venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py
 ```
 
-The Ukrainian-first
+The English
 [contamination policy](contamination-policy.md) documents the complete leakage
 disclosure, train-fixture separation, prohibited product/training reuse, and
 semantic version-bump rules. Frozen bytes are never edited in place.

--- a/docs/projects/ua-eval-harness/contamination-policy.md
+++ b/docs/projects/ua-eval-harness/contamination-policy.md
@@ -1,120 +1,127 @@
-# Політика замороження й запобігання витоку
+# Release freeze and contamination policy
 
-Ця політика стосується публічного оцінювання виправлень українських кальок і
-граматики `ua-gec-calque-grammar-public-v0` версії `0.1.0`. Вона не поширює
-оцінювальний набір на продукти, навчальні корпуси чи інші дослідницькі задачі.
+This policy applies to release `ua-gec-calque-grammar-public-v0`, semantic
+version `0.1.0`. It does not authorize reuse of the evaluation set in products,
+training corpora, or unrelated research tasks.
 
-## Заморожений склад
+## Frozen release contents
 
-Єдиним машинним реєстром релізу є
-`data/projects/ua_eval_harness/releases/v0.1.0/freeze_manifest.json`. Він
-фіксує SHA-256 для:
+The machine-readable release record is
+`data/projects/ua_eval_harness/releases/v0.1.0/freeze_manifest.json`. It records
+SHA-256 hashes for:
 
-- конфігурації й маніфесту вибірки, окремого disposition-маніфесту для
-  calque scoring та його конфігурації;
-- інструкції, схеми відповіді, екстрактора, оцінювача й необов'язкового
-  провайдерного запускатора;
-- VESUM source lock, marker parser і builder benchmark-dispositions;
-- пакета запитів, усіх збережених відповідей і агрегованих звітів трьох
-  базових систем;
-- 52 тренувальних прикладів, які дозволено використовувати лише як
-  development-fixtures і які не входять до held-out результатів.
+- the dataset configuration and manifest;
+- the separate calque scoring-disposition manifest and its configuration;
+- the task instruction, output schema, extractor, scorer, and optional
+  provider runner;
+- the VESUM source lock, marker parser, and scoring-disposition builder;
+- the source-only request packet, saved responses, and aggregate reports for
+  all three baselines;
+- 52 training-derived examples that may be used only as development fixtures
+  and do not contribute to held-out results.
 
-Перевірка не потребує мережі або провайдерних ключів:
+Verification requires neither network access nor provider credentials:
 
 ```bash
 .venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py
 ```
 
-Будь-яка невідповідність байтів, метаданих запуску, prompt/scorer receipt,
-покриття відповідей або політики агрегованих звітів завершує перевірку
-помилкою.
+The verifier fails if it finds a mismatch in artifact bytes, run metadata,
+prompt or scorer receipts, response coverage, or aggregate-report policy.
 
-## Цілісність поділу
+## Split integrity
 
-Джерелом є UA-GEC 2.0 на commit
-`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`. Хеші `LICENSE`, `README.md`,
-`data/metadata.csv` і `gec-fluency.test.m2` зафіксовано в freeze manifest.
+The source is UA-GEC 2.0 at commit
+`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`. The freeze records hashes for
+`LICENSE`, `README.md`, `data/metadata.csv`, and
+`data/gec-fluency/test/gec-fluency.test.m2`.
 
-Екстрактор перевіряє, що:
+The extractor verifies that:
 
-1. кожен document ID у metadata унікальний і має рівно один partition;
-2. множина документів у test M2 точно дорівнює множині test-документів у
-   metadata;
-3. автори train і test не перетинаються;
-4. усі 2 690 test-речень мають disposition: 677 включено, 2 013 виключено.
+1. every document ID in the metadata is unique and belongs to exactly one
+   partition;
+2. the document set in the test M2 file exactly matches the metadata's test
+   partition;
+3. the training and test partitions have no authors in common;
+4. all 2,690 test sentences have a disposition: 677 included and 2,013
+   excluded.
 
-Отже, перетин train/test становить нуль і на рівні авторів, і на рівні
-документів. 52 старі development-fixtures походять із train і залишаються
-окремими від held-out оцінювання.
+The training and test partitions therefore have zero author overlap and zero
+document overlap. The 52 development fixtures come from the training
+partition and remain separate from the held-out evaluation.
 
-## UA-GEC label і benchmark disposition
+## Upstream labels and benchmark dispositions
 
-`F/Calque` зберігається без змін як upstream label стандартизації UA-GEC. Це
-не є автоматичним твердженням нашого benchmark, що кожна початкова форма —
-калька. Окремий `scoring_dispositions_v1.json` містить рішення й причину для
-всіх 354 annotator-level edits.
+The release preserves `F/Calque` unchanged as an upstream UA-GEC
+standardization label. The label alone does not assert that every original
+form is a calque under this benchmark. A separate
+`scoring_dispositions_v1.json` records the decision and reason for all 354
+annotator-level edits.
 
-Відтворюваний exact-style probe використовує зафіксований dict_uk/VESUM
-`v6.8.0`. Серед 293 унікальних `F/Calque` spans він фіксує 49 style-marker
-collisions: 34 `bad`, 10 `slang`, 3 `arch`, 2 `rare`. Окремого `dial` token у
-цьому джерелі немає; офіційна семантика `arch` охоплює застаріле, архаїчне й
-інколи діалектне вживання. Тому реліз не заявляє «нуль діалектних
-конфліктів».
+The reproducible surface-form probe uses the pinned dict_uk/VESUM v6.8.0
+release, which was the latest stable upstream release available when public v0
+was frozen. Across 293 unique `F/Calque` spans, the probe finds 49 collisions
+with style markers: 34 `bad`, 10 `slang`, 3 `arch`, and 2 `rare`. The source
+does not provide a dedicated `dial` token. Its published `arch` semantics
+cover obsolete and archaic usage and may also cover dialectal usage. The
+benchmark therefore does not claim that there are zero dialect conflicts.
 
-Headline calque recall включає 338 annotations. Ще 16 не входять до headline:
-3 register-standardization, 2 heritage-conflict і 11 contested. Attestation
-або marker є evidence, а не готовим contextual adjudication. Випадки
-`тьоті`, `кришею`, `рижого`, `Спікери` та false surface collision `була`
-зафіксовано окремими regression receipts. Повну активацію marker-aware
-contextual policy відстежує #5092; п'ятислівний prototype seed не
-використовується.
+Headline calque recall includes 338 annotations. The remaining 16 are outside
+the headline metric: 3 register-standardization cases, 2 heritage conflicts,
+and 11 contested cases. Attestation or a style marker is evidence, not a
+complete contextual decision. The release records separate regression
+receipts for `тьоті`, `кришею`, `рижого`, `Спікери`, and the false
+surface-form collision `була`. Issue #5092 tracks the complete marker-aware
+contextual policy. The five-word prototype seed is not used.
 
-## Відомі контакти з даними
+## Known contact with evaluation data
 
-- Публічна інструкція не містить прикладів.
-- Детермінована literal-rule baseline будує правила лише з 52 train-derived
-  development-fixtures. Це навмисно слабка діагностична baseline, не
-  held-out-навчання.
-- Перед повним запуском дві source-only позиції було використано для
-  транспортної перевірки. Після неї уточнено лише вимогу зберігати пробіли й
-  пунктуацію. Gold-відповіді, edits і scores не переглядалися.
-- Реальну модель обрано за наперед чинним operator routing, а не за
-  результатами цього benchmark.
-- Під час генерації моделі передавалися тільки ID, source, source hash і
-  prompt hash. Gold targets, references, edits та score були відсутні.
+- The public task instruction contains no examples.
+- The deterministic literal-rule baseline derives rules only from the 52
+  training-derived development fixtures. It is an intentionally weak
+  diagnostic baseline, not training on the held-out set.
+- Two source-only items were used for a transport check before the complete
+  run. That check led only to a clarification that spaces and punctuation must
+  be preserved. Gold responses, edits, and scores were not inspected.
+- The real model was selected through the pre-existing operator routing policy,
+  not in response to benchmark results.
+- Generation requests contained only the item ID, source sentence, source
+  hash, and prompt hash. They did not contain gold targets, references, edits,
+  or scores.
 
-## Заборонене повторне використання
+## Prohibited reuse
 
-Публічні source, gold, IDs, hashes і похідні правила цього held-out набору
-заборонено додавати до:
+Public source sentences, gold corrections, IDs, hashes, and derived rules from
+this held-out set must not be added to:
 
-- Daily Practice або іншого learner-exercise inventory;
-- будь-якого training, fine-tuning, synthetic-data, preference-data чи DPO
-  inventory;
-- Hramatka, teacher-feedback або приватних regression/canary наборів;
-- Atlas чи іншого приватного продуктового стану.
+- Daily Practice or any other learner-exercise inventory;
+- training, fine-tuning, synthetic-data, preference-data, or DPO datasets;
+- Hramatka, teacher-feedback data, or private regression and canary sets;
+- Atlas or any other private product state.
 
-Збіг, знайдений після замороження, є contamination incident. Такий реліз не
-можна мовчки «виправити»: потрібні окремий incident record, нова версія,
-повторна екстракція, нові baselines і новий freeze manifest.
+A match discovered after the release freeze is a contamination incident. The
+affected release must not be silently repaired. Resolution requires a recorded
+incident, a new release version, a fresh extraction, new baselines, and a new
+freeze manifest.
 
-## Безпечне звітування
+## Safe reporting
 
-Публічні score reports містять тільки агрегати, support, uncertainty та
-provenance. Вони не можуть містити item IDs, source/target text, edit spans,
-raw responses або content hashes. Збережені model responses є окремими
-публічними артефактами для відтворення оцінки; звіт не дублює їх.
+Public score reports contain only aggregates, support counts, uncertainty
+estimates, and provenance. They must not contain item IDs, source or target
+text, edit spans, raw responses, or content hashes. Saved model responses are
+separate public artifacts that permit reproduction of the scores; aggregate
+reports do not duplicate them.
 
-## Версіонування
+## Versioning
 
-Заморожені байти не редагують на місці.
+Frozen bytes are never edited in place.
 
-- `PATCH`: документаційне або пакувальне виправлення без зміни dataset,
-  task, scorer чи результатів.
-- `MINOR`: сумісне доповнення task contract, scorer, runner або baselines.
-- `MAJOR`: зміна dataset, eligibility predicate, gold, split, primary metric
-  або несумісна зміна контракту.
+- `PATCH`: documentation or packaging corrections that do not change the
+  dataset, task, scorer, or results.
+- `MINOR`: backward-compatible additions to the task contract, scorer, runner,
+  or baselines.
+- `MAJOR`: changes to the dataset, eligibility rule, gold data, split, primary
+  metric, or any incompatible contract change.
 
-Кожна нова версія отримує окрему директорію freeze; старі freeze manifests
-зберігаються та мають залишатися незалежно перевірними.
+Each new release version receives its own freeze directory. Older freeze
+manifests remain available and independently verifiable.

--- a/docs/projects/ua-eval-harness/contamination-policy.md
+++ b/docs/projects/ua-eval-harness/contamination-policy.md
@@ -59,12 +59,11 @@ form is a calque under this benchmark. A separate
 annotator-level edits.
 
 The reproducible surface-form probe uses the pinned dict_uk/VESUM v6.8.0
-release, which was the latest stable upstream release available when public v0
-was frozen. Across 293 unique `F/Calque` spans, the probe finds 49 collisions
-with style markers: 34 `bad`, 10 `slang`, 3 `arch`, and 2 `rare`. The source
-does not provide a dedicated `dial` token. Its published `arch` semantics
-cover obsolete and archaic usage and may also cover dialectal usage. The
-benchmark therefore does not claim that there are zero dialect conflicts.
+release. Across 293 unique `F/Calque` spans, the probe finds 49 collisions with
+style markers: 34 `bad`, 10 `slang`, 3 `arch`, and 2 `rare`. The source does
+not provide a dedicated `dial` token. Its published `arch` semantics cover
+obsolete and archaic usage and may also cover dialectal usage. The benchmark
+therefore does not claim that there are zero dialect conflicts.
 
 Headline calque recall includes 338 annotations. The remaining 16 are outside
 the headline metric: 3 register-standardization cases, 2 heritage conflicts,

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -9,6 +9,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PUBLIC_ENGLISH_DOCS = (
     Path("docs/projects/ua-eval-harness/DATA_CARD.en.md"),
@@ -19,7 +22,7 @@ PUBLIC_ENGLISH_DOCS = (
 )
 
 _CYRILLIC_RE = re.compile(r"[\u0400-\u052f]")
-_FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+_MARKDOWN = MarkdownIt("commonmark")
 
 
 @dataclass(frozen=True, order=True)
@@ -30,12 +33,10 @@ class Finding:
     line: int
     column: int
     excerpt: str
+    message: str = "Cyrillic is not allowed in English running prose"
 
     def format(self) -> str:
-        return (
-            f"{display_path(self.path)}:{self.line}:{self.column}: "
-            f"Cyrillic is not allowed in English running prose: {self.excerpt}"
-        )
+        return f"{display_path(self.path)}:{self.line}:{self.column}: {self.message}: {self.excerpt}"
 
 
 def display_path(path: Path) -> str:
@@ -47,118 +48,120 @@ def display_path(path: Path) -> str:
         return str(path)
 
 
-def _mask(text: str) -> str:
-    """Replace content with spaces without changing offsets or line breaks."""
+def _token_span(token: Token, fallback: tuple[int, int]) -> tuple[int, int]:
+    if token.map is None:
+        return fallback
+    return token.map[0], token.map[1]
 
-    return "".join(char if char in "\r\n" else " " for char in text)
+
+def _visible_fragments(
+    tokens: list[Token],
+    fallback_span: tuple[int, int],
+) -> list[tuple[str, tuple[int, int]]]:
+    """Return rendered text fragments while excluding parsed Markdown code."""
+
+    fragments: list[tuple[str, tuple[int, int]]] = []
+    for token in tokens:
+        span = _token_span(token, fallback_span)
+        if token.type in {"code_block", "code_inline", "fence"}:
+            continue
+        if token.children:
+            fragments.extend(_visible_fragments(token.children, span))
+        elif token.content:
+            fragments.append((token.content, span))
+    return fragments
 
 
-def _mask_fenced_code(text: str) -> str:
-    """Mask CommonMark backtick and tilde fenced code blocks."""
+def _fence_is_closed(token: Token, source_lines: list[str]) -> bool:
+    """Return whether a parsed root-level fence has an explicit closing line."""
 
-    output: list[str] = []
-    fence_char: str | None = None
-    fence_width = 0
+    if token.map is None or not token.markup:
+        return False
+    start, end = token.map
+    marker = re.escape(token.markup[0])
+    width = len(token.markup)
+    closing = re.compile(rf"^ {{0,3}}{marker}{{{width},}}[ \t]*$")
+    return any(closing.fullmatch(source_lines[index]) for index in range(start + 1, min(end, len(source_lines))))
 
-    for line in text.splitlines(keepends=True):
-        body = line.rstrip("\r\n")
-        if fence_char is not None:
-            output.append(_mask(line))
-            closing = re.fullmatch(
-                rf" {{0,3}}{re.escape(fence_char)}{{{fence_width},}}[ \t]*",
-                body,
+
+def _unclosed_fence_findings(tokens: list[Token], source_lines: list[str], path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for token in tokens:
+        if token.type != "fence" or _fence_is_closed(token, source_lines):
+            continue
+        line_index = token.map[0] if token.map is not None else 0
+        excerpt = source_lines[line_index].strip() if source_lines else ""
+        findings.append(
+            Finding(
+                path=path,
+                line=line_index + 1,
+                column=1,
+                excerpt=excerpt,
+                message="Unclosed fenced code block is not allowed because it can hide later prose",
             )
-            if closing:
-                fence_char = None
-                fence_width = 0
-            continue
-
-        opening = _FENCE_OPEN_RE.match(body)
-        if opening is None:
-            output.append(line)
-            continue
-
-        marker, info = opening.groups()
-        if marker[0] == "`" and "`" in info:
-            output.append(line)
-            continue
-
-        fence_char = marker[0]
-        fence_width = len(marker)
-        output.append(_mask(line))
-
-    return "".join(output)
+        )
+    return findings
 
 
-def _backtick_run_length(text: str, start: int) -> int:
-    end = start
-    while end < len(text) and text[end] == "`":
+def _cyrillic_word(fragment: str, position: int) -> str:
+    start = position
+    end = position + 1
+    while start > 0 and _CYRILLIC_RE.fullmatch(fragment[start - 1]):
+        start -= 1
+    while end < len(fragment) and _CYRILLIC_RE.fullmatch(fragment[end]):
         end += 1
-    return end - start
+    return fragment[start:end]
 
 
-def _find_matching_backtick_run(text: str, start: int, width: int) -> int | None:
-    cursor = start
-    while cursor < len(text):
-        candidate = text.find("`", cursor)
-        if candidate < 0:
-            return None
-        candidate_width = _backtick_run_length(text, candidate)
-        if candidate_width == width:
-            return candidate
-        cursor = candidate + candidate_width
-    return None
+def _source_location(
+    fragment: str,
+    position: int,
+    span: tuple[int, int],
+    source_lines: list[str],
+) -> tuple[int, int, str]:
+    """Map a rendered Cyrillic fragment back to its source line."""
 
+    start_line, end_line = span
+    relative_line = fragment[:position].count("\n")
+    preferred_line = min(start_line + relative_line, max(start_line, end_line - 1))
+    word = _cyrillic_word(fragment, position)
+    candidate_lines = [preferred_line, *range(start_line, end_line)]
 
-def _mask_inline_code(text: str) -> str:
-    """Mask CommonMark-style inline code spans, including multiline spans."""
-
-    output = list(text)
-    cursor = 0
-    while cursor < len(text):
-        opening = text.find("`", cursor)
-        if opening < 0:
-            break
-        width = _backtick_run_length(text, opening)
-        closing = _find_matching_backtick_run(text, opening + width, width)
-        if closing is None:
-            cursor = opening + width
+    seen: set[int] = set()
+    for line_index in candidate_lines:
+        if line_index in seen or not (0 <= line_index < len(source_lines)):
             continue
-        for index in range(opening, closing + width):
-            if output[index] not in "\r\n":
-                output[index] = " "
-        cursor = closing + width
-    return "".join(output)
+        seen.add(line_index)
+        column = source_lines[line_index].find(word)
+        if column >= 0:
+            return line_index + 1, column + 1, source_lines[line_index].strip()
 
-
-def mask_code(text: str) -> str:
-    """Mask explicit Markdown code while preserving source coordinates."""
-
-    return _mask_inline_code(_mask_fenced_code(text))
+    excerpt = fragment.splitlines()[relative_line].strip()
+    return preferred_line + 1, 1, excerpt
 
 
 def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
     """Return Cyrillic occurrences outside explicit Markdown code."""
 
-    masked_lines = mask_code(text).splitlines()
     source_lines = text.splitlines()
-    findings: list[Finding] = []
+    tokens = _MARKDOWN.parse(text)
+    findings = _unclosed_fence_findings(tokens, source_lines, path)
 
-    for line_number, masked_line in enumerate(masked_lines, start=1):
-        match = _CYRILLIC_RE.search(masked_line)
+    for fragment, span in _visible_fragments(tokens, (0, len(source_lines))):
+        match = _CYRILLIC_RE.search(fragment)
         if match is None:
             continue
-        excerpt = source_lines[line_number - 1].strip()
+        line, column, excerpt = _source_location(fragment, match.start(), span, source_lines)
         findings.append(
             Finding(
                 path=path,
-                line=line_number,
-                column=match.start() + 1,
+                line=line,
+                column=column,
                 excerpt=excerpt,
             )
         )
 
-    return findings
+    return sorted(set(findings))
 
 
 def governed_paths() -> list[Path]:

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Reject Cyrillic running prose in the public English UA-eval documents."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_ENGLISH_DOCS = (
+    Path("docs/projects/ua-eval-harness/DATA_CARD.en.md"),
+    Path("docs/projects/ua-eval-harness/README.md"),
+    Path("docs/projects/ua-eval-harness/REPRODUCING.md"),
+    Path("docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md"),
+    Path("docs/projects/ua-eval-harness/contamination-policy.md"),
+)
+
+_CYRILLIC_RE = re.compile(r"[\u0400-\u052f]")
+_FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    """One Cyrillic character found in visible prose."""
+
+    path: Path
+    line: int
+    column: int
+    excerpt: str
+
+    def format(self) -> str:
+        return (
+            f"{display_path(self.path)}:{self.line}:{self.column}: "
+            f"Cyrillic is not allowed in English running prose: {self.excerpt}"
+        )
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _mask(text: str) -> str:
+    """Replace content with spaces without changing offsets or line breaks."""
+
+    return "".join(char if char in "\r\n" else " " for char in text)
+
+
+def _mask_fenced_code(text: str) -> str:
+    """Mask CommonMark backtick and tilde fenced code blocks."""
+
+    output: list[str] = []
+    fence_char: str | None = None
+    fence_width = 0
+
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        if fence_char is not None:
+            output.append(_mask(line))
+            closing = re.fullmatch(
+                rf" {{0,3}}{re.escape(fence_char)}{{{fence_width},}}[ \t]*",
+                body,
+            )
+            if closing:
+                fence_char = None
+                fence_width = 0
+            continue
+
+        opening = _FENCE_OPEN_RE.match(body)
+        if opening is None:
+            output.append(line)
+            continue
+
+        marker, info = opening.groups()
+        if marker[0] == "`" and "`" in info:
+            output.append(line)
+            continue
+
+        fence_char = marker[0]
+        fence_width = len(marker)
+        output.append(_mask(line))
+
+    return "".join(output)
+
+
+def _backtick_run_length(text: str, start: int) -> int:
+    end = start
+    while end < len(text) and text[end] == "`":
+        end += 1
+    return end - start
+
+
+def _find_matching_backtick_run(text: str, start: int, width: int) -> int | None:
+    cursor = start
+    while cursor < len(text):
+        candidate = text.find("`", cursor)
+        if candidate < 0:
+            return None
+        candidate_width = _backtick_run_length(text, candidate)
+        if candidate_width == width:
+            return candidate
+        cursor = candidate + candidate_width
+    return None
+
+
+def _mask_inline_code(text: str) -> str:
+    """Mask CommonMark-style inline code spans, including multiline spans."""
+
+    output = list(text)
+    cursor = 0
+    while cursor < len(text):
+        opening = text.find("`", cursor)
+        if opening < 0:
+            break
+        width = _backtick_run_length(text, opening)
+        closing = _find_matching_backtick_run(text, opening + width, width)
+        if closing is None:
+            cursor = opening + width
+            continue
+        for index in range(opening, closing + width):
+            if output[index] not in "\r\n":
+                output[index] = " "
+        cursor = closing + width
+    return "".join(output)
+
+
+def mask_code(text: str) -> str:
+    """Mask explicit Markdown code while preserving source coordinates."""
+
+    return _mask_inline_code(_mask_fenced_code(text))
+
+
+def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
+    """Return Cyrillic occurrences outside explicit Markdown code."""
+
+    masked_lines = mask_code(text).splitlines()
+    source_lines = text.splitlines()
+    findings: list[Finding] = []
+
+    for line_number, masked_line in enumerate(masked_lines, start=1):
+        match = _CYRILLIC_RE.search(masked_line)
+        if match is None:
+            continue
+        excerpt = source_lines[line_number - 1].strip()
+        findings.append(
+            Finding(
+                path=path,
+                line=line_number,
+                column=match.start() + 1,
+                excerpt=excerpt,
+            )
+        )
+
+    return findings
+
+
+def governed_paths() -> list[Path]:
+    """Return the complete public English document set."""
+
+    return [PROJECT_ROOT / path for path in PUBLIC_ENGLISH_DOCS]
+
+
+def _selected_paths(paths: list[Path] | None) -> list[Path]:
+    if paths is None:
+        return governed_paths()
+
+    governed = {path.resolve(): path for path in governed_paths()}
+    selected: list[Path] = []
+    seen: set[Path] = set()
+    for supplied in paths:
+        absolute = supplied if supplied.is_absolute() else PROJECT_ROOT / supplied
+        resolved = absolute.resolve()
+        if resolved in governed and resolved not in seen:
+            selected.append(governed[resolved])
+            seen.add(resolved)
+    return selected
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Optional pre-commit file list; non-governed paths are ignored.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    paths = _selected_paths(args.files)
+    missing = [path for path in paths if not path.is_file()]
+    findings: list[Finding] = []
+
+    for path in paths:
+        if path.is_file():
+            findings.extend(scan_text(path.read_text(encoding="utf-8"), path))
+
+    if not missing and not findings:
+        return 0
+
+    print(
+        "ERROR: public English UA-eval documents must use English running prose.",
+        file=sys.stderr,
+    )
+    for path in missing:
+        print(f"{display_path(path)}: governed document is missing", file=sys.stderr)
+    for finding in findings:
+        print(finding.format(), file=sys.stderr)
+    print(
+        "Put exact Ukrainian tokens or examples in Markdown code spans/blocks; put Ukrainian prose in DATA_CARD.uk.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -1,0 +1,87 @@
+"""Tests for the public English UA-eval document language gate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit.check_ua_eval_public_doc_language import (
+    PUBLIC_ENGLISH_DOCS,
+    governed_paths,
+    mask_code,
+    scan_text,
+)
+
+
+def test_rejects_hybrid_running_prose() -> None:
+    text = "# Reproduction\n\nSmoke спочатку перевіряє freeze manifest and all frozen hashes.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert findings[0].column == 7
+    assert "Smoke спочатку" in findings[0].excerpt
+
+
+def test_allows_ukrainian_only_in_explicit_code() -> None:
+    text = """# Examples
+
+The surface form `тьоті` is retained as evidence.
+
+```text
+Це точний український приклад.
+```
+
+The prose returns to English.
+"""
+
+    assert scan_text(text) == []
+
+
+def test_masks_multiline_and_variable_width_code_spans() -> None:
+    text = """English ``first `український`
+second`` prose.
+
+````text
+```
+Український приклад
+```
+````
+"""
+
+    masked = mask_code(text)
+
+    assert "український" not in masked
+    assert "Український" not in masked
+    assert masked.count("\n") == text.count("\n")
+    assert len(masked) == len(text)
+
+
+def test_rejects_visible_markdown_formatting_and_link_labels() -> None:
+    text = "This **український text** is visible.\nThis [українська назва](https://example.test) is also visible.\n"
+
+    findings = scan_text(text)
+
+    assert [finding.line for finding in findings] == [1, 2]
+
+
+def test_governed_set_is_explicit_and_current() -> None:
+    assert (
+        Path("docs/projects/ua-eval-harness/DATA_CARD.en.md"),
+        Path("docs/projects/ua-eval-harness/README.md"),
+        Path("docs/projects/ua-eval-harness/REPRODUCING.md"),
+        Path("docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md"),
+        Path("docs/projects/ua-eval-harness/contamination-policy.md"),
+    ) == PUBLIC_ENGLISH_DOCS
+
+
+def test_repository_public_english_docs_have_no_cyrillic_prose() -> None:
+    paths = governed_paths()
+
+    assert all(path.is_file() for path in paths)
+    findings = [finding for path in paths for finding in scan_text(path.read_text(encoding="utf-8"), path)]
+    assert findings == []

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -11,7 +11,6 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from audit.check_ua_eval_public_doc_language import (
     PUBLIC_ENGLISH_DOCS,
     governed_paths,
-    mask_code,
     scan_text,
 )
 
@@ -42,7 +41,7 @@ The prose returns to English.
     assert scan_text(text) == []
 
 
-def test_masks_multiline_and_variable_width_code_spans() -> None:
+def test_allows_multiline_and_variable_width_code_spans() -> None:
     text = """English ``first `український`
 second`` prose.
 
@@ -53,12 +52,36 @@ second`` prose.
 ````
 """
 
-    masked = mask_code(text)
+    assert scan_text(text) == []
 
-    assert "український" not in masked
-    assert "Український" not in masked
-    assert masked.count("\n") == text.count("\n")
-    assert len(masked) == len(text)
+
+def test_rejects_unclosed_fence_instead_of_hiding_rest_of_document() -> None:
+    text = """# Examples
+
+```text
+Example output.
+
+Український prose that must not be hidden.
+"""
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert "Unclosed fenced code block" in findings[0].message
+
+
+def test_stray_backticks_cannot_mask_across_markdown_blocks() -> None:
+    text = """English paragraph with a stray ` backtick.
+
+Український prose in another paragraph with ` another backtick.
+"""
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert "Український prose" in findings[0].excerpt
 
 
 def test_rejects_visible_markdown_formatting_and_link_labels() -> None:


### PR DESCRIPTION
## What changed

- rewrote the public v0 contamination policy as coherent English prose while preserving the frozen release facts, counts, licensing, split-integrity rules, and contamination restrictions;
- corrected the README description of that policy;
- added a deterministic language gate for the five public English UA-eval release documents;
- added a pre-commit hook and unconditional pytest coverage, including the exact `Smoke спочатку…` regression.

Exact Ukrainian forms remain permitted only as explicitly marked Markdown code/examples. The independently authored Ukrainian data card remains outside this English-only gate.

## Root cause

The public English documentation had no declared, enforceable language boundary. Markdown lint checked structure, link validation checked targets, and prior review scopes checked facts and changed files; none rejected Cyrillic running prose in an English document. That allowed machine-translated hybrid register to pass all existing gates.

## Reader impact

Researchers now receive the contamination policy in consistent English. Future Cyrillic prose in any governed English release document fails locally and in CI instead of relying on editorial memory.

## Validation

- `.venv/bin/python scripts/audit/check_ua_eval_public_doc_language.py`
- `.venv/bin/python -m pytest tests/test_ua_eval_public_doc_language.py -q` — 6 passed
- `.venv/bin/python -m ruff check scripts/audit/check_ua_eval_public_doc_language.py tests/test_ua_eval_public_doc_language.py`
- `.venv/bin/python -m ruff format --check scripts/audit/check_ua_eval_public_doc_language.py tests/test_ua_eval_public_doc_language.py`
- `.venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py` — 21 artifacts valid
- `.venv/bin/python scripts/projects/ua_eval_harness/smoke_public_v0.py` — all three saved runs reproduced
- `markdownlint-cli2` on all five governed documents — 0 errors
- `markdown-link-check` on the changed public documents — all links valid
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `git diff --check origin/main...HEAD`

Tracks the public UA-eval work under epic #2156.