### PR TITLE
fix(backup): protect recovery-critical local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,8 +409,8 @@ curriculum/l2-uk-en/*/*/knowledge_packet.md
 data/lexicon/slovnyk_cache/
 # Network-fetch enrichment caches (Wikipedia summaries, GRAC frequency). Churny +
 # growing toward the full-corpus target; like slovnyk_cache/ + the manifest they do
-# NOT belong in git. Kept local + Drive-backed via scripts/backup-data.sh (rsyncs all
-# of data/); CI never reads them (it hydrates the published release-asset manifest).
+# NOT belong in git. Kept local + versioned via scripts/backup-data.sh; CI never
+# reads them (it hydrates the published release-asset manifest).
 # Regenerate on demand via scripts/lexicon/enrich_manifest.py.
 data/lexicon/cache/
 # Generated build artifact: regenerate on demand with

--- a/README.md
+++ b/README.md
@@ -151,16 +151,18 @@ All work happens on `main` — no feature branches. Use `git worktree` for
 isolation when needed. Read `CLAUDE.md` + `docs/best-practices/` before
 touching pipeline code.
 
-Back up the large local state (SQLite DBs + MLX-encoded dense shards) to
-Google Drive manually whenever it matters:
+Back up gitignored epic handoffs/plans, local fleet state, SQLite databases,
+and MLX-encoded dense shards as encrypted, versioned restic snapshots:
 
 ```bash
-./scripts/backup-data.sh
+./scripts/backup-data.sh doctor
+./scripts/backup-data.sh backup            # preview
+./scripts/backup-data.sh backup --execute  # create a snapshot
 ```
 
-This rsyncs all of `data/` to the Google Drive for Desktop mount. No cron,
-no rclone config — Drive handles the upload in the background. See the
-script's top comment for details.
+The backup uses an rclone remote without writing through the Google Drive
+Desktop mount. Setup, verification, and staging-only restore instructions are
+in [docs/runbooks/data-backup.md](docs/runbooks/data-backup.md).
 
 ## Contributing
 

--- a/docs/DICTIONARY-PIPELINE-STATUS.md
+++ b/docs/DICTIONARY-PIPELINE-STATUS.md
@@ -67,5 +67,6 @@ Run with:
 ## Backup
 
 ```bash
-./scripts/backup-data.sh
+./scripts/backup-data.sh backup
+./scripts/backup-data.sh backup --execute
 ```

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -419,30 +419,25 @@ Wikipedia, and dictionary inputs.
 ### Recovery: when `data/sources.db` is empty or corrupt
 
 If `data/sources.db` is found at 0 bytes or with broken schema (the
-2026-04-25 wipe pattern), restore from the Google Drive backup —
-**do NOT run `build_sources_db.py --force`**, that rebuilds from
-JSONL inputs which lack the post-#1427 `ukrainian_wiki` table and
-the post-#1555 chunker policy.
+2026-04-25 wipe pattern), restore a versioned snapshot into an empty staging
+directory. **Do not restore over live `data/` and do not run
+`build_sources_db.py --force`**: that rebuilds from JSONL inputs which lack the
+post-#1427 `ukrainian_wiki` table and the post-#1555 chunker policy.
 
 ```bash
-# 1) Snapshot whatever is currently on disk (in case the "wipe" was
-#    actually something subtler and we want forensic evidence).
-cp data/sources.db "data/sources.db.bak-$(date +%Y%m%d-%H%M%S)"
-ls -lah data/sources.db data/sources.db.bak-*
+# 1) List snapshots and preview a staging-only restore.
+./scripts/backup-data.sh snapshots
+./scripts/backup-data.sh restore latest \
+  --to /absolute/path/to/empty-recovery-directory
 
-# 2) Check the GDrive backup age. Anything <30 days is fine; older
-#    than that means more re-ingest work after restore.
-#    Path resolution: $LU_GDRIVE_DATA env var if set, else glob the
-#    per-user GoogleDrive mount. (Email is not hardcoded in committed
-#    code — see #1577 Phase 1 Q4.)
-GDRIVE="${LU_GDRIVE_DATA:-$(ls -d "$HOME/Library/CloudStorage/"GoogleDrive-*/"My Drive/Projects/learn-ukrainian-data" 2>/dev/null | head -1)}"
-ls -lah "$GDRIVE/sources.db"
+# 2) Execute after checking the selected snapshot and target.
+./scripts/backup-data.sh restore latest \
+  --to /absolute/path/to/empty-recovery-directory \
+  --execute
 
-# 3) Restore from backup.
-cp "$GDRIVE/sources.db" data/sources.db
-
-# 4) Verify the restore worked: row counts should be non-trivial.
-sqlite3 data/sources.db "
+# 3) Verify the staged database. Row counts should be non-trivial.
+sqlite3 /absolute/path/to/empty-recovery-directory/data/sources.db "
+  PRAGMA quick_check;
   SELECT 'textbooks',         COUNT(*) FROM textbooks UNION ALL
   SELECT 'literary_texts',    COUNT(*) FROM literary_texts UNION ALL
   SELECT 'external_articles', COUNT(*) FROM external_articles UNION ALL
@@ -450,7 +445,11 @@ sqlite3 data/sources.db "
   SELECT 'ukrainian_wiki',    COUNT(*) FROM ukrainian_wiki;
 "
 
-# 5) Re-ingest any tables that were added AFTER the backup date.
+# 4) Stop writers, preserve the damaged live database outside the project,
+#    and copy back only the verified staged database. The backup script
+#    deliberately does not overwrite live data.
+
+# 5) Re-ingest any tables that were added AFTER the snapshot date.
 #    For backups older than 2026-04-23, ukrainian_wiki is missing.
 #    Use the per-subdir loop (NOT `wiki/ --encode` — that command is
 #    broken until #1570 ships, see scripts/wiki/ingest_ukrainian_wiki.py).
@@ -474,10 +473,13 @@ done
 .venv/bin/python scripts/wiki/cold_encode.py \
     --corpora ukrainian_wiki --resume
 
-# 7) Refresh the GDrive backup so the next session starts from a
-#    clean point.
-./scripts/backup-data.sh
+# 7) Preview and create a fresh versioned snapshot.
+./scripts/backup-data.sh backup
+./scripts/backup-data.sh backup --execute
 ```
+
+See `docs/runbooks/data-backup.md` for setup, integrity checks, exclusions,
+and the complete restore drill.
 
 ### Fetch Wikipedia Articles
 

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -134,6 +134,10 @@ Each successful snapshot contains `BACKUP-RECEIPT.json` with:
 - the count of untracked non-ignored files not included (normally zero);
 - exclusions, known missing paths, and the restore command.
 
+Path counts are calculated after exclusions are removed from the private
+staging tree, so they describe recoverable snapshot files rather than raw
+source-tree contents.
+
 The receipt intentionally records only top-level recovery labels, not private
 inner path names. The remote repository itself is encrypted. The final process
 exit code belongs to the operator log: an in-snapshot file cannot truthfully

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -1,0 +1,228 @@
+# Data Backup and Recovery
+
+`scripts/backup-data.sh` creates encrypted, versioned restic snapshots of the
+project's recovery-critical local state through an rclone remote. It does not
+write through the Google Drive Desktop mount, overwrite the previous backup,
+prune snapshots, or restore directly over live project data.
+
+Every snapshot contains these roots, in priority order:
+
+- every `.claude/*-epic/` directory, including driver plans and handoffs;
+- `batch_state/`;
+- `data/`, including SQLite databases, embeddings, and private inputs;
+- `GIT-WORKTREE.patch` when tracked changes have not been committed; and
+- `BACKUP-RECEIPT.json`.
+
+The script fails closed when `.claude/atlas-epic`, `batch_state`, `data`, or
+the destination configuration is missing. It also fails when a non-ignored
+untracked Git path is outside the declared recovery roots. This prevents a
+partial backup from appearing successful.
+
+The old `learn-ukrainian-data` Drive folder is a read-only legacy recovery
+source. Do not use it as the new restic repository path.
+
+## Safety model
+
+- `init`, `backup`, and `restore` are previews unless `--execute` is explicit.
+- A backup executes from a private copy-on-write staging tree outside the
+  checkout.
+- Every `*.db`, `*.sqlite`, and `*.sqlite3` under the selected roots is rebuilt
+  in staging with SQLite's online backup command and must pass
+  `PRAGMA quick_check` before upload.
+- SQLite WAL/SHM files, `__pycache__`, `.DS_Store`, and retired `qdrant/` data
+  are excluded.
+- The legacy `data/textbooks` and `data/vesum` symlinks are excluded only when
+  they resolve inside the old Drive backup. Other absolute or escaping
+  symlinks stop the backup.
+- Restore accepts only an absolute empty or nonexistent directory outside the
+  project, cloud mounts, and the legacy backup.
+- There is intentionally no `forget`, `prune`, or snapshot-delete command.
+- Restic commits snapshots atomically. A failed upload does not replace an
+  earlier recovery point.
+
+Restic documents the [rclone backend][restic-rclone], [backup dry runs][restic-backup],
+[restore dry runs][restic-restore], and [repository integrity checks][restic-check].
+SQLite documents why its [online backup API produces a consistent snapshot][sqlite-backup].
+
+[restic-rclone]: https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html#rclone
+[restic-backup]: https://restic.readthedocs.io/en/stable/040_backup.html#dry-runs
+[restic-restore]: https://restic.readthedocs.io/en/stable/050_restore.html#dry-runs
+[restic-check]: https://restic.readthedocs.io/en/stable/045_working_with_repos.html#checking-integrity-and-consistency
+[sqlite-backup]: https://www.sqlite.org/backup.html
+
+## One-time setup
+
+Install current restic and rclone releases:
+
+```bash
+brew install restic rclone
+restic version
+rclone version
+```
+
+Configure a dedicated rclone remote. The examples use `lu-gdrive`; another
+name is fine as long as the environment below matches it.
+
+```bash
+rclone config
+rclone lsd lu-gdrive:
+```
+
+Create a unique restic password file:
+
+```bash
+mkdir -p "$HOME/.config/restic"
+umask 077
+openssl rand -base64 48 > "$HOME/.config/restic/learn-ukrainian.password"
+chmod 600 "$HOME/.config/restic/learn-ukrainian.password"
+```
+
+Store the password separately in a password manager or offline recovery kit.
+Losing it makes every restic snapshot unrecoverable. Do not commit it and do
+not keep the only copy in the same cloud account as the repository.
+
+Set the repository and password-file locations in the shell environment:
+
+```bash
+export LU_BACKUP_REPOSITORY='rclone:lu-gdrive:Projects/learn-ukrainian-restic'
+export RESTIC_PASSWORD_FILE="$HOME/.config/restic/learn-ukrainian.password"
+```
+
+Preview repository initialization, confirm the remote path, and then execute
+it once:
+
+```bash
+./scripts/backup-data.sh init
+./scripts/backup-data.sh init --execute
+./scripts/backup-data.sh doctor
+```
+
+`doctor` reports `NOT READY` before initialization; that is expected.
+
+## Create a backup
+
+First run the non-mutating preview:
+
+```bash
+./scripts/backup-data.sh backup
+```
+
+Review the selected root list, byte/file counts, excluded legacy symlinks,
+known missing paths, and the restic change list. Then create the snapshot:
+
+```bash
+./scripts/backup-data.sh backup --execute
+```
+
+The execute path checks repository metadata after the snapshot. It does not
+prune old versions. Normal exits and handled interruptions clean the private
+staging directory and local operation lock. After a power loss, inspect any
+stale path reported by the next run before removing it.
+
+Each successful snapshot contains `BACKUP-RECEIPT.json` with:
+
+- UTC creation time, stable host label, Git SHA, and backup exit code;
+- the selected root labels with file and byte counts;
+- whether a tracked-worktree patch was needed;
+- the count of untracked non-ignored files not included (normally zero);
+- exclusions, known missing paths, and the restore command.
+
+The receipt intentionally records only top-level recovery labels, not private
+inner path names. The remote repository itself is encrypted.
+
+List snapshots and perform periodic integrity checks:
+
+```bash
+./scripts/backup-data.sh snapshots
+./scripts/backup-data.sh verify
+./scripts/backup-data.sh verify latest --read-data
+```
+
+`--read-data` downloads and verifies selected repository data and may be slow.
+Use it for a periodic restore drill, not necessarily after every backup.
+
+## Restore drill
+
+Choose a recovery filesystem with enough free space. The target must be
+absolute and empty (or not yet exist), and must not be under the repository or
+a cloud mount.
+
+```bash
+mkdir -p /absolute/path/to/recovery-parent
+./scripts/backup-data.sh restore latest \
+  --to /absolute/path/to/recovery-parent/restore-test
+./scripts/backup-data.sh restore latest \
+  --to /absolute/path/to/recovery-parent/restore-test \
+  --execute
+```
+
+The restored tree contains `.claude/`, `batch_state/`, `data/`, and the JSON
+receipt. Validate the receipt and databases before any live import:
+
+```bash
+jq . /absolute/path/to/recovery-parent/restore-test/BACKUP-RECEIPT.json
+sqlite3 /absolute/path/to/recovery-parent/restore-test/data/sources.db \
+  'PRAGMA quick_check;'
+find /absolute/path/to/recovery-parent/restore-test/data -type f | wc -l
+```
+
+After a wipe and clean reclone, restore the dual-write state without deleting
+anything already present:
+
+```bash
+RECOVERY_DIR=/absolute/path/to/recovery-parent/restore-test
+PROJECT_DIR=/absolute/path/to/clean/learn-ukrainian
+rsync -a "$RECOVERY_DIR/.claude/" "$PROJECT_DIR/.claude/"
+rsync -a "$RECOVERY_DIR/batch_state/" "$PROJECT_DIR/batch_state/"
+```
+
+If `GIT-WORKTREE.patch` exists, inspect it and run a check before deciding to
+apply it:
+
+```bash
+git -C "$PROJECT_DIR" apply --check "$RECOVERY_DIR/GIT-WORKTREE.patch"
+```
+
+Do not use `rsync --delete`. Copy `data/` back only after validating the
+specific recovery target and stopping its writers.
+
+For an incident:
+
+1. Stop processes that write the affected live database or directory.
+2. Preserve the damaged live item as forensic evidence on a different disk
+   when space permits.
+3. Restore into the staging target and validate checksums, database integrity,
+   and expected row/file counts.
+4. Copy back only the confirmed files. The backup script intentionally does
+   not perform this overwrite.
+5. Keep the staged restore until services and application checks pass.
+
+Never point `restore --to` at `data/`, the project root, `_quarantine`, the old
+Drive backup, or another directory containing files.
+
+## What is not backed up
+
+- `.git/objects`: committed history belongs on the Git remote.
+- `.venv/`, `node_modules/`, and generated `site/public/atlas/`: rebuild them
+  from committed configuration and release artifacts.
+- `_quarantine/`: incident evidence remains separately managed.
+- `data/qdrant/`: retired and rebuildable under ADR-005/006.
+- SQLite `*.db-wal` and `*.db-shm`: transient state incorporated into each
+  staged online database backup.
+- `data/textbooks` and `data/vesum` when they are legacy Drive symlinks. Their
+  targets remain in the legacy backup until a separate migration is planned.
+
+Run `doctor` after changing any source symlink. A new external or broken
+symlink is a hard failure rather than a silent omission or recursive copy.
+
+## Scheduling
+
+The script is suitable for launchd or cron after the one-time environment is
+available to that process. `backup --execute` returns nonzero for missing
+critical roots, unsafe symlinks, uncovered untracked files, corrupt SQLite
+databases, failed uploads, or failed repository checks. Send stdout and stderr
+to an operator-controlled log outside the repository and alert on every
+nonzero exit.
+
+Do not schedule retention or pruning until an operator approves a policy and
+multiple restore drills have succeeded.

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -145,10 +145,12 @@ List snapshots and perform periodic integrity checks:
 ```bash
 ./scripts/backup-data.sh snapshots
 ./scripts/backup-data.sh verify
-./scripts/backup-data.sh verify latest --read-data
+./scripts/backup-data.sh verify --read-data
 ```
 
