### PR TITLE
feat(runtime): add bounded ACPX shadow comparison

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -247,13 +247,22 @@ function renderAcpx(snapshot) {
   const seatSlots = [seats[0], seats[1]];
   const safety = snapshot.safety || {};
   const pins = snapshot.pins || {};
+  const comparison = snapshot.comparison_evidence || {};
   const calls = shadowCallCount(seats);
+  const comparisons = Number(comparison.comparisons);
+  const parity = Number(comparison.classification_parity);
+  const mismatches = Number(comparison.classification_mismatch);
   const mode = transport.mode;
   const facts = [
     ['Monitor env mode', mode, 'mode'],
     ['Default', transport.default_mode],
     ['Authority', displayLabel(transport.authority)],
     ['Shadow calls', calls],
+    ['Comparisons', Number.isFinite(comparisons) ? comparisons : null],
+    ['Class parity', Number.isFinite(parity) && Number.isFinite(comparisons) ? `${parity} / ${comparisons}` : null],
+    ['Class mismatches', Number.isFinite(mismatches) ? mismatches : null],
+    ['Duplicates suppressed', comparison.duplicates_suppressed],
+    ['Busy refusals', comparison.busy_refusals],
     ['ACPX pin', pins.acpx ? `v${pins.acpx}` : null],
     ['Grok CLI pin', pins.grok_cli ? `v${pins.grok_cli}` : null],
     ['Pin validation', pins.validation ? displayLabel(pins.validation) : null],
@@ -285,14 +294,18 @@ function renderAcpx(snapshot) {
     failover_authority: 'No failover authority',
     review_authority: 'No review authority',
   };
+  const safeWhenTrue = {
+    explicit_pilot_only: 'Explicit pilot only',
+  };
   const safetyMarkup = Object.entries(safety).filter(([, value]) => typeof value === 'boolean').map(([key, value]) => {
     if (Object.hasOwn(safeWhenFalse, key) && value === false) return `<span class="pill ok">${escapeHtml(safeWhenFalse[key])}</span>`;
+    if (Object.hasOwn(safeWhenTrue, key) && value === true) return `<span class="pill ok">${escapeHtml(safeWhenTrue[key])}</span>`;
     return `<span class="pill ${value ? 'warn' : 'gray'}">${escapeHtml(displayLabel(key))}: ${value ? 'enabled' : 'not enabled'}</span>`;
   }).join('');
   const inFlightMarkup = Number.isFinite(Number(safety.max_in_flight))
     ? `<span class="pill info">Max ${escapeHtml(safety.max_in_flight)} in flight</span>`
     : '';
-  const noCallsCopy = calls === 0 ? '<div class="empty">No shadow calls in window</div>' : '';
+  const noCallsCopy = calls === 0 && comparisons === 0 ? '<div class="empty">No shadow calls or comparisons in window</div>' : '';
   const factMarkup = facts.map(([label, value, kind]) => {
     if (kind === 'mode') {
       const modeClass = value === 'shadow' ? 'info' : value === 'off' ? 'gray' : 'err';

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1290,8 +1290,38 @@ with no records reports `no_evidence`; that is not a provider-health claim.
   },
   "pins": {
     "acpx": "0.13.0",
-    "grok_cli": "0.2.114",
+    "grok_cli": "0.2.117",
     "validation": "before_spawn"
+  },
+  "comparison_evidence": {
+    "window_days": 7,
+    "state": "observed",
+    "attempts": 3,
+    "comparisons": 2,
+    "classification_parity": 2,
+    "classification_mismatch": 0,
+    "duplicates_suppressed": 1,
+    "busy_refusals": 0,
+    "native": {
+      "total": 2,
+      "ok": 2,
+      "error": 0,
+      "timeout": 0,
+      "rate_limited": 0,
+      "total_duration_s": 8.2,
+      "tokens_observed": 1,
+      "total_tokens": 125
+    },
+    "shadow": {
+      "total": 2,
+      "ok": 2,
+      "error": 0,
+      "timeout": 0,
+      "rate_limited": 0,
+      "total_duration_s": 11.4,
+      "tokens_observed": 1,
+      "total_tokens": 138
+    }
   },
   "seats": [
     {
@@ -1315,6 +1345,7 @@ with no records reports `no_evidence`; that is not a provider-health claim.
   ],
   "safety": {
     "max_in_flight": 1,
+    "explicit_pilot_only": true,
     "backlog": false,
     "retries": false,
     "sessions": false,

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -97,7 +97,7 @@ Approved boundary (#6027 Codex, #6043 Grok):
 - Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); both adapters refuse to
   spawn on any other resolved version.
 - Grok seat also preflights the installed native Grok CLI at exact semver
-  `0.2.114` (wrong/missing/unparseable → refuse before prompt).
+  `0.2.117` (wrong/missing/unparseable → refuse before prompt).
 - Codex participant:
   `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
 - Grok participant:
@@ -118,6 +118,12 @@ Approved boundary (#6027 Codex, #6043 Grok):
   tools.
 - Correlation / shadow telemetry is **evidence only** — the existing participant
   result stays authoritative under shadow compare.
+- The only supported comparison caller is
+  `scripts.agent_runtime.acpx_pilot`: an explicit worktree-only command that
+  runs native first, then one shadow under a global non-blocking lock. It
+  suppresses replayed idempotency digests before either call, never queues or
+  retries, and persists sanitized classification/parity/duration/token
+  aggregates for `GET /api/runtime/acpx`.
 - ACPX authentication selection is explicit under `--auth-policy fail`:
   - Codex ChatGPT login: non-secret selector `ACPX_AUTH_CHAT_GPT=1`
   - Grok cached native login: adapter sets `ACPX_AUTH_CACHED_TOKEN=1` and

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -190,7 +190,10 @@ Persisted comparison evidence contains only target, outcome classes, parity,
 durations, token counts when exposed, and digests of correlation/idempotency
 values—never prompts, responses, raw identifiers, paths, sessions, commands,
 stderr, auth material, or tool data. The read-only Runtime dashboard aggregates
-that evidence; it cannot send or control ACPX traffic.
+that evidence; it cannot send or control ACPX traffic. The supporting native
+and shadow pilot-leg usage rows also suppress task/run/session identifiers,
+paths, telemetry labels, and stderr while retaining structured operational
+counts and outcomes.
 
 #### Safety and budgets (adapter contract)
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -110,7 +110,7 @@ snapshots, not permanent routing weights.
 - Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
   resolved binary version.
 - Grok seat additionally preflights the installed native Grok CLI at exact
-  semver `0.2.114` and refuses wrong/missing/unparseable versions before
+  semver `0.2.117` and refuses wrong/missing/unparseable versions before
   prompt.
 - Every invocation requires a non-empty, bounded, local `task_id`,
   `correlation_id`, and `idempotency_key`, plus
@@ -158,6 +158,39 @@ adapter's argv is fully confined and callers only ever set the `tool_config`
 keys it allowlists (`acpx_shadow`, `target_agent`, `correlation_id`,
 `idempotency_key`); this runbook describes ownership and safety, not a
 floating CLI surface.
+
+#### Explicit comparison pilot
+
+Run the dedicated pilot only from a dispatch/registered worktree. The prompt
+arrives on stdin rather than argv. Codex additionally requires its non-secret
+ChatGPT auth-method selector:
+
+```bash
+printf '%s\n' 'Reply with exactly READY.' |
+  ACPX_AUTH_CHAT_GPT=1 LU_ACPX_TRANSPORT=shadow \
+  .venv/bin/python -m scripts.agent_runtime.acpx_pilot \
+  --target codex --cwd . --task-id pilot-6063 \
+  --correlation-id pilot-6063-codex-v1 \
+  --idempotency-key pilot-6063-codex-v1
+```
+
+For Grok, use the same command with `--target grok` and omit
+`ACPX_AUTH_CHAT_GPT=1`; the adapter selects the existing cached Grok login.
+
+This surface calls the native seat first and exactly one ACPX shadow second.
+The native outcome and exit disposition remain authoritative even when the
+shadow fails or disagrees. One global non-blocking lock admits at most one
+comparison; contention returns immediately with no queue. A previously
+executed idempotency-key digest suppresses both calls, and there are no
+automatic retries or sessions. Runner failover is disabled for both pilot
+calls, so the command cannot silently add a second native or shadow attempt.
+
+The local terminal result may show both responses for operator inspection.
+Persisted comparison evidence contains only target, outcome classes, parity,
+durations, token counts when exposed, and digests of correlation/idempotency
+values—never prompts, responses, raw identifiers, paths, sessions, commands,
+stderr, auth material, or tool data. The read-only Runtime dashboard aggregates
+that evidence; it cannot send or control ACPX traffic.
 
 #### Safety and budgets (adapter contract)
 

--- a/scripts/agent_runtime/acpx_pilot.py
+++ b/scripts/agent_runtime/acpx_pilot.py
@@ -1,0 +1,405 @@
+"""Bounded native-plus-ACPX shadow comparison pilot (#6063).
+
+The native Codex or Grok invocation is always authoritative. A single
+read-only, stateless ACPX shadow call runs after it under one global
+non-blocking lock. There is no queue, retry, session, dispatch, chat, review,
+or failover behavior on this surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ``runner.py`` retains historical sibling imports such as ``ai_llm``. Make
+# this module runnable both as ``scripts.agent_runtime.acpx_pilot`` and under
+# the legacy ``PYTHONPATH=scripts`` package flavor.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from scripts.guardrails.worktree_containment import classify_repo_path
+
+from .adapters.acpx import (
+    GROK_SHADOW_EFFORT,
+    GROK_SHADOW_MODEL,
+    TRANSPORT_ENV,
+    _require_local_metadata_field,
+)
+from .errors import AgentStalledError, AgentTimeoutError, RateLimitedError
+from .result import Result
+from .runner import _invoke_direct_only, _invoke_native_once
+from .usage import _usage_dir, write_record
+
+PILOT_AGENT = "acpx-shadow-pilot"
+PILOT_ENTRYPOINT = "acpx-pilot"
+PILOT_EVENT = "acpx_shadow_comparison"
+_PROMPT_MAX_CHARS = 100_000
+_KNOWN_OUTCOMES = frozenset({"ok", "error", "rate_limited", "timeout"})
+
+
+@dataclass(frozen=True)
+class _Target:
+    native_agent: str
+    shadow_agent: str
+    native_model: str | None
+    shadow_model: str | None
+    native_effort: str | None
+    shadow_effort: str | None
+
+
+_TARGETS = {
+    "codex": _Target(
+        native_agent="codex",
+        shadow_agent="acpx-codex-shadow",
+        native_model=None,
+        shadow_model=None,
+        native_effort=None,
+        shadow_effort=None,
+    ),
+    "grok": _Target(
+        native_agent="grok",
+        shadow_agent="acpx-grok-shadow",
+        native_model=GROK_SHADOW_MODEL,
+        shadow_model=None,
+        native_effort=GROK_SHADOW_EFFORT,
+        shadow_effort=GROK_SHADOW_EFFORT,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PilotResult:
+    """In-memory pilot result; responses are never persisted as evidence."""
+
+    target: str
+    executed: bool
+    duplicate_suppressed: bool
+    busy: bool
+    native_outcome: str | None
+    shadow_outcome: str | None
+    classification_parity: bool | None
+    native: Result | None
+    shadow: Result | None
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _outcome(result: Result | None, error: BaseException | None) -> str:
+    if isinstance(error, RateLimitedError):
+        return "rate_limited"
+    if isinstance(error, (AgentTimeoutError, AgentStalledError)):
+        return "timeout"
+    if error is not None or result is None:
+        return "error"
+    recorded = str(result.usage_record.get("outcome") or "")
+    if recorded in _KNOWN_OUTCOMES:
+        return recorded
+    return "ok" if result.ok else "error"
+
+
+def _tokens(result: Result | None) -> int | None:
+    if result is None:
+        return None
+    value = result.usage_record.get("tokens")
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _comparison_record(
+    *,
+    target: str,
+    idempotency_digest: str,
+    correlation_digest: str,
+    outcome: str,
+    executed: bool,
+    duplicate: bool,
+    busy: bool,
+    native_outcome: str | None = None,
+    shadow_outcome: str | None = None,
+    native: Result | None = None,
+    shadow: Result | None = None,
+) -> dict[str, Any]:
+    native_duration = round(native.duration_s, 3) if native is not None else None
+    shadow_duration = round(shadow.duration_s, 3) if shadow is not None else None
+    duration = sum(value for value in (native_duration, shadow_duration) if value is not None)
+    parity = (
+        native_outcome == shadow_outcome
+        if native_outcome is not None and shadow_outcome is not None
+        else None
+    )
+    return {
+        "ts": datetime.now(UTC).isoformat(),
+        "agent": PILOT_AGENT,
+        "entrypoint": PILOT_ENTRYPOINT,
+        "event": PILOT_EVENT,
+        "model": "native-plus-shadow",
+        "mode": "read-only",
+        "outcome": outcome,
+        "target": target,
+        "executed": executed,
+        "duplicate": duplicate,
+        "busy": busy,
+        "native_outcome": native_outcome,
+        "shadow_outcome": shadow_outcome,
+        "classification_parity": parity,
+        "duration_s": round(duration, 3),
+        "native_duration_s": native_duration,
+        "shadow_duration_s": shadow_duration,
+        "native_tokens": _tokens(native),
+        "shadow_tokens": _tokens(shadow),
+        "correlation_digest": correlation_digest,
+        "idempotency_digest": idempotency_digest,
+    }
+
+
+def _has_executed_digest(evidence_dir: Path, digest: str) -> bool:
+    for path in evidence_dir.glob(f"usage_{PILOT_AGENT}-{PILOT_ENTRYPOINT}_*.jsonl"):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for raw in lines:
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if (
+                isinstance(record, dict)
+                and record.get("event") == PILOT_EVENT
+                and record.get("idempotency_digest") == digest
+                and record.get("executed") is True
+            ):
+                return True
+    return False
+
+
+@contextmanager
+def _pilot_lock(path: Path) -> Iterator[bool]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "a+", encoding="utf-8")  # noqa: SIM115
+    acquired = False
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+        except BlockingIOError:
+            pass
+        yield acquired
+    finally:
+        if acquired:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def _invoke_captured(
+    call: Callable[..., Result],
+    agent_name: str,
+    prompt: str,
+    **kwargs: Any,
+) -> tuple[Result | None, BaseException | None]:
+    try:
+        return call(agent_name, prompt, **kwargs), None
+    except Exception as exc:
+        return None, exc
+
+
+def run_pilot(
+    *,
+    target: str,
+    prompt: str,
+    cwd: Path,
+    task_id: str,
+    correlation_id: str,
+    idempotency_key: str,
+    hard_timeout: int = 300,
+    evidence_dir: Path | None = None,
+    lock_path: Path | None = None,
+    native_call: Callable[..., Result] = _invoke_native_once,
+    shadow_call: Callable[..., Result] = _invoke_direct_only,
+    record_sink: Callable[[dict[str, Any]], None] = write_record,
+) -> PilotResult:
+    """Run one authoritative native call followed by one observational shadow."""
+    if target not in _TARGETS:
+        raise ValueError(f"unsupported target {target!r}; choose from {sorted(_TARGETS)}")
+    if os.environ.get(TRANSPORT_ENV) != "shadow":
+        raise ValueError(f"{TRANSPORT_ENV}=shadow is required for the explicit comparison pilot")
+    if not prompt.strip():
+        raise ValueError("prompt must be non-empty")
+    if len(prompt) > _PROMPT_MAX_CHARS:
+        raise ValueError(f"prompt exceeds {_PROMPT_MAX_CHARS} characters")
+    if hard_timeout < 1:
+        raise ValueError("hard_timeout must be at least one second")
+
+    resolved_cwd = cwd.resolve()
+    path_class = classify_repo_path(resolved_cwd, cwd=resolved_cwd)
+    if path_class not in {"dispatch_worktree", "other_worktree"}:
+        raise ValueError(
+            "ACPX comparison cwd must be a registered or dispatch worktree; "
+            f"observed {path_class!r}"
+        )
+    validated_task = _require_local_metadata_field("task_id", task_id, adapter_label="AcpxPilot")
+    validated_correlation = _require_local_metadata_field(
+        "correlation_id", correlation_id, adapter_label="AcpxPilot"
+    )
+    validated_idempotency = _require_local_metadata_field(
+        "idempotency_key", idempotency_key, adapter_label="AcpxPilot"
+    )
+    idempotency_digest = _digest(validated_idempotency)
+    correlation_digest = _digest(validated_correlation)
+    evidence_root = evidence_dir or _usage_dir()
+    exclusive_path = lock_path or evidence_root.parent / "acpx_pilot" / "pilot.lock"
+
+    with _pilot_lock(exclusive_path) as acquired:
+        if not acquired:
+            record_sink(
+                _comparison_record(
+                    target=target,
+                    idempotency_digest=idempotency_digest,
+                    correlation_digest=correlation_digest,
+                    outcome="error",
+                    executed=False,
+                    duplicate=False,
+                    busy=True,
+                )
+            )
+            return PilotResult(target, False, False, True, None, None, None, None, None)
+
+        if _has_executed_digest(evidence_root, idempotency_digest):
+            record_sink(
+                _comparison_record(
+                    target=target,
+                    idempotency_digest=idempotency_digest,
+                    correlation_digest=correlation_digest,
+                    outcome="ok",
+                    executed=False,
+                    duplicate=True,
+                    busy=False,
+                )
+            )
+            return PilotResult(target, False, True, False, None, None, None, None, None)
+
+        spec = _TARGETS[target]
+        native, native_error = _invoke_captured(
+            native_call,
+            spec.native_agent,
+            prompt,
+            mode="read-only",
+            cwd=resolved_cwd,
+            model=spec.native_model,
+            task_id=validated_task,
+            session_id=None,
+            entrypoint="acpx-pilot-native",
+            hard_timeout=hard_timeout,
+            effort=spec.native_effort,
+        )
+        shadow, shadow_error = _invoke_captured(
+            shadow_call,
+            spec.shadow_agent,
+            prompt,
+            cwd=resolved_cwd,
+            model=spec.shadow_model,
+            task_id=validated_task,
+            tool_config={
+                "acpx_shadow": True,
+                "target_agent": target,
+                "correlation_id": validated_correlation,
+                "idempotency_key": validated_idempotency,
+            },
+            hard_timeout=hard_timeout,
+            effort=spec.shadow_effort,
+        )
+        native_outcome = _outcome(native, native_error)
+        shadow_outcome = _outcome(shadow, shadow_error)
+        parity = native_outcome == shadow_outcome
+        record_sink(
+            _comparison_record(
+                target=target,
+                idempotency_digest=idempotency_digest,
+                correlation_digest=correlation_digest,
+                outcome=native_outcome,
+                executed=True,
+                duplicate=False,
+                busy=False,
+                native_outcome=native_outcome,
+                shadow_outcome=shadow_outcome,
+                native=native,
+                shadow=shadow,
+            )
+        )
+        return PilotResult(
+            target,
+            True,
+            False,
+            False,
+            native_outcome,
+            shadow_outcome,
+            parity,
+            native,
+            shadow,
+        )
+
+
+def _read_prompt(path: str) -> str:
+    return sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+
+
+def _cli_payload(result: PilotResult) -> dict[str, Any]:
+    return {
+        "authority": "native",
+        "target": result.target,
+        "executed": result.executed,
+        "duplicate_suppressed": result.duplicate_suppressed,
+        "busy": result.busy,
+        "classification_parity": result.classification_parity,
+        "native": {
+            "outcome": result.native_outcome,
+            "response": result.native.response if result.native is not None else None,
+        },
+        "shadow": {
+            "outcome": result.shadow_outcome,
+            "response": result.shadow.response if result.shadow is not None else None,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, choices=sorted(_TARGETS))
+    parser.add_argument("--prompt-file", default="-", help="Prompt file, or - for stdin")
+    parser.add_argument("--cwd", required=True, type=Path)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--correlation-id", required=True)
+    parser.add_argument("--idempotency-key", required=True)
+    parser.add_argument("--hard-timeout", type=int, default=300)
+    args = parser.parse_args()
+    result = run_pilot(
+        target=args.target,
+        prompt=_read_prompt(args.prompt_file),
+        cwd=args.cwd,
+        task_id=args.task_id,
+        correlation_id=args.correlation_id,
+        idempotency_key=args.idempotency_key,
+        hard_timeout=args.hard_timeout,
+    )
+    print(json.dumps(_cli_payload(result), ensure_ascii=False))
+    if result.busy:
+        return 75
+    if result.duplicate_suppressed:
+        return 0
+    return 0 if result.native_outcome == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -110,9 +110,9 @@ _PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 # Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
 # Built-in acpx ``grok-build`` is intentionally unused: it expands to
 # ``grok agent stdio`` without a place for parent flags required by Grok
-# 0.2.114 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
+# 0.2.117 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
 # before ``stdio``).
-PINNED_GROK_VERSION = "0.2.114"
+PINNED_GROK_VERSION = "0.2.117"
 GROK_SHADOW_MODEL = "grok-4.5"
 GROK_SHADOW_EFFORT = "high"
 _GROK_PROFILE_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "profiles" / "acpx-grok-read-only.md"
@@ -373,7 +373,7 @@ _GROK_VERSION_RE = re.compile(r"\Agrok\s+(\d+\.\d+\.\d+)(?:\s|$)")
 def _probe_grok_version(binary: str) -> str:
     """Return exact semver from ``<binary> --version``, or "" on any failure.
 
-    Native Grok 0.2.114 prints ``grok 0.2.114 (<sha>) [stable]``. Wrong,
+    Native Grok 0.2.117 prints ``grok 0.2.117 (<sha>)``. Wrong,
     missing, or unparseable output fails closed before prompt.
     """
     try:
@@ -434,7 +434,7 @@ def _require_grok_profile() -> str:
 
 
 def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
-    """Shell-safe single ``--agent`` value with required Grok 0.2.114 argv order.
+    """Shell-safe single ``--agent`` value with required Grok 0.2.117 argv order.
 
     Exact token order (parent flags before ``stdio``)::
 

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -103,6 +103,12 @@ _PROVIDER_SECRET_ALLOWLIST = {
 }
 
 _PROVIDER_SAFE_NAME_ALLOWLIST = {
+    "acpx-codex-shadow": {
+        # Non-secret acpx@0.13.0 auth-method selector. The literal value "1"
+        # chooses the existing Codex ChatGPT login; no credential is carried
+        # in this variable.
+        "ACPX_AUTH_CHAT_GPT",
+    },
     "acpx-grok-shadow": {
         # acpx@0.13.0 treats this as a non-secret auth-method selector:
         # the literal value "1" chooses Grok's agent-managed cached_token
@@ -260,6 +266,8 @@ def build_agent_env(
         if _looks_sensitive_value(value):
             continue
         if _is_provider_safe_name(name, provider):
+            if name.upper().startswith("ACPX_AUTH_") and value != "1":
+                continue
             env[name] = value
             continue
         if _looks_sensitive_name(name):

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -34,6 +34,7 @@ class AgentEntry(TypedDict):
     capabilities: frozenset[str]
     cli_available: bool
     bridge_spawnable: NotRequired[bool]
+    direct_only: NotRequired[bool]
     resume_policy: str  # "bridge_only" | "never"
 
 
@@ -275,9 +276,8 @@ AGENTS: dict[str, AgentEntry] = {
     "acpx-codex-shadow": {
         # Experimental read-only shadow transport (#6027). Direct-only: never
         # returned by ``available_agents()`` (cli_available False), never a
-        # dispatch/routing/review/failover candidate. Callers must import
-        # ``AcpxAdapter`` directly and pass ``tool_config={"acpx_shadow": True}``
-        # with ``LU_ACPX_TRANSPORT=shadow`` set — see adapters/acpx.py.
+        # dispatch/routing/review/failover candidate. The bounded pilot is the
+        # sole public runner surface permitted to invoke this marked seat.
         "adapter": "scripts.agent_runtime.adapters.acpx:AcpxAdapter",
         # ACPX resolves its own agent default when no --model is supplied;
         # this direct-only seat must not advertise an invented catalog model.
@@ -285,15 +285,15 @@ AGENTS: dict[str, AgentEntry] = {
         "cost_tier": "unknown",
         "capabilities": frozenset(),
         "cli_available": False,
+        "direct_only": True,
         "resume_policy": "never",
     },
     "acpx-grok-shadow": {
         # Second experimental read-only shadow transport (#6043). Direct-only:
         # never returned by ``available_agents()`` (cli_available False), never
-        # a dispatch/routing/review/failover candidate. Callers must import
-        # ``AcpxGrokShadowAdapter`` directly and pass
-        # ``tool_config={"acpx_shadow": True, "target_agent": "grok"}`` with
-        # ``LU_ACPX_TRANSPORT=shadow`` set — see adapters/acpx.py. Fixed
+        # a dispatch/routing/review/failover candidate. The bounded pilot is
+        # the sole public runner surface permitted to invoke this marked seat.
+        # Fixed
         # effective model/effort live inside the custom --agent command; do
         # not advertise a catalog model here. Not a new coordination plane —
         # native Grok remains authoritative.
@@ -302,6 +302,7 @@ AGENTS: dict[str, AgentEntry] = {
         "cost_tier": "unknown",
         "capabilities": frozenset(),
         "cli_available": False,
+        "direct_only": True,
         "resume_policy": "never",
     },
     "agy": {

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -2326,7 +2326,11 @@ def _invoke_impl(
     """
     # ---------- 1. Resolve adapter ----------
     _validate_agent_name(agent_name)
-    adapter = _load_adapter(agent_name, allow_direct_only=allow_direct_only)
+    adapter = (
+        _load_adapter(agent_name, allow_direct_only=True)
+        if allow_direct_only
+        else _load_adapter(agent_name)
+    )
 
     # ---------- 2. Validate mode ----------
     if mode not in adapter.supported_modes:

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -106,6 +106,9 @@ _MCP_TOOL_EVENT_RE = re.compile(
 )
 _MCP_TRANSPORT_FAILURE_RE = re.compile(r"ERROR\s+rmcp::transport::worker:")
 _MCP_FAILURE_URL_RE = re.compile(r"url \((?P<url>https?://[^)\s]+)\)")
+_PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
+    {"acpx-pilot-native", "acpx-pilot-shadow"}
+)
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
@@ -682,10 +685,13 @@ def _build_usage_record(
     """Assemble the usage record dict per design doc § 4.5 schema."""
     # Ensure unbounded strings are capped so the JSON stays under POSIX PIPE_BUF (4KB)
     # to maintain atomic append guarantees in usage.py.
-    safe_cwd = str(cwd)[-250:] if cwd else ""
-    safe_task_id = task_id[:100] if task_id else None
-    safe_provider_session_id = session_id[:100] if session_id else None
-    telemetry_source = os.environ.get("LU_TELEMETRY_SOURCE")
+    privacy_limited = entrypoint in _PRIVACY_LIMITED_USAGE_ENTRYPOINTS
+    safe_cwd = None if privacy_limited else (str(cwd)[-250:] if cwd else "")
+    safe_task_id = None if privacy_limited else (task_id[:100] if task_id else None)
+    safe_provider_session_id = (
+        None if privacy_limited else (session_id[:100] if session_id else None)
+    )
+    telemetry_source = None if privacy_limited else os.environ.get("LU_TELEMETRY_SOURCE")
 
     record = {
         "ts": datetime.now(UTC).isoformat(),
@@ -695,12 +701,12 @@ def _build_usage_record(
         "cwd": safe_cwd,
         "model": model,
         "mode": mode,
-        "run_id": current_run_id()[:100],
-        "session_id": current_session_id()[:100],
+        "run_id": None if privacy_limited else current_run_id()[:100],
+        "session_id": None if privacy_limited else current_session_id()[:100],
         "provider_session_id": safe_provider_session_id,
-        "level": os.environ.get("LU_TELEMETRY_LEVEL"),
-        "slug": os.environ.get("LU_TELEMETRY_SLUG"),
-        "track": os.environ.get("LU_TELEMETRY_TRACK"),
+        "level": None if privacy_limited else os.environ.get("LU_TELEMETRY_LEVEL"),
+        "slug": None if privacy_limited else os.environ.get("LU_TELEMETRY_SLUG"),
+        "track": None if privacy_limited else os.environ.get("LU_TELEMETRY_TRACK"),
         "source": telemetry_source[:100] if telemetry_source else None,
         "duration_s": round(duration_s, 2),
         "input_chars": input_chars,
@@ -709,7 +715,11 @@ def _build_usage_record(
         "outcome": outcome,
         "rate_limited": rate_limited,
         "stalled": stalled,
-        "stderr_excerpt": (stderr_excerpt or "")[:500] if stderr_excerpt else None,
+        "stderr_excerpt": (
+            None
+            if privacy_limited
+            else ((stderr_excerpt or "")[:500] if stderr_excerpt else None)
+        ),
         "tokens": tokens,
     }
     safe_substitution = _safe_substitution_record(substitution)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -548,7 +548,7 @@ def _is_temp_file(path: Path) -> bool:
         return False
 
 
-def _load_adapter(name: str) -> AgentAdapter:
+def _load_adapter(name: str, *, allow_direct_only: bool = False) -> AgentAdapter:
     """Import the adapter class for ``name`` and cache the instance.
 
     Raises:
@@ -556,9 +556,6 @@ def _load_adapter(name: str) -> AgentAdapter:
             entry has ``cli_available: False``, or the adapter module
             cannot be imported.
     """
-    if name in _ADAPTER_CACHE:
-        return _ADAPTER_CACHE[name]
-
     try:
         entry = get_agent_entry(name)
     except KeyError:
@@ -566,13 +563,19 @@ def _load_adapter(name: str) -> AgentAdapter:
             f"Agent {name!r} is not in the registry. Available: {sorted(AGENTS.keys())}"
         ) from None
 
-    if not entry["cli_available"]:
+    direct_only_allowed = allow_direct_only and entry.get("direct_only") is True
+    if not entry["cli_available"] and not direct_only_allowed:
         raise AgentUnavailableError(
             f"Agent {name!r} is registered but not available "
-            f"(cli_available=False). This usually means its CLI does not "
-            f"exist yet (e.g., grok). Implement adapters/{name}.py and "
-            f"flip the registry flag to enable it."
+            f"(cli_available=False). Direct-only seats require their dedicated "
+            f"bounded invocation surface and never participate in normal "
+            f"routing, dispatch, review, or failover."
         )
+
+    # Permission is checked before cache access. A prior direct-only load must
+    # never make the same adapter reachable through normal ``invoke()``.
+    if name in _ADAPTER_CACHE:
+        return _ADAPTER_CACHE[name]
 
     dotted_path = entry["adapter"]
     if ":" not in dotted_path:
@@ -2248,6 +2251,8 @@ def _invoke_impl(
     initial_response_timeout: int | None = None,
     event_sink: Callable[..., None] | None = None,
     effort: str | None = None,
+    allow_direct_only: bool = False,
+    allow_runner_failover: bool = True,
 ) -> Result:
     """Runner implementation after any parent-owned isolation preparation.
 
@@ -2311,7 +2316,7 @@ def _invoke_impl(
     """
     # ---------- 1. Resolve adapter ----------
     _validate_agent_name(agent_name)
-    adapter = _load_adapter(agent_name)
+    adapter = _load_adapter(agent_name, allow_direct_only=allow_direct_only)
 
     # ---------- 2. Validate mode ----------
     if mode not in adapter.supported_modes:
@@ -2340,10 +2345,15 @@ def _invoke_impl(
 
     # ---------- 5. Pre-call rate-limit check ----------
     effective_model = model or adapter.default_model
-    failover_chain = load_failover_chain(
-        agent_name,
-        effective_model=effective_model,
+    failover_chain = (
+        load_failover_chain(agent_name, effective_model=effective_model)
+        if allow_runner_failover
+        else None
     )
+    if allow_direct_only and failover_chain is not None:
+        raise AgentUnavailableError(
+            f"Direct-only agent {agent_name!r} may not use runner failover"
+        )
     if failover_chain is not None:
         return _invoke_with_runner_failover(
             agent_name=agent_name,
@@ -2401,11 +2411,16 @@ def _invoke_impl(
         )
 
     # ---------- 6. Build invocation plan ----------
+    # Direct-only transports may use an adapter-owned model default that is
+    # intentionally a telemetry label rather than an argv override. Preserve
+    # a caller's explicit ``None`` for those adapters while retaining the
+    # effective label for headroom and usage records.
+    plan_model = model if allow_direct_only else effective_model
     plan = adapter.build_invocation(
         prompt=prompt,
         mode=mode,
         cwd=effective_cwd,
-        model=effective_model,
+        model=plan_model,
         task_id=task_id,
         session_id=session_id,
         tool_config=tool_config,
@@ -2589,3 +2604,82 @@ def invoke(
     finally:
         if launch is not None:
             launch.cleanup()
+
+
+def _invoke_direct_only(
+    agent_name: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    model: str | None = None,
+    task_id: str,
+    tool_config: dict,
+    hard_timeout: int = 300,
+    effort: str | None = None,
+) -> Result:
+    """Invoke one explicitly marked direct-only, read-only shadow seat.
+
+    This surface is deliberately narrower than :func:`invoke`: it cannot
+    resume a session, select a write-capable mode, enter normal
+    routing/failover/catalog selection, or choose its own entrypoint. The
+    bounded ACPX comparison pilot is the only supported caller.
+    """
+    try:
+        entry = get_agent_entry(agent_name)
+    except KeyError:
+        raise AgentUnavailableError(f"Agent {agent_name!r} is not in the registry") from None
+    if entry.get("direct_only") is not True or entry["cli_available"]:
+        raise AgentUnavailableError(
+            f"Agent {agent_name!r} is not an unavailable direct-only seat"
+        )
+    return _invoke_impl(
+        agent_name,
+        prompt,
+        mode="read-only",
+        cwd=cwd,
+        model=model,
+        task_id=task_id,
+        session_id=None,
+        tool_config=tool_config,
+        entrypoint="acpx-pilot-shadow",
+        hard_timeout=hard_timeout,
+        effort=effort,
+        allow_direct_only=True,
+        allow_runner_failover=False,
+    )
+
+
+def _invoke_native_once(
+    agent_name: str,
+    prompt: str,
+    *,
+    mode: str = "read-only",
+    cwd: Path,
+    model: str | None = None,
+    task_id: str,
+    session_id: str | None = None,
+    entrypoint: str = "acpx-pilot-native",
+    hard_timeout: int = 300,
+    effort: str | None = None,
+) -> Result:
+    """Invoke one native ACPX-pilot authority call without runner failover."""
+    if agent_name not in {"codex", "grok"}:
+        raise AgentUnavailableError(
+            f"Agent {agent_name!r} is not a supported ACPX pilot native seat"
+        )
+    if mode != "read-only" or session_id is not None or entrypoint != "acpx-pilot-native":
+        raise ValueError("ACPX pilot native invocation contract was altered")
+    return _invoke_impl(
+        agent_name,
+        prompt,
+        mode=mode,
+        cwd=cwd,
+        model=model,
+        task_id=task_id,
+        session_id=None,
+        tool_config=None,
+        entrypoint=entrypoint,
+        hard_timeout=hard_timeout,
+        effort=effort,
+        allow_runner_failover=False,
+    )

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -568,11 +568,21 @@ def _load_adapter(name: str, *, allow_direct_only: bool = False) -> AgentAdapter
 
     direct_only_allowed = allow_direct_only and entry.get("direct_only") is True
     if not entry["cli_available"] and not direct_only_allowed:
+        if entry.get("direct_only") is True:
+            detail = (
+                "Direct-only seats require their dedicated bounded invocation "
+                "surface and never participate in normal routing, dispatch, "
+                "review, or failover."
+            )
+        else:
+            detail = (
+                "This seat has no enabled runtime CLI/adapter. Enable its "
+                "intended adapter or launcher and flip the registry flag only "
+                "when the seat is operational."
+            )
         raise AgentUnavailableError(
             f"Agent {name!r} is registered but not available "
-            f"(cli_available=False). Direct-only seats require their dedicated "
-            f"bounded invocation surface and never participate in normal "
-            f"routing, dispatch, review, or failover."
+            f"(cli_available=False). {detail}"
         )
 
     # Permission is checked before cache access. A prior direct-only load must

--- a/scripts/agent_runtime/usage.py
+++ b/scripts/agent_runtime/usage.py
@@ -44,6 +44,11 @@ from typing import Any
 
 from secret_redactor import redact_text, redact_value
 
+try:
+    from scripts.common.repo_root import main_checkout_root
+except ImportError:  # pragma: no cover - package import path
+    from common.repo_root import main_checkout_root
+
 # Rate-limit window in seconds. History:
 #   2026-04-09: 5 hours (way too long; one false 429 nuked 5 hours of build)
 #   2026-04-10: 15 minutes (still blocked actively-responding Gemini for
@@ -89,8 +94,11 @@ _RATE_LIMIT_CACHE: dict[tuple[str, str], float] = {}
 
 def _usage_dir() -> Path:
     """Return the batch_state/api_usage/ directory, creating it if missing."""
-    # Resolve relative to repo root so this works from any cwd.
-    repo_root = Path(__file__).resolve().parents[2]
+    # All linked worktrees share the primary checkout's runtime-state plane so
+    # the Monitor API sees one fleet-wide usage stream and cross-process pilot
+    # locks/idempotency checks cannot split by worktree (#5171, #6063).
+    source_repo_root = Path(__file__).resolve().parents[2]
+    repo_root = main_checkout_root(source_repo_root)
     path = repo_root / "batch_state" / "api_usage"
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -135,6 +135,31 @@ def _update_outcome_bucket(bucket: dict[str, Any], record: dict[str, Any]) -> No
         bucket["total_duration_s"] = round(bucket["total_duration_s"] + float(duration), 3)
 
 
+def _new_comparison_side() -> dict[str, Any]:
+    side = {key: 0 for key in _KNOWN_OUTCOMES}
+    side.update({"total": 0, "total_duration_s": 0.0, "tokens_observed": 0, "total_tokens": 0})
+    return side
+
+
+def _update_comparison_side(
+    side: dict[str, Any],
+    record: dict[str, Any],
+    *,
+    prefix: str,
+) -> None:
+    outcome = str(record.get(f"{prefix}_outcome") or "")
+    side["total"] += 1
+    if outcome in _KNOWN_OUTCOMES:
+        side[outcome] += 1
+    duration = record.get(f"{prefix}_duration_s")
+    if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+        side["total_duration_s"] = round(side["total_duration_s"] + float(duration), 3)
+    tokens = record.get(f"{prefix}_tokens")
+    if isinstance(tokens, int) and not isinstance(tokens, bool) and tokens >= 0:
+        side["tokens_observed"] += 1
+        side["total_tokens"] += tokens
+
+
 def list_runtime_agents() -> list[dict[str, Any]]:
     agents: list[dict[str, Any]] = []
     for path in sorted(ADAPTERS_DIR.glob("*.py")):
@@ -236,11 +261,38 @@ def acpx_shadow_overview(*, days: int = 7) -> dict[str, Any]:
         str(seat["name"]): _new_outcome_bucket()
         for seat in seat_specs
     }
+    comparison = {
+        "attempts": 0,
+        "comparisons": 0,
+        "classification_parity": 0,
+        "classification_mismatch": 0,
+        "duplicates_suppressed": 0,
+        "busy_refusals": 0,
+        "native": _new_comparison_side(),
+        "shadow": _new_comparison_side(),
+    }
     records = _iter_usage_records(_usage_files(days=window_days))
     for record in records:
         record_agent = str(record.get("agent") or "")
         if record_agent in evidence_by_seat:
             _update_outcome_bucket(evidence_by_seat[record_agent], record)
+        if (
+            record_agent == "acpx-shadow-pilot"
+            and record.get("event") == "acpx_shadow_comparison"
+        ):
+            comparison["attempts"] += 1
+            if record.get("duplicate") is True:
+                comparison["duplicates_suppressed"] += 1
+            if record.get("busy") is True:
+                comparison["busy_refusals"] += 1
+            if record.get("executed") is True:
+                comparison["comparisons"] += 1
+                if record.get("classification_parity") is True:
+                    comparison["classification_parity"] += 1
+                elif record.get("classification_parity") is False:
+                    comparison["classification_mismatch"] += 1
+                _update_comparison_side(comparison["native"], record, prefix="native")
+                _update_comparison_side(comparison["shadow"], record, prefix="shadow")
 
     seats: list[dict[str, Any]] = []
     for seat in seat_specs:
@@ -271,9 +323,15 @@ def acpx_shadow_overview(*, days: int = 7) -> dict[str, Any]:
             "grok_cli": PINNED_GROK_VERSION,
             "validation": "before_spawn",
         },
+        "comparison_evidence": {
+            "window_days": window_days,
+            "state": "observed" if comparison["attempts"] else "no_evidence",
+            **comparison,
+        },
         "seats": seats,
         "safety": {
             "max_in_flight": 1,
+            "explicit_pilot_only": True,
             "backlog": False,
             "retries": False,
             "sessions": False,

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -905,7 +905,7 @@ def test_parse_response_nonzero_exit_with_end_turn_still_fails():
 # ---------------------------------------------------------------------------
 
 
-def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.114") -> Path:
+def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.117") -> Path:
     """Point the Grok seat at a fake absolute grok binary + version probe."""
     grok = tmp_path / "fake-grok-bin"
     grok.write_text("#!/bin/sh\necho stub-grok\n", encoding="utf-8")
@@ -1168,7 +1168,7 @@ def test_grok_build_invocation_accepts_none_or_fixed_model_and_effort(tmp_path, 
         assert plan.metadata["model"] == "grok-4.5"
         assert plan.metadata["effort"] == "high"
         assert plan.metadata["target_agent"] == "grok"
-        assert plan.metadata["grok_pinned_version"] == "0.2.114"
+        assert plan.metadata["grok_pinned_version"] == "0.2.117"
         assert plan.metadata["acpx_pinned_version"] == "0.13.0"
 
 
@@ -1359,10 +1359,10 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
     monkeypatch.setattr(
         acpx_module.subprocess,
         "run",
-        lambda *_a, **_k: _Proc("grok 0.2.114 (0c785038798) [stable]\n"),
+        lambda *_a, **_k: _Proc("grok 0.2.117 (f1c06093089f)\n"),
     )
     acpx_module._probe_grok_version.cache_clear()
-    assert acpx_module._probe_grok_version(str(binary)) == "0.2.114"
+    assert acpx_module._probe_grok_version(str(binary)) == "0.2.117"
 
     monkeypatch.setattr(
         acpx_module.subprocess,
@@ -1376,7 +1376,7 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         acpx_module.subprocess,
         "run",
         lambda *_a, **_k: _Proc(
-            "wrapper 9.9.9; grok 0.2.114 (0c785038798) [stable]\n"
+            "wrapper 9.9.9; grok 0.2.117 (f1c06093089f)\n"
         ),
     )
     acpx_module._probe_grok_version.cache_clear()
@@ -1386,7 +1386,7 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         acpx_module.subprocess,
         "run",
         lambda *_a, **_k: _Proc(
-            "grok 0.2.114 (0c785038798) [stable]\n",
+            "grok 0.2.117 (f1c06093089f)\n",
             "fatal: startup failed\n",
             returncode=1,
         ),

--- a/tests/agent_runtime/test_acpx_pilot.py
+++ b/tests/agent_runtime/test_acpx_pilot.py
@@ -59,6 +59,11 @@ def _run(
     records: list[dict[str, Any]] | None = None,
 ) -> PilotResult:
     monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    monkeypatch.setattr(
+        acpx_pilot,
+        "classify_repo_path",
+        lambda *_args, **_kwargs: "dispatch_worktree",
+    )
     evidence = tmp_path / "evidence"
     captured = records if records is not None else []
     return run_pilot(
@@ -163,6 +168,11 @@ def test_duplicate_idempotency_key_suppresses_both_model_calls(tmp_path, monkeyp
 
 def test_busy_lock_refuses_without_queueing_or_model_calls(tmp_path, monkeypatch):
     monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    monkeypatch.setattr(
+        acpx_pilot,
+        "classify_repo_path",
+        lambda *_args, **_kwargs: "dispatch_worktree",
+    )
     lock_path = tmp_path / "pilot.lock"
     lock_path.touch()
     handle = open(lock_path, "a+", encoding="utf-8")  # noqa: SIM115
@@ -199,7 +209,11 @@ def test_busy_lock_refuses_without_queueing_or_model_calls(tmp_path, monkeypatch
 
 def test_pilot_refuses_primary_checkout_before_any_model_call(tmp_path, monkeypatch):
     monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
-    primary = Path.cwd().parents[3]
+    monkeypatch.setattr(
+        acpx_pilot,
+        "classify_repo_path",
+        lambda *_args, **_kwargs: "primary_checkout",
+    )
     called = False
 
     def call(*_args, **_kwargs):
@@ -211,7 +225,7 @@ def test_pilot_refuses_primary_checkout_before_any_model_call(tmp_path, monkeypa
         run_pilot(
             target="codex",
             prompt="Return READY",
-            cwd=primary,
+            cwd=tmp_path,
             task_id="task-6063",
             correlation_id="corr-3",
             idempotency_key="idem-3",

--- a/tests/agent_runtime/test_acpx_pilot.py
+++ b/tests/agent_runtime/test_acpx_pilot.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import fcntl
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.agent_runtime import acpx_pilot
+from scripts.agent_runtime.errors import AgentUnavailableError
+from scripts.agent_runtime.result import Result
+
+PILOT_ENTRYPOINT = acpx_pilot.PILOT_ENTRYPOINT
+PilotResult = acpx_pilot.PilotResult
+run_pilot = acpx_pilot.run_pilot
+runner = importlib.import_module("scripts.agent_runtime.runner")
+
+
+def _result(agent: str, *, ok: bool = True, response: str = "READY", tokens: int = 7) -> Result:
+    outcome = "ok" if ok else "error"
+    return Result(
+        ok=ok,
+        agent=agent,
+        model="test-model",
+        mode="read-only",
+        response=response,
+        stderr_excerpt=None,
+        duration_s=1.25,
+        session_id=None,
+        rate_limited=False,
+        stalled=False,
+        returncode=0 if ok else 1,
+        usage_record={"outcome": outcome, "tokens": tokens},
+    )
+
+
+def _recording_sink(evidence_dir: Path, records: list[dict[str, Any]]):
+    path = evidence_dir / f"usage_acpx-shadow-pilot-{PILOT_ENTRYPOINT}_2026-07-31.jsonl"
+
+    def sink(record: dict[str, Any]) -> None:
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        records.append(record)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record) + "\n")
+
+    return sink
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    native_call,
+    shadow_call,
+    key: str = "idem-1",
+    records: list[dict[str, Any]] | None = None,
+) -> PilotResult:
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    evidence = tmp_path / "evidence"
+    captured = records if records is not None else []
+    return run_pilot(
+        target="codex",
+        prompt="Return READY",
+        cwd=Path.cwd(),
+        task_id="task-6063",
+        correlation_id="corr-secret",
+        idempotency_key=key,
+        evidence_dir=evidence,
+        lock_path=tmp_path / "pilot.lock",
+        native_call=native_call,
+        shadow_call=shadow_call,
+        record_sink=_recording_sink(evidence, captured),
+    )
+
+
+def test_pilot_runs_native_then_one_shadow_and_persists_sanitized_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    order: list[str] = []
+    calls: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
+
+    def native(agent, prompt, **kwargs):
+        order.append("native")
+        calls.append({"agent": agent, "prompt": prompt, **kwargs})
+        return _result(agent, response="native-private")
+
+    def shadow(agent, prompt, **kwargs):
+        order.append("shadow")
+        calls.append({"agent": agent, "prompt": prompt, **kwargs})
+        return _result(agent, response="shadow-private", tokens=9)
+
+    result = _run(
+        tmp_path,
+        monkeypatch,
+        native_call=native,
+        shadow_call=shadow,
+        records=records,
+    )
+
+    assert order == ["native", "shadow"]
+    assert result.native_outcome == "ok"
+    assert result.shadow_outcome == "ok"
+    assert result.classification_parity is True
+    assert calls[0]["agent"] == "codex"
+    assert calls[0]["entrypoint"] == "acpx-pilot-native"
+    assert calls[1]["agent"] == "acpx-codex-shadow"
+    assert calls[1]["tool_config"] == {
+        "acpx_shadow": True,
+        "target_agent": "codex",
+        "correlation_id": "corr-secret",
+        "idempotency_key": "idem-1",
+    }
+
+    evidence = records[-1]
+    assert evidence["executed"] is True
+    assert evidence["classification_parity"] is True
+    assert evidence["native_tokens"] == 7
+    assert evidence["shadow_tokens"] == 9
+    serialized = json.dumps(evidence)
+    for private in ("Return READY", "native-private", "shadow-private", "corr-secret", "idem-1"):
+        assert private not in serialized
+
+
+def test_shadow_failure_never_overrides_successful_native_result(tmp_path, monkeypatch):
+    def shadow(*_args, **_kwargs):
+        raise RuntimeError("shadow failed")
+
+    result = _run(
+        tmp_path,
+        monkeypatch,
+        native_call=lambda agent, *_args, **_kwargs: _result(agent, response="authority"),
+        shadow_call=shadow,
+    )
+
+    assert result.native is not None
+    assert result.native.response == "authority"
+    assert result.native_outcome == "ok"
+    assert result.shadow is None
+    assert result.shadow_outcome == "error"
+    assert result.classification_parity is False
+
+
+def test_duplicate_idempotency_key_suppresses_both_model_calls(tmp_path, monkeypatch):
+    calls = {"count": 0}
+
+    def call(agent, *_args, **_kwargs):
+        calls["count"] += 1
+        return _result(agent)
+
+    first = _run(tmp_path, monkeypatch, native_call=call, shadow_call=call)
+    second = _run(tmp_path, monkeypatch, native_call=call, shadow_call=call)
+
+    assert first.executed is True
+    assert second.executed is False
+    assert second.duplicate_suppressed is True
+    assert calls["count"] == 2
+
+
+def test_busy_lock_refuses_without_queueing_or_model_calls(tmp_path, monkeypatch):
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    lock_path = tmp_path / "pilot.lock"
+    lock_path.touch()
+    handle = open(lock_path, "a+", encoding="utf-8")  # noqa: SIM115
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    called = False
+
+    def call(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("must not invoke")
+
+    try:
+        result = run_pilot(
+            target="codex",
+            prompt="Return READY",
+            cwd=Path.cwd(),
+            task_id="task-6063",
+            correlation_id="corr-2",
+            idempotency_key="idem-2",
+            evidence_dir=tmp_path / "evidence",
+            lock_path=lock_path,
+            native_call=call,
+            shadow_call=call,
+            record_sink=lambda _record: None,
+        )
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+    assert result.busy is True
+    assert result.executed is False
+    assert called is False
+
+
+def test_pilot_refuses_primary_checkout_before_any_model_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    primary = Path.cwd().parents[3]
+    called = False
+
+    def call(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("must not invoke")
+
+    with pytest.raises(ValueError, match="worktree"):
+        run_pilot(
+            target="codex",
+            prompt="Return READY",
+            cwd=primary,
+            task_id="task-6063",
+            correlation_id="corr-3",
+            idempotency_key="idem-3",
+            evidence_dir=tmp_path,
+            native_call=call,
+            shadow_call=call,
+        )
+    assert called is False
+
+
+def test_normal_loader_still_refuses_cached_direct_only_adapter():
+    runner._ADAPTER_CACHE.pop("acpx-codex-shadow", None)
+    try:
+        adapter = runner._load_adapter("acpx-codex-shadow", allow_direct_only=True)
+        assert adapter.name == "acpx-codex-shadow"
+        with pytest.raises(AgentUnavailableError, match="Direct-only"):
+            runner._load_adapter("acpx-codex-shadow")
+    finally:
+        runner._ADAPTER_CACHE.pop("acpx-codex-shadow", None)
+
+
+def test_direct_only_surface_rejects_normal_available_agent():
+    with pytest.raises(AgentUnavailableError, match="not an unavailable direct-only seat"):
+        runner._invoke_direct_only(
+            "codex",
+            "prompt",
+            cwd=Path.cwd(),
+            task_id="task-6063",
+            tool_config={},
+        )
+
+
+def test_direct_only_surface_preserves_omitted_model_and_fixed_entrypoint(monkeypatch):
+    captured: dict[str, Any] = {}
+    sentinel = _result("acpx-codex-shadow")
+
+    def fake_invoke_impl(*args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(runner, "_invoke_impl", fake_invoke_impl)
+
+    result = runner._invoke_direct_only(
+        "acpx-codex-shadow",
+        "prompt",
+        cwd=Path.cwd(),
+        model=None,
+        task_id="task-6063",
+        tool_config={"acpx_shadow": True},
+    )
+
+    assert result is sentinel
+    assert captured["model"] is None
+    assert captured["mode"] == "read-only"
+    assert captured["session_id"] is None
+    assert captured["entrypoint"] == "acpx-pilot-shadow"
+    assert captured["allow_direct_only"] is True
+    assert captured["allow_runner_failover"] is False
+
+
+def test_native_once_surface_disables_runner_failover(monkeypatch):
+    captured: dict[str, Any] = {}
+    sentinel = _result("codex")
+
+    def fake_invoke_impl(*args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(runner, "_invoke_impl", fake_invoke_impl)
+
+    result = runner._invoke_native_once(
+        "codex",
+        "prompt",
+        cwd=Path.cwd(),
+        task_id="task-6063",
+    )
+
+    assert result is sentinel
+    assert captured["entrypoint"] == "acpx-pilot-native"
+    assert captured["allow_runner_failover"] is False
+
+
+def test_cli_exit_disposition_follows_native_not_failed_shadow(monkeypatch, capsys):
+    authoritative = _result("codex", response="authority")
+    result = PilotResult(
+        target="codex",
+        executed=True,
+        duplicate_suppressed=False,
+        busy=False,
+        native_outcome="ok",
+        shadow_outcome="error",
+        classification_parity=False,
+        native=authoritative,
+        shadow=None,
+    )
+    monkeypatch.setattr(acpx_pilot, "run_pilot", lambda **_kwargs: result)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "acpx_pilot.py",
+            "--target",
+            "codex",
+            "--cwd",
+            ".",
+            "--task-id",
+            "task-6063",
+            "--correlation-id",
+            "corr-4",
+            "--idempotency-key",
+            "idem-4",
+        ],
+    )
+    monkeypatch.setattr(acpx_pilot, "_read_prompt", lambda _path: "prompt")
+
+    assert acpx_pilot.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["authority"] == "native"
+    assert payload["native"]["response"] == "authority"
+    assert payload["shadow"]["outcome"] == "error"

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -125,6 +125,18 @@ def _install_fake_runtime(
     )
 
     adapter = _FailoverTestAdapter()
+    monkeypatch.setitem(
+        runner_mod.AGENTS,
+        "failover-test",
+        {
+            "adapter": "tests.fake:FailoverTestAdapter",
+            "default_model": "primary-model",
+            "cost_tier": "test",
+            "capabilities": frozenset(),
+            "cli_available": True,
+            "resume_policy": "never",
+        },
+    )
     runner_mod._ADAPTER_CACHE["failover-test"] = adapter
 
     records: list[dict[str, Any]] = []

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -211,6 +211,15 @@ def test_acpx_codex_shadow_entry_is_direct_only():
     assert "acpx-codex-shadow" not in available_agents()
 
 
+def test_unavailable_non_direct_seat_has_accurate_loader_guidance():
+    with pytest.raises(AgentUnavailableError) as exc_info:
+        _load_adapter("qwen")
+
+    message = str(exc_info.value)
+    assert "no enabled runtime CLI/adapter" in message
+    assert "Direct-only" not in message
+
+
 @pytest.mark.parametrize("entrypoint", ["acpx-pilot-native", "acpx-pilot-shadow"])
 def test_acpx_pilot_usage_records_strip_sensitive_context(
     entrypoint,

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -116,6 +116,7 @@ from agent_runtime.errors import (
 )
 from agent_runtime.registry import AGENTS, available_agents, get_agent_entry
 from agent_runtime.runner import (
+    _build_usage_record,
     _enforce_resume_policy,
     _ensure_write_cwd_isolated,
     _is_temp_file,
@@ -208,6 +209,55 @@ def test_acpx_codex_shadow_entry_is_direct_only():
     assert entry["resume_policy"] == "never"
     assert entry["capabilities"] == frozenset()
     assert "acpx-codex-shadow" not in available_agents()
+
+
+@pytest.mark.parametrize("entrypoint", ["acpx-pilot-native", "acpx-pilot-shadow"])
+def test_acpx_pilot_usage_records_strip_sensitive_context(
+    entrypoint,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LU_TELEMETRY_LEVEL", "secret-level")
+    monkeypatch.setenv("LU_TELEMETRY_SLUG", "secret-slug")
+    monkeypatch.setenv("LU_TELEMETRY_TRACK", "secret-track")
+    monkeypatch.setenv("LU_TELEMETRY_SOURCE", "secret-source")
+
+    record = _build_usage_record(
+        agent="codex",
+        entrypoint=entrypoint,
+        model="model",
+        mode="read-only",
+        task_id="secret-task",
+        cwd=tmp_path / "secret-worktree",
+        session_id="secret-provider-session",
+        duration_s=1.25,
+        input_chars=12,
+        output_chars=7,
+        returncode=1,
+        outcome="error",
+        rate_limited=False,
+        stalled=False,
+        stderr_excerpt="secret stderr",
+        tokens=3,
+    )
+
+    for key in (
+        "task_id",
+        "cwd",
+        "run_id",
+        "session_id",
+        "provider_session_id",
+        "level",
+        "slug",
+        "track",
+        "source",
+        "stderr_excerpt",
+    ):
+        assert record[key] is None
+    assert record["entrypoint"] == entrypoint
+    assert record["outcome"] == "error"
+    assert record["duration_s"] == 1.25
+    assert record["tokens"] == 3
 
 
 def test_acpx_grok_shadow_entry_is_direct_only():

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -204,6 +204,7 @@ def test_acpx_codex_shadow_entry_is_direct_only():
     # ACPX itself chooses the Codex model when this direct-only seat omits --model.
     assert entry["default_model"] is None
     assert entry["cli_available"] is False
+    assert entry["direct_only"] is True
     assert entry["resume_policy"] == "never"
     assert entry["capabilities"] == frozenset()
     assert "acpx-codex-shadow" not in available_agents()
@@ -216,6 +217,7 @@ def test_acpx_grok_shadow_entry_is_direct_only():
     # this direct-only seat must not advertise a catalog model.
     assert entry["default_model"] is None
     assert entry["cli_available"] is False
+    assert entry["direct_only"] is True
     assert entry["resume_policy"] == "never"
     assert entry["capabilities"] == frozenset()
     assert "acpx-grok-shadow" not in available_agents()

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -213,6 +213,41 @@ def test_acpx_grok_cached_login_selector_survives_without_xai_credentials():
     assert "ACPX_AUTH_XAI_API_KEY" not in env
 
 
+def test_acpx_codex_chatgpt_selector_survives_without_api_credentials():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "OPENAI_API_KEY": "openai-secret",
+            "ACPX_AUTH_CHAT_GPT": "1",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(provider="acpx-codex-shadow")
+
+    assert env["ACPX_AUTH_CHAT_GPT"] == "1"
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_acpx_auth_method_selectors_require_literal_one():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "ACPX_AUTH_CHAT_GPT": "unexpected",
+            "ACPX_AUTH_CACHED_TOKEN": "unexpected",
+        },
+        clear=True,
+    ):
+        codex_env = build_agent_env(provider="acpx-codex-shadow")
+        grok_env = build_agent_env(provider="acpx-grok-shadow")
+
+    assert "ACPX_AUTH_CHAT_GPT" not in codex_env
+    assert "ACPX_AUTH_CACHED_TOKEN" not in grok_env
+
+
 def test_hermes_home_override_reaches_hermes_backed_agents():
     with patch.dict(
         "os.environ",

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -276,7 +276,7 @@ def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned
     assert "minutes=120" in onboarding
     assert "not permanent routing weights" in lower
     assert "not a new coordination plane" in lower or "not** a new coordination plane" in lower
-    assert "0.2.114" in onboarding
+    assert "0.2.117" in onboarding
     assert "grok-4.5" in onboarding
     assert "--no-leader" in onboarding
     assert "--agent-profile" in onboarding
@@ -284,6 +284,11 @@ def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned
     assert "client flags alone do not remove native grok tools" in lower
     assert "grok-build" in lower
     assert "ACPX_AUTH_CACHED_TOKEN=1" in onboarding
+    assert "scripts.agent_runtime.acpx_pilot" in onboarding
+    assert "global non-blocking lock" in lower
+    assert "idempotency-key digest" in lower
+    assert "runtime dashboard" in lower
+    assert "cannot send or control acpx traffic" in lower
     runtime = all_owned["docs/agent-runtime-guide.md"]
     assert "acpx-grok-shadow" in runtime
     assert "AcpxGrokShadowAdapter" in runtime

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -106,13 +106,20 @@ def test_runtime_page_renders_read_only_acpx_shadow_transport_overview():
     assert "transport.default_mode" in html
     assert "seat.evidence?.total" in html
     assert "seat.evidence_state" in html
+    assert "snapshot.comparison_evidence" in html
+    assert "comparison.classification_parity" in html
+    assert "Duplicates suppressed" in html
+    assert "Busy refusals" in html
+    assert "safeWhenTrue" in html
+    assert "explicit_pilot_only: 'Explicit pilot only'" in html
+    assert "Object.hasOwn(safeWhenTrue, key) && value === true" in html
     assert "aggregate_evidence" not in html
     assert "snapshot.shadow_calls" not in html
     assert "transport.default ??" not in html
     assert "ACPX Shadow Transport" in html
     assert "Native runtime authoritative" in html
     assert "ACPX evidence is observational only." in html
-    assert "No shadow calls in window" in html
+    assert "No shadow calls or comparisons in window" in html
     assert "ACPX pin" in html
     assert "No dispatch authority" in html
     assert 'class="acpx-rail"' in html

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -123,6 +123,46 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
             }
         ],
     )
+    _write_usage_file(
+        usage_dir / f"usage_acpx-shadow-pilot-acpx-pilot_{today:%Y-%m-%d}.jsonl",
+        [
+            {
+                "ts": _iso(today - timedelta(minutes=1)),
+                "agent": "acpx-shadow-pilot",
+                "entrypoint": "acpx-pilot",
+                "event": "acpx_shadow_comparison",
+                "model": "native-plus-shadow",
+                "outcome": "ok",
+                "target": "grok",
+                "executed": True,
+                "duplicate": False,
+                "busy": False,
+                "native_outcome": "ok",
+                "shadow_outcome": "ok",
+                "classification_parity": True,
+                "native_duration_s": 4.0,
+                "shadow_duration_s": 6.25,
+                "native_tokens": 12,
+                "shadow_tokens": 15,
+                "correlation_digest": "must-not-leak",
+                "idempotency_digest": "must-not-leak",
+            },
+            {
+                "ts": _iso(today),
+                "agent": "acpx-shadow-pilot",
+                "entrypoint": "acpx-pilot",
+                "event": "acpx_shadow_comparison",
+                "model": "native-plus-shadow",
+                "outcome": "ok",
+                "target": "grok",
+                "executed": False,
+                "duplicate": True,
+                "busy": False,
+                "correlation_digest": "must-not-leak",
+                "idempotency_digest": "must-not-leak",
+            },
+        ],
+    )
 
     response = client.get("/api/runtime/acpx?days=7")
 
@@ -139,12 +179,24 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
     }
     assert data["pins"] == {
         "acpx": "0.13.0",
-        "grok_cli": "0.2.114",
+        "grok_cli": "0.2.117",
         "validation": "before_spawn",
     }
     assert data["safety"]["max_in_flight"] == 1
+    assert data["safety"]["explicit_pilot_only"] is True
     assert data["safety"]["chat"] is False
     assert data["safety"]["mutations"] is False
+    comparison = data["comparison_evidence"]
+    assert comparison["state"] == "observed"
+    assert comparison["attempts"] == 2
+    assert comparison["comparisons"] == 1
+    assert comparison["classification_parity"] == 1
+    assert comparison["classification_mismatch"] == 0
+    assert comparison["duplicates_suppressed"] == 1
+    assert comparison["native"]["ok"] == 1
+    assert comparison["native"]["total_tokens"] == 12
+    assert comparison["shadow"]["total_duration_s"] == 6.25
+    assert comparison["shadow"]["total_tokens"] == 15
 
     seats = {seat["name"]: seat for seat in data["seats"]}
     assert seats["acpx-codex-shadow"]["evidence_state"] == "no_evidence"
@@ -159,6 +211,8 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
         "cwd",
         "stderr_excerpt",
         "provider_session_id",
+        "correlation_digest",
+        "idempotency_digest",
         "must-not-leak",
     ):
         assert private_field not in serialized


### PR DESCRIPTION
## Summary

- add an explicit, worktree-only ACPX shadow pilot for Codex and Grok
- keep native execution authoritative and run exactly one bounded shadow comparison without routing, failover, sessions, or message controls
- persist privacy-safe aggregate evidence and expose it through the existing read-only Runtime API/UI
- pin the validated ACPX and Grok client versions and document agent onboarding/operator use

## Safety boundaries

- native result determines the command result; ACPX shadow failures cannot override it
- direct-only shadow seats remain unavailable to ordinary routing and dispatch
- global non-blocking lock plus digest replay suppression prevent uncontrolled duplicate traffic
- comparison events exclude prompts, responses, raw IDs, paths, sessions, stderr, auth, and tool data
- supporting native/shadow pilot-leg usage rows also suppress task/run/session IDs, paths, telemetry labels, and stderr
- Runtime UI remains visual/read-only with zero messaging or mutation controls

## Validation

- `330 passed in 27.76s` across ACPX pilot/adapter, runtime runner/sanitizer, API, UI contracts, onboarding docs, and repo-root tests
- Ruff, compileall, `git diff --check`, X-Agent trailer lint, and staged/commit-range OPSEC checks passed
- live Codex and Grok E2E on the privacy-fixed code: native `READY`, ACPX shadow `READY`, parity `true` for both seats
- live JSONL assertion: all four native/shadow pilot-leg records had task/run/session IDs, cwd, telemetry labels/source, and stderr null
- browser verification: both pins and comparison counters rendered, zero controls, `Explicit pilot only` rendered safe/green, zero console warnings/errors
- independent Claude Sonnet 5 local review completed; its one low-severity UI polarity finding was fixed and reverified
- sealed Claude Sonnet 5 PR review found a P2 pilot-leg telemetry privacy gap; the records are now sanitized and protected by regression tests
- GitHub CI exposed test dependence on local dispatch-worktree context; the tests now stub success/rejection classifications explicitly without changing the production guard

Closes #6063