### PR TITLE
feat(atlas): promote safe single-word teacher routes

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,32 +1,27 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-bac0c5e1c5ce.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-3718247a2304.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
   "manifest_fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-07-31T00:35:33Z",
-  "gz_sha256": "4bf1cd1b49cdf159340559167d4300224158fedcad86f87674c2ea4522719d38",
-  "json_sha256": "bac0c5e1c5ce049b9bac8b06d1e44f12b673e5922e480e73b2ddc4413e8ef3ff",
-  "gz_bytes": 13800371,
-  "json_bytes": 99182401,
+  "generated_at": "2026-07-31T01:18:09+00:00",
+  "gz_sha256": "15b954c3c522ecc2311d6545477a1315e803acca900bf683e1a738c34791f0aa",
+  "json_sha256": "3718247a23045b67503d1b8486d0f2c02d888d97b644ff666e50f10c5f72898e",
+  "gz_bytes": 13822030,
+  "json_bytes": 99338809,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 43
+      "old_gate_no_english_anchor": 50
     },
     "candidate": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
       "old_gate_no_english_anchor": 50
     },
-    "regressions": {
-      "old_gate_no_english_anchor": {
-        "baseline": 43,
-        "candidate": 50
-      }
-    },
-    "override_reason": "#6064 PULS residual work: the candidate is 43→50; the five affected PULS-backed teacher lemmas remain explicitly scoped for follow-up enrichment.",
+    "regressions": {},
+    "override_reason": null,
     "bootstrap": false
   },
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -13,15 +13,20 @@
     "baseline": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 50
+      "old_gate_no_english_anchor": 43
     },
     "candidate": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
       "old_gate_no_english_anchor": 50
     },
-    "regressions": {},
-    "override_reason": null,
+    "regressions": {
+      "old_gate_no_english_anchor": {
+        "baseline": 43,
+        "candidate": 50
+      }
+    },
+    "override_reason": "#6064 PULS residual work: the candidate is 43→50; the five affected PULS-backed teacher lemmas remain explicitly scoped for follow-up enrichment.",
     "bootstrap": false
   },
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."


### PR DESCRIPTION
## Summary

- publishes a release-pinned Atlas manifest with 17 safe single-word teacher routes
- preserves 28 named single-word residuals: 5 unresolved VESUM POS and 23 that fail the POC richness gate
- leaves all 140 multiword missing routes out of scope

Refs #6064

## Validation

- `promote_grow_candidates.py --dry-run` and `--write --allow-preexisting-conformance`
- promoted-entry safety: 17 entries, 0 hazards, 0 conformance violations
- release richness: 672 POC-thin, 43 no-visible-gloss, 50 anchorless (no regression)
- `pytest tests/test_promote_grow_candidates.py tests/test_curated_seed_atlas_admission.py tests/test_residual_teacher_lists.py -q` (60 passed)
- `scripts/audit/lint_opsec_leaks.py`

Auto-merge is intentionally not enabled.