### PR TITLE
feat(eval): add portable provider-neutral runner

### DIFF
--- a/data/projects/ua_eval_harness/model_run_config.example.json
+++ b/data/projects/ua_eval_harness/model_run_config.example.json
@@ -1,0 +1,29 @@
+{
+  "alias_resolution": {
+    "evidence": "provider model-list output, release documentation, or immutable receipt",
+    "requested": "provider-facing model alias",
+    "resolved": "exact model revision returned by the provider"
+  },
+  "auth_environment": [
+    "PROVIDER_API_KEY"
+  ],
+  "command_identity": {
+    "name": "provider command",
+    "version": "exact command version"
+  },
+  "decoding": {
+    "max_output_tokens": "not_exposed",
+    "safety": "not_exposed",
+    "seed": "not_exposed",
+    "stop": "not_exposed",
+    "temperature": "not_exposed",
+    "top_k": "not_exposed",
+    "top_p": "not_exposed"
+  },
+  "model": "public model name",
+  "model_version": "exact model revision",
+  "provider": "provider name",
+  "route": "provider route or endpoint class",
+  "run_id": "stable unique run identifier",
+  "schema_version": "ua_eval_model_run_config.v1"
+}

--- a/data/projects/ua_eval_harness/model_run_config_schema_v1.json
+++ b/data/projects/ua_eval_harness/model_run_config_schema_v1.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "alias_resolution": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "requested": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "resolved": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "requested",
+        "resolved",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "auth_environment": {
+      "items": {
+        "pattern": "^[A-Z_][A-Z0-9_]*$",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "command_identity": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "decoding": {
+      "additionalProperties": false,
+      "properties": {
+        "max_output_tokens": {},
+        "safety": {},
+        "seed": {},
+        "stop": {},
+        "temperature": {},
+        "top_k": {},
+        "top_p": {}
+      },
+      "required": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "seed",
+        "max_output_tokens",
+        "stop",
+        "safety"
+      ],
+      "type": "object"
+    },
+    "model": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "model_version": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "provider": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "route": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "run_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "ua_eval_model_run_config.v1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "run_id",
+    "provider",
+    "route",
+    "model",
+    "model_version",
+    "alias_resolution",
+    "decoding",
+    "command_identity"
+  ],
+  "type": "object"
+}

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -149,7 +149,12 @@ Prepare a source-only packet:
   --output /tmp/ua-eval-requests.jsonl
 ```
 
-Generate one response for each request, then import and score it:
+Generate one response for each request, then import and score it. The
+provider-neutral batch runner can call an arbitrary executable through a
+shell-free argument or standard-input interface, retain resumable receipts,
+and write import-ready metadata. See
+[REPRODUCING.md](REPRODUCING.md#evaluate-another-model) for its configuration
+contract and complete command.
 
 ```bash
 .venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py import \

--- a/docs/projects/ua-eval-harness/REPRODUCING.md
+++ b/docs/projects/ua-eval-harness/REPRODUCING.md
@@ -99,22 +99,72 @@ Create a source-only request packet:
   --output /tmp/ua-eval-requests.jsonl
 ```
 
-Generate responses outside the scorer using only the request fields. Then
-import them with versioned model, provider, and decoding metadata:
+The provider-neutral runner accepts any executable that can read the generated
+batch prompt from its final argument or standard input and return the required
+JSON object. Copy
+`data/projects/ua_eval_harness/model_run_config.example.json`, then replace
+every descriptive value with the exact provider, route, model revision, alias
+resolution, decoding controls, and command version used for the run. The
+machine-readable contract is
+`data/projects/ua_eval_harness/model_run_config_schema_v1.json`.
+
+For a command that reads the prompt from standard input:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/run_model_batch.py \
+  --requests /tmp/ua-eval-requests.jsonl \
+  --prompt data/projects/ua_eval_harness/minimal_edit_prompt_v1.txt \
+  --config /tmp/model-run-config.json \
+  --executable /path/to/provider-command \
+  --command-arg=batch \
+  --command-arg=--json \
+  --prompt-mode stdin \
+  --raw-output /tmp/ua-eval-run/raw-provider-output.jsonl \
+  --output /tmp/ua-eval-run/model-output.jsonl \
+  --metadata-output /tmp/ua-eval-run/model-metadata.json \
+  --state-dir /tmp/ua-eval-run/state \
+  --batch-size 40 \
+  --workers 1 \
+  --timeout 1800 \
+  --retries 1
+```
+
+Use `--prompt-mode argument` when the command expects the complete prompt as
+its final argument. Repeat `--command-arg` for each literal command argument;
+the runner never invokes a shell.
+
+Every provider invocation uses a retained working directory outside the
+repository. The child process receives only a small standard environment plus
+the environment-variable names explicitly allowed by the run config. Gold
+targets, references, edit spans, and scores are neither loaded nor supplied.
+
+Completed batch states are immutable and bound to the request packet, prompt,
+run config, model, and command. Re-running the same command with the same state
+directory verifies and reuses completed batches. A binding mismatch or an
+attempt to replace a different receipt fails closed. The metadata records
+timestamps, retries, exact response coverage, provider routing, alias
+resolution, decoding controls, command identity, and cryptographic receipts.
+
+The raw-provider-output file may contain provider transport events or model
+trace wrappers. Retain it for local auditing, but publish only the normalized
+model output, import metadata, saved responses, and aggregate score unless the
+provider's terms and disclosure policy explicitly permit more.
+
+Import the normalized output with the generated metadata, then score it:
 
 ```bash
 .venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py import \
   --requests /tmp/ua-eval-requests.jsonl \
-  --model-output /tmp/model-output.jsonl \
-  --metadata /tmp/model-metadata.json \
-  --output /tmp/saved-responses.jsonl
+  --model-output /tmp/ua-eval-run/model-output.jsonl \
+  --metadata /tmp/ua-eval-run/model-metadata.json \
+  --output /tmp/ua-eval-run/saved-responses.jsonl
 
 .venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py score \
-  --responses /tmp/saved-responses.jsonl \
-  --output /tmp/score-report.json
+  --responses /tmp/ua-eval-run/saved-responses.jsonl \
+  --output /tmp/ua-eval-run/score-report.json
 ```
 
 The importer rejects incomplete coverage, duplicate IDs, drift in source or
-prompt hashes, tampered responses, and fields that resemble hidden gold data.
-Live generation is optional and remains outside the credential-free
-reproduction path.
+prompt hashes, tampered responses, malformed provenance, and fields that
+resemble hidden gold data. Live generation remains optional and outside the
+credential-free reproduction path.

