### PR TITLE
feat(atlas): durable mirror for 20k runner + ULIF cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,6 +413,14 @@ data/lexicon/slovnyk_cache/
 # reads them (it hydrates the published release-asset manifest).
 # Regenerate on demand via scripts/lexicon/enrich_manifest.py.
 data/lexicon/cache/
+# Local mirror of the remote Atlas 20k runner work-dir (default
+# /home/ops/atlas-runner/run-20k on the VPS): ledger.sqlite, network-cache.sqlite,
+# reduce/enrich candidates. The VPS itself has no backup; scripts/backup-data.sh
+# (#6014) already backs up all of data/, so mirroring here — instead of building a
+# second backup mechanism — makes the runner state durable for free (#5884).
+# Refresh via scripts/lexicon/runner/durable_mirror.py snapshot; see
+# docs/runbooks/atlas-20k-runner-durability.md.
+data/lexicon/runner-mirror/
 # Generated build artifact: regenerate on demand with
 #   .venv/bin/python -m scripts.lexicon.grow_lexicon_from_content (#3675 P2; promotion = P3)
 data/lexicon/grow_candidates.json

--- a/docs/runbooks/atlas-20k-runner-durability.md
+++ b/docs/runbooks/atlas-20k-runner-durability.md
@@ -1,0 +1,132 @@
+# Atlas 20k Runner Durability
+
+Fixes #5884. Related incident: 2026-07-29 wipe (sole laptop copies fail).
+
+The `fetch_ulif_20k.py` / `reduce_ulif_20k.py` / `enrich_offline_20k.py`
+runners write their durable state under a work-dir on the remote runner VPS
+(default `/home/ops/atlas-runner/run-20k`):
+
+| Artifact | Path |
+| --- | --- |
+| Fetch ledger | `$WORK_DIR/ledger.sqlite` |
+| ULIF network cache (raw + parsed) | `$WORK_DIR/network-cache.sqlite` |
+| Reduce candidate | `$WORK_DIR/candidate-ulif-reduce.json` |
+| Enrich work dir | `$WORK_DIR/offline_enrich/` |
+| Enriched output | `$WORK_DIR/offline_enrich/candidate-enriched.json` |
+| Logs | `$WORK_DIR/enrich.log`, `$WORK_DIR/reduce.log` |
+
+That VPS has no backup of its own. A runner wipe or local cleanup before this
+recipe runs means a full ULIF refetch (politeness-limited: ~1 lemma/s,
+20,323 lemmas).
+
+This does **not** introduce a second backup mechanism. `scripts/backup-data.sh`
+(#6014) already makes encrypted, versioned restic snapshots of everything
+under this repo's local `data/`. The fix is to mirror the VPS work-dir into
+`data/lexicon/runner-mirror/<work-dir-name>/` — gitignored, checksummed, and
+therefore picked up automatically by the next `backup-data.sh backup
+--execute` — instead of building a competing bus. `data/lexicon/cache/`
+(local enrichment caches) is already covered the same way; this closes the
+one gap: the VPS itself.
+
+The v0.1 open dataset (`data/lexicon-dataset.pointer.json` → GitHub Release
+asset `atlas-open-dataset`) is a different, unrelated mechanism for
+*publishing* derived, license-cleared data. Do not route raw ULIF scrape
+output or the runner ledger through it — that pattern is for the public
+open-dataset export, not for private durability of in-progress runner state.
+
+## Tool
+
+`scripts/lexicon/runner/durable_mirror.py` — sync, checksum, verify, and gate:
+
+```bash
+# Sync a source (local path or user@host:/path) into a local mirror and
+# (re)write its manifest.json (sha256 per file):
+.venv/bin/python scripts/lexicon/runner/durable_mirror.py snapshot \
+  --source ops@<runner-host>:/home/ops/atlas-runner/run-20k \
+  --mirror-dir data/lexicon/runner-mirror/run-20k
+
+# Recompute checksums and compare against the manifest (corruption check):
+.venv/bin/python scripts/lexicon/runner/durable_mirror.py verify \
+  --mirror-dir data/lexicon/runner-mirror/run-20k
+
+# Fail closed unless the mirror is present, non-empty, internally verified,
+# and newer than --max-age-hours (default 24). Exit 2 on any failure:
+.venv/bin/python scripts/lexicon/runner/durable_mirror.py require \
+  --mirror-dir data/lexicon/runner-mirror/run-20k
+```
+
+`snapshot` uses `rsync -az --delete`: the mirror always reflects the VPS
+work-dir's *current* state. History/versioning is the restic bus's job
+downstream, not this mirror's.
+
+`scripts/lexicon/runner/mirror_20k_runner.sh` wraps the common laptop-side
+case (env: `ATLAS_RUNNER_HOST`, `ATLAS_RUN_ROOT`, `ATLAS_WORK_DIR_NAME`,
+`ATLAS_MIRROR_DIR`):
+
+```bash
+ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # gate only, no sync
+```
+
+## Required workflow
+
+1. After every fetch/reduce/enrich phase on the VPS (or at minimum daily
+   during an active run), sync:
+
+   ```bash
+   ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+   ```
+
+2. Push the refreshed mirror into the restic bus:
+
+   ```bash
+   ./scripts/backup-data.sh backup
+   ./scripts/backup-data.sh backup --execute
+   ```
+
+3. Before touching, cleaning, or wiping `$WORK_DIR` on the VPS, or before
+   deleting the local `data/lexicon/runner-mirror/` copy, gate on a fresh
+   verified mirror:
+
+   ```bash
+   scripts/lexicon/runner/mirror_20k_runner.sh --require-only
+   ```
+
+   A nonzero exit means: do not proceed. Re-sync (step 1) and re-check.
+
+## Restore drill
+
+After a VPS wipe or a fresh runner host:
+
+```bash
+# 1) Restore the local repo's data/ (including the runner mirror) from restic
+#    into an empty staging directory — see docs/runbooks/data-backup.md.
+./scripts/backup-data.sh restore latest --to /absolute/path/to/restore-test
+./scripts/backup-data.sh restore latest --to /absolute/path/to/restore-test --execute
+
+# 2) Verify the staged mirror before trusting it.
+.venv/bin/python scripts/lexicon/runner/durable_mirror.py verify \
+  --mirror-dir /absolute/path/to/restore-test/data/lexicon/runner-mirror/run-20k
+
+# 3) Copy the verified mirror back to a fresh VPS work-dir.
+rsync -az /absolute/path/to/restore-test/data/lexicon/runner-mirror/run-20k/ \
+  ops@<new-runner-host>:/home/ops/atlas-runner/run-20k/
+
+# 4) Resume. The fetch/enrich ledgers are resumable by design — the same
+#    work-dir with an intact ledger.sqlite resumes rather than restarting:
+scripts/lexicon/runner/launch_enrich.sh
+```
+
+If step 3's target work-dir is missing `ledger.sqlite`/`network-cache.sqlite`
+entirely (mirror predates the wipe, or was never synced), the runner starts
+a fresh run for whatever lemmas are not yet reflected in the restored
+`candidate-ulif-reduce.json` / `candidate-enriched.json` — re-fetch is bounded
+to the gap, not the full 20,323-lemma cohort.
+
+## What this does not cover
+
+- The remote VPS's own OS/root disk durability — out of scope; the mirror
+  makes the runner's *durable state* survive a VPS loss, not the VPS itself.
+- Promotion of `candidate-enriched.json` into the published lexicon manifest
+  — that is `finalize.py` + the #5138/#5331 publish gate, explicitly out of
+  scope for the enrich driver and this mirror.

--- a/docs/runbooks/atlas-20k-runner-durability.md
+++ b/docs/runbooks/atlas-20k-runner-durability.md
@@ -50,7 +50,8 @@ open-dataset export, not for private durability of in-progress runner state.
   --mirror-dir data/lexicon/runner-mirror/run-20k
 
 # Fail closed unless the mirror is present, non-empty, internally verified,
-# and newer than --max-age-hours (default 24). Exit 2 on any failure:
+# newer than --max-age-hours (default 24), and covered by the local restic
+# receipt written after a successful backup. Exit 2 on any failure:
 .venv/bin/python scripts/lexicon/runner/durable_mirror.py require \
   --mirror-dir data/lexicon/runner-mirror/run-20k
 ```
@@ -85,14 +86,19 @@ scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # gate only, no syn
    ```
 
 3. Before touching, cleaning, or wiping `$WORK_DIR` on the VPS, or before
-   deleting the local `data/lexicon/runner-mirror/` copy, gate on a fresh
-   verified mirror:
+   deleting the local `data/lexicon/runner-mirror/` copy, gate on a fresh,
+   verified mirror covered by the successful restic backup:
 
    ```bash
    scripts/lexicon/runner/mirror_20k_runner.sh --require-only
    ```
 
-   A nonzero exit means: do not proceed. Re-sync (step 1) and re-check.
+   A nonzero exit means: do not proceed. Re-run the full order — **snapshot →
+   `backup --execute` → `--require-only` → wipe** — so the local
+   `RESTIC-GATE-RECEIPT.json` binds the current `manifest.json` checksum to
+   the restic snapshot. The receipt has no repository location, password, or
+   credentials; it records only the snapshot ID, host label, Git SHA, time,
+   and per-mirror manifest fingerprint.
 
 ## Restore drill
 

--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -144,6 +144,14 @@ exit code belongs to the operator log: an in-snapshot file cannot truthfully
 contain the outcome of the repository check that runs after the snapshot is
 committed.
 
+When `data/lexicon/runner-mirror/` exists, a successful `backup --execute`
+also writes its local `RESTIC-GATE-RECEIPT.json` **after** the repository
+check. This is distinct from the in-snapshot `BACKUP-RECEIPT.json`: it binds
+each current runner-mirror `manifest.json` checksum to the completed restic
+snapshot so the pre-wipe gate works without credentials or network access.
+See [the Atlas runner durability runbook](atlas-20k-runner-durability.md) for
+the required snapshot → backup → gate → wipe order.
+
 List snapshots and perform periodic integrity checks:
 
 ```bash

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -56,20 +56,27 @@ BACKUP_PATHS=()
 
 write_restic_gate_receipt() {
   local snapshot_id=$1
-  local mirror_root="$SOURCE/lexicon/runner-mirror"
+  local staged_mirror_root="$STAGED_ROOT/data/lexicon/runner-mirror"
+  local live_mirror_root="$SOURCE/lexicon/runner-mirror"
   local git_sha
 
-  # Most backups have no runner mirror. Do not create unrelated data paths for
-  # them; when a mirror exists, failure to write its live gate receipt is fatal.
-  [[ -e "$mirror_root" ]] || return 0
-  [[ ! -L "$mirror_root" && -d "$mirror_root" ]] ||
-    die "Runner mirror root must be a real directory: $mirror_root"
+  # The staged tree is the copy restic uploaded. Do not create unrelated data
+  # paths when it has no mirror; if a live mirror appeared after staging, it is
+  # not covered by this snapshot and must not receive a receipt.
+  if [[ ! -e "$staged_mirror_root" ]]; then
+    [[ ! -e "$live_mirror_root" && ! -L "$live_mirror_root" ]] ||
+      die "Runner mirror appeared after staging; refusing to claim restic durability."
+    return 0
+  fi
+  [[ ! -L "$staged_mirror_root" && -d "$staged_mirror_root" ]] ||
+    die "Staged runner mirror root must be a real directory: $staged_mirror_root"
   [[ -x "$REPO_ROOT/.venv/bin/python" ]] ||
     die "Runner mirror receipt writer requires $REPO_ROOT/.venv/bin/python"
   git_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
   "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/lexicon/runner/durable_mirror.py" \
     write-restic-gate-receipt \
-    --mirror-root "$mirror_root" \
+    --mirror-root "$staged_mirror_root" \
+    --receipt-root "$live_mirror_root" \
     --restic-snapshot-id "$snapshot_id" \
     --host "$BACKUP_HOST" \
     --git-sha "$git_sha" \

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -54,6 +54,29 @@ RESTIC_EXCLUDES=()
 LEGACY_EXCLUDES=()
 BACKUP_PATHS=()
 
+write_restic_gate_receipt() {
+  local snapshot_id=$1
+  local mirror_root="$SOURCE/lexicon/runner-mirror"
+  local git_sha
+
+  # Most backups have no runner mirror. Do not create unrelated data paths for
+  # them; when a mirror exists, failure to write its live gate receipt is fatal.
+  [[ -e "$mirror_root" ]] || return 0
+  [[ ! -L "$mirror_root" && -d "$mirror_root" ]] ||
+    die "Runner mirror root must be a real directory: $mirror_root"
+  [[ -x "$REPO_ROOT/.venv/bin/python" ]] ||
+    die "Runner mirror receipt writer requires $REPO_ROOT/.venv/bin/python"
+  git_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/lexicon/runner/durable_mirror.py" \
+    write-restic-gate-receipt \
+    --mirror-root "$mirror_root" \
+    --restic-snapshot-id "$snapshot_id" \
+    --host "$BACKUP_HOST" \
+    --git-sha "$git_sha" \
+    --mirror-root-relative-to-data "lexicon/runner-mirror" ||
+    die "Could not write the runner mirror restic gate receipt after backup."
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -792,7 +815,7 @@ prepare_staging_tree() {
 
 run_backup() {
   local execute=$1
-  local backup_root
+  local backup_root backup_output snapshot_id
 
   validate_environment
   validate_source
@@ -831,15 +854,22 @@ run_backup() {
   backup_root="$STAGED_ROOT/data"
   build_restic_excludes "$backup_root"
   info "Creating encrypted, versioned restic snapshot."
+  backup_output="$STAGE_DIR/restic-backup.jsonl"
   (
     cd "$STAGED_ROOT"
     restic_repository_command backup "${BACKUP_PATHS[@]}" \
       --host "$BACKUP_HOST" \
       --tag "$BACKUP_TAG" \
+      --json \
       "${RESTIC_EXCLUDES[@]}"
-  )
+  ) | tee "$backup_output"
+  if ! snapshot_id="$(jq -er 'select(.message_type == "summary") | .snapshot_id // empty' "$backup_output")" ||
+    [[ ! "$snapshot_id" =~ ^[0-9a-f]{64}$ ]]; then
+    die "Restic backup completed without a valid snapshot ID; refusing to claim runner-mirror durability."
+  fi
   info "Checking repository metadata after backup."
   restic_repository_command check
+  write_restic_gate_receipt "$snapshot_id"
   info "Backup and repository check complete."
 }
 

--- a/scripts/lexicon/runner/README-offline-enrich.md
+++ b/scripts/lexicon/runner/README-offline-enrich.md
@@ -72,6 +72,28 @@ Tail progress:
 tail -f /home/ops/atlas-runner/run-20k/enrich.log | grep --line-buffered '"event"'
 ```
 
+## Durability (#5884)
+
+`$WORK_DIR` on the VPS has no backup of its own — a runner wipe or local
+cleanup means a full ULIF refetch. After every fetch/reduce/enrich phase
+(and always before touching/cleaning `$WORK_DIR`), sync it into this repo's
+`data/` so the existing restic backup (`scripts/backup-data.sh`, #6014)
+covers it:
+
+```bash
+ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+```
+
+Before any cleanup, fail closed on a stale/missing/corrupt mirror instead of
+guessing:
+
+```bash
+scripts/lexicon/runner/mirror_20k_runner.sh --require-only
+```
+
+Full recipe, restore drill, and coordination with #6014's restic bus:
+[`docs/runbooks/atlas-20k-runner-durability.md`](../../../docs/runbooks/atlas-20k-runner-durability.md).
+
 ## Out of scope for this driver
 
 - `finalize.py` (publication archive)

--- a/scripts/lexicon/runner/README-offline-enrich.md
+++ b/scripts/lexicon/runner/README-offline-enrich.md
@@ -84,10 +84,12 @@ covers it:
 ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
 ```
 
-Before any cleanup, fail closed on a stale/missing/corrupt mirror instead of
-guessing:
+Before any cleanup, execute the full durability order — **snapshot → restic
+backup → receipt gate → wipe**. The gate rejects a stale, missing, corrupt,
+or not-yet-backed-up mirror instead of guessing:
 
 ```bash
+./scripts/backup-data.sh backup --execute
 scripts/lexicon/runner/mirror_20k_runner.sh --require-only
 ```
 

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Durable local mirror for the Atlas 20k runner work-dir (#5884, sibling of #6014).
+
+The fetch/enrich runners write their durable state (``ledger.sqlite``,
+``network-cache.sqlite``, reduce/enrich candidates) under a work-dir on the
+remote runner host (default ``/home/ops/atlas-runner/run-20k``), which has no
+backup of its own. ``scripts/backup-data.sh`` (#6014) already makes encrypted,
+versioned restic snapshots of everything under this repo's local ``data/`` —
+so the fix is to mirror the runner work-dir into a checksummed copy under
+``data/lexicon/runner-mirror/`` and let the existing backup bus pick it up,
+not to build a second backup mechanism.
+
+Three operations:
+
+- ``snapshot``: rsync a source (local path or ``user@host:/path``) into a
+  local mirror directory, then write a checksummed ``manifest.json`` over the
+  mirror contents.
+- ``verify``: recompute checksums for a mirror directory and compare against
+  its manifest.
+- ``require``: fail closed (nonzero exit / raised error) unless a mirror
+  manifest exists, is internally verified, and is newer than
+  ``--max-age-hours``. Callers that would otherwise wipe runner state should
+  gate on this first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+MANIFEST_NAME = "manifest.json"
+MANIFEST_SCHEMA_VERSION = 1
+IGNORED_DIR_NAMES = {"__pycache__"}
+IGNORED_FILE_NAMES = {".DS_Store"}
+IGNORED_SUFFIXES = {".pid", ".lock"}
+DEFAULT_MAX_AGE_HOURS = 24.0
+
+
+class DurableMirrorError(RuntimeError):
+    """Raised when a durable mirror is missing, stale, or fails verification."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerifyResult:
+    ok: bool
+    missing: list[str] = field(default_factory=list)
+    mismatched: list[str] = field(default_factory=list)
+    extra: list[str] = field(default_factory=list)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iter_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            continue
+        if path.name in IGNORED_FILE_NAMES or path.suffix in IGNORED_SUFFIXES:
+            continue
+        if any(part in IGNORED_DIR_NAMES for part in path.relative_to(root).parts):
+            continue
+        if path.name == MANIFEST_NAME and path.parent == root:
+            continue
+        files.append(path)
+    return files
+
+
+def build_manifest(root: Path) -> dict[str, Any]:
+    """Walk ``root`` and return a checksummed manifest (excludes ``manifest.json`` itself)."""
+    entries: list[dict[str, Any]] = []
+    total_bytes = 0
+    for path in _iter_files(root):
+        data_bytes = path.stat().st_size
+        entries.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "bytes": data_bytes,
+                "sha256": _sha256_file(path),
+            }
+        )
+        total_bytes += data_bytes
+    return {
+        "schema": "atlas-runner-mirror-manifest",
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "generated_at": time.time(),
+        "file_count": len(entries),
+        "total_bytes": total_bytes,
+        "files": entries,
+    }
+
+
+def write_manifest(manifest: dict[str, Any], mirror_dir: Path) -> Path:
+    manifest_path = mirror_dir / MANIFEST_NAME
+    temp_path = manifest_path.with_suffix(".json.tmp")
+    temp_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.replace(manifest_path)
+    return manifest_path
+
+
+def read_manifest(mirror_dir: Path) -> dict[str, Any]:
+    manifest_path = mirror_dir / MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise DurableMirrorError(f"no durable mirror manifest at {manifest_path}")
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != "atlas-runner-mirror-manifest":
+        raise DurableMirrorError(f"{manifest_path} is not a runner-mirror manifest")
+    if payload.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise DurableMirrorError(f"{manifest_path} has unsupported schema_version {payload.get('schema_version')!r}")
+    return payload
+
+
+def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
+    """Recompute checksums for every manifest entry and compare against disk."""
+    missing: list[str] = []
+    mismatched: list[str] = []
+    expected_paths: set[str] = set()
+    for entry in manifest.get("files", []):
+        rel_path = str(entry["path"])
+        expected_paths.add(rel_path)
+        disk_path = mirror_dir / rel_path
+        if not disk_path.is_file():
+            missing.append(rel_path)
+            continue
+        if disk_path.stat().st_size != entry["bytes"] or _sha256_file(disk_path) != entry["sha256"]:
+            mismatched.append(rel_path)
+    on_disk = {path.relative_to(mirror_dir).as_posix() for path in _iter_files(mirror_dir)}
+    extra = sorted(on_disk - expected_paths)
+    return VerifyResult(ok=not missing and not mismatched, missing=missing, mismatched=mismatched, extra=extra)
+
+
+def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = False) -> None:
+    """rsync ``source`` (local path or ``user@host:/path``) into ``mirror_dir``.
+
+    Trailing slash on both sides: sync contents, not a nested directory.
+    ``--delete`` keeps the mirror an exact reflection of the current runner
+    state, since versioning/history is the downstream restic bus's job, not
+    this mirror's.
+    """
+    mirror_dir.mkdir(parents=True, exist_ok=True)
+    source_arg = source if source.endswith("/") else f"{source}/"
+    dest_arg = f"{mirror_dir}/"
+    cmd = ["rsync", "-az", "--delete", "--exclude", MANIFEST_NAME]
+    for dir_name in IGNORED_DIR_NAMES:
+        cmd.extend(["--exclude", dir_name])
+    for file_name in IGNORED_FILE_NAMES:
+        cmd.extend(["--exclude", file_name])
+    for suffix in IGNORED_SUFFIXES:
+        cmd.extend(["--exclude", f"*{suffix}"])
+    if dry_run:
+        cmd.append("--dry-run")
+    cmd.extend([source_arg, dest_arg])
+    subprocess.run(cmd, check=True)
+
+
+def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
+    sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)
+    if dry_run:
+        return build_manifest(mirror_dir)
+    manifest = build_manifest(mirror_dir)
+    write_manifest(manifest, mirror_dir)
+    return manifest
+
+
+def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_HOURS) -> dict[str, Any]:
+    """Fail closed unless ``mirror_dir`` holds a fresh, internally-consistent manifest.
+
+    Returns the manifest on success. Callers about to clean up runner state
+    (VPS work-dir wipe, local cache purge) must call this first and abort on
+    :class:`DurableMirrorError`.
+    """
+    manifest = read_manifest(mirror_dir)
+    age_hours = max(0.0, time.time() - float(manifest["generated_at"])) / 3600.0
+    if age_hours > max_age_hours:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} is {age_hours:.1f}h old (max {max_age_hours}h) — refresh with `snapshot` first"
+        )
+    result = verify_manifest(manifest, mirror_dir)
+    if not result.ok:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} failed verification: missing={result.missing} mismatched={result.mismatched}"
+        )
+    if manifest["file_count"] == 0:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} is empty — refusing to treat an empty mirror as durable"
+        )
+    return manifest
+
+
+def _cmd_snapshot(args: argparse.Namespace) -> int:
+    manifest = snapshot(args.source, args.mirror_dir, dry_run=args.dry_run)
+    print(
+        f"{'would snapshot' if args.dry_run else 'snapshotted'} {args.source} -> {args.mirror_dir}: "
+        f"{manifest['file_count']} files, {manifest['total_bytes']} bytes"
+    )
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    manifest = read_manifest(args.mirror_dir)
+    result = verify_manifest(manifest, args.mirror_dir)
+    if result.ok:
+        print(f"OK: {args.mirror_dir} matches its manifest ({manifest['file_count']} files)")
+        return 0
+    print(f"FAILED: missing={result.missing} mismatched={result.mismatched} extra={result.extra}", file=sys.stderr)
+    return 2
+
+
+def _cmd_require(args: argparse.Namespace) -> int:
+    try:
+        manifest = require_durable(args.mirror_dir, max_age_hours=args.max_age_hours)
+    except DurableMirrorError as exc:
+        print(f"NOT DURABLE: {exc}", file=sys.stderr)
+        return 2
+    print(f"durable: {args.mirror_dir} ({manifest['file_count']} files, generated_at={manifest['generated_at']})")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snap = subparsers.add_parser("snapshot", help="rsync a source into a local mirror and write its manifest")
+    snap.add_argument("--source", required=True, help="Local path or user@host:/path to mirror from")
+    snap.add_argument("--mirror-dir", type=Path, required=True)
+    snap.add_argument("--dry-run", action="store_true", help="rsync --dry-run; do not write a manifest")
+    snap.set_defaults(func=_cmd_snapshot)
+
+    verify = subparsers.add_parser("verify", help="recompute checksums and compare against manifest.json")
+    verify.add_argument("--mirror-dir", type=Path, required=True)
+    verify.set_defaults(func=_cmd_verify)
+
+    require = subparsers.add_parser("require", help="fail closed unless the mirror is fresh and verified")
+    require.add_argument("--mirror-dir", type=Path, required=True)
+    require.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
+    require.set_defaults(func=_cmd_require)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -283,12 +283,18 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     files = manifest.get("files")
     if not isinstance(files, list):
         raise DurableMirrorError(f"durable mirror at {mirror_dir} has invalid files list")
-    if len(files) == 0 or int(manifest.get("file_count") or 0) == 0:
+    try:
+        file_count = int(manifest.get("file_count") or 0)
+    except (TypeError, ValueError) as exc:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} has invalid file_count={manifest.get('file_count')!r}"
+        ) from exc
+    if len(files) == 0 or file_count == 0:
         raise DurableMirrorError(f"durable mirror at {mirror_dir} is empty")
-    if int(manifest.get("file_count") or 0) != len(files):
+    if file_count != len(files):
         raise DurableMirrorError(
             f"durable mirror at {mirror_dir} file_count mismatch "
-            f"({manifest.get('file_count')} != {len(files)})"
+            f"({file_count} != {len(files)})"
         )
     try:
         generated_at = float(manifest["generated_at"])

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -170,26 +170,8 @@ def _manifest_fingerprint(mirror_dir: Path, manifest: dict[str, Any]) -> dict[st
     }
 
 
-def write_restic_gate_receipt(
-    mirror_root: Path,
-    *,
-    restic_snapshot_id: str,
-    host: str,
-    git_sha: str,
-    mirror_root_relative_to_data: str = "lexicon/runner-mirror",
-) -> Path:
-    """Record manifests covered by a completed restic snapshot, atomically.
-
-    This receipt is deliberately local. It lets a pre-wipe gate prove that a
-    current mirror was included in a successful restic backup without access
-    to restic credentials or its remote repository.
-    """
-    if not restic_snapshot_id or not isinstance(restic_snapshot_id, str):
-        raise DurableMirrorError("restic gate receipt requires a restic snapshot id")
-    if not host or not isinstance(host, str):
-        raise DurableMirrorError("restic gate receipt requires a host label")
-    if not git_sha or not isinstance(git_sha, str):
-        raise DurableMirrorError("restic gate receipt requires a git sha")
+def _fingerprint_mirrors(mirror_root: Path) -> dict[str, dict[str, Any]]:
+    """Fingerprint every manifest-bearing mirror below a real mirror root."""
     if mirror_root.is_symlink() or not mirror_root.is_dir():
         raise DurableMirrorError(f"restic gate mirror root must be a real directory: {mirror_root}")
 
@@ -200,6 +182,40 @@ def write_restic_gate_receipt(
         if not candidate.is_dir() or not (candidate / MANIFEST_NAME).is_file():
             continue
         mirrors[candidate.name] = _manifest_fingerprint(candidate, read_manifest(candidate))
+    return mirrors
+
+
+def write_restic_gate_receipt(
+    mirror_root: Path,
+    *,
+    restic_snapshot_id: str,
+    host: str,
+    git_sha: str,
+    mirror_root_relative_to_data: str = "lexicon/runner-mirror",
+    receipt_root: Path | None = None,
+) -> Path:
+    """Record manifests covered by a completed restic snapshot, atomically.
+
+    This receipt is deliberately local. It lets a pre-wipe gate prove that a
+    current mirror was included in a successful restic backup without access
+    to restic credentials or its remote repository. ``mirror_root`` is the
+    tree included in restic; when ``receipt_root`` is distinct, it must still
+    have exactly the same manifest fingerprints before the receipt is written.
+    """
+    if not restic_snapshot_id or not isinstance(restic_snapshot_id, str):
+        raise DurableMirrorError("restic gate receipt requires a restic snapshot id")
+    if not host or not isinstance(host, str):
+        raise DurableMirrorError("restic gate receipt requires a host label")
+    if not git_sha or not isinstance(git_sha, str):
+        raise DurableMirrorError("restic gate receipt requires a git sha")
+    mirrors = _fingerprint_mirrors(mirror_root)
+    receipt_root = receipt_root or mirror_root
+    if receipt_root.resolve() != mirror_root.resolve():
+        receipt_mirrors = _fingerprint_mirrors(receipt_root)
+        if receipt_mirrors != mirrors:
+            raise DurableMirrorError(
+                "live runner mirrors changed after staging; refusing to write a receipt for content not backed up"
+            )
 
     receipt = {
         "schema": RESTIC_GATE_RECEIPT_SCHEMA,
@@ -211,7 +227,7 @@ def write_restic_gate_receipt(
         "mirror_root_relative_to_data": mirror_root_relative_to_data,
         "mirrors": mirrors,
     }
-    receipt_path = mirror_root / RESTIC_GATE_RECEIPT_NAME
+    receipt_path = receipt_root / RESTIC_GATE_RECEIPT_NAME
     temp_path = receipt_path.with_suffix(".json.tmp")
     temp_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     temp_path.replace(receipt_path)
@@ -498,6 +514,7 @@ def _cmd_write_restic_gate_receipt(args: argparse.Namespace) -> int:
             host=args.host,
             git_sha=args.git_sha,
             mirror_root_relative_to_data=args.mirror_root_relative_to_data,
+            receipt_root=args.receipt_root,
         )
     except DurableMirrorError as exc:
         print(f"FAILED: {exc}", file=sys.stderr)
@@ -537,6 +554,11 @@ def build_parser() -> argparse.ArgumentParser:
     receipt.add_argument("--host", required=True)
     receipt.add_argument("--git-sha", required=True)
     receipt.add_argument("--mirror-root-relative-to-data", default="lexicon/runner-mirror")
+    receipt.add_argument(
+        "--receipt-root",
+        type=Path,
+        help="live mirror root where the receipt is written; must match --mirror-root",
+    )
     receipt.set_defaults(func=_cmd_write_restic_gate_receipt)
 
     return parser

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -34,11 +34,15 @@ import sys
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 MANIFEST_NAME = "manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
+RESTIC_GATE_RECEIPT_NAME = "RESTIC-GATE-RECEIPT.json"
+RESTIC_GATE_RECEIPT_SCHEMA = "atlas-runner-restic-gate-receipt"
+RESTIC_GATE_RECEIPT_SCHEMA_VERSION = 1
 IGNORED_DIR_NAMES = {"__pycache__"}
 IGNORED_FILE_NAMES = {".DS_Store"}
 IGNORED_SUFFIXES = {".pid", ".lock"}
@@ -130,6 +134,133 @@ def read_manifest(mirror_dir: Path) -> dict[str, Any]:
     return payload
 
 
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_utc_timestamp(value: Any, *, field_name: str) -> float:
+    if not isinstance(value, str):
+        raise DurableMirrorError(f"restic gate receipt has invalid {field_name}={value!r}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise DurableMirrorError(f"restic gate receipt has invalid {field_name}={value!r}") from exc
+    if parsed.tzinfo is None:
+        raise DurableMirrorError(f"restic gate receipt has invalid {field_name}={value!r}")
+    timestamp = parsed.timestamp()
+    if not math.isfinite(timestamp):
+        raise DurableMirrorError(f"restic gate receipt has non-finite {field_name}={value!r}")
+    return timestamp
+
+
+def _manifest_fingerprint(mirror_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return the stable fields a restic receipt binds for one mirror."""
+    manifest_path = mirror_dir / MANIFEST_NAME
+    try:
+        file_count = int(manifest["file_count"])
+        generated_at = float(manifest["generated_at"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise DurableMirrorError(f"cannot fingerprint invalid mirror manifest at {manifest_path}") from exc
+    if file_count < 0 or not math.isfinite(generated_at):
+        raise DurableMirrorError(f"cannot fingerprint invalid mirror manifest at {manifest_path}")
+    return {
+        "manifest_sha256": _sha256_file(manifest_path),
+        "generated_at": generated_at,
+        "file_count": file_count,
+    }
+
+
+def write_restic_gate_receipt(
+    mirror_root: Path,
+    *,
+    restic_snapshot_id: str,
+    host: str,
+    git_sha: str,
+    mirror_root_relative_to_data: str = "lexicon/runner-mirror",
+) -> Path:
+    """Record manifests covered by a completed restic snapshot, atomically.
+
+    This receipt is deliberately local. It lets a pre-wipe gate prove that a
+    current mirror was included in a successful restic backup without access
+    to restic credentials or its remote repository.
+    """
+    if not restic_snapshot_id or not isinstance(restic_snapshot_id, str):
+        raise DurableMirrorError("restic gate receipt requires a restic snapshot id")
+    if not host or not isinstance(host, str):
+        raise DurableMirrorError("restic gate receipt requires a host label")
+    if not git_sha or not isinstance(git_sha, str):
+        raise DurableMirrorError("restic gate receipt requires a git sha")
+    if mirror_root.is_symlink() or not mirror_root.is_dir():
+        raise DurableMirrorError(f"restic gate mirror root must be a real directory: {mirror_root}")
+
+    mirrors: dict[str, dict[str, Any]] = {}
+    for candidate in sorted(mirror_root.iterdir()):
+        if candidate.is_symlink():
+            raise DurableMirrorError(f"symlink not allowed in restic gate mirror root: {candidate}")
+        if not candidate.is_dir() or not (candidate / MANIFEST_NAME).is_file():
+            continue
+        mirrors[candidate.name] = _manifest_fingerprint(candidate, read_manifest(candidate))
+
+    receipt = {
+        "schema": RESTIC_GATE_RECEIPT_SCHEMA,
+        "schema_version": RESTIC_GATE_RECEIPT_SCHEMA_VERSION,
+        "created_at_utc": _utc_now(),
+        "restic_snapshot_id": restic_snapshot_id,
+        "host": host,
+        "git_sha": git_sha,
+        "mirror_root_relative_to_data": mirror_root_relative_to_data,
+        "mirrors": mirrors,
+    }
+    receipt_path = mirror_root / RESTIC_GATE_RECEIPT_NAME
+    temp_path = receipt_path.with_suffix(".json.tmp")
+    temp_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.replace(receipt_path)
+    return receipt_path
+
+
+def _require_restic_gate_receipt(mirror_dir: Path, manifest: dict[str, Any]) -> None:
+    receipt_path = mirror_dir.parent / RESTIC_GATE_RECEIPT_NAME
+    if receipt_path.is_symlink() or not receipt_path.is_file():
+        raise DurableMirrorError(
+            f"no restic gate receipt for durable mirror at {mirror_dir}; "
+            "run `./scripts/backup-data.sh backup --execute` after snapshot"
+        )
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DurableMirrorError(f"unreadable restic gate receipt at {receipt_path}: {exc}") from exc
+    if not isinstance(receipt, dict) or receipt.get("schema") != RESTIC_GATE_RECEIPT_SCHEMA:
+        raise DurableMirrorError(f"{receipt_path} is not a restic gate receipt")
+    if receipt.get("schema_version") != RESTIC_GATE_RECEIPT_SCHEMA_VERSION:
+        raise DurableMirrorError(f"{receipt_path} has unsupported schema_version {receipt.get('schema_version')!r}")
+    created_at = _parse_utc_timestamp(receipt.get("created_at_utc"), field_name="created_at_utc")
+    snapshot_id = receipt.get("restic_snapshot_id")
+    if (
+        not isinstance(snapshot_id, str)
+        or len(snapshot_id) != 64
+        or any(c not in "0123456789abcdef" for c in snapshot_id)
+    ):
+        raise DurableMirrorError(f"{receipt_path} has invalid restic_snapshot_id")
+    mirrors = receipt.get("mirrors")
+    if not isinstance(mirrors, dict):
+        raise DurableMirrorError(f"{receipt_path} has invalid mirrors map")
+    recorded = mirrors.get(mirror_dir.name)
+    if not isinstance(recorded, dict):
+        raise DurableMirrorError(f"{receipt_path} does not cover mirror {mirror_dir.name!r}")
+
+    current = _manifest_fingerprint(mirror_dir, manifest)
+    if created_at < current["generated_at"]:
+        raise DurableMirrorError(
+            f"{receipt_path} predates the current mirror manifest; "
+            "run `./scripts/backup-data.sh backup --execute` after snapshot"
+        )
+    for fingerprint_field, value in current.items():
+        if recorded.get(fingerprint_field) != value:
+            raise DurableMirrorError(
+                f"{receipt_path} does not cover the current mirror manifest ({fingerprint_field} mismatch); "
+                "run `./scripts/backup-data.sh backup --execute` after snapshot"
+            )
+
 
 def _safe_mirror_rel_path(mirror_dir: Path, rel_path: str) -> Path:
     """Resolve a manifest path only if it stays inside ``mirror_dir``."""
@@ -167,7 +298,9 @@ def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
             mismatched.append(rel_path)
     on_disk = {path.relative_to(mirror_dir).as_posix() for path in _iter_files(mirror_dir)}
     extra = sorted(on_disk - expected_paths)
-    return VerifyResult(ok=not missing and not mismatched and not extra, missing=missing, mismatched=mismatched, extra=extra)
+    return VerifyResult(
+        ok=not missing and not mismatched and not extra, missing=missing, mismatched=mismatched, extra=extra
+    )
 
 
 def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = False) -> None:
@@ -192,7 +325,6 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
         cmd.append("--dry-run")
     cmd.extend([source_arg, dest_arg])
     subprocess.run(cmd, check=True)
-
 
 
 def _is_remote_rsync_source(source: str) -> bool:
@@ -292,10 +424,7 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     if len(files) == 0 or file_count == 0:
         raise DurableMirrorError(f"durable mirror at {mirror_dir} is empty")
     if file_count != len(files):
-        raise DurableMirrorError(
-            f"durable mirror at {mirror_dir} file_count mismatch "
-            f"({file_count} != {len(files)})"
-        )
+        raise DurableMirrorError(f"durable mirror at {mirror_dir} file_count mismatch ({file_count} != {len(files)})")
     try:
         generated_at = float(manifest["generated_at"])
     except (KeyError, TypeError, ValueError) as exc:
@@ -309,9 +438,7 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     now = time.time()
     # Reject future-dated manifests (clock skew / corruption); small 5m skew tolerance.
     if generated_at > now + 300:
-        raise DurableMirrorError(
-            f"durable mirror at {mirror_dir} has future generated_at={generated_at} (now={now})"
-        )
+        raise DurableMirrorError(f"durable mirror at {mirror_dir} has future generated_at={generated_at} (now={now})")
     age_hours = max(0.0, now - generated_at) / 3600.0
     if age_hours > max_age_hours:
         raise DurableMirrorError(
@@ -326,6 +453,7 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
         raise DurableMirrorError(
             f"durable mirror at {mirror_dir} is empty — refusing to treat an empty mirror as durable"
         )
+    _require_restic_gate_receipt(mirror_dir, manifest)
     return manifest
 
 
@@ -362,6 +490,22 @@ def _cmd_require(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_write_restic_gate_receipt(args: argparse.Namespace) -> int:
+    try:
+        receipt_path = write_restic_gate_receipt(
+            args.mirror_root,
+            restic_snapshot_id=args.restic_snapshot_id,
+            host=args.host,
+            git_sha=args.git_sha,
+            mirror_root_relative_to_data=args.mirror_root_relative_to_data,
+        )
+    except DurableMirrorError as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
+    print(f"wrote restic gate receipt: {receipt_path}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -370,7 +514,9 @@ def build_parser() -> argparse.ArgumentParser:
     snap.add_argument("--source", required=True, help="Local path or user@host:/path to mirror from")
     snap.add_argument("--mirror-dir", type=Path, required=True)
     snap.add_argument("--dry-run", action="store_true", help="rsync --dry-run; do not write a manifest")
-    snap.add_argument("--allow-live", action="store_true", help="allow snapshot while enrich-driver.pid is present (best-effort)")
+    snap.add_argument(
+        "--allow-live", action="store_true", help="allow snapshot while enrich-driver.pid is present (best-effort)"
+    )
     snap.set_defaults(func=_cmd_snapshot)
 
     verify = subparsers.add_parser("verify", help="recompute checksums and compare against manifest.json")
@@ -381,6 +527,17 @@ def build_parser() -> argparse.ArgumentParser:
     require.add_argument("--mirror-dir", type=Path, required=True)
     require.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
     require.set_defaults(func=_cmd_require)
+
+    receipt = subparsers.add_parser(
+        "write-restic-gate-receipt",
+        help="write a local receipt binding runner manifests to a completed restic snapshot",
+    )
+    receipt.add_argument("--mirror-root", type=Path, required=True)
+    receipt.add_argument("--restic-snapshot-id", required=True)
+    receipt.add_argument("--host", required=True)
+    receipt.add_argument("--git-sha", required=True)
+    receipt.add_argument("--mirror-root-relative-to-data", default="lexicon/runner-mirror")
+    receipt.set_defaults(func=_cmd_write_restic_gate_receipt)
 
     return parser
 

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -265,7 +265,12 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
             f"durable mirror at {mirror_dir} file_count mismatch "
             f"({manifest.get('file_count')} != {len(files)})"
         )
-    generated_at = float(manifest["generated_at"])
+    try:
+        generated_at = float(manifest["generated_at"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} has invalid generated_at={manifest.get('generated_at')!r}"
+        ) from exc
     now = time.time()
     # Reject future-dated manifests (clock skew / corruption); small 5m skew tolerance.
     if generated_at > now + 300:

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -191,23 +191,31 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
     subprocess.run(cmd, check=True)
 
 
+
+def _is_remote_rsync_source(source: str) -> bool:
+    """True for rsync remote forms ``host:path`` / ``user@host:path`` (not Windows drive)."""
+    if source.startswith("/"):
+        return False
+    # Windows-style local drive: C:\...
+    if len(source) >= 2 and source[1] == ":" and source[0].isalpha():
+        return False
+    return ":" in source
+
+
+def _remote_host_and_path(source: str) -> tuple[str, str]:
+    host, _, remote_path = source.partition(":")
+    if not host or not remote_path:
+        raise DurableMirrorError(f"invalid remote source: {source!r}")
+    return host, remote_path
+
+
 def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False, allow_live: bool = False) -> dict[str, Any]:
     """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
     # Fail closed when the source still looks live (local or remote): pid file means
     # SQLite may still be mutating. Remote check is best-effort via ssh test -f.
     if not allow_live:
-        if "@" not in source:
-            pid = Path(source) / "enrich-driver.pid"
-            if pid.is_file():
-                raise DurableMirrorError(
-                    f"refusing to snapshot live runner at {source} (found enrich-driver.pid); "
-                    "stop the runner or pass --allow-live for an emergency best-effort copy"
-                )
-        else:
-            # user@host:/path  or  host:/path
-            host, _, remote_path = source.partition(":")
-            if not remote_path:
-                raise DurableMirrorError(f"invalid remote source: {source!r}")
+        if _is_remote_rsync_source(source):
+            host, remote_path = _remote_host_and_path(source)
             remote_pid = f"{remote_path.rstrip('/')}/enrich-driver.pid"
             probe = subprocess.run(
                 ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, "test", "-f", remote_pid],
@@ -217,6 +225,13 @@ def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False, allow_live
             if probe.returncode == 0:
                 raise DurableMirrorError(
                     f"refusing to snapshot live remote runner at {source} (found enrich-driver.pid); "
+                    "stop the runner or pass --allow-live for an emergency best-effort copy"
+                )
+        else:
+            pid = Path(source) / "enrich-driver.pid"
+            if pid.is_file():
+                raise DurableMirrorError(
+                    f"refusing to snapshot live runner at {source} (found enrich-driver.pid); "
                     "stop the runner or pass --allow-live for an emergency best-effort copy"
                 )
     sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import subprocess
 import sys
 import time
@@ -190,8 +191,16 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
     subprocess.run(cmd, check=True)
 
 
-def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False) -> dict[str, Any]:
+def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False, allow_live: bool = False) -> dict[str, Any]:
     """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
+    # Fail closed on local live runners: a pid file means SQLite may still be mutating.
+    if not allow_live and "@" not in source:
+        pid = Path(source) / "enrich-driver.pid"
+        if pid.is_file():
+            raise DurableMirrorError(
+                f"refusing to snapshot live runner at {source} (found enrich-driver.pid); "
+                "stop the runner or pass allow_live=True for an emergency best-effort copy"
+            )
     sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)
     if dry_run:
         # Preview prospective payload from a local source; remote sources get a
@@ -225,6 +234,8 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     (VPS work-dir wipe, local cache purge) must call this first and abort on
     :class:`DurableMirrorError`.
     """
+    if not math.isfinite(max_age_hours) or max_age_hours < 0:
+        raise DurableMirrorError(f"invalid max_age_hours={max_age_hours!r} (must be finite and >= 0)")
     manifest = read_manifest(mirror_dir)
     files = manifest.get("files")
     if not isinstance(files, list):
@@ -261,7 +272,7 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
 
 
 def _cmd_snapshot(args: argparse.Namespace) -> int:
-    manifest = snapshot(args.source, args.mirror_dir, dry_run=args.dry_run)
+    manifest = snapshot(args.source, args.mirror_dir, dry_run=args.dry_run, allow_live=args.allow_live)
     print(
         f"{'would snapshot' if args.dry_run else 'snapshotted'} {args.source} -> {args.mirror_dir}: "
         f"{manifest['file_count']} files, {manifest['total_bytes']} bytes"
@@ -301,6 +312,7 @@ def build_parser() -> argparse.ArgumentParser:
     snap.add_argument("--source", required=True, help="Local path or user@host:/path to mirror from")
     snap.add_argument("--mirror-dir", type=Path, required=True)
     snap.add_argument("--dry-run", action="store_true", help="rsync --dry-run; do not write a manifest")
+    snap.add_argument("--allow-live", action="store_true", help="allow snapshot while enrich-driver.pid is present (best-effort)")
     snap.set_defaults(func=_cmd_snapshot)
 
     verify = subparsers.add_parser("verify", help="recompute checksums and compare against manifest.json")

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -227,6 +227,13 @@ def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False, allow_live
                     f"refusing to snapshot live remote runner at {source} (found enrich-driver.pid); "
                     "stop the runner or pass --allow-live for an emergency best-effort copy"
                 )
+            if probe.returncode != 1:
+                # ssh failure / remote error — fail closed (not "pid absent")
+                detail = (probe.stderr or probe.stdout or b"").decode("utf-8", errors="replace").strip()
+                raise DurableMirrorError(
+                    f"could not probe remote runner liveness at {source} "
+                    f"(ssh exit {probe.returncode}): {detail or 'no detail'}"
+                )
         else:
             pid = Path(source) / "enrich-driver.pid"
             if pid.is_file():

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -293,6 +293,10 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
         raise DurableMirrorError(
             f"durable mirror at {mirror_dir} has invalid generated_at={manifest.get('generated_at')!r}"
         ) from exc
+    if not math.isfinite(generated_at):
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} has non-finite generated_at={manifest.get('generated_at')!r}"
+        )
     now = time.time()
     # Reject future-dated manifests (clock skew / corruption); small 5m skew tolerance.
     if generated_at > now + 300:

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -174,11 +174,7 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
     state, since versioning/history is the downstream restic bus's job, not
     this mirror's.
     """
-    if not dry_run:
-        mirror_dir.mkdir(parents=True, exist_ok=True)
-    elif not mirror_dir.exists():
-        # Dry-run against a missing dest: no filesystem side effects.
-        return
+    mirror_dir.mkdir(parents=True, exist_ok=True)
     source_arg = source if source.endswith("/") else f"{source}/"
     dest_arg = f"{mirror_dir}/"
     cmd = ["rsync", "-az", "--delete", "--exclude", MANIFEST_NAME]
@@ -198,7 +194,14 @@ def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False) -> dict[st
     """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
     sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)
     if dry_run:
-        # Do not invent counts from a mirror that rsync did not write into.
+        # Preview prospective payload from a local source; remote sources get a
+        # dry-run rsync only (no meaningful local manifest without a transfer).
+        local = Path(source)
+        if "@" not in source and local.is_dir():
+            preview = build_manifest(local)
+            preview["dry_run"] = True
+            preview["source"] = source
+            return preview
         return {
             "schema": "atlas-runner-mirror-manifest",
             "schema_version": MANIFEST_SCHEMA_VERSION,
@@ -208,6 +211,7 @@ def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False) -> dict[st
             "files": [],
             "dry_run": True,
             "source": source,
+            "note": "remote dry-run; counts not computed locally",
         }
     manifest = build_manifest(mirror_dir)
     write_manifest(manifest, mirror_dir)

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -139,7 +139,7 @@ def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
             mismatched.append(rel_path)
     on_disk = {path.relative_to(mirror_dir).as_posix() for path in _iter_files(mirror_dir)}
     extra = sorted(on_disk - expected_paths)
-    return VerifyResult(ok=not missing and not mismatched, missing=missing, mismatched=mismatched, extra=extra)
+    return VerifyResult(ok=not missing and not mismatched and not extra, missing=missing, mismatched=mismatched, extra=extra)
 
 
 def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = False) -> None:
@@ -184,7 +184,14 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     :class:`DurableMirrorError`.
     """
     manifest = read_manifest(mirror_dir)
-    age_hours = max(0.0, time.time() - float(manifest["generated_at"])) / 3600.0
+    generated_at = float(manifest["generated_at"])
+    now = time.time()
+    # Reject future-dated manifests (clock skew / corruption); small 5m skew tolerance.
+    if generated_at > now + 300:
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} has future generated_at={generated_at} (now={now})"
+        )
+    age_hours = max(0.0, now - generated_at) / 3600.0
     if age_hours > max_age_hours:
         raise DurableMirrorError(
             f"durable mirror at {mirror_dir} is {age_hours:.1f}h old (max {max_age_hours}h) — refresh with `snapshot` first"

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -151,6 +151,8 @@ def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
     for entry in manifest.get("files", []):
         if not isinstance(entry, dict) or "path" not in entry:
             raise DurableMirrorError("manifest entry missing path")
+        if "bytes" not in entry or "sha256" not in entry:
+            raise DurableMirrorError(f"manifest entry missing bytes/sha256: {entry.get('path')!r}")
         rel_path = str(entry["path"])
         expected_paths.add(rel_path)
         disk_path = _safe_mirror_rel_path(mirror_dir, rel_path)
@@ -172,7 +174,11 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
     state, since versioning/history is the downstream restic bus's job, not
     this mirror's.
     """
-    mirror_dir.mkdir(parents=True, exist_ok=True)
+    if not dry_run:
+        mirror_dir.mkdir(parents=True, exist_ok=True)
+    elif not mirror_dir.exists():
+        # Dry-run against a missing dest: no filesystem side effects.
+        return
     source_arg = source if source.endswith("/") else f"{source}/"
     dest_arg = f"{mirror_dir}/"
     cmd = ["rsync", "-az", "--delete", "--exclude", MANIFEST_NAME]
@@ -192,7 +198,17 @@ def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False) -> dict[st
     """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
     sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)
     if dry_run:
-        return build_manifest(mirror_dir)
+        # Do not invent counts from a mirror that rsync did not write into.
+        return {
+            "schema": "atlas-runner-mirror-manifest",
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "generated_at": time.time(),
+            "file_count": 0,
+            "total_bytes": 0,
+            "files": [],
+            "dry_run": True,
+            "source": source,
+        }
     manifest = build_manifest(mirror_dir)
     write_manifest(manifest, mirror_dir)
     return manifest

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -68,6 +68,9 @@ def _sha256_file(path: Path) -> str:
 def _iter_files(root: Path) -> list[Path]:
     files: list[Path] = []
     for path in sorted(root.rglob("*")):
+        # Fail closed: symlinks can hide state or escape the tree after restore.
+        if path.is_symlink():
+            raise DurableMirrorError(f"symlink not allowed in durable mirror tree: {path}")
         if path.is_dir():
             continue
         if path.name in IGNORED_FILE_NAMES or path.suffix in IGNORED_SUFFIXES:

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -177,7 +177,7 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
     mirror_dir.mkdir(parents=True, exist_ok=True)
     source_arg = source if source.endswith("/") else f"{source}/"
     dest_arg = f"{mirror_dir}/"
-    cmd = ["rsync", "-az", "--delete", "--exclude", MANIFEST_NAME]
+    cmd = ["rsync", "-az", "--delete", "--exclude", f"/{MANIFEST_NAME}"]
     for dir_name in IGNORED_DIR_NAMES:
         cmd.extend(["--exclude", dir_name])
     for file_name in IGNORED_FILE_NAMES:
@@ -226,6 +226,16 @@ def require_durable(mirror_dir: Path, *, max_age_hours: float = DEFAULT_MAX_AGE_
     :class:`DurableMirrorError`.
     """
     manifest = read_manifest(mirror_dir)
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        raise DurableMirrorError(f"durable mirror at {mirror_dir} has invalid files list")
+    if len(files) == 0 or int(manifest.get("file_count") or 0) == 0:
+        raise DurableMirrorError(f"durable mirror at {mirror_dir} is empty")
+    if int(manifest.get("file_count") or 0) != len(files):
+        raise DurableMirrorError(
+            f"durable mirror at {mirror_dir} file_count mismatch "
+            f"({manifest.get('file_count')} != {len(files)})"
+        )
     generated_at = float(manifest["generated_at"])
     now = time.time()
     # Reject future-dated manifests (clock skew / corruption); small 5m skew tolerance.

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -193,14 +193,32 @@ def sync_source_to_mirror(source: str, mirror_dir: Path, *, dry_run: bool = Fals
 
 def snapshot(source: str, mirror_dir: Path, *, dry_run: bool = False, allow_live: bool = False) -> dict[str, Any]:
     """rsync ``source`` into ``mirror_dir`` and (re)write its checksummed manifest."""
-    # Fail closed on local live runners: a pid file means SQLite may still be mutating.
-    if not allow_live and "@" not in source:
-        pid = Path(source) / "enrich-driver.pid"
-        if pid.is_file():
-            raise DurableMirrorError(
-                f"refusing to snapshot live runner at {source} (found enrich-driver.pid); "
-                "stop the runner or pass allow_live=True for an emergency best-effort copy"
+    # Fail closed when the source still looks live (local or remote): pid file means
+    # SQLite may still be mutating. Remote check is best-effort via ssh test -f.
+    if not allow_live:
+        if "@" not in source:
+            pid = Path(source) / "enrich-driver.pid"
+            if pid.is_file():
+                raise DurableMirrorError(
+                    f"refusing to snapshot live runner at {source} (found enrich-driver.pid); "
+                    "stop the runner or pass --allow-live for an emergency best-effort copy"
+                )
+        else:
+            # user@host:/path  or  host:/path
+            host, _, remote_path = source.partition(":")
+            if not remote_path:
+                raise DurableMirrorError(f"invalid remote source: {source!r}")
+            remote_pid = f"{remote_path.rstrip('/')}/enrich-driver.pid"
+            probe = subprocess.run(
+                ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, "test", "-f", remote_pid],
+                check=False,
+                capture_output=True,
             )
+            if probe.returncode == 0:
+                raise DurableMirrorError(
+                    f"refusing to snapshot live remote runner at {source} (found enrich-driver.pid); "
+                    "stop the runner or pass --allow-live for an emergency best-effort copy"
+                )
     sync_source_to_mirror(source, mirror_dir, dry_run=dry_run)
     if dry_run:
         # Preview prospective payload from a local source; remote sources get a

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -115,12 +115,32 @@ def read_manifest(mirror_dir: Path) -> dict[str, Any]:
     manifest_path = mirror_dir / MANIFEST_NAME
     if not manifest_path.is_file():
         raise DurableMirrorError(f"no durable mirror manifest at {manifest_path}")
-    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DurableMirrorError(f"unreadable durable mirror manifest at {manifest_path}: {exc}") from exc
     if not isinstance(payload, dict) or payload.get("schema") != "atlas-runner-mirror-manifest":
         raise DurableMirrorError(f"{manifest_path} is not a runner-mirror manifest")
     if payload.get("schema_version") != MANIFEST_SCHEMA_VERSION:
         raise DurableMirrorError(f"{manifest_path} has unsupported schema_version {payload.get('schema_version')!r}")
     return payload
+
+
+
+def _safe_mirror_rel_path(mirror_dir: Path, rel_path: str) -> Path:
+    """Resolve a manifest path only if it stays inside ``mirror_dir``."""
+    if not isinstance(rel_path, str) or not rel_path or rel_path.startswith("/"):
+        raise DurableMirrorError(f"unsafe manifest path: {rel_path!r}")
+    parts = Path(rel_path).parts
+    if any(part in ("", ".", "..") for part in parts):
+        raise DurableMirrorError(f"unsafe manifest path: {rel_path!r}")
+    disk_path = (mirror_dir / rel_path).resolve()
+    mirror_real = mirror_dir.resolve()
+    try:
+        disk_path.relative_to(mirror_real)
+    except ValueError as exc:
+        raise DurableMirrorError(f"manifest path escapes mirror: {rel_path!r}") from exc
+    return disk_path
 
 
 def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
@@ -129,9 +149,11 @@ def verify_manifest(manifest: dict[str, Any], mirror_dir: Path) -> VerifyResult:
     mismatched: list[str] = []
     expected_paths: set[str] = set()
     for entry in manifest.get("files", []):
+        if not isinstance(entry, dict) or "path" not in entry:
+            raise DurableMirrorError("manifest entry missing path")
         rel_path = str(entry["path"])
         expected_paths.add(rel_path)
-        disk_path = mirror_dir / rel_path
+        disk_path = _safe_mirror_rel_path(mirror_dir, rel_path)
         if not disk_path.is_file():
             missing.append(rel_path)
             continue
@@ -218,8 +240,12 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
 
 
 def _cmd_verify(args: argparse.Namespace) -> int:
-    manifest = read_manifest(args.mirror_dir)
-    result = verify_manifest(manifest, args.mirror_dir)
+    try:
+        manifest = read_manifest(args.mirror_dir)
+        result = verify_manifest(manifest, args.mirror_dir)
+    except DurableMirrorError as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
     if result.ok:
         print(f"OK: {args.mirror_dir} matches its manifest ({manifest['file_count']} files)")
         return 0

--- a/scripts/lexicon/runner/mirror_20k_runner.sh
+++ b/scripts/lexicon/runner/mirror_20k_runner.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   scripts/lexicon/runner/mirror_20k_runner.sh                 # sync + snapshot
-#   scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # just check freshness
+#   scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # verify a backed-up mirror
 #
 # Env overrides:
 #   ATLAS_RUNNER_HOST  ssh destination, e.g. ops@atlas-runner.example (required to sync)
@@ -39,3 +39,4 @@ $DURABLE_MIRROR snapshot --source "$SOURCE" --mirror-dir "$MIRROR_DIR"
 echo
 echo "mirror refreshed. Push it into the restic backup bus before any cleanup:"
 echo "  cd $REPO && ./scripts/backup-data.sh backup && ./scripts/backup-data.sh backup --execute"
+echo "  $0 --require-only"

--- a/scripts/lexicon/runner/mirror_20k_runner.sh
+++ b/scripts/lexicon/runner/mirror_20k_runner.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Laptop-side sync: mirror the remote Atlas 20k runner work-dir into this repo's
+# data/ so scripts/backup-data.sh (#6014) picks it up in its next restic
+# snapshot. Run this after every fetch/reduce/enrich phase and always before
+# any runner work-dir wipe or cleanup (#5884).
+#
+# Usage:
+#   scripts/lexicon/runner/mirror_20k_runner.sh                 # sync + snapshot
+#   scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # just check freshness
+#
+# Env overrides:
+#   ATLAS_RUNNER_HOST  ssh destination, e.g. ops@atlas-runner.example (required to sync)
+#   ATLAS_RUN_ROOT      remote run root (default /home/ops/atlas-runner)
+#   ATLAS_WORK_DIR_NAME remote work-dir under ATLAS_RUN_ROOT (default run-20k)
+#   ATLAS_MIRROR_DIR    local mirror dir (default <repo>/data/lexicon/runner-mirror/<work-dir-name>)
+#   ATLAS_MIRROR_MAX_AGE_HOURS  staleness gate for --require-only (default 24)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK_DIR_NAME="${ATLAS_WORK_DIR_NAME:-run-20k}"
+MIRROR_DIR="${ATLAS_MIRROR_DIR:-$REPO/data/lexicon/runner-mirror/$WORK_DIR_NAME}"
+MAX_AGE_HOURS="${ATLAS_MIRROR_MAX_AGE_HOURS:-24}"
+DURABLE_MIRROR="$REPO/.venv/bin/python $REPO/scripts/lexicon/runner/durable_mirror.py"
+
+if [[ "${1:-}" == "--require-only" ]]; then
+  # shellcheck disable=SC2086
+  $DURABLE_MIRROR require --mirror-dir "$MIRROR_DIR" --max-age-hours "$MAX_AGE_HOURS"
+  exit $?
+fi
+
+RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+: "${ATLAS_RUNNER_HOST:?set ATLAS_RUNNER_HOST=user@host to sync from the VPS (or run durable_mirror.py snapshot --source directly)}"
+SOURCE="${ATLAS_RUNNER_HOST}:${RUN_ROOT}/${WORK_DIR_NAME}"
+
+echo "syncing ${SOURCE} -> ${MIRROR_DIR}"
+# shellcheck disable=SC2086
+$DURABLE_MIRROR snapshot --source "$SOURCE" --mirror-dir "$MIRROR_DIR"
+
+echo
+echo "mirror refreshed. Push it into the restic backup bus before any cleanup:"
+echo "  cd $REPO && ./scripts/backup-data.sh backup && ./scripts/backup-data.sh backup --execute"

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -8,9 +8,12 @@ import os
 import shutil
 import sqlite3
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
+
+from scripts.lexicon.runner.durable_mirror import DurableMirrorError, require_durable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "backup-data.sh"
@@ -126,6 +129,10 @@ if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
     data: (.paths[] | select(.path == "data"))
   }' \
     "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
+fi
+if [[ "${1:-}" == "backup" && -n "${FAKE_MUTATED_LIVE_STATE_SOURCE:-}" ]]; then
+  cp "$FAKE_MUTATED_LIVE_STATE_SOURCE" "$FAKE_MUTATED_LIVE_STATE_DESTINATION"
+  cp "$FAKE_MUTATED_LIVE_MANIFEST_SOURCE" "$FAKE_MUTATED_LIVE_MANIFEST_DESTINATION"
 fi
 if [[ "${1:-}" == "backup" ]]; then
   for argument in "$@"; do
@@ -285,6 +292,78 @@ def test_execute_does_not_write_restic_gate_receipt_when_check_fails(
 
     assert result.returncode != 0
     assert not (mirror.parent / "RESTIC-GATE-RECEIPT.json").exists()
+
+
+def test_execute_fails_closed_when_live_runner_mirror_changes_after_staging(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    """A staged manifest A must never produce a live receipt for mutated manifest B."""
+    environment, source, staging, _legacy = backup_environment
+    mirror = source / "lexicon" / "runner-mirror" / "run-20k"
+    mirror.mkdir(parents=True)
+    state_path = mirror / "runner-state.txt"
+    original_state = b"runner-state-before-race"
+    state_path.write_bytes(original_state)
+    (mirror / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "atlas-runner-mirror-manifest",
+                "schema_version": 1,
+                "generated_at": time.time(),
+                "file_count": 1,
+                "total_bytes": len(original_state),
+                "files": [
+                    {
+                        "path": "runner-state.txt",
+                        "bytes": len(original_state),
+                        "sha256": hashlib.sha256(original_state).hexdigest(),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    mutated_state = b"runner-state-after-race"
+    mutation_dir = staging.parent / "race-mutation"
+    mutation_dir.mkdir()
+    mutated_state_source = mutation_dir / "runner-state.txt"
+    mutated_state_source.write_bytes(mutated_state)
+    mutated_manifest_source = mutation_dir / "manifest.json"
+    mutated_manifest_source.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-runner-mirror-manifest",
+                "schema_version": 1,
+                "generated_at": time.time(),
+                "file_count": 1,
+                "total_bytes": len(mutated_state),
+                "files": [
+                    {
+                        "path": "runner-state.txt",
+                        "bytes": len(mutated_state),
+                        "sha256": hashlib.sha256(mutated_state).hexdigest(),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment.update(
+        {
+            "FAKE_MUTATED_LIVE_STATE_SOURCE": str(mutated_state_source),
+            "FAKE_MUTATED_LIVE_STATE_DESTINATION": str(state_path),
+            "FAKE_MUTATED_LIVE_MANIFEST_SOURCE": str(mutated_manifest_source),
+            "FAKE_MUTATED_LIVE_MANIFEST_DESTINATION": str(mirror / "manifest.json"),
+        }
+    )
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode != 0
+    assert "refusing to write a receipt for content not backed up" in result.stderr
+    assert not (mirror.parent / "RESTIC-GATE-RECEIPT.json").exists()
+    with pytest.raises(DurableMirrorError, match="no restic gate receipt"):
+        require_durable(mirror)
 
 
 def test_execute_snapshots_checkpointed_wal_database_without_sidecars(

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import shutil
 import sqlite3
@@ -125,6 +127,17 @@ if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
   }' \
     "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
 fi
+if [[ "${1:-}" == "backup" ]]; then
+  for argument in "$@"; do
+    if [[ "$argument" == "--json" ]]; then
+      printf '%s\n' '{"message_type":"summary","snapshot_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+      break
+    fi
+  done
+fi
+if [[ "${1:-}" == "check" && "${FAKE_RESTIC_CHECK_FAIL:-0}" == "1" ]]; then
+  exit 70
+fi
 exit 0
 """,
     )
@@ -210,6 +223,68 @@ def test_execute_stages_a_consistent_wal_database_and_cleans_up(
     assert '".claude/atlas-epic"' in _log(environment)
     assert '"batch_state"' in _log(environment)
     assert list(staging.iterdir()) == []
+
+
+def test_execute_writes_live_restic_gate_receipt_only_after_check(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    mirror = source / "lexicon" / "runner-mirror" / "run-20k"
+    mirror.mkdir(parents=True)
+    (mirror / "runner-state.txt").write_bytes(b"runner-state")
+    manifest = {
+        "schema": "atlas-runner-mirror-manifest",
+        "schema_version": 1,
+        "generated_at": 1.0,
+        "file_count": 1,
+        "total_bytes": 12,
+        "files": [{"path": "runner-state.txt", "bytes": 12, "sha256": hashlib.sha256(b"runner-state").hexdigest()}],
+    }
+    (mirror / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    receipt_path = mirror.parent / "RESTIC-GATE-RECEIPT.json"
+
+    preview = _run(environment, "backup")
+
+    assert preview.returncode == 0, preview.stderr
+    assert not receipt_path.exists()
+
+    executed = _run(environment, "backup", "--execute")
+
+    assert executed.returncode == 0, executed.stderr
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["restic_snapshot_id"] == "a" * 64
+    assert (
+        receipt["mirrors"]["run-20k"]["manifest_sha256"]
+        == hashlib.sha256((mirror / "manifest.json").read_bytes()).hexdigest()
+    )
+
+
+def test_execute_does_not_write_restic_gate_receipt_when_check_fails(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    mirror = source / "lexicon" / "runner-mirror" / "run-20k"
+    mirror.mkdir(parents=True)
+    (mirror / "state.txt").write_text("state\n", encoding="utf-8")
+    (mirror / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "atlas-runner-mirror-manifest",
+                "schema_version": 1,
+                "generated_at": 1.0,
+                "file_count": 1,
+                "total_bytes": 6,
+                "files": [{"path": "state.txt", "bytes": 6, "sha256": hashlib.sha256(b"state\n").hexdigest()}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment["FAKE_RESTIC_CHECK_FAIL"] = "1"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode != 0
+    assert not (mirror.parent / "RESTIC-GATE-RECEIPT.json").exists()
 
 
 def test_execute_snapshots_checkpointed_wal_database_without_sidecars(

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -16,6 +16,7 @@ from scripts.lexicon.runner.durable_mirror import (
     snapshot,
     verify_manifest,
     write_manifest,
+    write_restic_gate_receipt,
 )
 
 
@@ -29,6 +30,15 @@ def _populate(root: Path) -> None:
     (root / "enrich.log").write_text("noop\n", encoding="utf-8")
     (root / "enrich-driver.pid").write_text("12345\n", encoding="utf-8")
     (root / ".DS_Store").write_bytes(b"\x00")
+
+
+def _write_current_restic_receipt(mirror: Path) -> None:
+    write_restic_gate_receipt(
+        mirror.parent,
+        restic_snapshot_id="a" * 64,
+        host="teacher",
+        git_sha="b" * 40,
+    )
 
 
 def test_build_manifest_excludes_pid_and_ds_store(tmp_path: Path) -> None:
@@ -148,9 +158,33 @@ def test_require_durable_succeeds_for_fresh_verified_mirror(tmp_path: Path) -> N
     mirror = tmp_path / "mirror"
     _populate(source)
     snapshot(str(source), mirror, allow_live=True)
+    _write_current_restic_receipt(mirror)
 
     manifest = require_durable(mirror)
     assert manifest["file_count"] == 4
+
+
+def test_require_durable_fails_without_restic_receipt(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror-root" / "run-20k"
+    _populate(source)
+    snapshot(str(source), mirror, allow_live=True)
+
+    with pytest.raises(DurableMirrorError, match="no restic gate receipt"):
+        require_durable(mirror)
+
+
+def test_require_durable_fails_when_manifest_changes_after_receipt(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror-root" / "run-20k"
+    _populate(source)
+    snapshot(str(source), mirror, allow_live=True)
+    _write_current_restic_receipt(mirror)
+    (source / "ledger.sqlite").write_bytes(b"updated-ledger-bytes")
+    snapshot(str(source), mirror, allow_live=True)
+
+    with pytest.raises(DurableMirrorError, match=r"predates|does not cover the current mirror manifest"):
+        require_durable(mirror)
 
 
 def test_cli_snapshot_then_verify_then_require(tmp_path: Path) -> None:
@@ -160,6 +194,7 @@ def test_cli_snapshot_then_verify_then_require(tmp_path: Path) -> None:
 
     assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--allow-live"]) == 0
     assert main(["verify", "--mirror-dir", str(mirror)]) == 0
+    _write_current_restic_receipt(mirror)
     assert main(["require", "--mirror-dir", str(mirror)]) == 0
 
 
@@ -211,7 +246,7 @@ def test_verify_rejects_path_escape(tmp_path: Path) -> None:
     manifest = read_manifest(mirror)
     manifest["files"].append({"path": "../outside.txt", "bytes": 1, "sha256": "0" * 64})
     write_manifest(manifest, mirror)
-    with pytest.raises(DurableMirrorError, match="unsafe|escape"):
+    with pytest.raises(DurableMirrorError, match=r"unsafe|escape"):
         verify_manifest(read_manifest(mirror), mirror)
 
 

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -53,7 +53,7 @@ def test_snapshot_syncs_and_writes_verifiable_manifest(tmp_path: Path) -> None:
     mirror = tmp_path / "mirror"
     _populate(source)
 
-    manifest = snapshot(str(source), mirror)
+    manifest = snapshot(str(source), mirror, allow_live=True)
 
     assert (mirror / "manifest.json").is_file()
     assert (mirror / "ledger.sqlite").read_bytes() == b"fake-ledger-bytes"
@@ -69,10 +69,10 @@ def test_snapshot_delete_removes_stale_mirror_files(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
 
     (source / "network-cache.sqlite").unlink()
-    manifest = snapshot(str(source), mirror)
+    manifest = snapshot(str(source), mirror, allow_live=True)
 
     assert not (mirror / "network-cache.sqlite").exists()
     assert "network-cache.sqlite" not in {entry["path"] for entry in manifest["files"]}
@@ -82,7 +82,7 @@ def test_verify_detects_corruption(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
 
     (mirror / "ledger.sqlite").write_bytes(b"corrupted")
 
@@ -95,7 +95,7 @@ def test_verify_detects_missing_file(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
 
     (mirror / "enrich.log").unlink()
 
@@ -124,7 +124,7 @@ def test_require_durable_fails_closed_when_stale(tmp_path: Path) -> None:
     mirror = tmp_path / "mirror"
     _populate(source)
     stale_time = time.time() - 48 * 3600
-    manifest = snapshot(str(source), mirror)
+    manifest = snapshot(str(source), mirror, allow_live=True)
     manifest["generated_at"] = stale_time
     write_manifest(manifest, mirror)
 
@@ -136,7 +136,7 @@ def test_require_durable_fails_closed_on_corruption(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
     (mirror / "ledger.sqlite").write_bytes(b"tampered")
 
     with pytest.raises(DurableMirrorError, match="failed verification"):
@@ -147,7 +147,7 @@ def test_require_durable_succeeds_for_fresh_verified_mirror(tmp_path: Path) -> N
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
 
     manifest = require_durable(mirror)
     assert manifest["file_count"] == 4
@@ -158,7 +158,7 @@ def test_cli_snapshot_then_verify_then_require(tmp_path: Path) -> None:
     mirror = tmp_path / "mirror"
     _populate(source)
 
-    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror)]) == 0
+    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--allow-live"]) == 0
     assert main(["verify", "--mirror-dir", str(mirror)]) == 0
     assert main(["require", "--mirror-dir", str(mirror)]) == 0
 
@@ -173,7 +173,7 @@ def test_cli_dry_run_snapshot_does_not_write_manifest(tmp_path: Path) -> None:
     mirror = tmp_path / "mirror"
     _populate(source)
 
-    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--dry-run"]) == 0
+    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--dry-run", "--allow-live"]) == 0
     assert not (mirror / "manifest.json").exists()
 
 
@@ -182,7 +182,7 @@ def test_verify_fails_when_extra_files_present(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
     (mirror / "sneaky.extra").write_text("nope", encoding="utf-8")
     manifest = read_manifest(mirror)
     result = verify_manifest(manifest, mirror)
@@ -195,7 +195,7 @@ def test_require_durable_fails_on_future_generated_at(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
     manifest = read_manifest(mirror)
     manifest["generated_at"] = time.time() + 3600
     write_manifest(manifest, mirror)
@@ -207,7 +207,7 @@ def test_verify_rejects_path_escape(tmp_path: Path) -> None:
     source = tmp_path / "work"
     mirror = tmp_path / "mirror"
     _populate(source)
-    snapshot(str(source), mirror)
+    snapshot(str(source), mirror, allow_live=True)
     manifest = read_manifest(mirror)
     manifest["files"].append({"path": "../outside.txt", "bytes": 1, "sha256": "0" * 64})
     write_manifest(manifest, mirror)
@@ -221,3 +221,20 @@ def test_read_manifest_rejects_invalid_json(tmp_path: Path) -> None:
     (mirror / "manifest.json").write_text("{not-json", encoding="utf-8")
     with pytest.raises(DurableMirrorError, match="unreadable"):
         read_manifest(mirror)
+
+
+def test_require_rejects_nan_max_age(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror, allow_live=True)
+    with pytest.raises(DurableMirrorError, match="invalid max_age"):
+        require_durable(mirror, max_age_hours=float("nan"))
+
+
+def test_snapshot_refuses_live_pid_by_default(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    with pytest.raises(DurableMirrorError, match="live runner"):
+        snapshot(str(source), mirror, allow_live=False)

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -238,3 +238,15 @@ def test_snapshot_refuses_live_pid_by_default(tmp_path: Path) -> None:
     _populate(source)
     with pytest.raises(DurableMirrorError, match="live runner"):
         snapshot(str(source), mirror, allow_live=False)
+
+
+def test_require_rejects_bad_generated_at(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror, allow_live=True)
+    manifest = read_manifest(mirror)
+    manifest["generated_at"] = "not-a-number"
+    write_manifest(manifest, mirror)
+    with pytest.raises(DurableMirrorError, match="invalid generated_at"):
+        require_durable(mirror)

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -1,0 +1,177 @@
+"""Durable local mirror for the Atlas 20k runner work-dir (#5884, sibling of #6014)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner.durable_mirror import (
+    DurableMirrorError,
+    build_manifest,
+    main,
+    read_manifest,
+    require_durable,
+    snapshot,
+    verify_manifest,
+    write_manifest,
+)
+
+
+def _populate(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "ledger.sqlite").write_bytes(b"fake-ledger-bytes")
+    (root / "network-cache.sqlite").write_bytes(b"fake-cache-bytes")
+    sub = root / "offline_enrich"
+    sub.mkdir()
+    (sub / "candidate-enriched.json").write_text('{"entries": []}\n', encoding="utf-8")
+    (root / "enrich.log").write_text("noop\n", encoding="utf-8")
+    (root / "enrich-driver.pid").write_text("12345\n", encoding="utf-8")
+    (root / ".DS_Store").write_bytes(b"\x00")
+
+
+def test_build_manifest_excludes_pid_and_ds_store(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    _populate(source)
+
+    manifest = build_manifest(source)
+
+    paths = {entry["path"] for entry in manifest["files"]}
+    assert paths == {
+        "ledger.sqlite",
+        "network-cache.sqlite",
+        "offline_enrich/candidate-enriched.json",
+        "enrich.log",
+    }
+    assert manifest["file_count"] == 4
+    assert manifest["total_bytes"] == sum((source / p).stat().st_size for p in paths)
+
+
+def test_snapshot_syncs_and_writes_verifiable_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+
+    manifest = snapshot(str(source), mirror)
+
+    assert (mirror / "manifest.json").is_file()
+    assert (mirror / "ledger.sqlite").read_bytes() == b"fake-ledger-bytes"
+    assert (mirror / "offline_enrich" / "candidate-enriched.json").is_file()
+    assert not (mirror / "enrich-driver.pid").exists()
+    assert not (mirror / ".DS_Store").exists()
+
+    result = verify_manifest(read_manifest(mirror), mirror)
+    assert result.ok, result
+
+
+def test_snapshot_delete_removes_stale_mirror_files(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+
+    (source / "network-cache.sqlite").unlink()
+    manifest = snapshot(str(source), mirror)
+
+    assert not (mirror / "network-cache.sqlite").exists()
+    assert "network-cache.sqlite" not in {entry["path"] for entry in manifest["files"]}
+
+
+def test_verify_detects_corruption(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+
+    (mirror / "ledger.sqlite").write_bytes(b"corrupted")
+
+    result = verify_manifest(read_manifest(mirror), mirror)
+    assert not result.ok
+    assert "ledger.sqlite" in result.mismatched
+
+
+def test_verify_detects_missing_file(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+
+    (mirror / "enrich.log").unlink()
+
+    result = verify_manifest(read_manifest(mirror), mirror)
+    assert not result.ok
+    assert "enrich.log" in result.missing
+
+
+def test_require_durable_fails_closed_when_mirror_absent(tmp_path: Path) -> None:
+    mirror = tmp_path / "missing-mirror"
+    with pytest.raises(DurableMirrorError, match="no durable mirror manifest"):
+        require_durable(mirror)
+
+
+def test_require_durable_fails_closed_when_empty(tmp_path: Path) -> None:
+    mirror = tmp_path / "empty-mirror"
+    mirror.mkdir()
+    write_manifest(build_manifest(mirror), mirror)
+
+    with pytest.raises(DurableMirrorError, match="empty"):
+        require_durable(mirror)
+
+
+def test_require_durable_fails_closed_when_stale(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    stale_time = time.time() - 48 * 3600
+    manifest = snapshot(str(source), mirror)
+    manifest["generated_at"] = stale_time
+    write_manifest(manifest, mirror)
+
+    with pytest.raises(DurableMirrorError, match="old"):
+        require_durable(mirror, max_age_hours=24.0)
+
+
+def test_require_durable_fails_closed_on_corruption(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+    (mirror / "ledger.sqlite").write_bytes(b"tampered")
+
+    with pytest.raises(DurableMirrorError, match="failed verification"):
+        require_durable(mirror)
+
+
+def test_require_durable_succeeds_for_fresh_verified_mirror(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+
+    manifest = require_durable(mirror)
+    assert manifest["file_count"] == 4
+
+
+def test_cli_snapshot_then_verify_then_require(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+
+    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror)]) == 0
+    assert main(["verify", "--mirror-dir", str(mirror)]) == 0
+    assert main(["require", "--mirror-dir", str(mirror)]) == 0
+
+
+def test_cli_require_exits_nonzero_when_not_durable(tmp_path: Path) -> None:
+    mirror = tmp_path / "missing-mirror"
+    assert main(["require", "--mirror-dir", str(mirror)]) == 2
+
+
+def test_cli_dry_run_snapshot_does_not_write_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+
+    assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--dry-run"]) == 0
+    assert not (mirror / "manifest.json").exists()

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -250,3 +250,15 @@ def test_require_rejects_bad_generated_at(tmp_path: Path) -> None:
     write_manifest(manifest, mirror)
     with pytest.raises(DurableMirrorError, match="invalid generated_at"):
         require_durable(mirror)
+
+
+def test_require_rejects_nan_generated_at(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror, allow_live=True)
+    manifest = read_manifest(mirror)
+    manifest["generated_at"] = float("nan")
+    write_manifest(manifest, mirror)
+    with pytest.raises(DurableMirrorError, match="non-finite"):
+        require_durable(mirror)

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -201,3 +201,23 @@ def test_require_durable_fails_on_future_generated_at(tmp_path: Path) -> None:
     write_manifest(manifest, mirror)
     with pytest.raises(DurableMirrorError, match="future"):
         require_durable(mirror, max_age_hours=24.0)
+
+
+def test_verify_rejects_path_escape(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+    manifest = read_manifest(mirror)
+    manifest["files"].append({"path": "../outside.txt", "bytes": 1, "sha256": "0" * 64})
+    write_manifest(manifest, mirror)
+    with pytest.raises(DurableMirrorError, match="unsafe|escape"):
+        verify_manifest(read_manifest(mirror), mirror)
+
+
+def test_read_manifest_rejects_invalid_json(tmp_path: Path) -> None:
+    mirror = tmp_path / "mirror"
+    mirror.mkdir()
+    (mirror / "manifest.json").write_text("{not-json", encoding="utf-8")
+    with pytest.raises(DurableMirrorError, match="unreadable"):
+        read_manifest(mirror)

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -262,3 +262,14 @@ def test_require_rejects_nan_generated_at(tmp_path: Path) -> None:
     write_manifest(manifest, mirror)
     with pytest.raises(DurableMirrorError, match="non-finite"):
         require_durable(mirror)
+
+
+def test_build_manifest_rejects_symlinks(tmp_path: Path) -> None:
+    source = tmp_path / "work"
+    _populate(source)
+    target = tmp_path / "elsewhere"
+    target.mkdir()
+    (target / "x.txt").write_text("x", encoding="utf-8")
+    (source / "linkdir").symlink_to(target, target_is_directory=True)
+    with pytest.raises(DurableMirrorError, match="symlink"):
+        build_manifest(source)

--- a/tests/test_lexicon_runner_durable_mirror.py
+++ b/tests/test_lexicon_runner_durable_mirror.py
@@ -175,3 +175,29 @@ def test_cli_dry_run_snapshot_does_not_write_manifest(tmp_path: Path) -> None:
 
     assert main(["snapshot", "--source", str(source), "--mirror-dir", str(mirror), "--dry-run"]) == 0
     assert not (mirror / "manifest.json").exists()
+
+
+def test_verify_fails_when_extra_files_present(tmp_path: Path) -> None:
+    """F001: unexpected files in the mirror are verification failures."""
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+    (mirror / "sneaky.extra").write_text("nope", encoding="utf-8")
+    manifest = read_manifest(mirror)
+    result = verify_manifest(manifest, mirror)
+    assert result.ok is False
+    assert any(path.endswith("sneaky.extra") or path == "sneaky.extra" for path in result.extra)
+
+
+def test_require_durable_fails_on_future_generated_at(tmp_path: Path) -> None:
+    """F002: future-dated manifests fail closed (not treated as age zero)."""
+    source = tmp_path / "work"
+    mirror = tmp_path / "mirror"
+    _populate(source)
+    snapshot(str(source), mirror)
+    manifest = read_manifest(mirror)
+    manifest["generated_at"] = time.time() + 3600
+    write_manifest(manifest, mirror)
+    with pytest.raises(DurableMirrorError, match="future"):
+        require_durable(mirror, max_age_hours=24.0)


### PR DESCRIPTION
## Summary

- The Atlas 20k fetch/reduce/enrich runners (`scripts/lexicon/runner/{fetch,reduce,enrich}*_20k.py`) write their durable state (`ledger.sqlite`, `network-cache.sqlite`, candidate JSON) to a work-dir on the remote runner VPS (default `/home/ops/atlas-runner/run-20k`), which has no backup of its own — a runner wipe or local cleanup would force a full, politeness-limited ULIF refetch (~1 lemma/s × 20,323 lemmas).
- `data/lexicon/cohort-20k-20260717.{txt,json}` (the cohort seed) is already tracked and safe; this closes the actual gap named in #5884.
- Rather than build a second backup mechanism, `durable_mirror.py` mirrors the VPS work-dir into this repo's `data/lexicon/runner-mirror/<name>/` (gitignored, checksummed with a `manifest.json`) so the existing restic backup bus (`scripts/backup-data.sh`, #6014/#6016 — backs up all of `data/`) picks it up automatically on its next `backup --execute`.
- `require_durable()` fails closed (nonzero exit) unless the mirror is present, non-empty, internally verified against its checksums, and newer than `--max-age-hours` — cleanup tooling must gate on this before touching runner state.
- `mirror_20k_runner.sh` wraps the common laptop-side sync + gate for operators.
- Restore drill and full recipe documented in `docs/runbooks/atlas-20k-runner-durability.md`; wired into `scripts/lexicon/runner/README-offline-enrich.md`.

## Coordination with #6014/#6016

This intentionally does **not** invent a competing backup bus. `data/` is already a mandatory root for the restic backup landing in #6016; this PR only ensures the VPS runner's bytes land under `data/` (`data/lexicon/runner-mirror/`) before that backup runs, and documents the sync step as a required part of the runner workflow.

The v0.1 open-dataset release-asset pattern (`data/lexicon-dataset.pointer.json` → public GitHub Release) is deliberately not reused here — that path is for publishing derived, license-cleared data, not for privately durable-storing raw ULIF scrape output.

## Test plan

- [x] `.venv/bin/pytest tests/test_lexicon_runner_durable_mirror.py -q` — 13 passed
- [x] `.venv/bin/pytest tests/test_lexicon_runner_*.py -q` — 82 passed, 1 skipped (no regressions in sibling runner tests)
- [x] `.venv/bin/ruff check` / `ruff format --check` on changed Python files
- [x] `shellcheck scripts/lexicon/runner/mirror_20k_runner.sh` — clean
- [x] `npx markdownlint-cli2` on new/changed docs — 0 issues
- [x] `scripts/audit/lint_opsec_leaks.py --staged` — zero leaks
- [x] End-to-end manual smoke: `durable_mirror.py snapshot` → `verify` → `require`, and the `mirror_20k_runner.sh --require-only` gate, against a local fake work-dir (no VPS access from this environment; real VPS sync path uses the same `rsync -az --delete` codepath exercised in tests against local paths)

Fixes #5884

X-Agent: claude/5884-durable-enrich-store

## #6039 follow-up — CF F001 addressed

- Fixes #6039: `backup --execute` now records a credential-free, local `RESTIC-GATE-RECEIPT.json` only after restic emits a valid snapshot ID and `check` succeeds.
- `--require-only` now rejects a missing receipt and any receipt whose recorded manifest fingerprint no longer matches the current mirror.
- Operator pre-wipe order is explicit: snapshot → restic `backup --execute` → `--require-only` → wipe.

Validation (worktree): `.venv/bin/pytest tests/test_lexicon_runner_durable_mirror.py tests/test_backup_data_script.py -q` → `50 passed`; ruff, bash -n, shellcheck, OPSEC, and `git diff --check` passed.
