### PR TITLE
feat(practice): add local gold slice target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ CURATED_SEED_PRACTICE_SEED := $(CURATED_SEED_DIR)/curated-v5-practice-seed.json
 CURATED_SEED_REPORT := $(CURATED_SEED_DIR)/curated-v5-admission-report.json
 CURATED_SEED_LOCAL_SMOKE_OUT ?= batch_state/curated-v5-local-practice
 CURATED_SEED_LOCAL_SMOKE_TARGET ?= 700
+CURATED_SEED_GOLD_TARGET ?= 40
+CURATED_SEED_GOLD_OUT ?= site/public/lexicon
+CURATED_SEED_GOLD_VESUM_DB ?= data/vesum.db
 
-.PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh practice-admit-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
+.PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh practice-admit-curated-seed practice-gold-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
 
 # Refresh practice JSON API copies + /atlas runtime for local/dev word-page CTA.
 atlas-practice-api-hydrate:
@@ -27,6 +30,16 @@ practice-admit-curated-seed:
 	@test -f "$(CURATED_SEED_INPUT)" || { echo "missing private curated seed input" >&2; exit 2; }
 	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_INPUT)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(CURATED_SEED_PRACTICE_SEED)" --report-out "$(CURATED_SEED_REPORT)" --allow-missing-routes
 	$(PYTHON) scripts/audit/generate_practice_deck.py --manifest site/src/data/lexicon-manifest.json --local-practice-seed "$(CURATED_SEED_PRACTICE_SEED)" --out-dir "$(CURATED_SEED_LOCAL_SMOKE_OUT)" --target "$(CURATED_SEED_LOCAL_SMOKE_TARGET)"
+
+# Local-only vertical slice: these ignored static shards temporarily replace
+# hydrated practice shards so the existing /lexicon browser path can smoke them.
+# Restore the published local deck afterwards with `npm --prefix site run hydrate:practice`.
+practice-gold-curated-seed:
+	@test -f "$(CURATED_SEED_INPUT)" || { echo "missing private curated seed input" >&2; exit 2; }
+	@test "$(CURATED_SEED_GOLD_TARGET)" -ge 32 && test "$(CURATED_SEED_GOLD_TARGET)" -le 50 || { echo "gold target must be between 32 and 50" >&2; exit 2; }
+	@test -f "$(CURATED_SEED_GOLD_VESUM_DB)" || { echo "missing explicit VESUM database for gold slice" >&2; exit 2; }
+	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_INPUT)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(CURATED_SEED_PRACTICE_SEED)" --report-out "$(CURATED_SEED_REPORT)" --allow-missing-routes
+	$(PYTHON) scripts/audit/generate_practice_deck.py --manifest site/src/data/lexicon-manifest.json --local-practice-seed "$(CURATED_SEED_PRACTICE_SEED)" --out-dir "$(CURATED_SEED_GOLD_OUT)" --target "$(CURATED_SEED_GOLD_TARGET)" --seed-selection representative --disable-cloze --vesum-db "$(CURATED_SEED_GOLD_VESUM_DB)"
 
 atlas:
 	$(PYTHON) -m scripts.lexicon.build_data_manifest --write

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -161,6 +161,8 @@ class BuildConfig:
     gzip_limit: int = DEFAULT_GZIP_LIMIT
     fixture_note: str | None = None
     source_label: str = "manifest"
+    seed_selection: str = "priority"
+    cloze_enabled: bool = True
 
 
 @dataclass(frozen=True)
@@ -275,6 +277,9 @@ def _build_cloze_provenance(provenance: dict[str, Any]) -> dict[str, Any]:
 class RealVesumVerifier:
     """Runtime adapter for the production VESUM helper."""
 
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path
+
     def verify_words(
         self,
         words: list[str],
@@ -282,7 +287,7 @@ class RealVesumVerifier:
     ) -> dict[str, list[dict[str, Any]]]:
         from scripts.verification.vesum import verify_words
 
-        return verify_words(words, pos_filter=pos_filter)
+        return verify_words(words, pos_filter=pos_filter, db_path=self.db_path)
 
 
 class JsonVesumVerifier:
