### PR TITLE
feat(agent-runtime): add bounded Grok ACPX shadow seat

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1339,7 +1339,7 @@ Claude, Gemini, and Codex coordinate through distinct primitives. Pick the right
 | Fire-and-forget execution — run code, commit, push | **`scripts/delegate.py dispatch`** | Yes |
 | Durable fleet coordination / topology | **`scripts.fleet_comms`** (`plane-status`, …) + **file dual-write handoffs** (authoritative in every plane mode) | Hand-off files only as existing lane diaries; never invent a third bus |
 | Formal cross-family PR review | **`review-pr` / `publish-review-verdict`** | No (review evidence) |
-| Experimental structured Codex invocation | **ACPX adapter** (feature-flagged, default-off/shadow) | **No** (read-only/stateless; see onboarding runbook) |
+| Experimental structured Codex / Grok invocation | **ACPX adapters** `acpx-codex-shadow` + `acpx-grok-shadow` (feature-flagged, default-off/shadow; not a coordination plane) | **No** (read-only/stateless; see onboarding runbook) |
 | Buzz relay coordination | **Deferred** — not in this rollout | N/A |
 | Watch a long-running process (builds, reviews) emit events — **Claude only** | **`Monitor` tool** (Claude Code built-in) | N/A |
 | Watch a long-running process — **Gemini / Codex** | Shell-poll the Monitor API | N/A |
@@ -1351,7 +1351,7 @@ Claude, Gemini, and Codex coordinate through distinct primitives. Pick the right
 - `ai_agent_bridge` is for **communication**. `delegate.py dispatch` is for **execution**. Don't confuse them.
 - **`discuss` is not formal review.** Use `review-pr` / `publish-review-verdict` for CF.
 - Query `.venv/bin/python -m scripts.fleet_comms plane-status` — never hard-code a live plane mode.
-- ACPX is optional experimental transport only; rollback is feature-flag off + native runtime.
+- ACPX is optional experimental transport only (two direct-only seats: Codex pilot + Grok second pilot on broker-centrality evidence with limited direct-runtime sample); rollback is feature-flag off + native runtime. Grok + Codex ACPX is not a new coordination plane.
 - Never run a polling loop to check a background task — use `Monitor` or the bash `run_in_background` completion notification.
 
 ### Channel bridge — preferred for multi-turn

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -70,32 +70,56 @@ Ownership matrix, troubleshooting, and seat smoke (including ACPX scope):
 
 ACPX is an **experimental, feature-flagged structured invocation transport** —
 not a coordination plane and not a replacement for `discuss`, fleet-comms, or
-authoritative file handoffs.
+authoritative file handoffs. **Grok + Codex ACPX is not a new coordination plane** —
+two direct-only shadow seats only.
 
-Approved boundary (#6027):
+**Why Grok is the second pilot (#6043, API-backed):** in the 2026-07-30
+snapshot from `/api/comms/live-activity?limit=500&minutes=120`, all **95**
+broker dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
+**Claude 22**. The same-day 30-day sample from
+`/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
+Broker centrality is high; direct-runtime evidence is still limited — hence
+a thin second shadow pilot, not fleet-wide enablement. These are dated
+selection-evidence snapshots, not permanent routing weights.
+
+Approved boundary (#6027 Codex, #6043 Grok):
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow`, **default `off`**; rollback =
   set it back to `off` (or unset) to fall back to the native `runner.invoke`
-  transport.
-- Direct-only seat `acpx-codex-shadow` (`scripts/agent_runtime/adapters/acpx.py:AcpxAdapter`)
-  — never returned by `available_agents()`, never a dispatch/routing/review/
-  failover candidate.
-- Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); the adapter refuses to
+  transport (native Codex / native Grok remain authoritative).
+- Direct-only seats:
+  - `acpx-codex-shadow` (`scripts/agent_runtime/adapters/acpx.py:AcpxAdapter`)
+  - `acpx-grok-shadow` (`scripts/agent_runtime/adapters/acpx.py:AcpxGrokShadowAdapter`)
+  — never returned by `available_agents()`, never dispatch/routing/review/
+  failover candidates.
+- Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); both adapters refuse to
   spawn on any other resolved version.
