### PR TITLE
feat(atlas): admit private teacher rows to local practice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ PYTHON ?= .venv/bin/python
 
 CURATED_SEED_INPUT ?= .claude/atlas-epic/plans/curated-seed/v5-curated-with-provenance.jsonl
 CURATED_SEED_DIR ?= data/lexicon
-CURATED_SEED_PUBLIC_SEED := $(CURATED_SEED_DIR)/curated-v5-admission-seed.json
-CURATED_SEED_CANDIDATES := $(CURATED_SEED_DIR)/curated-v5-grow-candidates.json
 CURATED_SEED_PRACTICE_SEED := $(CURATED_SEED_DIR)/curated-v5-practice-seed.json
 CURATED_SEED_REPORT := $(CURATED_SEED_DIR)/curated-v5-admission-report.json
+CURATED_SEED_LOCAL_SMOKE_OUT ?= batch_state/curated-v5-local-practice
+CURATED_SEED_LOCAL_SMOKE_TARGET ?= 700
 
 .PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh practice-admit-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
 
@@ -25,13 +25,8 @@ atlas-local-practice-refresh: atlas-practice-api-hydrate atlas-export-runtime
 
 practice-admit-curated-seed:
 	@test -f "$(CURATED_SEED_INPUT)" || { echo "missing private curated seed input" >&2; exit 2; }
-	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_INPUT)" --public-seed-out "$(CURATED_SEED_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --candidates-out "$(CURATED_SEED_CANDIDATES)"
-	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(CURATED_SEED_CANDIDATES)" --allow-preexisting-conformance --write
-	$(PYTHON) scripts/lexicon/enrich_manifest.py --write
-	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(CURATED_SEED_PRACTICE_SEED)" --report-out "$(CURATED_SEED_REPORT)"
-	npm --prefix site run atlas:build-db
-	$(PYTHON) scripts/audit/generate_practice_deck.py --practice-seed "$(CURATED_SEED_PRACTICE_SEED)"
-	$(MAKE) atlas-local-practice-refresh
+	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_INPUT)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(CURATED_SEED_PRACTICE_SEED)" --report-out "$(CURATED_SEED_REPORT)" --allow-missing-routes
+	$(PYTHON) scripts/audit/generate_practice_deck.py --manifest site/src/data/lexicon-manifest.json --local-practice-seed "$(CURATED_SEED_PRACTICE_SEED)" --out-dir "$(CURATED_SEED_LOCAL_SMOKE_OUT)" --target "$(CURATED_SEED_LOCAL_SMOKE_TARGET)"
 
 atlas:
 	$(PYTHON) -m scripts.lexicon.build_data_manifest --write

--- a/docs/runbooks/teacher-curated-seed-rebuild.md
+++ b/docs/runbooks/teacher-curated-seed-rebuild.md
@@ -38,15 +38,17 @@ does not create sentences, locators, CEFR, or redistribution permission.
   `no_document_hit_vesum_forms`.
 - `has_candidates` with a retained locator remains rights status
   `private_local`, with admission mode
-  `pending_operator_redistribution_go` and `practice: false`.
+  `local_practice_private_teacher` and `practice: true`. This is a
+  recognition-only local Practice admission; it does not authorize a public
+  Practice seed, cloze example, or redistribution.
 - A candidate without a locator is fail-closed as
   `quarantined_missing_document_locator`.
 
-`pending_operator_redistribution_go` means that local evidence exists but the
+`local_practice_private_teacher` means that local evidence exists but the
 operator has not granted redistribution. It is not a license and does not make
-a row available to Practice or public export. The receipt hashes every mirrored
-file except itself and is refreshed only after a staged checksum-equivalent
-Drive copy is ready.
+a row available to public export. The receipt hashes every mirrored file except
+itself and is refreshed only after a staged checksum-equivalent Drive copy is
+ready.
 
 ```bash
 DRIVE_RECOVERY_ROOT="/absolute/path/to/My Drive/Projects/learn-ukrainian-incident-recovery/2026-07-30/atlas-epic-dual-write/teacher-curated-seed"
@@ -100,12 +102,14 @@ CURATED_SEED_INPUT=.claude/atlas-epic/plans/curated-seed/curated-seed.jsonl \
   make practice-admit-curated-seed
 ```
 
