### PR TITLE
docs(strategy): orient Ukrainian open-model data work

### DIFF
--- a/data/datasets/hramatka_literary_poltava_v1/README.md
+++ b/data/datasets/hramatka_literary_poltava_v1/README.md
@@ -1,35 +1,59 @@
-# Literary Ukrainian (Poltava Standard) Fine-Tuning Dataset (`hramatka_literary_poltava_v1`)
+# Literary Ukrainian Candidate Collection (`hramatka_literary_poltava_v1`)
 
-> **Target Audience**: UNLP Researchers, Gemma/Llama Fine-Tuners, and Ukrainian NLP Engineers.  
-> **Purpose**: Fine-tuning open-weights models (Gemma 4 31B, Llama 4, Mistral) on authentic, chronologically tagged Ukrainian literary prose (Poltava-Kyiv standard) to eliminate Soviet/Russianized calques and achieve native phonoaesthetic euphony (*милозвучність*).
+> **Status:** Internal candidate collection; not training-ready or approved for
+> publication.
+> **Target audience:** Dataset auditors and Ukrainian NLP researchers.
+> **Purpose:** Evaluate whether the selected literary records can become a
+> provenance-rich contribution to open-weight Ukrainian model development.
+
+The current JSONL contains 5,000 records, but it does not yet carry the
+release-level provenance, source license, redistribution status, deduplication
+receipt, or frozen train/validation/test split required for a defensible
+training release. The labels "pure," "decolonized," and "Poltava standard" have
+not been established by an expert audit and must not be used as dataset quality
+claims.
+
+The governing strategy is
+[Ukrainian Open-Model Data Infrastructure: North Star](../../../docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md).
 
 ---
 
-## Why Open Web Crawls Fail for Ukrainian
+## Research hypothesis
 
-Standard open LLMs (like Gemma or Llama) are trained on generic web crawls (Common Crawl, Wikipedia, news sites). In Ukrainian, generic web crawls are polluted with:
+Generic web corpora can contain:
 1. **Soviet Bureaucratic Calques (*канцеляризми*)**: Rigid, non-native phrasing translated literally from Russian.
 2. **Semantic Surzhyk**: Valid Ukrainian words assigned Russian meanings.
 3. **Phonoaesthetic Violations**: Disregarding Ukrainian euphony rules (*милозвучність*, alternation of *у/в*, *і/й*).
 
 ---
 
-## Dataset Overview
+These are hypotheses to measure against existing Ukrainian corpora and
+quality-filtering work, not established properties of every web crawl.
+
+## Candidate collection overview
 
 Modern Literary Ukrainian (*сучасна українська літературна мова*) was historically synthesized from the **Poltava-Middle Dnieper dialect region** (Kotlyarevsky, Shevchenko, Nechuy-Levytsky, Franko, Lesya Ukrainka).
 
-This dataset contains **curated, clean, chronologically tagged passages** extracted directly from our 137,700-chunk literary database (`data/sources.db`), spanning:
+The collection contains selected, chronologically tagged passages exported
+from the project's literary database. Its current source mix includes:
 - **Classic 19th Century Literature** (Kotlyarevsky, Shevchenko, Nechuy-Levytsky, Marko Vovchok)
 - **Modern 20th Century & Contemporary Ukrainian** (Rylsky, Tychyna, Kostenko, Stus)
 - **Ukrainian School Textbooks** (Grades 1–11, 2019 Pravopys)
 
 ---
 
-## Fine-Tuning Recipe for Gemma 4 31B
+## Required audit before training or release
 
-1. **Continued Pre-Training / SFT**: Train Gemma 4 31B on `hramatka_literary_poltava_v1.jsonl` using causal language modeling (CLM) with low rank adaptation (LoRA / QLoRA).
-2. **Result**: Aligns Gemma's token probabilities to authentic Poltava-Kyiv literary syntax and native Ukrainian euphony (*милозвучність*).
+1. Link every record to a stable source identifier and acquisition record.
+2. Record source license, copyright, redistribution, and model-training status.
+3. Verify author, work, year, language period, genre, and translation origin.
+4. Detect exact and near duplicates against training and evaluation inventories.
+5. Measure period, author, genre, region, register, and domain balance.
+6. Review samples for OCR artifacts, machine translation, editorial
+   modernization, Russian-language leakage, and encoding problems.
+7. Define consumer-specific, author-disjoint splits and contamination receipts.
+8. Obtain Ukrainian linguistic review for any quality, purity, or
+   decolonization claim.
 
