### PR TITLE
docs(eval): publish researcher-facing English surface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,6 +136,18 @@ repos:
         files: ^site/src/content/docs/.*\.mdx$
         stages: [pre-commit]
 
+      - id: check-ua-eval-public-doc-language
+        name: check public UA-eval English document language
+        entry: >-
+          bash scripts/pre_commit/project_python.sh
+          scripts/audit/check_ua_eval_public_doc_language.py --files
+        language: system
+        files: >-
+          (?x)^docs/projects/ua-eval-harness/
+          (DATA_CARD\.en|README|RELEASE_NOTES|REPRODUCING|THIRD_PARTY_NOTICES|
+          contamination-policy)\.md$
+        stages: [pre-commit]
+
       - id: check-mdx-forward-parity
         name: check forward MDX parity
         entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_mdx_forward_parity.py --files

--- a/docs/projects/ua-eval-harness/DATA_CARD.en.md
+++ b/docs/projects/ua-eval-harness/DATA_CARD.en.md
@@ -171,8 +171,8 @@ parser can also preserve comment-level dialect evidence. The release therefore
 does not claim that the dataset has no dialect conflicts. It makes no automatic
 regional exclusion, and any unresolved register, heritage, regional, or
 dialect-sensitive case stays outside headline calque scoring. Broader