-The Make target runs the existing admission helper, candidate promotion,
-enrichment, `generate_practice_deck.py`, API hydration, and Atlas runtime
-export. Its learner-facing output is the per-level
-`site/public/api/lexicon/practice-index.<level>.json` and
-`practice-lexemes.<level>.json` path. The recovery scaffold intentionally
-cannot pass this admission smoke: its zero rows are proof that the lost
-selection has not been fabricated. Once the authoritative table is restored,
-review its row count against the expected 1,018 rows before any Atlas or
-Practice write.
+The Make target runs the admission helper against the existing real Atlas
+manifest, then consumes the resulting local-only recognition overlay with
+`generate_practice_deck.py`. It writes smoke shards only under the ignored
+`batch_state/curated-v5-local-practice/` directory; it does not promote missing
+Atlas candidates, enrich or publish the manifest, hydrate public API shards, or
+export a public Practice runtime. Its default 700-item target keeps this a
+bounded local smoke rather than a public-scale deck rebuild. The recovery
+scaffold intentionally cannot pass this admission smoke: its zero rows are
+proof that the lost selection has not been fabricated. Once the authoritative
+table is restored, review its row count against the expected 1,018 rows before
+any Atlas or Practice write.

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -32,7 +32,7 @@ PACKAGE_FILES = (
     "package-manifest.json",
 )
 PRIVATE_LOCAL = "private_local"
-PENDING_REDISTRIBUTION_GO = "pending_operator_redistribution_go"
+LOCAL_PRACTICE_PRIVATE_TEACHER = "local_practice_private_teacher"
 NO_HIT_REASON = "no_document_hit_vesum_forms"
 
 
