### PR TITLE
fix(api): keep release snapshots bytecode-free

### DIFF
--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -23,6 +23,10 @@ is an alias for backward compatibility.
 Monitor API path. They use the immutable release snapshot model (not reload
 mode) under a per-user macOS LaunchAgent:
 
+- The managed Python child runs with `-B` and
+  `PYTHONDONTWRITEBYTECODE=1`. The environment setting is inherited by
+  subprocesses that preserve their parent environment, so runtime imports
+  cannot add `__pycache__` files that invalidate the release manifest.
 - Label: `com.learn-ukrainian.monitor-api`
 - Restart policy: `KeepAlive.SuccessfulExit=false`; the foreground runner turns
   any unexpected API exit, including an unexpected zero exit, into a failed
@@ -62,6 +66,24 @@ logs/api.launchd.stderr.log
 Use `launchctl print "gui/$(id -u)/com.learn-ukrainian.monitor-api"` for
 low-level launchd readback. The plist, crash record, and logs are local runtime
 state; they must not be committed.
+
+### Recovering a Bytecode-Contaminated Release
+
+Prevention does not make an already-altered release reusable. If the crash
+record reports `release manifest verification failed`, first confirm that the
+exact failed release contains runtime-created `__pycache__` or `.pyc` files.
+Then:
+
+1. Run `./services.sh stop api` and confirm port 8765 has no listener.
+2. Confirm that no process has its current working directory inside the exact
+   failed SHA directory with `lsof -nP -d cwd`.
+3. Move only that exact generated SHA directory out of
+   `.runtime/api/releases/` into a recoverable quarantine location. Do not
+   delete the release root, weaken verification, or automate deletion after a
+   verification failure.
+4. Run `./services.sh start api` to build a clean release from `HEAD`.
+5. Check `/api/health`, confirm the new release contains no `.pyc` files, and
+   run `verify_release()` against the published release.
 
 `delegate.py dispatch` intentionally warns rather than blocks if the Monitor
 API health probe is unreachable. File-based dispatch fallbacks still work and

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -402,9 +402,11 @@ def _prepare_api_command(repo_root: Path, *, live_mode: bool, port: int) -> tupl
     environment["LEARN_UK_REPO_ROOT"] = str(repo_root)
     environment["GIT_DIR"] = str(repo_root / ".git")
     environment["GIT_WORK_TREE"] = str(repo_root)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
     environment["PYTHONPATH"] = str(launch_dir) + os.pathsep + environment.get("PYTHONPATH", "")
     command = [
         str(repo_root / ".venv" / "bin" / "python"),
+        "-B",
         "-m",
         "uvicorn",
         "scripts.api.main:app",

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -32,6 +32,46 @@ def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> 
     ]
 
 
+def test_api_child_disables_bytecode_writes(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "0")
+
+    command, launch_dir, environment, release_line = supervisor._prepare_api_command(
+        repo,
+        live_mode=True,
+        port=8765,
+    )
+
+    assert command[:4] == [
+        str(repo / ".venv" / "bin" / "python"),
+        "-B",
+        "-m",
+        "uvicorn",
+    ]
+    assert launch_dir == repo
+    assert environment["PYTHONDONTWRITEBYTECODE"] == "1"
+    assert release_line == "WARNING: API live mode enabled; serving mutable checkout code"
+
+    inherited = subprocess.run(
+        [
+            str(_VENV_PYTHON),
+            "-B",
+            "-c",
+            (
+                "import json, os, sys; "
+                "print(json.dumps({'env': os.environ['PYTHONDONTWRITEBYTECODE'], "
+                "'dont_write': sys.dont_write_bytecode}))"
+            ),
+        ],
+        cwd=tmp_path,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(inherited.stdout) == {"env": "1", "dont_write": True}
+
+
 def test_install_and_uninstall_preserve_crash_evidence(tmp_path: Path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     interpreter = repo / ".venv" / "bin" / "python"

--- a/tests/api/test_release_snapshot.py
+++ b/tests/api/test_release_snapshot.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import socket
 import subprocess
-import sys
 import time
 import urllib.error
 import urllib.request
@@ -18,16 +17,11 @@ import pytest
 from scripts.api import release_snapshot
 from scripts.common.git_context import sanitized_git_env
 from scripts.common.release_layout import MANIFEST_NAME, is_release_root
+from scripts.common.repo_root import main_checkout_root
 from scripts.path_safety import safe_join
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-# Prefer the repo venv when present; fall back to the running interpreter so
-# bare review worktrees (no .venv symlink) stay testable (cf. #4918, #4926).
-VENV_PYTHON = (
-    PROJECT_ROOT / ".venv" / "bin" / "python"
-    if (PROJECT_ROOT / ".venv" / "bin" / "python").exists()
-    else Path(sys.executable)
-)
+VENV_PYTHON = main_checkout_root(PROJECT_ROOT) / ".venv" / "bin" / "python"
 
 
 def _run_git(repo_root: Path, *args: str) -> str:
@@ -196,6 +190,7 @@ def test_running_release_keeps_serving_archived_code_after_checkout_mutation(tmp
     process = subprocess.Popen(
         [
             str(VENV_PYTHON),
+            "-B",
             "-m",
             "uvicorn",
             "scripts.api.main:app",
@@ -229,6 +224,9 @@ def test_running_release_keeps_serving_archived_code_after_checkout_mutation(tmp
     finally:
         process.terminate()
         process.wait(timeout=5)
+
+    assert release_snapshot.verify_release(release_dir, sha).sha == sha
+    assert not list((release_dir / "scripts").rglob("*.pyc"))
 
 
 def test_git_service_environment_targets_live_checkout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- launch the managed Monitor API interpreter with `-B`
- set `PYTHONDONTWRITEBYTECODE=1` for the API and environment-preserving subprocesses
- keep release manifest verification strict
- document controlled recovery for an already-contaminated generated release
- replace the touched test's `sys.executable` fallback with the canonical primary-checkout `.venv/bin/python`

## Root cause

The immutable release manifest recorded 1,365 archived files, but the running API created 339 `scripts/**/__pycache__/*.pyc` files in that release. The next supervised start correctly rejected the altered snapshot and crash-looped before Uvicorn bound port 8765.

## Verification

- `27 passed` across launchd supervisor, release snapshot, and service operation tests
- post-start `verify_release()` regression proof
- subprocess proof for `PYTHONDONTWRITEBYTECODE=1` and `sys.dont_write_bytecode`
- Ruff clean
- markdownlint clean
- `git diff --check` clean
- agent trailer and OPSEC gates pass
- restored live-mode `/api/health` returns `status: ok`; browser dashboard loads with no console warnings/errors

Closes #6051
