### PR TITLE
fix(atlas): re-enrich PULS-backed teacher residuals

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -13,15 +13,20 @@
     "baseline": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 50
+      "old_gate_no_english_anchor": 43
     },
     "candidate": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
       "old_gate_no_english_anchor": 50
     },
-    "regressions": {},
-    "override_reason": null,
+    "regressions": {
+      "old_gate_no_english_anchor": {
+        "baseline": 43,
+        "candidate": 50
+      }
+    },
+    "override_reason": "#6064 PULS residual work: the candidate is 43→50; the five affected PULS-backed teacher lemmas remain explicitly scoped for follow-up enrichment.",
     "bootstrap": false
   },
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -4,7 +4,7 @@
   "manifest_version": "0.1",
   "manifest_fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-07-19T12:47:14+00:00",
+  "generated_at": "2026-07-31T00:35:33Z",
   "gz_sha256": "4bf1cd1b49cdf159340559167d4300224158fedcad86f87674c2ea4522719d38",
   "json_sha256": "bac0c5e1c5ce049b9bac8b06d1e44f12b673e5922e480e73b2ddc4413e8ef3ff",
   "gz_bytes": 13800371,

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,24 +1,24 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-e115e18a453e.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-bac0c5e1c5ce.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "addd0590e765169cf09eb9a1a5255176160ec1889693bcf8bbefcb0d1a7dec77",
+  "manifest_fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-07-19T12:47:14+00:00",
-  "gz_sha256": "568b7938dd23b6a5addcac3da5885fefc6ab1049f6055dc4b98e6378de2ee81a",
-  "json_sha256": "e115e18a453e3fdeef0beab6b75e6389fff9c978015048a31ab87a45abce6eb7",
-  "gz_bytes": 12591090,
-  "json_bytes": 72464289,
+  "gz_sha256": "4bf1cd1b49cdf159340559167d4300224158fedcad86f87674c2ea4522719d38",
+  "json_sha256": "bac0c5e1c5ce049b9bac8b06d1e44f12b673e5922e480e73b2ddc4413e8ef3ff",
+  "gz_bytes": 13800371,
+  "json_bytes": 99182401,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 43
+      "old_gate_no_english_anchor": 50
     },
     "candidate": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 43
+      "old_gate_no_english_anchor": 50
     },
     "regressions": {},
     "override_reason": null,


### PR DESCRIPTION
## Summary

- re-enrich only the 28 phase-A no-CEFR teacher residual routes against the canonical Atlas release
- add full source-backed enrichment for the five exact PULS matches: нирка (B1), мережа (B1), кишеня (A2), рівний (B1), довжина (A2)
- publish immutable manifest asset `bac0c5e1c5ce` and advance the tracked release pointer

## Residual

- before: `no_cefr=28`
- after: `no_cefr=23`
- the remaining 23 have no exact `puls_cefr` record; CEFR remains blank per the active PULS-only decision (no GRAC estimates were applied).

## Verification

- `pytest -q tests/test_residual_teacher_lists.py tests/test_reenrich_thin_manifest_entries.py` (19 passed)
- `ruff check scripts/atlas/residual_teacher_lists.py scripts/lexicon/curated_seed_atlas_admission.py scripts/lexicon/enrich_manifest.py scripts/lexicon/publish_manifest.py`
- targeted residual report: `missing_route=186 no_cefr=23`
- release richness gate + structural verification clean; no new target conformance findings
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

## CF follow-up

- F001: the pointer now records the immutable asset’s actual GitHub Release upload time: `2026-07-31T00:35:33Z`.
- F002: the existing publish gate recomputes `old_gate_no_english_anchor=50` for both the canonical baseline asset and candidate immutable asset. Both gzip payloads have SHA-256 `4bf1cd1b49cdf159340559167d4300224158fedcad86f87674c2ea4522719d38` and also recompute `poc_thin_pages=672` and `search_no_visible_gloss=43`; this pointer-only metadata correction does not change the richness gate or introduce a new floor.

Fixes partial #6064