@@ -241,8 +241,9 @@ def _has_locator(value: object) -> bool:
 def classify_rights_admission(sentence_status: str, locator: object) -> tuple[dict[str, object], dict[str, object]]:
     """Return fail-closed row rights and Practice admission for a restored seed row.
 
-    A document hit is not redistribution permission.  The only candidate state
-    below remains local-only until an operator explicitly grants redistribution.
+    A document hit is not redistribution permission. Locator-backed private
+    teacher material may be used in local recognition Practice, but remains
+    unavailable to every public redistribution path.
     """
     if sentence_status == "no_hit_strict_vesum":
         return (
@@ -275,12 +276,12 @@ def classify_rights_admission(sentence_status: str, locator: object) -> tuple[di
             {
                 "status": PRIVATE_LOCAL,
                 "redistributable": False,
-                "reason": "private_local_teacher_material_pending_operator_redistribution_go",
+                "reason": "private_local_teacher_material_not_redistributable",
             },
             {
-                "practice": False,
-                "mode": PENDING_REDISTRIBUTION_GO,
-                "reason": "private_local_rights_require_operator_redistribution_go",
+                "practice": True,
+                "mode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                "reason": "private_local_teacher_material_local_practice_only",
             },
         )
     return (
@@ -385,7 +386,7 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         if not isinstance(manifest, dict):
             raise ValueError(f"package manifest must be an object: {manifest_path}")
-        manifest["state"] = "rights_ledger_refreshed_pending_operator_redistribution_go"
+        manifest["state"] = "rights_ledger_refreshed_local_practice_private_teacher"
         admission_modes = Counter(str(row["admission"]["mode"]) for row in refreshed_seed)
         rights_statuses = Counter(str(row["rights"]["status"]) for row in refreshed_seed)
         manifest["row_counts"] = {
@@ -405,7 +406,8 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
             "redistribution": "operator GO required before redistributable may become true",
             "has_candidates_with_locator": {
                 "rights_status": PRIVATE_LOCAL,
-                "admission_mode": PENDING_REDISTRIBUTION_GO,
+                "admission_mode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                "practice": "local recognition only; public redistribution remains blocked",
             },
             "no_hit_strict_vesum": {
                 "admission_mode": "quarantined_no_document_hit",
@@ -417,7 +419,7 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
         source_recon = json.loads(source_recon_path.read_text(encoding="utf-8"))
         if not isinstance(source_recon, dict):
             raise ValueError(f"source recon must be an object: {source_recon_path}")
-        source_recon["admission"] = "rights_ledger_refreshed_pending_operator_redistribution_go"
+        source_recon["admission"] = "rights_ledger_refreshed_local_practice_private_teacher"
         source_recon["rights_refresh"] = {
             "rights_statuses": dict(sorted(rights_statuses.items())),
             "admission_modes": dict(sorted(admission_modes.items())),

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -2917,13 +2917,14 @@ def read_manifest(path: Path) -> list[dict[str, Any]]:
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
-def read_practice_seed(path: Path) -> list[dict[str, Any]]:
+def read_practice_seed(path: Path, *, allow_local_private: bool = False) -> list[dict[str, Any]]:
     """Read a reviewed practice admission overlay.
 
     The source Atlas entry remains authoritative for learner-facing lexical
     metadata.  A seed can only admit an already-public Atlas slug and attach a
     source-backed example; it cannot create a second Atlas entry or fabricate
-    a CEFR level.
+    a CEFR level. A local-only seed is accepted only through the explicit
+    local-private path and permits recognition drills without an example.
     """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict) or payload.get("schema") != "curated-v5-practice-seed-v1":
@@ -2932,6 +2933,9 @@ def read_practice_seed(path: Path) -> list[dict[str, Any]]:
     if not isinstance(entries, list) or not entries:
         raise ValueError(f"practice seed entries must be a nonempty list: {path}")
 
+    local_only = payload.get("localOnly") is True
+    if local_only and not allow_local_private:
+        raise ValueError(f"local-only practice seed requires --local-practice-seed: {path}")
     validated: list[dict[str, Any]] = []
     for index, row in enumerate(entries):
         if not isinstance(row, dict):
@@ -2941,9 +2945,25 @@ def read_practice_seed(path: Path) -> list[dict[str, Any]]:
         cefr = _normalize_cefr(row.get("cefr"))
         example = _clean_text(row.get("example"))
         provenance = row.get("provenance")
-        if not lemma or not slug or not cefr or not example or not isinstance(provenance, dict):
+        is_local_recognition = (
+            local_only
+            and row.get("sentenceStatus") == "has_candidates"
+            and row.get("admissionMode") == "local_practice_private_teacher"
+        )
+        if not lemma or not slug or not cefr:
             raise ValueError(
-                f"practice seed entries[{index}] requires lemma, slug, CEFR, example, and provenance: {path}"
+                f"practice seed entries[{index}] requires lemma, slug, and CEFR: {path}"
+            )
+        if is_local_recognition:
+            if example or provenance is not None:
+                raise ValueError(f"local-only practice seed entries[{index}] must not contain example or provenance: {path}")
+            validated.append(row)
+            continue
+        if local_only:
+            raise ValueError(f"local-only practice seed entries[{index}] must be local recognition rows: {path}")
+        if not example or not isinstance(provenance, dict):
+            raise ValueError(
+                f"practice seed entries[{index}] requires example and provenance: {path}"
             )
         if row.get("sentenceStatus") != "ok":
             raise ValueError(f"practice seed entries[{index}] must retain sentenceStatus=ok: {path}")
@@ -2988,17 +3008,22 @@ def merge_practice_seed_entries(
 
         admission = target.get("surface_admission")
         merged_admission = dict(admission) if isinstance(admission, dict) else {}
-        merged_admission[SURFACE_CLOZE] = bool(merged_admission.get(SURFACE_CLOZE))
+        is_local_recognition = seed.get("admissionMode") == "local_practice_private_teacher"
+        merged_admission[SURFACE_CLOZE] = False if is_local_recognition else bool(merged_admission.get(SURFACE_CLOZE))
         merged_admission["practice"] = True
-        merged[target_index] = {
+        merged_entry = {
             **target,
             "surface_admission": merged_admission,
-            "practice_example": {
+        }
+        if is_local_recognition:
+            merged_entry["local_practice_private_teacher"] = True
+        else:
+            merged_entry["practice_example"] = {
                 "text": seed["example"],
                 "provenance": seed["provenance"],
                 "seedRow": seed.get("seedRow"),
-            },
-        }
+            }
+        merged[target_index] = merged_entry
     return merged
 
 
@@ -3271,6 +3296,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Reviewed practice admission overlay; each row must already exist in Atlas.",
     )
+    parser.add_argument(
+        "--local-practice-seed",
+        type=Path,
+        help="Private local recognition-only overlay; do not use for public output.",
+    )
     parser.add_argument("--vesum-fixture", type=Path)
     parser.add_argument("--target", type=int, default=DEFAULT_TARGET)
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
@@ -3292,8 +3322,15 @@ def main(argv: list[str] | None = None) -> int:
         return run_broken_validator_fixtures()
 
     entries = read_manifest(args.manifest) if args.manifest else read_atlas_db(args.atlas_db)
+    if args.practice_seed and args.local_practice_seed:
+        parser.error("--practice-seed and --local-practice-seed are mutually exclusive")
     if args.practice_seed:
         entries = merge_practice_seed_entries(entries, read_practice_seed(args.practice_seed))
+    if args.local_practice_seed:
+        entries = merge_practice_seed_entries(
+            entries,
+            read_practice_seed(args.local_practice_seed, allow_local_private=True),
+        )
     allowlist = ReviewedSourceAllowlist.from_path(args.reviewed_allowlist)
     cloze_sources = read_cloze_sources(args.cloze_sources)
     heritage_pairs = read_heritage_pairs(args.heritage_pairs)

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -2483,7 +2483,10 @@ def _select_practice_lexemes(
     seed_entries = [
         entry
         for entry in eligible
-        if isinstance(entry.get("practice_example"), dict)
+        if (
+            isinstance(entry.get("practice_example"), dict)
+            or entry.get("local_practice_private_teacher") is True
+        )
         and is_surface_admitted(entry, SURFACE_PRACTICE)
     ]
     seed_entry_ids = {id(entry) for entry in seed_entries}

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -2962,8 +2962,6 @@ def read_practice_seed(path: Path, *, allow_local_private: bool = False) -> list
                 raise ValueError(f"local-only practice seed entries[{index}] must not contain example or provenance: {path}")
             validated.append(row)
             continue
-        if local_only:
-            raise ValueError(f"local-only practice seed entries[{index}] must be local recognition rows: {path}")
         if not example or not isinstance(provenance, dict):
             raise ValueError(
                 f"practice seed entries[{index}] requires example and provenance: {path}"

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -28,6 +28,7 @@ from scripts.sync.promote_module import _write_atomically
 
 PRACTICE_SCHEMA = "curated-v5-practice-seed-v1"
 PUBLIC_SCHEMA = "curated-v5-admission-seed-v1"
+LOCAL_PRACTICE_PRIVATE_TEACHER = "local_practice_private_teacher"
 _ASPECT_NOTE_RE = re.compile(r"\s*\((?:perf|impf)\)\s*$", re.IGNORECASE)
 
 
@@ -303,10 +304,6 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
     cefr_sources: Counter[str] = Counter()
     for row in rows:
         lemma = _text(row.get("lemma"))
-        target = routes.get(_lemma_key(lemma)) or routes_by_slug.get(_text(row.get("slug")))
-        if target is None:
-            atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "missing_public_route"})
-            continue
         status = _text(row.get("sentenceStatus"))
         status_counts[status] += 1
         admission = row.get("admission")
@@ -320,12 +317,23 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
                 }
             )
             continue
-        if status != "ok":
+        local_recognition = (
+            status == "has_candidates"
+            and _text(admission.get("mode")) == LOCAL_PRACTICE_PRIVATE_TEACHER
+        )
+        if status != "ok" and not local_recognition:
+            skipped_not_admitted.append(
+                {
+                    "seedRow": row.get("seedRow"),
+                    "lemma": lemma,
+                    "mode": _text(admission.get("mode")),
+                    "reason": "unsupported_practice_sentence_status",
+                }
+            )
             continue
-        example = _text(row.get("example"))
-        provenance = row.get("provenance")
-        if not example or not isinstance(provenance, dict):
-            atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "ok_row_missing_attestation"})
+        target = routes.get(_lemma_key(lemma)) or routes_by_slug.get(_text(row.get("slug")))
+        if target is None:
+            atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "missing_public_route"})
             continue
         cefr = _cefr(target)
         if cefr is None:
