### PR TITLE
fix(site): allow fsevents install scripts under npm 11 strict

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -71,6 +71,8 @@
   },
   "allowScripts": {
     "better-sqlite3@12.11.1": true,
-    "esbuild@0.28.1": true
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.2": true,
+    "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
## Summary
- Adds `fsevents@2.3.2` and `fsevents@2.3.3` to `site/package.json` `allowScripts` so `npm ci` succeeds on macOS under npm 11 strict allow-scripts.
- Unblocks `./services.sh` astro self-heal (`npm ci` when `node_modules/.bin/astro` is missing).

## Context
Post 2026-07-29 checkout recovery: clean `npm ci` failed with ESTRICTALLOWSCRIPTS for fsevents only.

## Test plan
- [x] `cd site && npm ci` succeeds with this allowScripts set
- [x] `./services.sh start` brings astro up
- [ ] CI green