### PR TITLE
feat(atlas): named residual lists for teacher local-practice smoke (#6064)

### DIFF
--- a/scripts/atlas/residual_teacher_lists.py
+++ b/scripts/atlas/residual_teacher_lists.py
@@ -1,0 +1,212 @@
+"""Named residual lists for the post-#6062 teacher local-practice smoke (#6064).
+
+#6062 admits every ``sentenceStatus=has_candidates`` private teacher row to
+local Practice regardless of whether its lemma has a public Atlas route or a
+pipeline-derived CEFR level — those two gates are only evaluated later, by
+``scripts.lexicon.curated_seed_atlas_admission.prepare_practice_seed``, when
+building the actual Practice seed. This module reuses that same classifier
+(it never re-derives route/CEFR membership itself) and splits its
+``atlas_failures`` / ``practice_skipped_no_cefr`` output into two named,
+deterministic residual lists so a teacher/operator can see what is left:
+
+- rows whose lemma has no public Atlas route at all (``missing_route.jsonl``)
+- rows whose lemma has a route but no pipeline CEFR (``no_cefr.jsonl``)
+
+Inputs are the private curated-seed package (gitignored; see
+``.claude/atlas-epic/plans/curated-seed/`` — ``curated-seed.jsonl`` +
+``practice-admission.jsonl``, produced by
+``scripts/atlas/rebuild_teacher_curated_seed.py``) and the hydrated public
+Atlas manifest (``site/src/data/lexicon-manifest.json``). Outputs are
+gitignored JSONL/JSON reports under ``batch_state/atlas/residual/`` — never
+the public learner site.
+
+This script never invents a lemma, a CEFR level, or a redistribution right;
+it only reports what the existing pipeline already decided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.curated_seed_atlas_admission import (
+    _manifest_entries,
+    normalize_rows,
+    prepare_practice_seed,
+)
+from scripts.lexicon.manifest_io import DEFAULT_MANIFEST, load_manifest
+
+DEFAULT_PACKAGE_ROOT = ROOT / ".claude" / "atlas-epic" / "plans" / "curated-seed"
+DEFAULT_OUTPUT_DIR = ROOT / "batch_state" / "atlas" / "residual"
+MISSING_ROUTE_REASON = "missing_public_route"
+SUMMARY_SCHEMA = "atlas-residual-teacher-lists-v1"
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError(f"JSONL rows must be objects: {path}")
+    return rows
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def verify_admission_consistency(seed_rows: list[dict[str, Any]], admission_rows: list[dict[str, Any]]) -> None:
+    """Cross-check the two private package files agree before trusting either.
+
+    Both files are dual-written from the same refresh (see
+    ``rebuild_teacher_curated_seed.refresh_rights_ledger``); a mismatch means
+    the package drifted between writes and residual counts would be unsafe.
+    """
+    by_row = {row.get("seedRow"): row for row in admission_rows}
+    if len(by_row) != len(admission_rows):
+        raise ValueError("practice-admission.jsonl contains duplicate seedRow values")
+    for row in seed_rows:
+        seed_row = row.get("seedRow")
+        ledger = by_row.get(seed_row)
+        if ledger is None:
+            raise ValueError(f"seed row {seed_row} missing from practice-admission.jsonl")
+        raw_admission = row.get("admission")
+        admission: dict[str, Any] = raw_admission if isinstance(raw_admission, dict) else {}
+        if bool(ledger.get("practice")) != (admission.get("practice") is True):
+            raise ValueError(f"seed row {seed_row}: practice flag disagrees between the two package files")
+        if str(ledger.get("mode") or "") != str(admission.get("mode") or ""):
+            raise ValueError(f"seed row {seed_row}: admission mode disagrees between the two package files")
+
+
+def load_package_rows(package_root: Path) -> list[dict[str, Any]]:
+    """Read + cross-validate the private curated-seed package (gitignored)."""
+    seed_path = package_root / "curated-seed.jsonl"
+    admission_path = package_root / "practice-admission.jsonl"
+    if not seed_path.is_file():
+        raise FileNotFoundError(
+            f"curated-seed.jsonl not found under {package_root}. This is the gitignored private "
+            "teacher package (.claude/atlas-epic/plans/curated-seed/); rebuild it with "
+            "scripts/atlas/rebuild_teacher_curated_seed.py before running residual reporting."
+        )
+    seed_rows = _read_jsonl(seed_path)
+    if admission_path.is_file():
+        verify_admission_consistency(seed_rows, _read_jsonl(admission_path))
+    return seed_rows
+
+
+def _routes_by_lemma_key(manifest_path: Path) -> dict[str, dict[str, Any]]:
+    """Public-route lemma index, matching ``prepare_practice_seed``'s own filter."""
+    return {
+        _lemma_key(str(entry.get("lemma") or "")): entry
+        for entry in _manifest_entries(manifest_path)
+        if str(entry.get("lemma") or "").strip()
+        and str(entry.get("url_slug") or "").strip()
+        and entry.get("pos") != "grammar term"
+    }
+
+
+def classify_residuals(rows: list[dict[str, Any]], manifest_path: Path) -> dict[str, Any]:
+    """Split the existing admission classifier's failures into named residuals.
+
+    Reuses ``curated_seed_atlas_admission.prepare_practice_seed`` verbatim —
+    this function never re-derives route or CEFR membership itself.
+    """
+    normalized = normalize_rows(rows)
+    _seed, report = prepare_practice_seed(normalized, manifest_path)
+    admission_by_seed_row = {row.get("seedRow"): row.get("admission") or {} for row in normalized}
+
+    missing_route: list[dict[str, Any]] = []
+    other_atlas_failures: list[dict[str, Any]] = []
+    for failure in report["atlas_failures"]:
+        if failure.get("reason") == MISSING_ROUTE_REASON:
+            seed_row = failure.get("seedRow")
+            mode = str(admission_by_seed_row.get(seed_row, {}).get("mode") or "")
+            missing_route.append({"seedRow": seed_row, "lemma": failure.get("lemma"), "mode": mode})
+        else:
+            other_atlas_failures.append(failure)
+
+    routes = _routes_by_lemma_key(manifest_path)
+    no_cefr: list[dict[str, Any]] = []
+    for entry in report["practice_skipped_no_cefr"]:
+        lemma = str(entry.get("lemma") or "")
+        target = routes.get(_lemma_key(lemma))
+        no_cefr.append(
+            {
+                "seedRow": entry.get("seedRow"),
+                "lemma": entry.get("lemma"),
+                "url_slug": str(target.get("url_slug") or "") if target else "",
+            }
+        )
+
+    summary: dict[str, Any] = {
+        "schema": SUMMARY_SCHEMA,
+        "issue": 6064,
+        "counts": {
+            "input_rows": len(rows),
+            **report["counts"],
+            "missing_route": len(missing_route),
+            "no_cefr": len(no_cefr),
+            "other_atlas_failures": len(other_atlas_failures),
+        },
+    }
+    if other_atlas_failures:
+        summary["other_atlas_failures"] = other_atlas_failures
+    return {"missing_route": missing_route, "no_cefr": no_cefr, "summary": summary}
+
+
+def write_residual_reports(result: dict[str, Any], output_dir: Path) -> None:
+    _write_jsonl(output_dir / "missing_route.jsonl", result["missing_route"])
+    _write_jsonl(output_dir / "no_cefr.jsonl", result["no_cefr"])
+    _write_json(output_dir / "summary.json", result["summary"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package-root",
+        type=Path,
+        default=DEFAULT_PACKAGE_ROOT,
+        help="Private curated-seed package root (gitignored .claude/atlas-epic/plans/curated-seed/).",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Atlas manifest path (default: hydrate site/src/data/lexicon-manifest.json).",
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+
+    rows = load_package_rows(args.package_root)
+    manifest_path = args.manifest
+    if manifest_path is None:
+        load_manifest()
+        manifest_path = DEFAULT_MANIFEST
+
+    result = classify_residuals(rows, manifest_path)
+    write_residual_reports(result, args.output_dir)
+
+    counts = result["summary"]["counts"]
+    print(
+        f"input_rows={counts['input_rows']} practice_admitted_rows={counts['practice_admitted_rows']} "
+        f"missing_route={counts['missing_route']} no_cefr={counts['no_cefr']} -> {args.output_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/atlas/residual_teacher_lists.py
+++ b/scripts/atlas/residual_teacher_lists.py
@@ -75,6 +75,7 @@ def verify_admission_consistency(seed_rows: list[dict[str, Any]], admission_rows
     by_row = {row.get("seedRow"): row for row in admission_rows}
     if len(by_row) != len(admission_rows):
         raise ValueError("practice-admission.jsonl contains duplicate seedRow values")
+    seed_row_keys = {row.get("seedRow") for row in seed_rows}
     for row in seed_rows:
         seed_row = row.get("seedRow")
         ledger = by_row.get(seed_row)
@@ -86,6 +87,11 @@ def verify_admission_consistency(seed_rows: list[dict[str, Any]], admission_rows
             raise ValueError(f"seed row {seed_row}: practice flag disagrees between the two package files")
         if str(ledger.get("mode") or "") != str(admission.get("mode") or ""):
             raise ValueError(f"seed row {seed_row}: admission mode disagrees between the two package files")
+    extra_seed_rows = set(by_row) - seed_row_keys
+    if extra_seed_rows:
+        raise ValueError(
+            f"practice-admission.jsonl has seedRow(s) not in curated-seed.jsonl: {sorted(extra_seed_rows)}"
+        )
 
 
 def load_package_rows(package_root: Path) -> list[dict[str, Any]]:

--- a/scripts/atlas/residual_teacher_lists.py
+++ b/scripts/atlas/residual_teacher_lists.py
@@ -103,9 +103,15 @@ def load_package_rows(package_root: Path) -> list[dict[str, Any]]:
             "teacher package (.claude/atlas-epic/plans/curated-seed/); rebuild it with "
             "scripts/atlas/rebuild_teacher_curated_seed.py before running residual reporting."
         )
+    if not admission_path.is_file():
+        raise FileNotFoundError(
+            f"practice-admission.jsonl not found under {package_root}. This is the gitignored private "
+            "teacher rights ledger (.claude/atlas-epic/plans/curated-seed/), dual-written alongside "
+            "curated-seed.jsonl; rebuild it with scripts/atlas/rebuild_teacher_curated_seed.py before "
+            "running residual reporting."
+        )
     seed_rows = _read_jsonl(seed_path)
-    if admission_path.is_file():
-        verify_admission_consistency(seed_rows, _read_jsonl(admission_path))
+    verify_admission_consistency(seed_rows, _read_jsonl(admission_path))
     return seed_rows
 
 

--- a/scripts/atlas/residual_teacher_lists.py
+++ b/scripts/atlas/residual_teacher_lists.py
@@ -36,12 +36,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.lexicon.build_data_manifest import _lemma_key
-from scripts.lexicon.curated_seed_atlas_admission import (
-    _manifest_entries,
-    normalize_rows,
-    prepare_practice_seed,
-)
+from scripts.lexicon.curated_seed_atlas_admission import normalize_rows, prepare_practice_seed
 from scripts.lexicon.manifest_io import DEFAULT_MANIFEST, load_manifest
 
 DEFAULT_PACKAGE_ROOT = ROOT / ".claude" / "atlas-epic" / "plans" / "curated-seed"
@@ -115,17 +110,6 @@ def load_package_rows(package_root: Path) -> list[dict[str, Any]]:
     return seed_rows
 
 
-def _routes_by_lemma_key(manifest_path: Path) -> dict[str, dict[str, Any]]:
-    """Public-route lemma index, matching ``prepare_practice_seed``'s own filter."""
-    return {
-        _lemma_key(str(entry.get("lemma") or "")): entry
-        for entry in _manifest_entries(manifest_path)
-        if str(entry.get("lemma") or "").strip()
-        and str(entry.get("url_slug") or "").strip()
-        and entry.get("pos") != "grammar term"
-    }
-
-
 def classify_residuals(rows: list[dict[str, Any]], manifest_path: Path) -> dict[str, Any]:
     """Split the existing admission classifier's failures into named residuals.
 
@@ -146,18 +130,14 @@ def classify_residuals(rows: list[dict[str, Any]], manifest_path: Path) -> dict[
         else:
             other_atlas_failures.append(failure)
 
-    routes = _routes_by_lemma_key(manifest_path)
-    no_cefr: list[dict[str, Any]] = []
-    for entry in report["practice_skipped_no_cefr"]:
-        lemma = str(entry.get("lemma") or "")
-        target = routes.get(_lemma_key(lemma))
-        no_cefr.append(
-            {
-                "seedRow": entry.get("seedRow"),
-                "lemma": entry.get("lemma"),
-                "url_slug": str(target.get("url_slug") or "") if target else "",
-            }
-        )
+    no_cefr: list[dict[str, Any]] = [
+        {
+            "seedRow": entry.get("seedRow"),
+            "lemma": entry.get("lemma"),
+            "url_slug": str(entry.get("url_slug") or ""),
+        }
+        for entry in report["practice_skipped_no_cefr"]
+    ]
 
     summary: dict[str, Any] = {
         "schema": SUMMARY_SCHEMA,

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -337,7 +337,9 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
             continue
         cefr = _cefr(target)
         if cefr is None:
-            skipped_no_cefr.append({"seedRow": row.get("seedRow"), "lemma": lemma})
+            skipped_no_cefr.append(
+                {"seedRow": row.get("seedRow"), "lemma": lemma, "url_slug": _text(target.get("url_slug"))}
+            )
             continue
         level, source = cefr
         cefr_sources[source] += 1

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "144e0d2b1da319bc326c5546844395c7341aa0c0208fc42f7685298cb2923c85",
+  "fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "317396d1f63fe0b14450b02b1deb260c0a41a05e52309a6e313c8f7fe5563de1"
+        "sha256": "f9a4b9a9504d52fb1c5ea30a9bb8931c4f0022aa44e8e880544f5bde2605dfb0"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -300,7 +300,25 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
         "practice_skipped_no_cefr": 1,
         "practice_cefr_sources": {"PULS": 2},
     }
-    assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений"}]
+    assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений", "url_slug": "неоцінений"}]
+
+
+def test_practice_seed_no_cefr_records_url_slug_when_route_matched_via_slug(tmp_path: Path) -> None:
+    """The manifest route for this seed row lives under a homograph lemma
+    (mirroring ``вчителька`` / ``учителька`` — see ``_slug_for_url``'s
+    docstring), so the lemma-key lookup misses and the slug fallback is
+    what actually resolves ``target``. The no-CEFR residual record must
+    still carry that resolved ``url_slug``, not an empty string."""
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "учителька", "url_slug": "вчителька", "pos": "noun"}],
+    )
+    rows = [{"seedRow": 1, "lemma": "вчителька", "slug": "вчителька", "sentenceStatus": "ok", "example": "Вчителька увійшла.", "provenance": {"source_file": "x", "credit": "y"}, "admission": {"practice": True, "mode": "admitted", "reason": "rights_cleared"}}]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert seed["entries"] == []
+    assert report["practice_skipped_no_cefr"] == [{"seedRow": 1, "lemma": "вчителька", "url_slug": "вчителька"}]
 
 
 def test_private_local_candidates_admit_recognition_only_when_route_and_cefr_exist(tmp_path: Path) -> None:

--- a/tests/test_residual_teacher_lists.py
+++ b/tests/test_residual_teacher_lists.py
@@ -203,3 +203,31 @@ def test_verify_admission_consistency_detects_duplicate_admission_rows() -> None
 
     with pytest.raises(ValueError, match="duplicate seedRow"):
         residual.verify_admission_consistency(seed_rows, admission_rows)
+
+
+def test_verify_admission_consistency_detects_extra_admission_seed_row() -> None:
+    """practice-admission.jsonl carrying a seedRow absent from curated-seed.jsonl
+    means the package drifted between writes just as much as a missing row does
+    (#6065 F001) — the original check only looked one direction."""
+    seed_rows = [_seed_row(1, "Справедливий")]
+    admission_rows = [
+        {"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "local_practice_private_teacher"},
+        {"seedRow": 2, "lemma": "Оренда", "practice": True, "mode": "local_practice_private_teacher"},
+    ]
+
+    with pytest.raises(ValueError, match=r"seedRow\(s\) not in curated-seed\.jsonl"):
+        residual.verify_admission_consistency(seed_rows, admission_rows)
+
+
+def test_load_package_rows_detects_extra_admission_seed_row(tmp_path: Path) -> None:
+    _write_jsonl_file(tmp_path / "curated-seed.jsonl", [_seed_row(1, "Справедливий")])
+    _write_jsonl_file(
+        tmp_path / "practice-admission.jsonl",
+        [
+            {"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "local_practice_private_teacher"},
+            {"seedRow": 2, "lemma": "Оренда", "practice": True, "mode": "local_practice_private_teacher"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"seedRow\(s\) not in curated-seed\.jsonl"):
+        residual.load_package_rows(tmp_path)

--- a/tests/test_residual_teacher_lists.py
+++ b/tests/test_residual_teacher_lists.py
@@ -130,6 +130,13 @@ def test_load_package_rows_missing_seed_file_raises(tmp_path: Path) -> None:
         residual.load_package_rows(tmp_path)
 
 
+def test_load_package_rows_missing_admission_file_raises(tmp_path: Path) -> None:
+    _write_jsonl_file(tmp_path / "curated-seed.jsonl", [_seed_row(1, "Справедливий")])
+
+    with pytest.raises(FileNotFoundError, match=r"practice-admission\.jsonl not found"):
+        residual.load_package_rows(tmp_path)
+
+
 def test_load_package_rows_accepts_agreeing_package(tmp_path: Path) -> None:
     seed_rows = [_seed_row(1, "Справедливий"), _seed_row(2, "Оренда", practice=False, mode="quarantined_no_document_hit")]
     _write_jsonl_file(tmp_path / "curated-seed.jsonl", seed_rows)

--- a/tests/test_residual_teacher_lists.py
+++ b/tests/test_residual_teacher_lists.py
@@ -1,0 +1,179 @@
+"""Residual teacher-practice lists reuse the existing atlas admission classifier (#6064)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.atlas import residual_teacher_lists as residual
+
+
+def _manifest(path: Path, entries: list[dict[str, object]]) -> Path:
+    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _seed_row(
+    seed_row: int,
+    lemma: str,
+    *,
+    status: str = "has_candidates",
+    practice: bool = True,
+    mode: str = "local_practice_private_teacher",
+    reason: str = "private_local_teacher_material_local_practice_only",
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "seedRow": seed_row,
+        "lemma": lemma,
+        "gloss": "gloss",
+        "sentenceStatus": status,
+        "admission": {"practice": practice, "mode": mode, "reason": reason},
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def _write_jsonl_file(path: Path, rows: list[dict[str, object]]) -> Path:
+    path.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def test_classify_residuals_splits_missing_route_and_no_cefr(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [
+            {"lemma": "Справедливий", "url_slug": "справедливий", "pos": "adj", "enrichment": {"cefr": {"level": "B1", "source": "PULS"}}},
+            {"lemma": "Витерти", "url_slug": "витерти", "pos": "verb"},
+        ],
+    )
+    rows = [
+        _seed_row(1, "Справедливий"),  # clean: route + cefr
+        _seed_row(2, "Оренда"),  # no manifest entry at all
+        _seed_row(3, "Витерти"),  # route but no cefr block
+    ]
+
+    result = residual.classify_residuals(rows, manifest)
+
+    assert result["missing_route"] == [{"seedRow": 2, "lemma": "оренда", "mode": "local_practice_private_teacher"}]
+    assert result["no_cefr"] == [{"seedRow": 3, "lemma": "витерти", "url_slug": "витерти"}]
+    assert result["summary"]["counts"]["missing_route"] == 1
+    assert result["summary"]["counts"]["no_cefr"] == 1
+    assert result["summary"]["counts"]["input_rows"] == 3
+    assert result["summary"]["counts"]["practice_admitted_rows"] == 1
+    assert "other_atlas_failures" not in result["summary"]
+
+
+def test_classify_residuals_ignores_rows_not_admitted_to_practice(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path / "manifest.json", [])
+    rows = [
+        _seed_row(
+            1,
+            "Незрозуміле",
+            status="no_hit_strict_vesum",
+            practice=False,
+            mode="quarantined_no_document_hit",
+            reason="no_document_hit_vesum_forms",
+        )
+    ]
+
+    result = residual.classify_residuals(rows, manifest)
+
+    assert result["missing_route"] == []
+    assert result["no_cefr"] == []
+    assert result["summary"]["counts"]["missing_route"] == 0
+    assert result["summary"]["counts"]["practice_admitted_rows"] == 0
+
+
+def test_classify_residuals_buckets_non_route_failures_separately(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "Слово", "url_slug": "слово", "pos": "noun", "enrichment": {"cefr": {"level": "A1", "source": "PULS"}}}],
+    )
+    # sentenceStatus=ok + a non-local admission mode requires attestation;
+    # this row has a route + CEFR but no example/provenance, so it fails for a
+    # different reason than a missing route.
+    rows = [_seed_row(1, "Слово", status="ok", mode="admitted", reason="rights_cleared")]
+
+    result = residual.classify_residuals(rows, manifest)
+
+    assert result["missing_route"] == []
+    assert result["summary"]["counts"]["other_atlas_failures"] == 1
+    assert result["summary"]["other_atlas_failures"] == [
+        {"seedRow": 1, "lemma": "слово", "reason": "ok_row_missing_attestation"}
+    ]
+
+
+def test_write_residual_reports_writes_three_files(tmp_path: Path) -> None:
+    result = {
+        "missing_route": [{"seedRow": 2, "lemma": "оренда", "mode": "local_practice_private_teacher"}],
+        "no_cefr": [{"seedRow": 3, "lemma": "витерти", "url_slug": "витерти"}],
+        "summary": {"schema": residual.SUMMARY_SCHEMA, "counts": {"missing_route": 1, "no_cefr": 1}},
+    }
+    output_dir = tmp_path / "residual"
+
+    residual.write_residual_reports(result, output_dir)
+
+    missing_route_lines = (output_dir / "missing_route.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in missing_route_lines] == result["missing_route"]
+    no_cefr_lines = (output_dir / "no_cefr.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in no_cefr_lines] == result["no_cefr"]
+    summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary == result["summary"]
+
+
+def test_load_package_rows_missing_seed_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"curated-seed\.jsonl not found"):
+        residual.load_package_rows(tmp_path)
+
+
+def test_load_package_rows_accepts_agreeing_package(tmp_path: Path) -> None:
+    seed_rows = [_seed_row(1, "Справедливий"), _seed_row(2, "Оренда", practice=False, mode="quarantined_no_document_hit")]
+    _write_jsonl_file(tmp_path / "curated-seed.jsonl", seed_rows)
+    _write_jsonl_file(
+        tmp_path / "practice-admission.jsonl",
+        [
+            {"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "local_practice_private_teacher"},
+            {"seedRow": 2, "lemma": "Оренда", "practice": False, "mode": "quarantined_no_document_hit"},
+        ],
+    )
+
+    rows = residual.load_package_rows(tmp_path)
+
+    assert [row["seedRow"] for row in rows] == [1, 2]
+
+
+def test_load_package_rows_detects_practice_flag_drift(tmp_path: Path) -> None:
+    _write_jsonl_file(tmp_path / "curated-seed.jsonl", [_seed_row(1, "Справедливий", practice=True)])
+    _write_jsonl_file(
+        tmp_path / "practice-admission.jsonl",
+        [{"seedRow": 1, "lemma": "Справедливий", "practice": False, "mode": "local_practice_private_teacher"}],
+    )
+
+    with pytest.raises(ValueError, match="practice flag disagrees"):
+        residual.load_package_rows(tmp_path)
+
+
+def test_load_package_rows_detects_mode_drift(tmp_path: Path) -> None:
+    _write_jsonl_file(tmp_path / "curated-seed.jsonl", [_seed_row(1, "Справедливий", mode="local_practice_private_teacher")])
+    _write_jsonl_file(
+        tmp_path / "practice-admission.jsonl",
+        [{"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "some_other_mode"}],
+    )
+
+    with pytest.raises(ValueError, match="admission mode disagrees"):
+        residual.load_package_rows(tmp_path)
+
+
+def test_verify_admission_consistency_detects_duplicate_admission_rows() -> None:
+    seed_rows = [_seed_row(1, "Справедливий")]
+    admission_rows = [
+        {"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "local_practice_private_teacher"},
+        {"seedRow": 1, "lemma": "Справедливий", "practice": True, "mode": "local_practice_private_teacher"},
+    ]
+
+    with pytest.raises(ValueError, match="duplicate seedRow"):
+        residual.verify_admission_consistency(seed_rows, admission_rows)

--- a/tests/test_residual_teacher_lists.py
+++ b/tests/test_residual_teacher_lists.py
@@ -67,6 +67,25 @@ def test_classify_residuals_splits_missing_route_and_no_cefr(tmp_path: Path) -> 
     assert "other_atlas_failures" not in result["summary"]
 
 
+def test_classify_residuals_no_cefr_records_url_slug_from_slug_matched_route(tmp_path: Path) -> None:
+    """The manifest route lives under a homograph lemma (``учителька`` for
+    the ``вчителька`` route, mirroring ``_slug_for_url``'s own docstring
+    example), so ``prepare_practice_seed`` only resolves it via the slug
+    fallback. The residual ``no_cefr`` entry must carry that resolved
+    ``url_slug`` rather than re-deriving it from a lemma-only index that
+    would miss the match."""
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "учителька", "url_slug": "вчителька", "pos": "noun"}],
+    )
+    rows = [_seed_row(1, "Вчителька", status="ok", mode="admitted", reason="rights_cleared", extra={"example": "Вчителька увійшла.", "provenance": {"source_file": "x", "credit": "y"}})]
+
+    result = residual.classify_residuals(rows, manifest)
+
+    assert result["missing_route"] == []
+    assert result["no_cefr"] == [{"seedRow": 1, "lemma": "вчителька", "url_slug": "вчителька"}]
+
+
 def test_classify_residuals_ignores_rows_not_admitted_to_practice(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path / "manifest.json", [])
     rows = [


### PR DESCRIPTION
## Summary
- Links #6064. Adds `scripts/atlas/residual_teacher_lists.py`, which reuses the existing `scripts.lexicon.curated_seed_atlas_admission.prepare_practice_seed` classifier (never re-derives Atlas route or CEFR membership itself) and splits its `atlas_failures` / `practice_skipped_no_cefr` output into two named, deterministic residual lists for the post-#6062 private teacher local-practice cohort: rows with no public Atlas route at all, and rows with a route but no pipeline-derived CEFR.
- Reads the gitignored private package (`.claude/atlas-epic/plans/curated-seed/curated-seed.jsonl` + `practice-admission.jsonl`, cross-validated against each other for drift) and the hydrated `site/src/data/lexicon-manifest.json`; emits `missing_route.jsonl`, `no_cefr.jsonl`, and `summary.json` to gitignored `batch_state/atlas/residual/` — never the public learner site.
- A live run against the current private package matches the brief's estimate exactly: `missing_route=186`, `no_cefr=28` (out of 818 `has_candidates` rows admitted to local practice; 604 are already fully ready).
- **This PR does not claim residual=0.** It only reports the two gaps; growing/promoting the 186 missing lemmas into the Atlas is explicitly out of scope (separate later PR per the brief).

## Test plan
- [x] `.venv/bin/pytest tests/test_residual_teacher_lists.py tests/test_curated_seed_atlas_admission.py` (28 passed) — new tests use inline fixtures, no private package in git
- [x] `.venv/bin/ruff check scripts/atlas/residual_teacher_lists.py tests/test_residual_teacher_lists.py`
- [x] `.venv/bin/mypy scripts/atlas/residual_teacher_lists.py` (no new errors)
- [x] Live dry run against the real private package + hydrated manifest confirmed counts and gitignored output paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)