### PR TITLE
fix(codex): keep root model user-selectable

### DIFF
--- a/agents_extensions/codex/config.toml
+++ b/agents_extensions/codex/config.toml
@@ -1,8 +1,8 @@
-# Shared project defaults for Codex App, CLI, and IDE surfaces.
+# Shared project behavior for Codex App, CLI, and IDE surfaces.
+# Root model and reasoning defaults intentionally remain user-scoped so the
+# desktop model picker can override them for each task.
 # Codex owns context compaction; repository hooks add durable fleet hydration
 # only when a launcher has explicitly bound an epic driver.
-model = "gpt-5.6-sol"
-model_reasoning_effort = "high"
 
 [features]
 multi_agent = true

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -170,9 +170,11 @@ touch ~/.secret/zai.key && chmod 600 ~/.secret/zai.key
 ${EDITOR:-nano} ~/.secret/zai.key   # paste the key alone, save, quit
 ```
 
-The trusted `agents_extensions/codex/config.toml` overlay gives Codex App and
-CLI the same Sol/high root and Terra/medium V2 defaults. `start-codex.sh`
-launches the CLI with:
+The trusted `agents_extensions/codex/config.toml` overlay leaves the root model
+and reasoning effort user-selectable while giving Codex App and CLI the same
+Terra/medium V2 child defaults. Personal root defaults belong in
+`~/.codex/config.toml`; task-specific choices come from the model picker or CLI
+flags. `start-codex.sh` launches the CLI with:
 
 - interactive Codex in dangerous bypass mode
 - live web search; project config supplies Codex 0.145 multi-agent V2

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -74,11 +74,11 @@ def test_codex_manifest_uses_only_supported_result_event() -> None:
     assert "PostToolUseFailure" not in hooks
 
 
-def test_codex_app_and_cli_share_bounded_native_context_defaults() -> None:
+def test_codex_project_config_leaves_root_model_user_selectable() -> None:
     config = tomllib.loads(PROJECT_CONFIG.read_text(encoding="utf-8"))
 
-    assert config["model"] == "gpt-5.6-sol"
-    assert config["model_reasoning_effort"] == "high"
+    assert "model" not in config
+    assert "model_reasoning_effort" not in config
     assert config["features"] == {
         "multi_agent": True,
         "remote_compaction_v2": True,


### PR DESCRIPTION
## Summary

- remove root `model` and `model_reasoning_effort` pins from the canonical project Codex overlay
- keep the existing Terra/medium child-agent defaults unchanged
- update the configuration contract test and operator documentation

## Root cause

The trusted project `.codex/config.toml` was generated from `agents_extensions/codex/config.toml`, which pinned Sol/high at project scope. That project layer repeatedly overrode task-level desktop choices after deployment/reload. The personal config remains the Sol/high default; the project layer is now deliberately unpinned.

## Validation

- `23 passed`: `tests/test_codex_hooks_contract.py` and `tests/test_dispatch_telemetry.py`
- Ruff passed
- Markdownlint passed
- `git diff --check` passed
- OPSEC leak scan passed
- deploy completed successfully and live `.codex/config.toml` matches the canonical source
- source-blind proof: a fresh Codex process in this project ran `gpt-5.6-luna` with `low` reasoning and returned `MODEL_PICKER_OVERRIDE_OK`

## Independent review

Claude Sonnet 5 (Anthropic family) reviewed the frozen three-file diff and returned **PASS** with no actionable findings. It confirmed configuration precedence, deployment survival, contract coverage, and adjacent telemetry behavior.