### PR TITLE
fix(atlas): refresh teacher seed rights ledger

### DIFF
--- a/docs/runbooks/teacher-curated-seed-rebuild.md
+++ b/docs/runbooks/teacher-curated-seed-rebuild.md
@@ -27,6 +27,41 @@ run without `--drive-root`, refuses to reuse an existing destination unless
 `--replace-existing` is explicit, and verifies the copied checksums. A sole
 local package is intentionally a failure.
 
+## Rights-ledger refresh after table recovery
+
+Once an authoritative private table has been restored, refresh its existing
+package and the same Drive mirror together. The refresh is deterministic and
+does not create sentences, locators, CEFR, or redistribution permission.
+
+- `no_hit_strict_vesum` receives admission mode
+  `quarantined_no_document_hit` with reason
+  `no_document_hit_vesum_forms`.
+- `has_candidates` with a retained locator remains rights status
+  `private_local`, with admission mode
+  `pending_operator_redistribution_go` and `practice: false`.
+- A candidate without a locator is fail-closed as
+  `quarantined_missing_document_locator`.
+
+`pending_operator_redistribution_go` means that local evidence exists but the
+operator has not granted redistribution. It is not a license and does not make
+a row available to Practice or public export. The receipt hashes every mirrored
+file except itself and is refreshed only after a staged checksum-equivalent
+Drive copy is ready.
+
+```bash
+DRIVE_RECOVERY_ROOT="/absolute/path/to/My Drive/Projects/learn-ukrainian-incident-recovery/2026-07-30/atlas-epic-dual-write/teacher-curated-seed"
+
+.venv/bin/python -m scripts.atlas.rebuild_teacher_curated_seed \
+  --package-root .claude/atlas-epic/plans/curated-seed \
+  --drive-root "$DRIVE_RECOVERY_ROOT" \
+  --refresh-rights-ledger
+```
+
+Run the admission helper directly against the checksum-verified Atlas manifest
+for a dry-run report. Its `practice_skipped_not_admitted` count is distinct from
+`practice_skipped_no_cefr`: a pending rights row must never be mislabeled as a
+missing-CEFR row.
+
 ## Run the recovery scaffold
 
 Set the two machine-local paths before running the command. The first is the

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -339,6 +339,8 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
     ledger_by_row = {row.get("seedRow"): row for row in ledger_rows}
     if len(ledger_by_row) != len(ledger_rows):
         raise ValueError("rights ledger contains duplicate seedRow values")
+    if len({row.get("seedRow") for row in seed_rows}) != len(seed_rows):
+        raise ValueError("curated seed contains duplicate seedRow values")
     if {row.get("seedRow") for row in seed_rows} != set(ledger_by_row):
         raise ValueError("curated seed and rights ledger seedRow values differ")
 

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -309,6 +309,13 @@ def _sync_tree(source: Path, destination: Path) -> None:
 
 def _restore_tree(backup: Path, destination: Path) -> None:
     """Restore a verified pre-refresh copy after a dual-write failure."""
+    backup_files = {path.relative_to(backup) for path in backup.rglob("*") if path.is_file()}
+    backup_directories = {path.relative_to(backup) for path in backup.rglob("*") if path.is_dir()}
+    for path in sorted(destination.rglob("*"), reverse=True):
+        if path.is_file() and path.relative_to(destination) not in backup_files:
+            path.unlink()
+        elif path.is_dir() and path.relative_to(destination) not in backup_directories:
+            path.rmdir()
     _sync_tree(backup, destination)
     if _tree_checksums(backup) != _tree_checksums(destination):
         raise RuntimeError(f"rollback checksum mismatch: {destination}")
@@ -351,7 +358,7 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
         refreshed["admission"] = admission
         refreshed_seed.append(refreshed)
         ledger["rightsStatus"] = rights["status"]
