### PR TITLE
fix(backup): handle production runtime edge cases

### DIFF
--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -299,7 +299,9 @@ validate_environment() {
 }
 
 repository_is_initialized() {
-  restic cat config >/dev/null 2>&1
+  RESTIC_REPOSITORY="$REPOSITORY" \
+    RESTIC_PASSWORD_FILE="$PASSWORD_FILE" \
+    restic cat config >/dev/null 2>&1
 }
 
 require_initialized_repository() {
@@ -531,10 +533,32 @@ clone_tree() {
 sqlite_backup_command() {
   local source_db=$1
   local destination_db=$2
+  local immutable_check readonly_error source_uri
 
   [[ "$source_db" != *"'"* && "$destination_db" != *"'"* ]] ||
     die "SQLite backup paths may not contain a single quote."
-  sqlite3 -readonly "$source_db" ".backup '$destination_db'"
+  if readonly_error="$(
+    sqlite3 -readonly "$source_db" ".backup '$destination_db'" 2>&1
+  )"; then
+    return
+  fi
+
+  if [[ ! -e "$source_db-wal" && ! -e "$source_db-shm" && ! -e "$source_db-journal" ]]; then
+    source_uri=${source_db//%/%25}
+    source_uri=${source_uri//#/%23}
+    source_uri=${source_uri//\?/%3F}
+    source_uri="file:$source_uri?mode=ro&immutable=1"
+    if immutable_check="$(
+      sqlite3 "$source_uri" 'PRAGMA quick_check;' 2>/dev/null
+    )" && [[ "$immutable_check" == "ok" ]]; then
+      info "Using verified immutable fallback for SQLite source without journal sidecars."
+      sqlite3 "$source_uri" ".backup '$destination_db'"
+      return
+    fi
+  fi
+
+  [[ -z "$readonly_error" ]] || printf '%s\n' "$readonly_error" >&2
+  return 1
 }
 
 stage_sqlite_databases() {

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -97,6 +97,9 @@ fi
 if [[ "${1:-}" == "cat" && "${FAKE_REPOSITORY_STATE:-initialized}" != "initialized" ]]; then
   exit 1
 fi
+if [[ "${1:-}" == "cat" && -z "${RESTIC_REPOSITORY:-}" ]]; then
+  exit 78
+fi
 if [[ "${1:-}" == "backup" && -n "${FAKE_DB_RELATIVE:-}" ]]; then
   rows="$(sqlite3 "file:$PWD/$FAKE_DB_RELATIVE?mode=ro&immutable=1" \
     'SELECT COUNT(*) FROM recovery_probe;')"
@@ -204,6 +207,30 @@ def test_execute_stages_a_consistent_wal_database_and_cleans_up(
     assert '"status":"prepared-before-snapshot-write"' in _log(environment)
     assert '".claude/atlas-epic"' in _log(environment)
     assert '"batch_state"' in _log(environment)
+    assert list(staging.iterdir()) == []
+
+
+def test_execute_snapshots_checkpointed_wal_database_without_sidecars(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    database = source / "checkpointed.db"
+    connection = sqlite3.connect(database)
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("CREATE TABLE recovery_probe (value TEXT NOT NULL)")
+    connection.execute("INSERT INTO recovery_probe VALUES ('checkpointed')")
+    connection.commit()
+    connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    connection.close()
+    assert not database.with_name("checkpointed.db-wal").exists()
+    assert not database.with_name("checkpointed.db-shm").exists()
+    environment["FAKE_DB_RELATIVE"] = "data/checkpointed.db"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert "Using verified immutable fallback" in result.stdout
+    assert "db_rows=<1>" in _log(environment)
     assert list(staging.iterdir()) == []
 
 
@@ -556,13 +583,25 @@ def test_doctor_summarizes_validation_failure(
     assert "Doctor found 1 blocking problem(s)." in result.stderr
 
 
-def test_refuses_staging_inside_project_checkout(
+def test_doctor_checks_initialized_repository_with_validated_environment(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
 ) -> None:
     environment, _source, _staging, _legacy = backup_environment
-    environment["LU_BACKUP_TMPDIR"] = str(REPO_ROOT / "batch_state")
+
+    result = _run(environment, "doctor")
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: restic repository is initialized" in result.stdout
+    assert "Doctor checks passed." in result.stdout
+
+
+def test_refuses_staging_inside_project_checkout(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    environment["LU_BACKUP_TMPDIR"] = str(source.parent / "batch_state")
 
     result = _run(environment, "backup")
 
     assert result.returncode != 0
-    assert "Staging directory must be outside the project checkout" in result.stderr
+    assert "Staging directory must be outside the selected project checkout" in result.stderr

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -595,7 +595,19 @@ def test_doctor_checks_initialized_repository_with_validated_environment(
     assert "Doctor checks passed." in result.stdout
 
 
-def test_refuses_staging_inside_project_checkout(
+def test_refuses_staging_inside_script_checkout(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, _staging, _legacy = backup_environment
+    environment["LU_BACKUP_TMPDIR"] = str(REPO_ROOT / "scripts")
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Staging directory must be outside the project checkout" in result.stderr
+
+
+def test_refuses_staging_inside_selected_project_checkout(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
 ) -> None:
     environment, source, _staging, _legacy = backup_environment

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -225,6 +226,21 @@ def test_execute_snapshots_checkpointed_wal_database_without_sidecars(
     assert not database.with_name("checkpointed.db-wal").exists()
     assert not database.with_name("checkpointed.db-shm").exists()
     environment["FAKE_DB_RELATIVE"] = "data/checkpointed.db"
+    real_sqlite3 = shutil.which("sqlite3", path=os.environ["PATH"])
+    assert real_sqlite3 is not None
+    environment["REAL_SQLITE3"] = real_sqlite3
+    fake_bin = Path(environment["PATH"].split(":", maxsplit=1)[0])
+    _write_executable(
+        fake_bin / "sqlite3",
+        """#!/bin/bash
+set -eu
+if [[ "${1:-}" == "-readonly" && "${2:-}" == */checkpointed.db ]]; then
+  printf '%s\n' 'simulated read-only open failure' >&2
+  exit 14
+fi
+exec "$REAL_SQLITE3" "$@"
+""",
+    )
 
     result = _run(environment, "backup", "--execute")
 


### PR DESCRIPTION
## Summary

- make the restic repository probe self-contained so `doctor` works after subshell validation
- safely snapshot checkpointed WAL-format SQLite databases when journal sidecars are absent
- retain the normal online-backup path for live databases and cover both staging boundaries

Closes #6014

## Verification

- `bash -n scripts/backup-data.sh`
- `shellcheck scripts/backup-data.sh`
- `pytest -q tests/test_backup_data_script.py` — 24 passed
- production `doctor` with `RESTIC_REPOSITORY` deliberately unset — passed
- production backup passed the former `data/atlas.db` failure point and is uploading
- OPSEC lint and agent-trailer lint — passed

## Independent review

Claude Sonnet 5 initially blocked on dropped `repo_real` guard coverage. Follow-up commit `c14d3ed7d4` restored a distinct test; re-review verdict: PASS, no blockers.