-contextual activation of dictionary markers remains tracked in
-[issue #5092](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5092).
+contextual activation of dictionary markers is outside this release, and
+unresolved cases fail closed.
 
 This conservative boundary affects only the headline calque claim. Overall
 exact-edit metrics continue to report performance over all selected UA-GEC
@@ -219,9 +219,9 @@ It is not suitable for:
   cultural appropriateness, or human language competence;
 - drawing conclusions about individual authors or source-language groups;
 - grading learners, hiring, or other high-stakes decisions;
-- training, fine-tuning, synthetic corruption, preference data, or DPO;
-- serving as content for Daily Practice, Hramatka, teacher-feedback
-  inventories, Atlas, private regression sets, or private canaries.
+- training, fine-tuning, synthetic corruption, or preference data;
+- serving as learner exercises, teacher-feedback inventories, private
+  regression corpora, or non-public application state.
 
 ## Limitations
 
@@ -278,10 +278,10 @@ exclude item text, IDs, edits, raw responses, and content hashes.
 
 Public held-out source text, gold targets, IDs, hashes, and derived rules must
 not enter training or fine-tuning data, synthetic-data or preference-data
-pipelines, Daily Practice, Hramatka, teacher-feedback inventories, Atlas,
-private product data, regression sets, or canaries. A discovered leak is a
-contamination incident: the affected release requires a recorded incident, a
-new version, a new extraction, new baselines, and a new freeze.
+pipelines, learner exercises, teacher-feedback inventories, non-public
+application data, or regression corpora. A discovered leak is a contamination
+incident: the affected release requires a recorded incident, a new version, a
+new extraction, new baselines, and a new freeze.
 
 The complete restrictions and disclosures are in the
 [contamination policy](contamination-policy.md).

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -1,318 +1,192 @@
-# Ukrainian calque + grammar evaluation
+# Ukrainian minimal-edit correction benchmark
 
-> **Canonical tracker:** [GitHub epic #2156](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2156)
->
-> **Verified status (2026-07-28):** the 52 train-derived rows remain development
-> fixtures only. The public lane now has a 677-item held-out manifest, a
-> source-only saved-response interface, exact edit P/R/F0.5 scoring, and
-> reproducible baseline receipts. It is not a leaderboard.
+This package evaluates systems that make minimal corrections to Ukrainian
+calques and grammar. It contains a deterministic 677-sentence evaluation set,
+a source-only request format, saved baseline responses, an exact-edit scorer,
+and cryptographic receipts for independent verification.
 
-## Mission
+The package is intended for research and system evaluation. It is not a
+leaderboard, a training corpus, a general measure of Ukrainian-language
+quality, or an assessment of any person.
 
-Build a reproducible public minimal-edit correction evaluation for Ukrainian
-calques and grammar from UA-GEC. The final package must provide deterministic
-gold extraction, standard edit scoring, version-pinned baselines, and a
-stranger-runnable release without private product data or provider secrets.
+## Release status
 
-The accepted project direction is:
+Release `0.1.0` is the current immutable freeze. Release `0.1.1` is a
+corrective packaging release in preparation: it preserves the dataset, task,
+scorer, and `0.1.0` results while improving the public documentation,
+provenance, and model-response workflow. See
+[RELEASE_NOTES.md](RELEASE_NOTES.md) for the exact boundary.
 
-- no dedicated Ukrainian calque harness is known;
-- UA-GEC reuse is welcome;
-- the evaluation set is the highest priority;
-- a reproducible baseline harness is a close second.
+## Start here
 
-The project does not create a broad Ukrainian leaderboard or composite
-"Ukrainian quality" score.
+The six authoritative English documents are:
 
-## Verified capability truth
+- [README.md](README.md): package map and quick start;
+- [DATA_CARD.en.md](DATA_CARD.en.md): dataset, metrics, limitations, and
+  baseline interpretation;
+- [REPRODUCING.md](REPRODUCING.md): complete verification and evaluation
+  commands;
+- [contamination-policy.md](contamination-policy.md): freeze and prohibited
+  reuse policy;
+- [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md): source, license, and
+  attribution evidence;
+- [RELEASE_NOTES.md](RELEASE_NOTES.md): versioned changes and compatibility.
 
-Repository inspection on 2026-07-28 established:
+Files required to verify or score the benchmark are under:
 
-- `data/projects/ua_eval_harness/evalset_v1.jsonl` contains 52 rows:
-  32 `F/Calque`, 12 `G/Case`, and 8 `G/Gender`;
-- all 52 source items are from UA-GEC train partitions
-  (`gec-fluency/train` or `gec-only/train`), not an upstream held-out split;
-- `compile_evalset.py` reads a pre-curated local 52-item source and does not
-  apply a frozen upstream eligibility, split, or exclusion predicate;
-- heritage protection is a five-token hard-coded seed, not a versioned
-  VESUM/heritage integration, and no current row exercises it;
-- the former mock-only evaluator and custom substring metric were prototype
-  behavior and have been replaced by the saved-response scorer described
-  below.
+- `data/projects/ua_eval_harness/`: frozen data, task contracts, saved
+  responses, score reports, and release manifests;
+- `scripts/projects/ua_eval_harness/`: extraction, validation, scoring, and
+  smoke-test commands.
 
-The 52 rows may be used for parser/scorer development and regression only.
-They are never included in held-out scores. The deterministic fixture-rule
-baseline is the only v1 component that reads them, and its fixture-file hash is
-recorded in the saved-run header.
+Most repository content is unrelated to this benchmark and can be ignored.
+In particular, development notes, archived translations, website code,
+curriculum material, and quality-gate documentation are not part of the
+research package or its frozen release.
 
-The public held-out extraction manifest is separate:
+## Quick verification
 
-- `heldout_manifest_config.json` pins UA-GEC commit
-  `4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`, CC BY 4.0 evidence,
-  metadata, and the `gec-fluency/test` M2 file by SHA-256;
-- `heldout_manifest_v1.json` accounts for all 2,690 upstream test sentences:
-  677 included calque/grammar records and 2,013 exclusion receipts;
-- all 166 test documents and 76 test authors are preserved, with zero author
-  overlap against the upstream train split.
-
-Historical receipts remain useful but bounded:
-
-- [issue #5608](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5608)
-  and [PR #5610](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5610)
-  delivered the local compiler prototype;
-- [PR #5633](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5633)
-  delivered the mock-only evaluator prototype.
-
-Their closed/merged states do not prove that a public benchmark or live
-baseline harness exists.
-
-## Frozen task direction
-
-The target is minimal-edit Ukrainian sentence correction:
-
-1. Model input contains the source sentence and versioned task instruction.
-2. Gold targets and edit spans are never model inputs.
-3. Model responses are saved before scoring.
-4. A standard edit scorer reports precision, recall, and F0.5.
-5. Exact corrected-sentence accuracy is a companion metric.
-6. Results report per-tag support, uncertainty, unchanged output, and
-   over-editing.
-
-The public set is derived from the pinned UA-GEC `gec-fluency/test` split.
-The frozen predicate includes every tokenized sentence with an `F/Calque` or
-`G/*` edit and applies only those edits per annotator. Final size is an
-observed result, not a quota. The manifest preserves upstream sentence
-locators, writer/document splits, original tags, attribution,
-source/reference hashes, and explicit inclusion/exclusion reasons.
-
-`F/Calque` remains an unchanged **UA-GEC standardization label**, not a claim
-that this benchmark independently adjudicated every source form as a calque.
-The separate `scoring_dispositions_v1.json` records the benchmark decision for
-all 354 annotator-level `F/Calque` edits (293 unique spans). Its hash-locked
-dict_uk/VESUM v6.8.0 probe finds 49 unique spans with exact style-marker
-collisions: 34 `bad`, 10 `slang`, 3 `arch`, and 2 `rare`. The release admits
-338 annotations to headline calque recall and fails closed on 16:
-
-- 3 are conversational/register standardizations;
-- 2 are heritage conflicts;
-- 11 remain contested.
-
-Attestation or a style marker is evidence, not automatic contextual
-adjudication. In particular, the shared surface `була` is not heritage-flagged:
-the `arch` analysis belongs to adjective `булий`, while the sentence uses the
-clean verb analysis `бути`. The committed receipts and tests cover that
-morphological collision, the bounded `тьоті`, `кришею`, `рижого`, and
-`Спікери` decisions, all 10 slang collisions, upstream-label preservation, and
-fail-closed abstention. Full contextual marker activation remains tracked by
-issue #5092; no five-token seed participates in public scoring.
-
-Verify the committed artifact without an upstream checkout:
+Requirements are Git, `uv`, and CPython 3.12.8. Verification does not require a
+model-provider account or credential.
 
 ```bash
-.venv/bin/python scripts/projects/ua_eval_harness/build_heldout_manifest.py \
-  --verify-existing
-```
-
-Reproduce it from the exact pinned UA-GEC checkout:
-
-```bash
-.venv/bin/python scripts/projects/ua_eval_harness/build_heldout_manifest.py \
-  --ua-gec-root /path/to/ua-gec \
-  --check
-```
-
-## Saved-response runner and standard scoring
-
-`evaluate_model.py` separates generation from scoring with two versioned JSONL
-contracts:
-
-- `ua_eval_generation_requests.v1` contains only item ID, source sentence,
-  source hash, and prompt hash;
-- `ua_eval_saved_responses.v1` retains raw response text plus prompt, model,
-  provider, model version, decoding, runner, request, response, manifest, and
-  source hashes.
-
-Both contracts declare `gold_fields_supplied: []`. Validators reject missing
-items, duplicate IDs, manifest drift, prompt drift, source drift, response
-tampering, or any declared target/reference/edit input field.
-
-Prepare the frozen source-only packet:
-
-```bash
-.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py prepare \
-  --output data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl
-```
-
-Generate and score the credential-free baselines:
-
-```bash
-.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py baseline \
-  --kind identity \
-  --output data/projects/ua_eval_harness/baselines/v1/identity.responses.jsonl
-
-.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py baseline \
-  --kind fixture-rules \
-  --output data/projects/ua_eval_harness/baselines/v1/fixture-rules.responses.jsonl
-
-.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py score \
-  --responses data/projects/ua_eval_harness/baselines/v1/identity.responses.jsonl \
-  --output data/projects/ua_eval_harness/baselines/v1/identity.report.json
-```
-
-The optional real-model generator runs Codex CLI in an empty temporary
-directory with a read-only sandbox and repository/user rules disabled. It
-receives the source-only packet, never the manifest:
-
-```bash
-.venv/bin/python scripts/projects/ua_eval_harness/run_codex_baseline.py \
-  --requests data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl \
-  --model gpt-5.6-terra \
-  --output /tmp/gpt-5.6-terra.raw.jsonl \
-  --metadata-output /tmp/gpt-5.6-terra.metadata.json
-
-.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py import \
-  --requests data/projects/ua_eval_harness/baselines/v1/generation_requests.jsonl \
-  --model-output /tmp/gpt-5.6-terra.raw.jsonl \
-  --metadata /tmp/gpt-5.6-terra.metadata.json \
-  --output data/projects/ua_eval_harness/baselines/v1/gpt-5.6-terra.responses.jsonl
-```
-
-The primary metric is correction edit precision, recall, and F0.5 under exact
-source-token-span plus replacement matching. This follows the
-[official UNLP 2023 evaluation contract](https://github.com/asivokon/unlp-2023-shared-task/tree/fbff22905f8c9a3677c900d56599284151c029e6):
-a true positive must exactly match the source span and correction of the
-annotator selected for that sentence. V1 selects the best-F0.5 annotator per
-sentence with a deterministic tie-break; every report states this reference
-policy. Exact corrected-sentence accuracy is a companion metric. Reports also
-contain unchanged-output and over-editing rates, stable corpus annotation
-support, selected-reference support and Wilson recall intervals per tag, and
-deterministic sentence-bootstrap intervals for F0.5 and exact accuracy.
-
-The dependency-free v1 scorer uses a frozen Wagner-Fischer token aligner. It
-implements the official metric semantics but does not claim byte-for-byte
-ERRANT alignment parity for ambiguous alignments; the scorer ID, reference
-commit, implementation note, and all input hashes are recorded in every
-report.
-
-The complete [v1 baseline receipts](../../../data/projects/ua_eval_harness/baselines/v1/README.md)
-include identity, train-fixture literal rules, and a source-only
-`gpt-5.6-terra` run. Across all retained UA-GEC standardization and grammar
-labels, Terra scores 0.2439 edit F0.5 and 0.1610 exact-sentence accuracy. Its
-heritage-aware headline calque recall is 0.1410 (33/234 selected-reference
-annotations). The report retains all 677 raw responses and full run
-provenance. Calque precision is intentionally `null`: untyped hypothesis-only
-false positives cannot honestly be assigned to the calque tag.
-
-## Immutable release freeze
-
-Release `0.1.0` is pinned by one
-[freeze manifest](../../../data/projects/ua_eval_harness/releases/v0.1.0/freeze_manifest.json).
-It records the exact dataset, task, prompt, schema, scorer, runner, request,
-saved-response, and report hashes together with split-integrity and generation
-provenance. Verify every frozen byte and the aggregate-report privacy contract
-offline:
-
-```bash
-.venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py
-```
-
-The Ukrainian-first
-[contamination policy](contamination-policy.md) documents the complete leakage
-disclosure, train-fixture separation, prohibited product/training reuse, and
-semantic version-bump rules. Frozen bytes are never edited in place.
-
-## Public v0
-
-The stranger-runnable release is documented by the authoritative
-[English data card](DATA_CARD.en.md), the [reproduction guide](REPRODUCING.md),
-and complete [third-party notices](THIRD_PARTY_NOTICES.md). The superseded
-Ukrainian translation is preserved in the
-[documentation archive](../../archive/ua-eval-harness/README.md) and is not
-part of the current release. A clean checkout can reproduce all frozen reports
-without provider credentials:
-
-```bash
+git clone https://github.com/learn-ukrainian/learn-ukrainian.github.io.git
+cd learn-ukrainian.github.io
 uv venv --python 3.12.8
 .venv/bin/python scripts/projects/ua_eval_harness/smoke_public_v0.py
 ```
 
-The smoke verifies the release freeze, validates each complete saved-response
-run, re-scores all three baselines, and requires exact report-object equality.
+The smoke test validates the release manifest and re-scores every saved
+baseline response. The expected `0.1.0` result is:
 
-## Ownership and data boundaries
+```text
+identity: 677 responses, edit F0.5=0.0000, headline calque R=0.0000, exact=0.0000
+deterministic fixture rules: 677 responses, edit F0.5=0.0000, headline calque R=0.0000, exact=0.0000
+gpt-5.6-terra saved run: 677 responses, edit F0.5=0.2439, headline calque R=0.1410, exact=0.1610
+public v0 smoke passed: frozen scoring reproduced without provider credentials
+```
 
-Four lanes cooperate but retain separate ownership:
+For individual verification commands, upstream rebuild instructions, and the
+model-response contract, see [REPRODUCING.md](REPRODUCING.md).
 
-- **#2156 — public evaluation:** public UA-GEC-derived gold, standard scoring,
-  baselines, freeze/versioning, documentation, and release.
-- **#4913 — internal quality machinery:** QG schemas, finding envelopes,
-  validators, internal gates, product adapters, and private calibration.
-- **#4542 / #5254 — Hramatka:** teacher-facing product and private Hramatka
-  regression calibration. Teachers are users, not annotators.
-- **#4387 / #4700 — Atlas and Daily Practice:** provenance-aware
-  lexical/heritage evidence and independently rights-cleared learner material.
+## Task contract
 
-These inventories remain separate:
+Each request contains only:
 
-- frozen public benchmark gold;
-- private Hramatka regression cases;
-- teacher feedback and lesson payloads;
-- Atlas source sentences;
-- Daily Practice exercise inventory;
-- model responses and result metadata;
-- any future training data.
+- a stable item ID;
+- the original Ukrainian sentence;
+- the SHA-256 digest of that sentence;
+- the SHA-256 digest of the frozen instruction.
 
-Public gold must not enter Daily Practice or training. Product findings and
-teacher feedback may inform private regressions but never automatically become
-public gold. Atlas evidence may cause abstention or a contested-heritage
-warning; it must not silently override UA-GEC gold.
+The model returns the complete corrected sentence without explanation. Gold
+targets, annotator references, edit spans, and scores are never included in
+generation requests. Responses are saved before scoring so that a run can be
+re-evaluated without contacting its provider.
 
-Only thin infrastructure may be shared: stable schemas and upstream tags, span
-normalization, scorer interfaces, validator/configuration versions,
-VESUM/heritage evidence semantics, and provenance conventions.
+The instruction requests the smallest changes needed to correct calques and
+grammar. It excludes unrelated spelling, punctuation, style, and fluency
+changes unless a grammatical correction requires them.
 
-## Ordered execution queue
+## Dataset and split
 
-1. [#5966 — reconcile capability truth and freeze the task/data contract](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5966)
-2. [#5967 — build the deterministic held-out UA-GEC extraction manifest](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5967)
-3. [#5636 — standard GEC scorer, saved-response adapter, and baselines](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5636)
-4. [#4626 — freeze manifest, split integrity, and contamination policy](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4626)
-5. [#4541 — stranger-runnable public v0, data card, and baseline report](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4541)
+The evaluation set is derived deterministically from
+[UA-GEC 2.0](https://github.com/grammarly/ua-gec) at commit
+[`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`](https://github.com/grammarly/ua-gec/tree/4757f72f192c4a41e4c8fb1d9690a948f87cf6d6).
+It retains every sentence in the `gec-fluency/test` partition with at least
+one `F/Calque` or `G/*` annotation.
 
-EleutherAI/lm-eval compatibility is optional after the saved-response runner
-and standard scorer are proven. It is not a v0 prerequisite.
+| Measure | Count |
+| --- | ---: |
+| Included sentences | 677 |
+| Excluded test sentences | 2,013 |
+| Total test sentences accounted for | 2,690 |
+| Acceptable annotator references | 918 |
+| In-scope annotations | 1,608 |
+| Test documents | 166 |
+| Test authors | 76 |
 
-## Non-goals
+The upstream training and test partitions have zero author overlap and zero
+document overlap. A separate set of 52 training-derived examples is used only
+by a diagnostic literal-rule baseline and never contributes to held-out
+results.
 
-- factuality, BIO, cultural-grounding, or seminar fact checking;
-- synthetic corruption, DPO, fine-tuning, training, or training-data creation;
-- Hramatka, Atlas, Daily Practice, curriculum, or dataset implementation in
-  the governance cycle;
-- Surzhyk, Polonism, or Anglicism expansion;
-- a new leaderboard or arbitrary dataset-size target;
-- teacher/community annotation, approval, or external-person dependency;
-- treating heritage evidence as a boolean Russianism truth layer.
+## Metrics
 
-## Release gates
+Overall edit precision, recall, and F0.5 use exact source-token spans and exact
+replacement text. When a sentence has several annotator references, the
+scorer selects the reference that maximizes the prediction's F0.5 with a
+deterministic tie-break. Exact corrected-sentence accuracy is also reported.
 
-The epic remains open until:
+Calque-specific claims use headline calque recall. The source corpus contains
+354 retained `F/Calque` annotations; 338 are admitted to headline scoring after
+a separate evidence-backed disposition. Sixteen register, heritage, or
+contextually unresolved annotations remain outside that headline metric.
 
-1. the upstream eligibility predicate and held-out manifest are frozen;
-2. every eligible record has attribution and an exclusion disposition;
-3. a standard scorer accepts saved responses;
-4. identity, deterministic, and one real version-pinned model baseline run;
-5. per-tag support and uncertainty are reported;
-6. the data card, license, limitations, and contamination policy exist;
-7. clean-clone scoring is proven;
-8. no private/product data has entered public gold; and
-9. the package runs without Hramatka, teacher data, Atlas private state, or
-   provider secrets.
+Calque precision is not reported because model-produced edits do not carry
+reliable error-type labels. Overall exact-edit precision still covers every
+predicted edit. The [English data card](DATA_CARD.en.md) defines the metrics
+and their limitations in detail.
 
-## Related records
+## Saved `0.1.0` baselines
 
-- [Ownership and data-boundary decision](../../decisions/2026-07-28-public-ua-eval-ownership-and-data-boundaries.md)
-- [Internal QG epic #4913](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4913)
-- [Hramatka epic #4542](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4542)
-- [Atlas epic #4387](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4387)
-- [Daily Practice epic #4700](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4700)
-- [UA-GEC upstream repository](https://github.com/grammarly/ua-gec)
+| Saved run | Edit P | Edit R | Edit F0.5 | Headline calque R | Exact sentence |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Identity v1 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 |
+| Train-fixture literal rules v1 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 |
+| `gpt-5.6-terra` | 0.3110 | 0.1309 | 0.2439 | 0.1410 | 0.1610 |
+
+These controls demonstrate the scorer and saved-response workflow. They do not
+establish a general ranking of model quality. Live regeneration is not
+expected to be byte-identical when a provider does not expose deterministic
+decoding controls; the saved responses and scoring results are reproducible.
+
+## Evaluate another system
+
+Prepare a source-only packet:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py prepare \
+  --output /tmp/ua-eval-requests.jsonl
+```
+
+Generate one response for each request, then import and score it:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py import \
+  --requests /tmp/ua-eval-requests.jsonl \
+  --model-output /tmp/model-output.jsonl \
+  --metadata /tmp/model-metadata.json \
+  --output /tmp/saved-responses.jsonl
+
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py score \
+  --responses /tmp/saved-responses.jsonl \
+  --output /tmp/score-report.json
+```
+
+The importer fails on incomplete coverage, duplicate IDs, receipt drift,
+tampered responses, or fields resembling hidden gold data. The response file
+and metadata contract are documented in
+[REPRODUCING.md](REPRODUCING.md#evaluate-another-model).
+
+## Provenance, licensing, and reuse
+
+UA-GEC-derived data is licensed under CC BY 4.0. Bounded evidence derived from
+dict_uk/VESUM is licensed under CC BY-NC-SA 4.0. Repository software is
+licensed under MIT; that software license does not replace the licenses
+applying to data and evidence.
+
+Read [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) before redistribution or
+commercial use. Read
+[contamination-policy.md](contamination-policy.md) before evaluating a model
+that may have trained on public benchmark material. Held-out content and
+derived rules must not be used for training, fine-tuning, synthetic data,
+preference data, learner exercises, or regression corpora.
+
+## Citation
+
+When reporting results, identify the repository, semantic release version,
+saved-response metadata, and freeze-manifest digest. Cite UA-GEC and
+dict_uk/VESUM as specified in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md). Report enough decoding and
+provider metadata to distinguish the evaluated system without including
+credentials or hidden benchmark fields.

--- a/docs/projects/ua-eval-harness/RELEASE_NOTES.md
+++ b/docs/projects/ua-eval-harness/RELEASE_NOTES.md
@@ -1,0 +1,37 @@
+# Release notes
+
+## 0.1.1 — corrective packaging release
+
+Status: release candidate.
+
+This patch preserves the `0.1.0` dataset, prompt, schema, scoring policy,
+scorer behavior, and saved results. It does not revise benchmark scores.
+
+Changes:
+
+- established six authoritative English release documents and an automated
+  language and release-surface gate;
+- separated unrelated development, archive, and quality-gate material from the
+  researcher documentation;
+- clarified which repository files are required for verification and which
+  can be ignored;
+- added the VESUM retrieval date and asset size to the public provenance;
+- prepared a provider-neutral response import and execution workflow;
+- reserved a separate immutable `0.1.1` freeze so that `0.1.0` bytes remain
+  independently verifiable.
+
+The final `0.1.1` entry will identify the added baseline, release-manifest
+digest, and published release URL after those artifacts are frozen.
+
+## 0.1.0 — initial public freeze
+
+The initial release established:
+
+- the deterministic 677-sentence UA-GEC evaluation set;
+- the minimal-edit task instruction and JSON response schema;
+- exact-edit F0.5 and heritage-aware headline calque recall;
+- identity, training-fixture literal-rule, and `gpt-5.6-terra` saved baselines;
+- split-integrity, contamination, license, and cryptographic freeze receipts.
+
+Release `0.1.0` is immutable. Corrective packaging work must use a new release
+directory and may not alter its frozen bytes.

--- a/docs/projects/ua-eval-harness/REPRODUCING.md
+++ b/docs/projects/ua-eval-harness/REPRODUCING.md
@@ -86,8 +86,8 @@ The asset and the derived evidence are licensed under CC BY-NC-SA 4.0. See
 pinned revision, license, and evidence receipts.
 
 VESUM attestations and style markers identify candidates; they do not decide
-contextual calque status automatically. Broader contextual activation remains
-tracked in issue #5092. Public v0 excludes unresolved records from headline
+contextual calque status automatically. Broader contextual activation is
+outside this release. Public v0 excludes unresolved records from headline
 scoring.
 
 ## Evaluate another model

--- a/docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md
+++ b/docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md
@@ -45,7 +45,7 @@ The benchmark-disposition evidence receipts were derived from:
   [`bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824`](https://github.com/brown-uk/dict_uk/tree/bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824)
 - **Pinned release asset:**
   [`dict_corp_vis.txt.bz2`](https://github.com/brown-uk/dict_uk/releases/download/v6.8.0/dict_corp_vis.txt.bz2),
-  SHA-256
+  retrieved `2026-07-30`, size `18,195,377` bytes, SHA-256
   `e33803783ac138e6f3af2cf0e9428ba146c0ecfda7f5c41fe83ae00c7af24be9`
 - **License:** [Creative Commons Attribution-NonCommercial-ShareAlike 4.0
   International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/)

--- a/docs/projects/ua-eval-harness/contamination-policy.md
+++ b/docs/projects/ua-eval-harness/contamination-policy.md
@@ -1,120 +1,128 @@
-# Політика замороження й запобігання витоку
+# Release freeze and contamination policy
 
-Ця політика стосується публічного оцінювання виправлень українських кальок і
-граматики `ua-gec-calque-grammar-public-v0` версії `0.1.0`. Вона не поширює
-оцінювальний набір на продукти, навчальні корпуси чи інші дослідницькі задачі.
+This policy applies to the `ua-gec-calque-grammar-public-v0` release family.
+The immutable `0.1.0` freeze remains valid; corrective release `0.1.1`
+preserves its dataset, task, scorer, and results. This policy does not
+authorize reuse of the evaluation set in products, training corpora, or
+unrelated research tasks.
 
-## Заморожений склад
+## Frozen release contents
 
-Єдиним машинним реєстром релізу є
-`data/projects/ua_eval_harness/releases/v0.1.0/freeze_manifest.json`. Він
-фіксує SHA-256 для:
+Each release has a machine-readable record under
+`data/projects/ua_eval_harness/releases/`. It records SHA-256 hashes for:
 
-- конфігурації й маніфесту вибірки, окремого disposition-маніфесту для
-  calque scoring та його конфігурації;
-- інструкції, схеми відповіді, екстрактора, оцінювача й необов'язкового
-  провайдерного запускатора;
-- VESUM source lock, marker parser і builder benchmark-dispositions;
-- пакета запитів, усіх збережених відповідей і агрегованих звітів трьох
-  базових систем;
-- 52 тренувальних прикладів, які дозволено використовувати лише як
-  development-fixtures і які не входять до held-out результатів.
+- the dataset configuration and manifest;
+- the separate calque scoring-disposition manifest and its configuration;
+- the task instruction, output schema, extractor, scorer, and optional
+  provider runner;
+- the VESUM source lock, marker parser, and scoring-disposition builder;
+- the source-only request packet, saved responses, and aggregate reports for
+  all three baselines;
+- 52 training-derived examples that may be used only as development fixtures
+  and do not contribute to held-out results.
 
-Перевірка не потребує мережі або провайдерних ключів:
+Verification requires neither network access nor provider credentials:
 
 ```bash
 .venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py
 ```
 
-Будь-яка невідповідність байтів, метаданих запуску, prompt/scorer receipt,
-покриття відповідей або політики агрегованих звітів завершує перевірку
-помилкою.
+The verifier fails if it finds a mismatch in artifact bytes, run metadata,
+prompt or scorer receipts, response coverage, or aggregate-report policy.
 
-## Цілісність поділу
+## Split integrity
 
-Джерелом є UA-GEC 2.0 на commit
-`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`. Хеші `LICENSE`, `README.md`,
-`data/metadata.csv` і `gec-fluency.test.m2` зафіксовано в freeze manifest.
+The source is UA-GEC 2.0 at commit
+`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`. The freeze records hashes for
+`LICENSE`, `README.md`, `data/metadata.csv`, and
+`data/gec-fluency/test/gec-fluency.test.m2`.
 
-Екстрактор перевіряє, що:
+The extractor verifies that:
 
-1. кожен document ID у metadata унікальний і має рівно один partition;
-2. множина документів у test M2 точно дорівнює множині test-документів у
-   metadata;
-3. автори train і test не перетинаються;
-4. усі 2 690 test-речень мають disposition: 677 включено, 2 013 виключено.
+1. every document ID in the metadata is unique and belongs to exactly one
+   partition;
+2. the document set in the test M2 file exactly matches the metadata's test
+   partition;
+3. the training and test partitions have no authors in common;
+4. all 2,690 test sentences have a disposition: 677 included and 2,013
+   excluded.
 
-Отже, перетин train/test становить нуль і на рівні авторів, і на рівні
-документів. 52 старі development-fixtures походять із train і залишаються
-окремими від held-out оцінювання.
+The training and test partitions therefore have zero author overlap and zero
+document overlap. The 52 development fixtures come from the training
+partition and remain separate from the held-out evaluation.
 
-## UA-GEC label і benchmark disposition
+## Upstream labels and benchmark dispositions
 
-`F/Calque` зберігається без змін як upstream label стандартизації UA-GEC. Це
-не є автоматичним твердженням нашого benchmark, що кожна початкова форма —
-калька. Окремий `scoring_dispositions_v1.json` містить рішення й причину для
-всіх 354 annotator-level edits.
+The release preserves `F/Calque` unchanged as an upstream UA-GEC
+standardization label. The label alone does not assert that every original
+form is a calque under this benchmark. A separate
+`scoring_dispositions_v1.json` records the decision and reason for all 354
+annotator-level edits.
 
-Відтворюваний exact-style probe використовує зафіксований dict_uk/VESUM
-`v6.8.0`. Серед 293 унікальних `F/Calque` spans він фіксує 49 style-marker
-collisions: 34 `bad`, 10 `slang`, 3 `arch`, 2 `rare`. Окремого `dial` token у
-цьому джерелі немає; офіційна семантика `arch` охоплює застаріле, архаїчне й
-інколи діалектне вживання. Тому реліз не заявляє «нуль діалектних
-конфліктів».
+The reproducible surface-form probe uses the pinned dict_uk/VESUM v6.8.0
+release. Across 293 unique `F/Calque` spans, the probe finds 49 collisions with
+style markers: 34 `bad`, 10 `slang`, 3 `arch`, and 2 `rare`. The source does
+not provide a dedicated `dial` token. Its published `arch` semantics cover
+obsolete and archaic usage and may also cover dialectal usage. The benchmark
+therefore does not claim that there are zero dialect conflicts.
 
-Headline calque recall включає 338 annotations. Ще 16 не входять до headline:
-3 register-standardization, 2 heritage-conflict і 11 contested. Attestation
-або marker є evidence, а не готовим contextual adjudication. Випадки
-`тьоті`, `кришею`, `рижого`, `Спікери` та false surface collision `була`
-зафіксовано окремими regression receipts. Повну активацію marker-aware
-contextual policy відстежує #5092; п'ятислівний prototype seed не
-використовується.
+Headline calque recall includes 338 annotations. The remaining 16 are outside
+the headline metric: 3 register-standardization cases, 2 heritage conflicts,
+and 11 contested cases. Attestation or a style marker is evidence, not a
+complete contextual decision. The release records separate regression
+receipts for `тьоті`, `кришею`, `рижого`, `Спікери`, and the false
+surface-form collision `була`. Broader marker-aware contextual activation is
+outside this release; unresolved cases fail closed. The five-word prototype
+seed is not used.
 
-## Відомі контакти з даними
+## Known contact with evaluation data
 
-- Публічна інструкція не містить прикладів.
-- Детермінована literal-rule baseline будує правила лише з 52 train-derived
-  development-fixtures. Це навмисно слабка діагностична baseline, не
-  held-out-навчання.
-- Перед повним запуском дві source-only позиції було використано для
-  транспортної перевірки. Після неї уточнено лише вимогу зберігати пробіли й
-  пунктуацію. Gold-відповіді, edits і scores не переглядалися.
-- Реальну модель обрано за наперед чинним operator routing, а не за
-  результатами цього benchmark.
-- Під час генерації моделі передавалися тільки ID, source, source hash і
-  prompt hash. Gold targets, references, edits та score були відсутні.
+- The public task instruction contains no examples.
+- The deterministic literal-rule baseline derives rules only from the 52
+  training-derived development fixtures. It is an intentionally weak
+  diagnostic baseline, not training on the held-out set.
+- Two source-only items were used for a transport check before the complete
+  run. That check led only to a clarification that spaces and punctuation must
+  be preserved. Gold responses, edits, and scores were not inspected.
+- The evaluated model configuration was fixed before generation and was not
+  selected using benchmark results.
+- Generation requests contained only the item ID, source sentence, source
+  hash, and prompt hash. They did not contain gold targets, references, edits,
+  or scores.
 
-## Заборонене повторне використання
+## Prohibited reuse
 
-Публічні source, gold, IDs, hashes і похідні правила цього held-out набору
-заборонено додавати до:
+Public source sentences, gold corrections, IDs, hashes, and derived rules from
+this held-out set must not be added to:
 
-- Daily Practice або іншого learner-exercise inventory;
-- будь-якого training, fine-tuning, synthetic-data, preference-data чи DPO
-  inventory;
-- Hramatka, teacher-feedback або приватних regression/canary наборів;
-- Atlas чи іншого приватного продуктового стану.
+- learner-facing exercise inventories;
+- training, fine-tuning, synthetic-data, or preference-data corpora;
+- teacher-feedback data or private regression corpora;
+- any non-public application state.
 
-Збіг, знайдений після замороження, є contamination incident. Такий реліз не
-можна мовчки «виправити»: потрібні окремий incident record, нова версія,
-повторна екстракція, нові baselines і новий freeze manifest.
+A match discovered after the release freeze is a contamination incident. The
+affected release must not be silently repaired. Resolution requires a recorded
+incident, a new release version, a fresh extraction, new baselines, and a new
+freeze manifest.
 
-## Безпечне звітування
+## Safe reporting
 
-Публічні score reports містять тільки агрегати, support, uncertainty та
-provenance. Вони не можуть містити item IDs, source/target text, edit spans,
-raw responses або content hashes. Збережені model responses є окремими
-публічними артефактами для відтворення оцінки; звіт не дублює їх.
+Public score reports contain only aggregates, support counts, uncertainty
+estimates, and provenance. They must not contain item IDs, source or target
+text, edit spans, raw responses, or content hashes. Saved model responses are
+separate public artifacts that permit reproduction of the scores; aggregate
+reports do not duplicate them.
 
-## Версіонування
+## Versioning
 
-Заморожені байти не редагують на місці.
+Frozen bytes are never edited in place.
 
-- `PATCH`: документаційне або пакувальне виправлення без зміни dataset,
-  task, scorer чи результатів.
-- `MINOR`: сумісне доповнення task contract, scorer, runner або baselines.
-- `MAJOR`: зміна dataset, eligibility predicate, gold, split, primary metric
-  або несумісна зміна контракту.
+- `PATCH`: documentation or packaging corrections that do not change the
+  dataset, task, scorer, or results.
+- `MINOR`: backward-compatible additions to the task contract, scorer, runner,
+  or baselines.
+- `MAJOR`: changes to the dataset, eligibility rule, gold data, split, primary
+  metric, or any incompatible contract change.
 
-Кожна нова версія отримує окрему директорію freeze; старі freeze manifests
-зберігаються та мають залишатися незалежно перевірними.
+Each new release version receives its own freeze directory. Older freeze
+manifests remain available and independently verifiable.

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Validate language and public-surface boundaries in UA-eval documents."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_ENGLISH_DOCS = (
+    Path("docs/projects/ua-eval-harness/DATA_CARD.en.md"),
+    Path("docs/projects/ua-eval-harness/README.md"),
+    Path("docs/projects/ua-eval-harness/RELEASE_NOTES.md"),
+    Path("docs/projects/ua-eval-harness/REPRODUCING.md"),
+    Path("docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md"),
+    Path("docs/projects/ua-eval-harness/contamination-policy.md"),
+)
+
+_CYRILLIC_RE = re.compile(r"[\u0400-\u052f]")
+_NON_PUBLIC_PATTERNS = (
+    re.compile(r"\b(?:Daily Practice|Hramatka|Atlas)\b", re.IGNORECASE),
+    re.compile(r"\b(?:Codex CLI|operator routing|fleet[- ]comms)\b", re.IGNORECASE),
+    re.compile(r"\b(?:issue|epic|pull request|PR)\s+#\d+\b", re.IGNORECASE),
+    re.compile(r"\bDPO\b"),
+    re.compile(r"\bcanar(?:y|ies)\b", re.IGNORECASE),
+)
+_MARKDOWN = MarkdownIt("commonmark")
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    """One Cyrillic character found in visible prose."""
+
+    path: Path
+    line: int
+    column: int
+    excerpt: str
+    message: str = "Cyrillic is not allowed in English running prose"
+
+    def format(self) -> str:
+        return f"{display_path(self.path)}:{self.line}:{self.column}: {self.message}: {self.excerpt}"
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _token_span(token: Token, fallback: tuple[int, int]) -> tuple[int, int]:
+    if token.map is None:
+        return fallback
+    return token.map[0], token.map[1]
+
+
+def _visible_fragments(
+    tokens: list[Token],
+    fallback_span: tuple[int, int],
+) -> list[tuple[str, tuple[int, int]]]:
+    """Return rendered text fragments while excluding parsed Markdown code."""
+
+    fragments: list[tuple[str, tuple[int, int]]] = []
+    for token in tokens:
+        span = _token_span(token, fallback_span)
+        if token.type in {"code_block", "code_inline", "fence"}:
+            continue
+        if token.children:
+            fragments.extend(_visible_fragments(token.children, span))
+        elif token.content:
+            fragments.append((token.content, span))
+    return fragments
+
+
+def _fence_is_closed(token: Token, source_lines: list[str]) -> bool:
+    """Return whether a parsed root-level fence has an explicit closing line."""
+
+    if token.map is None or not token.markup:
+        return False
+    start, end = token.map
+    marker = re.escape(token.markup[0])
+    width = len(token.markup)
+    closing = re.compile(rf"^ {{0,3}}{marker}{{{width},}}[ \t]*$")
+    return any(closing.fullmatch(source_lines[index]) for index in range(start + 1, min(end, len(source_lines))))
+
+
+def _unclosed_fence_findings(tokens: list[Token], source_lines: list[str], path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for token in tokens:
+        if token.type != "fence" or _fence_is_closed(token, source_lines):
+            continue
+        line_index = token.map[0] if token.map is not None else 0
+        excerpt = source_lines[line_index].strip() if source_lines else ""
+        findings.append(
+            Finding(
+                path=path,
+                line=line_index + 1,
+                column=1,
+                excerpt=excerpt,
+                message="Unclosed fenced code block is not allowed because it can hide later prose",
+            )
+        )
+    return findings
+
+
+def _cyrillic_word(fragment: str, position: int) -> str:
+    start = position
+    end = position + 1
+    while start > 0 and _CYRILLIC_RE.fullmatch(fragment[start - 1]):
+        start -= 1
+    while end < len(fragment) and _CYRILLIC_RE.fullmatch(fragment[end]):
+        end += 1
+    return fragment[start:end]
+
+
+def _source_location(
+    fragment: str,
+    position: int,
+    span: tuple[int, int],
+    source_lines: list[str],
+) -> tuple[int, int, str]:
+    """Map a rendered Cyrillic fragment back to its source line."""
+
+    start_line, end_line = span
+    relative_line = fragment[:position].count("\n")
+    preferred_line = min(start_line + relative_line, max(start_line, end_line - 1))
+    word = _cyrillic_word(fragment, position)
+    candidate_lines = [preferred_line, *range(start_line, end_line)]
+
+    seen: set[int] = set()
+    for line_index in candidate_lines:
+        if line_index in seen or not (0 <= line_index < len(source_lines)):
+            continue
+        seen.add(line_index)
+        column = source_lines[line_index].find(word)
+        if column >= 0:
+            return line_index + 1, column + 1, source_lines[line_index].strip()
+
+    excerpt = fragment.splitlines()[relative_line].strip()
+    return preferred_line + 1, 1, excerpt
+
+
+def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
+    """Return prohibited prose outside explicit Markdown code."""
+
+    source_lines = text.splitlines()
+    tokens = _MARKDOWN.parse(text)
+    findings = _unclosed_fence_findings(tokens, source_lines, path)
+
+    for fragment, span in _visible_fragments(tokens, (0, len(source_lines))):
+        cyrillic_match = _CYRILLIC_RE.search(fragment)
+        if cyrillic_match is not None:
+            line, column, excerpt = _source_location(
+                fragment,
+                cyrillic_match.start(),
+                span,
+                source_lines,
+            )
+            findings.append(
+                Finding(
+                    path=path,
+                    line=line,
+                    column=column,
+                    excerpt=excerpt,
+                )
+            )
+
+        for pattern in _NON_PUBLIC_PATTERNS:
+            non_public_match = pattern.search(fragment)
+            if non_public_match is None:
+                continue
+            line, column, excerpt = _source_location(
+                fragment,
+                non_public_match.start(),
+                span,
+                source_lines,
+            )
+            findings.append(
+                Finding(
+                    path=path,
+                    line=line,
+                    column=column,
+                    excerpt=excerpt,
+                    message="Internal project terminology is not allowed in public release prose",
+                )
+            )
+
+    return sorted(set(findings))
+
+
+def governed_paths() -> list[Path]:
+    """Return the complete public English document set."""
+
+    return [PROJECT_ROOT / path for path in PUBLIC_ENGLISH_DOCS]
+
+
+def _selected_paths(paths: list[Path] | None) -> list[Path]:
+    if paths is None:
+        return governed_paths()
+
+    governed = {path.resolve(): path for path in governed_paths()}
+    selected: list[Path] = []
+    seen: set[Path] = set()
+    for supplied in paths:
+        absolute = supplied if supplied.is_absolute() else PROJECT_ROOT / supplied
+        resolved = absolute.resolve()
+        if resolved in governed and resolved not in seen:
+            selected.append(governed[resolved])
+            seen.add(resolved)
+    return selected
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Optional pre-commit file list; non-governed paths are ignored.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    paths = _selected_paths(args.files)
+    missing = [path for path in paths if not path.is_file()]
+    findings: list[Finding] = []
+
+    for path in paths:
+        if path.is_file():
+            findings.extend(scan_text(path.read_text(encoding="utf-8"), path))
+
+    if not missing and not findings:
+        return 0
+
+    print(
+        "ERROR: public UA-eval documents violate the English or release-surface boundary.",
+        file=sys.stderr,
+    )
+    for path in missing:
+        print(f"{display_path(path)}: governed document is missing", file=sys.stderr)
+    for finding in findings:
+        print(finding.format(), file=sys.stderr)
+    print(
+        "Keep Ukrainian examples in Markdown code and keep project-management or non-public product terms out of release prose.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -92,8 +92,9 @@ def _link_destinations(
     destinations: list[tuple[str, tuple[int, int]]] = []
     for token in tokens:
         span = _token_span(token, fallback_span)
-        if token.type == "link_open":
-            destination = token.attrGet("href")
+        destination_attribute = {"link_open": "href", "image": "src"}.get(token.type)
+        if destination_attribute is not None:
+            destination = token.attrGet(destination_attribute)
             if destination:
                 destinations.append((destination, span))
         if token.children:

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -22,7 +22,7 @@ PUBLIC_ENGLISH_DOCS = (
     Path("docs/projects/ua-eval-harness/contamination-policy.md"),
 )
 
-_CYRILLIC_RE = re.compile(r"[\u0400-\u052f]")
+_CYRILLIC_RE = re.compile(r"[\u0400-\u052f]+")
 _NON_PUBLIC_PATTERNS = (
     re.compile(r"\b(?:Daily Practice|Hramatka|Atlas)\b", re.IGNORECASE),
     re.compile(r"\b(?:Codex CLI|operator routing|fleet[- ]comms)\b", re.IGNORECASE),
@@ -111,28 +111,32 @@ def _unclosed_fence_findings(tokens: list[Token], source_lines: list[str], path:
     return findings
 
 
-def _cyrillic_word(fragment: str, position: int) -> str:
-    start = position
-    end = position + 1
-    while start > 0 and _CYRILLIC_RE.fullmatch(fragment[start - 1]):
-        start -= 1
-    while end < len(fragment) and _CYRILLIC_RE.fullmatch(fragment[end]):
-        end += 1
-    return fragment[start:end]
+def _nth_index(text: str, needle: str, occurrence: int) -> int:
+    """Return the zero-based offset of one exact occurrence, or ``-1``."""
+
+    start = 0
+    for _ in range(occurrence + 1):
+        index = text.find(needle, start)
+        if index < 0:
+            return -1
+        start = index + len(needle)
+    return index
 
 
 def _source_location(
     fragment: str,
     position: int,
+    needle: str,
     span: tuple[int, int],
     source_lines: list[str],
 ) -> tuple[int, int, str]:
-    """Map a rendered Cyrillic fragment back to its source line."""
+    """Map an exact rendered-text match back to its source line."""
 
     start_line, end_line = span
     relative_line = fragment[:position].count("\n")
     preferred_line = min(start_line + relative_line, max(start_line, end_line - 1))
-    word = _cyrillic_word(fragment, position)
+    fragment_line_start = fragment.rfind("\n", 0, position) + 1
+    occurrence = fragment[fragment_line_start:position].count(needle)
     candidate_lines = [preferred_line, *range(start_line, end_line)]
 
     seen: set[int] = set()
@@ -140,7 +144,7 @@ def _source_location(
         if line_index in seen or not (0 <= line_index < len(source_lines)):
             continue
         seen.add(line_index)
-        column = source_lines[line_index].find(word)
+        column = _nth_index(source_lines[line_index], needle, occurrence)
         if column >= 0:
             return line_index + 1, column + 1, source_lines[line_index].strip()
 
@@ -156,11 +160,11 @@ def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
     findings = _unclosed_fence_findings(tokens, source_lines, path)
 
     for fragment, span in _visible_fragments(tokens, (0, len(source_lines))):
-        cyrillic_match = _CYRILLIC_RE.search(fragment)
-        if cyrillic_match is not None:
+        for cyrillic_match in _CYRILLIC_RE.finditer(fragment):
             line, column, excerpt = _source_location(
                 fragment,
                 cyrillic_match.start(),
+                cyrillic_match.group(0),
                 span,
                 source_lines,
             )
@@ -174,24 +178,23 @@ def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
             )
 
         for pattern in _NON_PUBLIC_PATTERNS:
-            non_public_match = pattern.search(fragment)
-            if non_public_match is None:
-                continue
-            line, column, excerpt = _source_location(
-                fragment,
-                non_public_match.start(),
-                span,
-                source_lines,
-            )
-            findings.append(
-                Finding(
-                    path=path,
-                    line=line,
-                    column=column,
-                    excerpt=excerpt,
-                    message="Internal project terminology is not allowed in public release prose",
+            for non_public_match in pattern.finditer(fragment):
+                line, column, excerpt = _source_location(
+                    fragment,
+                    non_public_match.start(),
+                    non_public_match.group(0),
+                    span,
+                    source_lines,
                 )
-            )
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=line,
+                        column=column,
+                        excerpt=excerpt,
+                        message="Internal project terminology is not allowed in public release prose",
+                    )
+                )
 
     return sorted(set(findings))
 

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -198,7 +198,7 @@ def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
                 )
             )
 
-        for pattern in _NON_PUBLIC_PATTERNS:
+        for pattern in (*_NON_PUBLIC_PATTERNS, *_NON_PUBLIC_LINK_PATTERNS):
             for non_public_match in pattern.finditer(fragment):
                 line, column, excerpt = _source_location(
                     fragment,

--- a/scripts/audit/check_ua_eval_public_doc_language.py
+++ b/scripts/audit/check_ua_eval_public_doc_language.py
@@ -26,9 +26,12 @@ _CYRILLIC_RE = re.compile(r"[\u0400-\u052f]+")
 _NON_PUBLIC_PATTERNS = (
     re.compile(r"\b(?:Daily Practice|Hramatka|Atlas)\b", re.IGNORECASE),
     re.compile(r"\b(?:Codex CLI|operator routing|fleet[- ]comms)\b", re.IGNORECASE),
-    re.compile(r"\b(?:issue|epic|pull request|PR)\s+#\d+\b", re.IGNORECASE),
+    re.compile(r"#\d{3,}\b"),
     re.compile(r"\bDPO\b"),
     re.compile(r"\bcanar(?:y|ies)\b", re.IGNORECASE),
+)
+_NON_PUBLIC_LINK_PATTERNS = (
+    re.compile(r"https?://github\.com/[^)\s]+/(?:issues|pull)/\d+\b", re.IGNORECASE),
 )
 _MARKDOWN = MarkdownIt("commonmark")
 
@@ -78,6 +81,24 @@ def _visible_fragments(
         elif token.content:
             fragments.append((token.content, span))
     return fragments
+
+
+def _link_destinations(
+    tokens: list[Token],
+    fallback_span: tuple[int, int],
+) -> list[tuple[str, tuple[int, int]]]:
+    """Return Markdown link destinations with their enclosing source spans."""
+
+    destinations: list[tuple[str, tuple[int, int]]] = []
+    for token in tokens:
+        span = _token_span(token, fallback_span)
+        if token.type == "link_open":
+            destination = token.attrGet("href")
+            if destination:
+                destinations.append((destination, span))
+        if token.children:
+            destinations.extend(_link_destinations(token.children, span))
+    return destinations
 
 
 def _fence_is_closed(token: Token, source_lines: list[str]) -> bool:
@@ -181,6 +202,26 @@ def scan_text(text: str, path: Path = Path("<memory>")) -> list[Finding]:
             for non_public_match in pattern.finditer(fragment):
                 line, column, excerpt = _source_location(
                     fragment,
+                    non_public_match.start(),
+                    non_public_match.group(0),
+                    span,
+                    source_lines,
+                )
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=line,
+                        column=column,
+                        excerpt=excerpt,
+                        message="Internal project terminology is not allowed in public release prose",
+                    )
+                )
+
+    for destination, span in _link_destinations(tokens, (0, len(source_lines))):
+        for pattern in _NON_PUBLIC_LINK_PATTERNS:
+            for non_public_match in pattern.finditer(destination):
+                line, column, excerpt = _source_location(
+                    destination,
                     non_public_match.start(),
                     non_public_match.group(0),
                     span,

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -99,7 +99,7 @@ def test_rejects_internal_project_terms_in_running_prose() -> None:
 
     assert len(findings) == 3
     assert [finding.column for finding in findings] == [
-        text.index("issue") + 1,
+        text.index("#1234") + 1,
         text.index("Hramatka") + 1,
         text.index("canaries") + 1,
     ]
@@ -126,6 +126,25 @@ def test_reports_multiline_internal_term_on_its_source_line() -> None:
     assert len(findings) == 1
     assert findings[0].line == 2
     assert findings[0].column == 1
+
+
+def test_rejects_bare_tracker_number_in_visible_prose() -> None:
+    text = "The release was tracked elsewhere at #5092.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].column == text.index("#5092") + 1
+
+
+def test_rejects_tracker_reference_hidden_in_link_destination() -> None:
+    destination = "https://github.com/example/project/issues/5092"
+    text = f"See [public-looking notes]({destination}).\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].column == text.index(destination) + 1
 
 
 def test_allows_internal_looking_tokens_only_as_code_evidence() -> None:

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -147,6 +147,16 @@ def test_rejects_tracker_reference_hidden_in_link_destination() -> None:
     assert findings[0].column == text.index(destination) + 1
 
 
+def test_rejects_bare_tracker_url_in_visible_prose() -> None:
+    destination = "https://github.com/example/project/pull/5092"
+    text = f"Details were tracked at {destination} outside the release.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].column == text.index(destination) + 1
+
+
 def test_allows_internal_looking_tokens_only_as_code_evidence() -> None:
     text = "A migration test may contain the literal path `issues/1234`.\n"
 

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -147,6 +147,16 @@ def test_rejects_tracker_reference_hidden_in_link_destination() -> None:
     assert findings[0].column == text.index(destination) + 1
 
 
+def test_rejects_tracker_reference_hidden_in_image_source() -> None:
+    destination = "https://github.com/example/project/issues/5092"
+    text = f"![public illustration]({destination})\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].column == text.index(destination) + 1
+
+
 def test_rejects_bare_tracker_url_in_visible_prose() -> None:
     destination = "https://github.com/example/project/pull/5092"
     text = f"Details were tracked at {destination} outside the release.\n"

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -1,0 +1,126 @@
+"""Tests for the public English UA-eval document language gate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit.check_ua_eval_public_doc_language import (
+    PUBLIC_ENGLISH_DOCS,
+    governed_paths,
+    scan_text,
+)
+
+
+def test_rejects_hybrid_running_prose() -> None:
+    text = "# Reproduction\n\nSmoke спочатку перевіряє freeze manifest and all frozen hashes.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert findings[0].column == 7
+    assert "Smoke спочатку" in findings[0].excerpt
+
+
+def test_allows_ukrainian_only_in_explicit_code() -> None:
+    text = """# Examples
+
+The surface form `тьоті` is retained as evidence.
+
+```text
+Це точний український приклад.
+```
+
+The prose returns to English.
+"""
+
+    assert scan_text(text) == []
+
+
+def test_allows_multiline_and_variable_width_code_spans() -> None:
+    text = """English ``first `український`
+second`` prose.
+
+````text
+```
+Український приклад
+```
+````
+"""
+
+    assert scan_text(text) == []
+
+
+def test_rejects_unclosed_fence_instead_of_hiding_rest_of_document() -> None:
+    text = """# Examples
+
+```text
+Example output.
+
+Український prose that must not be hidden.
+"""
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert "Unclosed fenced code block" in findings[0].message
+
+
+def test_stray_backticks_cannot_mask_across_markdown_blocks() -> None:
+    text = """English paragraph with a stray ` backtick.
+
+Український prose in another paragraph with ` another backtick.
+"""
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 3
+    assert "Український prose" in findings[0].excerpt
+
+
+def test_rejects_visible_markdown_formatting_and_link_labels() -> None:
+    text = "This **український text** is visible.\nThis [українська назва](https://example.test) is also visible.\n"
+
+    findings = scan_text(text)
+
+    assert [finding.line for finding in findings] == [1, 2]
+
+
+def test_rejects_internal_project_terms_in_running_prose() -> None:
+    text = "See issue #1234 and send the examples to Hramatka canaries.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 3
+    assert all("Internal project terminology" in finding.message for finding in findings)
+
+
+def test_allows_internal_looking_tokens_only_as_code_evidence() -> None:
+    text = "A migration test may contain the literal path `issues/1234`.\n"
+
+    assert scan_text(text) == []
+
+
+def test_governed_set_is_explicit_and_current() -> None:
+    assert (
+        Path("docs/projects/ua-eval-harness/DATA_CARD.en.md"),
+        Path("docs/projects/ua-eval-harness/README.md"),
+        Path("docs/projects/ua-eval-harness/RELEASE_NOTES.md"),
+        Path("docs/projects/ua-eval-harness/REPRODUCING.md"),
+        Path("docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md"),
+        Path("docs/projects/ua-eval-harness/contamination-policy.md"),
+    ) == PUBLIC_ENGLISH_DOCS
+
+
+def test_repository_public_english_docs_have_no_cyrillic_prose() -> None:
+    paths = governed_paths()
+
+    assert all(path.is_file() for path in paths)
+    findings = [finding for path in paths for finding in scan_text(path.read_text(encoding="utf-8"), path)]
+    assert findings == []

--- a/tests/test_ua_eval_public_doc_language.py
+++ b/tests/test_ua_eval_public_doc_language.py
@@ -20,10 +20,10 @@ def test_rejects_hybrid_running_prose() -> None:
 
     findings = scan_text(text)
 
-    assert len(findings) == 1
-    assert findings[0].line == 3
-    assert findings[0].column == 7
-    assert "Smoke спочатку" in findings[0].excerpt
+    assert len(findings) == 2
+    assert [finding.line for finding in findings] == [3, 3]
+    assert [finding.column for finding in findings] == [7, 16]
+    assert all("Smoke спочатку" in finding.excerpt for finding in findings)
 
 
 def test_allows_ukrainian_only_in_explicit_code() -> None:
@@ -89,7 +89,7 @@ def test_rejects_visible_markdown_formatting_and_link_labels() -> None:
 
     findings = scan_text(text)
 
-    assert [finding.line for finding in findings] == [1, 2]
+    assert [finding.line for finding in findings] == [1, 2, 2]
 
 
 def test_rejects_internal_project_terms_in_running_prose() -> None:
@@ -98,7 +98,34 @@ def test_rejects_internal_project_terms_in_running_prose() -> None:
     findings = scan_text(text)
 
     assert len(findings) == 3
+    assert [finding.column for finding in findings] == [
+        text.index("issue") + 1,
+        text.index("Hramatka") + 1,
+        text.index("canaries") + 1,
+    ]
     assert all("Internal project terminology" in finding.message for finding in findings)
+
+
+def test_rejects_every_repeated_internal_term_in_one_fragment() -> None:
+    text = "Atlas notes mention Atlas again.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 2
+    assert [finding.column for finding in findings] == [
+        text.index("Atlas") + 1,
+        text.rindex("Atlas") + 1,
+    ]
+
+
+def test_reports_multiline_internal_term_on_its_source_line() -> None:
+    text = "Public release prose continues here.\nHramatka is an internal product name.\n"
+
+    findings = scan_text(text)
+
+    assert len(findings) == 1
+    assert findings[0].line == 2
+    assert findings[0].column == 1
 
 
 def test_allows_internal_looking_tokens_only_as_code_evidence() -> None:


### PR DESCRIPTION
## What changed

- rewrote the six authoritative UA-eval public documents as professional researcher-facing English;
- documented package scope, clean-clone setup, scoring, limitations, licensing, contamination controls, citation, and release history;
- pinned VESUM/dict_uk v6.8.0 with exact commit, asset checksum, retrieval date, and licenses;
- added a fail-closed public-language/privacy checker and tests;
- added the checker to pre-commit.

## Validation

- public-language checker passed;
- 30 focused UA-eval documentation/compiler/harness tests passed;
- Ruff passed;
- Markdown lint passed on all six authoritative documents;
- every local Markdown link target in the six-document package exists;
- `git diff --check`, agent-trailer lint, and OPSEC lint passed.

Focused successor to #6020, replayed onto current `main` after #6042 merged. Tracks #6012. Parent stream: #2156.

X-Agent: codex/ua-eval-v011-public-english-final