-        ledger["redistributable"] = False
+        ledger["redistributable"] = rights["redistributable"]
         ledger["rightsReason"] = rights["reason"]
         refreshed_ledger.append(ledger)
         admissions.append(

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -234,7 +234,7 @@ def _tree_checksums(root: Path) -> dict[str, str]:
 
 def _has_locator(value: object) -> bool:
     if isinstance(value, Mapping):
-        return bool(value)
+        return any(str(v or "").strip() for v in value.values())
     return bool(str(value or "").strip())
 
 

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -13,6 +13,7 @@ import argparse
 import hashlib
 import json
 import shutil
+import tempfile
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
@@ -30,6 +31,23 @@ PACKAGE_FILES = (
     "source-recon.json",
     "package-manifest.json",
 )
+PRIVATE_LOCAL = "private_local"
+PENDING_REDISTRIBUTION_GO = "pending_operator_redistribution_go"
+NO_HIT_REASON = "no_document_hit_vesum_forms"
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError(f"JSONL rows must be objects: {path}")
+    return rows
+
+
+def _write_jsonl(path: Path, rows: Iterable[Mapping[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
 
 
 def _sha256(path: Path) -> str:
@@ -205,6 +223,234 @@ def _package_checksums(root: Path, names: Iterable[str] = PACKAGE_FILES) -> dict
     return {name: _sha256(root / name) for name in names}
 
 
+def _tree_checksums(root: Path) -> dict[str, str]:
+    """Hash every mirrored package file except its self-referential receipt."""
+    return {
+        path.relative_to(root).as_posix(): _sha256(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and path.name != "receipt.json"
+    }
+
+
+def _has_locator(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return bool(value)
+    return bool(str(value or "").strip())
+
+
+def classify_rights_admission(sentence_status: str, locator: object) -> tuple[dict[str, object], dict[str, object]]:
+    """Return fail-closed row rights and Practice admission for a restored seed row.
+
+    A document hit is not redistribution permission.  The only candidate state
+    below remains local-only until an operator explicitly grants redistribution.
+    """
+    if sentence_status == "no_hit_strict_vesum":
+        return (
+            {
+                "status": PRIVATE_LOCAL,
+                "redistributable": False,
+                "reason": NO_HIT_REASON,
+            },
+            {
+                "practice": False,
+                "mode": "quarantined_no_document_hit",
+                "reason": NO_HIT_REASON,
+            },
+        )
+    if sentence_status == "has_candidates":
+        if not _has_locator(locator):
+            return (
+                {
+                    "status": "quarantined_missing_document_locator",
+                    "redistributable": False,
+                    "reason": "has_candidates_without_document_locator",
+                },
+                {
+                    "practice": False,
+                    "mode": "quarantined_missing_document_locator",
+                    "reason": "has_candidates_without_document_locator",
+                },
+            )
+        return (
+            {
+                "status": PRIVATE_LOCAL,
+                "redistributable": False,
+                "reason": "private_local_teacher_material_pending_operator_redistribution_go",
+            },
+            {
+                "practice": False,
+                "mode": PENDING_REDISTRIBUTION_GO,
+                "reason": "private_local_rights_require_operator_redistribution_go",
+            },
+        )
+    return (
+        {
+            "status": "quarantined_unreviewed_sentence_status",
+            "redistributable": False,
+            "reason": f"unsupported_sentence_status_{sentence_status or 'missing'}",
+        },
+        {
+            "practice": False,
+            "mode": "quarantined_unreviewed_sentence_status",
+            "reason": f"unsupported_sentence_status_{sentence_status or 'missing'}",
+        },
+    )
+
+
+def _sync_tree(source: Path, destination: Path) -> None:
+    """Copy a staged package file-by-file without relying on cloud dir-renames."""
+    for path in sorted(source.rglob("*")):
+        if path.is_dir():
+            continue
+        target = destination / path.relative_to(source)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+
+
+def _restore_tree(backup: Path, destination: Path) -> None:
+    """Restore a verified pre-refresh copy after a dual-write failure."""
+    _sync_tree(backup, destination)
+    if _tree_checksums(backup) != _tree_checksums(destination):
+        raise RuntimeError(f"rollback checksum mismatch: {destination}")
+
+
+def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, object]:
+    """Refresh explicit rights/admission records and mirror the whole private package.
+
+    This path never derives a sentence, locator, CEFR value, or redistribution
+    permission.  It only classifies the restored strict-VESUM retrieval states.
+    """
+    if not package_root.is_dir():
+        raise ValueError(f"package root does not exist: {package_root}")
+    if not drive_root.is_dir():
+        raise ValueError(f"Drive mirror root does not exist: {drive_root}")
+    if _tree_checksums(package_root) != _tree_checksums(drive_root):
+        raise ValueError("local package and Drive mirror differ before refresh; inspect before replacing either copy")
+
+    seed_rows = _read_jsonl(package_root / "curated-seed.jsonl")
+    ledger_rows = _read_jsonl(package_root / "rights-ledger.jsonl")
+    ledger_by_row = {row.get("seedRow"): row for row in ledger_rows}
+    if len(ledger_by_row) != len(ledger_rows):
+        raise ValueError("rights ledger contains duplicate seedRow values")
+    if {row.get("seedRow") for row in seed_rows} != set(ledger_by_row):
+        raise ValueError("curated seed and rights ledger seedRow values differ")
+
+    refreshed_seed: list[dict[str, object]] = []
+    refreshed_ledger: list[dict[str, object]] = []
+    admissions: list[dict[str, object]] = []
+    for seed in seed_rows:
+        seed_row = seed.get("seedRow")
+        ledger = dict(ledger_by_row[seed_row])
+        status = str(seed.get("sentenceStatus") or "").strip()
+        ledger_status = str(ledger.get("sentenceStatus") or "").strip()
+        if ledger_status != status:
+            raise ValueError(f"seed row {seed_row} has mismatched rights-ledger sentence status")
+        rights, admission = classify_rights_admission(status, ledger.get("locator"))
+        refreshed = dict(seed)
+        refreshed["rights"] = rights
+        refreshed["admission"] = admission
+        refreshed_seed.append(refreshed)
+        ledger["rightsStatus"] = rights["status"]
+        ledger["redistributable"] = False
+        ledger["rightsReason"] = rights["reason"]
+        refreshed_ledger.append(ledger)
+        admissions.append(
+            {
+                "seedRow": seed_row,
+                "lemma": seed.get("lemma"),
+                "practice": admission["practice"],
+                "mode": admission["mode"],
+                "reason": admission["reason"],
+                "exampleCount": ledger.get("exampleCount", 0),
+            }
+        )
+
+    parent = package_root.parent
+    with tempfile.TemporaryDirectory(prefix=f".{package_root.name}.refresh-", dir=parent) as temporary:
+        staged_root = Path(temporary) / package_root.name
+        shutil.copytree(package_root, staged_root)
+        _write_jsonl(staged_root / "curated-seed.jsonl", refreshed_seed)
+        _write_jsonl(staged_root / "rights-ledger.jsonl", refreshed_ledger)
+        _write_jsonl(staged_root / "practice-admission.jsonl", admissions)
+        manifest_path = staged_root / "package-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(manifest, dict):
+            raise ValueError(f"package manifest must be an object: {manifest_path}")
+        manifest["state"] = "rights_ledger_refreshed_pending_operator_redistribution_go"
+        admission_modes = Counter(str(row["admission"]["mode"]) for row in refreshed_seed)
+        rights_statuses = Counter(str(row["rights"]["status"]) for row in refreshed_seed)
+        manifest["row_counts"] = {
+            "curated_seed": len(refreshed_seed),
+            "rights_ledger": len(refreshed_ledger),
+            "practice_admission": len(admissions),
+            "rows_no_hit": sum(row.get("sentenceStatus") == "no_hit_strict_vesum" for row in refreshed_seed),
+            "rows_with_candidates": sum(row.get("sentenceStatus") == "has_candidates" for row in refreshed_seed),
+            "rights_private_local": sum(row["rights"]["status"] == PRIVATE_LOCAL for row in refreshed_seed),
+            "practice_admitted": sum(row["admission"]["practice"] is True for row in refreshed_seed),
+            "quarantined_missing_document_locator": admission_modes["quarantined_missing_document_locator"],
+            "quarantined_unreviewed_sentence_status": admission_modes[
+                "quarantined_unreviewed_sentence_status"
+            ],
+        }
+        manifest["rights_admission_policy"] = {
+            "redistribution": "operator GO required before redistributable may become true",
+            "has_candidates_with_locator": {
+                "rights_status": PRIVATE_LOCAL,
+                "admission_mode": PENDING_REDISTRIBUTION_GO,
+            },
+            "no_hit_strict_vesum": {
+                "admission_mode": "quarantined_no_document_hit",
+                "reason": NO_HIT_REASON,
+            },
+        }
+        _write_json(manifest_path, manifest)
+        source_recon_path = staged_root / "source-recon.json"
+        source_recon = json.loads(source_recon_path.read_text(encoding="utf-8"))
+        if not isinstance(source_recon, dict):
+            raise ValueError(f"source recon must be an object: {source_recon_path}")
+        source_recon["admission"] = "rights_ledger_refreshed_pending_operator_redistribution_go"
+        source_recon["rights_refresh"] = {
+            "rights_statuses": dict(sorted(rights_statuses.items())),
+            "admission_modes": dict(sorted(admission_modes.items())),
+            "practice_admitted": manifest["row_counts"]["practice_admitted"],
+        }
+        _write_json(source_recon_path, source_recon)
+        receipt = {
+            "schema": "teacher-curated-seed-recovery-receipt-v1",
+            "created_at": datetime.now(UTC).isoformat(),
+            "state": manifest["state"],
+            "document_policy": "master_docx private vault only",
+            "row_count": len(refreshed_seed),
+            "rows_no_hit": manifest["row_counts"]["rows_no_hit"],
+            "rows_with_candidates": manifest["row_counts"]["rows_with_candidates"],
+            "practice_admitted": manifest["row_counts"]["practice_admitted"],
+            "drive_mirror": str(drive_root),
+            "package_sha256": _tree_checksums(staged_root),
+        }
+        _write_json(staged_root / "receipt.json", receipt)
+
+        with (
+            tempfile.TemporaryDirectory(prefix=f".{package_root.name}.backup-", dir=parent) as local_temporary,
+            tempfile.TemporaryDirectory(prefix=f".{drive_root.name}.backup-", dir=drive_root.parent) as drive_temporary,
+        ):
+            local_backup = Path(local_temporary) / package_root.name
+            drive_backup = Path(drive_temporary) / drive_root.name
+            shutil.copytree(package_root, local_backup)
+            shutil.copytree(drive_root, drive_backup)
+            try:
+                _sync_tree(staged_root, drive_root)
+                if _tree_checksums(staged_root) != _tree_checksums(drive_root):
+                    raise RuntimeError("Drive mirror checksum mismatch after refresh")
+                _sync_tree(staged_root, package_root)
+                if _tree_checksums(staged_root) != _tree_checksums(package_root):
+                    raise RuntimeError("local package checksum mismatch after refresh")
+            except Exception:
+                _restore_tree(drive_backup, drive_root)
+                _restore_tree(local_backup, package_root)
+                raise
+    return receipt
+
+
 def build_package(
     *,
     package_root: Path,
@@ -268,13 +514,26 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--package-root", type=Path, required=True)
     parser.add_argument("--drive-root", type=Path)
     parser.add_argument("--replace-existing", action="store_true")
+    parser.add_argument(
+        "--refresh-rights-ledger",
+        action="store_true",
+        help="Refresh explicit local-only rights/admission states for a restored package.",
+    )
     parser.add_argument("--source-inventory-root", type=Path, default=ROOT / "data/lexicon/source-inventory")
     parser.add_argument(
         "--decision-root", type=Path, default=ROOT / "data/lexicon/source-inventory-review-decisions"
     )
     parser.add_argument("--cloze-path", type=Path, default=ROOT / "site/src/data/lexicon-teacher-cloze.json")
-    parser.add_argument("--drive-source-root", type=Path, required=True)
+    parser.add_argument("--drive-source-root", type=Path)
     args = parser.parse_args(argv)
+    if args.refresh_rights_ledger:
+        if args.drive_root is None:
+            parser.error("--refresh-rights-ledger requires --drive-root")
+        receipt = refresh_rights_ledger(package_root=args.package_root, drive_root=args.drive_root)
+        print(json.dumps(receipt, ensure_ascii=False, indent=2))
+        return 0
+    if args.drive_source_root is None:
+        parser.error("--drive-source-root is required unless --refresh-rights-ledger is used")
     receipt = build_package(
         package_root=args.package_root,
         drive_root=args.drive_root,

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -86,6 +86,15 @@ def normalize_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
             # The public projection never carries a path to the private source
             # document; only corpus attestation provenance survives.
             row["provenance"] = provenance
+        admission = raw.get("admission")
+        if isinstance(admission, dict):
+            # This is a gate, not a rights assertion: it keeps dry-runs from
+            # counting a private/local row as Practice-eligible.
+            row["admission"] = {
+                "practice": admission.get("practice") is True,
+                "mode": _text(admission.get("mode")),
+                "reason": _text(admission.get("reason")),
+            }
         normalized.append(row)
     return normalized
 
@@ -287,6 +296,7 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
     }
     routes_by_slug = {_text(entry.get("url_slug")): entry for entry in public_entries}
     atlas_failures: list[dict[str, Any]] = []
+    skipped_not_admitted: list[dict[str, Any]] = []
     skipped_no_cefr: list[dict[str, Any]] = []
     practice_rows: list[dict[str, Any]] = []
     status_counts: Counter[str] = Counter()
@@ -299,6 +309,17 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
             continue
         status = _text(row.get("sentenceStatus"))
         status_counts[status] += 1
+        admission = row.get("admission")
+        if isinstance(admission, dict) and admission.get("practice") is not True:
+            skipped_not_admitted.append(
+                {
+                    "seedRow": row.get("seedRow"),
+                    "lemma": lemma,
+                    "mode": _text(admission.get("mode")),
+                    "reason": _text(admission.get("reason")),
+                }
+            )
+            continue
         if status != "ok":
             continue
         example = _text(row.get("example"))
@@ -319,9 +340,11 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
             "active_seed_rows": len(rows), "unique_seed_lemmas": len({_lemma_key(_text(row.get("lemma"))) for row in rows}),
             "public_atlas_rows": len(rows) - len(atlas_failures), "atlas_failures": len(atlas_failures),
             "sentence_status": dict(sorted(status_counts.items())), "practice_admitted_rows": len(practice_rows),
+            "practice_skipped_not_admitted": len(skipped_not_admitted),
             "practice_skipped_no_cefr": len(skipped_no_cefr), "practice_cefr_sources": dict(sorted(cefr_sources.items())),
         },
         "atlas_failures": atlas_failures,
+        "practice_skipped_not_admitted": skipped_not_admitted,
         "practice_skipped_no_cefr": skipped_no_cefr,
     }
     seed = {"schema": PRACTICE_SCHEMA, "deckSlug": "curated-v5-full", "title": "Curated v5 practice admission", "selectionNote": "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets.", "entries": practice_rows}

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -310,13 +310,13 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         status = _text(row.get("sentenceStatus"))
         status_counts[status] += 1
         admission = row.get("admission")
-        if isinstance(admission, dict) and admission.get("practice") is not True:
+        if not isinstance(admission, dict) or admission.get("practice") is not True:
             skipped_not_admitted.append(
                 {
                     "seedRow": row.get("seedRow"),
                     "lemma": lemma,
-                    "mode": _text(admission.get("mode")),
-                    "reason": _text(admission.get("reason")),
+                    "mode": _text(admission.get("mode")) if isinstance(admission, dict) else "",
+                    "reason": _text(admission.get("reason")) if isinstance(admission, dict) else "missing_admission_record",
                 }
             )
             continue

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "97dc6d0995d3bd20ad621072b0c08a945a42d217ede330392818d9b9ff63315d",
+  "fingerprint": "a422c11ed2a049d43fc79aa4b1e7430828f1ff230e20a87c79102bdbba1260a5",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "756f7d122704364dd51cc8af27e94da4acbbe4df52019f55f7a22da486cef447"
+        "sha256": "78c1da24d28bac8b98c7295fefe43f18f466476c6d23f48423a44766dbd9d7dc"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "a422c11ed2a049d43fc79aa4b1e7430828f1ff230e20a87c79102bdbba1260a5",
+  "fingerprint": "8638becb56b912746b8dc58b3d40c8a12d22d12382278ab0d7e04b27190ef2e5",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "78c1da24d28bac8b98c7295fefe43f18f466476c6d23f48423a44766dbd9d7dc"
+        "sha256": "b5ce43cb799128c425a4468c625fc0c5137411b683ec094b4f844611ca29f1b0"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -269,11 +269,12 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
         ],
     )
     provenance = {"source_file": "ukrlib-example", "credit": "Автор"}
+    admitted = {"practice": True, "mode": "admitted", "reason": "rights_cleared"}
     rows = [
-        {"seedRow": 1, "lemma": "відомий", "sentenceStatus": "ok", "example": "Відомий приклад.", "provenance": provenance},
-        {"seedRow": 2, "lemma": "відомий", "sentenceStatus": "ok", "example": "Другий приклад.", "provenance": provenance},
-        {"seedRow": 3, "lemma": "рідкісний", "sentenceStatus": "no_hit"},
-        {"seedRow": 4, "lemma": "неоцінений", "sentenceStatus": "ok", "example": "Неоцінений приклад.", "provenance": provenance},
+        {"seedRow": 1, "lemma": "відомий", "sentenceStatus": "ok", "example": "Відомий приклад.", "provenance": provenance, "admission": admitted},
+        {"seedRow": 2, "lemma": "відомий", "sentenceStatus": "ok", "example": "Другий приклад.", "provenance": provenance, "admission": admitted},
+        {"seedRow": 3, "lemma": "рідкісний", "sentenceStatus": "no_hit", "admission": admitted},
+        {"seedRow": 4, "lemma": "неоцінений", "sentenceStatus": "ok", "example": "Неоцінений приклад.", "provenance": provenance, "admission": admitted},
     ]
 
     seed, report = admission.prepare_practice_seed(rows, manifest)
@@ -324,4 +325,29 @@ def test_practice_seed_reports_rights_gate_separately_from_missing_cefr(tmp_path
             "mode": "pending_operator_redistribution_go",
             "reason": "private_local_rights_require_operator_redistribution_go",
         }
+    ]
+
+
+@pytest.mark.parametrize("invalid_admission", [pytest.param(None, id="missing"), pytest.param("admitted", id="non_mapping")])
+def test_practice_seed_fails_closed_for_missing_or_invalid_admission(tmp_path: Path, invalid_admission: object) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "відомий", "url_slug": "відомий", "pos": "adj", "enrichment": {"cefr": "A2"}}],
+    )
+    row = {
+        "seedRow": 1,
+        "lemma": "відомий",
+        "sentenceStatus": "ok",
+        "example": "Відомий приклад.",
+        "provenance": {"source_file": "ukrlib-example", "credit": "Автор"},
+    }
+    if invalid_admission is not None:
+        row["admission"] = invalid_admission
+
+    seed, report = admission.prepare_practice_seed([row], manifest)
+
+    assert seed["entries"] == []
+    assert report["counts"]["practice_skipped_not_admitted"] == 1
+    assert report["practice_skipped_not_admitted"] == [
+        {"seedRow": 1, "lemma": "відомий", "mode": "", "reason": "missing_admission_record"}
     ]

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -286,7 +286,42 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
         "atlas_failures": 0,
         "sentence_status": {"no_hit": 1, "ok": 3},
         "practice_admitted_rows": 2,