@@ -2470,6 +2475,55 @@ def _level_payload(
     return payload
 
 
+def _representative_seed_entries(
+    seed_entries: list[dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Select seed entries evenly across available CEFR/POS strata.
+
+    This is deliberately only an explicit gold-slice profile.  Normal decks
+    retain their priority ordering; a small verification deck needs coverage
+    across the admitted set without inventing any lexical metadata.
+    """
+    strata: dict[int, dict[str, list[dict[str, Any]]]] = {}
+    for entry in seed_entries:
+        level = _cefr_level(entry) or ""
+        rank = CEFR_RANK.get(level, len(CEFR_RANK))
+        pos = _clean_text(entry.get("pos")) or "other"
+        strata.setdefault(rank, {}).setdefault(pos, []).append(entry)
+
+    level_queues: dict[int, list[dict[str, Any]]] = {}
+    for rank, pos_groups in strata.items():
+        for entries in pos_groups.values():
+            entries.sort(key=_stable_lemma_id)
+        queue: list[dict[str, Any]] = []
+        while True:
+            added = False
+            for pos in sorted(pos_groups):
+                entries = pos_groups[pos]
+                if entries:
+                    queue.append(entries.pop(0))
+                    added = True
+            if not added:
+                break
+        level_queues[rank] = queue
+
+    selected: list[dict[str, Any]] = []
+    while len(selected) < limit:
+        added = False
+        for rank in sorted(level_queues):
+            entries = level_queues[rank]
+            if not entries:
+                continue
+            selected.append(entries.pop(0))
+            added = True
+            if len(selected) == limit:
+                break
+        if not added:
+            break
+    return selected
+
+
 def _select_practice_lexemes(
     entries: list[dict[str, Any]],
     verifier: VesumVerifier,
@@ -2494,6 +2548,8 @@ def _select_practice_lexemes(
     course_entries = [entry for entry in non_seed_entries if _course_usage(entry)]
     fill_entries = [entry for entry in non_seed_entries if not _course_usage(entry)]
     seed_entries.sort(key=_stable_lemma_id)
+    if config.seed_selection == "representative":
+        seed_entries = _representative_seed_entries(seed_entries, config.target)
     course_entries.sort(key=_course_key)
     fill_entries.sort(
         key=lambda entry: (CEFR_RANK.get(_cefr_level(entry) or "", len(CEFR_RANK)), _stable_lemma_id(entry))
@@ -2599,7 +2655,7 @@ def build_practice_shards(
         for level in CEFR_ORDER
     }
     for _entry, lexeme in lexemes_by_entry:
-        if is_surface_admitted(_entry, SURFACE_CLOZE):
+        if config.cloze_enabled and is_surface_admitted(_entry, SURFACE_CLOZE):
             source_rows = [
                 *cloze_by_lemma_id.get(lexeme["lemmaId"], []),
                 *cloze_by_lemma.get(lexeme["lemmaPlain"], []),
@@ -3303,10 +3359,26 @@ def main(argv: list[str] | None = None) -> int:
         help="Private local recognition-only overlay; do not use for public output.",
     )
     parser.add_argument("--vesum-fixture", type=Path)
+    parser.add_argument(
+        "--vesum-db",
+        type=Path,
+        help="Explicit VESUM database path, including a validated local shadow.",
+    )
     parser.add_argument("--target", type=int, default=DEFAULT_TARGET)
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
     parser.add_argument("--gzip-limit", type=int, default=DEFAULT_GZIP_LIMIT)
     parser.add_argument("--fixture-note", type=str)
+    parser.add_argument(
+        "--seed-selection",
+        choices=("priority", "representative"),
+        default="priority",
+        help="How an explicit practice seed is selected before course/fill entries.",
+    )
+    parser.add_argument(
+        "--disable-cloze",
+        action="store_true",
+        help="Emit no cloze cards, even for otherwise cloze-admitted entries.",
+    )
     parser.add_argument(
         "--broken-validator-fixtures",
         action="store_true",
@@ -3345,7 +3417,7 @@ def main(argv: list[str] | None = None) -> int:
         verifier = (
             JsonVesumVerifier.from_path(args.vesum_fixture)
             if args.vesum_fixture
-            else RealVesumVerifier()
+            else RealVesumVerifier(args.vesum_db)
         )
         _lexemes_by_entry, all_lexemes, by_plain_lemma, _lexemes_by_id = _select_practice_lexemes(
             entries,
@@ -3359,7 +3431,7 @@ def main(argv: list[str] | None = None) -> int:
     verifier: VesumVerifier = (
         JsonVesumVerifier.from_path(args.vesum_fixture)
         if args.vesum_fixture
-        else RealVesumVerifier()
+        else RealVesumVerifier(args.vesum_db)
     )
     config = BuildConfig(
         target=args.target,
@@ -3367,6 +3439,8 @@ def main(argv: list[str] | None = None) -> int:
         gzip_limit=args.gzip_limit,
         fixture_note=args.fixture_note,
         source_label="fixture" if args.vesum_fixture or args.manifest else "atlas.db",
+        seed_selection=args.seed_selection,
+        cloze_enabled=not args.disable_cloze,
     )
     shards = build_practice_shards(
         entries,

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -11,6 +11,7 @@ from scripts.audit.generate_practice_deck import (
     DRILL_MODES,
     BuildConfig,
     JsonVesumVerifier,
+    RealVesumVerifier,
     ReviewedSourceAllowlist,
     _build_classify_items,
     _build_heritage_items,
@@ -204,6 +205,50 @@ def test_local_practice_seed_rows_are_selected_before_ordinary_course_entries() 
     assert [entry["url_slug"] for entry, _lexeme in selected] == ["справедливий"]
 
 
+def test_representative_seed_selection_round_robins_available_cefr_and_pos_strata() -> None:
+    entries = [
+        {
+            "lemma": lemma,
+            "url_slug": lemma,
+            "gloss": "fixture gloss",
+            "pos": pos,
+            "enrichment": {"cefr": {"level": cefr}},
+            "surface_admission": {"practice": True, "cloze": False},
+            "local_practice_private_teacher": True,
+        }
+        for lemma, cefr, pos in (
+            ("а", "A1", "noun"),
+            ("б", "A1", "noun"),
+            ("в", "A1", "verb"),
+            ("г", "A2", "noun"),
+            ("ґ", "A2", "verb"),
+        )
+    ]
+
+    selected, _lexemes, _by_plain_lemma, _by_id = _select_practice_lexemes(
+        entries,
+        JsonVesumVerifier.from_path(VESUM),
+        BuildConfig(target=5, source_label="fixture", seed_selection="representative"),
+    )
+
+    assert [entry["url_slug"] for entry, _lexeme in selected] == ["а", "г", "в", "ґ", "б"]
+
+
+def test_real_vesum_verifier_uses_an_explicit_database_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_verify_words(words: list[str], *, pos_filter: str | None, db_path: Path) -> dict[str, list[dict]]:
+        observed.update(words=words, pos_filter=pos_filter, db_path=db_path)
+        return {word: [] for word in words}
+
+    from scripts.verification import vesum
+
+    monkeypatch.setattr(vesum, "verify_words", fake_verify_words)
+    database = tmp_path / "vesum-shadow.db"
+    assert RealVesumVerifier(database).verify_words(["слово"], pos_filter="noun") == {"слово": []}
+    assert observed == {"words": ["слово"], "pos_filter": "noun", "db_path": database}
+
+
 def test_practice_seed_entries_are_selected_before_ordinary_course_entries() -> None:
     entries = [
         {
@@ -338,6 +383,13 @@ def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     assert shards["A1"]["index"]["counts"]["lexemes"] == 7
     assert shards["A1"]["index"]["counts"]["cloze"] == 0
     assert shards["A1"]["cloze"]["cloze"] == []
+
+
+def test_disable_cloze_emits_no_cards_even_when_curated_sources_are_available() -> None:
+    shards = _build(BuildConfig(cloze_enabled=False))
+
+    assert all(not item["hasCloze"] for shard in shards.values() for item in shard["index"]["items"])
+    assert all(not shard["cloze"]["cloze"] for shard in shards.values())
 
 
 def test_deck_version_changes_when_any_deck_input_changes() -> None:

--- a/tests/test_makefile_practice_admit.py
+++ b/tests/test_makefile_practice_admit.py
@@ -26,3 +26,24 @@ def test_curated_admit_dry_run_consumes_only_the_local_practice_overlay() -> Non
     assert "enrich_manifest.py --write" not in output
     assert "atlas:build-db" not in output
     assert "atlas-local-practice-refresh" not in output
+
+
+def test_gold_slice_dry_run_uses_bounded_local_static_shards_without_cloze() -> None:
+    result = subprocess.run(
+        ["make", "-n", "practice-gold-curated-seed"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout
+    assert 'test "40" -ge 32' in output
+    assert 'test "40" -le 50' in output
+    assert 'site/public/lexicon' in output
+    assert '--target "40"' in output
+    assert "--seed-selection representative" in output
+    assert "--disable-cloze" in output
+    assert '--vesum-db "data/vesum.db"' in output
+    assert "practice-deck-publish" not in output
+    assert "atlas-local-practice-refresh" not in output


### PR DESCRIPTION
Fixes #5792

## Local gold slice
- Adds `make practice-gold-curated-seed` for a bounded 32–50 local-only static Practice deck (default 40).
- Uses a validated explicit VESUM database path and deterministic CEFR-first, POS-within-level selection.
- Hard-disables cloze and writes ignored local shards to the existing `/lexicon/practice-*.json` route; it does not publish a pointer or release asset.

## Evidence
- Admitted local-recognition pool: 604 rows; public-safe cloze rows: 0.
- Built slice: 40 items (8 each A1/A2/B1/B2/C1), 12 POS categories, 45 static shard files, 0 cloze cards.
- Static asset audit passed against the generated shard set.
- Isolated Astro smoke on port 4322 served `/words-of-the-day/practice/` (200) and the A1/C1 static index shards (8 items, 0 cloze each).

## Verification
- `.venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_makefile_practice_admit.py -q`
- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py tests/test_generate_practice_deck.py tests/test_makefile_practice_admit.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No auto-merge: formal cross-family review and CI are still required.