-`--read-data` downloads and verifies selected repository data and may be slow.
+`verify` checks the repository rather than one snapshot: restic does not
+support a positional snapshot ID for `check`. `--read-data` downloads and
+verifies repository data and may be slow.
 Use it for a periodic restore drill, not necessarily after every backup.
 
 ## Restore drill

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -27,6 +27,10 @@ restic rclone path with that final directory name.
 - `init`, `backup`, and `restore` are previews unless `--execute` is explicit.
 - A backup executes from a private copy-on-write staging tree outside the
   checkout.
+- Staging capacity is checked against every selected recovery tree, SQLite
+  snapshot overhead, and a 2 GiB reserve before an execute path starts.
+- On macOS, source and staging must be on the same volume before APFS
+  copy-on-write staging; a cross-volume staging location fails closed.
 - On Linux filesystems without reflink support, only a bounded source tree of
   at most 64 MiB may fall back to a normal copy; larger trees fail closed.
 - Every `*.db`, `*.sqlite`, and `*.sqlite3` under the selected roots is rebuilt

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -19,13 +19,16 @@ untracked Git path is outside the declared recovery roots. This prevents a
 partial backup from appearing successful.
 
 The old `learn-ukrainian-data` Drive folder is a read-only legacy recovery
-source. Do not use it as the new restic repository path.
+source. Do not use it as the new restic repository path; the script rejects a
+restic rclone path with that final directory name.
 
 ## Safety model
 
 - `init`, `backup`, and `restore` are previews unless `--execute` is explicit.
 - A backup executes from a private copy-on-write staging tree outside the
   checkout.
+- On Linux filesystems without reflink support, only a bounded source tree of
+  at most 64 MiB may fall back to a normal copy; larger trees fail closed.
 - Every `*.db`, `*.sqlite`, and `*.sqlite3` under the selected roots is rebuilt
   in staging with SQLite's online backup command and must pass
   `PRAGMA quick_check` before upload.
@@ -121,14 +124,17 @@ stale path reported by the next run before removing it.
 
 Each successful snapshot contains `BACKUP-RECEIPT.json` with:
 
-- UTC creation time, stable host label, Git SHA, and backup exit code;
+- UTC creation time, stable host label, Git SHA, and receipt preparation status;
 - the selected root labels with file and byte counts;
 - whether a tracked-worktree patch was needed;
 - the count of untracked non-ignored files not included (normally zero);
 - exclusions, known missing paths, and the restore command.
 
 The receipt intentionally records only top-level recovery labels, not private
-inner path names. The remote repository itself is encrypted.
+inner path names. The remote repository itself is encrypted. The final process
+exit code belongs to the operator log: an in-snapshot file cannot truthfully
+contain the outcome of the repository check that runs after the snapshot is
+committed.
 
 List snapshots and perform periodic integrity checks:
 

--- a/docs/runbooks/wiki-rebuild.md
+++ b/docs/runbooks/wiki-rebuild.md
@@ -39,11 +39,8 @@ ls -lah data/sources.db
     --corpora textbook_sections,external,wikipedia,ukrainian_wiki --dry-run
 # Expected: all four show "up_to_date: true"
 
-# 3) GDrive backup is fresh (<24h old)
-#    Path resolution: $LU_GDRIVE_DATA env var if set, else glob the
-#    per-user GoogleDrive mount. (Email is not hardcoded — see #1577 Phase 1 Q4.)
-GDRIVE="${LU_GDRIVE_DATA:-$(ls -d "$HOME/Library/CloudStorage/"GoogleDrive-*/"My Drive/Projects/learn-ukrainian-data" 2>/dev/null | head -1)}"
-ls -lah "$GDRIVE/sources.db"
+# 3) The latest versioned snapshot is fresh (<24h old)
+./scripts/backup-data.sh snapshots
 
 # 4) #1569 multi-agent writer support is merged (compile.py --writer flag exists)
 .venv/bin/python scripts/wiki/compile.py --help | grep -A1 -- "--writer"
@@ -212,15 +209,16 @@ Pace: ~15 units/s for compiled-wiki chunks. 30K chunks → ~33 min.
 
 ---
 
-## Refresh GDrive backup
+## Create a fresh versioned backup
 
 ```bash
-./scripts/backup-data.sh
+./scripts/backup-data.sh backup
+./scripts/backup-data.sh backup --execute
 ```
 
 Captures sources.db (now with the new `ukrainian_wiki` corpus) plus
-`data/embeddings/` (which has the new dense shards). After this, the
-rebuild is durable across hardware failures.
+`data/embeddings/` (which has the new dense shards) in an encrypted snapshot.
+After this, the rebuild is durable across hardware failures.
 
 ---
 

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -171,6 +171,20 @@ file_mode() {
   stat -c '%a' "$path"
 }
 