+        "practice_skipped_not_admitted": 0,
         "practice_skipped_no_cefr": 1,
         "practice_cefr_sources": {"PULS": 2},
     }
     assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений"}]
+
+
+def test_practice_seed_reports_rights_gate_separately_from_missing_cefr(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "відомий", "url_slug": "відомий", "pos": "adj"}],
+    )
+    rows = [
+        {
+            "seedRow": 1,
+            "lemma": "відомий",
+            "sentenceStatus": "has_candidates",
+            "admission": {
+                "practice": False,
+                "mode": "pending_operator_redistribution_go",
+                "reason": "private_local_rights_require_operator_redistribution_go",
+            },
+        }
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert seed["entries"] == []
+    assert report["counts"]["practice_admitted_rows"] == 0
+    assert report["counts"]["practice_skipped_not_admitted"] == 1
+    assert report["counts"]["practice_skipped_no_cefr"] == 0
+    assert report["practice_skipped_not_admitted"] == [
+        {
+            "seedRow": 1,
+            "lemma": "відомий",
+            "mode": "pending_operator_redistribution_go",
+            "reason": "private_local_rights_require_operator_redistribution_go",
+        }
+    ]

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -186,3 +186,49 @@ def test_refresh_rights_ledger_mirrors_explicit_states(tmp_path: Path) -> None:
     assert refreshed_admission[0]["practice"] is False
     assert receipt["practice_admitted"] == 0
     assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)