--- a/scripts/projects/ua_eval_harness/run_model_batch.py
+++ b/scripts/projects/ua_eval_harness/run_model_batch.py
@@ -1,0 +1,989 @@
+#!/usr/bin/env python3
+"""Run a source-only UA evaluation packet through an arbitrary model command.
+
+This module deliberately knows nothing about gold data or scoring. It validates
+the public request packet, invokes a caller-supplied command from retained
+directories outside the repository, and emits strictly shaped output plus
+resumable provenance receipts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+REQUEST_SCHEMA = "ua_eval_generation_requests.v1"
+STATE_SCHEMA = "ua_eval_model_batch_state.v1"
+CONFIG_SCHEMA = "ua_eval_model_run_config.v1"
+METADATA_SCHEMA = "ua_eval_model_run_metadata.v1"
+RUNNER_VERSION = "ua_eval_provider_neutral_batch_runner.v1.2"
+JSON_TRANSPORT_PROTOCOL = "json_object_with_unicode_escaped_quotes.v1"
+TAGGED_TRANSPORT_PROTOCOL = "tagged_text_blocks.v1"
+EXPECTED_REQUEST_COUNT = 677
+GOLD_FIELDS = frozenset(
+    {
+        "answer",
+        "edit",
+        "edits",
+        "gold",
+        "reference",
+        "references",
+        "target",
+        "targets",
+    }
+)
+HEADER_FIELDS = frozenset(
+    {
+        "type",
+        "schema_version",
+        "manifest_id",
+        "manifest_payload_sha256",
+        "prompt_path",
+        "prompt_sha256",
+        "input_fields",
+        "gold_fields_supplied",
+        "request_count",
+    }
+)
+REQUEST_FIELDS = frozenset(
+    {
+        "type",
+        "item_id",
+        "source",
+        "source_sha256",
+        "prompt_sha256",
+        "request_sha256",
+    }
+)
+DECODING_FIELDS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "top_k",
+        "seed",
+        "max_output_tokens",
+        "stop",
+        "safety",
+    }
+)
+CONFIG_FIELDS = frozenset(
+    {
+        "schema_version",
+        "run_id",
+        "provider",
+        "route",
+        "model",
+        "model_version",
+        "alias_resolution",
+        "decoding",
+        "command_identity",
+    }
+)
+ALIAS_FIELDS = frozenset({"requested", "resolved", "evidence"})
+COMMAND_IDENTITY_FIELDS = frozenset({"name", "version"})
+ENV_NAME = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+THOUGHT_WRAPPER = re.compile(
+    r"^\s*<(?:think|thought)>.*?</(?:think|thought)>\s*",
+    re.DOTALL | re.IGNORECASE,
+)
+JSON_FENCE = re.compile(
+    r"\A```(?:json)?[ \t]*\r?\n(?P<body>.*?)(?:\r?\n)?```[ \t]*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
+TAGGED_FENCE = re.compile(
+    r"\A```(?:text|plaintext)?[ \t]*\r?\n(?P<body>.*?)(?:\r?\n)?```[ \t]*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
+TAGGED_HEADER = re.compile(r"<<<UA-EVAL-RESPONSE item_id=(?P<item_id>[A-Za-z0-9_-]+)>>>\n")
+TAGGED_END = "\n<<<UA-EVAL-END>>>"
+
+
+class RunnerError(ValueError):
+    """The public input, provider output, or resumable state is invalid."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _is_hash(value: Any) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _publish_text(path: Path, text: str) -> None:
+    """Create an immutable receipt, or verify an identical existing receipt."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileExistsError:
+        try:
+            existing = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RunnerError(f"cannot validate existing immutable receipt: {path}") from exc
+        if existing != text:
+            raise RunnerError(f"refusing to replace a different immutable receipt: {path}") from None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RunnerError(f"cannot read JSONL: {path}") from exc
+    rows: list[dict[str, Any]] = []
+    for number, line in enumerate(lines, 1):
+        if not line.strip():
+            raise RunnerError(f"blank JSONL line {number}")
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RunnerError(f"invalid JSONL line {number}") from exc
+        if not isinstance(row, dict):
+            raise RunnerError(f"JSONL line {number} is not an object")
+        rows.append(row)
+    if not rows:
+        raise RunnerError("request packet is empty")
+    return rows
+
+
+def load_source_only_packet(path: Path) -> tuple[dict[str, Any], list[dict[str, str]], str]:
+    """Load the exact public request packet without manifest or gold access."""
+
+    rows = _read_jsonl(path)
+    header = rows[0]
+    if (
+        set(header) != HEADER_FIELDS
+        or header.get("type") != "request_run"
+        or header.get("schema_version") != REQUEST_SCHEMA
+    ):
+        raise RunnerError("request header does not match the source-only schema")
+    if header["gold_fields_supplied"] != [] or header["input_fields"] != [
+        "item_id",
+        "source",
+        "source_sha256",
+        "prompt_sha256",
+    ]:
+        raise RunnerError("request header violates the gold firewall")
+    if header["request_count"] != EXPECTED_REQUEST_COUNT or len(rows) - 1 != EXPECTED_REQUEST_COUNT:
+        raise RunnerError("request packet must contain exactly 677 request rows")
+    for field in ("manifest_id", "prompt_path"):
+        if not isinstance(header[field], str) or not header[field]:
+            raise RunnerError(f"request header has empty {field}")
+    if not _is_hash(header["manifest_payload_sha256"]) or not _is_hash(header["prompt_sha256"]):
+        raise RunnerError("request header hash is malformed")
+
+    requests: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for number, row in enumerate(rows[1:], 2):
+        if GOLD_FIELDS & set(row):
+            raise RunnerError(f"request row {number} contains a gold-shaped field")
+        if set(row) != REQUEST_FIELDS or row.get("type") != "request":
+            raise RunnerError(f"request row {number} contains unknown or missing fields")
+        if not all(isinstance(row[field], str) for field in REQUEST_FIELDS - {"type"}):
+            raise RunnerError(f"request row {number} contains non-string values")
+        item_id = row["item_id"]
+        if not item_id or item_id in seen:
+            raise RunnerError(f"request row {number} has missing or duplicate item_id")
+        if not row["source"] or row["prompt_sha256"] != header["prompt_sha256"]:
+            raise RunnerError(f"request row {number} source or prompt hash mismatch")
+        payload = {field: row[field] for field in ("item_id", "source", "source_sha256", "prompt_sha256")}
+        if not _is_hash(row["source_sha256"]) or not _is_hash(row["request_sha256"]):
+            raise RunnerError(f"request row {number} has malformed hashes")
+        if (
+            _sha256_text(row["source"]) != row["source_sha256"]
+            or _sha256_text(_canonical_json(payload)) != row["request_sha256"]
+        ):
+            raise RunnerError(f"request row {number} hash validation failed")
+        seen.add(item_id)
+        requests.append({"item_id": item_id, "source": row["source"]})
+    packet_sha256 = _sha256_text("\n".join(_canonical_json(row) for row in rows))
+    return header, requests, packet_sha256
+
+
+def _nonempty_string_object(value: Any, required: frozenset[str], label: str) -> None:
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or any(not isinstance(value[field], str) or not value[field] for field in required)
+    ):
+        raise RunnerError(f"run config {label} must declare {sorted(required)}")
+
+
+def load_run_config(path: Path) -> dict[str, Any]:
+    """Load exact provider, model, route, alias, decoding, and tool metadata."""
+
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("cannot read required run config JSON") from exc
+    if (
+        not isinstance(config, dict)
+        or set(config) - (CONFIG_FIELDS | {"auth_environment"})
+        or not CONFIG_FIELDS.issubset(config)
+        or config.get("schema_version") != CONFIG_SCHEMA
+    ):
+        raise RunnerError("run config has missing or unknown fields")
+    for field in CONFIG_FIELDS - {
+        "schema_version",
+        "alias_resolution",
+        "command_identity",
+        "decoding",
+    }:
+        if not isinstance(config[field], str) or not config[field]:
+            raise RunnerError(f"run config has empty {field}")
+    _nonempty_string_object(config["alias_resolution"], ALIAS_FIELDS, "alias_resolution")
+    _nonempty_string_object(
+        config["command_identity"],
+        COMMAND_IDENTITY_FIELDS,
+        "command_identity",
+    )
+    if not isinstance(config["decoding"], dict) or set(config["decoding"]) != DECODING_FIELDS:
+        raise RunnerError("run config must declare every decoding field")
+    auth = config.get("auth_environment", [])
+    if not isinstance(auth, list) or any(not isinstance(name, str) or not ENV_NAME.fullmatch(name) for name in auth):
+        raise RunnerError("run config auth_environment must contain environment variable names")
+    return config
+
+
+def _child_environment(auth_names: Sequence[str]) -> dict[str, str]:
+    allowed = {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "TMPDIR",
+        "XDG_CONFIG_HOME",
+    }
+    allowed.update(auth_names)
+    return {name: value for name, value in os.environ.items() if name in allowed}
+
+
+def _temporary_parent() -> Path:
+    candidates = (Path(tempfile.gettempdir()), Path("/tmp"))
+    root = ROOT.resolve()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if not resolved.is_relative_to(root):
+            return resolved
+    raise RunnerError("no scratch directory is available outside the repository")
+
+
+def _transport_protocol(response_format: str) -> str:
+    if response_format == "json":
+        return JSON_TRANSPORT_PROTOCOL
+    if response_format == "tagged":
+        return TAGGED_TRANSPORT_PROTOCOL
+    raise RunnerError("response format must be json or tagged")
+
+
+def _batch_prompt(
+    instruction: str,
+    batch: Sequence[Mapping[str, str]],
+    response_format: str = "json",
+) -> str:
+    payload = {
+        "instruction": instruction,
+        "records": [{"item_id": row["item_id"], "source": row["source"]} for row in batch],
+    }
+    if response_format == "tagged":
+        return (
+            "Return one plain-text block for every supplied item_id in the same "
+            "order, using exactly this form:\n"
+            "<<<UA-EVAL-RESPONSE item_id=THE_EXACT_ITEM_ID>>>\n"
+            "THE_CORRECTED_SENTENCE\n"
+            "<<<UA-EVAL-END>>>\n"
+            "Do not escape sentence characters. Do not add fields, explanations, "
+            "or code fences.\n\n" + _canonical_json(payload)
+        )
+    _transport_protocol(response_format)
+    return (
+        "Return exactly one JSON object with exactly this shape: "
+        '{"responses":[{"item_id":"...","raw_response":"..."}]}. '
+        "Return one row for every supplied item_id in the same order. "
+        "Inside raw_response JSON strings, encode every quotation-mark character "
+        "as the JSON Unicode escape \\u0022 and every backslash character as "
+        "\\u005c. Write each Unicode escape with exactly one backslash; never "
+        "copy input JSON escape syntax. "
+        "Do not add fields, explanations, or code fences.\n\n" + _canonical_json(payload)
+    )
+
+
+def _parse_exact_object(text: str) -> dict[str, Any]:
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        match = JSON_FENCE.fullmatch(candidate)
+        if match is None:
+            raise RunnerError("provider response contains a non-exact code fence")
+        candidate = match.group("body").strip()
+    if not candidate.startswith("{"):
+        unwrapped = THOUGHT_WRAPPER.sub("", candidate, count=1)
+        if unwrapped == candidate:
+            raise RunnerError("provider response is not a JSON object")
+        candidate = unwrapped.strip()
+    try:
+        decoder = json.JSONDecoder()
+        value, end = decoder.raw_decode(candidate)
+    except json.JSONDecodeError as exc:
+        raise RunnerError("provider response contains malformed JSON") from exc
+    if candidate[end:].strip() or not isinstance(value, dict):
+        raise RunnerError("provider response is not one exact JSON object")
+    return value
+
+
+def _assistant_text_from_event(event: Any) -> str | None:
+    if not isinstance(event, dict):
+        return None
+    if event.get("type") == "text":
+        part = event.get("part")
+        if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+            return part["text"]
+    if event.get("role") == "assistant":
+        content = event.get("text", event.get("content"))
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            fragments = [
+                part.get("text") for part in content if isinstance(part, dict) and isinstance(part.get("text"), str)
+            ]
+            if fragments:
+                return "".join(fragments)
+    for value in event.values():
+        if isinstance(value, dict):
+            found = _assistant_text_from_event(value)
+            if found is not None:
+                return found
+    return None
+
+
+def _validate_provider_payload(
+    payload: Mapping[str, Any],
+    expected_ids: Sequence[str],
+) -> list[dict[str, str]]:
+    if set(payload) != {"responses"} or not isinstance(payload["responses"], list):
+        raise RunnerError("provider response must contain exactly a responses list")
+    responses = payload["responses"]
+    if len(responses) != len(expected_ids):
+        raise RunnerError("provider response count does not match the batch")
+    normalized: list[dict[str, str]] = []
+    for row, expected_id in zip(responses, expected_ids, strict=True):
+        if not isinstance(row, dict) or set(row) != {"item_id", "raw_response"}:
+            raise RunnerError("provider response row has unknown or missing fields")
+        if not isinstance(row["item_id"], str) or not isinstance(row["raw_response"], str):
+            raise RunnerError("provider response row values must be strings")
+        if row["item_id"] != expected_id:
+            raise RunnerError("provider response IDs must exactly match requested order")
+        normalized.append({"item_id": row["item_id"], "raw_response": row["raw_response"]})
+    return normalized
+
+
+def _ndjson_assistant_text(raw_text: str) -> str:
+    assistant_text: str | None = None
+    try:
+        for line in raw_text.splitlines():
+            if line.strip():
+                found = _assistant_text_from_event(json.loads(line))
+                if found is not None:
+                    assistant_text = found
+    except json.JSONDecodeError:
+        raise RunnerError("provider response is not a direct response or NDJSON event stream") from None
+    if assistant_text is None:
+        raise RunnerError("provider response has no assistant text event")
+    return assistant_text
+
+
+def _parse_tagged_response(text: str, expected_ids: Sequence[str]) -> list[dict[str, str]]:
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        match = TAGGED_FENCE.fullmatch(candidate)
+        if match is None:
+            raise RunnerError("provider response contains a non-exact code fence")
+        candidate = match.group("body")
+    responses: list[dict[str, str]] = []
+    position = 0
+    while position < len(candidate):
+        match = TAGGED_HEADER.match(candidate, position)
+        if match is None:
+            raise RunnerError("tagged response has an invalid block header")
+        content_start = match.end()
+        content_end = candidate.find(TAGGED_END, content_start)
+        if content_end < 0:
+            raise RunnerError("tagged response has an unterminated block")
+        responses.append(
+            {
+                "item_id": match.group("item_id"),
+                "raw_response": candidate[content_start:content_end],
+            }
+        )
+        position = content_end + len(TAGGED_END)
+        if position < len(candidate):
+            if candidate[position] != "\n":
+                raise RunnerError("tagged response has text between blocks")
+            position += 1
+    return _validate_provider_payload({"responses": responses}, expected_ids)
+
+
+def parse_provider_response(
+    raw_text: str,
+    expected_ids: Sequence[str],
+    response_format: str = "json",
+) -> list[dict[str, str]]:
+    """Accept a direct response or final assistant text from an NDJSON stream."""
+
+    _transport_protocol(response_format)
+    if response_format == "tagged":
+        candidate = raw_text
+        if not candidate.lstrip().startswith(("<<<UA-EVAL-RESPONSE", "```")):
+            candidate = _ndjson_assistant_text(raw_text)
+        return _parse_tagged_response(candidate, expected_ids)
+
+    try:
+        payload = _parse_exact_object(raw_text)
+        if set(payload) == {"responses"}:
+            return _validate_provider_payload(payload, expected_ids)
+    except RunnerError:
+        payload = None
+    if payload is None or set(payload) != {"responses"}:
+        payload = _parse_exact_object(_ndjson_assistant_text(raw_text))
+    return _validate_provider_payload(payload, expected_ids)
+
+
+def _subprocess_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _write_process_receipts(
+    invocation_cwd: Path,
+    *,
+    attempted_at: str,
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+) -> dict[str, Any]:
+    stdout_sha256 = _sha256_text(stdout)
+    stderr_sha256 = _sha256_text(stderr)
+    _publish_text(invocation_cwd / "stdout.txt", stdout)
+    _publish_text(invocation_cwd / "stderr.txt", stderr)
+    receipt = {
+        "attempted_at": attempted_at,
+        "finished_at": _now(),
+        "returncode": returncode,
+        "stdout_sha256": stdout_sha256,
+        "stderr_sha256": stderr_sha256,
+    }
+    _publish_text(
+        invocation_cwd / "process-receipt.json",
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return receipt
+
+
+def _write_acceptance_receipt(
+    invocation_cwd: Path,
+    *,
+    accepted: bool,
+    error_class: str | None = None,
+    message: str | None = None,
+) -> None:
+    receipt = {
+        "accepted": accepted,
+        "error_class": error_class,
+        "message": message,
+        "recorded_at": _now(),
+    }
+    _publish_text(
+        invocation_cwd / "acceptance-receipt.json",
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _state_path(state_dir: Path, batch_index: int) -> Path:
+    return state_dir / f"batch-{batch_index:04d}.json"
+
+
+def _load_state(
+    path: Path,
+    *,
+    binding_sha256: str,
+    batch_sha256: str,
+    expected_ids: Sequence[str],
+    response_format: str,
+) -> dict[str, Any]:
+    try:
+        state_text = path.read_text(encoding="utf-8")
+        state = json.loads(state_text)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError(f"cannot validate completed state {path.name}") from exc
+    required = {
+        "schema_version",
+        "binding_sha256",
+        "batch_sha256",
+        "raw_provider_output",
+        "raw_provider_output_sha256",
+        "responses",
+        "started_at",
+        "completed_at",
+        "attempts",
+        "failed_attempts",
+    }
+    if not isinstance(state, dict) or set(state) != required:
+        raise RunnerError(f"completed state schema mismatch: {path.name}")
+    if state["schema_version"] != STATE_SCHEMA:
+        raise RunnerError(f"completed state version mismatch: {path.name}")
+    if state["binding_sha256"] != binding_sha256:
+        raise RunnerError(f"completed state binding mismatch: {path.name}")
+    if state["batch_sha256"] != batch_sha256:
+        raise RunnerError(f"completed state batch mismatch: {path.name}")
+    if (
+        not isinstance(state["raw_provider_output"], str)
+        or _sha256_text(state["raw_provider_output"]) != state["raw_provider_output_sha256"]
+    ):
+        raise RunnerError(f"completed state raw output mismatch: {path.name}")
+    parsed = parse_provider_response(
+        state["raw_provider_output"],
+        expected_ids,
+        response_format,
+    )
+    if (
+        state["responses"] != parsed
+        or not isinstance(state["attempts"], int)
+        or state["attempts"] < 1
+        or not isinstance(state["failed_attempts"], list)
+        or len(state["failed_attempts"]) != state["attempts"] - 1
+    ):
+        raise RunnerError(f"completed state response mismatch: {path.name}")
+    state["state_sha256"] = _sha256_text(state_text)
+    return state
+
+
+def _run_one_batch(
+    batch_index: int,
+    batch: Sequence[Mapping[str, str]],
+    *,
+    instruction: str,
+    executable: str,
+    command_args: Sequence[str],
+    prompt_mode: str,
+    timeout: int,
+    retries: int,
+    environment: Mapping[str, str],
+    state_dir: Path,
+    binding_sha256: str,
+    response_format: str,
+) -> dict[str, Any]:
+    expected_ids = [row["item_id"] for row in batch]
+    batch_sha256 = _sha256_text(_canonical_json(list(batch)))
+    path = _state_path(state_dir, batch_index)
+    if path.exists():
+        return _load_state(
+            path,
+            binding_sha256=binding_sha256,
+            batch_sha256=batch_sha256,
+            expected_ids=expected_ids,
+            response_format=response_format,
+        )
+
+    prompt = _batch_prompt(instruction, batch, response_format)
+    failures: list[dict[str, Any]] = []
+    started_at = _now()
+    for attempt in range(1, retries + 2):
+        attempt_at = _now()
+        invocation_cwd: Path | None = None
+        process_receipt: dict[str, Any] | None = None
+        try:
+            invocation_cwd = Path(
+                tempfile.mkdtemp(
+                    prefix=f"ua-eval-model-{batch_index:04d}-{attempt:02d}-",
+                    dir=_temporary_parent(),
+                )
+            )
+            command = [executable, *command_args]
+            command_input: str | None = None
+            if prompt_mode == "argument":
+                command.append(prompt)
+            else:
+                command_input = prompt
+            result = subprocess.run(
+                command,
+                cwd=invocation_cwd,
+                env=dict(environment),
+                input=command_input,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            process_receipt = _write_process_receipts(
+                invocation_cwd,
+                attempted_at=attempt_at,
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+            if result.returncode:
+                raise RunnerError(f"provider command returned nonzero status {result.returncode}")
+            raw_output = result.stdout
+            responses = parse_provider_response(
+                raw_output,
+                expected_ids,
+                response_format,
+            )
+            _write_acceptance_receipt(invocation_cwd, accepted=True)
+            state = {
+                "schema_version": STATE_SCHEMA,
+                "binding_sha256": binding_sha256,
+                "batch_sha256": batch_sha256,
+                "raw_provider_output": raw_output,
+                "raw_provider_output_sha256": _sha256_text(raw_output),
+                "responses": responses,
+                "started_at": started_at,
+                "completed_at": _now(),
+                "attempts": attempt,
+                "failed_attempts": failures,
+            }
+            state_text = json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+            _publish_text(path, state_text)
+            return _load_state(
+                path,
+                binding_sha256=binding_sha256,
+                batch_sha256=batch_sha256,
+                expected_ids=expected_ids,
+                response_format=response_format,
+            )
+        except (RunnerError, subprocess.TimeoutExpired, OSError) as exc:
+            message = str(exc)
+            if isinstance(exc, OSError) and exc.errno == errno.E2BIG:
+                message = (
+                    "provider command exceeded the operating-system argument limit; "
+                    "use prompt mode stdin or a smaller batch size"
+                )
+            if invocation_cwd is not None and process_receipt is None:
+                process_receipt = _write_process_receipts(
+                    invocation_cwd,
+                    attempted_at=attempt_at,
+                    returncode=None,
+                    stdout=_subprocess_text(getattr(exc, "stdout", None)),
+                    stderr=_subprocess_text(getattr(exc, "stderr", None)),
+                )
+            if invocation_cwd is not None:
+                _write_acceptance_receipt(
+                    invocation_cwd,
+                    accepted=False,
+                    error_class=type(exc).__name__,
+                    message=message[-240:],
+                )
+            evidence = process_receipt or {
+                "stdout_sha256": _sha256_text(""),
+                "stderr_sha256": _sha256_text(""),
+            }
+            failures.append(
+                {
+                    "batch_index": batch_index,
+                    "attempt": attempt,
+                    "attempted_at": attempt_at,
+                    "error_class": type(exc).__name__,
+                    "message_tail": message[-240:],
+                    "invocation_directory_token": (invocation_cwd.name if invocation_cwd is not None else None),
+                    "stdout_sha256": evidence["stdout_sha256"],
+                    "stderr_sha256": evidence["stderr_sha256"],
+                }
+            )
+    raise RunnerError(f"batch {batch_index} exhausted {retries + 1} attempts")
+
+
+def run(
+    *,
+    requests_path: Path,
+    prompt_path: Path,
+    config_path: Path,
+    executable: str,
+    command_args: Sequence[str],
+    prompt_mode: str,
+    raw_output_path: Path,
+    output_path: Path,
+    metadata_path: Path,
+    state_dir: Path,
+    failed_output_path: Path | None = None,
+    batch_size: int = 40,
+    workers: int = 1,
+    timeout: int = 1800,
+    retries: int = 1,
+    response_format: str = "json",
+) -> None:
+    """Execute or resume a complete source-only model run."""
+
+    if batch_size < 1 or workers < 1 or timeout < 1 or retries < 0 or prompt_mode not in {"argument", "stdin"}:
+        raise RunnerError("batch, worker, timeout, retry, or prompt-mode bounds are invalid")
+    transport_protocol = _transport_protocol(response_format)
+    header, requests, packet_sha256 = load_source_only_packet(requests_path)
+    try:
+        instruction = prompt_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RunnerError("cannot read frozen instruction") from exc
+    if not instruction.strip() or _sha256_text(instruction) != header["prompt_sha256"]:
+        raise RunnerError("frozen instruction is empty or does not match the packet")
+    config = load_run_config(config_path)
+    command_hash = _sha256_text(
+        _canonical_json(
+            {
+                "executable": executable,
+                "arguments": list(command_args),
+                "prompt_mode": prompt_mode,
+            }
+        )
+    )
+    config_hash = _sha256_text(_canonical_json(config))
+    binding_sha256 = _sha256_text(
+        _canonical_json(
+            {
+                "packet": packet_sha256,
+                "prompt": header["prompt_sha256"],
+                "run_id": config["run_id"],
+                "model": config["model"],
+                "command": command_hash,
+                "config": config_hash,
+                "runner_version": RUNNER_VERSION,
+                "transport_protocol": transport_protocol,
+                "batch_size": batch_size,
+            }
+        )
+    )
+    batches = [
+        (index, requests[offset : offset + batch_size])
+        for index, offset in enumerate(range(0, len(requests), batch_size))
+    ]
+    state_dir.mkdir(parents=True, exist_ok=True)
+    completed: dict[int, dict[str, Any]] = {}
+    environment = _child_environment(config.get("auth_environment", []))
+    batch_iterator = iter(batches)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures: dict[Future[dict[str, Any]], int] = {}
+
+        def submit_next() -> bool:
+            try:
+                index, batch = next(batch_iterator)
+            except StopIteration:
+                return False
+            future = executor.submit(
+                _run_one_batch,
+                index,
+                batch,
+                instruction=instruction,
+                executable=executable,
+                command_args=command_args,
+                prompt_mode=prompt_mode,
+                timeout=timeout,
+                retries=retries,
+                environment=environment,
+                state_dir=state_dir,
+                binding_sha256=binding_sha256,
+                response_format=response_format,
+            )
+            futures[future] = index
+            return True
+
+        for _ in range(min(workers, len(batches))):
+            submit_next()
+        while futures:
+            done, _ = wait(futures, return_when=FIRST_COMPLETED)
+            for future in done:
+                index = futures.pop(future)
+                completed[index] = future.result()
+                submit_next()
+
+    raw_rows: list[dict[str, Any]] = []
+    normalized: list[dict[str, str]] = []
+    batch_receipts: list[dict[str, Any]] = []
+    failed_attempts: list[dict[str, Any]] = []
+    for index, batch in batches:
+        state = completed[index]
+        expected_ids = [row["item_id"] for row in batch]
+        responses = parse_provider_response(
+            state["raw_provider_output"],
+            expected_ids,
+            response_format,
+        )
+        raw_rows.append(
+            {
+                "batch_index": index,
+                "batch_sha256": state["batch_sha256"],
+                "raw_provider_output_sha256": state["raw_provider_output_sha256"],
+                "raw_provider_output": state["raw_provider_output"],
+            }
+        )
+        normalized.extend(responses)
+        failed_attempts.extend(state["failed_attempts"])
+        batch_receipts.append(
+            {
+                "batch_index": index,
+                "batch_sha256": state["batch_sha256"],
+                "raw_provider_output_sha256": state["raw_provider_output_sha256"],
+                "state_sha256": state["state_sha256"],
+                "attempts": state["attempts"],
+                "started_at": state["started_at"],
+                "completed_at": state["completed_at"],
+            }
+        )
+    response_ids = [row["item_id"] for row in normalized]
+    if response_ids != [row["item_id"] for row in requests] or len(set(response_ids)) != EXPECTED_REQUEST_COUNT:
+        raise RunnerError("final aggregation does not exactly cover the request packet")
+
+    raw_text = "".join(_canonical_json(row) + "\n" for row in raw_rows)
+    output_text = "".join(_canonical_json(row) + "\n" for row in normalized)
+    failed_rows: list[dict[str, Any]] = []
+    for failure in failed_attempts:
+        token = failure["invocation_directory_token"]
+        if not isinstance(token, str) or not token.startswith("ua-eval-model-"):
+            raise RunnerError("failed attempt has an invalid invocation token")
+        invocation_dir = _temporary_parent() / token
+        try:
+            stdout = (invocation_dir / "stdout.txt").read_text(encoding="utf-8")
+            stderr = (invocation_dir / "stderr.txt").read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RunnerError("cannot read retained failed-attempt output") from exc
+        if _sha256_text(stdout) != failure["stdout_sha256"] or _sha256_text(stderr) != failure["stderr_sha256"]:
+            raise RunnerError("retained failed-attempt output hash mismatch")
+        failed_rows.append(
+            {
+                **failure,
+                "raw_provider_output": stdout,
+                "provider_stderr": stderr,
+            }
+        )
+    failed_text = "".join(_canonical_json(row) + "\n" for row in failed_rows)
+    _publish_text(raw_output_path, raw_text)
+    _publish_text(output_path, output_text)
+    if failed_output_path is not None and failed_rows:
+        _publish_text(failed_output_path, failed_text)
+    generation_metadata = {
+        "route": config["route"],
+        "alias_resolution": config["alias_resolution"],
+        "command_identity": config["command_identity"],
+        "command_sha256": command_hash,
+        "config_sha256": config_hash,
+        "request_packet_sha256": packet_sha256,
+        "prompt_sha256": header["prompt_sha256"],
+        "request_schema": REQUEST_SCHEMA,
+        "transport_protocol": transport_protocol,
+        "response_count": len(normalized),
+        "response_ids_sha256": _sha256_text(_canonical_json(response_ids)),
+        "raw_output_sha256": _sha256_text(raw_text),
+        "model_output_sha256": _sha256_text(output_text),
+        "batch_size": batch_size,
+        "workers": workers,
+        "timeout_seconds": timeout,
+        "prompt_mode": prompt_mode,
+        "run_started_at": min(receipt["started_at"] for receipt in batch_receipts),
+        "generated_at": max(receipt["completed_at"] for receipt in batch_receipts),
+        "gold_fields_supplied": [],
+        "batch_receipts": batch_receipts,
+        "retry_counts": {str(receipt["batch_index"]): receipt["attempts"] - 1 for receipt in batch_receipts},
+        "failed_attempts": failed_attempts,
+        "response_normalization": [
+            "extract final assistant text from a recognized NDJSON event when needed",
+            "remove one exact optional transport code fence before schema validation",
+        ],
+        "isolation": ("each provider invocation used a retained working directory outside the repository"),
+    }
+    metadata = {
+        "schema_version": METADATA_SCHEMA,
+        "run_id": config["run_id"],
+        "provider": config["provider"],
+        "model": config["model"],
+        "model_version": config["model_version"],
+        "decoding": config["decoding"],
+        "runner_version": RUNNER_VERSION,
+        "generation_metadata": generation_metadata,
+    }
+    _publish_text(
+        metadata_path,
+        json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", type=Path, required=True)
+    parser.add_argument("--prompt", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--executable", required=True)
+    parser.add_argument("--command-arg", action="append", default=[])
+    parser.add_argument(
+        "--prompt-mode",
+        choices=["argument", "stdin"],
+        default="argument",
+    )
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--metadata-output", type=Path, required=True)
+    parser.add_argument("--failed-output", type=Path)
+    parser.add_argument("--state-dir", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=40)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument(
+        "--response-format",
+        choices=["json", "tagged"],
+        default="json",
+    )
+    args = parser.parse_args(argv)
+    try:
+        run(
+            requests_path=args.requests,
+            prompt_path=args.prompt,
+            config_path=args.config,
+            executable=args.executable,
+            command_args=args.command_arg,
+            prompt_mode=args.prompt_mode,
+            raw_output_path=args.raw_output,
+            output_path=args.output,
+            metadata_path=args.metadata_output,
+            state_dir=args.state_dir,
+            failed_output_path=args.failed_output,
+            batch_size=args.batch_size,
+            workers=args.workers,
+            timeout=args.timeout,
+            retries=args.retries,
+            response_format=args.response_format,
+        )
+    except (RunnerError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ua_eval_model_runner.py
+++ b/tests/test_ua_eval_model_runner.py
@@ -1,0 +1,582 @@
+"""Tests for the provider-neutral, source-only UA evaluation model runner."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.ua_eval_harness import run_model_batch as runner
+from scripts.projects.ua_eval_harness.evaluate_model import (
+    import_model_responses,
+    load_manifest,
+    load_saved_responses,
+    prepare_requests,
+)
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _write_once(path: Path, text: str) -> None:
+    if path.exists():
+        assert path.read_text(encoding="utf-8") == text
+        return
+    path.write_text(text, encoding="utf-8")
+
+
+def _packet(tmp_path: Path, *, extra_field: str | None = None) -> tuple[Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    prompt = tmp_path / "prompt.txt"
+    _write_once(prompt, "Correct each source sentence.")
+    prompt_sha = _sha(prompt.read_text(encoding="utf-8"))
+    header = {
+        "type": "request_run",
+        "schema_version": runner.REQUEST_SCHEMA,
+        "manifest_id": "public-test-packet",
+        "manifest_payload_sha256": "a" * 64,
+        "prompt_path": "public/prompt.txt",
+        "prompt_sha256": prompt_sha,
+        "input_fields": ["item_id", "source", "source_sha256", "prompt_sha256"],
+        "gold_fields_supplied": [],
+        "request_count": runner.EXPECTED_REQUEST_COUNT,
+    }
+    rows: list[dict[str, object]] = [header]
+    for number in range(runner.EXPECTED_REQUEST_COUNT):
+        source = f"source sentence {number}"
+        payload = {
+            "item_id": f"item-{number:04d}",
+            "source": source,
+            "source_sha256": _sha(source),
+            "prompt_sha256": prompt_sha,
+        }
+        row = {
+            "type": "request",
+            **payload,
+            "request_sha256": _sha(_canonical(payload)),
+        }
+        if number == 0 and extra_field:
+            row[extra_field] = "forbidden"
+        rows.append(row)
+    path = tmp_path / "requests.jsonl"
+    _write_once(path, "".join(_canonical(row) + "\n" for row in rows))
+    return path, prompt
+
+
+def _config(tmp_path: Path, **overrides: object) -> Path:
+    config: dict[str, object] = {
+        "schema_version": runner.CONFIG_SCHEMA,
+        "run_id": "public-test-run",
+        "provider": "test-provider",
+        "route": "test-route",
+        "model": "test-model",
+        "model_version": "test-revision",
+        "alias_resolution": {
+            "requested": "test-model",
+            "resolved": "test-revision",
+            "evidence": "test fixture",
+        },
+        "command_identity": {"name": "fake-provider", "version": "1.0"},
+        "decoding": {
+            "temperature": "not_exposed",
+            "top_p": "not_exposed",
+            "top_k": "not_exposed",
+            "seed": "not_exposed",
+            "max_output_tokens": "not_exposed",
+            "stop": "not_exposed",
+            "safety": "not_exposed",
+        },
+        "auth_environment": ["FAKE_LOG", "FAKE_MODE"],
+    }
+    config.update(overrides)
+    path = tmp_path / "config.json"
+    _write_once(path, json.dumps(config))
+    return path
+
+
+def _fake_script(tmp_path: Path) -> Path:
+    path = tmp_path / "fake_provider.py"
+    _write_once(
+        path,
+        """import json
+import os
+import pathlib
+import sys
+
+log = pathlib.Path(os.environ["FAKE_LOG"])
+old = log.read_text() if log.exists() else ""
+log.write_text(old + os.getcwd() + "\\n")
+mode = os.environ.get("FAKE_MODE", "success")
+if mode == "fail_first" and not old:
+    raise SystemExit(9)
+if mode == "malformed":
+    print("not json")
+    raise SystemExit(0)
+prompt = sys.stdin.read() if os.environ.get("FAKE_STDIN") else sys.argv[-1]
+data = json.loads(prompt.split("\\n\\n", 1)[1])
+responses = [
+    {"item_id": row["item_id"], "raw_response": row["source"]}
+    for row in data["records"]
+]
+if mode == "duplicate":
+    responses[1]["item_id"] = responses[0]["item_id"]
+if mode == "missing":
+    responses.pop()
+if mode == "unknown":
+    responses[0]["item_id"] = "unknown-id"
+if mode == "out_of_order":
+    responses.reverse()
+if mode == "extra":
+    responses[0]["extra"] = "no"
+payload = {"responses": responses}
+text = json.dumps(payload, ensure_ascii=False)
+if mode in {"ndjson", "fenced_ndjson", "opencode_ndjson"}:
+    if mode == "fenced_ndjson":
+        text = "```json\\n" + text + "\\n```"
+    if mode == "opencode_ndjson":
+        text = "```json\\n" + text + "\\n```"
+        event = {
+            "type": "text",
+            "part": {"type": "text", "text": text},
+        }
+    else:
+        event = {
+            "type": "event",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+    print(json.dumps(event))
+elif mode in {"tagged", "tagged_fence"}:
+    tagged = "\\n".join(
+        f'<<<UA-EVAL-RESPONSE item_id={row["item_id"]}>>>'
+        f'\\n{row["raw_response"]}\\n<<<UA-EVAL-END>>>'
+        for row in responses
+    )
+    if mode == "tagged_fence":
+        tagged = "```text\\n" + tagged + "\\n```"
+    event = {"type": "text", "part": {"type": "text", "text": tagged}}
+    print(json.dumps(event))
+elif mode == "thought":
+    print("<think>provider trace</think>" + text)
+else:
+    print(text)
+""",
+    )
+    return path
+
+
+def _venv_python() -> Path:
+    executable = Path(".venv/bin/python").resolve()
+    assert executable.is_file(), "tests require the repository .venv/bin/python"
+    return executable
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    mode: str = "success",
+    retries: int = 0,
+    batch_size: int = 677,
+    prompt_mode: str = "argument",
+    response_format: str = "json",
+) -> tuple[Path, Path, Path, Path]:
+    requests, prompt = _packet(tmp_path)
+    environment = {
+        "FAKE_MODE": mode,
+    }
+    config_overrides: dict[str, object] = {}
+    if prompt_mode == "stdin":
+        environment["FAKE_STDIN"] = "1"
+        config_overrides["auth_environment"] = [
+            "FAKE_LOG",
+            "FAKE_MODE",
+            "FAKE_STDIN",
+        ]
+    config = _config(tmp_path, **config_overrides)
+    script = _fake_script(tmp_path)
+    log = tmp_path / "calls.log"
+    environment["FAKE_LOG"] = str(log)
+    previous = {name: os.environ.get(name) for name in environment}
+    os.environ.update(environment)
+    raw = tmp_path / "raw.jsonl"
+    output = tmp_path / "output.jsonl"
+    metadata = tmp_path / "metadata.json"
+    state = tmp_path / "state"
+    try:
+        runner.run(
+            requests_path=requests,
+            prompt_path=prompt,
+            config_path=config,
+            executable=str(_venv_python()),
+            command_args=[str(script.resolve())],
+            prompt_mode=prompt_mode,
+            raw_output_path=raw,
+            output_path=output,
+            metadata_path=metadata,
+            state_dir=state,
+            failed_output_path=tmp_path / "failed.jsonl",
+            batch_size=batch_size,
+            workers=1,
+            timeout=10,
+            retries=retries,
+            response_format=response_format,
+        )
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    return raw, output, metadata, state
+
+
+@pytest.mark.parametrize("prompt_mode", ["argument", "stdin"])
+def test_runs_source_only_batches_outside_repository_and_writes_metadata(
+    tmp_path: Path,
+    prompt_mode: str,
+) -> None:
+    raw, output, metadata_path, _ = _run(
+        tmp_path,
+        mode="ndjson",
+        batch_size=300,
+        prompt_mode=prompt_mode,
+    )
+
+    outputs = [json.loads(line) for line in output.read_text().splitlines()]
+    raw_rows = [json.loads(line) for line in raw.read_text().splitlines()]
+    metadata = json.loads(metadata_path.read_text())
+    generation = metadata["generation_metadata"]
+    assert len(outputs) == runner.EXPECTED_REQUEST_COUNT
+    assert len(raw_rows) == 3
+    assert metadata["schema_version"] == runner.METADATA_SCHEMA
+    assert metadata["run_id"] == "public-test-run"
+    assert set(metadata["decoding"]) == runner.DECODING_FIELDS
+    assert generation["gold_fields_supplied"] == []
+    assert generation["response_count"] == runner.EXPECTED_REQUEST_COUNT
+    assert generation["transport_protocol"] == runner.JSON_TRANSPORT_PROTOCOL
+    assert len(generation["batch_receipts"]) == 3
+    assert generation["retry_counts"] == {"0": 0, "1": 0, "2": 0}
+    call_paths = (tmp_path / "calls.log").read_text().splitlines()
+    assert call_paths
+    assert all(not Path(path).resolve().is_relative_to(runner.ROOT) for path in call_paths)
+    assert all(Path(path).is_dir() for path in call_paths)
+
+
+def test_packet_firewall_rejects_unknown_and_gold_shaped_fields(
+    tmp_path: Path,
+) -> None:
+    for field in ("unexpected", "target"):
+        requests, _ = _packet(tmp_path / field, extra_field=field)
+        with pytest.raises(runner.RunnerError):
+            runner.load_source_only_packet(requests)
+
+
+def test_committed_packet_and_example_config_match_runner_contract() -> None:
+    packet = Path("data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl")
+    header, requests, packet_sha256 = runner.load_source_only_packet(packet)
+    config = runner.load_run_config(Path("data/projects/ua_eval_harness/model_run_config.example.json"))
+
+    assert header["request_count"] == runner.EXPECTED_REQUEST_COUNT
+    assert len(requests) == runner.EXPECTED_REQUEST_COUNT
+    assert len(packet_sha256) == 64
+    assert config["schema_version"] == runner.CONFIG_SCHEMA
+    assert set(config["decoding"]) == runner.DECODING_FIELDS
+
+
+def test_run_config_requires_exact_alias_decoding_and_tool_receipts(
+    tmp_path: Path,
+) -> None:
+    for index, override in enumerate(
+        (
+            {"alias_resolution": "ambiguous"},
+            {"decoding": {"temperature": 0}},
+            {"command_identity": {"name": "missing-version"}},
+        )
+    ):
+        config_dir = tmp_path / str(index)
+        config_dir.mkdir()
+        config = _config(config_dir, **override)
+        with pytest.raises(runner.RunnerError):
+            runner.load_run_config(config)
+
+
+def test_accepts_only_narrow_machine_response_wrappers() -> None:
+    payload = '{"responses":[{"item_id":"item-1","raw_response":"fixed"}]}'
+    assert runner.parse_provider_response(
+        f"<think>provider trace</think>{payload}",
+        ["item-1"],
+    ) == [{"item_id": "item-1", "raw_response": "fixed"}]
+    for fenced in (f"```json\n{payload}\n```", f"```json\n{payload}```"):
+        assert runner.parse_provider_response(
+            fenced,
+            ["item-1"],
+        ) == [{"item_id": "item-1", "raw_response": "fixed"}]
+    with pytest.raises(runner.RunnerError):
+        runner.parse_provider_response(f"Explanation: {payload}", ["item-1"])
+    with pytest.raises(runner.RunnerError):
+        runner.parse_provider_response(
+            f"```json\n{payload}\n```\nExplanation",
+            ["item-1"],
+        )
+
+
+def test_batch_transport_declares_unambiguous_json_escaping() -> None:
+    prompt = runner._batch_prompt(
+        "Correct the sentence.",
+        [{"item_id": "item-1", "source": 'A "quoted" source.'}],
+    )
+    envelope, payload = prompt.split("\n\n", 1)
+    assert "JSON Unicode escape \\u0022" in envelope
+    assert "every backslash character as \\u005c" in envelope
+    assert json.loads(payload)["records"] == [
+        {"item_id": "item-1", "source": 'A "quoted" source.'},
+    ]
+
+
+@pytest.mark.parametrize("mode", ["tagged", "tagged_fence"])
+def test_tagged_transport_preserves_sentence_characters(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    raw, output, metadata_path, _ = _run(
+        tmp_path,
+        mode=mode,
+        response_format="tagged",
+    )
+    assert len(raw.read_text().splitlines()) == 1
+    outputs = [json.loads(line) for line in output.read_text().splitlines()]
+    assert len(outputs) == runner.EXPECTED_REQUEST_COUNT
+    assert outputs[0]["raw_response"] == "source sentence 0"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["generation_metadata"]["transport_protocol"] == runner.TAGGED_TRANSPORT_PROTOCOL
+
+
+def test_tagged_transport_rejects_wrong_order_and_extra_text() -> None:
+    valid = '<<<UA-EVAL-RESPONSE item_id=item-1>>>\nA "quoted" sentence with a backslash \\\\.\n<<<UA-EVAL-END>>>'
+    assert runner.parse_provider_response(
+        valid,
+        ["item-1"],
+        "tagged",
+    ) == [
+        {
+            "item_id": "item-1",
+            "raw_response": 'A "quoted" sentence with a backslash \\\\.',
+        }
+    ]
+    with pytest.raises(runner.RunnerError):
+        runner.parse_provider_response(
+            f"{valid}\nExplanation",
+            ["item-1"],
+            "tagged",
+        )
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["malformed", "duplicate", "missing", "unknown", "out_of_order", "extra"],
+)
+def test_rejects_nonexact_responses_without_final_outputs(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    with pytest.raises(runner.RunnerError):
+        _run(tmp_path, mode=mode)
+    assert not (tmp_path / "raw.jsonl").exists()
+    assert not (tmp_path / "output.jsonl").exists()
+    assert not (tmp_path / "metadata.json").exists()
+    call_paths = (tmp_path / "calls.log").read_text().splitlines()
+    assert call_paths and all(Path(path).is_dir() for path in call_paths)
+
+
+def test_retries_and_preserves_failure_receipts(tmp_path: Path) -> None:
+    _, _, metadata_path, state_dir = _run(
+        tmp_path,
+        mode="fail_first",
+        retries=1,
+    )
+    metadata = json.loads(metadata_path.read_text())
+    generation = metadata["generation_metadata"]
+    assert generation["retry_counts"] == {"0": 1}
+    assert len(generation["failed_attempts"]) == 1
+    failed = generation["failed_attempts"][0]
+    assert failed == {
+        "batch_index": 0,
+        "attempt": 1,
+        "attempted_at": failed["attempted_at"],
+        "error_class": "RunnerError",
+        "message_tail": "provider command returned nonzero status 9",
+        "invocation_directory_token": failed["invocation_directory_token"],
+        "stdout_sha256": _sha(""),
+        "stderr_sha256": _sha(""),
+    }
+    state = json.loads((state_dir / "batch-0000.json").read_text())
+    assert state["failed_attempts"] == generation["failed_attempts"]
+    failed_rows = [json.loads(line) for line in (tmp_path / "failed.jsonl").read_text().splitlines()]
+    assert len(failed_rows) == 1
+    assert failed_rows[0]["raw_provider_output"] == ""
+    assert failed_rows[0]["provider_stderr"] == ""
+    invocation_paths = [Path(path) for path in (tmp_path / "calls.log").read_text().splitlines()]
+    assert len(invocation_paths) == 2
+    for path in invocation_paths:
+        assert (path / "stdout.txt").is_file()
+        assert (path / "stderr.txt").is_file()
+        assert (path / "process-receipt.json").is_file()
+        acceptance = json.loads((path / "acceptance-receipt.json").read_text())
+        assert acceptance["accepted"] is (path == invocation_paths[-1])
+
+
+def test_accepts_fenced_json_and_preserves_raw_provider_output(tmp_path: Path) -> None:
+    raw, output, metadata_path, _ = _run(
+        tmp_path,
+        mode="opencode_ndjson",
+    )
+    raw_row = json.loads(raw.read_text())
+    assert "```json" in raw_row["raw_provider_output"]
+    assert len(output.read_text().splitlines()) == runner.EXPECTED_REQUEST_COUNT
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["generation_metadata"]["response_normalization"] == [
+        "extract final assistant text from a recognized NDJSON event when needed",
+        "remove one exact optional transport code fence before schema validation",
+    ]
+
+
+def test_stops_scheduling_after_first_exhausted_batch(tmp_path: Path) -> None:
+    with pytest.raises(runner.RunnerError, match="batch 0 exhausted"):
+        _run(
+            tmp_path,
+            mode="malformed",
+            batch_size=300,
+        )
+    assert len((tmp_path / "calls.log").read_text().splitlines()) == 1
+
+
+def test_argument_limit_failure_is_retained_with_portable_guidance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation_parent = tmp_path / "invocations"
+    invocation_parent.mkdir()
+    monkeypatch.setattr(runner, "_temporary_parent", lambda: invocation_parent)
+
+    def fail_to_start(*args: object, **kwargs: object) -> None:
+        raise OSError(errno.E2BIG, "Argument list too long")
+
+    monkeypatch.setattr(runner.subprocess, "run", fail_to_start)
+    with pytest.raises(runner.RunnerError, match="batch 0 exhausted"):
+        _run(tmp_path, batch_size=677)
+
+    invocation_dirs = list(invocation_parent.glob("ua-eval-model-*"))
+    assert len(invocation_dirs) == 1
+    acceptance = json.loads(
+        (invocation_dirs[0] / "acceptance-receipt.json").read_text()
+    )
+    assert acceptance["accepted"] is False
+    assert acceptance["error_class"] == "OSError"
+    assert acceptance["message"] == (
+        "provider command exceeded the operating-system argument limit; "
+        "use prompt mode stdin or a smaller batch size"
+    )
+
+
+def test_resume_is_idempotent_and_does_not_reinvoke_provider(tmp_path: Path) -> None:
+    raw, output, metadata, state = _run(tmp_path)
+    calls_before = (tmp_path / "calls.log").read_text()
+    artifacts_before = {path: path.read_bytes() for path in (raw, output, metadata, state / "batch-0000.json")}
+    _run(tmp_path)
+    assert (tmp_path / "calls.log").read_text() == calls_before
+    assert {path: path.read_bytes() for path in artifacts_before} == artifacts_before
+
+
+def test_completed_state_binding_mismatch_is_a_hard_failure(tmp_path: Path) -> None:
+    raw, output, metadata, state = _run(tmp_path)
+    requests, prompt = _packet(tmp_path)
+    different_config = tmp_path / "different-config"
+    different_config.mkdir()
+    config = _config(different_config, model="different-model")
+    script = _fake_script(tmp_path)
+    with pytest.raises(runner.RunnerError, match="binding mismatch"):
+        runner.run(
+            requests_path=requests,
+            prompt_path=prompt,
+            config_path=config,
+            executable=str(_venv_python()),
+            command_args=[str(script.resolve())],
+            prompt_mode="argument",
+            raw_output_path=raw,
+            output_path=output,
+            metadata_path=metadata,
+            state_dir=state,
+            batch_size=677,
+            timeout=10,
+        )
+
+
+def test_runner_metadata_imports_and_saved_response_validates(tmp_path: Path) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    requests = prepare_requests()
+    requests_path.write_text(
+        "".join(_canonical(row) + "\n" for row in requests),
+        encoding="utf-8",
+    )
+    prompt = Path("data/projects/ua_eval_harness/minimal_edit_prompt_v1.txt").resolve()
+    config = _config(
+        tmp_path,
+        auth_environment=["FAKE_LOG", "FAKE_MODE", "FAKE_STDIN"],
+    )
+    script = _fake_script(tmp_path)
+    log = tmp_path / "calls.log"
+    previous = {
+        "FAKE_LOG": os.environ.get("FAKE_LOG"),
+        "FAKE_STDIN": os.environ.get("FAKE_STDIN"),
+    }
+    os.environ.update({"FAKE_LOG": str(log), "FAKE_STDIN": "1"})
+    raw = tmp_path / "raw.jsonl"
+    output = tmp_path / "output.jsonl"
+    metadata = tmp_path / "metadata.json"
+    state = tmp_path / "state"
+    try:
+        runner.run(
+            requests_path=requests_path,
+            prompt_path=prompt,
+            config_path=config,
+            executable=str(_venv_python()),
+            command_args=[str(script.resolve())],
+            prompt_mode="stdin",
+            raw_output_path=raw,
+            output_path=output,
+            metadata_path=metadata,
+            state_dir=state,
+            batch_size=677,
+            timeout=10,
+        )
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    imported = import_model_responses(
+        requests_path=requests_path,
+        model_output_path=output,
+        metadata_path=metadata,
+    )
+    saved = tmp_path / "saved.jsonl"
+    saved.write_text(
+        "".join(_canonical(row) + "\n" for row in imported),
+        encoding="utf-8",
+    )
+    manifest, items = load_manifest()
+    header, responses = load_saved_responses(saved, manifest=manifest, items=items)
+    assert header["generation_metadata"]["route"] == "test-route"
+    assert len(responses) == runner.EXPECTED_REQUEST_COUNT


### PR DESCRIPTION
## What changed

- adds the source-only, provider-neutral batch runner and public run-config schema/example
- preserves raw provider output, normalized responses, retry evidence, and immutable per-attempt receipts separately
- supports strict JSON and tagged transports without exposing held-out gold
- documents generation and import commands for external researchers
- makes Linux argument-limit failures explicit and retained, while validating full 677-response import through portable stdin transport

## Why

The public 0.1.1 package needs a provider-independent generation path with complete provenance. The first runner candidate also exposed a Linux-only `E2BIG` failure when a full packet was passed as one command argument; this replacement fixes that root cause before the release freeze is generated.

## Impact

Researchers can invoke any command-line model provider, resume interrupted runs, inspect raw/retry evidence, and import an exact 677-item response set without access to scoring gold.

## Validation

- `23 passed` in `tests/test_ua_eval_model_runner.py`
- Ruff clean on the runner and tests
- public-document language gate passed
- JSON schemas parsed
- Markdown lint passed
- OPSEC lint and `git diff --check` passed
- all commits carry `X-Agent` trailers

Part of #6012 (stream epic #2156). Supersedes the runner portions of #6021 and #6025.