----
-
-*Dataset exported from the Learn Ukrainian Project repository.*
+No fine-tuning result is claimed. Training remains parked until a scoped
+consumer need, a reviewed data card, and explicit approval exist.

--- a/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
+++ b/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
@@ -49,11 +49,16 @@ Our project's durable competitive advantage is **NOT** in custom fine-tuned mode
 
 ---
 
-## 3. Operational Policy
+## 3. Historical proposals and current disposition
 
-1. **Use Frontier API Models for Production**: Rely on **Gemini 3.6 Flash** (12s, 10/10 PASS) and **Gemini 3.1 Pro** for production lesson generation today.
-2. **Keep Open Models Light & Zero-Shot / Harness-Driven**: Do not spend heavy compute or hundreds of dollars fine-tuning Gemma 4 31B. Use lightweight prompt harness constraints and rely on our deterministic QG linters to clean output.
-3. **Dataset Contribution**: Publish our clean datasets (`hramatka_literary_poltava_v1`) for the open-source UNLP community, but keep our project's primary focus on curriculum engine architecture.
+1. The model-specific production recommendation was never supported by a
+   reproducible qualification and is withdrawn.
+2. The recommendation not to train local model weights now is retained by the
+   current north star, with future training requiring a scoped need and
+   approval.
+3. The instruction to publish `hramatka_literary_poltava_v1` as a clean dataset
+   is withdrawn. It is an internal candidate collection pending provenance,
+   rights, deduplication, split, contamination, and linguistic audits.
 
 ---
 

--- a/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
+++ b/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
@@ -9,7 +9,7 @@
 > for the evidence-backed direction and current data boundaries. This file is
 > retained as historical context.
 >
-> **Status**: APPROVED / ARCHITECTURAL STRATEGY  
+> **Status**: SUPERSEDED — historical context only
 > **Date**: July 24, 2026  
 > **Authors**: Lead Architecture Review, UNLP Case Study Task Force  
 > **Target Epic**: #4542 (Hramatka Long-Term Strategy & Model Agnosticism)

--- a/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
+++ b/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
@@ -1,5 +1,12 @@
 # ADR 016: Base Model Leapfrogging & Data/Harness Value Preservation
 
+> **Superseded for current strategy:** The durable-asset insight is retained,
+> but the unsupported model-ranking and production-policy claims below are not
+> authoritative. Use
+> [Ukrainian Open-Model Data Infrastructure: North Star](../strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md)
+> for the evidence-backed direction and current data boundaries. This file is
+> retained as historical context.
+>
 > **Status**: APPROVED / ARCHITECTURAL STRATEGY  
 > **Date**: July 24, 2026  
 > **Authors**: Lead Architecture Review, UNLP Case Study Task Force  
@@ -12,6 +19,7 @@
 The UNLP community invested heavy compute and human annotation resources into fine-tuning **Gemma 3** into **Lapa / Lapa-Ukrainian** to improve Ukrainian tokenization and grammar. Shortly after release, Google launched **Gemma 4 31B**, whose base capabilities and native multilingual tokenization immediately outperformed the custom fine-tuned Lapa model.
 
 ### **The "Base Model Leapfrogging" Reality**:
+
 1. **Model Weights Deprecate Rapidly**: Fine-tuning an $N$-th generation base model (e.g. Gemma 3 or Gemma 4) carries high risk because the next frontier base model ($N+1$) will inevitably crush the custom fine-tune.
 2. **Compute Sunk Cost Risk**: Investing heavy financial resources in custom weight training on mid-tier open models provides short-lived returns compared to leveraging frontier API models (Gemini 3.6 Flash).
 

--- a/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
+++ b/docs/architecture/ADR_016_BASE_MODEL_LEAPFROGGING_AND_DATASET_VALUATIONS.md
@@ -1,7 +1,9 @@
 # ADR 016: Base Model Leapfrogging & Data/Harness Value Preservation
 
-> **Superseded for current strategy:** The durable-asset insight is retained,
-> but the unsupported model-ranking and production-policy claims below are not
+> **Superseded for current strategy:** Only the general asset-category insight
+> is retained: data, evidence, and evaluation tooling can outlast one model
+> generation. Specific model rankings, inventory counts, data-quality,
+> purity/decolonization, and production-policy claims below are not
 > authoritative. Use
 > [Ukrainian Open-Model Data Infrastructure: North Star](../strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md)
 > for the evidence-backed direction and current data boundaries. This file is