@@ -333,7 +341,24 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
             continue
         level, source = cefr
         cefr_sources[source] += 1
-        practice_rows.append({"seedRow": row.get("seedRow"), "lemma": _text(target.get("lemma")), "slug": _text(target.get("url_slug")), "cefr": level, "example": example, "provenance": provenance, "sentenceStatus": "ok"})
+        practice_row: dict[str, Any] = {
+            "seedRow": row.get("seedRow"),
+            "lemma": _text(target.get("lemma")),
+            "slug": _text(target.get("url_slug")),
+            "cefr": level,
+            "sentenceStatus": status,
+        }
+        if local_recognition:
+            practice_row["admissionMode"] = LOCAL_PRACTICE_PRIVATE_TEACHER
+        else:
+            example = _text(row.get("example"))
+            provenance = row.get("provenance")
+            if not example or not isinstance(provenance, dict):
+                atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "ok_row_missing_attestation"})
+                continue
+            practice_row["example"] = example
+            practice_row["provenance"] = provenance
+        practice_rows.append(practice_row)
     report = {
         "schema": "curated-v5-admission-report-v1",
         "counts": {
@@ -347,7 +372,20 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         "practice_skipped_not_admitted": skipped_not_admitted,
         "practice_skipped_no_cefr": skipped_no_cefr,
     }
-    seed = {"schema": PRACTICE_SCHEMA, "deckSlug": "curated-v5-full", "title": "Curated v5 practice admission", "selectionNote": "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets.", "entries": practice_rows}
+    local_only = any(row.get("admissionMode") == LOCAL_PRACTICE_PRIVATE_TEACHER for row in practice_rows)
+    seed = {
+        "schema": PRACTICE_SCHEMA,
+        "deckSlug": "curated-v5-full",
+        "title": "Curated v5 practice admission",
+        "selectionNote": (
+            "Locator-backed private teacher rows with public Atlas routes and pipeline-derived CEFR; "
+            "local recognition only, never cloze or public export."
+            if local_only
+            else "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets."
+        ),
+        "localOnly": local_only,
+        "entries": practice_rows,
+    }
     return seed, report
 
 
@@ -366,6 +404,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--candidates-out", type=Path)
     parser.add_argument("--practice-seed-out", type=Path)
     parser.add_argument("--report-out", type=Path)
+    parser.add_argument(
+        "--allow-missing-routes",
+        action="store_true",
+        help="Permit local-only recognition output while reporting unresolved Atlas routes.",
+    )
     parser.add_argument(
         "--fill-existing-glosses",
         action="store_true",
@@ -403,6 +446,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.write and not (args.fill_existing_glosses or args.fill_existing_pos):
         parser.error("--write requires --fill-existing-glosses or --fill-existing-pos")
+    if args.allow_missing_routes and (args.public_seed_out or args.candidates_out):
+        parser.error("--allow-missing-routes is restricted to local Practice output")
 
     manifest: dict[str, Any] | None = None
     if args.fill_existing_glosses or args.fill_existing_pos:
@@ -453,7 +498,7 @@ def main(argv: list[str] | None = None) -> int:
             _write_json(args.practice_seed_out, seed)
         if args.report_out:
             _write_json(args.report_out, report)
-        if report["atlas_failures"]:
+        if report["atlas_failures"] and not args.allow_missing_routes:
             print(f"Atlas admission has {len(report['atlas_failures'])} hard failure(s)", file=sys.stderr)
             return 1
     return 0

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -498,8 +498,13 @@ def main(argv: list[str] | None = None) -> int:
             _write_json(args.practice_seed_out, seed)
         if args.report_out:
             _write_json(args.report_out, report)
-        if report["atlas_failures"] and not args.allow_missing_routes:
-            print(f"Atlas admission has {len(report['atlas_failures'])} hard failure(s)", file=sys.stderr)
+        hard_failures = [
+            failure
+            for failure in report["atlas_failures"]
+            if failure.get("reason") != "missing_public_route" or not args.allow_missing_routes
+        ]
+        if hard_failures:
+            print(f"Atlas admission has {len(hard_failures)} hard failure(s)", file=sys.stderr)
             return 1
     return 0
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "8638becb56b912746b8dc58b3d40c8a12d22d12382278ab0d7e04b27190ef2e5",
+  "fingerprint": "144e0d2b1da319bc326c5546844395c7341aa0c0208fc42f7685298cb2923c85",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "b5ce43cb799128c425a4468c625fc0c5137411b683ec094b4f844611ca29f1b0"
+        "sha256": "317396d1f63fe0b14450b02b1deb260c0a41a05e52309a6e313c8f7fe5563de1"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -379,8 +379,39 @@ def test_cli_allows_missing_routes_only_for_local_practice_output(tmp_path: Path
                 str(tmp_path / "public.json"),
                 "--allow-missing-routes",
             ]
-        )
+    )
     assert error.value.code == 2
