### PR TITLE
fix(orchestration): canonical native-or-body membership validator (#6028)

### DIFF
--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -63,33 +63,38 @@ def load_registry(path: Path = REGISTRY_PATH) -> dict[str, list[int]]:
     return registry
 
 
-def _gh_json(args: list[str], timeout_s: float = 30.0):
+def _gh_json(args: list[str], timeout_s: float = 30.0, *, cwd: Path = ROOT):
     proc = subprocess.run(
-        ["gh", *args], capture_output=True, text=True, timeout=timeout_s, cwd=ROOT
+        ["gh", *args], capture_output=True, text=True, timeout=timeout_s, cwd=cwd
     )
     if proc.returncode != 0:
         raise RuntimeError(f"gh {' '.join(args[:3])}… failed: {proc.stderr.strip()[:200]}")
     return json.loads(proc.stdout)
 
 
-def fetch_open_issues() -> list[dict]:
+def fetch_open_issues(repo_root: Path = ROOT) -> list[dict]:
     return _gh_json(
         ["issue", "list", "--state", "open", "--limit", "500",
-         "--json", "number,title"]
+         "--json", "number,title"],
+        cwd=repo_root,
     )
 
 
-_REPO_CACHE: dict[str, str] = {}
+# Keyed by resolved repo root so a closeout invocation configured for one
+# checkout never reuses another checkout's owner/name (a caller auditing two
+# different worktrees in the same process must not cross-contaminate).
+_REPO_CACHE: dict[str, tuple[str, str]] = {}
 
 
-def _repo_owner_name() -> tuple[str, str]:
-    """Resolve the actual owner/name once — GraphQL -f fields do NOT expand
-    the gh {owner}/{repo} placeholders (REST paths do). Caught by live probe."""
-    if not _REPO_CACHE:
-        data = _gh_json(["repo", "view", "--json", "owner,name"])
-        _REPO_CACHE["owner"] = data["owner"]["login"]
-        _REPO_CACHE["name"] = data["name"]
-    return _REPO_CACHE["owner"], _REPO_CACHE["name"]
+def _repo_owner_name(repo_root: Path = ROOT) -> tuple[str, str]:
+    """Resolve the actual owner/name once per repo root — GraphQL -f fields do
+    NOT expand the gh {owner}/{repo} placeholders (REST paths do). Caught by
+    live probe."""
+    key = str(repo_root)
+    if key not in _REPO_CACHE:
+        data = _gh_json(["repo", "view", "--json", "owner,name"], cwd=repo_root)
+        _REPO_CACHE[key] = (data["owner"]["login"], data["name"])
+    return _REPO_CACHE[key]
 
 
 # GraphQL subIssues pagination (item 7, PR #4998 corrective pass): an "exact"