@@ -27,25 +29,17 @@ The UNLP community invested heavy compute and human annotation resources into fi
 
 ## 2. Strategic Asset Allocation: Where Our Value Lies
 
-Our project's durable competitive advantage is **NOT** in custom fine-tuned model weights. Our durable assets are **Model-Agnostic Engine Components**:
+The historical proposal identified four potentially durable asset categories.
+This is not a current inventory or a quality assessment:
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                     DURABLE PROJECT ASSETS (Immune to Model Leaps)      │
-├─────────────────────────────────────────────────────────────────────────┤
-│ 1. Curated Decolonized Corpus (`data/sources.db`)                        │
-│    • 137,700 literary chunks, 54,900 textbook chunks, tagged by period │
-├─────────────────────────────────────────────────────────────────────────┤
-│ 2. Morphological Ground Truth Engine (`data/vesum.db`)                   │
-│    • 409,000 lemmas & 6.7M inflected forms for deterministic audit      │
-├─────────────────────────────────────────────────────────────────────────┤
-│ 3. Deterministic QG Linter & Euphony Rules (`scripts/audit/`)            │
-│    • Rules enforcing State Standard 2024 & zero-Russianism gates        │
-├─────────────────────────────────────────────────────────────────────────┤
-│ 4. Hramatka Prompt Harness V3 (Dynamic System Constraints)               │
-│    • Runtime structural control enforcing 8/8 activity types & density  │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+1. Literary and reference source inventories, pending provenance, rights,
+   quality, and balance audits.
+2. VESUM-backed morphology integration, with the exact version, counts,
+   semantics, and license pinned for each use.
+3. Validation and evidence tooling, limited to the rules and behavior that
+   tests actually verify.
+4. Prompt and evaluation harnesses, durable only where their interfaces,
+   inputs, and results remain reproducible across models.
 
 ---
 

--- a/docs/strategy/STRATEGY_MAKING_GOOGLE_NOTICE_OUR_BENCHMARKS.md
+++ b/docs/strategy/STRATEGY_MAKING_GOOGLE_NOTICE_OUR_BENCHMARKS.md
@@ -1,5 +1,12 @@
 # Architectural Strategy: How to Make Google DeepMind & Gemma Teams Notice Our Work
 
+> **Superseded:** This visibility-first strategy is not the project's current
+> north star. Use
+> [Ukrainian Open-Model Data Infrastructure: North Star](UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md)
+> for current direction. The probability estimates and publication-readiness
+> claims below were not evidence-backed and must not guide work. This file is
+> retained only as historical context.
+>
 > **Purpose**: Tactical roadmap for establishing our Ukrainian benchmark suite and datasets as industry-standard evaluation baselines recognized by Google DeepMind and the open-source AI community.  
 > **Date**: July 24, 2026
 
@@ -32,6 +39,7 @@ Google AI, Gemma, and DeepMind research teams do **not** discover private code r
 ## 3. The 3-Step Execution Plan to Maximizing Visibility
 
 ### **Step 1: Open-Source the Benchmark Suite (`zno-textbook-drill-v1`)**