-- Initially **one** read-only/stateless **Codex** ACP participant
-  (`tool_config={"acpx_shadow": True, "target_agent": "codex"}`).
+- Grok seat also preflights the installed native Grok CLI at exact semver
+  `0.2.114` (wrong/missing/unparseable → refuse before prompt).
+- Codex participant:
+  `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
+- Grok participant:
+  `tool_config={"acpx_shadow": True, "target_agent": "grok"}`.
+  Fixed effective model/effort `grok-4.5` / `high`. Custom agent command
+  (never built-in `grok-build`): absolute Grok binary +
+  `agent --model grok-4.5 --reasoning-effort high --agent-profile
+  <hash-pinned-project-no-tool-profile> --no-leader stdio`. The project-owned
+  profile is digest-checked before every spawn and removes write, shell,
+  subagent, memory, web, MCP, and LSP tools at the Grok server boundary.
 - Adapter safety contract: one in-flight prompt, zero backlog, zero automatic
   prompt retries, bounded timeout/cancellation, required non-empty/bounded
   `task_id`, `correlation_id`, and `idempotency_key` (local runtime metadata
   only — never ACP protocol flags, argv, or stdin; never published to
   fleet-comms, dispatch authority, or review evidence), primary-checkout and
-  write-permission refusal.
+  write-permission refusal. ACPX client confinement and the Grok no-tool
+  profile are both required: client flags alone do not remove native Grok
+  tools.
 - Correlation / shadow telemetry is **evidence only** — the existing participant
   result stays authoritative under shadow compare.
-- ACPX authentication selection is explicit. For an existing local ChatGPT
-  Codex login, verify `codex login status`, then set the non-secret selector
-  `ACPX_AUTH_CHAT_GPT=1` for the bounded process. A missing selector fails
-  closed under `--auth-policy fail`; never put API keys in repo files or logs.
+- ACPX authentication selection is explicit under `--auth-policy fail`:
+  - Codex ChatGPT login: non-secret selector `ACPX_AUTH_CHAT_GPT=1`
+  - Grok cached native login: adapter sets `ACPX_AUTH_CACHED_TOKEN=1` and
+    scrubs ambient XAI API-key auth selectors (never read/store/log credentials)
 - Standard ACP usage reports `used` (tokens currently in context) and `size`
   (context-window capacity). Shadow telemetry records `used`; it must never
   report `size` as consumed tokens.

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -76,7 +76,9 @@ two direct-only shadow seats only.
 **Why Grok is the second pilot (#6043, API-backed):** in the 2026-07-30
 snapshot from `/api/comms/live-activity?limit=500&minutes=120`, all **95**
 broker dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
-**Claude 22**. The same-day 30-day sample from
+**Claude 22** among the three busiest senders; the remaining **22** were
+**Gemini 11**, **OpenCode 6**, **GLM 4**, and **AGY 1**. The same-day
+30-day sample from
 `/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
 Broker centrality is high; direct-runtime evidence is still limited — hence
 a thin second shadow pilot, not fleet-wide enablement. These are dated

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -93,7 +93,9 @@ Grok stay authoritative under shadow compare.
 **Seat-selection evidence (#6043, API-backed):** in the 2026-07-30 snapshot
 from `/api/comms/live-activity?limit=500&minutes=120`, all **95** broker
 dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
-**Claude 22**. The same-day 30-day runtime sample from
+**Claude 22** among the three busiest senders; the remaining **22** were
+**Gemini 11**, **OpenCode 6**, **GLM 4**, and **AGY 1**. The same-day
+30-day runtime sample from
 `/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
 Broker centrality is therefore strong for Grok, while **direct-runtime
 evidence remains limited** — Grok is a deliberately conservative second

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -39,7 +39,7 @@ caps or live modes.
 | **`discuss`** (bridge) | Bounded multi-agent deliberation and design input | Implementation, merge authority, or the formal cross-family review gate |
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution in a worktree | Durable fleet authority or formal CF |
 | **Fleet-comms + file handoffs** | Durable coordination and authority today; **file dual-write remains authoritative in every current plane mode** | Competing message buses; silent plane/retention/eligibility flips |
-| **ACPX** | Experimental **structured invocation transport only** — initially one read-only/stateless Codex participant behind a default-off/shadow feature flag | Persistent sessions, backlog, auto-retries, agent-to-agent chat, plane flips, review eligibility |
+| **ACPX** | Experimental **structured invocation transport only** — two direct-only read-only/stateless shadow seats (Codex, Grok) behind a default-off/shadow feature flag; not a coordination plane | Persistent sessions, backlog, auto-retries, agent-to-agent chat, plane flips, review eligibility |
 | **Buzz** | **Explicitly deferred** | Anything in this rollout — relay-as-authority conflicts with the current authority model |
 
 ### Discuss is not formal review
@@ -86,24 +86,53 @@ become a second coordination plane.
 ### ACPX — experimental transport boundary
 
 ACPX is **not** a coordination product and **not** a second fleet bus.
+Two direct-only shadow seats (Codex + Grok) are **not a new coordination plane** —
+fleet-comms + file dual-write stay authoritative, and native Codex / native
+Grok stay authoritative under shadow compare.
 
-**Exact contract (#6027):**
+**Seat-selection evidence (#6043, API-backed):** in the 2026-07-30 snapshot
+from `/api/comms/live-activity?limit=500&minutes=120`, all **95** broker
+dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
+**Claude 22**. The same-day 30-day runtime sample from
+`/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
+Broker centrality is therefore strong for Grok, while **direct-runtime
+evidence remains limited** — Grok is a deliberately conservative second
+pilot, not fleet-wide enablement. These are dated selection-evidence
+snapshots, not permanent routing weights.
+
+**Exact contract (#6027 Codex pilot, #6043 Grok second pilot):**
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow`, **default `off`**.
-- Direct-only seat name `acpx-codex-shadow`; never registered for dispatch,
-  routing, review, or failover.
-- Local pin `acpx@0.13.0` — the adapter refuses to spawn on any other
+- Direct-only seat names `acpx-codex-shadow` and `acpx-grok-shadow`; never
+  registered for dispatch, routing, review, or failover.
+- Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
   resolved binary version.
+- Grok seat additionally preflights the installed native Grok CLI at exact
+  semver `0.2.114` and refuses wrong/missing/unparseable versions before
+  prompt.
 - Every invocation requires a non-empty, bounded, local `task_id`,
-  `correlation_id`, and `idempotency_key`, plus `tool_config={"acpx_shadow":
-  True, "target_agent": "codex"}`, targets **Codex**, and runs against a
-  read-only, non-primary worktree.
+  `correlation_id`, and `idempotency_key`, plus
+  `tool_config={"acpx_shadow": True, "target_agent": "codex"|"grok"}`, and
+  runs against a read-only, non-primary worktree.
 
 **In scope (approved):**
 
-- Feature-flagged adapter (default off / shadow comparison).
-- Exactly one read-only/stateless **Codex** ACP participant for structured
-  invocation.
+- Feature-flagged adapters (default off / shadow comparison).
+- Exactly one read-only/stateless **Codex** ACP participant
+  (`acpx-codex-shadow`) and exactly one read-only/stateless **Grok** ACP
+  participant (`acpx-grok-shadow`) for structured invocation.
+- Grok fixed effective model/effort: `grok-4.5` / `high` (caller may pass
+  only `None` or those exact values; metadata never fabricates otherwise).
+- Grok ACP server command (single custom agent argument; never built-in
+  `grok-build`, which cannot force `--no-leader`): absolute resolved Grok
+  binary plus exact argv order
+  `agent --model grok-4.5 --reasoning-effort high --agent-profile
+  <hash-pinned-project-no-tool-profile> --no-leader stdio`.
+- The project-owned Grok profile is digest-checked before every spawn. Its
+  empty tool allowlist plus explicit denylist removes write, shell, subagent,
+  memory, web, MCP, and LSP tools inside the Grok ACP server. This is required
+  in addition to ACPX `--deny-all --no-fs --no-terminal --allowed-tools ""`:
+  ACPX client flags alone do not remove native Grok tools.
 - Correlation / idempotency fields recorded as **evidence** (local runtime
   metadata only — never ACP protocol flags, argv, or stdin; never published
   to fleet-comms, dispatch authority, or review evidence), not as a new
@@ -119,6 +148,8 @@ ACPX is **not** a coordination product and **not** a second fleet bus.
 - Plane-mode or retention changes via ACPX
 - Review-eligibility changes via ACPX
 - Primary-checkout writes or write-mode ACP work
+- Treating Grok + Codex ACPX as a coordination plane, review bus, or
+  fleet-comms replacement
 
 **Do not invent CLI flags, endpoints, or review eligibility here.** The
 adapter's argv is fully confined and callers only ever set the `tool_config`
@@ -145,6 +176,7 @@ floating CLI surface.
 | --- | --- |
 | Feature flag off | Expected default — use native `runner.invoke` / bridge / discuss paths |
 | `AUTH_REQUIRED` with an existing ChatGPT Codex login | Verify `codex login status`, then set the non-secret per-process selector `ACPX_AUTH_CHAT_GPT=1`; `--auth-policy fail` deliberately refuses implicit method selection |
+| `AUTH_REQUIRED` on the Grok shadow seat | Establish the native Grok CLI's cached login outside this adapter; the Grok adapter automatically sets the non-secret per-process selector `ACPX_AUTH_CACHED_TOKEN=1` and scrubs ambient XAI API-key auth selectors so cached native login is the only accepted path |
 | Other auth failure | Fail closed; do not retry in-adapter; fix credentials outside the adapter and never store or log API keys in the repository |
 | Timeout / cancel | Treat as terminal for that prompt; no auto-replay |
 | Crash / malformed NDJSON | Classify and record; do not promote partial output to authority |
@@ -156,9 +188,12 @@ floating CLI surface.
 
 1. Disable the ACPX feature flag (default-off posture).
 2. Continue on native agent runtime transport
-   (`scripts/agent_runtime/` via `runner.invoke`, bridge, `delegate.py`).
+   (`scripts/agent_runtime/` via `runner.invoke`, bridge, `delegate.py`) —
+   native Codex and native Grok remain the authoritative paths.
 3. Leave fleet-comms plane mode and formal-review eligibility unchanged.
 4. Keep file dual-write handoffs current.
+5. Grok + Codex ACPX seats are independent observability pilots only; turning
+   either (or both) off is not a plane cutover.
 
 ### Buzz — deferred
 

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -1,11 +1,21 @@
-"""AcpxAdapter — experimental read-only shadow transport for ACPX (#6027).
+"""ACPX experimental read-only shadow transport (#6027, #6043).
 
-Wraps ``acpx codex exec`` (https://www.npmjs.com/package/acpx), a headless CLI
-client for the Agent Client Protocol (ACP). This adapter is Stage 0/1 scaffolding
-only: a feature-flagged, direct-only, observability seat for exactly one
-read-only/stateless Codex ACP participant. It is never registered for model
-selection, catalog, review eligibility, or failover (see registry.py entry
-``cli_available: False``).
+Wraps the project-local ``acpx@0.13.0`` headless CLI
+(https://www.npmjs.com/package/acpx) for the Agent Client Protocol (ACP).
+
+Two **separate** direct-only seats share this module:
+
+- ``AcpxAdapter`` / ``acpx-codex-shadow`` (#6027) — fixed Codex participant
+  via ``acpx … codex exec``
+- ``AcpxGrokShadowAdapter`` / ``acpx-grok-shadow`` (#6043) — fixed Grok
+  participant via a custom ``--agent`` command that forces native Grok
+  ``agent … --agent-profile <hash-pinned-no-tool-profile> --no-leader stdio``
+  (never the built-in ``grok-build`` name, which cannot place parent flags
+  before ``stdio``)
+
+Neither seat is registered for model selection, catalog, review eligibility,
+or failover (``cli_available: False``). They are not a second coordination
+plane: native Codex/Grok remain authoritative under shadow compare.
 
 Contract captured empirically from the pinned local ``acpx@0.13.0`` install
 (``node_modules/acpx``), not guessed:
@@ -13,10 +23,10 @@ Contract captured empirically from the pinned local ``acpx@0.13.0`` install
 - ``exec`` is always one-shot and never reuses a saved session or queue
   owner — confirmed by reading ``handleExec`` in ``dist/cli.js``, which calls
   ``runOnce()`` directly instead of the queue-owner path ``prompt`` uses.
-  This is what makes ``codex exec`` structurally safe for a stateless,
-  no-queue, non-persistent shadow call: we never need to reject "queue" or
-  "session" behavior at our own layer because the CLI subcommand itself has
-  none.
+  This is what makes ``codex exec`` / custom-agent ``exec`` structurally safe
+  for a stateless, no-queue, non-persistent shadow call: we never need to
+  reject "queue" or "session" behavior at our own layer because the CLI
+  subcommand itself has none.
 - Exit codes (``src/types.ts`` EXIT_CODES): SUCCESS=0, ERROR=1, USAGE=2,
   TIMEOUT=3, NO_SESSION=4, PERMISSION_DENIED=5, INTERRUPTED=130.
 - ``--format json --json-strict`` streams the raw ACP JSON-RPC exchange as
@@ -36,8 +46,12 @@ Contract captured empirically from the pinned local ``acpx@0.13.0`` install
   ``params.update.content == {"type": "text", "text": "..."}``; the terminal
   ``session/prompt`` response carries ``result.stopReason`` in
   ``{"end_turn", "max_tokens", "max_turn_requests", "refusal", "cancelled"}``.
+- Auth method selection under ``--auth-policy fail`` is explicit via non-secret
+  per-process selectors such as ``ACPX_AUTH_CHAT_GPT=1`` (Codex ChatGPT login)
+  and ``ACPX_AUTH_CACHED_TOKEN=1`` (Grok cached native login). Never invent
+  additional selectors; never read/store/log credentials.
 
-Confinement is structural, not probabilistic: every invocation this adapter
+Confinement is structural, not probabilistic: every invocation either adapter
 builds passes ``--deny-all --no-fs --no-terminal --allowed-tools ""
 --auth-policy fail --non-interactive-permissions fail --max-turns 1
 --prompt-retries 0`` unconditionally. There is no code path that can loosen
@@ -46,15 +60,18 @@ any of these — a caller cannot pass permission/tool overrides through
 markers plus local correlation/idempotency metadata — and rejects anything
 else before spawn).
 
-Issue: #6027
+Issues: #6027 (Codex pilot), #6043 (second Grok pilot).
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import re
+import shlex
+import shutil
 import subprocess
 from functools import lru_cache
 from pathlib import Path
@@ -87,12 +104,34 @@ PINNED_VERSION = "0.13.0"
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 
+# Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
+# Built-in acpx ``grok-build`` is intentionally unused: it expands to
+# ``grok agent stdio`` without a place for parent flags required by Grok
+# 0.2.114 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
+# before ``stdio``).
+PINNED_GROK_VERSION = "0.2.114"
+GROK_SHADOW_MODEL = "grok-4.5"
+GROK_SHADOW_EFFORT = "high"
+_GROK_PROFILE_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "profiles" / "acpx-grok-read-only.md"
+_GROK_PROFILE_SHA256 = "5831398f7204be279e908371b5f0990d5e5e725a323091232e184083649d7158"
+# Non-secret acpx 0.13.0 auth-method selector for a cached native Grok login.
+GROK_AUTH_CACHED_TOKEN_ENV = "ACPX_AUTH_CACHED_TOKEN"
+# Ambient XAI API-key selectors that would compete with cached_token under
+# --auth-policy fail. Scrubbed from the child env so the only accepted path
+# is the cached native login selector above. Never read as credential values.
+_GROK_XAI_API_KEY_ENV_UNSETS: tuple[str, ...] = (
+    "XAI_API_KEY",
+    "GROK_API_KEY",
+    "ACPX_AUTH_XAI_API_KEY",
+    "ACPX_AUTH_API_KEY",
+)
+
 # tool_config allowlist. Anything outside this set is rejected before spawn
 # — this is the enforcement point for "unsupported permission/tool config"
 # in the approved reject-before-spawn list. No key here can loosen
-# confinement; "target_agent" can only ever be re-affirmed as "codex".
-# "correlation_id"/"idempotency_key" are local runtime metadata only (see
-# _require_local_metadata_field): never forwarded to the ACP wire protocol.
+# confinement; each seat re-affirms its own fixed target_agent ("codex" or
+# "grok"). "correlation_id"/"idempotency_key" are local runtime metadata only
+# (see _require_local_metadata_field): never forwarded to the ACP wire protocol.
 _ALLOWED_TOOL_CONFIG_KEYS = frozenset(
     {"acpx_shadow", "target_agent", "correlation_id", "idempotency_key"}
 )
@@ -206,7 +245,12 @@ def _probe_acpx_version(binary: str) -> str:
     return (proc.stdout or "").strip()
 
 
-def _require_local_metadata_field(name: str, value: str | None) -> str:
+def _require_local_metadata_field(
+    name: str,
+    value: str | None,
+    *,
+    adapter_label: str = "AcpxAdapter",
+) -> str:
     """Validate a local runtime-metadata identifier, or refuse before spawn.
 
     Applies to ``task_id``, ``correlation_id``, and ``idempotency_key``:
@@ -215,18 +259,201 @@ def _require_local_metadata_field(name: str, value: str | None) -> str:
     protocol flags, argv, or stdin — see ``_ALLOWED_TOOL_CONFIG_KEYS``.
     """
     if value is None or not value.strip():
-        raise AcpxShadowRefusalError(f"AcpxAdapter: {name} must be a non-empty local identifier")
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: {name} must be a non-empty local identifier"
+        )
     stripped = value.strip()
     if len(stripped) > _METADATA_FIELD_MAX_LEN:
         raise AcpxShadowRefusalError(
-            f"AcpxAdapter: {name} exceeds the {_METADATA_FIELD_MAX_LEN}-char bound for local metadata"
+            f"{adapter_label}: {name} exceeds the {_METADATA_FIELD_MAX_LEN}-char "
+            "bound for local metadata"
         )
     if not _METADATA_FIELD_RE.match(stripped):
         raise AcpxShadowRefusalError(
-            f"AcpxAdapter: {name}={stripped!r} must match a bounded local identifier "
+            f"{adapter_label}: {name}={stripped!r} must match a bounded local identifier "
             f"pattern ({_METADATA_FIELD_RE.pattern}); refusing to forward unsafe metadata"
         )
     return stripped
+
+
+def _require_shadow_transport(*, adapter_label: str) -> None:
+    transport = os.environ.get(TRANSPORT_ENV, "off").strip().lower()
+    if transport != "shadow":
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: refusing to spawn ({TRANSPORT_ENV}={transport!r}); "
+            f"set {TRANSPORT_ENV}=shadow to enable the experimental ACPX shadow seat "
+            "(default is off)"
+        )
+
+
+def _require_shadow_tool_config(
+    tool_config: dict | None,
+    *,
+    adapter_label: str,
+    required_target: str,
+) -> dict[str, Any]:
+    tc = dict(tool_config or {})
+    unsupported_keys = set(tc) - _ALLOWED_TOOL_CONFIG_KEYS
+    if unsupported_keys:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: unsupported tool_config keys {sorted(unsupported_keys)!r}; "
+            f"only {sorted(_ALLOWED_TOOL_CONFIG_KEYS)!r} are recognized"
+        )
+    if tc.get("acpx_shadow") is not True:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: tool_config must set acpx_shadow=True as an explicit "
+            "per-call marker of shadow intent; the feature flag alone is not enough"
+        )
+    target_agent = tc.get("target_agent", required_target)
+    if target_agent != required_target:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: target_agent={target_agent!r} rejected; this seat supports "
+            f"exactly one ACP participant: {required_target}"
+        )
+    return tc
+
+
+def _require_non_primary_worktree(cwd: Path, *, adapter_label: str) -> None:
+    if _worktree_containment.classify_repo_path(cwd, cwd=cwd) == "primary_checkout":
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: refusing to spawn against the protected primary checkout "
+            f"({cwd}); run ACPX shadow calls from a worktree"
+        )
+
+
+def _require_pinned_acpx_binary(*, adapter_label: str) -> str:
+    if not _PINNED_BINARY.is_file():
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: pinned binary not found at {_PINNED_BINARY}; run "
+            f"`npm install acpx@{PINNED_VERSION} --save-exact --save-dev` first. "
+            "A global/PATH acpx binary is never used as a substitute."
+        )
+    binary = str(_PINNED_BINARY)
+    observed_version = _probe_acpx_version(binary)
+    if observed_version != PINNED_VERSION:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: resolved acpx binary reports version {observed_version!r} "
+            f"(expected pinned {PINNED_VERSION!r}); refusing to spawn on a version mismatch"
+        )
+    return binary
+
+
+def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
+    """Shared structural confinement flags for every ACPX shadow seat."""
+    return [
+        binary,
+        "--cwd",
+        str(cwd),
+        "--format",
+        "json",
+        "--json-strict",
+        "--auth-policy",
+        "fail",
+        "--deny-all",
+        "--non-interactive-permissions",
+        "fail",
+        "--no-fs",
+        "--no-terminal",
+        "--allowed-tools",
+        "",
+        "--max-turns",
+        "1",
+        "--prompt-retries",
+        "0",
+    ]
+
+
+_GROK_VERSION_RE = re.compile(r"\Agrok\s+(\d+\.\d+\.\d+)(?:\s|$)")
+
+
+@lru_cache(maxsize=4)
+def _probe_grok_version(binary: str) -> str:
+    """Return exact semver from ``<binary> --version``, or "" on any failure.
+
+    Native Grok 0.2.114 prints ``grok 0.2.114 (<sha>) [stable]``. Wrong,
+    missing, or unparseable output fails closed before prompt.
+    """
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    text = (proc.stdout or "").strip()
+    match = _GROK_VERSION_RE.match(text)
+    return match.group(1) if match else ""
+
+
+def _resolve_grok_binary() -> str:
+    """Resolve the installed ``grok`` CLI to an absolute path, or refuse.
+
+    Uses PATH lookup then ``Path.resolve()`` so the shell-safe ``--agent``
+    command embeds an absolute binary. Does not fall back to inventing paths.
+    """
+    found = shutil.which("grok")
+    if not found:
+        raise AcpxShadowRefusalError(
+            "AcpxGrokShadowAdapter: grok binary not found on PATH; install the "
+            f"native Grok CLI at exact semver {PINNED_GROK_VERSION} before using "
+            "the acpx-grok-shadow seat"
+        )
+    resolved = Path(found).resolve()
+    if not resolved.is_file():
+        raise AcpxShadowRefusalError(
+            f"AcpxGrokShadowAdapter: resolved grok path {resolved} is not a file"
+        )
+    return str(resolved)
+
+
+def _require_grok_profile() -> str:
+    """Return the exact project-owned no-tool profile, or refuse before spawn."""
+    try:
+        content = _GROK_PROFILE_PATH.read_bytes()
+    except OSError as exc:
+        raise AcpxShadowRefusalError(
+            f"AcpxGrokShadowAdapter: required no-tool Grok profile unavailable at "
+            f"{_GROK_PROFILE_PATH}: {exc}"
+        ) from exc
+    observed = hashlib.sha256(content).hexdigest()
+    if observed != _GROK_PROFILE_SHA256:
+        raise AcpxShadowRefusalError(
+            "AcpxGrokShadowAdapter: no-tool Grok profile digest mismatch "
+            f"(observed {observed!r}, expected {_GROK_PROFILE_SHA256!r}); "
+            "refusing to spawn with an unreviewed tool policy"
+        )
+    return str(_GROK_PROFILE_PATH)
+
+
+def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
+    """Shell-safe single ``--agent`` value with required Grok 0.2.114 argv order.
+
+    Exact token order (parent flags before ``stdio``)::
+
+        ABS_GROK agent --model grok-4.5 --reasoning-effort high
+        --agent-profile ABS_PROFILE --no-leader stdio
+
+    Never uses the ACPX built-in ``grok-build`` name.
+    """
+    return shlex.join(
+        [
+            abs_grok,
+            "agent",
+            "--model",
+            GROK_SHADOW_MODEL,
+            "--reasoning-effort",
+            GROK_SHADOW_EFFORT,
+            "--agent-profile",
+            profile_path,
+            "--no-leader",
+            "stdio",
+        ]
+    )
 
 
 class AcpxAdapter:
@@ -293,32 +520,12 @@ class AcpxAdapter:
                 f"AcpxAdapter: unsupported mode {mode!r}; only 'read-only' is permitted for the ACPX shadow seat"
             )
 
-        transport = os.environ.get(TRANSPORT_ENV, "off").strip().lower()
-        if transport != "shadow":
-            raise AcpxShadowRefusalError(
-                f"AcpxAdapter: refusing to spawn ({TRANSPORT_ENV}={transport!r}); "
-                f"set {TRANSPORT_ENV}=shadow to enable the experimental ACPX shadow seat "
-                "(default is off)"
-            )
-
-        tc = dict(tool_config or {})
-        unsupported_keys = set(tc) - _ALLOWED_TOOL_CONFIG_KEYS
-        if unsupported_keys:
-            raise AcpxShadowRefusalError(
-                f"AcpxAdapter: unsupported tool_config keys {sorted(unsupported_keys)!r}; "
-                f"only {sorted(_ALLOWED_TOOL_CONFIG_KEYS)!r} are recognized"
-            )
-        if tc.get("acpx_shadow") is not True:
-            raise AcpxShadowRefusalError(
-                "AcpxAdapter: tool_config must set acpx_shadow=True as an explicit "
-                "per-call marker of shadow intent; the feature flag alone is not enough"
-            )
-        target_agent = tc.get("target_agent", "codex")
-        if target_agent != "codex":
-            raise AcpxShadowRefusalError(
-                f"AcpxAdapter: target_agent={target_agent!r} rejected; this seat supports "
-                "exactly one ACP participant: codex"
-            )
+        _require_shadow_transport(adapter_label="AcpxAdapter")
+        tc = _require_shadow_tool_config(
+            tool_config,
+            adapter_label="AcpxAdapter",
+            required_target="codex",
+        )
 
         validated_task_id = _require_local_metadata_field("task_id", task_id)
         correlation_id = _require_local_metadata_field("correlation_id", tc.get("correlation_id"))
@@ -330,41 +537,10 @@ class AcpxAdapter:
                 "`exec` only and never resumes a named or persistent ACP session"
             )
 
-        if _worktree_containment.classify_repo_path(cwd, cwd=cwd) == "primary_checkout":
-            raise AcpxShadowRefusalError(
-                f"AcpxAdapter: refusing to spawn against the protected primary checkout "
-                f"({cwd}); run ACPX shadow calls from a worktree"
-            )
+        _require_non_primary_worktree(cwd, adapter_label="AcpxAdapter")
+        binary = _require_pinned_acpx_binary(adapter_label="AcpxAdapter")
 
-        binary = self._resolve_pinned_binary()
-        observed_version = _probe_acpx_version(binary)
-        if observed_version != PINNED_VERSION:
-            raise AcpxShadowRefusalError(
-                f"AcpxAdapter: resolved acpx binary reports version {observed_version!r} "
-                f"(expected pinned {PINNED_VERSION!r}); refusing to spawn on a version mismatch"
-            )
-
-        cmd: list[str] = [
-            binary,
-            "--cwd",
-            str(cwd),
-            "--format",
-            "json",
-            "--json-strict",
-            "--auth-policy",
-            "fail",
-            "--deny-all",
-            "--non-interactive-permissions",
-            "fail",
-            "--no-fs",
-            "--no-terminal",
-            "--allowed-tools",
-            "",
-            "--max-turns",
-            "1",
-            "--prompt-retries",
-            "0",
-        ]
+        cmd: list[str] = _confinement_prefix_argv(binary, cwd)
         if model:
             cmd.extend(["--model", model])
         if effort is not None:
@@ -392,6 +568,11 @@ class AcpxAdapter:
 
     @classmethod
     def _resolve_pinned_binary(cls) -> str:
+        """Resolve the project-local acpx binary path without version probing.
+
+        Kept for callers/tests that only need the path check. Version pin
+        enforcement lives in :func:`_require_pinned_acpx_binary`.
+        """
         if not _PINNED_BINARY.is_file():
             raise AcpxShadowRefusalError(
                 f"AcpxAdapter: pinned binary not found at {_PINNED_BINARY}; run "
@@ -565,5 +746,176 @@ class AcpxAdapter:
         happens, so the runner's stdout streaming watchdog is a complete
         liveness signal on its own.
         """
+        _ = plan
+        return ()
+
+
+class AcpxGrokShadowAdapter:
+    """Adapter for a fixed Grok Build ACP participant via ACPX (#6043).
+
+    Separate public class from :class:`AcpxAdapter` — not a generic
+    caller-selectable multipurpose adapter. Canonical seat name is
+    ``acpx-grok-shadow``; fixed per-call target is ``target_agent="grok"``.
+
+    Builds one confined shape only:
+
+    - project-local ``acpx@0.13.0``
+    - custom ``--agent`` command from the absolute installed Grok binary at
+      exact semver :data:`PINNED_GROK_VERSION`, never the built-in
+      ``grok-build`` name
+    - exact hash-pinned project profile with no tools plus an explicit
+      write/shell/subagent/web/MCP/memory denylist
+    - fixed model/effort ``grok-4.5`` / ``high`` inside that agent command
+    - ``ACPX_AUTH_CACHED_TOKEN=1`` under ``--auth-policy fail``, with ambient
+      XAI API-key auth selectors scrubbed
+    - one-shot ``exec``, no session, deny-all / no-fs / no-terminal
+    """
+
+    name: str = "acpx-grok-shadow"
+    # Fixed effective model baked into the --agent command. Telemetry must
+    # report this value; callers may only pass None or the same string.
+    default_model: str = GROK_SHADOW_MODEL
+    supported_modes: frozenset[str] = frozenset({"read-only"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        """Build the confined Grok ACPX shadow invocation, or refuse before spawn.
+
+        Refusal conditions (all raise :class:`AcpxShadowRefusalError` unless
+        noted), matching the approved #6043 contract:
+
+        - ``mode`` is not ``"read-only"`` (plain ``ValueError``)
+        - ``LU_ACPX_TRANSPORT`` is not exactly ``"shadow"``
+        - missing ``acpx_shadow=True`` or unsupported ``tool_config`` keys
+        - ``target_agent`` is not ``"grok"``
+        - ``session_id`` is not None
+        - ``cwd`` is the protected primary checkout
+        - project-local acpx missing / wrong version
+        - Grok binary missing / wrong / unparseable version
+        - no-tool profile missing or changed from its reviewed digest
+        - caller ``model`` is not ``None`` or ``grok-4.5``
+        - caller ``effort`` is not ``None`` or ``high``
+        - missing/blank/oversized/unsafe local metadata fields
+        """
+        if mode not in self.supported_modes:
+            raise ValueError(
+                f"AcpxGrokShadowAdapter: unsupported mode {mode!r}; only 'read-only' "
+                "is permitted for the ACPX shadow seat"
+            )
+
+        _require_shadow_transport(adapter_label="AcpxGrokShadowAdapter")
+        tc = _require_shadow_tool_config(
+            tool_config,
+            adapter_label="AcpxGrokShadowAdapter",
+            required_target="grok",
+        )
+
+        if model is not None and model != GROK_SHADOW_MODEL:
+            raise AcpxShadowRefusalError(
+                f"AcpxGrokShadowAdapter: model={model!r} rejected; caller may only pass "
+                f"None or {GROK_SHADOW_MODEL!r} (effective model is always {GROK_SHADOW_MODEL!r})"
+            )
+        if effort is not None and effort != GROK_SHADOW_EFFORT:
+            raise AcpxShadowRefusalError(
+                f"AcpxGrokShadowAdapter: effort={effort!r} rejected; caller may only pass "
+                f"None or {GROK_SHADOW_EFFORT!r} (effective effort is always {GROK_SHADOW_EFFORT!r})"
+            )
+
+        validated_task_id = _require_local_metadata_field(
+            "task_id", task_id, adapter_label="AcpxGrokShadowAdapter"
+        )
+        correlation_id = _require_local_metadata_field(
+            "correlation_id",
+            tc.get("correlation_id"),
+            adapter_label="AcpxGrokShadowAdapter",
+        )
+        idempotency_key = _require_local_metadata_field(
+            "idempotency_key",
+            tc.get("idempotency_key"),
+            adapter_label="AcpxGrokShadowAdapter",
+        )
+
+        if session_id is not None:
+            raise AcpxShadowRefusalError(
+                "AcpxGrokShadowAdapter: session_id must be None; the ACPX shadow seat is "
+                "one-shot `exec` only and never resumes a named or persistent ACP session"
+            )
+
+        _require_non_primary_worktree(cwd, adapter_label="AcpxGrokShadowAdapter")
+        acpx_binary = _require_pinned_acpx_binary(adapter_label="AcpxGrokShadowAdapter")
+
+        grok_binary = _resolve_grok_binary()
+        observed_grok = _probe_grok_version(grok_binary)
+        if observed_grok != PINNED_GROK_VERSION:
+            raise AcpxShadowRefusalError(
+                f"AcpxGrokShadowAdapter: resolved grok binary reports version "
+                f"{observed_grok!r} (expected pinned {PINNED_GROK_VERSION!r}); "
+                "refusing to spawn on a version mismatch"
+            )
+
+        profile_path = _require_grok_profile()
+        agent_command = _build_grok_agent_command(grok_binary, profile_path)
+        cmd: list[str] = _confinement_prefix_argv(acpx_binary, cwd)
+        # --agent is a single shell-safe command string. Do not combine with a
+        # positional agent token (acpx grammar), and never emit built-in
+        # "grok-build".
+        cmd.extend(["--agent", agent_command, "exec", "-f", "-"])
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload=prompt,
+            output_file=None,
+            env_overrides={GROK_AUTH_CACHED_TOKEN_ENV: "1"},
+            env_unsets=_GROK_XAI_API_KEY_ENV_UNSETS,
+            liveness_paths=(),
+            metadata={
+                "acpx_shadow": True,
+                "acpx_pinned_version": PINNED_VERSION,
+                "grok_pinned_version": PINNED_GROK_VERSION,
+                "grok_profile_sha256": _GROK_PROFILE_SHA256,
+                "target_agent": "grok",
+                # Effective values are fixed; never fabricate caller-supplied
+                # alternatives in telemetry.
+                "model": GROK_SHADOW_MODEL,
+                "effort": GROK_SHADOW_EFFORT,
+                "task_id": validated_task_id,
+                "correlation_id": correlation_id,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse ACPX NDJSON using the same fail-closed Codex shadow parser."""
+        return AcpxAdapter().parse_response(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            output_file=output_file,
+            plan=plan,
+            call_start_time=call_start_time,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """No fallback liveness files — acpx streams NDJSON directly to stdout."""
         _ = plan
         return ()

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -49,7 +49,10 @@ Contract captured empirically from the pinned local ``acpx@0.13.0`` install
 - Auth method selection under ``--auth-policy fail`` is explicit via non-secret
   per-process selectors such as ``ACPX_AUTH_CHAT_GPT=1`` (Codex ChatGPT login)
   and ``ACPX_AUTH_CACHED_TOKEN=1`` (Grok cached native login). Never invent
-  additional selectors; never read/store/log credentials.
+  additional selectors; never read/store/log credentials. The Grok selector
+  was verified live against the pinned custom ``--agent`` command: the
+  selector produced a successful one-shot response, while the same runtime
+  path with the selector stripped failed closed as ``AUTH_REQUIRED``.
 
 Confinement is structural, not probabilistic: every invocation either adapter
 builds passes ``--deny-all --no-fs --no-terminal --allowed-tools ""

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -103,6 +103,13 @@ _PROVIDER_SECRET_ALLOWLIST = {
 }
 
 _PROVIDER_SAFE_NAME_ALLOWLIST = {
+    "acpx-grok-shadow": {
+        # acpx@0.13.0 treats this as a non-secret auth-method selector:
+        # the literal value "1" chooses Grok's agent-managed cached_token
+        # method. It is not a cached token or credential value. Real XAI
+        # API-key selectors remain outside every allowlist and are stripped.
+        "ACPX_AUTH_CACHED_TOKEN",
+    },
     "gemini": {
         "GEMINI_AUTH_MODE",
     },

--- a/scripts/agent_runtime/profiles/acpx-grok-read-only.md
+++ b/scripts/agent_runtime/profiles/acpx-grok-read-only.md
@@ -1,0 +1,28 @@
+---
+name: acpx-grok-read-only
+description: No-tool profile for the bounded ACPX Grok shadow seat.
+prompt_mode: full
+permission_mode: plan
+tools: []
+disallowedTools:
+  - search_replace
+  - bash
+  - web_search
+  - web_fetch
+  - todo_write
+  - task
+  - kill_task
+  - get_task_output
+  - memory_search
+  - memory_get
+  - search_tool
+  - use_tool
+  - lsp
+agents_md: true
+---
+
+You are the no-tool Grok participant in a bounded, read-only ACPX shadow
+comparison. Answer the prompt directly from the supplied context. Do not read,
+create, modify, rename, or delete files. Do not execute commands, use web or
+MCP tools, access memory, or spawn subagents. If the prompt requires any such
+action, state that the shadow seat cannot perform it.

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -287,6 +287,23 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": False,
         "resume_policy": "never",
     },
+    "acpx-grok-shadow": {
+        # Second experimental read-only shadow transport (#6043). Direct-only:
+        # never returned by ``available_agents()`` (cli_available False), never
+        # a dispatch/routing/review/failover candidate. Callers must import
+        # ``AcpxGrokShadowAdapter`` directly and pass
+        # ``tool_config={"acpx_shadow": True, "target_agent": "grok"}`` with
+        # ``LU_ACPX_TRANSPORT=shadow`` set — see adapters/acpx.py. Fixed
+        # effective model/effort live inside the custom --agent command; do
+        # not advertise a catalog model here. Not a new coordination plane —
+        # native Grok remains authoritative.
+        "adapter": "scripts.agent_runtime.adapters.acpx:AcpxGrokShadowAdapter",
+        "default_model": None,
+        "cost_tier": "unknown",
+        "capabilities": frozenset(),
+        "cli_available": False,
+        "resume_policy": "never",
+    },
     "agy": {
         # Antigravity CLI shipping Gemini Flash 3.6 (was 3.5) on a separate meter from
         # gemini-cli. Added 2026-05-20 for the seminar-writer ADR bakeoff

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1,4 +1,4 @@
-"""Tests for AcpxAdapter — the experimental ACPX read-only shadow seat (#6027).
+"""Tests for ACPX shadow seats — Codex (#6027) and Grok (#6043).
 
 The NDJSON transcripts below (inlined as module-level constants rather than
 ``tests/fixtures/acpx/*.ndjson`` files, to keep this seat's changed-file
@@ -13,17 +13,23 @@ suite verifies against. No test in this file spawns a real subprocess or
 touches the network; all process-lifecycle categories (success, cancel,
 timeout, crash, malformed/partial NDJSON, duplicate replay, auth failure) are
 exercised as pure ``parse_response()`` calls over fixture stdout, exactly as
-the runner would call the adapter after collecting subprocess output.
+the runner would call the adapter after collecting subprocess output. Grok
+build-invocation tests mock binary resolution and version probes only.
 """
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 import pytest
 
 from scripts.agent_runtime.adapters import acpx as acpx_module
-from scripts.agent_runtime.adapters.acpx import AcpxAdapter, AcpxShadowRefusalError
+from scripts.agent_runtime.adapters.acpx import (
+    AcpxAdapter,
+    AcpxGrokShadowAdapter,
+    AcpxShadowRefusalError,
+)
 
 _SUCCESS_NDJSON = (
     '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1,'
@@ -892,3 +898,505 @@ def test_parse_response_nonzero_exit_with_end_turn_still_fails():
     )
     assert result.ok is False
     assert result.response == ""
+
+
+# ---------------------------------------------------------------------------
+# AcpxGrokShadowAdapter — second bounded shadow seat (#6043)
+# ---------------------------------------------------------------------------
+
+
+def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.114") -> Path:
+    """Point the Grok seat at a fake absolute grok binary + version probe."""
+    grok = tmp_path / "fake-grok-bin"
+    grok.write_text("#!/bin/sh\necho stub-grok\n", encoding="utf-8")
+    grok.chmod(0o755)
+    monkeypatch.setattr(acpx_module, "_resolve_grok_binary", lambda: str(grok.resolve()))
+    monkeypatch.setattr(acpx_module, "_probe_grok_version", lambda _binary: version)
+    return grok.resolve()
+
+
+def _build_grok(
+    adapter: AcpxGrokShadowAdapter,
+    *,
+    cwd: Path,
+    prompt: str = "ping",
+    model: str | None = None,
+    task_id: str | None = "t-1",
+    session_id: str | None = None,
+    tool_config: dict | None = None,
+    effort: str | None = None,
+):
+    if tool_config is None:
+        tool_config = {
+            "acpx_shadow": True,
+            "target_agent": "grok",
+            "correlation_id": "corr-1",
+            "idempotency_key": "idem-1",
+        }
+    return adapter.build_invocation(
+        prompt=prompt,
+        mode="read-only",
+        cwd=cwd,
+        model=model,
+        task_id=task_id,
+        session_id=session_id,
+        tool_config=tool_config,
+        effort=effort,
+    )
+
+
+def test_grok_adapter_identity_is_read_only_only():
+    adapter = AcpxGrokShadowAdapter()
+    assert adapter.name == "acpx-grok-shadow"
+    assert adapter.default_model == "grok-4.5"
+    assert adapter.supported_modes == frozenset({"read-only"})
+
+
+def test_grok_build_invocation_refuses_when_flag_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv(acpx_module.TRANSPORT_ENV, raising=False)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="LU_ACPX_TRANSPORT"):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_refuses_when_flag_off(tmp_path, monkeypatch):
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "off")
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_requires_explicit_shadow_marker(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="acpx_shadow"):
+        _build_grok(adapter, cwd=tmp_path, tool_config={})
+
+
+def test_grok_build_invocation_rejects_unsupported_tool_config(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="unsupported tool_config"):
+        _build_grok(
+            adapter,
+            cwd=tmp_path,
+            tool_config={
+                "acpx_shadow": True,
+                "target_agent": "grok",
+                "allowed_tools": ["Bash"],
+            },
+        )
+
+
+def test_grok_build_invocation_rejects_non_grok_target(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="target_agent"):
+        _build_grok(
+            adapter,
+            cwd=tmp_path,
+            tool_config={
+                "acpx_shadow": True,
+                "target_agent": "codex",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+
+def test_grok_build_invocation_rejects_session_id(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="session_id"):
+        _build_grok(adapter, cwd=tmp_path, session_id="prior-session")
+
+
+def test_grok_build_invocation_rejects_wrong_model(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="model="):
+        _build_grok(adapter, cwd=tmp_path, model="grok-3")
+
+
+def test_grok_build_invocation_rejects_wrong_effort(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="effort="):
+        _build_grok(adapter, cwd=tmp_path, effort="low")
+
+
+def test_grok_build_invocation_refuses_primary_checkout(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        acpx_module._worktree_containment,
+        "classify_repo_path",
+        lambda *_args, **_kwargs: "primary_checkout",
+    )
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="primary checkout"):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_rejects_acpx_version_mismatch(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path, version="0.12.1")
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="version"):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_rejects_grok_version_mismatch(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path, version="0.2.100")
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="grok binary reports version"):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_rejects_unparseable_grok_version(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path, version="")
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(AcpxShadowRefusalError, match="version"):
+        _build_grok(adapter, cwd=tmp_path)
+
+
+def test_grok_build_invocation_fixed_command_and_ordering(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    grok = _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    plan = _build_grok(adapter, cwd=tmp_path, prompt="shadow compare prompt")
+
+    assert plan.cmd[0] == str(acpx_module._PINNED_BINARY)
+    assert Path(plan.cmd[0]).is_absolute() or plan.cmd[0].startswith(str(tmp_path))
+    assert "grok-build" not in plan.cmd
+    assert "codex" not in plan.cmd
+    assert plan.cmd[-3:] == ["exec", "-f", "-"]
+    assert "--agent" in plan.cmd
+    agent_idx = plan.cmd.index("--agent")
+    agent_cmd = plan.cmd[agent_idx + 1]
+    # Single --agent argument: absolute shell-safe binary + exact argv order.
+    expected_agent = " ".join(
+        [
+            shlex.quote(str(grok)),
+            "agent",
+            "--model",
+            "grok-4.5",
+            "--reasoning-effort",
+            "high",
+            "--agent-profile",
+            str(acpx_module._GROK_PROFILE_PATH),
+            "--no-leader",
+            "stdio",
+        ]
+    )
+    assert agent_cmd == expected_agent
+    tokens = shlex.split(agent_cmd)
+    assert tokens[0] == str(grok)
+    assert Path(tokens[0]).is_absolute()
+    assert tokens[1:] == [
+        "agent",
+        "--model",
+        "grok-4.5",
+        "--reasoning-effort",
+        "high",
+        "--agent-profile",
+        str(acpx_module._GROK_PROFILE_PATH),
+        "--no-leader",
+        "stdio",
+    ]
+    # --agent must not be combined with a positional agent name before exec.
+    assert plan.cmd[agent_idx + 2] == "exec"
+
+    pairs = list(zip(plan.cmd, plan.cmd[1:], strict=False))
+    assert ("--auth-policy", "fail") in pairs
+    assert ("--non-interactive-permissions", "fail") in pairs
+    assert ("--allowed-tools", "") in pairs
+    assert ("--max-turns", "1") in pairs
+    assert ("--prompt-retries", "0") in pairs
+    assert "--deny-all" in plan.cmd
+    assert "--no-fs" in plan.cmd
+    assert "--no-terminal" in plan.cmd
+    assert "--model" not in plan.cmd  # model lives only inside --agent
+    assert plan.stdin_payload == "shadow compare prompt"
+    assert "shadow compare prompt" not in plan.cmd
+
+
+def test_grok_build_invocation_accepts_none_or_fixed_model_and_effort(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    for model, effort in ((None, None), ("grok-4.5", None), (None, "high"), ("grok-4.5", "high")):
+        plan = _build_grok(adapter, cwd=tmp_path, model=model, effort=effort)
+        assert plan.metadata["model"] == "grok-4.5"
+        assert plan.metadata["effort"] == "high"
+        assert plan.metadata["target_agent"] == "grok"
+        assert plan.metadata["grok_pinned_version"] == "0.2.114"
+        assert plan.metadata["acpx_pinned_version"] == "0.13.0"
+
+
+def test_grok_build_invocation_auth_env_sets_cached_token_and_scrubs_xai_keys(
+    tmp_path, monkeypatch
+):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    plan = _build_grok(adapter, cwd=tmp_path)
+    assert plan.env_overrides == {"ACPX_AUTH_CACHED_TOKEN": "1"}
+    assert "XAI_API_KEY" in plan.env_unsets
+    assert "GROK_API_KEY" in plan.env_unsets
+    assert "ACPX_AUTH_XAI_API_KEY" in plan.env_unsets
+    assert "ACPX_AUTH_API_KEY" in plan.env_unsets
+    # Never forward credentials into argv, stdin, or metadata.
+    for blob in (plan.cmd, [plan.stdin_payload], list(plan.metadata.values())):
+        serialized = " ".join(str(x) for x in blob)
+        assert "sk-" not in serialized
+        assert "xai-" not in serialized.lower() or "xai_api_key" not in serialized.lower()
+
+
+def test_grok_build_invocation_stamps_metadata_without_forwarding(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    plan = _build_grok(
+        adapter,
+        cwd=tmp_path,
+        prompt="investigate flaky test",
+        task_id="task-grok-42",
+        tool_config={
+            "acpx_shadow": True,
+            "target_agent": "grok",
+            "correlation_id": "corr-g.1",
+            "idempotency_key": "idem-g:9",
+        },
+    )
+    assert plan.metadata["task_id"] == "task-grok-42"
+    assert plan.metadata["correlation_id"] == "corr-g.1"
+    assert plan.metadata["idempotency_key"] == "idem-g:9"
+    for value in ("task-grok-42", "corr-g.1", "idem-g:9"):
+        assert value not in plan.cmd
+        assert value not in plan.stdin_payload
+
+
+def test_grok_build_invocation_rejects_write_mode(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path)
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(ValueError, match="mode"):
+        adapter.build_invocation(
+            prompt="ping",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model=None,
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_shadow": True,
+                "target_agent": "grok",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+
+def test_grok_parse_response_success_compatible_with_codex_parser():
+    adapter = AcpxGrokShadowAdapter()
+    result = adapter.parse_response(
+        stdout=_SUCCESS_NDJSON,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+    assert result.ok is True
+    assert result.response == "Hello world."
+    assert result.session_id is None
+    assert result.tool_calls == []
+
+
+def test_grok_parse_response_timeout_and_auth_fail_closed():
+    adapter = AcpxGrokShadowAdapter()
+    timeout = adapter.parse_response(
+        stdout=_TIMEOUT_NDJSON, stderr="", returncode=3, output_file=None
+    )
+    assert timeout.ok is False
+    assert "TIMEOUT" in timeout.stderr_excerpt
+
+    auth = adapter.parse_response(
+        stdout=_AUTH_REQUIRED_NDJSON, stderr="", returncode=1, output_file=None
+    )
+    assert auth.ok is False
+    assert "AUTH_REQUIRED" in auth.stderr_excerpt
+
+
+def test_grok_parse_response_cancel_crash_malformed_replay_fail_closed():
+    adapter = AcpxGrokShadowAdapter()
+    for stdout, rc, needle in (
+        (_CANCELLED_NDJSON, 0, "cancelled"),
+        (_CRASH_NO_TERMINAL_NDJSON, -9, "without a terminal"),
+        (_MALFORMED_LINE_NDJSON, -9, "malformed"),
+        (_DUPLICATE_REPLAY_NDJSON, 0, "duplicate"),
+        (_AGENT_DISCONNECTED_NDJSON, 1, "AGENT_DISCONNECTED"),
+    ):
+        result = adapter.parse_response(stdout=stdout, stderr="", returncode=rc, output_file=None)
+        assert result.ok is False
+        assert result.response == ""
+        assert needle.lower() in (result.stderr_excerpt or "").lower()
+
+
+def test_codex_adapter_unchanged_still_targets_codex_only(tmp_path, monkeypatch):
+    """Regression: Codex seat must not become a generic multi-agent adapter."""
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    adapter = AcpxAdapter()
+    plan = _build(adapter, cwd=tmp_path)
+    assert adapter.name == "acpx-codex-shadow"
+    assert "codex" in plan.cmd
+    assert "exec" in plan.cmd
+    assert "--agent" not in plan.cmd
+    assert "grok-build" not in plan.cmd
+    assert plan.env_overrides == {}
+    assert plan.env_unsets == ()
+    with pytest.raises(AcpxShadowRefusalError, match="target_agent"):
+        _build(
+            adapter,
+            cwd=tmp_path,
+            tool_config={
+                "acpx_shadow": True,
+                "target_agent": "grok",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+
+def test_build_grok_agent_command_quotes_absolute_paths_with_spaces(tmp_path):
+    abs_path = tmp_path / "path with spaces" / "grok"
+    profile_path = tmp_path / "profile with spaces" / "read only.md"
+    abs_path.parent.mkdir(parents=True)
+    profile_path.parent.mkdir(parents=True)
+    abs_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    profile_path.write_text("---\nname: read-only\n---\n", encoding="utf-8")
+    cmd = acpx_module._build_grok_agent_command(str(abs_path), str(profile_path))
+    tokens = shlex.split(cmd)
+    assert tokens[0] == str(abs_path)
+    assert tokens[1:] == [
+        "agent",
+        "--model",
+        "grok-4.5",
+        "--reasoning-effort",
+        "high",
+        "--agent-profile",
+        str(profile_path),
+        "--no-leader",
+        "stdio",
+    ]
+
+
+def test_grok_profile_is_exact_and_digest_mismatch_fails_closed(tmp_path, monkeypatch):
+    assert acpx_module._require_grok_profile() == str(acpx_module._GROK_PROFILE_PATH)
+
+    changed = tmp_path / "changed-profile.md"
+    changed.write_text("---\nname: changed\n---\n", encoding="utf-8")
+    monkeypatch.setattr(acpx_module, "_GROK_PROFILE_PATH", changed)
+    with pytest.raises(AcpxShadowRefusalError, match="digest mismatch"):
+        acpx_module._require_grok_profile()
+
+
+def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path):
+    binary = tmp_path / "grok"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+
+    class _Proc:
+        def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
+
+    monkeypatch.setattr(
+        acpx_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Proc("grok 0.2.114 (0c785038798) [stable]\n"),
+    )
+    acpx_module._probe_grok_version.cache_clear()
+    assert acpx_module._probe_grok_version(str(binary)) == "0.2.114"
+
+    monkeypatch.setattr(
+        acpx_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Proc("not a version string"),
+    )
+    acpx_module._probe_grok_version.cache_clear()
+    assert acpx_module._probe_grok_version(str(binary)) == ""
+
+    monkeypatch.setattr(
+        acpx_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Proc(
+            "wrapper 9.9.9; grok 0.2.114 (0c785038798) [stable]\n"
+        ),
+    )
+    acpx_module._probe_grok_version.cache_clear()
+    assert acpx_module._probe_grok_version(str(binary)) == ""
+
+    monkeypatch.setattr(
+        acpx_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Proc(
+            "grok 0.2.114 (0c785038798) [stable]\n",
+            "fatal: startup failed\n",
+            returncode=1,
+        ),
+    )
+    acpx_module._probe_grok_version.cache_clear()
+    assert acpx_module._probe_grok_version(str(binary)) == ""
+
+    def _boom(*_a, **_k):
+        raise OSError("missing")
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _boom)
+    acpx_module._probe_grok_version.cache_clear()
+    assert acpx_module._probe_grok_version(str(binary)) == ""

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -194,6 +194,7 @@ def test_registry_has_known_agents():
         "agy",
         "cursor",
         "acpx-codex-shadow",
+        "acpx-grok-shadow",
     }
 
 
@@ -206,6 +207,18 @@ def test_acpx_codex_shadow_entry_is_direct_only():
     assert entry["resume_policy"] == "never"
     assert entry["capabilities"] == frozenset()
     assert "acpx-codex-shadow" not in available_agents()
+
+
+def test_acpx_grok_shadow_entry_is_direct_only():
+    entry = get_agent_entry("acpx-grok-shadow")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.acpx:AcpxGrokShadowAdapter"
+    # Fixed effective model/effort live inside the custom --agent command;
+    # this direct-only seat must not advertise a catalog model.
+    assert entry["default_model"] is None
+    assert entry["cli_available"] is False
+    assert entry["resume_policy"] == "never"
+    assert entry["capabilities"] == frozenset()
+    assert "acpx-grok-shadow" not in available_agents()
 
 
 def test_cursor_entry_is_well_formed():

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -192,6 +192,27 @@ def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
     assert "UNRELATED" not in env
 
 
+def test_acpx_grok_cached_login_selector_survives_without_xai_credentials():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "XAI_API_KEY": "xai-secret",
+            "ACPX_AUTH_XAI_API_KEY": "xai-selector-secret",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(
+            provider="acpx-grok-shadow",
+            overrides={"ACPX_AUTH_CACHED_TOKEN": "1"},
+        )
+
+    assert env["ACPX_AUTH_CACHED_TOKEN"] == "1"
+    assert "XAI_API_KEY" not in env
+    assert "ACPX_AUTH_XAI_API_KEY" not in env
+
+
 def test_hermes_home_override_reaches_hermes_backed_agents():
     with patch.dict(
         "os.environ",

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -96,6 +96,7 @@ def test_five_ownership_surfaces(onboarding: str) -> None:
     assert "structured" in lower and "transport" in lower
     assert "read-only" in lower or "read only" in lower
     assert "codex" in lower
+    assert "grok" in lower
     assert "feature flag" in lower or "feature-flag" in lower or "default-off" in lower
     # Buzz deferred
     assert "buzz" in lower
@@ -254,12 +255,49 @@ def test_acpx_default_off_rollback(onboarding: str, all_owned: dict[str, str]) -
     assert "rollback" in runtime or "flag off" in runtime or ("default" in runtime and "off" in runtime)
 
 
+def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned: dict[str, str]) -> None:
+    """#6043 — Grok second pilot: broker evidence, two seats, not a new plane."""
+    lower = onboarding.lower()
+    assert "acpx-codex-shadow" in onboarding
+    assert "acpx-grok-shadow" in onboarding
+    assert "95" in onboarding
+    assert "codex 26" in lower or "codex **26**" in lower or "**codex 26**" in lower
+    assert "grok-atlas" in lower
+    assert "claude 22" in lower or "claude **22**" in lower or "**claude 22**" in lower
+    assert "grok 1" in lower or "grok **1**" in lower or "**grok 1**" in lower
+    assert "broker" in lower
+    assert "direct-runtime" in lower or "direct runtime" in lower
+    assert "2026-07-30" in onboarding
+    assert "minutes=120" in onboarding
+    assert "not permanent routing weights" in lower
+    assert "not a new coordination plane" in lower or "not** a new coordination plane" in lower
+    assert "0.2.114" in onboarding
+    assert "grok-4.5" in onboarding
+    assert "--no-leader" in onboarding
+    assert "--agent-profile" in onboarding
+    assert "digest-checked" in lower
+    assert "client flags alone do not remove native grok tools" in lower
+    assert "grok-build" in lower
+    assert "ACPX_AUTH_CACHED_TOKEN=1" in onboarding
+    runtime = all_owned["docs/agent-runtime-guide.md"]
+    assert "acpx-grok-shadow" in runtime
+    assert "AcpxGrokShadowAdapter" in runtime
+    assert "ACPX_AUTH_CACHED_TOKEN=1" in runtime
+    assert "not a new coordination plane" in runtime.lower()
+    scripts = all_owned["docs/SCRIPTS.md"].lower()
+    assert "acpx-grok-shadow" in scripts or "grok second pilot" in scripts
+    assert "not a new coordination plane" in scripts
+
+
 def test_acpx_does_not_fabricate_cli_flags(onboarding: str) -> None:
     """Stable boundary only — no invented acpx subcommands in the onboarding contract."""
-    # This exact non-secret selector is live-proven against the pinned ACPX
-    # and an existing `codex login` ChatGPT session. Keep every other ACPX_*
-    # assignment forbidden so the docs cannot grow an imagined auth surface.
-    allowed_auth_selector = "ACPX_AUTH_CHAT_GPT=1"
+    # Live-proven non-secret selectors only. Codex ChatGPT login (#6027) and
+    # Grok cached_token (#6043). Keep every other ACPX_* assignment forbidden
+    # so the docs cannot grow an imagined auth surface.
+    allowed_auth_selectors = (
+        "ACPX_AUTH_CHAT_GPT=1",
+        "ACPX_AUTH_CACHED_TOKEN=1",
+    )
     forbidden_cli = re.compile(
         r"""
         (?:
@@ -273,10 +311,14 @@ def test_acpx_does_not_fabricate_cli_flags(onboarding: str) -> None:
     )
     failures: list[str] = []
     for line_no, line in enumerate(onboarding.splitlines(), start=1):
-        if forbidden_cli.search(line.replace(allowed_auth_selector, "")):
+        scrubbed = line
+        for allowed in allowed_auth_selectors:
+            scrubbed = scrubbed.replace(allowed, "")
+        if forbidden_cli.search(scrubbed):
             failures.append(f"agent-seat-onboarding.md:{line_no}: {line.strip()}")
     assert not failures, "Fabricated ACPX CLI surface:\n" + "\n".join(failures)
-    assert allowed_auth_selector in onboarding
+    for allowed in allowed_auth_selectors:
+        assert allowed in onboarding
     assert "do not invent" in onboarding.lower() or "do **not** invent" in onboarding.lower()
 
 

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -264,6 +264,11 @@ def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned
     assert "codex 26" in lower or "codex **26**" in lower or "**codex 26**" in lower
     assert "grok-atlas" in lower
     assert "claude 22" in lower or "claude **22**" in lower or "**claude 22**" in lower
+    assert "remaining **22**" in onboarding
+    assert "gemini 11" in lower or "gemini **11**" in lower or "**gemini 11**" in lower
+    assert "opencode 6" in lower or "opencode **6**" in lower or "**opencode 6**" in lower
+    assert "glm 4" in lower or "glm **4**" in lower or "**glm 4**" in lower
+    assert "agy 1" in lower or "agy **1**" in lower or "**agy 1**" in lower
     assert "grok 1" in lower or "grok **1**" in lower or "**grok 1**" in lower
     assert "broker" in lower
     assert "direct-runtime" in lower or "direct runtime" in lower


### PR DESCRIPTION
Closes #6043

## Summary

- add a separate `acpx-grok-shadow` adapter and direct-only registry entry; normal routing, dispatch, failover, and review eligibility remain unchanged
- exact-pin ACPX 0.13.0 and native Grok 0.2.114; force `grok-4.5` at `high`, `--no-leader`, one-shot exec, no session, no retries, and explicit cached-login selection
- bind Grok to a project-owned, SHA-256-pinned no-tool profile; ACPX client confinement and native Grok tool removal are both enforced
- document the dated API selection evidence: 2026-07-30 broker snapshot (Codex 26, grok-atlas 25, Claude 22 of 95) and smaller 30-day direct-runtime sample (Codex 20, Claude 15, Grok 1)
- preserve native Grok as the authoritative result; this remains a default-off shadow pilot, not a coordination plane

## Verification

- `pytest` focused adapter/runtime/onboarding/env suite: 280 passed
- Ruff on all changed Python: passed
- markdownlint-cli2 on all changed Markdown: passed
- `git diff --check`: passed
- OPSEC leak lint: passed
- X-Agent trailer lint: passed
- actual pinned binaries: ACPX 0.13.0; Grok 0.2.114
- native Grok and ACPX Grok both returned the same bounded marker with zero tool calls
- adversarial write prompt: explicit read-only refusal, zero tool calls, target absent, Git status unchanged
- forced 1-second watchdog timeout: fail closed (`hard_timeout`, rc -9, no result); immediate next invocation recovered successfully
- token usage was not exposed by this Grok ACP stream and is recorded as `null`, never fabricated

## Safety boundary

The first live mutation test proved ACPX client flags alone do not remove native Grok tools. This PR therefore adds and digest-pins the native no-tool profile; the same mutation test then refused and left the tree unchanged. Formal current-head cross-family review and CI are still pending before ready/merge.

X-Agent: codex/6043-acpx-grok-shadow