@@ -114,9 +119,9 @@ _SUBISSUES_NEXT_PAGE_QUERY = (
 _MAX_SUBISSUE_PAGES = 50
 
 
-def _fetch_subissues_page(epic: int, cursor: str | None) -> dict:
+def _fetch_subissues_page(epic: int, cursor: str | None, repo_root: Path = ROOT) -> dict:
     """One GraphQL page of ``issue.subIssues`` (+ ``body`` on the first page)."""
-    owner, name = _repo_owner_name()
+    owner, name = _repo_owner_name(repo_root)
     if cursor is None:
         args = [
             "-F", "number=" + str(epic),
@@ -130,7 +135,7 @@ def _fetch_subissues_page(epic: int, cursor: str | None) -> dict:
             "-f", f"cursor={cursor}",
             "-f", _SUBISSUES_NEXT_PAGE_QUERY,
         ]
-    data = _gh_json(["api", "graphql", *args])
+    data = _gh_json(["api", "graphql", *args], cwd=repo_root)
     return (data.get("data") or {}).get("repository", {}).get("issue") or {}
 
 
@@ -165,13 +170,15 @@ def _paginate_subissues(
     return native, body
 
 
-def fetch_epic_membership(epic: int) -> tuple[set[int], set[int]]:
+def fetch_epic_membership(epic: int, repo_root: Path = ROOT) -> tuple[set[int], set[int]]:
     """Return (native_sub_issue_numbers, body_reference_numbers) for one epic.
 
     Native sub-issues are paginated (see ``_paginate_subissues``) so an epic
     with more than 100 children is not silently truncated to its first page.
     """
-    native, body = _paginate_subissues(epic, _fetch_subissues_page)
+    native, body = _paginate_subissues(
+        epic, lambda e, c: _fetch_subissues_page(e, c, repo_root)
+    )
     refs = {int(m) for m in ISSUE_REF_RE.findall(body)}
     return native, refs
 
@@ -298,17 +305,28 @@ def _effective_membership(
     return index
 
 
-def run_audit() -> dict:
-    registry = load_registry()
-    open_issues = fetch_open_issues()
+def run_audit(repo_root: Path | None = None) -> dict:
+    """Run one live audit, scoped to ``repo_root`` (defaults to this module's
+    own checkout, ``ROOT``, preserving the plain-CLI default behavior).
+
+    Every input — the stream registry, ``gh`` execution cwd for open-issue and
+    epic-membership fetches, and the cache the report is written to — uses the
+    SAME resolved root, so a caller auditing a non-default checkout (e.g. a
+    closeout invocation bound to another worktree) never validates membership
+    against, or writes a cache into, this module's own repo instead.
+    """
+    root = repo_root.resolve() if repo_root is not None else ROOT
+    registry = load_registry(root / "scripts" / "config" / "issue_streams.yaml")
+    open_issues = fetch_open_issues(root)
     membership = {
-        epic: fetch_epic_membership(epic)
+        epic: fetch_epic_membership(epic, root)
         for epics in registry.values()
         for epic in epics
     }
     report = classify(open_issues, registry, membership)
-    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CACHE_PATH.write_text(json.dumps(report, ensure_ascii=False, indent=1), encoding="utf-8")
+    cache_path = root / "batch_state" / "issue_stream_audit.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(report, ensure_ascii=False, indent=1), encoding="utf-8")
     return report
 
 

--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -386,6 +386,37 @@ def _valid_open_numbers(value: object) -> bool:
     return isinstance(value, list) and all(_is_positive_int(n) for n in value)
 
 
+def validate_membership_report(report: object, max_age_s: int) -> dict | None:
+    """Validate an already-fetched (in-memory) audit report and return it, or
+    ``None`` if it fails closed.
+
+    Same freshness/shape rules as :func:`read_membership_index` — extracted so
+    a caller carrying one fresh live ``run_audit()`` snapshot through a single
+    observation (task_lifecycle's canonical membership validator) can apply
+    the exact same fail-closed semantics as the file-cache path below, without
+    a second round trip through disk.
+    """
+    if not isinstance(report, dict):
+        return None
+
+    generated_at = report.get("generated_at")
+    if isinstance(generated_at, bool) or not isinstance(generated_at, (int, float)):
+        return None
+    if not math.isfinite(generated_at):
+        return None
+    age = time.time() - generated_at
+    if age > max_age_s or age < -CACHE_FUTURE_SKEW_S:
+        return None
+
+    index = report.get("effective_membership")
+    if not _valid_membership_index(index):
+        return None
+    open_numbers = report.get("open_issue_numbers")
+    if open_numbers is not None and not _valid_open_numbers(open_numbers):
+        return None
+    return report
+
+
 def read_membership_index(max_age_s: int, *, cache_path: Path | None = None) -> dict | None:
     """Return the effective issue→epic membership index from a FRESH cache.
 
@@ -406,25 +437,7 @@ def read_membership_index(max_age_s: int, *, cache_path: Path | None = None) -> 
         report = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-    if not isinstance(report, dict):
-        return None
-
-    generated_at = report.get("generated_at")
-    if isinstance(generated_at, bool) or not isinstance(generated_at, (int, float)):
-        return None
-    if not math.isfinite(generated_at):
-        return None
-    age = time.time() - generated_at
-    if age > max_age_s or age < -CACHE_FUTURE_SKEW_S:
-        return None
-
-    index = report.get("effective_membership")
-    if not _valid_membership_index(index):
-        return None
-    open_numbers = report.get("open_issue_numbers")
-    if open_numbers is not None and not _valid_open_numbers(open_numbers):
-        return None
-    return report
+    return validate_membership_report(report, max_age_s)
 
 
 def make_membership_resolver(report: dict) -> MembershipResolver:

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -800,12 +800,11 @@ def cmd_init(args: argparse.Namespace) -> int:
     adapter = GhGitHubAdapter(Path(args.repo_root))
     issue = adapter.read_issue(identity["repository"], identity["github_issue_number"])
     registered_epics = adapter.registered_stream_epics()
-    # Native precedence needs no audit at all; only fetch the live snapshot
-    # when native parentage doesn't already resolve the identity's exact epic.
+    # Native precedence needs no audit at all: any native parent — matching or
+    # not — decides the outcome alone in resolve_membership. Only fetch the
+    # live audit snapshot when native parentage is absent.
     membership_report = (
-        None
-        if issue["parent_epic"] == identity["stream_epic"]
-        else adapter.membership_audit_report()
+        None if issue["parent_epic"] is not None else adapter.membership_audit_report()
     )
     membership = task_lifecycle.resolve_membership(
         issue_number=identity["github_issue_number"],

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -316,16 +316,20 @@ class GhGitHubAdapter:
         identity = ledger["identity"]
         repository = identity["repository"]
         issue = self.read_issue(repository, identity["github_issue_number"])
-        # Native precedence needs no audit. Only fetch the live membership
-        # snapshot when it's actually needed to resolve body evidence — for
-        # the lifecycle issue itself, or for a transferred-scope follow-up
-        # issue (whose own native status isn't known until read below). One
-        # fetch is shared by both resolutions — never a second live audit
-        # within this observation.
-        remaining = ledger["remaining_scope"]
-        needs_membership_audit = (
-            issue.get("parent_epic") != identity["stream_epic"]
-            or (remaining["status"] == "transferred" and remaining.get("follow_up_issue"))
+        follow_up = self._follow_up(
+            repository,
+            identity["github_issue_number"],
+            issue["body"],
+            ledger["remaining_scope"],
+        )
+        # Native GitHub parentage is conclusive on its own — present (even a
+        # mismatched) native parent must never fall through to body evidence,
+        # so it never needs a live audit. Only a missing native parent (on
+        # the lifecycle issue itself, or on the transferred-scope follow-up
+        # read above) leaves body evidence as the sole path, and that is the
+        # only case that justifies fetching the live membership snapshot.
+        needs_membership_audit = issue.get("parent_epic") is None or (
+            follow_up is not None and follow_up.get("parent_epic") is None
         )
         membership_audit = self.membership_audit_report() if needs_membership_audit else None
         pr_number = ledger["pr"]["number"]
@@ -360,12 +364,7 @@ class GhGitHubAdapter:
             "pr": pr,
             "comments": comments,
             "deployments": deployments,
-            "follow_up": self._follow_up(
-                repository,
-                identity["github_issue_number"],
-                issue["body"],
-                ledger["remaining_scope"],
-            ),
+            "follow_up": follow_up,
         }
 
     def observe(

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -96,11 +96,16 @@ class GhGitHubAdapter:
         than one issue in a single observation (the lifecycle issue and a
         transferred-scope follow-up issue) must call this ONCE and carry the
         same snapshot through both resolutions rather than re-auditing.
+
+        Scoped to ``self.repo_root`` — never the auditor module's own
+        checkout — so a closeout invocation configured for another
+        checkout/worktree audits and caches against the SAME repository it is
+        validating membership for.
         """
         from scripts.orchestration import issue_stream_audit
 
         try:
-            return issue_stream_audit.run_audit()
+            return issue_stream_audit.run_audit(self.repo_root)
         except (OSError, ValueError, RuntimeError, subprocess.TimeoutExpired) as exc:
             raise task_lifecycle.LifecycleError(
                 f"cannot run the issue-stream membership audit: {exc}"

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -88,6 +88,24 @@ class GhGitHubAdapter:
             ) from exc
         return sorted({epic for epics in registry.values() for epic in epics})
 
+    def membership_audit_report(self) -> dict[str, Any]:
+        """One fresh, live issue-stream membership audit snapshot.
+
+        Feeds :func:`task_lifecycle.resolve_membership` for the canonical
+        native-or-unique-body proof. Callers that need membership for more
+        than one issue in a single observation (the lifecycle issue and a
+        transferred-scope follow-up issue) must call this ONCE and carry the
+        same snapshot through both resolutions rather than re-auditing.
+        """
+        from scripts.orchestration import issue_stream_audit
+
+        try:
+            return issue_stream_audit.run_audit()
+        except (OSError, ValueError, RuntimeError, subprocess.TimeoutExpired) as exc:
+            raise task_lifecycle.LifecycleError(
+                f"cannot run the issue-stream membership audit: {exc}"
+            ) from exc
+
     @staticmethod
     def _owner_name(repository: str) -> tuple[str, str]:
         try:
@@ -293,6 +311,18 @@ class GhGitHubAdapter:
         identity = ledger["identity"]
         repository = identity["repository"]
         issue = self.read_issue(repository, identity["github_issue_number"])
+        # Native precedence needs no audit. Only fetch the live membership
+        # snapshot when it's actually needed to resolve body evidence — for
+        # the lifecycle issue itself, or for a transferred-scope follow-up
+        # issue (whose own native status isn't known until read below). One
+        # fetch is shared by both resolutions — never a second live audit
+        # within this observation.
+        remaining = ledger["remaining_scope"]
+        needs_membership_audit = (
+            issue.get("parent_epic") != identity["stream_epic"]
+            or (remaining["status"] == "transferred" and remaining.get("follow_up_issue"))
+        )
+        membership_audit = self.membership_audit_report() if needs_membership_audit else None
         pr_number = ledger["pr"]["number"]
         pr: dict[str, Any] = {
             "number": None,
@@ -320,6 +350,7 @@ class GhGitHubAdapter:
         return {
             "repository": repository,
             "registered_stream_epics": self.registered_stream_epics(),
+            "membership_audit": membership_audit,
             "issue": issue,
             "pr": pr,
             "comments": comments,
@@ -348,6 +379,7 @@ class GhGitHubAdapter:
             github = {
                 "repository": identity["repository"],
                 "registered_stream_epics": [],
+                "membership_audit": None,
                 "issue": {
                     "number": identity["github_issue_number"],
                     "state": None,
@@ -763,12 +795,26 @@ def cmd_init(args: argparse.Namespace) -> int:
     identity = task_identity.validate_identity(_json_file(Path(args.identity_file)))
     adapter = GhGitHubAdapter(Path(args.repo_root))
     issue = adapter.read_issue(identity["repository"], identity["github_issue_number"])
-    if identity["stream_epic"] not in adapter.registered_stream_epics():
+    registered_epics = adapter.registered_stream_epics()
+    # Native precedence needs no audit at all; only fetch the live snapshot
+    # when native parentage doesn't already resolve the identity's exact epic.
+    membership_report = (
+        None
+        if issue["parent_epic"] == identity["stream_epic"]
+        else adapter.membership_audit_report()
+    )
+    membership = task_lifecycle.resolve_membership(
+        issue_number=identity["github_issue_number"],
+        stream_epic=identity["stream_epic"],
+        native_parent_epic=issue["parent_epic"],
+        registered_epics=registered_epics,
+        membership_report=membership_report,
+    )
+    if not membership["valid"]:
         raise task_lifecycle.LifecycleError(
-            "task identity stream epic is absent from scripts/config/issue_streams.yaml"
+            "issue membership does not resolve to the identity's exact registered "
+            f"stream epic: {membership['reason']}"
         )
-    if issue["parent_epic"] != identity["stream_epic"]:
-        raise task_lifecycle.LifecycleError("issue is not a native child of the identity's exact stream epic")
     now = args.now or utc_now()
     snapshot = task_lifecycle.build_ac_snapshot(
         issue["body"], _load_policy(Path(args.ac_policy)), finalized_at=now

--- a/scripts/orchestration/task_lifecycle.py
+++ b/scripts/orchestration/task_lifecycle.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from jsonschema import Draft202012Validator, FormatChecker
 
-from scripts.orchestration import task_identity
+from scripts.orchestration import issue_stream_audit, task_identity
 
 SCHEMA_VERSION = "task-lifecycle.v1"
 AC_SCHEMA_VERSION = "acceptance-criteria.v1"
@@ -132,6 +132,121 @@ def lifecycle_id(identity: Mapping[str, Any]) -> str:
             "stream_epic": canonical["stream_epic"],
         }
     )
+
+
+def resolve_membership(
+    *,
+    issue_number: int,
+    stream_epic: int,
+    native_parent_epic: int | None,
+    registered_epics: list[int] | None,
+    membership_report: Mapping[str, Any] | None,
+    max_age_s: int = 3600,
+) -> dict[str, Any]:
+    """Canonical native-or-unique-body membership proof (issue #6028).
+
+    This is the ONE validator every membership gate in the fleet must call:
+    lifecycle initialization (``task_closeout.cmd_init``), observation/
+    reconciliation (:func:`evaluate`), and every remote mutation gate
+    (``task_closeout._assert_mutation_ready``) — so drift discovered by any
+    one of them is enforced identically by all the others.
+
+    Native GitHub sub-issue parentage is authoritative and takes precedence
+    over any body-derived evidence: if ``native_parent_epic`` is set at all,
+    it alone decides the outcome — a native parent that differs from
+    ``stream_epic`` is a hard rejection, never a fall-through to body
+    evidence. Only when there is NO native parent does a fresh
+    ``issue_stream_audit`` effective-membership proof get consulted, and only
+    when it resolves this exact issue to exactly one effective epic equal to
+    ``stream_epic``. That proof is sourced entirely from the epic-side
+    checklist/reference ``issue_stream_audit`` already interprets — never from
+    the child issue's own body, so a child's own ``Refs #<epic>`` prose can
+    never establish membership here.
+
+    Fails **closed** — ``valid: False`` — for every failure mode: the
+    identity's stream epic absent from the registry, a native parent that
+    disagrees, and (for the body path) audit evidence that is missing, stale,
+    malformed, orphaned, wrong-epic, multi-homed, or otherwise ambiguous.
+
+    The return value always carries the four AC-PROVENANCE fields — method
+    (``"native"`` / ``"body"`` / ``None``), epic, the audit's
+    ``generated_at``, and a deterministic digest of the effective-membership
+    index that was consulted — so every caller can persist identical
+    provenance regardless of which path accepted (or rejected) the proof.
+    """
+    if not isinstance(registered_epics, list) or stream_epic not in registered_epics:
+        return {
+            "valid": False,
+            "method": None,
+            "epic": None,
+            "generated_at": None,
+            "digest": None,
+            "reason": "identity stream epic is absent from the registered issue-stream epics",
+        }
+    if native_parent_epic is not None:
+        if native_parent_epic == stream_epic:
+            return {
+                "valid": True,
+                "method": "native",
+                "epic": stream_epic,
+                "generated_at": None,
+                "digest": None,
+                "reason": None,
+            }
+        return {
+            "valid": False,
+            "method": None,
+            "epic": native_parent_epic,
+            "generated_at": None,
+            "digest": None,
+            "reason": (
+                "issue has a native parent epic that differs from the identity's "
+                "exact registered stream epic"
+            ),
+        }
+    validated_report = issue_stream_audit.validate_membership_report(membership_report, max_age_s)
+    if validated_report is None:
+        return {
+            "valid": False,
+            "method": None,
+            "epic": None,
+            "generated_at": None,
+            "digest": None,
+            "reason": "fresh issue-stream membership audit evidence is missing, stale, or malformed",
+        }
+    generated_at = validated_report.get("generated_at")
+    index = validated_report.get("effective_membership") or {}
+    evidence_digest = digest(index)
+    entry = index.get(str(issue_number))
+    if not isinstance(entry, dict) or not entry.get("unique_stream"):
+        return {
+            "valid": False,
+            "method": None,
+            "epic": None,
+            "generated_at": generated_at,
+            "digest": evidence_digest,
+            "reason": "issue is orphaned or ambiguously multi-homed in the fresh membership audit",
+        }
+    if stream_epic not in (entry.get("epics") or []):
+        return {
+            "valid": False,
+            "method": None,
+            "epic": None,
+            "generated_at": generated_at,
+            "digest": evidence_digest,
+            "reason": (
+                "membership audit resolves the issue to a different epic than the "
+                "identity's exact stream epic"
+            ),
+        }
+    return {
+        "valid": True,
+        "method": entry.get("via"),
+        "epic": stream_epic,
+        "generated_at": generated_at,
+        "digest": evidence_digest,
+        "reason": None,
+    }
 
 
 def parse_issue_acceptance_criteria(body: str) -> list[dict[str, Any]]:
@@ -917,14 +1032,22 @@ def evaluate(payload: Mapping[str, Any], observation: Mapping[str, Any]) -> dict
     if github.get("repository") != identity["repository"]:
         hard.append("authoritative GitHub repository does not match task identity")
     registered_epics = github.get("registered_stream_epics")
-    if not isinstance(registered_epics, list) or identity["stream_epic"] not in registered_epics:
-        hard.append("identity stream epic is absent from the registered issue-stream epics")
     if issue.get("number") != identity["github_issue_number"]:
         hard.append("authoritative GitHub issue does not match task identity")
     if issue.get("url") != identity["github_issue_url"]:
         hard.append("authoritative GitHub issue URL does not match task identity")
-    if issue.get("parent_epic") != identity["stream_epic"]:
-        hard.append("issue is not linked to the identity's exact registered stream epic")
+    membership = resolve_membership(
+        issue_number=identity["github_issue_number"],
+        stream_epic=identity["stream_epic"],
+        native_parent_epic=issue.get("parent_epic"),
+        registered_epics=registered_epics,
+        membership_report=github.get("membership_audit"),
+    )
+    if not membership["valid"]:
+        hard.append(
+            "issue membership does not resolve to the identity's exact registered "
+            f"stream epic: {membership['reason']}"
+        )
 
     issue_criteria: list[dict[str, Any]] = []
     try:
@@ -1117,10 +1240,18 @@ def evaluate(payload: Mapping[str, Any], observation: Mapping[str, Any]) -> dict
         follow_up = github.get("follow_up") or {}
         if follow_up.get("number") != remaining["follow_up_issue"]:
             hard.append("authoritative follow-up issue does not match transferred scope")
-        if follow_up.get("parent_epic") != remaining["follow_up_stream_epic"]:
-            hard.append("follow-up issue does not have the exact transferred stream epic")
-        if remaining["follow_up_stream_epic"] not in (registered_epics or []):
-            hard.append("follow-up issue epic is absent from the registered issue-stream epics")
+        follow_up_membership = resolve_membership(
+            issue_number=remaining["follow_up_issue"],
+            stream_epic=remaining["follow_up_stream_epic"],
+            native_parent_epic=follow_up.get("parent_epic"),
+            registered_epics=registered_epics,
+            membership_report=github.get("membership_audit"),
+        )
+        if not follow_up_membership["valid"]:
+            hard.append(
+                "follow-up issue membership does not resolve to the transferred "
+                f"stream epic: {follow_up_membership['reason']}"
+            )
         if not follow_up.get("reciprocal_links_verified"):
             hard.append("original and follow-up issues are not reciprocally linked")
 
@@ -1200,6 +1331,7 @@ def evaluate(payload: Mapping[str, Any], observation: Mapping[str, Any]) -> dict
         "preclose_missing_evidence": preclose_missing,
         "preclose_unchecked": preclose_unchecked,
         "goal_reached": goal_reached,
+        "membership": membership,
     }
 
 
@@ -1227,6 +1359,7 @@ def reconcile(
                 "last_success_state": result["last_success_state"],
                 "goal_reached": result["goal_reached"],
                 "valid_evidence": result["valid_evidence"],
+                "membership": result["membership"],
             },
         },
     }

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.orchestration import task_closeout, task_identity, task_lifecycle
+from scripts.orchestration import issue_stream_audit, task_closeout, task_identity, task_lifecycle
 
 NOW = "2026-07-16T10:00:00Z"
 HEAD = "a" * 40
@@ -311,6 +311,32 @@ def test_missing_authorization_is_durable_and_nonmutating(tmp_path: Path) -> Non
     assert result["remote_mutation_performed"] is False
     assert ledger["current_state"] == "BLOCKED_WITH_RECEIPT"
     assert "--authorize" in ledger["mutation_receipts"][-1]["detail"]
+
+
+def test_membership_audit_report_forwards_adapter_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Review finding F001 (PR #6030): ``GhGitHubAdapter.membership_audit_report``
+    must carry ``self.repo_root`` into ``issue_stream_audit.run_audit`` — every
+    call site that reaches it (init/reconcile/mutation/closeout, all routed
+    through this one adapter method) must audit and cache against the
+    checkout the adapter itself was constructed for, never the auditor
+    module's own ``ROOT``."""
+    captured: dict[str, object] = {}
+
+    def fake_run_audit(repo_root: Path) -> dict:
+        captured["repo_root"] = repo_root
+        return {"ok": True, "effective_membership": {}}
+
+    monkeypatch.setattr(issue_stream_audit, "run_audit", fake_run_audit)
+
+    adapter = task_closeout.GhGitHubAdapter(tmp_path)
+    report = adapter.membership_audit_report()
+
+    assert report == {"ok": True, "effective_membership": {}}
+    assert captured["repo_root"] == adapter.repo_root
+    assert adapter.repo_root == tmp_path.resolve()
+    assert adapter.repo_root != issue_stream_audit.ROOT
 
 
 def test_github_adapter_normalizes_parent_pr_checks_and_deployments(tmp_path: Path) -> None:

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from copy import deepcopy
 from pathlib import Path
 
@@ -403,6 +404,161 @@ def test_github_adapter_normalizes_parent_pr_checks_and_deployments(tmp_path: Pa
         if any(value.endswith("/deployments") for value in args) and "-f" in args
     )
     assert deployment_call[deployment_call.index("--method") + 1] == "GET"
+
+
+def _identity_dict(**overrides: object) -> dict:
+    identity = task_identity.build_identity(
+        repository="org/repo",
+        stream_epic=10,
+        stream_epic_url=None,
+        github_issue_number=42,
+        github_issue_url=None,
+        semantic_title="Enforce task closeout",
+        task_family="infrastructure",
+        role="implementer",
+        predecessor_task_id="thread-old",
+        replacement_task_id="thread-new",
+        lineage_id="lineage-closeout",
+        generation=2,
+        terminal_goal="merge",
+        lifecycle_state="confirmed",
+    )
+    identity.update(overrides)
+    return identity
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _init_args(tmp_path: Path, identity_path: Path) -> object:
+    policy_path = _write_json(
+        tmp_path / "policy.json",
+        {"AC-IMPL": {"due_state": "IMPLEMENTATION_READY", "required_evidence": ["test"]}},
+    )
+    return task_closeout.build_parser().parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "init",
+            "--identity-file",
+            str(identity_path),
+            "--ac-policy",
+            str(policy_path),
+            "--author-family",
+            "codex",
+            "--required-check",
+            "CI Gate",
+            "--state-file",
+            str(tmp_path / "lifecycle.json"),
+            "--now",
+            NOW,
+        ]
+    )
+
+
+def _stub_read_issue(*, parent_epic: int | None) -> object:
+    def _read_issue(self, repository: str, issue_number: int) -> dict:
+        return {
+            "number": issue_number,
+            "state": "OPEN",
+            "body": "- [ ] **AC-IMPL** — Implementation is verified.\n",
+            "url": f"https://github.com/{repository}/issues/{issue_number}",
+            "closed_at": None,
+            "parent_epic": parent_epic,
+        }
+
+    return _read_issue
+
+
+def test_cmd_init_accepts_native_membership_without_a_live_audit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity_path = _write_json(tmp_path / "identity.json", _identity_dict())
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter, "read_issue", _stub_read_issue(parent_epic=10)
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "registered_stream_epics", lambda self: [10])
+
+    def _fail_audit(self) -> dict:
+        raise AssertionError("native membership must not trigger a live membership audit")
+
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "membership_audit_report", _fail_audit)
+
+    assert task_closeout.cmd_init(_init_args(tmp_path, identity_path)) == 0
+    ledger = task_lifecycle.load_lifecycle(tmp_path / "lifecycle.json")
+    assert ledger["identity"]["stream_epic"] == 10
+
+
+def test_cmd_init_accepts_unique_body_membership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity_path = _write_json(tmp_path / "identity.json", _identity_dict())
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter, "read_issue", _stub_read_issue(parent_epic=None)
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "registered_stream_epics", lambda self: [10])
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter,
+        "membership_audit_report",
+        lambda self: {
+            "generated_at": time.time(),
+            "effective_membership": {
+                "42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}
+            },
+            "open_issue_numbers": [42, 10],
+        },
+    )
+
+    assert task_closeout.cmd_init(_init_args(tmp_path, identity_path)) == 0
+    ledger = task_lifecycle.load_lifecycle(tmp_path / "lifecycle.json")
+    assert ledger["identity"]["stream_epic"] == 10
+
+
+def test_cmd_init_rejects_orphaned_issue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity_path = _write_json(tmp_path / "identity.json", _identity_dict())
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter, "read_issue", _stub_read_issue(parent_epic=None)
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "registered_stream_epics", lambda self: [10])
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter,
+        "membership_audit_report",
+        lambda self: {
+            "generated_at": time.time(),
+            "effective_membership": {},
+            "open_issue_numbers": [42, 10],
+        },
+    )
+
+    with pytest.raises(task_lifecycle.LifecycleError, match="stream epic"):
+        task_closeout.cmd_init(_init_args(tmp_path, identity_path))
+    assert not (tmp_path / "lifecycle.json").exists()
+
+
+def test_mutation_gates_fail_closed_on_membership_drift(tmp_path: Path) -> None:
+    """The exact same membership validator gates init, reconcile, AND every
+    mutation action — a lifecycle that reconciled fine while native must
+    still block sync-acs, arm-auto-merge, and close-issue once native
+    parentage disappears with no fresh body-audit evidence available."""
+    path, _ = _ledger(tmp_path, review=False)
+    drifted = _observation()
+    drifted["github"]["issue"]["parent_epic"] = None
+    adapter = FakeAdapter(drifted)
+
+    for action in ("sync-acs", "arm-auto-merge", "close-issue"):
+        with pytest.raises(task_lifecycle.LifecycleError, match="stream epic"):
+            task_closeout.perform_mutation(
+                path,
+                adapter,
+                action=action,
+                authorized_by="codex/5297",
+                branch="codex/42-closeout",
+                worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+                now=NOW,
+            )
+    assert adapter.calls == []
 
 
 def test_github_read_failure_becomes_a_blocked_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -622,6 +622,30 @@ def test_cmd_init_accepts_native_membership_without_a_live_audit(
     assert ledger["identity"]["stream_epic"] == 10
 
 
+def test_cmd_init_rejects_wrong_native_parent_without_a_live_audit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Review finding F003 (PR #6030): a native parent that disagrees with the
+    identity's stream epic is a conclusive, deterministic rejection on its
+    own — ``cmd_init`` must not fetch a live membership audit first. Fetching
+    the audit here would let an unrelated audit failure (or the ``_fail_audit``
+    stub below) mask the correct stream-membership error."""
+    identity_path = _write_json(tmp_path / "identity.json", _identity_dict())
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter, "read_issue", _stub_read_issue(parent_epic=99)
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "registered_stream_epics", lambda self: [10])
+
+    def _fail_audit(self) -> dict:
+        raise AssertionError("a wrong native parent must not trigger a live membership audit")
+
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "membership_audit_report", _fail_audit)
+
+    with pytest.raises(task_lifecycle.LifecycleError, match="stream epic"):
+        task_closeout.cmd_init(_init_args(tmp_path, identity_path))
+    assert not (tmp_path / "lifecycle.json").exists()
+
+
 def test_cmd_init_accepts_unique_body_membership(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -432,6 +432,111 @@ def test_github_adapter_normalizes_parent_pr_checks_and_deployments(tmp_path: Pa
     assert deployment_call[deployment_call.index("--method") + 1] == "GET"
 
 
+def _transferred_ledger_and_reader(
+    tmp_path: Path,
+    *,
+    primary_parent_epic: int | None,
+    follow_up_parent_epic: int | None,
+    follow_up_issue: int = 99,
+) -> tuple[dict, list[int], object]:
+    """Build a lifecycle whose remaining scope was transferred to a follow-up
+    issue, plus a ``read_issue`` stub that records every issue number it is
+    asked to read and reports the given native parents for the primary (#42)
+    and follow-up (``follow_up_issue``) issues."""
+    _, ledger = _ledger(tmp_path)
+    ledger["remaining_scope"] = {
+        "status": "transferred",
+        "summary": "remaining work moved to the follow-up issue",
+        "follow_up_issue": follow_up_issue,
+        "follow_up_stream_epic": 20,
+        "evidence_ids": [],
+    }
+    calls: list[int] = []
+    parents = {42: primary_parent_epic, follow_up_issue: follow_up_parent_epic}
+
+    def _read_issue(self, repository: str, issue_number: int) -> dict:
+        calls.append(issue_number)
+        return {
+            "number": issue_number,
+            "state": "OPEN",
+            "body": f"Refs #{follow_up_issue}" if issue_number == 42 else "Refs #42",
+            "url": f"https://github.com/{repository}/issues/{issue_number}",
+            "closed_at": None,
+            "parent_epic": parents[issue_number],
+        }
+
+    return ledger, calls, _read_issue
+
+
+def test_github_observation_skips_audit_when_primary_and_follow_up_are_native(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Review finding F001 (PR #6030 second pass): a transferred-scope
+    follow-up must not force a live membership audit when both the primary
+    issue and the follow-up already have authoritative native parents."""
+    ledger, calls, read_issue = _transferred_ledger_and_reader(
+        tmp_path, primary_parent_epic=10, follow_up_parent_epic=20
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "read_issue", read_issue)
+
+    def _fail_audit(self) -> dict:
+        raise AssertionError("native primary + native follow-up must not trigger a live audit")
+
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "membership_audit_report", _fail_audit)
+    adapter = task_closeout.GhGitHubAdapter(tmp_path)
+    monkeypatch.setattr(adapter, "registered_stream_epics", lambda: [10, 20])
+    monkeypatch.setattr(adapter, "_read_pr", lambda repository, pr_number: {"number": pr_number, "checks": []})
+    monkeypatch.setattr(adapter, "_comments", lambda repository, pr_number: [])
+
+    github = adapter._github_observation(ledger)
+
+    assert github["membership_audit"] is None
+    assert github["follow_up"]["number"] == 99
+    assert calls.count(42) == 1
+    assert calls.count(99) == 1
+
+
+@pytest.mark.parametrize(
+    "primary_parent_epic,follow_up_parent_epic",
+    [
+        (None, 20),
+        (10, None),
+        (None, None),
+    ],
+    ids=["primary-lacks-native", "follow-up-lacks-native", "both-lack-native"],
+)
+def test_github_observation_fetches_audit_when_either_relevant_issue_lacks_native_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    primary_parent_epic: int | None,
+    follow_up_parent_epic: int | None,
+) -> None:
+    """Body evidence (and therefore a live audit) is still required whenever
+    the primary issue or the present transferred follow-up has no native
+    parent to resolve membership on its own."""
+    ledger, calls, read_issue = _transferred_ledger_and_reader(
+        tmp_path,
+        primary_parent_epic=primary_parent_epic,
+        follow_up_parent_epic=follow_up_parent_epic,
+    )
+    monkeypatch.setattr(task_closeout.GhGitHubAdapter, "read_issue", read_issue)
+    monkeypatch.setattr(
+        task_closeout.GhGitHubAdapter,
+        "membership_audit_report",
+        lambda self: {"sentinel": True},
+    )
+    adapter = task_closeout.GhGitHubAdapter(tmp_path)
+    monkeypatch.setattr(adapter, "registered_stream_epics", lambda: [10, 20])
+    monkeypatch.setattr(adapter, "_read_pr", lambda repository, pr_number: {"number": pr_number, "checks": []})
+    monkeypatch.setattr(adapter, "_comments", lambda repository, pr_number: [])
+
+    github = adapter._github_observation(ledger)
+
+    assert github["membership_audit"] == {"sentinel": True}
+    assert calls.count(42) == 1
+    assert calls.count(99) == 1
+
+
 def _identity_dict(**overrides: object) -> dict:
     identity = task_identity.build_identity(
         repository="org/repo",

--- a/tests/orchestration/test_task_lifecycle.py
+++ b/tests/orchestration/test_task_lifecycle.py
@@ -643,3 +643,321 @@ def test_every_lifecycle_boundary_survives_durable_resume(
 
     assert resumed == task_lifecycle.validate_lifecycle(ledger)
     assert task_lifecycle.carrier_projection(resumed)["current_state"] == state
+
+
+# --------------------------------------------------------------------------- #
+# #6028 — resolve_membership: the ONE canonical native-or-unique-body proof
+# shared by lifecycle initialization, reconciliation, and every mutation gate.
+# --------------------------------------------------------------------------- #
+def _fresh_report(now: float, index: dict) -> dict:
+    return {
+        "generated_at": now,
+        "effective_membership": index,
+        "open_issue_numbers": [42, 10],
+    }
+
+
+def test_resolve_membership_native_success() -> None:
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=10,
+        registered_epics=[10, 20],
+        membership_report=None,
+    )
+    assert result == {
+        "valid": True,
+        "method": "native",
+        "epic": 10,
+        "generated_at": None,
+        "digest": None,
+        "reason": None,
+    }
+
+
+def test_resolve_membership_unique_body_success() -> None:
+    import time
+
+    now = time.time()
+    report = _fresh_report(
+        now, {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}}
+    )
+
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10, 20],
+        membership_report=report,
+    )
+
+    assert result["valid"] is True
+    assert result["method"] == "body"
+    assert result["epic"] == 10
+    assert result["generated_at"] == now
+    assert result["digest"].startswith("sha256:")
+
+
+def test_resolve_membership_native_precedence_over_conflicting_body_evidence() -> None:
+    """Native parentage decides the outcome outright — a native parent that
+    disagrees with the identity's stream epic is rejected, never falls
+    through to body evidence even when body evidence would say otherwise."""
+    import time
+
+    report = _fresh_report(
+        time.time(),
+        {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}},
+    )
+
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=20,
+        registered_epics=[10, 20],
+        membership_report=report,
+    )
+
+    assert result["valid"] is False
+    assert result["method"] is None
+    assert "native parent epic" in result["reason"]
+
+
+def test_resolve_membership_rejects_missing_audit_evidence() -> None:
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=None,
+    )
+    assert result["valid"] is False
+    assert result["method"] is None
+    assert "missing" in result["reason"]
+
+
+def test_resolve_membership_rejects_stale_audit_evidence() -> None:
+    import time
+
+    report = _fresh_report(
+        time.time() - 10_000,
+        {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}},
+    )
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=report,
+    )
+    assert result["valid"] is False
+    assert "stale" in result["reason"]
+
+
+def test_resolve_membership_rejects_malformed_audit_evidence() -> None:
+    import time
+
+    report = _fresh_report(time.time(), {"42": {"epics": [10]}})  # missing required fields
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=report,
+    )
+    assert result["valid"] is False
+    assert "malformed" in result["reason"]
+
+
+def test_resolve_membership_rejects_orphan() -> None:
+    """No native parent AND no entry at all in the fresh audit index — this is
+    also the shape a CHILD-SIDE-ONLY ``Refs #10`` reference produces: the
+    auditor's effective-membership index is built exclusively from what the
+    epic body says, so a mention that lives only in the child issue's own
+    prose never creates an entry here."""
+    import time
+
+    report = _fresh_report(time.time(), {})
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=report,
+    )
+    assert result["valid"] is False
+    assert "orphan" in result["reason"]
+
+
+def test_resolve_membership_rejects_wrong_epic() -> None:
+    import time
+
+    report = _fresh_report(
+        time.time(),
+        {"42": {"epics": [20], "streams": ["other"], "via": "body", "unique_stream": True}},
+    )
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10, 20],
+        membership_report=report,
+    )
+    assert result["valid"] is False
+    assert "different epic" in result["reason"]
+
+
+def test_resolve_membership_rejects_multi_home() -> None:
+    import time
+
+    report = _fresh_report(
+        time.time(),
+        {
+            "42": {
+                "epics": [10, 20],
+                "streams": ["infra", "other"],
+                "via": "body",
+                "unique_stream": False,
+            }
+        },
+    )
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10, 20],
+        membership_report=report,
+    )
+    assert result["valid"] is False
+    assert "ambiguously multi-homed" in result["reason"]
+
+
+def test_resolve_membership_rejects_unregistered_stream_epic() -> None:
+    result = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=10,
+        registered_epics=[99],
+        membership_report=None,
+    )
+    assert result["valid"] is False
+    assert "registered issue-stream" in result["reason"]
+
+
+def test_resolve_membership_digest_is_deterministic_over_the_index() -> None:
+    import time
+
+    now = time.time()
+    index = {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}}
+    first = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=_fresh_report(now, index),
+    )
+    second = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=_fresh_report(now, dict(index)),
+    )
+    changed = task_lifecycle.resolve_membership(
+        issue_number=42,
+        stream_epic=10,
+        native_parent_epic=None,
+        registered_epics=[10],
+        membership_report=_fresh_report(
+            now,
+            {
+                **index,
+                "7": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True},
+            },
+        ),
+    )
+    assert first["digest"] == second["digest"]
+    assert first["digest"] != changed["digest"]
+
+
+# --------------------------------------------------------------------------- #
+# #6028 — evaluate()/reconcile() wire resolve_membership in for the primary
+# issue and drift is caught fresh on every subsequent reconcile.
+# --------------------------------------------------------------------------- #
+def test_evaluate_accepts_unique_body_membership_and_records_provenance() -> None:
+    import time
+
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+    observation["github"]["issue"]["parent_epic"] = None
+    now = time.time()
+    observation["github"]["membership_audit"] = _fresh_report(
+        now, {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}}
+    )
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] != "BLOCKED_WITH_RECEIPT"
+    assert result["membership"] == {
+        "valid": True,
+        "method": "body",
+        "epic": 10,
+        "generated_at": now,
+        "digest": result["membership"]["digest"],
+        "reason": None,
+    }
+    assert result["membership"]["digest"].startswith("sha256:")
+
+
+def test_evaluate_rejects_body_membership_without_fresh_audit() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+    observation["github"]["issue"]["parent_epic"] = None
+    observation["github"]["membership_audit"] = None
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "issue membership" in " ".join(result["hard_blockers"])
+    assert result["membership"]["valid"] is False
+
+
+def test_reconcile_persists_membership_provenance_in_the_receipt() -> None:
+    import time
+
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+    observation["github"]["issue"]["parent_epic"] = None
+    now = time.time()
+    observation["github"]["membership_audit"] = _fresh_report(
+        now, {"42": {"epics": [10], "streams": ["infra"], "via": "body", "unique_stream": True}}
+    )
+
+    _updated, receipt, _ = task_lifecycle.reconcile(ledger, observation, now=NOW)
+
+    projection = receipt["observation"]["projection"]
+    assert projection["membership"]["method"] == "body"
+    assert projection["membership"]["epic"] == 10
+
+
+def test_membership_drift_blocks_a_later_reconcile() -> None:
+    """Membership accepted on one reconcile is NOT cached — a later
+    reconcile with an observation that no longer proves membership (native
+    parent gone, no fresh body audit) must fail closed, even though the
+    ledger previously reconciled cleanly."""
+    ledger = _ready_evidence(_ledger())
+    first_observation = _observation(_body())
+    ledger, first_receipt, _ = task_lifecycle.reconcile(ledger, first_observation, now=NOW)
+    assert first_receipt["state"] != "BLOCKED_WITH_RECEIPT"
+
+    drifted_observation = _observation(_body())
+    drifted_observation["github"]["issue"]["parent_epic"] = None
+    drifted_observation["github"]["membership_audit"] = None
+
+    ledger, second_receipt, replayed = task_lifecycle.reconcile(
+        ledger, drifted_observation, now="2026-07-16T11:00:00Z"
+    )
+
+    assert replayed is False
+    assert second_receipt["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "issue membership" in " ".join(second_receipt["hard_blockers"])
+    assert ledger["current_state"] == "BLOCKED_WITH_RECEIPT"

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 
 import pytest
 
+from scripts.orchestration import issue_stream_audit
 from scripts.orchestration.issue_stream_audit import (
     _MAX_SUBISSUE_PAGES,
     _paginate_subissues,
@@ -14,6 +16,7 @@ from scripts.orchestration.issue_stream_audit import (
     make_issue_resolver,
     make_membership_resolver,
     read_membership_index,
+    run_audit,
     validate_membership_report,
 )
 
@@ -436,3 +439,147 @@ def test_paginate_subissues_bounded_against_runaway_pagination():
     native, _body = _paginate_subissues(100, fetch_page)
     assert calls["n"] == _MAX_SUBISSUE_PAGES
     assert len(native) == _MAX_SUBISSUE_PAGES
+
+
+# --------------------------------------------------------------------------- #
+# Review finding F001 (PR #6030) — ``run_audit`` must carry an explicit repo
+# root all the way through registry lookup, ``gh`` execution cwd, and the
+# cache it writes, instead of the module's own ``ROOT``. Fake ``gh`` via
+# ``subprocess.run`` (not a higher-level seam) so the cwd threading itself is
+# proven, not assumed.
+# --------------------------------------------------------------------------- #
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = 0
+
+
+def _make_repo(root, *, epics: list[int]) -> None:
+    (root / "scripts" / "config").mkdir(parents=True)
+    (root / "scripts" / "config" / "issue_streams.yaml").write_text(
+        "streams:\n  s:\n    title: s\n    epics: " + json.dumps(epics) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _fake_gh_run(calls, *, owner: str, name: str, open_issues: list[dict]):
+    """A ``subprocess.run`` stand-in recording every ``(args, cwd)`` pair and
+    answering the exact three ``gh`` calls ``run_audit`` makes for a registry
+    with a single epic and no native/body children."""
+
+    def _run(args, capture_output, text, timeout, cwd):
+        calls.append((tuple(args), cwd))
+        assert args[0] == "gh"
+        if args[1:3] == ["issue", "list"]:
+            return _FakeCompletedProcess(json.dumps(open_issues))
+        if args[1:3] == ["repo", "view"]:
+            return _FakeCompletedProcess(
+                json.dumps({"owner": {"login": owner}, "name": name})
+            )
+        if args[1] == "api" and args[2] == "graphql":
+            return _FakeCompletedProcess(
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "issue": {
+                                    "body": "",
+                                    "subIssues": {
+                                        "nodes": [],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected gh invocation: {args}")
+
+    return _run
+
+
+def test_run_audit_scopes_registry_gh_execution_and_cache_to_explicit_root(
+    tmp_path, monkeypatch
+):
+    """A non-default ``repo_root`` passed to ``run_audit`` must be honored for
+    the registry, every ``gh`` call's cwd, and the cache write — never the
+    auditor module's own ``ROOT`` (finding F001: a closeout invocation
+    configured for another checkout must not validate against, or cache
+    into, the wrong repository)."""
+    monkeypatch.setattr(issue_stream_audit, "_REPO_CACHE", {})
+    other_root = tmp_path / "unrelated-checkout"
+    _make_repo(other_root, epics=[999])
+
+    target_root = tmp_path / "target-checkout"
+    _make_repo(target_root, epics=[100])
+
+    calls: list[tuple[tuple, object]] = []
+    monkeypatch.setattr(
+        issue_stream_audit.subprocess,
+        "run",
+        _fake_gh_run(calls, owner="acme", name="target-repo", open_issues=[]),
+    )
+
+    report = run_audit(target_root)
+
+    assert report["streams"] == {"s": [100]}
+    # Every gh subprocess call ran with cwd pinned to the requested root —
+    # never the unrelated sibling root, never the module's own ROOT.
+    assert calls, "expected at least one gh invocation"
+    assert {cwd for _args, cwd in calls} == {target_root.resolve()}
+
+    cache_path = target_root / "batch_state" / "issue_stream_audit.json"
+    assert cache_path.exists()
+    assert not (other_root / "batch_state" / "issue_stream_audit.json").exists()
+
+
+def test_run_audit_default_root_preserves_module_root_behavior(tmp_path, monkeypatch):
+    """Calling ``run_audit()`` with no argument must still resolve against the
+    module's own ``ROOT`` — the fix must not change plain CLI behavior."""
+    monkeypatch.setattr(issue_stream_audit, "_REPO_CACHE", {})
+    fake_root = tmp_path / "module-root-stand-in"
+    _make_repo(fake_root, epics=[7])
+    monkeypatch.setattr(issue_stream_audit, "ROOT", fake_root)
+
+    calls: list[tuple[tuple, object]] = []
+    monkeypatch.setattr(
+        issue_stream_audit.subprocess,
+        "run",
+        _fake_gh_run(calls, owner="acme", name="default-repo", open_issues=[]),
+    )
+
+    report = run_audit()
+
+    assert report["streams"] == {"s": [7]}
+    assert {cwd for _args, cwd in calls} == {fake_root}
+    assert (fake_root / "batch_state" / "issue_stream_audit.json").exists()
+
+
+def test_repo_owner_name_cache_keyed_by_root_does_not_leak(tmp_path, monkeypatch):
+    """``_repo_owner_name`` must resolve independently per root — a cache
+    warmed for one checkout must not answer for a different one."""
+    monkeypatch.setattr(issue_stream_audit, "_REPO_CACHE", {})
+    root_a = tmp_path / "repo-a"
+    root_b = tmp_path / "repo-b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    answers = {str(root_a): ("owner-a", "repo-a"), str(root_b): ("owner-b", "repo-b")}
+
+    def _run(args, capture_output, text, timeout, cwd):
+        assert args[1:3] == ["repo", "view"]
+        owner, name = answers[str(cwd)]
+        return _FakeCompletedProcess(json.dumps({"owner": {"login": owner}, "name": name}))
+
+    monkeypatch.setattr(issue_stream_audit.subprocess, "run", _run)
+
+    assert issue_stream_audit._repo_owner_name(root_a) == ("owner-a", "repo-a")
+    assert issue_stream_audit._repo_owner_name(root_b) == ("owner-b", "repo-b")
+    # Re-resolving root_a must still return root_a's own answer, not root_b's
+    # (proves the cache key is the root, not a single shared slot).
+    assert issue_stream_audit._repo_owner_name(root_a) == ("owner-a", "repo-a")

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -14,6 +14,7 @@ from scripts.orchestration.issue_stream_audit import (
     make_issue_resolver,
     make_membership_resolver,
     read_membership_index,
+    validate_membership_report,
 )
 
 
@@ -340,6 +341,32 @@ def test_read_membership_index_rejects_malformed_open_numbers(tmp_path):
     report["open_issue_numbers"] = [42, "100", -1, True]
     cache.write_text(json.dumps(report), encoding="utf-8")
     assert read_membership_index(3600, cache_path=cache) is None
+
+
+# --------------------------------------------------------------------------- #
+# #6028 — validate_membership_report: same fail-closed rules as
+# read_membership_index, applied to an in-memory (not file-cached) report, so
+# task_lifecycle.resolve_membership can carry one live run_audit() snapshot
+# through a single observation without a second round trip through disk.
+# --------------------------------------------------------------------------- #
+def test_validate_membership_report_accepts_fresh_in_memory_report():
+    import time
+
+    report = _valid_report(time.time())
+    assert validate_membership_report(report, 3600) == report
+
+
+def test_validate_membership_report_rejects_stale_in_memory_report():
+    import time
+
+    report = _valid_report(time.time() - 10_000)
+    assert validate_membership_report(report, 3600) is None
+
+
+def test_validate_membership_report_rejects_non_dict():
+    assert validate_membership_report(None, 3600) is None
+    assert validate_membership_report("not-a-report", 3600) is None
+    assert validate_membership_report([], 3600) is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Implements #6028's canonical capped-epic membership semantics: one shared `task_lifecycle.resolve_membership` validator now gates lifecycle initialization, observation/reconciliation, and every remote mutation (`sync-acs`, `arm-auto-merge`, `close-issue`) — replacing three independently-drifting native-only `parent_epic` checks.

- **Native precedence, unchanged**: a native GitHub sub-issue parent still decides membership outright when present; a disagreeing native parent is a hard rejection, never a fall-through to body evidence.
- **Body fallback, epic-side only**: when there is no native parent, membership only resolves through a *fresh* `issue_stream_audit` effective-membership proof — built exclusively from what the stream epic's own body says. A child issue's own `Refs #<epic>` prose is never consulted (failure mode 1).
- **Fail-closed everywhere**: missing, stale, malformed, orphaned, wrong-epic, multi-homed, or ambiguous evidence is rejected before implementation or any remote mutation (failure mode 2).
- **One validator, no drift**: `task_closeout.cmd_init`, `task_lifecycle.evaluate`/`reconcile`, and `task_closeout._assert_mutation_ready` all call the same function — a lifecycle that reconciled cleanly is fail-closed again the moment membership drifts on a later reconcile or mutation attempt (failure modes 3 & 4).
- **No special case**: the validator is fully generic; nothing is keyed to issue #6027 or epic #4707 (failure mode 5).
- **Provenance**: every accepted/rejected proof carries `method` (`native`/`body`/`None`), `epic`, the audit's `generated_at`, and a deterministic digest of the effective-membership index consulted — persisted into `observation_receipts[*].observation.projection.membership`.
- **One audit per observation**: `issue_stream_audit` gains `validate_membership_report` (extracted from `read_membership_index`) so a single live `run_audit()` snapshot can be validated in-memory and shared across the lifecycle issue and any transferred-scope follow-up issue in one observation, instead of auditing twice. The audit is skipped entirely when native parentage already resolves membership.

## Test plan

- [x] `.venv/bin/python -m pytest tests/orchestration/test_issue_stream_audit... tests/test_issue_stream_audit.py tests/orchestration/test_task_closeout.py tests/orchestration/test_task_lifecycle.py tests/orchestration/test_task_lifecycle_carriers.py -q` → 94 passed (note: the canonical auditor test file lives at `tests/test_issue_stream_audit.py`, not `tests/orchestration/test_issue_stream_audit.py`)
- [x] `.venv/bin/python -m ruff check scripts/orchestration/issue_stream_audit.py scripts/orchestration/task_closeout.py scripts/orchestration/task_lifecycle.py tests/orchestration tests/test_issue_stream_audit.py` → all checks passed
- [x] `.venv/bin/python -m scripts.orchestration.issue_stream_audit --check` → ran live successfully (pre-existing backlog orphans/multi-homed unrelated to this change)
- [x] `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → zero leaks
- [x] `git diff --check` → clean
- [ ] AC-LIVE (behavior_proof, due_state MERGED): a fresh live audit proving #6027 resolves uniquely to epic #4707 via the epic body, plus `task_closeout init`/first reconciliation for #6027 — deliberately deferred to post-merge per the dispatch brief (no auto-close keyword used here; live proof and reconciliation remain before #6028 itself closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)