+filesystem_device() {
+  local path=$1
+  local device
+
+  if device="$(stat -f '%d' "$path" 2>/dev/null)" &&
+    [[ "$device" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$device"
+    return
+  fi
+  device="$(stat -c '%d' "$path")" || return 1
+  [[ "$device" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$device"
+}
+
 canonical_existing_dir() {
   local path=$1
   [[ -d "$path" ]] || return 1
@@ -182,6 +196,10 @@ canonical_target() {
   local parent base
 
   [[ "$path" == /* ]] || die "Path must be absolute: $path"
+  [[ "$path" != "/" ]] || {
+    printf '/\n'
+    return
+  }
   parent="$(dirname "$path")"
   base="$(basename "$path")"
   [[ "$base" != "." && "$base" != ".." ]] || die "Unsafe target path: $path"
@@ -193,6 +211,7 @@ canonical_target() {
 path_is_within() {
   local child=$1
   local parent=$2
+  [[ "$parent" == "/" && "$child" == /* ]] && return
   [[ "$child" == "$parent" || "$child" == "$parent/"* ]]
 }
 
@@ -459,11 +478,12 @@ available_kib() {
 }
 
 check_staging_space() {
-  local db_bytes required_kib free_kib
+  local source_bytes db_bytes required_kib free_kib
   local -r safety_kib=$((2 * 1024 * 1024))
 
+  source_bytes="$(backup_tree_size_bytes)"
   db_bytes="$(db_size_bytes)"
-  required_kib=$(((db_bytes + 1023) / 1024 + safety_kib))
+  required_kib=$(((source_bytes + db_bytes + 1023) / 1024 + safety_kib))
   free_kib="$(available_kib)"
   [[ "$free_kib" =~ ^[0-9]+$ ]] || die "Could not determine staging free space."
   ((free_kib >= required_kib)) ||
@@ -473,10 +493,16 @@ check_staging_space() {
 clone_tree() {
   local source=$1
   local destination=$2
-  local source_bytes source_files
+  local source_bytes source_files source_device destination_device
 
   case "$(uname -s)" in
     Darwin)
+      source_device="$(filesystem_device "$source")" ||
+        die "Could not determine source volume for copy-on-write staging: $source"
+      destination_device="$(filesystem_device "$(dirname "$destination")")" ||
+        die "Could not determine staging volume for copy-on-write staging: $destination"
+      [[ "$source_device" == "$destination_device" ]] ||
+        die "APFS copy-on-write staging requires source and staging on the same volume."
       /bin/cp -cRp "$source" "$destination" ||
         die "APFS copy-on-write staging failed; refusing a full data copy."
       ;;
@@ -579,6 +605,17 @@ tree_file_stats() {
     count=$((count + 1))
   done < <(find "$tree" -type f -print0)
   printf '%s %s\n' "$total" "$count"
+}
+
+backup_tree_size_bytes() {
+  local total=0 relative source_path bytes files
+
+  for relative in "${BACKUP_PATHS[@]}"; do
+    source_path="$(source_for_backup_path "$relative")"
+    read -r bytes files < <(tree_file_stats "$source_path")
+    total=$((total + bytes))
+  done
+  printf '%s\n' "$total"
 }
 
 print_backup_selection() {

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -565,6 +565,35 @@ stage_sqlite_databases() {
   done < <(list_sqlite_sources)
 }
 
+remove_staged_path() {
+  local path=$1
+
+  [[ -e "$path" || -L "$path" ]] || return 0
+  path_is_within "$path" "$STAGED_ROOT" ||
+    die "Refusing to remove an exclusion outside the private staging tree."
+  find "$path" -depth -delete ||
+    die "Could not remove excluded content from private staging: ${path#"$STAGED_ROOT"/}"
+}
+
+remove_staged_exclusions() {
+  local directory relative
+
+  info "Removing excluded content from the private staging tree."
+  remove_staged_path "$STAGED_ROOT/data/qdrant"
+  if ((${#LEGACY_EXCLUDES[@]} > 0)); then
+    for relative in "${LEGACY_EXCLUDES[@]}"; do
+      remove_staged_path "$STAGED_ROOT/data/$relative"
+    done
+  fi
+  while IFS= read -r -d '' directory; do
+    remove_staged_path "$directory"
+  done < <(find "$STAGED_ROOT" -type d -name __pycache__ -prune -print0)
+  find "$STAGED_ROOT" -type f \
+    \( -name '*.db-wal' -o -name '*.db-shm' -o -name '.DS_Store' \) \
+    -delete ||
+    die "Could not remove excluded sidecars from the private staging tree."
+}
+
 build_restic_excludes() {
   local root=$1
   local relative
@@ -728,6 +757,7 @@ prepare_staging_tree() {
     clone_tree "$source_path" "$destination"
   done
   stage_sqlite_databases
+  remove_staged_exclusions
   create_worktree_patch
   write_backup_receipt
 }

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -61,7 +61,7 @@ Usage:
   ./scripts/backup-data.sh init [--execute]
   ./scripts/backup-data.sh backup [--execute]
   ./scripts/backup-data.sh snapshots
-  ./scripts/backup-data.sh verify [SNAPSHOT] [--read-data]
+  ./scripts/backup-data.sh verify [--read-data]
   ./scripts/backup-data.sh restore SNAPSHOT --to ABSOLUTE_EMPTY_DIR [--execute]
 
 Safety:
@@ -364,6 +364,8 @@ discover_backup_paths() {
   local epic
 
   BACKUP_PATHS=()
+  [[ ! -L "$PROJECT_ROOT/.claude" ]] ||
+    die "Recovery parent must not be a symlink: .claude"
   [[ -d "$PROJECT_ROOT/.claude/atlas-epic" ]] ||
     die "Required recovery path is missing: .claude/atlas-epic"
   [[ ! -L "$PROJECT_ROOT/.claude/atlas-epic" ]] ||
@@ -950,7 +952,6 @@ main() {
       restic snapshots --host "$BACKUP_HOST" --tag "$BACKUP_TAG"
       ;;
     verify)
-      snapshot=""
       read_data=0
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -961,8 +962,7 @@ main() {
             die "Unknown option: $1"
             ;;
           *)
-            [[ -z "$snapshot" ]] || die "verify accepts at most one snapshot ID."
-            snapshot=$1
+            die "verify checks the repository and does not accept snapshot IDs."
             ;;
         esac
         shift
@@ -970,13 +970,7 @@ main() {
       validate_environment
       require_initialized_repository
       if [[ "$read_data" -eq 1 ]]; then
-        if [[ -n "$snapshot" ]]; then
-          restic check --read-data "$snapshot"
-        else
-          restic check --read-data
-        fi
-      elif [[ -n "$snapshot" ]]; then
-        restic check "$snapshot"
+        restic check --read-data
       else
         restic check
       fi

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -40,6 +40,7 @@ readonly PASSWORD_FILE="${RESTIC_PASSWORD_FILE:-}"
 readonly BACKUP_TAG="${LU_BACKUP_TAG:-learn-ukrainian-data}"
 readonly BACKUP_HOST="${LU_BACKUP_HOST:-learn-ukrainian}"
 readonly MIN_RESTIC_VERSION="0.19.0"
+readonly MAX_FULL_COPY_BYTES=$((64 * 1024 * 1024))
 readonly CLOUD_ROOT="${HOME}/Library/CloudStorage"
 readonly TMP_ROOT="${LU_BACKUP_TMPDIR:-${TMPDIR:-/tmp}}"
 readonly LOCK_DIR="$TMP_ROOT/learn-ukrainian-backup.${UID}.lock"
@@ -50,6 +51,7 @@ STAGED_ROOT=""
 LOCK_HELD=0
 LEGACY_DIR=""
 RESTIC_EXCLUDES=()
+LEGACY_EXCLUDES=()
 BACKUP_PATHS=()
 
 usage() {
@@ -233,7 +235,7 @@ validate_password_file() {
 }
 
 validate_repository_config() {
-  local remote_spec remote_name
+  local remote_spec remote_name remote_path
 
   [[ -n "$REPOSITORY" ]] ||
     die "Set LU_BACKUP_REPOSITORY to rclone:<remote>:<path>."
@@ -242,8 +244,15 @@ validate_repository_config() {
 
   remote_spec=${REPOSITORY#rclone:}
   remote_name=${remote_spec%%:*}
+  remote_path=${remote_spec#*:}
   [[ -n "$remote_name" && "$remote_spec" == *:* && "${remote_spec#*:}" != "" ]] ||
     die "Invalid rclone repository. Expected rclone:<remote>:<path>."
+  remote_path=${remote_path%/}
+  case "$remote_path" in
+    learn-ukrainian-data|*/learn-ukrainian-data)
+      die "Refusing to initialize or write restic inside the legacy mutable backup path."
+      ;;
+  esac
 
   if ! rclone listremotes | grep -Fqx "$remote_name:"; then
     die "rclone remote '$remote_name:' is not configured. Run 'rclone config' first."
@@ -283,7 +292,9 @@ validate_source_symlinks() {
   local link relative target resolved
   local source_real
 
+  [[ ! -L "$SOURCE" ]] || die "Backup source must not be a symlink: data"
   source_real="$(canonical_existing_dir "$SOURCE")"
+  LEGACY_EXCLUDES=()
   while IFS= read -r -d '' link; do
     relative=${link#"$SOURCE"/}
     target="$(readlink "$link")"
@@ -295,6 +306,7 @@ validate_source_symlinks() {
         die "Legacy symlink found but the legacy Drive directory is unavailable: $relative"
       path_is_within "$resolved" "$LEGACY_DIR" ||
         die "Known legacy symlink points outside the legacy backup: $relative -> $target"
+      LEGACY_EXCLUDES+=("$relative")
       echo "EXCLUDED legacy Drive symlink: $relative -> $target"
       continue
     fi
@@ -461,6 +473,7 @@ check_staging_space() {
 clone_tree() {
   local source=$1
   local destination=$2
+  local source_bytes source_files
 
   case "$(uname -s)" in
     Darwin)
@@ -468,8 +481,18 @@ clone_tree() {
         die "APFS copy-on-write staging failed; refusing a full data copy."
       ;;
     Linux)
-      cp -a --reflink=always "$source" "$destination" ||
-        die "Copy-on-write staging failed; refusing a full data copy."
+      if cp -a --reflink=always "$source" "$destination" 2>/dev/null; then
+        return
+      fi
+      if [[ -e "$destination" ]]; then
+        find "$destination" -depth -delete
+      fi
+      read -r source_bytes source_files < <(tree_file_stats "$source")
+      ((source_bytes <= MAX_FULL_COPY_BYTES)) ||
+        die "Copy-on-write staging failed for $source_files files (${source_bytes} bytes); refusing a large full copy."
+      info "Copy-on-write unavailable; using bounded full-copy fallback (${source_bytes} bytes)."
+      cp -a "$source" "$destination" ||
+        die "Bounded full-copy staging failed."
       ;;
     *)
       die "Copy-on-write staging is unsupported on this operating system."
@@ -516,16 +539,20 @@ stage_sqlite_databases() {
 
 build_restic_excludes() {
   local root=$1
+  local relative
 
   RESTIC_EXCLUDES=(
     --exclude "$root/qdrant"
-    --exclude "$root/textbooks"
-    --exclude "$root/vesum"
     --exclude '**/*.db-wal'
     --exclude '**/*.db-shm'
     --exclude '**/__pycache__/**'
     --exclude '**/.DS_Store'
   )
+  if ((${#LEGACY_EXCLUDES[@]} > 0)); then
+    for relative in "${LEGACY_EXCLUDES[@]}"; do
+      RESTIC_EXCLUDES+=(--exclude "$root/$relative")
+    done
+  fi
 }
 
 source_for_backup_path() {
@@ -582,7 +609,7 @@ create_worktree_patch() {
 write_backup_receipt() {
   local inventory_file="$STAGE_DIR/path-inventory.jsonl"
   local relative bytes files git_sha git_dirty untracked_count
-  local inventory_json known_missing created_at
+  local inventory_json known_missing created_at exclusions_json
 
   : > "$inventory_file"
   for relative in "${BACKUP_PATHS[@]}"; do
@@ -610,6 +637,17 @@ write_backup_receipt() {
     known_missing='[".claude/atlas-epic/plans/curated-seed"]'
   fi
   created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  exclusions_json='["data/qdrant", "*.db-wal", "*.db-shm", "__pycache__", ".DS_Store"]'
+  if ((${#LEGACY_EXCLUDES[@]} > 0)); then
+    for relative in "${LEGACY_EXCLUDES[@]}"; do
+      exclusions_json="$(
+        jq -cn \
+          --argjson current "$exclusions_json" \
+          --arg path "data/$relative legacy symlink" \
+          '$current + [$path]'
+      )"
+    done
+  fi
 
   jq -n \
     --arg created_at "$created_at" \
@@ -620,6 +658,7 @@ write_backup_receipt() {
     --argjson untracked_count "$untracked_count" \
     --argjson paths "$inventory_json" \
     --argjson known_missing "$known_missing" \
+    --argjson exclusions "$exclusions_json" \
     '{
       schema_version: 1,
       created_at_utc: $created_at,
@@ -628,18 +667,10 @@ write_backup_receipt() {
       git_tracked_changes: $git_dirty,
       git_untracked_files_not_included: $untracked_count,
       tag: $tag,
-      backup_exit_code: 0,
+      receipt_status: "prepared-before-snapshot-write",
       paths: $paths,
       known_missing_paths: $known_missing,
-      exclusions: [
-        "data/qdrant",
-        "data/textbooks legacy symlink",
-        "data/vesum legacy symlink",
-        "*.db-wal",
-        "*.db-shm",
-        "__pycache__",
-        ".DS_Store"
-      ],
+      exclusions: $exclusions,
       restore_command: "./scripts/backup-data.sh restore latest --to /absolute/empty/directory --execute"
     }' > "$STAGED_ROOT/BACKUP-RECEIPT.json"
   BACKUP_PATHS+=("BACKUP-RECEIPT.json")
@@ -800,7 +831,7 @@ run_init() {
 }
 
 run_doctor() {
-  local failures=0
+  local failures=0 validation_output
 
   echo "Backup source: $SOURCE"
   echo "Repository: ${REPOSITORY:-<unset>}"
@@ -816,12 +847,16 @@ run_doctor() {
   done
 
   if [[ "$failures" -eq 0 ]]; then
-    validate_environment
-    validate_source
-    if repository_is_initialized; then
-      echo "OK: restic repository is initialized"
+    if validation_output="$( (validate_environment; validate_source) 2>&1)"; then
+      [[ -z "$validation_output" ]] || printf '%s\n' "$validation_output"
+      if repository_is_initialized; then
+        echo "OK: restic repository is initialized"
+      else
+        echo "NOT READY: restic repository is not initialized"
+        failures=$((failures + 1))
+      fi
     else
-      echo "NOT READY: restic repository is not initialized"
+      printf 'NOT READY: %s\n' "$validation_output" >&2
       failures=$((failures + 1))
     fi
   fi

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -1,98 +1,947 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
-# Backup all of data/ to Google Drive.
+# Versioned, encrypted backup and staging-only restore for recovery-critical
+# project state.
 #
-#   Usage:    ./scripts/backup-data.sh
-#   When:     manually, whenever you want a fresh snapshot.
-#             Typical triggers: after rebuilding sources.db / vesum.db,
-#             or after running scripts/wiki/cold_encode.py.
-#   Where:    rsyncs to the Google Drive for Desktop mount, so files
-#             sync to Drive in the background. No rclone, no OAuth,
-#             no cron. Drive keeps its own per-file version history
-#             for rollback.
-#   Covers:   everything in data/ (sources.db, vesum.db, wiki_cache.db,
-#             data/embeddings/ dense shards, any JSONL, agent bridge
-#             DBs). Excludes only SQLite WAL/SHM files (transient) +
-#             __pycache__ + .DS_Store.
-#   Notes:    data/embeddings/ costs ~3h of MLX encoding to regenerate
-#             (scripts/wiki/cold_encode.py --all-corpora), so it's
-#             worth shipping.
+# This script intentionally does not write to the Google Drive Desktop mount.
+# It uses restic's rclone backend so snapshots are versioned, deduplicated, and
+# transferred without hydrating Drive's local File Provider cache.
 #
-# Single canonical backup script. If this file is missing, that is the
-# backup path. There are no other backup scripts.
+# Covers:
+#   .claude/*-epic/  Gitignored driver plans and handoffs
+#   batch_state/     Gitignored local fleet/delegate state
+#   data/            SQLite databases, embeddings, and private inputs
+#
+# Required environment:
+#   LU_BACKUP_REPOSITORY=rclone:<remote>:<path>
+#   RESTIC_PASSWORD_FILE=/absolute/path/to/mode-600-password-file
+#
+# Start with:
+#   ./scripts/backup-data.sh doctor
+#   ./scripts/backup-data.sh init
+#   ./scripts/backup-data.sh init --execute
+#   ./scripts/backup-data.sh backup
+#   ./scripts/backup-data.sh backup --execute
+#
+# Mutating commands are previews unless --execute is present. There is no
+# prune/delete command. See docs/runbooks/data-backup.md.
 
-set -euo pipefail
+set -Eeuo pipefail
+umask 077
 
-# Resolve the Google Drive data directory.
-#   1. $LU_GDRIVE_DATA explicit override (set in ~/.bash_secrets)
-#   2. Glob ~/Library/CloudStorage/GoogleDrive-* for the per-user mount
-#      (avoids hardcoding the user's email — wartime contributor risk
-#      per #1577 Phase 1 Q4)
-if [[ -n "${LU_GDRIVE_DATA:-}" ]]; then
-  GDRIVE="$LU_GDRIVE_DATA"
-else
-  GDRIVE=""
-  for mount in "$HOME/Library/CloudStorage/"GoogleDrive-*; do
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+readonly REPO_ROOT
+readonly PROJECT_ROOT="${LU_BACKUP_PROJECT_ROOT:-$REPO_ROOT}"
+readonly SOURCE="$PROJECT_ROOT/data"
+readonly REPOSITORY="${LU_BACKUP_REPOSITORY:-${RESTIC_REPOSITORY:-}}"
+readonly PASSWORD_FILE="${RESTIC_PASSWORD_FILE:-}"
+readonly BACKUP_TAG="${LU_BACKUP_TAG:-learn-ukrainian-data}"
+readonly BACKUP_HOST="${LU_BACKUP_HOST:-learn-ukrainian}"
+readonly MIN_RESTIC_VERSION="0.19.0"
+readonly CLOUD_ROOT="${HOME}/Library/CloudStorage"
+readonly TMP_ROOT="${LU_BACKUP_TMPDIR:-${TMPDIR:-/tmp}}"
+readonly LOCK_DIR="$TMP_ROOT/learn-ukrainian-backup.${UID}.lock"
+readonly STAGE_PATH="$TMP_ROOT/learn-ukrainian-backup.${UID}.stage"
+
+STAGE_DIR=""
+STAGED_ROOT=""
+LOCK_HELD=0
+LEGACY_DIR=""
+RESTIC_EXCLUDES=()
+BACKUP_PATHS=()
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/backup-data.sh doctor
+  ./scripts/backup-data.sh init [--execute]
+  ./scripts/backup-data.sh backup [--execute]
+  ./scripts/backup-data.sh snapshots
+  ./scripts/backup-data.sh verify [SNAPSHOT] [--read-data]
+  ./scripts/backup-data.sh restore SNAPSHOT --to ABSOLUTE_EMPTY_DIR [--execute]
+
+Safety:
+  - init, backup, and restore are previews unless --execute is supplied.
+  - backup requires epic state, batch_state/, data/, and full source coverage.
+  - successful snapshots contain BACKUP-RECEIPT.json and a restore command.
+  - restore refuses non-empty, project, cloud, and legacy-backup targets.
+  - no command prunes or deletes snapshots.
+
+Required environment:
+  LU_BACKUP_REPOSITORY  Restic rclone backend, for example:
+                        rclone:lu-gdrive:Projects/learn-ukrainian-restic
+  RESTIC_PASSWORD_FILE Absolute path to a mode-600 restic password file.
+
+Optional environment:
+  LU_BACKUP_PROJECT_ROOT
+                        Project checkout (default: script's repository).
+  LU_BACKUP_LEGACY_DIR Read-only legacy Drive directory used for symlink checks.
+  LU_BACKUP_TMPDIR      Private staging parent (default: $TMPDIR or /tmp).
+  LU_BACKUP_TAG         Restic tag (default: learn-ukrainian-data).
+  LU_BACKUP_HOST        Stable restic host label (default: learn-ukrainian).
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "==> $*"
+}
+
+cleanup() {
+  local status=$?
+
+  if [[ -n "$STAGE_DIR" && -d "$STAGE_DIR" ]]; then
+    case "$STAGE_DIR" in
+      "$TMP_ROOT"/learn-ukrainian-backup.*)
+        find "$STAGE_DIR" -depth -delete
+        ;;
+      *)
+        echo "WARNING: refusing to clean unexpected staging path: $STAGE_DIR" >&2
+        ;;
+    esac
+  fi
+
+  if [[ "$LOCK_HELD" -eq 1 && -d "$LOCK_DIR" ]]; then
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+
+  return "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+require_command() {
+  local name=$1
+  local install_hint=${2:-}
+
+  if ! command -v "$name" >/dev/null 2>&1; then
+    if [[ -n "$install_hint" ]]; then
+      die "$name is required. Install it with: $install_hint"
+    fi
+    die "$name is required but was not found in PATH."
+  fi
+}
+
+version_at_least() {
+  local actual=$1
+  local minimum=$2
+  local actual_major actual_minor actual_patch
+  local minimum_major minimum_minor minimum_patch
+
+  actual=${actual%%-*}
+  minimum=${minimum%%-*}
+  IFS=. read -r actual_major actual_minor actual_patch <<<"$actual"
+  IFS=. read -r minimum_major minimum_minor minimum_patch <<<"$minimum"
+  actual_minor=${actual_minor:-0}
+  actual_patch=${actual_patch:-0}
+  minimum_minor=${minimum_minor:-0}
+  minimum_patch=${minimum_patch:-0}
+
+  ((actual_major > minimum_major)) ||
+    ((actual_major == minimum_major && actual_minor > minimum_minor)) ||
+    ((actual_major == minimum_major && actual_minor == minimum_minor &&
+      actual_patch >= minimum_patch))
+}
+
+check_restic_version() {
+  local version
+  version="$(restic version | awk 'NR == 1 {print $2}')"
+  [[ -n "$version" ]] || die "Could not determine the installed restic version."
+  version_at_least "$version" "$MIN_RESTIC_VERSION" ||
+    die "restic $MIN_RESTIC_VERSION or newer is required; found $version."
+}
+
+file_mode() {
+  local path=$1
+  local mode
+
+  if mode="$(stat -f '%Lp' "$path" 2>/dev/null)"; then
+    printf '%s\n' "$mode"
+    return
+  fi
+  stat -c '%a' "$path"
+}
+
+canonical_existing_dir() {
+  local path=$1
+  [[ -d "$path" ]] || return 1
+  (cd "$path" && pwd -P)
+}
+
+canonical_target() {
+  local path=$1
+  local parent base
+
+  [[ "$path" == /* ]] || die "Path must be absolute: $path"
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  [[ "$base" != "." && "$base" != ".." ]] || die "Unsafe target path: $path"
+  parent="$(canonical_existing_dir "$parent")" ||
+    die "Target parent does not exist: $(dirname "$path")"
+  printf '%s/%s\n' "$parent" "$base"
+}
+
+path_is_within() {
+  local child=$1
+  local parent=$2
+  [[ "$child" == "$parent" || "$child" == "$parent/"* ]]
+}
+
+paths_overlap() {
+  local first=$1
+  local second=$2
+  path_is_within "$first" "$second" || path_is_within "$second" "$first"
+}
+
+resolve_legacy_dir() {
+  local mount candidate
+
+  if [[ -n "${LU_BACKUP_LEGACY_DIR:-}" ]]; then
+    LEGACY_DIR="$(canonical_existing_dir "$LU_BACKUP_LEGACY_DIR")" ||
+      die "LU_BACKUP_LEGACY_DIR is not an existing directory."
+    return
+  fi
+
+  for mount in "$CLOUD_ROOT"/GoogleDrive-*; do
     candidate="$mount/My Drive/Projects/learn-ukrainian-data"
     if [[ -d "$candidate" ]]; then
-      GDRIVE="$candidate"
-      break
+      LEGACY_DIR="$(canonical_existing_dir "$candidate")"
+      return
     fi
   done
-fi
+}
 
-# Resolve script-relative source path so the script works regardless
-# of where it's checked out.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SRC="$(cd "$SCRIPT_DIR/.." && pwd)/data"
+validate_password_file() {
+  local mode
 
-echo "=== Backing up data to Google Drive ==="
-echo "Source: $SRC"
-echo "Target: $GDRIVE"
-echo ""
+  [[ -n "$PASSWORD_FILE" ]] ||
+    die "RESTIC_PASSWORD_FILE must point to a mode-600 password file."
+  [[ "$PASSWORD_FILE" == /* ]] ||
+    die "RESTIC_PASSWORD_FILE must be an absolute path."
+  [[ -f "$PASSWORD_FILE" ]] || die "Password file does not exist: $PASSWORD_FILE"
+  mode="$(file_mode "$PASSWORD_FILE")"
+  (( (8#$mode & 077) == 0 )) ||
+    die "Password file must not be accessible by group/others (mode is $mode)."
+  export RESTIC_PASSWORD_FILE="$PASSWORD_FILE"
+}
 
-if [[ -z "$GDRIVE" ]]; then
-  echo "ERROR: cannot resolve Google Drive mount." >&2
-  echo "Set \$LU_GDRIVE_DATA in your environment, or sign in to Google Drive Desktop" >&2
-  echo "and ensure ~/Library/CloudStorage/GoogleDrive-*/My Drive/Projects/learn-ukrainian-data exists." >&2
-  exit 1
-fi
+validate_repository_config() {
+  local remote_spec remote_name
 
-if [[ ! -d "$(dirname "$GDRIVE")" ]]; then
-  echo "ERROR: Google Drive for Desktop mount not found at:" >&2
-  echo "  $(dirname "$GDRIVE")" >&2
-  echo "Make sure Google Drive for Desktop is running and your account is signed in." >&2
-  exit 1
-fi
+  [[ -n "$REPOSITORY" ]] ||
+    die "Set LU_BACKUP_REPOSITORY to rclone:<remote>:<path>."
+  [[ "$REPOSITORY" == rclone:*:* ]] ||
+    die "LU_BACKUP_REPOSITORY must use restic's rclone:<remote>:<path> backend."
 
-mkdir -p "$GDRIVE"
+  remote_spec=${REPOSITORY#rclone:}
+  remote_name=${remote_spec%%:*}
+  [[ -n "$remote_name" && "$remote_spec" == *:* && "${remote_spec#*:}" != "" ]] ||
+    die "Invalid rclone repository. Expected rclone:<remote>:<path>."
 
-rsync -av \
-  --exclude='qdrant/' \
-  --exclude='*.db-shm' \
-  --exclude='*.db-wal' \
-  --exclude='__pycache__/' \
-  --exclude='.DS_Store' \
-  "$SRC/" "$GDRIVE/"
-# `qdrant/` exclude: Qdrant is retired (ADR-005/006) but ~4.6G of old
-# storage is still on disk. Not worth backing up — regenerable from
-# JSONL if ever needed. Safe to `rm -rf data/qdrant/` locally to
-# reclaim the space; this exclude just keeps the dir out of Drive
-# whether or not it's been cleaned up locally.
+  if ! rclone listremotes | grep -Fqx "$remote_name:"; then
+    die "rclone remote '$remote_name:' is not configured. Run 'rclone config' first."
+  fi
+  export RESTIC_REPOSITORY="$REPOSITORY"
+}
 
-echo ""
-echo "=== Backup complete ==="
-du -sh "$GDRIVE"
-echo ""
-echo "Files backed up:"
-find "$GDRIVE" -type f | wc -l | xargs echo "  Total files:"
-find "$GDRIVE" -name '*.jsonl' | wc -l | xargs echo "  JSONL files:"
-find "$GDRIVE" -name '*.db' | wc -l | xargs echo "  SQLite DBs:"
-if [[ -d "$GDRIVE/embeddings" ]]; then
-  find "$GDRIVE/embeddings" -type f -name 'shard-*.npy' | wc -l \
-    | xargs echo "  Dense shards:"
-  du -sh "$GDRIVE/embeddings" | awk '{print "  Embeddings size:", $1}'
-fi
-echo ""
-echo "Drive will sync these to the cloud in the background."
-echo "Confirm sync completion in the Google Drive menu bar icon before shutting down."
+validate_environment() {
+  require_command restic "brew install restic"
+  require_command rclone "brew install rclone"
+  require_command sqlite3
+  require_command find
+  require_command git
+  require_command jq "brew install jq"
+  require_command realpath
+  require_command touch
+  check_restic_version
+  validate_password_file
+  validate_repository_config
+
+  [[ "$PROJECT_ROOT" == /* ]] || die "LU_BACKUP_PROJECT_ROOT must be absolute."
+  [[ -d "$PROJECT_ROOT" ]] || die "Project checkout does not exist: $PROJECT_ROOT"
+  [[ -d "$SOURCE" ]] || die "Backup source does not exist: $SOURCE"
+  [[ -d "$TMP_ROOT" ]] || die "Staging parent does not exist: $TMP_ROOT"
+}
+
+repository_is_initialized() {
+  restic cat config >/dev/null 2>&1
+}
+
+require_initialized_repository() {
+  repository_is_initialized ||
+    die "Restic repository is not initialized. Preview and run 'init --execute'."
+}
+
+validate_source_symlinks() {
+  local link relative target resolved
+  local source_real
+
+  source_real="$(canonical_existing_dir "$SOURCE")"
+  while IFS= read -r -d '' link; do
+    relative=${link#"$SOURCE"/}
+    target="$(readlink "$link")"
+    resolved="$(realpath "$link" 2>/dev/null)" ||
+      die "Broken symlink in backup source: $relative -> $target"
+
+    if [[ "$relative" == "textbooks" || "$relative" == "vesum" ]]; then
+      [[ -n "$LEGACY_DIR" ]] ||
+        die "Legacy symlink found but the legacy Drive directory is unavailable: $relative"
+      path_is_within "$resolved" "$LEGACY_DIR" ||
+        die "Known legacy symlink points outside the legacy backup: $relative -> $target"
+      echo "EXCLUDED legacy Drive symlink: $relative -> $target"
+      continue
+    fi
+
+    [[ "$target" != /* ]] ||
+      die "Absolute symlink is not backup-safe: $relative -> $target"
+    path_is_within "$resolved" "$source_real" ||
+      die "Symlink escapes the backup source: $relative -> $target"
+  done < <(
+    find "$SOURCE" \
+      -path "$SOURCE/qdrant" -prune -o \
+      -type l -print0
+  )
+}
+
+validate_tree_symlinks() {
+  local tree=$1
+  local label=$2
+  local link relative target resolved tree_real
+
+  [[ ! -L "$tree" ]] || die "Backup root must not be a symlink: $label"
+  tree_real="$(canonical_existing_dir "$tree")"
+  while IFS= read -r -d '' link; do
+    relative=${link#"$tree"/}
+    target="$(readlink "$link")"
+    resolved="$(realpath "$link" 2>/dev/null)" ||
+      die "Broken symlink in $label: $relative -> $target"
+    [[ "$target" != /* ]] ||
+      die "Absolute symlink is not backup-safe in $label: $relative -> $target"
+    path_is_within "$resolved" "$tree_real" ||
+      die "Symlink escapes $label: $relative -> $target"
+  done < <(find "$tree" -type l -print0)
+}
+
+discover_backup_paths() {
+  local epic
+
+  BACKUP_PATHS=()
+  [[ -d "$PROJECT_ROOT/.claude/atlas-epic" ]] ||
+    die "Required recovery path is missing: .claude/atlas-epic"
+  [[ ! -L "$PROJECT_ROOT/.claude/atlas-epic" ]] ||
+    die "Required recovery path must not be a symlink: .claude/atlas-epic"
+  [[ -d "$PROJECT_ROOT/batch_state" ]] ||
+    die "Required recovery path is missing: batch_state"
+  [[ ! -L "$PROJECT_ROOT/batch_state" ]] ||
+    die "Required recovery path must not be a symlink: batch_state"
+
+  for epic in "$PROJECT_ROOT"/.claude/*-epic; do
+    [[ -d "$epic" ]] || continue
+    [[ ! -L "$epic" ]] ||
+      die "Epic recovery path must not be a symlink: ${epic#"$PROJECT_ROOT"/}"
+    [[ "$(basename "$epic")" =~ ^[a-z0-9-]+-epic$ ]] ||
+      die "Epic recovery path has an unsafe label: $(basename "$epic")"
+    BACKUP_PATHS+=(".claude/$(basename "$epic")")
+  done
+  BACKUP_PATHS+=("batch_state" "data")
+}
+
+path_has_backup_coverage() {
+  local relative=$1
+  local backup_path
+
+  for backup_path in "${BACKUP_PATHS[@]}"; do
+    path_is_within "$relative" "$backup_path" && return 0
+  done
+  return 1
+}
+
+validate_untracked_coverage() {
+  local relative uncovered=0
+
+  while IFS= read -r -d '' relative; do
+    path_has_backup_coverage "$relative" && continue
+    echo "UNBACKED untracked Git path: $relative" >&2
+    uncovered=$((uncovered + 1))
+  done < <(git -C "$PROJECT_ROOT" ls-files --others --exclude-standard -z)
+  [[ "$uncovered" -eq 0 ]] ||
+    die "$uncovered untracked path(s) are outside Git and declared recovery roots."
+}
+
+validate_source() {
+  local source_real repo_real project_real tmp_real git_root relative
+
+  source_real="$(canonical_existing_dir "$SOURCE")"
+  repo_real="$(canonical_existing_dir "$REPO_ROOT")"
+  project_real="$(canonical_existing_dir "$PROJECT_ROOT")"
+  tmp_real="$(canonical_existing_dir "$TMP_ROOT")"
+  git_root="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" ||
+    die "Project root is not a Git checkout: $PROJECT_ROOT"
+  git_root="$(canonical_existing_dir "$git_root")"
+  [[ "$git_root" == "$project_real" ]] ||
+    die "LU_BACKUP_PROJECT_ROOT must be the Git checkout root."
+
+  paths_overlap "$source_real" "$tmp_real" &&
+    die "Staging directory and backup source overlap."
+  paths_overlap "$repo_real" "$tmp_real" &&
+    die "Staging directory must be outside the project checkout."
+  paths_overlap "$project_real" "$tmp_real" &&
+    die "Staging directory must be outside the selected project checkout."
+  [[ "$source_real" != "$project_real" ]] ||
+    die "Refusing to back up the entire repository as data/."
+  resolve_legacy_dir
+  discover_backup_paths
+  validate_untracked_coverage
+  validate_source_symlinks
+  for relative in "${BACKUP_PATHS[@]}"; do
+    [[ "$relative" != "data" ]] || continue
+    validate_tree_symlinks "$PROJECT_ROOT/$relative" "$relative"
+  done
+}
+
+acquire_lock() {
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    die "Another backup operation holds the local lock: $LOCK_DIR"
+  fi
+  LOCK_HELD=1
+}
+
+list_sqlite_sources() {
+  local relative
+
+  find "$SOURCE" \
+    -path "$SOURCE/qdrant" -prune -o \
+    -type f \( -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' \) \
+    -print0
+  for relative in "${BACKUP_PATHS[@]}"; do
+    [[ "$relative" != "data" ]] || continue
+    find "$PROJECT_ROOT/$relative" \
+      -type f \( -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' \) \
+      -print0
+  done
+}
+
+db_size_bytes() {
+  local total=0 database size
+
+  while IFS= read -r -d '' database; do
+    if size="$(stat -f '%z' "$database" 2>/dev/null)"; then
+      :
+    else
+      size="$(stat -c '%s' "$database")"
+    fi
+    total=$((total + size))
+  done < <(list_sqlite_sources)
+  printf '%s\n' "$total"
+}
+
+available_kib() {
+  df -Pk "$TMP_ROOT" | awk 'NR == 2 {print $4}'
+}
+
+check_staging_space() {
+  local db_bytes required_kib free_kib
+  local -r safety_kib=$((2 * 1024 * 1024))
+
+  db_bytes="$(db_size_bytes)"
+  required_kib=$(((db_bytes + 1023) / 1024 + safety_kib))
+  free_kib="$(available_kib)"
+  [[ "$free_kib" =~ ^[0-9]+$ ]] || die "Could not determine staging free space."
+  ((free_kib >= required_kib)) ||
+    die "Insufficient staging space: need at least ${required_kib} KiB, have ${free_kib} KiB."
+}
+
+clone_tree() {
+  local source=$1
+  local destination=$2
+
+  case "$(uname -s)" in
+    Darwin)
+      /bin/cp -cRp "$source" "$destination" ||
+        die "APFS copy-on-write staging failed; refusing a full data copy."
+      ;;
+    Linux)
+      cp -a --reflink=always "$source" "$destination" ||
+        die "Copy-on-write staging failed; refusing a full data copy."
+      ;;
+    *)
+      die "Copy-on-write staging is unsupported on this operating system."
+      ;;
+  esac
+}
+
+sqlite_backup_command() {
+  local source_db=$1
+  local destination_db=$2
+
+  [[ "$source_db" != *"'"* && "$destination_db" != *"'"* ]] ||
+    die "SQLite backup paths may not contain a single quote."
+  sqlite3 -readonly "$source_db" ".backup '$destination_db'"
+}
+
+stage_sqlite_databases() {
+  local source_db relative staged_db check_output source_mode
+
+  while IFS= read -r -d '' source_db; do
+    if path_is_within "$source_db" "$SOURCE"; then
+      relative="data/${source_db#"$SOURCE"/}"
+    elif path_is_within "$source_db" "$PROJECT_ROOT"; then
+      relative=${source_db#"$PROJECT_ROOT"/}
+    else
+      die "SQLite source escaped configured backup roots: $source_db"
+    fi
+    staged_db="$STAGED_ROOT/$relative"
+    info "Creating consistent SQLite snapshot: $relative"
+    find "$staged_db" -maxdepth 0 -type f -delete
+    sqlite_backup_command "$source_db" "$staged_db" ||
+      die "SQLite online backup failed: $relative"
+    source_mode="$(file_mode "$source_db")"
+    chmod "$source_mode" "$staged_db"
+    touch -r "$source_db" "$staged_db"
+    touch -r "$(dirname "$source_db")" "$(dirname "$staged_db")"
+    check_output="$(
+      sqlite3 "file:$staged_db?mode=ro&immutable=1" 'PRAGMA quick_check;'
+    )" || die "SQLite quick_check failed to run: $relative"
+    [[ "$check_output" == "ok" ]] ||
+      die "SQLite quick_check rejected staged database $relative: $check_output"
+  done < <(list_sqlite_sources)
+}
+
+build_restic_excludes() {
+  local root=$1
+
+  RESTIC_EXCLUDES=(
+    --exclude "$root/qdrant"
+    --exclude "$root/textbooks"
+    --exclude "$root/vesum"
+    --exclude '**/*.db-wal'
+    --exclude '**/*.db-shm'
+    --exclude '**/__pycache__/**'
+    --exclude '**/.DS_Store'
+  )
+}
+
+source_for_backup_path() {
+  local relative=$1
+
+  if [[ "$relative" == "data" ]]; then
+    printf '%s\n' "$SOURCE"
+  else
+    printf '%s/%s\n' "$PROJECT_ROOT" "$relative"
+  fi
+}
+
+tree_file_stats() {
+  local tree=$1
+  local total=0 count=0 file size
+
+  while IFS= read -r -d '' file; do
+    if size="$(stat -f '%z' "$file" 2>/dev/null)"; then
+      :
+    else
+      size="$(stat -c '%s' "$file")"
+    fi
+    total=$((total + size))
+    count=$((count + 1))
+  done < <(find "$tree" -type f -print0)
+  printf '%s %s\n' "$total" "$count"
+}
+
+print_backup_selection() {
+  local relative source_path bytes files
+  local missing_seed="$PROJECT_ROOT/.claude/atlas-epic/plans/curated-seed"
+
+  info "Recovery roots selected (repo-local sole copies first):"
+  for relative in "${BACKUP_PATHS[@]}"; do
+    source_path="$(source_for_backup_path "$relative")"
+    read -r bytes files < <(tree_file_stats "$source_path")
+    printf '  %s files=%s bytes=%s\n' "$relative" "$files" "$bytes"
+  done
+  echo "  BACKUP-RECEIPT.json generated during an executed backup"
+  echo "  GIT-WORKTREE.patch generated when tracked changes are present"
+  if [[ ! -d "$missing_seed" ]]; then
+    echo "WARNING: known previously lost path is absent: .claude/atlas-epic/plans/curated-seed" >&2
+  fi
+}
+
+create_worktree_patch() {
+  if ! git -C "$PROJECT_ROOT" diff --quiet HEAD --; then
+    git -C "$PROJECT_ROOT" diff --binary HEAD -- \
+      > "$STAGED_ROOT/GIT-WORKTREE.patch"
+    BACKUP_PATHS+=("GIT-WORKTREE.patch")
+  fi
+}
+
+write_backup_receipt() {
+  local inventory_file="$STAGE_DIR/path-inventory.jsonl"
+  local relative bytes files git_sha git_dirty untracked_count
+  local inventory_json known_missing created_at
+
+  : > "$inventory_file"
+  for relative in "${BACKUP_PATHS[@]}"; do
+    read -r bytes files < <(tree_file_stats "$STAGED_ROOT/$relative")
+    jq -cn \
+      --arg path "$relative" \
+      --argjson files "$files" \
+      --argjson bytes "$bytes" \
+      '{path: $path, files: $files, bytes: $bytes}' \
+      >> "$inventory_file"
+  done
+  inventory_json="$(jq -s '.' "$inventory_file")"
+  find "$inventory_file" -maxdepth 0 -type f -delete
+
+  git_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
+  git_dirty=false
+  git -C "$PROJECT_ROOT" diff --quiet HEAD -- || git_dirty=true
+  untracked_count=0
+  while IFS= read -r -d '' relative; do
+    path_has_backup_coverage "$relative" && continue
+    untracked_count=$((untracked_count + 1))
+  done < <(git -C "$PROJECT_ROOT" ls-files --others --exclude-standard -z)
+  known_missing='[]'
+  if [[ ! -d "$PROJECT_ROOT/.claude/atlas-epic/plans/curated-seed" ]]; then
+    known_missing='[".claude/atlas-epic/plans/curated-seed"]'
+  fi
+  created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  jq -n \
+    --arg created_at "$created_at" \
+    --arg host "$BACKUP_HOST" \
+    --arg git_sha "$git_sha" \
+    --arg tag "$BACKUP_TAG" \
+    --argjson git_dirty "$git_dirty" \
+    --argjson untracked_count "$untracked_count" \
+    --argjson paths "$inventory_json" \
+    --argjson known_missing "$known_missing" \
+    '{
+      schema_version: 1,
+      created_at_utc: $created_at,
+      host: $host,
+      git_sha: $git_sha,
+      git_tracked_changes: $git_dirty,
+      git_untracked_files_not_included: $untracked_count,
+      tag: $tag,
+      backup_exit_code: 0,
+      paths: $paths,
+      known_missing_paths: $known_missing,
+      exclusions: [
+        "data/qdrant",
+        "data/textbooks legacy symlink",
+        "data/vesum legacy symlink",
+        "*.db-wal",
+        "*.db-shm",
+        "__pycache__",
+        ".DS_Store"
+      ],
+      restore_command: "./scripts/backup-data.sh restore latest --to /absolute/empty/directory --execute"
+    }' > "$STAGED_ROOT/BACKUP-RECEIPT.json"
+  BACKUP_PATHS+=("BACKUP-RECEIPT.json")
+}
+
+prepare_staging_tree() {
+  local relative source_path destination
+
+  STAGED_ROOT="$STAGE_DIR/project-state"
+  mkdir -m 700 "$STAGED_ROOT"
+  for relative in "${BACKUP_PATHS[@]}"; do
+    source_path="$(source_for_backup_path "$relative")"
+    destination="$STAGED_ROOT/$relative"
+    mkdir -p "$(dirname "$destination")"
+    info "Staging recovery root: $relative"
+    clone_tree "$source_path" "$destination"
+  done
+  stage_sqlite_databases
+  create_worktree_patch
+  write_backup_receipt
+}
+
+run_backup() {
+  local execute=$1
+  local backup_root
+
+  validate_environment
+  validate_source
+  require_initialized_repository
+  print_backup_selection
+
+  if [[ "$execute" -eq 0 ]]; then
+    info "Backup preview only; no snapshot will be written."
+    backup_root="$SOURCE"
+    build_restic_excludes "$backup_root"
+    (
+      cd "$PROJECT_ROOT"
+      restic backup "${BACKUP_PATHS[@]}" \
+        --dry-run \
+        --verbose=2 \
+        --host "$BACKUP_HOST" \
+        --tag "$BACKUP_TAG" \
+        "${RESTIC_EXCLUDES[@]}"
+    )
+    echo "Preview complete. Re-run with --execute to create a snapshot."
+    return
+  fi
+
+  acquire_lock
+  check_staging_space
+  STAGE_DIR="$STAGE_PATH"
+  [[ ! -L "$STAGE_DIR" ]] ||
+    die "Refusing symlink at the private staging path: $STAGE_DIR"
+  if [[ -e "$STAGE_DIR" ]]; then
+    die "Stale staging path exists; inspect and remove it before retrying: $STAGE_DIR"
+  fi
+  mkdir -m 700 "$STAGE_DIR"
+  info "Creating private copy-on-write staging tree."
+  prepare_staging_tree
+
+  backup_root="$STAGED_ROOT/data"
+  build_restic_excludes "$backup_root"
+  info "Creating encrypted, versioned restic snapshot."
+  (
+    cd "$STAGED_ROOT"
+    restic backup "${BACKUP_PATHS[@]}" \
+      --host "$BACKUP_HOST" \
+      --tag "$BACKUP_TAG" \
+      "${RESTIC_EXCLUDES[@]}"
+  )
+  info "Checking repository metadata after backup."
+  restic check
+  info "Backup and repository check complete."
+}
+
+validate_restore_target() {
+  local target=$1
+  local target_real repo_real project_real source_real cloud_real
+
+  target_real="$(canonical_target "$target")"
+  repo_real="$(canonical_existing_dir "$REPO_ROOT")"
+  project_real="$(canonical_existing_dir "$PROJECT_ROOT")"
+  source_real="$(canonical_existing_dir "$SOURCE")"
+
+  [[ ! -L "$target_real" ]] ||
+    die "Restore target must not be a symlink: $target_real"
+  [[ ! -e "$target_real" || -d "$target_real" ]] ||
+    die "Restore target exists and is not a directory: $target_real"
+  paths_overlap "$target_real" "$repo_real" &&
+    die "Restore target must be outside the project checkout."
+  paths_overlap "$target_real" "$project_real" &&
+    die "Restore target must be outside the selected project checkout."
+  paths_overlap "$target_real" "$source_real" &&
+    die "Restore target must not overlap the live backup source."
+
+  if [[ -d "$CLOUD_ROOT" ]]; then
+    cloud_real="$(canonical_existing_dir "$CLOUD_ROOT")"
+    paths_overlap "$target_real" "$cloud_real" &&
+      die "Restore target must be outside CloudStorage."
+  fi
+
+  resolve_legacy_dir
+  if [[ -n "$LEGACY_DIR" ]] && paths_overlap "$target_real" "$LEGACY_DIR"; then
+    die "Restore target must not overlap the read-only legacy backup."
+  fi
+
+  if [[ -e "$target_real" ]] &&
+    [[ -n "$(find "$target_real" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    die "Restore target must be empty: $target_real"
+  fi
+
+  printf '%s\n' "$target_real"
+}
+
+run_restore() {
+  local snapshot=$1
+  local target=$2
+  local execute=$3
+  local target_real
+  local -a args
+
+  validate_environment
+  require_initialized_repository
+  [[ -n "$snapshot" && "$snapshot" != -* ]] || die "Invalid snapshot ID."
+  target_real="$(validate_restore_target "$target")"
+
+  args=(restore "$snapshot" --target "$target_real" --overwrite never)
+  if [[ "$execute" -eq 0 ]]; then
+    info "Restore preview only; no files will be written."
+    restic "${args[@]}" --dry-run --verbose=2
+    echo "Preview complete. Re-run with --execute to restore into: $target_real"
+    return
+  fi
+
+  acquire_lock
+  restic "${args[@]}"
+  info "Restore complete. Validate the staged data before any live import: $target_real"
+}
+
+run_init() {
+  local execute=$1
+
+  validate_environment
+  validate_source
+  if repository_is_initialized; then
+    die "Restic repository is already initialized."
+  fi
+  if [[ "$execute" -eq 0 ]]; then
+    info "Initialization preview only; no repository will be created."
+    echo "Repository: $REPOSITORY"
+    echo "Re-run with --execute after confirming the remote and password recovery plan."
+    return
+  fi
+  acquire_lock
+  restic init
+  restic check
+  info "Repository initialized and checked."
+}
+
+run_doctor() {
+  local failures=0
+
+  echo "Backup source: $SOURCE"
+  echo "Repository: ${REPOSITORY:-<unset>}"
+  echo "Legacy Drive directory: read-only discovery"
+
+  for command in restic rclone sqlite3 find git jq realpath touch; do
+    if command -v "$command" >/dev/null 2>&1; then
+      echo "OK: $command"
+    else
+      echo "MISSING: $command"
+      failures=$((failures + 1))
+    fi
+  done
+
+  if [[ "$failures" -eq 0 ]]; then
+    validate_environment
+    validate_source
+    if repository_is_initialized; then
+      echo "OK: restic repository is initialized"
+    else
+      echo "NOT READY: restic repository is not initialized"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if [[ "$failures" -ne 0 ]]; then
+    echo "Doctor found $failures blocking problem(s)." >&2
+    return 1
+  fi
+  echo "Doctor checks passed."
+}
+
+parse_execute_only() {
+  local execute=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --execute)
+        execute=1
+        ;;
+      *)
+        die "Unknown option: $1"
+        ;;
+    esac
+    shift
+  done
+  printf '%s\n' "$execute"
+}
+
+main() {
+  local command=${1:-help}
+  local execute snapshot target read_data
+  shift || true
+
+  case "$command" in
+    help|-h|--help)
+      usage
+      ;;
+    doctor)
+      [[ $# -eq 0 ]] || die "doctor does not accept arguments."
+      run_doctor
+      ;;
+    init)
+      execute="$(parse_execute_only "$@")"
+      run_init "$execute"
+      ;;
+    backup)
+      execute="$(parse_execute_only "$@")"
+      run_backup "$execute"
+      ;;
+    snapshots)
+      [[ $# -eq 0 ]] || die "snapshots does not accept arguments."
+      validate_environment
+      require_initialized_repository
+      restic snapshots --host "$BACKUP_HOST" --tag "$BACKUP_TAG"
+      ;;
+    verify)
+      snapshot=""
+      read_data=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --read-data)
+            read_data=1
+            ;;
+          -*)
+            die "Unknown option: $1"
+            ;;
+          *)
+            [[ -z "$snapshot" ]] || die "verify accepts at most one snapshot ID."
+            snapshot=$1
+            ;;
+        esac
+        shift
+      done
+      validate_environment
+      require_initialized_repository
+      if [[ "$read_data" -eq 1 ]]; then
+        if [[ -n "$snapshot" ]]; then
+          restic check --read-data "$snapshot"
+        else
+          restic check --read-data
+        fi
+      elif [[ -n "$snapshot" ]]; then
+        restic check "$snapshot"
+      else
+        restic check
+      fi
+      ;;
+    restore)
+      snapshot=""
+      target=""
+      execute=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --to)
+            shift
+            [[ $# -gt 0 ]] || die "--to requires an absolute directory."
+            target=$1
+            ;;
+          --execute)
+            execute=1
+            ;;
+          -*)
+            die "Unknown option: $1"
+            ;;
+          *)
+            [[ -z "$snapshot" ]] || die "restore accepts exactly one snapshot ID."
+            snapshot=$1
+            ;;
+        esac
+        shift
+      done
+      [[ -n "$snapshot" ]] || die "restore requires a snapshot ID."
+      [[ -n "$target" ]] || die "restore requires --to ABSOLUTE_EMPTY_DIR."
+      run_restore "$snapshot" "$target" "$execute"
+      ;;
+    *)
+      usage >&2
+      die "Unknown command: $command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -392,6 +392,23 @@ def test_data_root_must_not_be_a_symlink(
     assert "arg=<backup>" not in _log(environment)
 
 
+def test_claude_parent_must_not_be_a_symlink(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    claude_directory = source.parent / ".claude"
+    external_claude = tmp_path / "external-claude"
+    claude_directory.rename(external_claude)
+    claude_directory.symlink_to(external_claude, target_is_directory=True)
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Recovery parent must not be a symlink: .claude" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
 def test_restore_is_a_dry_run_and_refuses_unsafe_targets(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
     tmp_path: Path,
@@ -466,6 +483,31 @@ def test_init_requires_execute_before_creating_repository(
     assert executed.returncode == 0, executed.stderr
     assert "arg=<init>" in _log(environment)
     assert "arg=<check>" in _log(environment)
+
+
+def test_verify_checks_repository_and_rejects_snapshot_arguments(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+
+    metadata_check = _run(environment, "verify")
+
+    assert metadata_check.returncode == 0, metadata_check.stderr
+    assert "arg=<check>" in _log(environment)
+    assert "arg=<--read-data>" not in _log(environment)
+
+    Path(environment["FAKE_RESTIC_LOG"]).write_text("", encoding="utf-8")
+    data_check = _run(environment, "verify", "--read-data")
+
+    assert data_check.returncode == 0, data_check.stderr
+    assert "arg=<check> arg=<--read-data>" in _log(environment)
+
+    Path(environment["FAKE_RESTIC_LOG"]).write_text("", encoding="utf-8")
+    rejected = _run(environment, "verify", "latest")
+
+    assert rejected.returncode != 0
+    assert "does not accept snapshot IDs" in rejected.stderr
+    assert _log(environment) == ""
 
 
 def test_doctor_summarizes_validation_failure(

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -107,8 +107,18 @@ if [[ "${1:-}" == "backup" && -n "${FAKE_REQUIRED_RELATIVE:-}" ]]; then
   printf 'staged_required=<%s>\n' "$FAKE_REQUIRED_RELATIVE" \
     >> "$FAKE_RESTIC_LOG"
 fi
+if [[ "${1:-}" == "backup" && -n "${FAKE_FORBIDDEN_RELATIVES:-}" ]]; then
+  for forbidden in $FAKE_FORBIDDEN_RELATIVES; do
+    test ! -e "$PWD/$forbidden"
+    printf 'staged_excluded=<%s>\n' "$forbidden" >> "$FAKE_RESTIC_LOG"
+  done
+fi
 if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
-  jq -c '{status: .receipt_status, paths: [.paths[].path]}' \
+  jq -c '{
+    status: .receipt_status,
+    paths: [.paths[].path],
+    data: (.paths[] | select(.path == "data"))
+  }' \
     "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
 fi
 exit 0
@@ -208,6 +218,27 @@ def test_execute_rejects_a_corrupt_database_before_upload(
     assert result.returncode != 0
     assert "SQLite online backup failed: data/corrupt.db" in result.stderr
     assert "arg=<backup>" not in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_receipt_counts_match_post_exclusion_snapshot_contents(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    (source / "qdrant").mkdir()
+    (source / "qdrant" / "retired.bin").write_bytes(b"not recoverable")
+    (source / "__pycache__").mkdir()
+    (source / "__pycache__" / "cache.pyc").write_bytes(b"not recoverable")
+    (source / "sidecar.db-wal").write_bytes(b"not recoverable")
+    (source / ".DS_Store").write_bytes(b"not recoverable")
+    (source / "keep.txt").write_bytes(b"keep\n")
+    environment["FAKE_FORBIDDEN_RELATIVES"] = "data/qdrant data/__pycache__ data/sidecar.db-wal data/.DS_Store"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert '"data":{"path":"data","files":1,"bytes":5}' in _log(environment)
+    assert _log(environment).count("staged_excluded=<") == 4
     assert list(staging.iterdir()) == []
 
 

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -1,0 +1,373 @@
+"""Safety and recovery tests for scripts/backup-data.sh."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "backup-data.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o700)
+
+
+@pytest.fixture
+def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
+    fake_bin = tmp_path / "bin"
+    project = tmp_path / "project"
+    source = project / "data"
+    staging = tmp_path / "staging"
+    legacy = tmp_path / "legacy"
+    password_file = tmp_path / "restic-password"
+    log = tmp_path / "restic.log"
+
+    for directory in (
+        fake_bin,
+        source,
+        project / ".claude" / "atlas-epic",
+        project / "batch_state",
+        staging,
+        legacy,
+        tmp_path / "home",
+    ):
+        directory.mkdir(parents=True)
+    (project / "README.md").write_text("fixture\n", encoding="utf-8")
+    (project / ".claude" / "atlas-epic" / "HANDOFF.md").write_text(
+        "recover me\n",
+        encoding="utf-8",
+    )
+    (project / "batch_state" / "state.txt").write_text(
+        "recover me too\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(project)], check=True)
+    subprocess.run(
+        ["git", "-C", str(project), "add", "README.md"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "-c",
+            "user.name=Backup Test",
+            "-c",
+            "user.email=backup-test@example.invalid",
+            "commit",
+            "-qm",
+            "test fixture",
+        ],
+        check=True,
+    )
+    password_file.write_text("test-only-password\n", encoding="utf-8")
+    password_file.chmod(0o600)
+
+    _write_executable(
+        fake_bin / "rclone",
+        """#!/bin/bash
+set -eu
+if [[ "${1:-}" == "listremotes" ]]; then
+  printf '%s\n' 'testdrive:'
+  exit 0
+fi
+exit 64
+""",
+    )
+    _write_executable(
+        fake_bin / "restic",
+        """#!/bin/bash
+set -eu
+if [[ "${1:-}" == "version" ]]; then
+  printf '%s\n' 'restic 0.19.1 compiled with go1.24.0 on darwin/arm64'
+  exit 0
+fi
+{
+  printf 'cwd=<%s>' "$PWD"
+  printf ' arg=<%s>' "$@"
+  printf '\n'
+} >> "$FAKE_RESTIC_LOG"
+if [[ "${1:-}" == "cat" && "${FAKE_REPOSITORY_STATE:-initialized}" != "initialized" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "backup" && -n "${FAKE_DB_RELATIVE:-}" ]]; then
+  rows="$(sqlite3 "file:$PWD/$FAKE_DB_RELATIVE?mode=ro&immutable=1" \
+    'SELECT COUNT(*) FROM recovery_probe;')"
+  printf 'db_rows=<%s>\n' "$rows" >> "$FAKE_RESTIC_LOG"
+fi
+if [[ "${1:-}" == "backup" && -n "${FAKE_REQUIRED_RELATIVE:-}" ]]; then
+  test -f "$PWD/$FAKE_REQUIRED_RELATIVE"
+  printf 'staged_required=<%s>\n' "$FAKE_REQUIRED_RELATIVE" \
+    >> "$FAKE_RESTIC_LOG"
+fi
+if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
+  jq -c '{exit: .backup_exit_code, paths: [.paths[].path]}' \
+    "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
+fi
+exit 0
+""",
+    )
+
+    environment = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path / "home"),
+        "LU_BACKUP_REPOSITORY": "rclone:testdrive:Projects/test-restic",
+        "RESTIC_PASSWORD_FILE": str(password_file),
+        "LU_BACKUP_PROJECT_ROOT": str(project),
+        "LU_BACKUP_TMPDIR": str(staging),
+        "LU_BACKUP_LEGACY_DIR": str(legacy),
+        "FAKE_RESTIC_LOG": str(log),
+        "FAKE_REPOSITORY_STATE": "initialized",
+    }
+    return environment, source, staging, legacy
+
+
+def _run(
+    environment: dict[str, str],
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", str(SCRIPT), *arguments],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+
+
+def _log(environment: dict[str, str]) -> str:
+    path = Path(environment["FAKE_RESTIC_LOG"])
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_backup_defaults_to_repository_dry_run(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    source_file = source / "valuable.txt"
+    source_file.write_text("do not mutate\n", encoding="utf-8")
+
+    result = _run(environment, "backup")
+
+    assert result.returncode == 0, result.stderr
+    assert "Backup preview only" in result.stdout
+    assert "arg=<backup>" in _log(environment)
+    assert "arg=<--dry-run>" in _log(environment)
+    assert source_file.read_text(encoding="utf-8") == "do not mutate\n"
+    assert list(staging.iterdir()) == []
+
+
+def test_execute_stages_a_consistent_wal_database_and_cleans_up(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    database = source / "live.db"
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute("CREATE TABLE recovery_probe (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO recovery_probe VALUES ('first')")
+        connection.commit()
+        connection.execute("INSERT INTO recovery_probe VALUES ('latest')")
+        connection.commit()
+        assert database.with_name("live.db-wal").exists()
+        environment["FAKE_DB_RELATIVE"] = "data/live.db"
+        environment["FAKE_REQUIRED_RELATIVE"] = ".claude/atlas-epic/HANDOFF.md"
+
+        result = _run(environment, "backup", "--execute")
+    finally:
+        connection.close()
+
+    assert result.returncode == 0, result.stderr
+    assert "Creating consistent SQLite snapshot: data/live.db" in result.stdout
+    assert "db_rows=<2>" in _log(environment)
+    assert "staged_required=<.claude/atlas-epic/HANDOFF.md>" in _log(environment)
+    assert '"exit":0' in _log(environment)
+    assert '".claude/atlas-epic"' in _log(environment)
+    assert '"batch_state"' in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_execute_rejects_a_corrupt_database_before_upload(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    (source / "corrupt.db").write_bytes(b"not a sqlite database")
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode != 0
+    assert "SQLite online backup failed: data/corrupt.db" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_execute_snapshots_sqlite3_database_from_batch_state(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    database = source.parent / "batch_state" / "monitor.sqlite3"
+    connection = sqlite3.connect(database)
+    connection.execute("CREATE TABLE recovery_probe (value TEXT NOT NULL)")
+    connection.execute("INSERT INTO recovery_probe VALUES ('batch')")
+    connection.commit()
+    connection.close()
+    environment["FAKE_DB_RELATIVE"] = "batch_state/monitor.sqlite3"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert "consistent SQLite snapshot: batch_state/monitor.sqlite3" in result.stdout
+    assert "db_rows=<1>" in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_execute_preserves_tracked_changes_as_a_patch(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    (source.parent / "README.md").write_text("changed locally\n", encoding="utf-8")
+    environment["FAKE_REQUIRED_RELATIVE"] = "GIT-WORKTREE.patch"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert "staged_required=<GIT-WORKTREE.patch>" in _log(environment)
+    assert '"GIT-WORKTREE.patch"' in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_backup_fails_closed_when_required_repo_state_is_missing(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    atlas_epic = source.parent / ".claude" / "atlas-epic"
+    (atlas_epic / "HANDOFF.md").unlink()
+    atlas_epic.rmdir()
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Required recovery path is missing: .claude/atlas-epic" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_backup_fails_closed_for_uncovered_untracked_path(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    (source.parent / "sole-copy.txt").write_text("not declared\n", encoding="utf-8")
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "UNBACKED untracked Git path: sole-copy.txt" in result.stderr
+    assert "outside Git and declared recovery roots" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_symlink_policy_excludes_known_legacy_links_and_rejects_escapes(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, source, _staging, legacy = backup_environment
+    (legacy / "textbooks").mkdir()
+    (source / "textbooks").symlink_to(legacy / "textbooks")
+
+    accepted = _run(environment, "backup")
+
+    assert accepted.returncode == 0, accepted.stderr
+    assert "EXCLUDED legacy Drive symlink: textbooks" in accepted.stdout
+
+    escaped_target = tmp_path / "outside-source"
+    escaped_target.mkdir()
+    (source / "unexpected-link").symlink_to(escaped_target)
+    rejected = _run(environment, "backup")
+
+    assert rejected.returncode != 0
+    assert "Absolute symlink is not backup-safe" in rejected.stderr
+
+
+def test_restore_is_a_dry_run_and_refuses_unsafe_targets(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    restore_target = tmp_path / "restore-target"
+
+    preview = _run(environment, "restore", "latest", "--to", str(restore_target))
+
+    assert preview.returncode == 0, preview.stderr
+    assert "Restore preview only" in preview.stdout
+    assert "arg=<restore>" in _log(environment)
+    assert "arg=<--dry-run>" in _log(environment)
+    assert "arg=<--overwrite> arg=<never>" in _log(environment)
+    assert not restore_target.exists()
+
+    restore_target.mkdir()
+    (restore_target / "keep.txt").write_text("occupied\n", encoding="utf-8")
+    Path(environment["FAKE_RESTIC_LOG"]).write_text("", encoding="utf-8")
+    occupied = _run(environment, "restore", "latest", "--to", str(restore_target))
+
+    assert occupied.returncode != 0
+    assert "Restore target must be empty" in occupied.stderr
+    assert "arg=<restore>" not in _log(environment)
+
+    file_target = tmp_path / "not-a-directory"
+    file_target.write_text("keep\n", encoding="utf-8")
+    file_result = _run(environment, "restore", "latest", "--to", str(file_target))
+    assert file_result.returncode != 0
+    assert "is not a directory" in file_result.stderr
+
+    symlink_target = tmp_path / "symlink-target"
+    symlink_target.symlink_to(REPO_ROOT / "data")
+    symlink_result = _run(
+        environment,
+        "restore",
+        "latest",
+        "--to",
+        str(symlink_target),
+    )
+    assert symlink_result.returncode != 0
+    assert "must not be a symlink" in symlink_result.stderr
+
+
+def test_init_requires_execute_before_creating_repository(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    environment["FAKE_REPOSITORY_STATE"] = "missing"
+
+    preview = _run(environment, "init")
+
+    assert preview.returncode == 0, preview.stderr
+    assert "Initialization preview only" in preview.stdout
+    assert "arg=<init>" not in _log(environment)
+
+    Path(environment["FAKE_RESTIC_LOG"]).write_text("", encoding="utf-8")
+    executed = _run(environment, "init", "--execute")
+
+    assert executed.returncode == 0, executed.stderr
+    assert "arg=<init>" in _log(environment)
+    assert "arg=<check>" in _log(environment)
+
+
+def test_refuses_staging_inside_project_checkout(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    environment["LU_BACKUP_TMPDIR"] = str(REPO_ROOT / "batch_state")
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Staging directory must be outside the project checkout" in result.stderr

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -108,7 +108,7 @@ if [[ "${1:-}" == "backup" && -n "${FAKE_REQUIRED_RELATIVE:-}" ]]; then
     >> "$FAKE_RESTIC_LOG"
 fi
 if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
-  jq -c '{exit: .backup_exit_code, paths: [.paths[].path]}' \
+  jq -c '{status: .receipt_status, paths: [.paths[].path]}' \
     "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
 fi
 exit 0
@@ -191,7 +191,7 @@ def test_execute_stages_a_consistent_wal_database_and_cleans_up(
     assert "Creating consistent SQLite snapshot: data/live.db" in result.stdout
     assert "db_rows=<2>" in _log(environment)
     assert "staged_required=<.claude/atlas-epic/HANDOFF.md>" in _log(environment)
-    assert '"exit":0' in _log(environment)
+    assert '"status":"prepared-before-snapshot-write"' in _log(environment)
     assert '".claude/atlas-epic"' in _log(environment)
     assert '"batch_state"' in _log(environment)
     assert list(staging.iterdir()) == []
@@ -275,6 +275,19 @@ def test_backup_fails_closed_for_uncovered_untracked_path(
     assert "arg=<backup>" not in _log(environment)
 
 
+def test_refuses_legacy_mutable_backup_as_restic_repository(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    environment["LU_BACKUP_REPOSITORY"] = "rclone:testdrive:Projects/learn-ukrainian-data"
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Refusing to initialize or write restic inside the legacy" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
 def test_symlink_policy_excludes_known_legacy_links_and_rejects_escapes(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
     tmp_path: Path,
@@ -295,6 +308,40 @@ def test_symlink_policy_excludes_known_legacy_links_and_rejects_escapes(
 
     assert rejected.returncode != 0
     assert "Absolute symlink is not backup-safe" in rejected.stderr
+
+
+def test_real_textbooks_directory_is_included(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    textbooks = source / "textbooks"
+    textbooks.mkdir()
+    (textbooks / "local-source.txt").write_text("preserve\n", encoding="utf-8")
+    environment["FAKE_REQUIRED_RELATIVE"] = "data/textbooks/local-source.txt"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert "staged_required=<data/textbooks/local-source.txt>" in _log(environment)
+    assert str(textbooks) not in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_data_root_must_not_be_a_symlink(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    external_data = tmp_path / "external-data"
+    external_data.mkdir()
+    source.rmdir()
+    source.symlink_to(external_data)
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Backup source must not be a symlink: data" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
 
 
 def test_restore_is_a_dry_run_and_refuses_unsafe_targets(
@@ -359,6 +406,21 @@ def test_init_requires_execute_before_creating_repository(
     assert executed.returncode == 0, executed.stderr
     assert "arg=<init>" in _log(environment)
     assert "arg=<check>" in _log(environment)
+
+
+def test_doctor_summarizes_validation_failure(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    atlas_epic = source.parent / ".claude" / "atlas-epic"
+    (atlas_epic / "HANDOFF.md").unlink()
+    atlas_epic.rmdir()
+
+    result = _run(environment, "doctor")
+
+    assert result.returncode != 0
+    assert "NOT READY: ERROR: Required recovery path is missing" in result.stderr
+    assert "Doctor found 1 blocking problem(s)." in result.stderr
 
 
 def test_refuses_staging_inside_project_checkout(

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -211,6 +211,54 @@ def test_execute_rejects_a_corrupt_database_before_upload(
     assert list(staging.iterdir()) == []
 
 
+def test_execute_refuses_when_full_tree_would_exceed_staging_space(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    (source / "valuable.txt").write_text("sole copy\n", encoding="utf-8")
+    fake_bin = Path(environment["PATH"].split(":", maxsplit=1)[0])
+    _write_executable(
+        fake_bin / "df",
+        """#!/bin/bash
+printf '%s\\n' 'Filesystem 1024-blocks Used Available Capacity Mounted on'
+printf '%s\\n' 'testfs 4194304 0 2097152 0% /staging'
+""",
+    )
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode != 0
+    assert "Insufficient staging space" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_darwin_rejects_cross_volume_copy_on_write_staging(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    fake_bin = Path(environment["PATH"].split(":", maxsplit=1)[0])
+    _write_executable(fake_bin / "uname", "#!/bin/bash\nprintf '%s\\n' Darwin\n")
+    _write_executable(
+        fake_bin / "stat",
+        """#!/bin/bash
+if [[ "${1:-}" == '-f' && "${2:-}" == '%d' ]]; then
+  case "${3:-}" in
+    */project/*) printf '%s\\n' 101 ;;
+    *) printf '%s\\n' 202 ;;
+  esac
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+""",
+    )
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode != 0
+    assert "requires source and staging on the same volume" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
 def test_execute_snapshots_sqlite3_database_from_batch_state(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
 ) -> None:
@@ -386,6 +434,18 @@ def test_restore_is_a_dry_run_and_refuses_unsafe_targets(
     )
     assert symlink_result.returncode != 0
     assert "must not be a symlink" in symlink_result.stderr
+
+
+def test_restore_refuses_filesystem_root_as_project_overlap(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+
+    result = _run(environment, "restore", "latest", "--to", "/")
+
+    assert result.returncode != 0
+    assert "Restore target must be outside the project checkout" in result.stderr
+    assert "arg=<restore>" not in _log(environment)
 
 
 def test_init_requires_execute_before_creating_repository(


### PR DESCRIPTION
## Summary

- replace the mutable Google Drive Desktop rsync mirror with encrypted, versioned restic snapshots over an explicit rclone backend
- fail closed unless gitignored epic state, `batch_state/`, `data/`, SQLite consistency, source coverage, and restore-target safety all pass
- add a JSON receipt, tracked-worktree patch recovery, staging-only restore workflow, operator runbook, and incident-focused regression tests

## Incident coverage

The snapshot prioritizes every `.claude/*-epic/` root and `batch_state/` before `data/`. `.claude/atlas-epic` and `batch_state/` are mandatory. Non-ignored untracked paths outside Git or declared roots stop the run. The old Drive data folder remains read-only; only validated legacy data symlinks are excluded, while real local directories with the same names remain protected.

Generated site assets, dependencies, `.git/objects`, `_quarantine`, and retired Qdrant state are not presented as sole-copy backups.

## Verification

- `/bin/bash -n scripts/backup-data.sh`
- `shellcheck -x scripts/backup-data.sh`
- `ruff check` and `ruff format --check` on `tests/test_backup_data_script.py`
- `pytest tests/test_backup_data_script.py -q` — 21 passed
- markdownlint — 0 errors on the new runbook and changed recovery runbooks
- `git diff --check`
- staged OPSEC lint — 8 files, zero leaks
- agent trailer lint — PASS

Behavior proof used the checksum-verified official restic 0.19.1 Darwin ARM64 binary, an isolated temporary local rclone remote/config, temporary epic roots, `batch_state/*.sqlite3`, `data/*.db`, and an empty restore target. Init preview/execute, backup preview/execute, snapshot listing, repository-wide full data verification, restore preview/execute, receipt validation, both SQLite integrity checks, a real `data/textbooks` directory, post-exclusion receipt totals, excluded-file absence after restore, and staging cleanup all passed. No production repository, Drive account, password, or project data was mutated.

Fixes #6014

X-Agent: codex/6014-backup-safety