+
+    attestation_manifest = _manifest(
+        tmp_path / "attestation-manifest.json",
+        [{"lemma": "відомий", "url_slug": "відомий", "pos": "adj", "enrichment": {"cefr": "A2"}}],
+    )
+    seed_input.write_text(
+        json.dumps(
+            {
+                "seedRow": 2,
+                "lemma": "відомий",
+                "sentenceStatus": "ok",
+                "admission": {"practice": True, "mode": "admitted"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert admission.main(
+        [
+            "--input",
+            str(seed_input),
+            "--manifest",
+            str(attestation_manifest),
+            "--practice-seed-out",
+            str(tmp_path / "attestation-practice.json"),
+            "--report-out",
+            str(tmp_path / "attestation-report.json"),
+            "--allow-missing-routes",
+        ]
+    ) == 1
 
 
 def test_practice_seed_reports_rights_gate_separately_from_missing_cefr(tmp_path: Path) -> None:

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -273,7 +273,16 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
     rows = [
         {"seedRow": 1, "lemma": "відомий", "sentenceStatus": "ok", "example": "Відомий приклад.", "provenance": provenance, "admission": admitted},
         {"seedRow": 2, "lemma": "відомий", "sentenceStatus": "ok", "example": "Другий приклад.", "provenance": provenance, "admission": admitted},
-        {"seedRow": 3, "lemma": "рідкісний", "sentenceStatus": "no_hit", "admission": admitted},
+        {
+            "seedRow": 3,
+            "lemma": "рідкісний",
+            "sentenceStatus": "no_hit",
+            "admission": {
+                "practice": False,
+                "mode": "quarantined_no_document_hit",
+                "reason": "no_document_hit_vesum_forms",
+            },
+        },
         {"seedRow": 4, "lemma": "неоцінений", "sentenceStatus": "ok", "example": "Неоцінений приклад.", "provenance": provenance, "admission": admitted},
     ]
 
@@ -287,11 +296,91 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
         "atlas_failures": 0,
         "sentence_status": {"no_hit": 1, "ok": 3},
         "practice_admitted_rows": 2,
-        "practice_skipped_not_admitted": 0,
+        "practice_skipped_not_admitted": 1,
         "practice_skipped_no_cefr": 1,
         "practice_cefr_sources": {"PULS": 2},
     }
     assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений"}]
+
+
+def test_private_local_candidates_admit_recognition_only_when_route_and_cefr_exist(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "відомий", "url_slug": "відомий", "pos": "adj", "enrichment": {"cefr": "A2"}}],
+    )
+    rows = [
+        {
+            "seedRow": 1,
+            "lemma": "відомий",
+            "sentenceStatus": "has_candidates",
+            "admission": {
+                "practice": True,
+                "mode": "local_practice_private_teacher",
+                "reason": "private_local_teacher_material_local_practice_only",
+            },
+        }
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert seed["localOnly"] is True
+    assert seed["entries"] == [
+        {
+            "seedRow": 1,
+            "lemma": "відомий",
+            "slug": "відомий",
+            "cefr": "A2",
+            "sentenceStatus": "has_candidates",
+            "admissionMode": "local_practice_private_teacher",
+        }
+    ]
+    assert report["counts"]["practice_admitted_rows"] == 1
+    assert report["counts"]["practice_skipped_no_cefr"] == 0
+
+
+def test_cli_allows_missing_routes_only_for_local_practice_output(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path / "manifest.json", [])
+    seed_input = tmp_path / "seed.jsonl"
+    seed_input.write_text(
+        json.dumps(
+            {
+                "seedRow": 1,
+                "lemma": "відомий",
+                "sentenceStatus": "has_candidates",
+                "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert admission.main(
+        [
+            "--input",
+            str(seed_input),
+            "--manifest",
+            str(manifest),
+            "--practice-seed-out",
+            str(tmp_path / "practice.json"),
+            "--report-out",
+            str(tmp_path / "report.json"),
+            "--allow-missing-routes",
+        ]
+    ) == 0
+    with pytest.raises(SystemExit) as error:
+        admission.main(
+            [
+                "--input",
+                str(seed_input),
+                "--manifest",
+                str(manifest),
+                "--public-seed-out",
+                str(tmp_path / "public.json"),
+                "--allow-missing-routes",
+            ]
+        )
+    assert error.value.code == 2
 
 
 def test_practice_seed_reports_rights_gate_separately_from_missing_cefr(tmp_path: Path) -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -139,6 +139,43 @@ def test_local_practice_seed_requires_explicit_opt_in_and_never_creates_a_cloze_
     assert "practice_example" not in merged[0]
 
 
+def test_local_practice_seed_accepts_attested_rows_alongside_local_recognition_rows(tmp_path: Path) -> None:
+    seed_path = tmp_path / "mixed-seed.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "schema": "curated-v5-practice-seed-v1",
+                "localOnly": True,
+                "entries": [
+                    {
+                        "seedRow": 1,
+                        "lemma": "слово",
+                        "slug": "слово",
+                        "cefr": "A1",
+                        "sentenceStatus": "has_candidates",
+                        "admissionMode": "local_practice_private_teacher",
+                    },
+                    {
+                        "seedRow": 2,
+                        "lemma": "речення",
+                        "slug": "речення",
+                        "cefr": "A1",
+                        "sentenceStatus": "ok",
+                        "example": "Це речення.",
+                        "provenance": {"source_file": "fixture", "credit": "Fixture"},
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    rows = read_practice_seed(seed_path, allow_local_private=True)
+
+    assert [row["seedRow"] for row in rows] == [1, 2]
+
+
 def test_local_practice_seed_rows_are_selected_before_ordinary_course_entries() -> None:
     entries = [
         {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -139,6 +139,34 @@ def test_local_practice_seed_requires_explicit_opt_in_and_never_creates_a_cloze_
     assert "practice_example" not in merged[0]
 
 
+def test_local_practice_seed_rows_are_selected_before_ordinary_course_entries() -> None:
+    entries = [
+        {
+            "lemma": "справедливий",
+            "url_slug": "справедливий",
+            "gloss": "fair",
+            "enrichment": {"cefr": {"level": "A2"}},
+            "surface_admission": {"practice": True, "cloze": False},
+            "local_practice_private_teacher": True,
+        },
+        {
+            "lemma": "витирати",
+            "url_slug": "витирати",
+            "gloss": "wipe",
+            "enrichment": {"cefr": {"level": "A2"}},
+            "course_usage": [{"module": "fixture"}],
+        },
+    ]
+
+    selected, _lexemes, _by_plain_lemma, _by_id = _select_practice_lexemes(
+        entries,
+        JsonVesumVerifier.from_path(VESUM),
+        BuildConfig(target=1, source_label="fixture"),
+    )
+
+    assert [entry["url_slug"] for entry, _lexeme in selected] == ["справедливий"]
+
+
 def test_practice_seed_entries_are_selected_before_ordinary_course_entries() -> None:
     entries = [
         {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -103,6 +103,42 @@ def test_curated_v5_seed_admits_existing_atlas_entries_with_provenance() -> None
         assert lexemes[row["slug"]]["exampleProvenance"] == row["provenance"]
 
 
+def test_local_practice_seed_requires_explicit_opt_in_and_never_creates_a_cloze_example(tmp_path: Path) -> None:
+    seed_path = tmp_path / "local-seed.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "schema": "curated-v5-practice-seed-v1",
+                "localOnly": True,
+                "entries": [
+                    {
+                        "seedRow": 1,
+                        "lemma": "слово",
+                        "slug": "слово",
+                        "cefr": "A1",
+                        "sentenceStatus": "has_candidates",
+                        "admissionMode": "local_practice_private_teacher",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="requires --local-practice-seed"):
+        read_practice_seed(seed_path)
+
+    merged = merge_practice_seed_entries(
+        [{"lemma": "слово", "url_slug": "слово", "gloss": "word", "enrichment": {"cefr": "A1"}}],
+        read_practice_seed(seed_path, allow_local_private=True),
+    )
+
+    assert merged[0]["surface_admission"] == {"cloze": False, "practice": True}
+    assert merged[0]["local_practice_private_teacher"] is True
+    assert "practice_example" not in merged[0]
+
+
 def test_practice_seed_entries_are_selected_before_ordinary_course_entries() -> None:
     entries = [
         {

--- a/tests/test_makefile_practice_admit.py
+++ b/tests/test_makefile_practice_admit.py
@@ -8,7 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_curated_admit_dry_run_refreshes_practice_api_and_atlas_runtime() -> None:
+def test_curated_admit_dry_run_consumes_only_the_local_practice_overlay() -> None:
     result = subprocess.run(
         ["make", "-n", "practice-admit-curated-seed"],
         cwd=ROOT,
@@ -18,7 +18,11 @@ def test_curated_admit_dry_run_refreshes_practice_api_and_atlas_runtime() -> Non
     )
 
     output = result.stdout
-    deck = output.index("generate_practice_deck.py --practice-seed")
-    hydrate = output.index("hydrate-lexicon-api-shards.ts")
-    export = output.index("scripts.atlas.export_runtime_shards")
-    assert deck < hydrate < export
+    assert "generate_practice_deck.py --manifest site/src/data/lexicon-manifest.json --local-practice-seed" in output
+    assert "--allow-missing-routes" in output
+    assert '--target "700"' in output
+    assert 'batch_state/curated-v5-local-practice' in output
+    assert "promote_grow_candidates" not in output
+    assert "enrich_manifest.py --write" not in output
+    assert "atlas:build-db" not in output
+    assert "atlas-local-practice-refresh" not in output

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -136,8 +136,9 @@ def test_classify_rights_admission_is_explicit_and_fail_closed() -> None:
 
     assert rights["status"] == "private_local"
     assert rights["redistributable"] is False
-    assert admission["mode"] == "pending_operator_redistribution_go"
-    assert admission["practice"] is False
+    assert rights["reason"] == "private_local_teacher_material_not_redistributable"
+    assert admission["mode"] == "local_practice_private_teacher"
+    assert admission["practice"] is True
 
     rights, admission = rebuild.classify_rights_admission("ok", "source/chunk/1")
 
@@ -181,10 +182,10 @@ def test_refresh_rights_ledger_mirrors_explicit_states(tmp_path: Path) -> None:
     refreshed_seed = [json.loads(line) for line in (package / "curated-seed.jsonl").read_text(encoding="utf-8").splitlines()]
     refreshed_admission = [json.loads(line) for line in (package / "practice-admission.jsonl").read_text(encoding="utf-8").splitlines()]
     assert refreshed_seed[0]["rights"]["status"] == "private_local"
-    assert refreshed_seed[0]["admission"]["mode"] == "pending_operator_redistribution_go"
+    assert refreshed_seed[0]["admission"]["mode"] == "local_practice_private_teacher"
     assert refreshed_seed[1]["admission"]["reason"] == "no_document_hit_vesum_forms"
-    assert refreshed_admission[0]["practice"] is False
-    assert receipt["practice_admitted"] == 0
+    assert refreshed_admission[0]["practice"] is True
+    assert receipt["practice_admitted"] == 1
     assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)
 
 


### PR DESCRIPTION
Closes #6022

Local-only admission
- Locator-backed has_candidates rows become local_practice_private_teacher with rights.redistributable false.
- The private local overlay is recognition-only: cloze is forced off and it contains no example text or provenance.
- Regular/public seed consumption rejects the local-only mode. The Make smoke writes only ignored batch_state shards.

Real local proof
- Refreshed package and Drive mirror: 1,037 rows; 818 candidate rows; 219 no-hit rows; 818 local Practice admissions; zero redistributable rows; checksum parity passed.
- Release-pinned manifest smoke: 604 admitted, 186 missing-route, 28 missing-CEFR, 219 not-admitted/no-hit; 45 local smoke shards; no public site output from the intended smoke command.

Verification
- Targeted pytest: 85 passed.
- Ruff on changed Python and test files passed.
- The local Make smoke used the private curated seed with the real manifest.
- Staged OPSEC, diff, agent-trailer, and manifest-fingerprint checks passed.
- Independent Claude review passed after three repair cycles; no findings remain.

No auto-merge requested. Cross-family review required.