### PR TITLE
fix(api): wait for asynchronous launchd unload

### DIFF
--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -34,8 +34,10 @@ mode) under a per-user macOS LaunchAgent:
 - Crash-loop protection: `ThrottleInterval=30`, so `launchd` cannot respawn a
   repeatedly failing server faster than once every 30 seconds.
 - Operator stop: `./services.sh stop api` disables and unloads the agent before
-  the listener is signalled. It remains stopped across terminal close and
-  login; only a later `start` or `restart` enables it again.
+  the listener is signalled. Because `launchctl bootout` completes
+  asynchronously, the supervisor waits up to 12 seconds for launchd to confirm
+  removal before reporting a stop failure. The API remains stopped across
+  terminal close and login; only a later `start` or `restart` enables it again.
 
 The normal start path installs or reconciles the plist automatically. To
 inspect or remove it explicitly, run these commands from the merged primary

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from collections import deque
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
@@ -27,6 +28,8 @@ LABEL = "com.learn-ukrainian.monitor-api"
 PORT = 8765
 THROTTLE_INTERVAL_SECONDS = 30
 _LOG_ROTATE_BYTES = 10 * 1024 * 1024
+_STOP_UNLOAD_TIMEOUT_SECONDS = 12.0
+_STOP_UNLOAD_POLL_SECONDS = 0.1
 
 
 class LaunchdError(RuntimeError):
@@ -193,6 +196,32 @@ def _loaded_readback() -> subprocess.CompletedProcess[str]:
     return _launchctl(["print", _target()])
 
 
+def _monotonic() -> float:
+    return time.monotonic()
+
+
+def _sleep(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+def _wait_for_unload() -> None:
+    """Wait for launchd's asynchronous bootout to remove the service."""
+    deadline = _monotonic() + _STOP_UNLOAD_TIMEOUT_SECONDS
+    while True:
+        readback = _loaded_readback()
+        if readback.returncode != 0:
+            return
+
+        remaining = deadline - _monotonic()
+        if remaining <= 0:
+            raise LaunchdError(
+                "launchd service did not unload within "
+                f"{_STOP_UNLOAD_TIMEOUT_SECONDS:.1f}s after bootout: {_target()} "
+                f"(last launchctl print exit {readback.returncode})"
+            )
+        _sleep(min(_STOP_UNLOAD_POLL_SECONDS, remaining))
+
+
 def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdError:
     detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
     return LaunchdError(f"launchctl {action} failed: {detail}")
@@ -267,10 +296,7 @@ def stop(*, home: Path) -> dict[str, object]:
         booted_out = _launchctl(["bootout", _target()])
         if booted_out.returncode != 0:
             raise _failure("bootout", booted_out)
-
-    readback = _loaded_readback()
-    if readback.returncode == 0:
-        raise LaunchdError(f"launchd service remains loaded after stop: {_target()}")
+        _wait_for_unload()
     return {"action": "stop", "label": LABEL, "loaded": False, "plist_path": str(plist_path(home))}
 
 

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -114,6 +114,53 @@ def test_stop_disables_before_bootout(tmp_path: Path, monkeypatch) -> None:
     assert [command[0] for command in commands] == ["disable", "print", "bootout", "print"]
 
 
+def test_stop_waits_for_delayed_launchd_unload(tmp_path: Path, monkeypatch) -> None:
+    commands: list[list[str]] = []
+    sleeps: list[float] = []
+    print_results = iter([0, 0, 1])
+
+    def fake_launchctl(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        returncode = next(print_results) if command[0] == "print" else 0
+        return subprocess.CompletedProcess(command, returncode, "", "not loaded" if returncode else "")
+
+    monkeypatch.setattr(supervisor, "_launchctl", fake_launchctl)
+    monkeypatch.setattr(supervisor, "_sleep", sleeps.append)
+
+    result = supervisor.stop(home=tmp_path / "home")
+
+    assert result["loaded"] is False
+    assert [command[0] for command in commands] == ["disable", "print", "bootout", "print", "print"]
+    assert sleeps == [supervisor._STOP_UNLOAD_POLL_SECONDS]
+
+
+def test_stop_fails_after_bounded_launchd_unload_wait(tmp_path: Path, monkeypatch) -> None:
+    commands: list[list[str]] = []
+    sleeps: list[float] = []
+    clock = iter([100.0, 100.0, 112.0])
+
+    def fake_launchctl(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "service remains registered", "")
+
+    monkeypatch.setattr(supervisor, "_launchctl", fake_launchctl)
+    monkeypatch.setattr(supervisor, "_monotonic", lambda: next(clock))
+    monkeypatch.setattr(supervisor, "_sleep", sleeps.append)
+
+    try:
+        supervisor.stop(home=tmp_path / "home")
+    except supervisor.LaunchdError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("stop() should fail when launchd never unloads the service")
+
+    assert f"within {supervisor._STOP_UNLOAD_TIMEOUT_SECONDS:.1f}s after bootout" in message
+    assert supervisor._target() in message
+    assert "last launchctl print exit 0" in message
+    assert [command[0] for command in commands] == ["disable", "print", "bootout", "print", "print"]
+    assert sleeps == [supervisor._STOP_UNLOAD_POLL_SECONDS]
+
+
 def test_unexpected_exit_records_signal_and_stderr_tail(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
 


### PR DESCRIPTION
## Summary

- wait up to 12 seconds for asynchronous `launchctl bootout` removal
- keep polling monotonic and fail clearly if launchd stays loaded
- cover delayed success and bounded timeout paths
- document restart behavior

## Verification

- `.venv/bin/python -m pytest tests/api/test_launchd_supervisor.py tests/api/test_services_ops.py -q` — 14 passed
- `.venv/bin/ruff check scripts/api/launchd_supervisor.py tests/api/test_launchd_supervisor.py` — passed
- `npx --yes markdownlint-cli2@0.20.0 docs/best-practices/local-api-server.md` — 0 errors
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged` — passed
- real macOS launchd smoke: patched stop returned `loaded=false` in 1s; normal supervised start restored `/api/health` in 37s; ACPX endpoint responded; active release had zero `.pyc` files

## Independent review

Claude Sonnet 5 (Anthropic), read-only cross-family review: PASS, no findings, confidence 0.9.

Closes #6053