+
 - Build an automated 1-command evaluation CLI:
   ```bash
   python scripts/eval/run_benchmark.py --model google/gemma-4-31b-it --output report.json
@@ -39,9 +47,11 @@ Google AI, Gemma, and DeepMind research teams do **not** discover private code r
 - Tests models on 5 dimensions: VESUM morphological precision, zero-Russianism linter, State Standard 2024 compliance, 8/8 activity density, and phonoaesthetic euphony (*милозвучність*).
 
 ### **Step 2: Publish Datasets on HuggingFace Hub**
+
 - Upload `hramatka-uk-pedagogy-v1` and `hramatka-literary-poltava-v1` with paper-grade documentation, metadata tags, and dataset cards.
 
 ### **Step 3: Publish Technical Report**
+
 - Title: *"Empirical Qualification of Gemma 4 31B and Gemini 3.6 Flash on Ukrainian Pedagogical Authoring and Decolonization"*.
 - Submit to HuggingFace Papers and share with the UNLP & Google DeepMind research communities.
 

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -1,0 +1,278 @@
+# Ukrainian Open-Model Data Infrastructure: North Star
+
+> **Status:** Operator-confirmed strategic direction; evidence snapshot
+> **Recorded:** 2026-07-30
+> **Applies to:** Ukrainian model evaluation, dataset work, training-data
+> preparation, and UNLP ecosystem monitoring
+> **Does not authorize:** model training, dataset publication, or mixing
+> evaluation gold into training data
+
+## North star
+
+Our ultimate goal is to help AI produce measurably better, authentically
+Ukrainian language.
+
+We will pursue that goal by giving open-weight model teams reusable Ukrainian
+language infrastructure:
+
+- trusted and well-documented data;
+- morphology-aware coverage and diagnostics;
+- narrow, credible evaluations of important failure modes;
+- reproducible preparation and training recipes; and
+- evidence that distinguishes standardization errors from legitimate
+  historical, regional, dialectal, and register variation.
+
+We are not trying to win by training and maintaining our own general-purpose
+model weights. Base models can leapfrog a local fine-tune in one release.
+Curated data, provenance, evaluation, and tooling transfer to every new model
+generation.
+
+This direction implements the existing accepted decision to prioritize grammar
+and lexical naturalness while parking model fine-tuning. It also preserves the
+accepted boundary between public evaluation gold, private product data, and
+future training data.
+
+## Why the size of Ukrainian matters
+
+The operator's current working estimate is about 254,000 modern Ukrainian
+lemmas before historical vocabulary and other extensions. This estimate must
+receive a citable source and a precise definition before external use.
+
+Current local project documentation reports approximately 409,000 VESUM lemma
+records and 6.7 million generated forms. These figures depend on the VESUM
+version and on what is counted as a distinct lemma or form. The upstream VESUM
+project describes a dictionary of words, paradigms, part-of-speech tags, style
+markers, and generated word forms. It includes markers such as rare, archaic,
+slang, and discouraged usage. Its data are CC BY-NC-SA 4.0, which constrains
+redistribution and commercial training uses.
+
+Millions of possible forms do **not** mean that a model must memorize every
+form. A subword model can learn productive declension, conjugation, agreement,
+and word formation. Proper Ukrainian preparation must nevertheless expose
+enough balanced, contextual evidence for the model to learn those rules rather
+than merely imitate the most frequent web forms.
+
+This changes the data problem:
+
+- a lemma list is not a training corpus;
+- a generated form without context does not teach sense, government,
+  collocation, register, stress, or discourse use;
+- raw frequency alone underrepresents rare paradigm cells and productive
+  patterns;
+- indiscriminate oversampling can make archaic, dialectal, or rare forms look
+  falsely ordinary; and
+- filtering Russian influence must not erase legitimate cognates, heritage
+  forms, regional Ukrainian, or code-switching research data.
+
+The useful unit is therefore a **provenanced contextual example with linguistic
+attributes**, not an isolated word form.
+
+## What the Ukrainian NLP community already has
+
+This is an orientation map, not an exhaustive catalog. The weekly Ukrainian
+NLP ecosystem watch remains the mechanism for keeping it current.
+
+| Layer | Important existing assets | What they already solve |
+| --- | --- | --- |
+| Morphology and lexical tooling | [VESUM / `dict_uk`](https://github.com/brown-uk/dict_uk) | Large inflectional lexicon, generated paradigms, POS tags, and usage markers |
+| Large native-text corpora | [Kobza](https://aclanthology.org/2025.unlp-1.14/), UberText and other `lang-uk` corpora | Pretraining-scale Ukrainian text; Kobza reports nearly 60B tokens and deduplication |
+| Human correction data | [UA-GEC](https://github.com/grammarly/ua-gec) | Professionally annotated Ukrainian grammar and fluency corrections with metadata |
+| Silver correction data | [OmniGEC](https://aclanthology.org/2025.unlp-1.17/) | Larger automatically corrected Ukrainian and multilingual GEC data |
+| Open model adaptation | [Lapa](https://aclanthology.org/2026.unlp-1.14/) | Reproducible Gemma 3 adaptation: tokenizer surgery, quality filtering, instruction-data construction, models, data, and code |
+| Language proficiency evaluation | [UNLP gold-standard benchmark](https://aclanthology.org/2026.unlp-1.12/) and the [`lang-uk` Ukrainian LLM leaderboard](https://huggingface.co/datasets/lang-uk/ukrainian-llm-leaderboard-results) | Broad grammar, vocabulary, orthography, and model comparison |
+| Minimal-edit GEC evaluation | [UNLP prompting study](https://aclanthology.org/2026.unlp-1.13/) and the UNLP 2023 UA-GEC shared task | Standard GEC scoring, strong fine-tuned baselines, and detailed prompt baselines |
+| Specialized datasets and benchmarks | [ZNO-Vision](https://aclanthology.org/2025.unlp-1.2/), [lexical stress and phonemization](https://aclanthology.org/2025.unlp-1.11/), [native paraphrases](https://aclanthology.org/2026.unlp-1.17/), UD treebanks, NER, sentiment, manipulation, idiom, translation, RAG, ASR, and dialect resources | Strong coverage of many bounded Ukrainian tasks and modalities |
+
+The conclusion is important: **the community does not lack datasets in
+general**. A new contribution must identify the exact uncovered phenomenon,
+consumer, license, and evaluation question.
+
+## Gaps that remain valuable
+
+### 1. Contextual lexical naturalness and language-contact errors
+
+Generic GEC is already well served. There is still room for expert-grounded
+data about:
+
+- semantic calques and sense transfer;
+- collocations and case government;
+- bureaucratic and translation-like constructions;
+- minimal pairs that separate acceptable Ukrainian from contextually wrong
+  usage; and
+- corrections with more than one acceptable Ukrainian realization.
+
+This is where the current public calque-and-grammar evaluation is relevant, but
+its 677 error-containing sentences are only a first instrument.
+
+### 2. Protection against linguistic erasure
+
+A decolonizing dataset cannot be a blacklist of forms that resemble Russian.
+It needs hard positive examples for:
+
+- authentic cognates;
+- historical and heritage forms;
+- regional and dialectal Ukrainian;
+- conversational and marked registers; and
+- contested cases that should remain unresolved rather than be normalized
+  automatically.
+
+Each decision needs a source, scope, confidence, and disposition. This is an
+area where our Atlas evidence model and conservative VESUM use can be unusually
+helpful.
+
+### 3. Morphology-aware coverage rather than word-count scale
+
+Training and evaluation packages need diagnostics by:
+
+- lemma frequency band;
+- part of speech and paradigm cell;
+- agreement and syntactic dependency;
+- seen versus unseen lemma;
+- rare but productive inflection;
+- tokenizer fertility and fragmentation; and
+- modern, historical, regional, and register strata.
+
+VESUM can verify forms and organize coverage. Its licensing and dictionary
+semantics mean we must not simply convert it into unrestricted training text.
+
+### 4. Provenance-rich, rights-clear, quality-scored source data
+
+Large corpora exist, but their scale does not eliminate source-quality,
+rights, duplication, machine-translation, Russian-influence, domain-balance,
+or historical-balance questions. Open model teams benefit from:
+
+- per-document provenance and stable source identifiers;
+- explicit license and redistribution status;
+- time, domain, genre, region, and register metadata;
+- deduplication and contamination receipts;
+- language and translation-origin confidence; and
+- quality-filter labels with auditable examples.
+
+### 5. Clean, contamination-resistant evaluation
+
+The current public release contains only sentences with at least one in-scope
+error. Future releases need:
+
+- no-change controls;
+- hard positives that must not be "corrected";
+- more expert references for legitimate alternatives;
+- sequestered or regularly renewed test material;
+- category-balanced reporting; and
+- uncertainty estimates and frozen run metadata.
+
+Benchmark cases must remain outside training data.
+
+### 6. Model-ready interfaces
+
+Researchers should not have to reverse-engineer a corpus to use it. The same
+reviewed source records should support separate, reproducible exports for:
+
+- continued pretraining;
+- supervised correction or instruction tuning;
+- preference data;
+- quality-filter training; and
+- held-out evaluation.
+
+Those exports must stay distinct and carry lineage back to the source record.
+
+## What this project can credibly contribute
+
+### Already available
+
+- Public Ukrainian calque-and-grammar evaluation release `0.1.1`: 677 held-out
+  UA-GEC sentences, 918 acceptable references, 1,608 in-scope annotations,
+  exact-edit scoring, reproducibility receipts, and saved closed- and
+  open-weight baselines.
+- A working provenance and evidence architecture for heritage-sensitive
+  language judgments.
+- A weekly Ukrainian NLP ecosystem watch.
+- A 5,000-record literary export that can become a useful candidate collection
+  after an audit.
+
+### Immediate work
+
+1. Maintain a source-linked UNLP asset and gap map. Record datasets, licenses,
+   task coverage, model baselines, and unresolved gaps without claiming that
+   our work is unique before comparison.
+2. Audit the 5,000-record literary export. Resolve source lineage, rights,
+   deduplication, split strategy, period and genre balance, translation
+   provenance, and quality. Until then, call it a **candidate collection**, not
+   a pure or training-ready dataset.
+3. Analyze errors and model disagreements in the 677-item evaluation. Use them
+   to define the next annotation categories rather than merely adding model
+   rows to a table.
+4. Design the next evaluation slice with no-change controls, heritage and
+   dialect hard positives, multiple acceptable references, and category
+   coverage targets.
+5. Specify one canonical source-record schema and separate exporters for
+   training, preference, filtering, and evaluation views.
+6. Build morphology and tokenizer coverage reports that open-weight teams can
+   run before and after adaptation.
+
+### Collaboration target
+
+After the audits, offer narrow assets to Lapa, `lang-uk`, UA-GEC, and other
+open-weight Ukrainian teams:
+
+- data slices they can inspect and reproduce;
+- diagnostics they can run on any new base model;
+- failure-focused evaluation with protected legitimate variation; and
+- evidence-backed annotation guidelines.
+
+The offer should start with their unmet need, not with our desire to publish a
+dataset.
+
+## Model-running policy
+
+Model baselines are experiments, not the mission.
+
+Run a model only when the result answers a named question, such as:
+
+- Does a new open-weight generation remove a specific failure category?
+- Does a tokenizer change improve Ukrainian fertility and downstream quality?
+- Does a training-data slice improve held-out morphology without increasing
+  overcorrection?
+- Does a detailed Ukrainian prompt expose a capability that a generic prompt
+  hides?
+
+Open-weight models are the primary integration target because researchers can
+inspect, reproduce, adapt, and redistribute their work. Closed models remain
+useful as comparison ceilings, candidate annotators, or prompt-sensitivity
+probes. A closed-model score is not itself a durable community contribution.
+
+Do not compare scores across different benchmarks as if they measured the same
+thing. For example, the UNLP 2026 prompting result for Gemini 3.1 Pro is a
+minimal-edit UA-GEC result under a specialized prompt. It does not establish
+that the same model is best on broad Ukrainian proficiency, lexical
+naturalness, or our narrower evaluation.
+
+## Anti-distraction test
+
+Before beginning work, answer all five questions:
+
+1. Which documented Ukrainian failure or ecosystem gap does this address?
+2. Who in the open-weight Ukrainian community can use the output?
+3. Why do existing data, tools, or benchmarks not already solve it?
+4. What artifact remains useful after the next base model release?
+5. How will we measure improvement without contaminating the evaluation?
+
+If those answers are missing, the work is not ready.
+
+## Evidence and uncertainty
+
+Primary references used for this snapshot:
+
+- [UNLP 2025 proceedings](https://aclanthology.org/volumes/2025.unlp-1/)
+- [UNLP 2026 proceedings](https://aclanthology.org/volumes/2026.unlp-1/)
+- [VESUM / `dict_uk`](https://github.com/brown-uk/dict_uk)
+- [UA-GEC](https://github.com/grammarly/ua-gec)
+- [Kobza and Modern-LiBERTa](https://aclanthology.org/2025.unlp-1.14/)
+- [Lapa adaptation](https://aclanthology.org/2026.unlp-1.14/)
+- [OmniGEC](https://aclanthology.org/2025.unlp-1.17/)
+- [UNLP gold-standard proficiency benchmark](https://aclanthology.org/2026.unlp-1.12/)
+- [Minimal-edit Ukrainian GEC prompting study](https://aclanthology.org/2026.unlp-1.13/)
+
+Claims that Gemma 4 currently leads a particular Ukrainian leaderboard must be
+tied to a frozen leaderboard snapshot and its exact task aggregate before
+external publication. The operator's observation is strategically useful, but
+the rank and benchmark definition must remain reproducible.


### PR DESCRIPTION
## Summary

- record the operator-confirmed north star: contribute durable Ukrainian data, morphology diagnostics, and evaluation infrastructure for open-weight teams rather than train model weights ourselves
- map major UNLP assets and identify evidence-backed gaps
- relabel the 5,000-row literary export as an internal candidate pending provenance, rights, deduplication, split, and linguistic audits
- mark two stale visibility/model-policy documents as superseded

Related to #2156; this PR does not change the frozen public evaluation or authorize training/data publication.

## Verification

- markdownlint-cli2 on all four changed Markdown files
- git diff --check
- staged OPSEC leak audit
- agent trailer audit
- protected configuration and generated-artifact checks