+
+
+def test_refresh_rights_ledger_rolls_back_both_copies_after_post_sync_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = tmp_path / "package"
+    mirror = tmp_path / "drive" / "teacher-seed"
+    package.mkdir()
+    mirror.parent.mkdir(parents=True)
+    seed_row = {"seedRow": 1, "lemma": "слово", "sentenceStatus": "has_candidates"}
+    ledger_row = {
+        "seedRow": 1,
+        "lemma": "слово",
+        "sentenceStatus": "has_candidates",
+        "locator": "chunk/1",
+    }
+    _write(package / "curated-seed.jsonl", json.dumps(seed_row, ensure_ascii=False) + "\n")
+    _write(package / "rights-ledger.jsonl", json.dumps(ledger_row, ensure_ascii=False) + "\n")
+    _write(package / "practice-admission.jsonl", "")
+    _write(package / "package-manifest.json", json.dumps({"schema": "teacher-curated-seed-recovery-v1"}))
+    _write(package / "source-recon.json", "{}")
+    shutil.copytree(package, mirror)
+    package_before = {path.relative_to(package): path.read_bytes() for path in package.rglob("*") if path.is_file()}
+    mirror_before = {path.relative_to(mirror): path.read_bytes() for path in mirror.rglob("*") if path.is_file()}
+
+    original_sync_tree = rebuild._sync_tree
+    sync_calls = 0
+
+    def fail_after_drive_sync(source: Path, destination: Path) -> None:
+        nonlocal sync_calls
+        sync_calls += 1
+        if sync_calls == 2:
+            raise OSError("simulated local package sync failure")
+        original_sync_tree(source, destination)
+
+    monkeypatch.setattr(rebuild, "_sync_tree", fail_after_drive_sync)
+
+    with pytest.raises(OSError, match="simulated local package sync failure"):
+        rebuild.refresh_rights_ledger(package_root=package, drive_root=mirror)
+
+    assert {
+        path.relative_to(package): path.read_bytes() for path in package.rglob("*") if path.is_file()
+    } == package_before
+    assert {
+        path.relative_to(mirror): path.read_bytes() for path in mirror.rglob("*") if path.is_file()
+    } == mirror_before

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -256,3 +256,14 @@ def test_refresh_rights_ledger_rolls_back_both_copies_after_post_sync_failure(
     assert {
         path.relative_to(mirror): path.read_bytes() for path in mirror.rglob("*") if path.is_file()
     } == mirror_before
+
+
+def test_has_locator_rejects_empty_mapping_values() -> None:
+    from scripts.atlas.rebuild_teacher_curated_seed import _has_locator, classify_rights_admission
+
+    assert _has_locator({"source_file": None, "offset": None}) is False
+    assert _has_locator({"note": ""}) is False
+    assert _has_locator({"locator": "teacher_doc_paragraphs:1"}) is True
+    rights, admission = classify_rights_admission("has_candidates", {"source_file": None})
+    assert rights["status"] == "quarantined_missing_document_locator"
+    assert admission.get("practice") is False

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -188,6 +188,30 @@ def test_refresh_rights_ledger_mirrors_explicit_states(tmp_path: Path) -> None:
     assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)
 
 
