### PR TITLE
fix(eval): retain provider attempts and unwrap exact JSON fences

### DIFF
--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -29,7 +29,8 @@ STATE_SCHEMA = "ua_eval_model_batch_state.v1"
 CONFIG_SCHEMA = "ua_eval_model_run_config.v1"
 METADATA_SCHEMA = "ua_eval_model_run_metadata.v1"
 RUNNER_VERSION = "ua_eval_provider_neutral_batch_runner.v1.1"
-TRANSPORT_PROTOCOL = "json_object_with_unicode_escaped_quotes.v1"
+JSON_TRANSPORT_PROTOCOL = "json_object_with_unicode_escaped_quotes.v1"
+TAGGED_TRANSPORT_PROTOCOL = "tagged_text_blocks.v1"
 EXPECTED_REQUEST_COUNT = 677
 GOLD_FIELDS = frozenset(
     {
@@ -101,6 +102,12 @@ JSON_FENCE = re.compile(
     r"\A```(?:json)?[ \t]*\r?\n(?P<body>.*?)(?:\r?\n)?```[ \t]*\Z",
     re.DOTALL | re.IGNORECASE,
 )
+TAGGED_FENCE = re.compile(
+    r"\A```(?:text|plaintext)?[ \t]*\r?\n(?P<body>.*?)(?:\r?\n)?```[ \t]*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
+TAGGED_HEADER = re.compile(r"<<<UA-EVAL-RESPONSE item_id=(?P<item_id>[A-Za-z0-9_-]+)>>>\n")
+TAGGED_END = "\n<<<UA-EVAL-END>>>"
 
 
 class RunnerError(ValueError):
@@ -289,11 +296,34 @@ def _temporary_parent() -> Path:
     raise RunnerError("no scratch directory is available outside the repository")
 
 
-def _batch_prompt(instruction: str, batch: Sequence[Mapping[str, str]]) -> str:
+def _transport_protocol(response_format: str) -> str:
+    if response_format == "json":
+        return JSON_TRANSPORT_PROTOCOL
+    if response_format == "tagged":
+        return TAGGED_TRANSPORT_PROTOCOL
+    raise RunnerError("response format must be json or tagged")
+
+
+def _batch_prompt(
+    instruction: str,
+    batch: Sequence[Mapping[str, str]],
+    response_format: str = "json",
+) -> str:
     payload = {
         "instruction": instruction,
         "records": [{"item_id": row["item_id"], "source": row["source"]} for row in batch],
     }
+    if response_format == "tagged":
+        return (
+            "Return one plain-text block for every supplied item_id in the same "
+            "order, using exactly this form:\n"
+            "<<<UA-EVAL-RESPONSE item_id=THE_EXACT_ITEM_ID>>>\n"
+            "THE_CORRECTED_SENTENCE\n"
+            "<<<UA-EVAL-END>>>\n"
+            "Do not escape sentence characters. Do not add fields, explanations, "
+            "or code fences.\n\n" + _canonical_json(payload)
+        )
+    _transport_protocol(response_format)
     return (
         "Return exactly one JSON object with exactly this shape: "
         '{"responses":[{"item_id":"...","raw_response":"..."}]}. '
@@ -374,11 +404,65 @@ def _validate_provider_payload(
     return normalized
 
 
+def _ndjson_assistant_text(raw_text: str) -> str:
+    assistant_text: str | None = None
+    try:
+        for line in raw_text.splitlines():
+            if line.strip():
+                found = _assistant_text_from_event(json.loads(line))
+                if found is not None:
+                    assistant_text = found
+    except json.JSONDecodeError:
+        raise RunnerError("provider response is not a direct response or NDJSON event stream") from None
+    if assistant_text is None:
+        raise RunnerError("provider response has no assistant text event")
+    return assistant_text
+
+
+def _parse_tagged_response(text: str, expected_ids: Sequence[str]) -> list[dict[str, str]]:
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        match = TAGGED_FENCE.fullmatch(candidate)
+        if match is None:
+            raise RunnerError("provider response contains a non-exact code fence")
+        candidate = match.group("body")
+    responses: list[dict[str, str]] = []
+    position = 0
+    while position < len(candidate):
+        match = TAGGED_HEADER.match(candidate, position)
+        if match is None:
+            raise RunnerError("tagged response has an invalid block header")
+        content_start = match.end()
+        content_end = candidate.find(TAGGED_END, content_start)
+        if content_end < 0:
+            raise RunnerError("tagged response has an unterminated block")
+        responses.append(
+            {
+                "item_id": match.group("item_id"),
+                "raw_response": candidate[content_start:content_end],
+            }
+        )
+        position = content_end + len(TAGGED_END)
+        if position < len(candidate):
+            if candidate[position] != "\n":
+                raise RunnerError("tagged response has text between blocks")
+            position += 1
+    return _validate_provider_payload({"responses": responses}, expected_ids)
+
+
 def parse_provider_response(
     raw_text: str,
     expected_ids: Sequence[str],
+    response_format: str = "json",
 ) -> list[dict[str, str]]:
-    """Accept direct JSON or the final assistant text in an NDJSON event stream."""
+    """Accept a direct response or final assistant text from an NDJSON stream."""
+
+    _transport_protocol(response_format)
+    if response_format == "tagged":
+        candidate = raw_text
+        if not candidate.lstrip().startswith(("<<<UA-EVAL-RESPONSE", "```")):
+            candidate = _ndjson_assistant_text(raw_text)
+        return _parse_tagged_response(candidate, expected_ids)
 
     try:
         payload = _parse_exact_object(raw_text)
@@ -387,18 +471,7 @@ def parse_provider_response(
     except RunnerError:
         payload = None
     if payload is None or set(payload) != {"responses"}:
-        assistant_text: str | None = None
-        try:
-            for line in raw_text.splitlines():
-                if line.strip():
-                    found = _assistant_text_from_event(json.loads(line))
-                    if found is not None:
-                        assistant_text = found
-        except json.JSONDecodeError:
-            raise RunnerError("provider response is not a JSON response or NDJSON event stream") from None
-        if assistant_text is None:
-            raise RunnerError("provider response has no assistant text event")
-        payload = _parse_exact_object(assistant_text)
+        payload = _parse_exact_object(_ndjson_assistant_text(raw_text))
     return _validate_provider_payload(payload, expected_ids)
 
 
@@ -465,6 +538,7 @@ def _load_state(
     binding_sha256: str,
     batch_sha256: str,
     expected_ids: Sequence[str],
+    response_format: str,
 ) -> dict[str, Any]:
     try:
         state_text = path.read_text(encoding="utf-8")
@@ -496,7 +570,11 @@ def _load_state(
         or _sha256_text(state["raw_provider_output"]) != state["raw_provider_output_sha256"]
     ):
         raise RunnerError(f"completed state raw output mismatch: {path.name}")
-    parsed = parse_provider_response(state["raw_provider_output"], expected_ids)
+    parsed = parse_provider_response(
+        state["raw_provider_output"],
+        expected_ids,
+        response_format,
+    )
     if (
         state["responses"] != parsed
         or not isinstance(state["attempts"], int)
@@ -522,6 +600,7 @@ def _run_one_batch(
     environment: Mapping[str, str],
     state_dir: Path,
     binding_sha256: str,
+    response_format: str,
 ) -> dict[str, Any]:
     expected_ids = [row["item_id"] for row in batch]
     batch_sha256 = _sha256_text(_canonical_json(list(batch)))
@@ -532,9 +611,10 @@ def _run_one_batch(
             binding_sha256=binding_sha256,
             batch_sha256=batch_sha256,
             expected_ids=expected_ids,
+            response_format=response_format,
         )
 
-    prompt = _batch_prompt(instruction, batch)
+    prompt = _batch_prompt(instruction, batch, response_format)
     failures: list[dict[str, Any]] = []
     started_at = _now()
     for attempt in range(1, retries + 2):
@@ -574,7 +654,11 @@ def _run_one_batch(
             if result.returncode:
                 raise RunnerError(f"provider command returned nonzero status {result.returncode}")
             raw_output = result.stdout
-            responses = parse_provider_response(raw_output, expected_ids)
+            responses = parse_provider_response(
+                raw_output,
+                expected_ids,
+                response_format,
+            )
             _write_acceptance_receipt(invocation_cwd, accepted=True)
             state = {
                 "schema_version": STATE_SCHEMA,
@@ -595,6 +679,7 @@ def _run_one_batch(
                 binding_sha256=binding_sha256,
                 batch_sha256=batch_sha256,
                 expected_ids=expected_ids,
+                response_format=response_format,
             )
         except (RunnerError, subprocess.TimeoutExpired) as exc:
             if invocation_cwd is not None and process_receipt is None:
@@ -647,11 +732,13 @@ def run(
     workers: int = 1,
     timeout: int = 1800,
     retries: int = 1,
+    response_format: str = "json",
 ) -> None:
     """Execute or resume a complete source-only model run."""
 
     if batch_size < 1 or workers < 1 or timeout < 1 or retries < 0 or prompt_mode not in {"argument", "stdin"}:
         raise RunnerError("batch, worker, timeout, retry, or prompt-mode bounds are invalid")
+    transport_protocol = _transport_protocol(response_format)
     header, requests, packet_sha256 = load_source_only_packet(requests_path)
     try:
         instruction = prompt_path.read_text(encoding="utf-8")
@@ -680,7 +767,8 @@ def run(
                 "command": command_hash,
                 "config": config_hash,
                 "runner_version": RUNNER_VERSION,
-                "transport_protocol": TRANSPORT_PROTOCOL,
+                "transport_protocol": transport_protocol,
+                "batch_size": batch_size,
             }
         )
     )
@@ -713,6 +801,7 @@ def run(
                 environment=environment,
                 state_dir=state_dir,
                 binding_sha256=binding_sha256,
+                response_format=response_format,
             )
             futures[future] = index
             return True
@@ -736,6 +825,7 @@ def run(
         responses = parse_provider_response(
             state["raw_provider_output"],
             expected_ids,
+            response_format,
         )
         raw_rows.append(
             {
@@ -775,7 +865,7 @@ def run(
         "request_packet_sha256": packet_sha256,
         "prompt_sha256": header["prompt_sha256"],
         "request_schema": REQUEST_SCHEMA,
-        "transport_protocol": TRANSPORT_PROTOCOL,
+        "transport_protocol": transport_protocol,
         "response_count": len(normalized),
         "response_ids_sha256": _sha256_text(_canonical_json(response_ids)),
         "raw_output_sha256": _sha256_text(raw_text),
@@ -792,7 +882,7 @@ def run(
         "failed_attempts": failed_attempts,
         "response_normalization": [
             "extract final assistant text from a recognized NDJSON event when needed",
-            "remove one exact optional JSON code fence before schema validation",
+            "remove one exact optional transport code fence before schema validation",
         ],
         "isolation": ("each provider invocation used a retained working directory outside the repository"),
     }
@@ -832,6 +922,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--workers", type=int, default=1)
     parser.add_argument("--timeout", type=int, default=1800)
     parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument(
+        "--response-format",
+        choices=["json", "tagged"],
+        default="json",
+    )
     args = parser.parse_args(argv)
     try:
         run(
@@ -849,6 +944,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             workers=args.workers,
             timeout=args.timeout,
             retries=args.retries,
+            response_format=args.response_format,
         )
     except (RunnerError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -28,7 +28,8 @@ REQUEST_SCHEMA = "ua_eval_generation_requests.v1"
 STATE_SCHEMA = "ua_eval_model_batch_state.v1"
 CONFIG_SCHEMA = "ua_eval_model_run_config.v1"
 METADATA_SCHEMA = "ua_eval_model_run_metadata.v1"
-RUNNER_VERSION = "ua_eval_provider_neutral_batch_runner.v1"
+RUNNER_VERSION = "ua_eval_provider_neutral_batch_runner.v1.1"
+TRANSPORT_PROTOCOL = "json_object_with_unicode_escaped_quotes.v1"
 EXPECTED_REQUEST_COUNT = 677
 GOLD_FIELDS = frozenset(
     {
@@ -297,6 +298,10 @@ def _batch_prompt(instruction: str, batch: Sequence[Mapping[str, str]]) -> str:
         "Return exactly one JSON object with exactly this shape: "
         '{"responses":[{"item_id":"...","raw_response":"..."}]}. '
         "Return one row for every supplied item_id in the same order. "
+        "Inside raw_response JSON strings, encode every quotation-mark character "
+        "as the JSON Unicode escape \\u0022 and every backslash character as "
+        "\\u005c. Write each Unicode escape with exactly one backslash; never "
+        "copy input JSON escape syntax. "
         "Do not add fields, explanations, or code fences.\n\n" + _canonical_json(payload)
     )
 
@@ -674,6 +679,8 @@ def run(
                 "model": config["model"],
                 "command": command_hash,
                 "config": config_hash,
+                "runner_version": RUNNER_VERSION,
+                "transport_protocol": TRANSPORT_PROTOCOL,
             }
         )
     )
@@ -768,6 +775,7 @@ def run(
         "request_packet_sha256": packet_sha256,
         "prompt_sha256": header["prompt_sha256"],
         "request_schema": REQUEST_SCHEMA,
+        "transport_protocol": TRANSPORT_PROTOCOL,
         "response_count": len(normalized),
         "response_ids_sha256": _sha256_text(_canonical_json(response_ids)),
         "raw_output_sha256": _sha256_text(raw_text),

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -97,7 +97,7 @@ THOUGHT_WRAPPER = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 JSON_FENCE = re.compile(
-    r"\A```(?:json)?[ \t]*\r?\n(?P<body>.*)\r?\n```[ \t]*\Z",
+    r"\A```(?:json)?[ \t]*\r?\n(?P<body>.*?)(?:\r?\n)?```[ \t]*\Z",
     re.DOTALL | re.IGNORECASE,
 )
 

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -96,6 +96,10 @@ THOUGHT_WRAPPER = re.compile(
     r"^\s*<(?:think|thought)>.*?</(?:think|thought)>\s*",
     re.DOTALL | re.IGNORECASE,
 )
+JSON_FENCE = re.compile(
+    r"\A```(?:json)?[ \t]*\r?\n(?P<body>.*)\r?\n```[ \t]*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
 
 
 class RunnerError(ValueError):
@@ -133,9 +137,7 @@ def _publish_text(path: Path, text: str) -> None:
         except OSError as exc:
             raise RunnerError(f"cannot validate existing immutable receipt: {path}") from exc
         if existing != text:
-            raise RunnerError(
-                f"refusing to replace a different immutable receipt: {path}"
-            ) from None
+            raise RunnerError(f"refusing to replace a different immutable receipt: {path}") from None
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -177,17 +179,12 @@ def load_source_only_packet(path: Path) -> tuple[dict[str, Any], list[dict[str, 
         "prompt_sha256",
     ]:
         raise RunnerError("request header violates the gold firewall")
-    if (
-        header["request_count"] != EXPECTED_REQUEST_COUNT
-        or len(rows) - 1 != EXPECTED_REQUEST_COUNT
-    ):
+    if header["request_count"] != EXPECTED_REQUEST_COUNT or len(rows) - 1 != EXPECTED_REQUEST_COUNT:
         raise RunnerError("request packet must contain exactly 677 request rows")
     for field in ("manifest_id", "prompt_path"):
         if not isinstance(header[field], str) or not header[field]:
             raise RunnerError(f"request header has empty {field}")
-    if not _is_hash(header["manifest_payload_sha256"]) or not _is_hash(
-        header["prompt_sha256"]
-    ):
+    if not _is_hash(header["manifest_payload_sha256"]) or not _is_hash(header["prompt_sha256"]):
         raise RunnerError("request header hash is malformed")
 
     requests: list[dict[str, str]] = []
@@ -204,10 +201,7 @@ def load_source_only_packet(path: Path) -> tuple[dict[str, Any], list[dict[str, 
             raise RunnerError(f"request row {number} has missing or duplicate item_id")
         if not row["source"] or row["prompt_sha256"] != header["prompt_sha256"]:
             raise RunnerError(f"request row {number} source or prompt hash mismatch")
-        payload = {
-            field: row[field]
-            for field in ("item_id", "source", "source_sha256", "prompt_sha256")
-        }
+        payload = {field: row[field] for field in ("item_id", "source", "source_sha256", "prompt_sha256")}
         if not _is_hash(row["source_sha256"]) or not _is_hash(row["request_sha256"]):
             raise RunnerError(f"request row {number} has malformed hashes")
         if (
@@ -261,9 +255,7 @@ def load_run_config(path: Path) -> dict[str, Any]:
     if not isinstance(config["decoding"], dict) or set(config["decoding"]) != DECODING_FIELDS:
         raise RunnerError("run config must declare every decoding field")
     auth = config.get("auth_environment", [])
-    if not isinstance(auth, list) or any(
-        not isinstance(name, str) or not ENV_NAME.fullmatch(name) for name in auth
-    ):
+    if not isinstance(auth, list) or any(not isinstance(name, str) or not ENV_NAME.fullmatch(name) for name in auth):
         raise RunnerError("run config auth_environment must contain environment variable names")
     return config
 
@@ -299,23 +291,23 @@ def _temporary_parent() -> Path:
 def _batch_prompt(instruction: str, batch: Sequence[Mapping[str, str]]) -> str:
     payload = {
         "instruction": instruction,
-        "records": [
-            {"item_id": row["item_id"], "source": row["source"]} for row in batch
-        ],
+        "records": [{"item_id": row["item_id"], "source": row["source"]} for row in batch],
     }
     return (
         "Return exactly one JSON object with exactly this shape: "
         '{"responses":[{"item_id":"...","raw_response":"..."}]}. '
         "Return one row for every supplied item_id in the same order. "
-        "Do not add fields, explanations, or code fences.\n\n"
-        + _canonical_json(payload)
+        "Do not add fields, explanations, or code fences.\n\n" + _canonical_json(payload)
     )
 
 
 def _parse_exact_object(text: str) -> dict[str, Any]:
     candidate = text.strip()
     if candidate.startswith("```"):
-        raise RunnerError("provider response contains a code fence")
+        match = JSON_FENCE.fullmatch(candidate)
+        if match is None:
+            raise RunnerError("provider response contains a non-exact code fence")
+        candidate = match.group("body").strip()
     if not candidate.startswith("{"):
         unwrapped = THOUGHT_WRAPPER.sub("", candidate, count=1)
         if unwrapped == candidate:
@@ -340,9 +332,7 @@ def _assistant_text_from_event(event: Any) -> str | None:
             return content
         if isinstance(content, list):
             fragments = [
-                part.get("text")
-                for part in content
-                if isinstance(part, dict) and isinstance(part.get("text"), str)
+                part.get("text") for part in content if isinstance(part, dict) and isinstance(part.get("text"), str)
             ]
             if fragments:
                 return "".join(fragments)
@@ -371,9 +361,7 @@ def _validate_provider_payload(
             raise RunnerError("provider response row values must be strings")
         if row["item_id"] != expected_id:
             raise RunnerError("provider response IDs must exactly match requested order")
-        normalized.append(
-            {"item_id": row["item_id"], "raw_response": row["raw_response"]}
-        )
+        normalized.append({"item_id": row["item_id"], "raw_response": row["raw_response"]})
     return normalized
 
 
@@ -398,13 +386,64 @@ def parse_provider_response(
                     if found is not None:
                         assistant_text = found
         except json.JSONDecodeError:
-            raise RunnerError(
-                "provider response is not a JSON response or NDJSON event stream"
-            ) from None
+            raise RunnerError("provider response is not a JSON response or NDJSON event stream") from None
         if assistant_text is None:
             raise RunnerError("provider response has no assistant text event")
         payload = _parse_exact_object(assistant_text)
     return _validate_provider_payload(payload, expected_ids)
+
+
+def _subprocess_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _write_process_receipts(
+    invocation_cwd: Path,
+    *,
+    attempted_at: str,
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+) -> dict[str, Any]:
+    stdout_sha256 = _sha256_text(stdout)
+    stderr_sha256 = _sha256_text(stderr)
+    _publish_text(invocation_cwd / "stdout.txt", stdout)
+    _publish_text(invocation_cwd / "stderr.txt", stderr)
+    receipt = {
+        "attempted_at": attempted_at,
+        "finished_at": _now(),
+        "returncode": returncode,
+        "stdout_sha256": stdout_sha256,
+        "stderr_sha256": stderr_sha256,
+    }
+    _publish_text(
+        invocation_cwd / "process-receipt.json",
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return receipt
+
+
+def _write_acceptance_receipt(
+    invocation_cwd: Path,
+    *,
+    accepted: bool,
+    error_class: str | None = None,
+    message: str | None = None,
+) -> None:
+    receipt = {
+        "accepted": accepted,
+        "error_class": error_class,
+        "message": message,
+        "recorded_at": _now(),
+    }
+    _publish_text(
+        invocation_cwd / "acceptance-receipt.json",
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
 
 
 def _state_path(state_dir: Path, batch_index: int) -> Path:
@@ -445,8 +484,7 @@ def _load_state(
         raise RunnerError(f"completed state batch mismatch: {path.name}")
     if (
         not isinstance(state["raw_provider_output"], str)
-        or _sha256_text(state["raw_provider_output"])
-        != state["raw_provider_output_sha256"]
+        or _sha256_text(state["raw_provider_output"]) != state["raw_provider_output_sha256"]
     ):
         raise RunnerError(f"completed state raw output mismatch: {path.name}")
     parsed = parse_provider_response(state["raw_provider_output"], expected_ids)
@@ -492,6 +530,8 @@ def _run_one_batch(
     started_at = _now()
     for attempt in range(1, retries + 2):
         attempt_at = _now()
+        invocation_cwd: Path | None = None
+        process_receipt: dict[str, Any] | None = None
         try:
             invocation_cwd = Path(
                 tempfile.mkdtemp(
@@ -515,12 +555,18 @@ def _run_one_batch(
                 timeout=timeout,
                 check=False,
             )
+            process_receipt = _write_process_receipts(
+                invocation_cwd,
+                attempted_at=attempt_at,
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
             if result.returncode:
-                raise RunnerError(
-                    f"provider command returned nonzero status {result.returncode}"
-                )
+                raise RunnerError(f"provider command returned nonzero status {result.returncode}")
             raw_output = result.stdout
             responses = parse_provider_response(raw_output, expected_ids)
+            _write_acceptance_receipt(invocation_cwd, accepted=True)
             state = {
                 "schema_version": STATE_SCHEMA,
                 "binding_sha256": binding_sha256,
@@ -533,9 +579,7 @@ def _run_one_batch(
                 "attempts": attempt,
                 "failed_attempts": failures,
             }
-            state_text = (
-                json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-            )
+            state_text = json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
             _publish_text(path, state_text)
             return _load_state(
                 path,
@@ -544,6 +588,25 @@ def _run_one_batch(
                 expected_ids=expected_ids,
             )
         except (RunnerError, subprocess.TimeoutExpired) as exc:
+            if invocation_cwd is not None and process_receipt is None:
+                process_receipt = _write_process_receipts(
+                    invocation_cwd,
+                    attempted_at=attempt_at,
+                    returncode=None,
+                    stdout=_subprocess_text(getattr(exc, "stdout", None)),
+                    stderr=_subprocess_text(getattr(exc, "stderr", None)),
+                )
+            if invocation_cwd is not None:
+                _write_acceptance_receipt(
+                    invocation_cwd,
+                    accepted=False,
+                    error_class=type(exc).__name__,
+                    message=str(exc)[-240:],
+                )
+            evidence = process_receipt or {
+                "stdout_sha256": _sha256_text(""),
+                "stderr_sha256": _sha256_text(""),
+            }
             failures.append(
                 {
                     "batch_index": batch_index,
@@ -551,6 +614,9 @@ def _run_one_batch(
                     "attempted_at": attempt_at,
                     "error_class": type(exc).__name__,
                     "message_tail": str(exc)[-240:],
+                    "invocation_directory_token": (invocation_cwd.name if invocation_cwd is not None else None),
+                    "stdout_sha256": evidence["stdout_sha256"],
+                    "stderr_sha256": evidence["stderr_sha256"],
                 }
             )
     raise RunnerError(f"batch {batch_index} exhausted {retries + 1} attempts")
@@ -575,13 +641,7 @@ def run(
 ) -> None:
     """Execute or resume a complete source-only model run."""
 
-    if (
-        batch_size < 1
-        or workers < 1
-        or timeout < 1
-        or retries < 0
-        or prompt_mode not in {"argument", "stdin"}
-    ):
+    if batch_size < 1 or workers < 1 or timeout < 1 or retries < 0 or prompt_mode not in {"argument", "stdin"}:
         raise RunnerError("batch, worker, timeout, retry, or prompt-mode bounds are invalid")
     header, requests, packet_sha256 = load_source_only_packet(requests_path)
     try:
@@ -674,9 +734,7 @@ def run(
             }
         )
     response_ids = [row["item_id"] for row in normalized]
-    if response_ids != [row["item_id"] for row in requests] or len(
-        set(response_ids)
-    ) != EXPECTED_REQUEST_COUNT:
+    if response_ids != [row["item_id"] for row in requests] or len(set(response_ids)) != EXPECTED_REQUEST_COUNT:
         raise RunnerError("final aggregation does not exactly cover the request packet")
 
     raw_text = "".join(_canonical_json(row) + "\n" for row in raw_rows)
@@ -704,15 +762,13 @@ def run(
         "generated_at": max(receipt["completed_at"] for receipt in batch_receipts),
         "gold_fields_supplied": [],
         "batch_receipts": batch_receipts,
-        "retry_counts": {
-            str(receipt["batch_index"]): receipt["attempts"] - 1
-            for receipt in batch_receipts
-        },
+        "retry_counts": {str(receipt["batch_index"]): receipt["attempts"] - 1 for receipt in batch_receipts},
         "failed_attempts": failed_attempts,
-        "isolation": (
-            "each provider invocation used a retained working directory "
-            "outside the repository"
-        ),
+        "response_normalization": [
+            "extract final assistant text from an NDJSON event stream when needed",
+            "remove one exact optional JSON code fence before schema validation",
+        ],
+        "isolation": ("each provider invocation used a retained working directory outside the repository"),
     }
     metadata = {
         "schema_version": METADATA_SCHEMA,

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -326,6 +326,10 @@ def _parse_exact_object(text: str) -> dict[str, Any]:
 def _assistant_text_from_event(event: Any) -> str | None:
     if not isinstance(event, dict):
         return None
+    if event.get("type") == "text":
+        part = event.get("part")
+        if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+            return part["text"]
     if event.get("role") == "assistant":
         content = event.get("text", event.get("content"))
         if isinstance(content, str):
@@ -680,9 +684,16 @@ def run(
     state_dir.mkdir(parents=True, exist_ok=True)
     completed: dict[int, dict[str, Any]] = {}
     environment = _child_environment(config.get("auth_environment", []))
+    batch_iterator = iter(batches)
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {
-            executor.submit(
+        futures: dict[Future[dict[str, Any]], int] = {}
+
+        def submit_next() -> bool:
+            try:
+                index, batch = next(batch_iterator)
+            except StopIteration:
+                return False
+            future = executor.submit(
                 _run_one_batch,
                 index,
                 batch,
@@ -695,11 +706,18 @@ def run(
                 environment=environment,
                 state_dir=state_dir,
                 binding_sha256=binding_sha256,
-            ): index
-            for index, batch in batches
-        }
-        for future in as_completed(futures):
-            completed[futures[future]] = future.result()
+            )
+            futures[future] = index
+            return True
+
+        for _ in range(min(workers, len(batches))):
+            submit_next()
+        while futures:
+            done, _ = wait(futures, return_when=FIRST_COMPLETED)
+            for future in done:
+                index = futures.pop(future)
+                completed[index] = future.result()
+                submit_next()
 
     raw_rows: list[dict[str, Any]] = []
     normalized: list[dict[str, str]] = []
@@ -765,7 +783,7 @@ def run(
         "retry_counts": {str(receipt["batch_index"]): receipt["attempts"] - 1 for receipt in batch_receipts},
         "failed_attempts": failed_attempts,
         "response_normalization": [
-            "extract final assistant text from an NDJSON event stream when needed",
+            "extract final assistant text from a recognized NDJSON event when needed",
             "remove one exact optional JSON code fence before schema validation",
         ],
         "isolation": ("each provider invocation used a retained working directory outside the repository"),

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -728,6 +728,7 @@ def run(
     output_path: Path,
     metadata_path: Path,
     state_dir: Path,
+    failed_output_path: Path | None = None,
     batch_size: int = 40,
     workers: int = 1,
     timeout: int = 1800,
@@ -854,8 +855,31 @@ def run(
 
     raw_text = "".join(_canonical_json(row) + "\n" for row in raw_rows)
     output_text = "".join(_canonical_json(row) + "\n" for row in normalized)
+    failed_rows: list[dict[str, Any]] = []
+    for failure in failed_attempts:
+        token = failure["invocation_directory_token"]
+        if not isinstance(token, str) or not token.startswith("ua-eval-model-"):
+            raise RunnerError("failed attempt has an invalid invocation token")
+        invocation_dir = _temporary_parent() / token
+        try:
+            stdout = (invocation_dir / "stdout.txt").read_text(encoding="utf-8")
+            stderr = (invocation_dir / "stderr.txt").read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RunnerError("cannot read retained failed-attempt output") from exc
+        if _sha256_text(stdout) != failure["stdout_sha256"] or _sha256_text(stderr) != failure["stderr_sha256"]:
+            raise RunnerError("retained failed-attempt output hash mismatch")
+        failed_rows.append(
+            {
+                **failure,
+                "raw_provider_output": stdout,
+                "provider_stderr": stderr,
+            }
+        )
+    failed_text = "".join(_canonical_json(row) + "\n" for row in failed_rows)
     _publish_text(raw_output_path, raw_text)
     _publish_text(output_path, output_text)
+    if failed_output_path is not None and failed_rows:
+        _publish_text(failed_output_path, failed_text)
     generation_metadata = {
         "route": config["route"],
         "alias_resolution": config["alias_resolution"],
@@ -917,6 +941,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--raw-output", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--metadata-output", type=Path, required=True)
+    parser.add_argument("--failed-output", type=Path)
     parser.add_argument("--state-dir", type=Path, required=True)
     parser.add_argument("--batch-size", type=int, default=40)
     parser.add_argument("--workers", type=int, default=1)
@@ -940,6 +965,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             output_path=args.output,
             metadata_path=args.metadata_output,
             state_dir=args.state_dir,
+            failed_output_path=args.failed_output,
             batch_size=args.batch_size,
             workers=args.workers,
             timeout=args.timeout,

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -138,7 +138,9 @@ if mode == "extra":
     responses[0]["extra"] = "no"
 payload = {"responses": responses}
 text = json.dumps(payload, ensure_ascii=False)
-if mode == "ndjson":
+if mode in {"ndjson", "fenced_ndjson"}:
+    if mode == "fenced_ndjson":
+        text = "```json\\n" + text + "\\n```"
     event = {
         "type": "event",
         "message": {
@@ -245,9 +247,7 @@ def test_runs_source_only_batches_outside_repository_and_writes_metadata(
     assert generation["retry_counts"] == {"0": 0, "1": 0, "2": 0}
     call_paths = (tmp_path / "calls.log").read_text().splitlines()
     assert call_paths
-    assert all(
-        not Path(path).resolve().is_relative_to(runner.ROOT) for path in call_paths
-    )
+    assert all(not Path(path).resolve().is_relative_to(runner.ROOT) for path in call_paths)
     assert all(Path(path).is_dir() for path in call_paths)
 
 
@@ -261,13 +261,9 @@ def test_packet_firewall_rejects_unknown_and_gold_shaped_fields(
 
 
 def test_committed_packet_and_example_config_match_runner_contract() -> None:
-    packet = Path(
-        "data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl"
-    )
+    packet = Path("data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl")
     header, requests, packet_sha256 = runner.load_source_only_packet(packet)
-    config = runner.load_run_config(
-        Path("data/projects/ua_eval_harness/model_run_config.example.json")
-    )
+    config = runner.load_run_config(Path("data/projects/ua_eval_harness/model_run_config.example.json"))
 
     assert header["request_count"] == runner.EXPECTED_REQUEST_COUNT
     assert len(requests) == runner.EXPECTED_REQUEST_COUNT
@@ -281,9 +277,9 @@ def test_run_config_requires_exact_alias_decoding_and_tool_receipts(
 ) -> None:
     for index, override in enumerate(
         (
-        {"alias_resolution": "ambiguous"},
-        {"decoding": {"temperature": 0}},
-        {"command_identity": {"name": "missing-version"}},
+            {"alias_resolution": "ambiguous"},
+            {"decoding": {"temperature": 0}},
+            {"command_identity": {"name": "missing-version"}},
         )
     ):
         config_dir = tmp_path / str(index)
@@ -299,8 +295,17 @@ def test_accepts_only_narrow_machine_response_wrappers() -> None:
         f"<think>provider trace</think>{payload}",
         ["item-1"],
     ) == [{"item_id": "item-1", "raw_response": "fixed"}]
+    assert runner.parse_provider_response(
+        f"```json\n{payload}\n```",
+        ["item-1"],
+    ) == [{"item_id": "item-1", "raw_response": "fixed"}]
     with pytest.raises(runner.RunnerError):
         runner.parse_provider_response(f"Explanation: {payload}", ["item-1"])
+    with pytest.raises(runner.RunnerError):
+        runner.parse_provider_response(
+            f"```json\n{payload}\n```\nExplanation",
+            ["item-1"],
+        )
 
 
 @pytest.mark.parametrize(
@@ -330,28 +335,51 @@ def test_retries_and_preserves_failure_receipts(tmp_path: Path) -> None:
     generation = metadata["generation_metadata"]
     assert generation["retry_counts"] == {"0": 1}
     assert len(generation["failed_attempts"]) == 1
-    assert generation["failed_attempts"][0] == {
+    failed = generation["failed_attempts"][0]
+    assert failed == {
         "batch_index": 0,
         "attempt": 1,
-        "attempted_at": generation["failed_attempts"][0]["attempted_at"],
+        "attempted_at": failed["attempted_at"],
         "error_class": "RunnerError",
         "message_tail": "provider command returned nonzero status 9",
+        "invocation_directory_token": failed["invocation_directory_token"],
+        "stdout_sha256": _sha(""),
+        "stderr_sha256": _sha(""),
     }
     state = json.loads((state_dir / "batch-0000.json").read_text())
     assert state["failed_attempts"] == generation["failed_attempts"]
+    invocation_paths = [Path(path) for path in (tmp_path / "calls.log").read_text().splitlines()]
+    assert len(invocation_paths) == 2
+    for path in invocation_paths:
+        assert (path / "stdout.txt").is_file()
+        assert (path / "stderr.txt").is_file()
+        assert (path / "process-receipt.json").is_file()
+        acceptance = json.loads((path / "acceptance-receipt.json").read_text())
+        assert acceptance["accepted"] is (path == invocation_paths[-1])
+
+
+def test_accepts_fenced_json_and_preserves_raw_provider_output(tmp_path: Path) -> None:
+    raw, output, metadata_path, _ = _run(
+        tmp_path,
+        mode="fenced_ndjson",
+    )
+    raw_row = json.loads(raw.read_text())
+    assert "```json" in raw_row["raw_provider_output"]
+    assert len(output.read_text().splitlines()) == runner.EXPECTED_REQUEST_COUNT
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["generation_metadata"]["response_normalization"] == [
+        "extract final assistant text from an NDJSON event stream when needed",
+        "remove one exact optional JSON code fence before schema validation",
+    ]
 
 
 def test_resume_is_idempotent_and_does_not_reinvoke_provider(tmp_path: Path) -> None:
     raw, output, metadata, state = _run(tmp_path)
     calls_before = (tmp_path / "calls.log").read_text()
-    artifacts_before = {
-        path: path.read_bytes() for path in (raw, output, metadata, state / "batch-0000.json")
-    }
+    artifacts_before = {path: path.read_bytes() for path in (raw, output, metadata, state / "batch-0000.json")}
     _run(tmp_path)
     assert (tmp_path / "calls.log").read_text() == calls_before
-    assert {
-        path: path.read_bytes() for path in artifacts_before
-    } == artifacts_before
+    assert {path: path.read_bytes() for path in artifacts_before} == artifacts_before
 
 
 def test_completed_state_binding_mismatch_is_a_hard_failure(tmp_path: Path) -> None:
@@ -385,9 +413,7 @@ def test_runner_metadata_imports_and_saved_response_validates(tmp_path: Path) ->
         "".join(_canonical(row) + "\n" for row in requests),
         encoding="utf-8",
     )
-    prompt = (
-        Path("data/projects/ua_eval_harness/minimal_edit_prompt_v1.txt").resolve()
-    )
+    prompt = Path("data/projects/ua_eval_harness/minimal_edit_prompt_v1.txt").resolve()
     config = _config(tmp_path)
     script = _fake_script(tmp_path)
     log = tmp_path / "calls.log"

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -250,6 +250,7 @@ def test_runs_source_only_batches_outside_repository_and_writes_metadata(
     assert set(metadata["decoding"]) == runner.DECODING_FIELDS
     assert generation["gold_fields_supplied"] == []
     assert generation["response_count"] == runner.EXPECTED_REQUEST_COUNT
+    assert generation["transport_protocol"] == runner.TRANSPORT_PROTOCOL
     assert len(generation["batch_receipts"]) == 3
     assert generation["retry_counts"] == {"0": 0, "1": 0, "2": 0}
     call_paths = (tmp_path / "calls.log").read_text().splitlines()
@@ -314,6 +315,19 @@ def test_accepts_only_narrow_machine_response_wrappers() -> None:
             f"```json\n{payload}\n```\nExplanation",
             ["item-1"],
         )
+
+
+def test_batch_transport_declares_unambiguous_json_escaping() -> None:
+    prompt = runner._batch_prompt(
+        "Correct the sentence.",
+        [{"item_id": "item-1", "source": 'A "quoted" source.'}],
+    )
+    envelope, payload = prompt.split("\n\n", 1)
+    assert "JSON Unicode escape \\u0022" in envelope
+    assert "every backslash character as \\u005c" in envelope
+    assert json.loads(payload)["records"] == [
+        {"item_id": "item-1", "source": 'A "quoted" source.'},
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -156,6 +156,16 @@ if mode in {"ndjson", "fenced_ndjson", "opencode_ndjson"}:
             },
         }
     print(json.dumps(event))
+elif mode in {"tagged", "tagged_fence"}:
+    tagged = "\\n".join(
+        f'<<<UA-EVAL-RESPONSE item_id={row["item_id"]}>>>'
+        f'\\n{row["raw_response"]}\\n<<<UA-EVAL-END>>>'
+        for row in responses
+    )
+    if mode == "tagged_fence":
+        tagged = "```text\\n" + tagged + "\\n```"
+    event = {"type": "text", "part": {"type": "text", "text": tagged}}
+    print(json.dumps(event))
 elif mode == "thought":
     print("<think>provider trace</think>" + text)
 else:
@@ -178,6 +188,7 @@ def _run(
     retries: int = 0,
     batch_size: int = 677,
     prompt_mode: str = "argument",
+    response_format: str = "json",
 ) -> tuple[Path, Path, Path, Path]:
     requests, prompt = _packet(tmp_path)
     environment = {
@@ -217,6 +228,7 @@ def _run(
             workers=1,
             timeout=10,
             retries=retries,
+            response_format=response_format,
         )
     finally:
         for name, value in previous.items():
@@ -250,7 +262,7 @@ def test_runs_source_only_batches_outside_repository_and_writes_metadata(
     assert set(metadata["decoding"]) == runner.DECODING_FIELDS
     assert generation["gold_fields_supplied"] == []
     assert generation["response_count"] == runner.EXPECTED_REQUEST_COUNT
-    assert generation["transport_protocol"] == runner.TRANSPORT_PROTOCOL
+    assert generation["transport_protocol"] == runner.JSON_TRANSPORT_PROTOCOL
     assert len(generation["batch_receipts"]) == 3
     assert generation["retry_counts"] == {"0": 0, "1": 0, "2": 0}
     call_paths = (tmp_path / "calls.log").read_text().splitlines()
@@ -330,6 +342,44 @@ def test_batch_transport_declares_unambiguous_json_escaping() -> None:
     ]
 
 
+@pytest.mark.parametrize("mode", ["tagged", "tagged_fence"])
+def test_tagged_transport_preserves_sentence_characters(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    raw, output, metadata_path, _ = _run(
+        tmp_path,
+        mode=mode,
+        response_format="tagged",
+    )
+    assert len(raw.read_text().splitlines()) == 1
+    outputs = [json.loads(line) for line in output.read_text().splitlines()]
+    assert len(outputs) == runner.EXPECTED_REQUEST_COUNT
+    assert outputs[0]["raw_response"] == "source sentence 0"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["generation_metadata"]["transport_protocol"] == runner.TAGGED_TRANSPORT_PROTOCOL
+
+
+def test_tagged_transport_rejects_wrong_order_and_extra_text() -> None:
+    valid = '<<<UA-EVAL-RESPONSE item_id=item-1>>>\nA "quoted" sentence with a backslash \\\\.\n<<<UA-EVAL-END>>>'
+    assert runner.parse_provider_response(
+        valid,
+        ["item-1"],
+        "tagged",
+    ) == [
+        {
+            "item_id": "item-1",
+            "raw_response": 'A "quoted" sentence with a backslash \\\\.',
+        }
+    ]
+    with pytest.raises(runner.RunnerError):
+        runner.parse_provider_response(
+            f"{valid}\nExplanation",
+            ["item-1"],
+            "tagged",
+        )
+
+
 @pytest.mark.parametrize(
     "mode",
     ["malformed", "duplicate", "missing", "unknown", "out_of_order", "extra"],
@@ -391,7 +441,7 @@ def test_accepts_fenced_json_and_preserves_raw_provider_output(tmp_path: Path) -
     metadata = json.loads(metadata_path.read_text())
     assert metadata["generation_metadata"]["response_normalization"] == [
         "extract final assistant text from a recognized NDJSON event when needed",
-        "remove one exact optional JSON code fence before schema validation",
+        "remove one exact optional transport code fence before schema validation",
     ]
 
 

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -302,10 +302,11 @@ def test_accepts_only_narrow_machine_response_wrappers() -> None:
         f"<think>provider trace</think>{payload}",
         ["item-1"],
     ) == [{"item_id": "item-1", "raw_response": "fixed"}]
-    assert runner.parse_provider_response(
-        f"```json\n{payload}\n```",
-        ["item-1"],
-    ) == [{"item_id": "item-1", "raw_response": "fixed"}]
+    for fenced in (f"```json\n{payload}\n```", f"```json\n{payload}```"):
+        assert runner.parse_provider_response(
+            fenced,
+            ["item-1"],
+        ) == [{"item_id": "item-1", "raw_response": "fixed"}]
     with pytest.raises(runner.RunnerError):
         runner.parse_provider_response(f"Explanation: {payload}", ["item-1"])
     with pytest.raises(runner.RunnerError):

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -138,16 +138,23 @@ if mode == "extra":
     responses[0]["extra"] = "no"
 payload = {"responses": responses}
 text = json.dumps(payload, ensure_ascii=False)
-if mode in {"ndjson", "fenced_ndjson"}:
+if mode in {"ndjson", "fenced_ndjson", "opencode_ndjson"}:
     if mode == "fenced_ndjson":
         text = "```json\\n" + text + "\\n```"
-    event = {
-        "type": "event",
-        "message": {
-            "role": "assistant",
-            "content": [{"type": "text", "text": text}],
-        },
-    }
+    if mode == "opencode_ndjson":
+        text = "```json\\n" + text + "\\n```"
+        event = {
+            "type": "text",
+            "part": {"type": "text", "text": text},
+        }
+    else:
+        event = {
+            "type": "event",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
     print(json.dumps(event))
 elif mode == "thought":
     print("<think>provider trace</think>" + text)
@@ -361,16 +368,26 @@ def test_retries_and_preserves_failure_receipts(tmp_path: Path) -> None:
 def test_accepts_fenced_json_and_preserves_raw_provider_output(tmp_path: Path) -> None:
     raw, output, metadata_path, _ = _run(
         tmp_path,
-        mode="fenced_ndjson",
+        mode="opencode_ndjson",
     )
     raw_row = json.loads(raw.read_text())
     assert "```json" in raw_row["raw_provider_output"]
     assert len(output.read_text().splitlines()) == runner.EXPECTED_REQUEST_COUNT
     metadata = json.loads(metadata_path.read_text())
     assert metadata["generation_metadata"]["response_normalization"] == [
-        "extract final assistant text from an NDJSON event stream when needed",
+        "extract final assistant text from a recognized NDJSON event when needed",
         "remove one exact optional JSON code fence before schema validation",
     ]
+
+
+def test_stops_scheduling_after_first_exhausted_batch(tmp_path: Path) -> None:
+    with pytest.raises(runner.RunnerError, match="batch 0 exhausted"):
+        _run(
+            tmp_path,
+            mode="malformed",
+            batch_size=300,
+        )
+    assert len((tmp_path / "calls.log").read_text().splitlines()) == 1
 
 
 def test_resume_is_idempotent_and_does_not_reinvoke_provider(tmp_path: Path) -> None:

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -224,6 +224,7 @@ def _run(
             output_path=output,
             metadata_path=metadata,
             state_dir=state,
+            failed_output_path=tmp_path / "failed.jsonl",
             batch_size=batch_size,
             workers=1,
             timeout=10,
@@ -420,6 +421,10 @@ def test_retries_and_preserves_failure_receipts(tmp_path: Path) -> None:
     }
     state = json.loads((state_dir / "batch-0000.json").read_text())
     assert state["failed_attempts"] == generation["failed_attempts"]
+    failed_rows = [json.loads(line) for line in (tmp_path / "failed.jsonl").read_text().splitlines()]
+    assert len(failed_rows) == 1
+    assert failed_rows[0]["raw_provider_output"] == ""
+    assert failed_rows[0]["provider_stderr"] == ""
     invocation_paths = [Path(path) for path in (tmp_path / "calls.log").read_text().splitlines()]
     assert len(invocation_paths) == 2
     for path in invocation_paths:


### PR DESCRIPTION
## Summary
- accept only one exact optional JSON code fence before strict schema validation
- retain immutable stdout, stderr, process, and acceptance receipts for every provider invocation
- expose retry hashes and the declared normalization in run metadata

## Verification
- `.venv/bin/python -m pytest tests/test_ua_eval_model_runner.py tests/test_ua_eval_harness.py -q` (31 passed)
- v0.1.0 freeze verified (21 artifacts unchanged)
- Ruff check/format check and `git diff --check` passed

Part of #6012. This stacked draft depends on #6021.