+def test_refresh_rights_ledger_rejects_duplicate_curated_seed_rows(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    mirror = tmp_path / "drive" / "teacher-seed"
+    package.mkdir()
+    mirror.parent.mkdir(parents=True)
+    seed_rows = [
+        {"seedRow": 1, "lemma": "слово", "sentenceStatus": "has_candidates"},
+        {"seedRow": 1, "lemma": "інше", "sentenceStatus": "no_hit_strict_vesum"},
+    ]
+    ledger_rows = [
+        {"seedRow": 1, "lemma": "слово", "sentenceStatus": "has_candidates", "locator": "chunk/1"},
+        {"seedRow": 2, "lemma": "інше", "sentenceStatus": "no_hit_strict_vesum", "locator": None},
+    ]
+    for name, rows in (("curated-seed.jsonl", seed_rows), ("rights-ledger.jsonl", ledger_rows)):
+        _write(package / name, "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows))
+    _write(package / "practice-admission.jsonl", "")
+    _write(package / "package-manifest.json", json.dumps({"schema": "teacher-curated-seed-recovery-v1"}))
+    _write(package / "source-recon.json", "{}")
+    shutil.copytree(package, mirror)
+
+    with pytest.raises(ValueError, match="curated seed contains duplicate seedRow values"):
+        rebuild.refresh_rights_ledger(package_root=package, drive_root=mirror)
+
+
 def test_refresh_rights_ledger_rolls_back_both_copies_after_post_sync_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -115,3 +116,73 @@ def test_existing_package_requires_explicit_replacement(tmp_path: Path) -> None:
         **_inputs(tmp_path),
     )
     assert receipt["package_file_count"] == 5
+
+
+def test_classify_rights_admission_is_explicit_and_fail_closed() -> None:
+    rights, admission = rebuild.classify_rights_admission("no_hit_strict_vesum", None)
+
+    assert rights == {
+        "status": "private_local",
+        "redistributable": False,
+        "reason": "no_document_hit_vesum_forms",
+    }
+    assert admission == {
+        "practice": False,
+        "mode": "quarantined_no_document_hit",
+        "reason": "no_document_hit_vesum_forms",
+    }
+
+    rights, admission = rebuild.classify_rights_admission("has_candidates", "source/chunk/1")
+
+    assert rights["status"] == "private_local"
+    assert rights["redistributable"] is False
+    assert admission["mode"] == "pending_operator_redistribution_go"
+    assert admission["practice"] is False
+
+    rights, admission = rebuild.classify_rights_admission("ok", "source/chunk/1")
+
+    assert rights["status"] == "quarantined_unreviewed_sentence_status"
+    assert admission["mode"] == "quarantined_unreviewed_sentence_status"
+
+
+def test_classify_rights_admission_quarantines_missing_locator() -> None:
+    rights, admission = rebuild.classify_rights_admission("has_candidates", None)
+
+    assert rights["status"] == "quarantined_missing_document_locator"
+    assert admission == {
+        "practice": False,
+        "mode": "quarantined_missing_document_locator",
+        "reason": "has_candidates_without_document_locator",
+    }
+
+
+def test_refresh_rights_ledger_mirrors_explicit_states(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    mirror = tmp_path / "drive" / "teacher-seed"
+    package.mkdir()
+    mirror.parent.mkdir(parents=True)
+    seed_rows = [
+        {"seedRow": 1, "lemma": "слово", "sentenceStatus": "has_candidates"},
+        {"seedRow": 2, "lemma": "інше", "sentenceStatus": "no_hit_strict_vesum"},
+    ]
+    ledger_rows = [
+        {"seedRow": 1, "lemma": "слово", "sentenceStatus": "has_candidates", "locator": "chunk/1"},
+        {"seedRow": 2, "lemma": "інше", "sentenceStatus": "no_hit_strict_vesum", "locator": None},
+    ]
+    for name, rows in (("curated-seed.jsonl", seed_rows), ("rights-ledger.jsonl", ledger_rows)):
+        _write(package / name, "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows))
+    _write(package / "practice-admission.jsonl", "")
+    _write(package / "package-manifest.json", json.dumps({"schema": "teacher-curated-seed-recovery-v1"}))
+    _write(package / "source-recon.json", "{}")
+    shutil.copytree(package, mirror)
+
+    receipt = rebuild.refresh_rights_ledger(package_root=package, drive_root=mirror)
+
+    refreshed_seed = [json.loads(line) for line in (package / "curated-seed.jsonl").read_text(encoding="utf-8").splitlines()]
+    refreshed_admission = [json.loads(line) for line in (package / "practice-admission.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert refreshed_seed[0]["rights"]["status"] == "private_local"
+    assert refreshed_seed[0]["admission"]["mode"] == "pending_operator_redistribution_go"
+    assert refreshed_seed[1]["admission"]["reason"] == "no_document_hit_vesum_forms"
+    assert refreshed_admission[0]["practice"] is False
+    assert receipt["practice_admitted"] == 0
+    assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)


### PR DESCRIPTION
## Summary

- refreshes the private teacher seed rights ledger with explicit local-only/quarantine reasons and mirrors it to the existing Drive recovery destination
- separates rights-gate skips from missing-CEFR skips in the Atlas admission report
- documents and tests the deterministic, fail-closed refresh path

## Measured residual

| Metric | Count |
| --- | ---: |
| package rows | 1,037 |
| private_local | 1,037 |
| no-hit strict VESUM | 219 |
| pending operator redistribution GO | 818 |
| Practice admitted | 0 |
| Practice skipped: no CEFR | 0 |
| Atlas hard failures | 310 |
| Practice skipped: rights gate | 727 |

The helper exits 1 for the 310 Atlas hard failures; this is an intentional residual measurement, not a passing admission. The checksum-verified local and Drive private-package copies were refreshed together.

## Verification

- `.venv/bin/pytest -q tests/test_rebuild_teacher_curated_seed.py tests/test_curated_seed_atlas_admission.py`
- `.venv/bin/ruff check scripts/atlas/rebuild_teacher_curated_seed.py scripts/lexicon/curated_seed_atlas_admission.py tests/test_rebuild_teacher_curated_seed.py tests/test_curated_seed_atlas_admission.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/teacher-curated-seed-rebuild.md`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main...HEAD`

Refs #6022

No auto-merge: AC-ADMIT remains blocked by explicit redistribution authorization and unresolved Atlas routes.