### PR TITLE
feat(atlas): VESUM-proxy attestation for paste-text deck candidates

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 4899e9ded83bbbb3cecffce32354560f0c5b3415038be89fe565a78ef375c659
+  components_sha256: 2c223b2d808a9549b49a09e1e5d0e0fe71fb7c77b1fafa8f844696fe44fcbd81
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1100,7 +1100,11 @@ components:
         type: () => void
         description: onClose prop.
         ukrainian_text: 'false'
-      optional: []
+      optional:
+      - name: shardBaseUrl
+        type: string
+        description: shardBaseUrl prop.
+        ukrainian_text: 'false'
     nested_types: {}
     example:
       chromeLocale: <'en' | 'uk'>

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -37,23 +37,26 @@ interface LexiconCustomDeckManagerProps {
 type CandidateWord = PasteCandidate;
 
 // Module-level cache: the Atlas attestation index is ~4MB and shared by every
-// wizard open in this tab session, so fetch it once.
-let attestationIndexPromise: Promise<Map<string, AtlasAttestationRow>> | null = null;
+// wizard open in this tab session, so fetch it once per shard base URL.
+const attestationIndexPromises = new Map<string, Promise<Map<string, AtlasAttestationRow>>>();
 
-function loadAttestationIndex(shardBaseUrl: string): Promise<Map<string, AtlasAttestationRow>> {
-  if (!attestationIndexPromise) {
-    attestationIndexPromise = fetch(`${shardBaseUrl}/search-index.json`)
+export function loadAttestationIndex(shardBaseUrl: string): Promise<Map<string, AtlasAttestationRow>> {
+  const key = shardBaseUrl.trim().replace(/\/+$/, '');
+  let promise = attestationIndexPromises.get(key);
+  if (!promise) {
+    promise = fetch(`${key}/search-index.json`)
       .then((res) => {
         if (!res.ok) throw new Error(`Attestation index fetch failed: ${res.status}`);
         return res.json() as Promise<AtlasAttestationRow[]>;
       })
       .then((rows) => buildAtlasAttestationIndex(rows))
       .catch((err) => {
-        attestationIndexPromise = null; // allow retry on next open
+        attestationIndexPromises.delete(key); // allow retry on next open
         throw err;
       });
+    attestationIndexPromises.set(key, promise);
   }
-  return attestationIndexPromise;
+  return promise;
 }
 
 export function LexiconCustomDeckManager({
@@ -199,7 +202,7 @@ export function LexiconCustomDeckManager({
   }, []);
 
   // Bulk toggles: a specific CEFR level, or every unverified (unattested) candidate
-  const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'UNVERIFIED', enable: boolean) => {
+  const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2' | 'UNVERIFIED', enable: boolean) => {
     setCandidates((prev) =>
       prev.map((item) => {
         const inGroup = group === 'UNVERIFIED' ? item.status === 'unverified' : item.cefr === group;
@@ -596,7 +599,7 @@ export function LexiconCustomDeckManager({
 
                   {/* Bulk group toggles, including the unverified group */}
                   <div style={{ display: 'flex', gap: '0.3rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
-                    {(['A1', 'A2', 'B1', 'B2', 'UNVERIFIED'] as const).map((group) => (
+                    {(['A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'UNVERIFIED'] as const).map((group) => (
                       <React.Fragment key={group}>
                         <button type="button" className="btn btn-sm" style={{ fontSize: '0.7rem' }} onClick={() => toggleGroupSelection(group, true)}>
                           +{group === 'UNVERIFIED' ? '❓' : group}

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -19,6 +19,8 @@ import { parseDocumentFile, extractDocumentClozeItems, parsePlainTextWithTransla
 import {
   buildAtlasAttestationIndex,
   classifyPasteCandidates,
+  isSaveEligiblePasteCandidate,
+  selectSaveEligiblePasteCandidates,
   summarizePasteCandidates,
   type AtlasAttestationRow,
   type PasteCandidate,
@@ -194,20 +196,27 @@ export function LexiconCustomDeckManager({
   // Attestation + CEFR distribution counts (real Atlas data, never invented)
   const cefrCounts = useMemo(() => summarizePasteCandidates(candidates), [candidates]);
 
-  // Toggle individual word selection
+  // Toggle individual word selection. Selecting (not deselecting) is fail-closed:
+  // a candidate with no real Atlas CEFR level can never be flipped to selected,
+  // so `selected` always predicts what will actually be saved (#6073 F001).
   const toggleCandidateSelection = useCallback((index: number) => {
     setCandidates((prev) =>
-      prev.map((item, idx) => (idx === index ? { ...item, selected: !item.selected } : item))
+      prev.map((item, idx) => {
+        if (idx !== index) return item;
+        const nextSelected = !item.selected;
+        if (nextSelected && !isSaveEligiblePasteCandidate(item)) return item;
+        return { ...item, selected: nextSelected };
+      })
     );
   }, []);
 
-  // Bulk toggles: a specific CEFR level, or every unverified (unattested) candidate
-  const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2' | 'UNVERIFIED', enable: boolean) => {
+  // Bulk toggle for a specific CEFR level. Unverified candidates have no CEFR
+  // group and are intentionally excluded from bulk-select (#6073 F001) — never
+  // invent a level to make them selectable, and never let a bulk action move
+  // them into a saved deck.
+  const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2', enable: boolean) => {
     setCandidates((prev) =>
-      prev.map((item) => {
-        const inGroup = group === 'UNVERIFIED' ? item.status === 'unverified' : item.cefr === group;
-        return inGroup ? { ...item, selected: enable } : item;
-      })
+      prev.map((item) => (item.cefr === group ? { ...item, selected: enable } : item))
     );
   }, []);
 
@@ -215,7 +224,11 @@ export function LexiconCustomDeckManager({
   const handleSaveDeck = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      const selectedWords = candidates.filter((c) => c.selected).map((c) => c.text);
+      // Fail-closed final gate (#6073 F001): only atlas-attested candidates with a
+      // real CEFR level are ever materialized into a saved deck, regardless of how
+      // `selected` got set — no unverified/no-CEFR word can reach practice and hit
+      // a downstream level-invent fallback.
+      const selectedWords = selectSaveEligiblePasteCandidates(candidates).map((c) => c.text);
       if (selectedWords.length === 0 || !deckTitle.trim()) return;
 
       const saved = saveLocalCustomSet({
@@ -540,7 +553,11 @@ export function LexiconCustomDeckManager({
                         : `Selected words: ${cefrCounts.selected} of ${cefrCounts.total}`}
                     </div>
                     <div style={{ display: 'flex', gap: '0.3rem' }}>
-                      <button type="button" className="btn btn-sm" onClick={() => setCandidates((prev) => prev.map((c) => ({ ...c, selected: true })))}>
+                      <button
+                        type="button"
+                        className="btn btn-sm"
+                        onClick={() => setCandidates((prev) => prev.map((c) => ({ ...c, selected: isSaveEligiblePasteCandidate(c) })))}
+                      >
                         {chromeLocale === 'uk' ? 'Обрати всі' : 'Select All'}
                       </button>
                       <button type="button" className="btn btn-sm" onClick={() => setCandidates((prev) => prev.map((c) => ({ ...c, selected: false })))}>
@@ -597,15 +614,17 @@ export function LexiconCustomDeckManager({
                     ))}
                   </div>
 
-                  {/* Bulk group toggles, including the unverified group */}
+                  {/* Bulk group toggles by CEFR level. Unverified candidates have no
+                      level group and are deliberately excluded — never bulk-select
+                      them into a saved deck (#6073 F001). */}
                   <div style={{ display: 'flex', gap: '0.3rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
-                    {(['A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'UNVERIFIED'] as const).map((group) => (
+                    {(['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const).map((group) => (
                       <React.Fragment key={group}>
                         <button type="button" className="btn btn-sm" style={{ fontSize: '0.7rem' }} onClick={() => toggleGroupSelection(group, true)}>
-                          +{group === 'UNVERIFIED' ? '❓' : group}
+                          +{group}
                         </button>
                         <button type="button" className="btn btn-sm" style={{ fontSize: '0.7rem' }} onClick={() => toggleGroupSelection(group, false)}>
-                          -{group === 'UNVERIFIED' ? '❓' : group}
+                          -{group}
                         </button>
                       </React.Fragment>
                     ))}

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -84,7 +84,7 @@ export function LexiconCustomDeckManager({
   // Candidates extracted from document or paste
   const [candidates, setCandidates] = useState<CandidateWord[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [levelFilter, setLevelFilter] = useState<'ALL' | 'A1' | 'A2' | 'B1' | 'B2' | 'UNVERIFIED'>('ALL');
+  const [levelFilter, setLevelFilter] = useState<'ALL' | 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2' | 'UNVERIFIED'>('ALL');
   const [isClassifying, setIsClassifying] = useState(false);
   const [attestationError, setAttestationError] = useState<string | null>(null);
 
@@ -601,7 +601,7 @@ export function LexiconCustomDeckManager({
                       onChange={(e) => setSearchQuery(e.target.value)}
                       style={{ padding: '0.3rem 0.6rem', borderRadius: '6px', background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: '0.8rem', flex: 1 }}
                     />
-                    {(['ALL', 'A1', 'A2', 'B1', 'B2', 'UNVERIFIED'] as const).map((lvl) => (
+                    {(['ALL', 'A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'UNVERIFIED'] as const).map((lvl) => (
                       <button
                         key={lvl}
                         type="button"

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -16,6 +16,13 @@ import {
   deleteLocalCustomSet,
 } from '../lib/lexicon/custom-decks';
 import { parseDocumentFile, extractDocumentClozeItems, parsePlainTextWithTranslations, type ImportedDeck } from '../lib/lexicon/document-importer';
+import {
+  buildAtlasAttestationIndex,
+  classifyPasteCandidates,
+  summarizePasteCandidates,
+  type AtlasAttestationRow,
+  type PasteCandidate,
+} from '../lib/lexicon/paste-text-vocab';
 import type { PracticeClozeItem } from '../lib/lexicon/srs';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
 
@@ -24,12 +31,29 @@ interface LexiconCustomDeckManagerProps {
   activeDeckFilter: string;
   onSelectDeckFilter: (filterId: string) => void;
   onClose: () => void;
+  shardBaseUrl?: string;
 }
 
-interface CandidateWord {
-  text: string;
-  level: 'A1' | 'A2' | 'B1' | 'B2';
-  selected: boolean;
+type CandidateWord = PasteCandidate;
+
+// Module-level cache: the Atlas attestation index is ~4MB and shared by every
+// wizard open in this tab session, so fetch it once.
+let attestationIndexPromise: Promise<Map<string, AtlasAttestationRow>> | null = null;
+
+function loadAttestationIndex(shardBaseUrl: string): Promise<Map<string, AtlasAttestationRow>> {
+  if (!attestationIndexPromise) {
+    attestationIndexPromise = fetch(`${shardBaseUrl}/search-index.json`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Attestation index fetch failed: ${res.status}`);
+        return res.json() as Promise<AtlasAttestationRow[]>;
+      })
+      .then((rows) => buildAtlasAttestationIndex(rows))
+      .catch((err) => {
+        attestationIndexPromise = null; // allow retry on next open
+        throw err;
+      });
+  }
+  return attestationIndexPromise;
 }
 
 export function LexiconCustomDeckManager({
@@ -37,6 +61,7 @@ export function LexiconCustomDeckManager({
   activeDeckFilter,
   onSelectDeckFilter,
   onClose,
+  shardBaseUrl = '/lexicon',
 }: LexiconCustomDeckManagerProps) {
   const [customSets, setCustomSets] = useState<CustomSet[]>(() => readLocalCustomSets());
   const [activeTab, setActiveTab] = useState<'decks' | 'wizard'>('decks');
@@ -54,7 +79,9 @@ export function LexiconCustomDeckManager({
   // Candidates extracted from document or paste
   const [candidates, setCandidates] = useState<CandidateWord[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [levelFilter, setLevelFilter] = useState<'ALL' | 'A1' | 'A2' | 'B1' | 'B2'>('ALL');
+  const [levelFilter, setLevelFilter] = useState<'ALL' | 'A1' | 'A2' | 'B1' | 'B2' | 'UNVERIFIED'>('ALL');
+  const [isClassifying, setIsClassifying] = useState(false);
+  const [attestationError, setAttestationError] = useState<string | null>(null);
 
   // Drive sync state
   const [isDriveSyncing, setIsDriveSyncing] = useState(false);
@@ -109,24 +136,33 @@ export function LexiconCustomDeckManager({
     }
   }, [chromeLocale]);
 
-  // Process raw text into candidate words with CEFR heuristics
-  const processTextToCandidates = useCallback((words: string[], defaultTitle = ''): void => {
+  // Extract candidate words, then classify each against the VESUM-verified
+  // Atlas index: attested words get a real CEFR level + gloss, everything
+  // else is flagged "unverified" and left deselected (#5882 — no silent invent).
+  const processTextToCandidates = useCallback(async (words: string[], defaultTitle = ''): Promise<void> => {
     const uniqueWords = Array.from(new Set(words.map((w) => w.toLowerCase().trim()).filter((w) => w.length >= 2)));
-    const parsedCandidates: CandidateWord[] = uniqueWords.map((word) => {
-      // Basic CEFR level distribution heuristic
-      let level: 'A1' | 'A2' | 'B1' | 'B2' = 'A1';
-      if (word.length > 8) level = 'B2';
-      else if (word.length > 6) level = 'B1';
-      else if (word.length > 4) level = 'A2';
-      return { text: word, level, selected: true };
-    });
 
-    setCandidates(parsedCandidates);
+    setIsClassifying(true);
+    setAttestationError(null);
+    let index: Map<string, AtlasAttestationRow>;
+    try {
+      index = await loadAttestationIndex(shardBaseUrl);
+    } catch {
+      index = new Map();
+      setAttestationError(
+        chromeLocale === 'uk'
+          ? 'Не вдалося перевірити слова за словником Atlas. Усі слова позначені як неперевірені.'
+          : 'Could not verify words against the Atlas dictionary. All words are flagged unverified.',
+      );
+    }
+    setIsClassifying(false);
+
+    setCandidates(classifyPasteCandidates(uniqueWords, index));
     if (defaultTitle && !deckTitle) {
       setDeckTitle(defaultTitle);
     }
     setWizardStep(2);
-  }, [deckTitle]);
+  }, [deckTitle, chromeLocale, shardBaseUrl]);
 
   const [importedClozeItems, setImportedClozeItems] = useState<PracticeClozeItem[]>([]);
 
@@ -138,31 +174,22 @@ export function LexiconCustomDeckManager({
       if (parsed.cloze_items) {
         setImportedClozeItems(parsed.cloze_items);
       }
-      processTextToCandidates(parsed.lemma_keys, parsed.title);
+      await processTextToCandidates(parsed.lemma_keys, parsed.title);
     } catch (err: any) {
       setParseError(err?.message || 'Failed to read document');
     }
   }, [processTextToCandidates]);
 
-  const handlePasteSubmit = useCallback(() => {
+  const handlePasteSubmit = useCallback(async () => {
     if (!pastedText.trim()) return;
     const { lemmaKeys, wordTranslations } = parsePlainTextWithTranslations(pastedText);
     const clozes = extractDocumentClozeItems(pastedText, lemmaKeys, wordTranslations);
     setImportedClozeItems(clozes);
-    processTextToCandidates(lemmaKeys, chromeLocale === 'uk' ? 'Моя імпортована колода' : 'My Imported Deck');
+    await processTextToCandidates(lemmaKeys, chromeLocale === 'uk' ? 'Моя імпортована колода' : 'My Imported Deck');
   }, [pastedText, processTextToCandidates, chromeLocale]);
 
-  // CEFR Distribution Counts
-  const cefrCounts = useMemo(() => {
-    const counts = { A1: 0, A2: 0, B1: 0, B2: 0, total: candidates.length, selected: 0 };
-    for (const c of candidates) {
-      if (c.selected) {
-        counts.selected++;
-        counts[c.level]++;
-      }
-    }
-    return counts;
-  }, [candidates]);
+  // Attestation + CEFR distribution counts (real Atlas data, never invented)
+  const cefrCounts = useMemo(() => summarizePasteCandidates(candidates), [candidates]);
 
   // Toggle individual word selection
   const toggleCandidateSelection = useCallback((index: number) => {
@@ -171,10 +198,13 @@ export function LexiconCustomDeckManager({
     );
   }, []);
 
-  // Bulk level toggles
-  const toggleLevelSelection = useCallback((level: 'A1' | 'A2' | 'B1' | 'B2', enable: boolean) => {
+  // Bulk toggles: a specific CEFR level, or every unverified (unattested) candidate
+  const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'UNVERIFIED', enable: boolean) => {
     setCandidates((prev) =>
-      prev.map((item) => (item.level === level ? { ...item, selected: enable } : item))
+      prev.map((item) => {
+        const inGroup = group === 'UNVERIFIED' ? item.status === 'unverified' : item.cefr === group;
+        return inGroup ? { ...item, selected: enable } : item;
+      })
     );
   }, []);
 
@@ -213,7 +243,8 @@ export function LexiconCustomDeckManager({
   // Filtered Candidates for Grid View
   const filteredCandidates = useMemo(() => {
     return candidates.map((item, originalIdx) => ({ ...item, originalIdx })).filter((item) => {
-      if (levelFilter !== 'ALL' && item.level !== levelFilter) return false;
+      if (levelFilter === 'UNVERIFIED' && item.status !== 'unverified') return false;
+      else if (levelFilter !== 'ALL' && levelFilter !== 'UNVERIFIED' && item.cefr !== levelFilter) return false;
       if (searchQuery && !item.text.includes(searchQuery.toLowerCase().trim())) return false;
       return true;
     });
@@ -481,10 +512,13 @@ export function LexiconCustomDeckManager({
                       <button
                         type="button"
                         className="btn btn-accent"
-                        onClick={handlePasteSubmit}
+                        onClick={() => void handlePasteSubmit()}
+                        disabled={isClassifying}
                         style={{ marginTop: '0.75rem', width: '100%' }}
                       >
-                        ⚡ {chromeLocale === 'uk' ? 'Витягнути слова' : 'Extract Words'}
+                        {isClassifying
+                          ? (chromeLocale === 'uk' ? '⏳ Перевірка за словником...' : '⏳ Checking dictionary...')
+                          : `⚡ ${chromeLocale === 'uk' ? 'Витягнути слова' : 'Extract Words'}`}
                       </button>
                     </div>
                   )}
@@ -512,13 +546,31 @@ export function LexiconCustomDeckManager({
                     </div>
                   </div>
 
-                  {/* CEFR Distribution Bar */}
+                  {/* CEFR + Attestation Distribution Bar */}
                   <div className="cefr-distribution-bar">
-                    <div className="cefr-seg-a1" style={{ width: `${(cefrCounts.A1 / (cefrCounts.selected || 1)) * 100}%` }} title={`A1: ${cefrCounts.A1}`} />
-                    <div className="cefr-seg-a2" style={{ width: `${(cefrCounts.A2 / (cefrCounts.selected || 1)) * 100}%` }} title={`A2: ${cefrCounts.A2}`} />
-                    <div className="cefr-seg-b1" style={{ width: `${(cefrCounts.B1 / (cefrCounts.selected || 1)) * 100}%` }} title={`B1: ${cefrCounts.B1}`} />
-                    <div className="cefr-seg-b2" style={{ width: `${(cefrCounts.B2 / (cefrCounts.selected || 1)) * 100}%` }} title={`B2: ${cefrCounts.B2}`} />
+                    <div className="cefr-seg-a1" style={{ width: `${(cefrCounts.byLevel.A1 / (cefrCounts.selected || 1)) * 100}%` }} title={`A1: ${cefrCounts.byLevel.A1}`} />
+                    <div className="cefr-seg-a2" style={{ width: `${(cefrCounts.byLevel.A2 / (cefrCounts.selected || 1)) * 100}%` }} title={`A2: ${cefrCounts.byLevel.A2}`} />
+                    <div className="cefr-seg-b1" style={{ width: `${(cefrCounts.byLevel.B1 / (cefrCounts.selected || 1)) * 100}%` }} title={`B1: ${cefrCounts.byLevel.B1}`} />
+                    <div className="cefr-seg-b2" style={{ width: `${(cefrCounts.byLevel.B2 / (cefrCounts.selected || 1)) * 100}%` }} title={`B2: ${cefrCounts.byLevel.B2}`} />
+                    <div className="cefr-seg-c1" style={{ width: `${(cefrCounts.byLevel.C1 / (cefrCounts.selected || 1)) * 100}%` }} title={`C1: ${cefrCounts.byLevel.C1}`} />
+                    <div className="cefr-seg-c2" style={{ width: `${(cefrCounts.byLevel.C2 / (cefrCounts.selected || 1)) * 100}%` }} title={`C2: ${cefrCounts.byLevel.C2}`} />
                   </div>
+
+                  {/* Attestation banner — every candidate is checked against the Atlas
+                      dictionary; nothing outside it is treated as confirmed vocabulary. */}
+                  <div style={{ display: 'flex', gap: '1rem', fontSize: '0.78rem', color: '#94a3b8', margin: '0.5rem 0 0.75rem' }}>
+                    <span>✅ {chromeLocale === 'uk' ? `У словнику: ${cefrCounts.attested}` : `In dictionary: ${cefrCounts.attested}`}</span>
+                    <span>❓ {chromeLocale === 'uk' ? `Неперевірено: ${cefrCounts.unverified}` : `Unverified: ${cefrCounts.unverified}`}</span>
+                  </div>
+                  {attestationError ? (
+                    <p style={{ color: '#fbbf24', fontSize: '0.8rem', marginBottom: '0.5rem' }}>{attestationError}</p>
+                  ) : cefrCounts.unverified > 0 ? (
+                    <p style={{ color: '#94a3b8', fontSize: '0.78rem', marginBottom: '0.5rem' }}>
+                      {chromeLocale === 'uk'
+                        ? 'Неперевірені слова відсутні в нашому словнику Atlas і не обрані за замовчуванням — перегляньте перед додаванням.'
+                        : "Unverified words aren't in our Atlas dictionary yet and are deselected by default — review before adding."}
+                    </p>
+                  ) : null}
 
                   {/* Level Filters & Search */}
                   <div style={{ display: 'flex', gap: '0.4rem', margin: '0.75rem 0', flexWrap: 'wrap' }}>
@@ -529,7 +581,7 @@ export function LexiconCustomDeckManager({
                       onChange={(e) => setSearchQuery(e.target.value)}
                       style={{ padding: '0.3rem 0.6rem', borderRadius: '6px', background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: '0.8rem', flex: 1 }}
                     />
-                    {(['ALL', 'A1', 'A2', 'B1', 'B2'] as const).map((lvl) => (
+                    {(['ALL', 'A1', 'A2', 'B1', 'B2', 'UNVERIFIED'] as const).map((lvl) => (
                       <button
                         key={lvl}
                         type="button"
@@ -537,8 +589,22 @@ export function LexiconCustomDeckManager({
                         onClick={() => setLevelFilter(lvl)}
                         style={{ fontSize: '0.75rem' }}
                       >
-                        {lvl}
+                        {lvl === 'UNVERIFIED' ? '❓' : lvl}
                       </button>
+                    ))}
+                  </div>
+
+                  {/* Bulk group toggles, including the unverified group */}
+                  <div style={{ display: 'flex', gap: '0.3rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
+                    {(['A1', 'A2', 'B1', 'B2', 'UNVERIFIED'] as const).map((group) => (
+                      <React.Fragment key={group}>
+                        <button type="button" className="btn btn-sm" style={{ fontSize: '0.7rem' }} onClick={() => toggleGroupSelection(group, true)}>
+                          +{group === 'UNVERIFIED' ? '❓' : group}
+                        </button>
+                        <button type="button" className="btn btn-sm" style={{ fontSize: '0.7rem' }} onClick={() => toggleGroupSelection(group, false)}>
+                          -{group === 'UNVERIFIED' ? '❓' : group}
+                        </button>
+                      </React.Fragment>
                     ))}
                   </div>
 
@@ -549,10 +615,15 @@ export function LexiconCustomDeckManager({
                         key={item.originalIdx}
                         className={`word-inspector-chip ${item.selected ? 'selected' : 'excluded'}`}
                         onClick={() => toggleCandidateSelection(item.originalIdx)}
+                        title={item.status === 'unverified'
+                          ? (chromeLocale === 'uk' ? 'Немає в словнику Atlas — неперевірено' : 'Not in the Atlas dictionary — unverified')
+                          : (item.gloss ?? undefined)}
                       >
                         <span>{item.selected ? '✓' : '✗'}</span>
                         <span>{item.text}</span>
-                        <span className={`word-chip-badge badge-${item.level.toLowerCase()}`}>{item.level}</span>
+                        <span className={`word-chip-badge badge-${item.cefr ? item.cefr.toLowerCase() : 'unverified'}`}>
+                          {item.cefr ?? '❓'}
+                        </span>
                       </div>
                     ))}
                   </div>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -3206,6 +3206,7 @@ function LexiconPracticeIsland({
             <LexiconCustomDeckManager
               chromeLocale={chromeLocale}
               activeDeckFilter={selectedDeckFilter}
+              shardBaseUrl={shardBaseUrl}
               onSelectDeckFilter={(id) => {
                 // F2 (PR #5837 review): route through the same guarded switch flow as the
                 // deck-filter chips — the manager must offer a fresh session too, not

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1074,6 +1074,8 @@ details.solution-block > *:last-child {
 .cefr-seg-a2 { background: #3b82f6; }
 .cefr-seg-b1 { background: #a855f7; }
 .cefr-seg-b2 { background: #f97316; }
+.cefr-seg-c1 { background: #ec4899; }
+.cefr-seg-c2 { background: #eab308; }
 
 /* Interactive Word Chips */
 .word-chip-grid {
@@ -1133,6 +1135,9 @@ details.solution-block > *:last-child {
 .badge-a2 { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
 .badge-b1 { background: rgba(168, 85, 247, 0.2); color: #c084fc; }
 .badge-b2 { background: rgba(249, 115, 22, 0.2); color: #fb923c; }
+.badge-c1 { background: rgba(236, 72, 153, 0.2); color: #f472b6; }
+.badge-c2 { background: rgba(234, 179, 8, 0.2); color: #fbbf24; }
+.badge-unverified { background: rgba(148, 163, 184, 0.2); color: #cbd5e1; }
 
 /* Dropzone */
 .importer-dropzone {

--- a/site/src/lib/lexicon/paste-text-vocab.ts
+++ b/site/src/lib/lexicon/paste-text-vocab.ts
@@ -6,7 +6,10 @@
  * doubles as a client-side attestation source with zero extra bundle cost.
  * A pasted word is "atlas_attested" only when it resolves to a real Atlas
  * row; everything else is "unverified" and deselected by default so no
- * unattested string is ever silently treated as confirmed vocabulary.
+ * unattested string is ever silently treated as confirmed vocabulary. An
+ * attested row with no parseable CEFR level is also left deselected — it
+ * needs manual review, and no level is ever invented (e.g. defaulting it
+ * to A1) just to make it selectable.
  */
 
 import { CEFR_LEVELS, parseCefrLevel, type CefrLevel } from './levels';
@@ -68,13 +71,15 @@ export function classifyPasteCandidates(
   return lemmaKeys.map((text) => {
     const row = attestationIndex.get(text.toLocaleLowerCase());
     if (row) {
+      const cefr = parseCefrLevel(row.c);
       return {
         text,
-        cefr: parseCefrLevel(row.c),
+        cefr,
         status: 'atlas_attested',
         atlasSlug: row.s,
         gloss: cleanGloss(row.g),
-        selected: true,
+        // No parseable CEFR level → leave deselected for manual review, never invent one.
+        selected: cefr !== null,
       };
     }
     return {

--- a/site/src/lib/lexicon/paste-text-vocab.ts
+++ b/site/src/lib/lexicon/paste-text-vocab.ts
@@ -93,6 +93,28 @@ export function classifyPasteCandidates(
   });
 }
 
+/**
+ * A candidate is safe to persist into a saved deck only when it resolves to a
+ * real Atlas row with a real CEFR level. Unverified words and attested rows
+ * with no parseable CEFR level are never save-eligible — nothing downstream
+ * (e.g. a practice-session level fallback) may invent a level just because a
+ * bulk toggle or a stray click left `selected` true on an unqualified row.
+ */
+export function isSaveEligiblePasteCandidate(candidate: PasteCandidate): boolean {
+  return candidate.status === 'atlas_attested' && candidate.cefr !== null;
+}
+
+/**
+ * The fail-closed save set: candidates the user selected AND that are
+ * save-eligible. This is the final gate before a paste-text deck is
+ * persisted — the authoritative check regardless of how `selected` got set.
+ */
+export function selectSaveEligiblePasteCandidates(
+  candidates: readonly PasteCandidate[],
+): PasteCandidate[] {
+  return candidates.filter((c) => c.selected && isSaveEligiblePasteCandidate(c));
+}
+
 /** Tally selection/attestation/CEFR counts for the wizard's review step. */
 export function summarizePasteCandidates(
   candidates: readonly PasteCandidate[],

--- a/site/src/lib/lexicon/paste-text-vocab.ts
+++ b/site/src/lib/lexicon/paste-text-vocab.ts
@@ -1,0 +1,114 @@
+/**
+ * Paste-text deck builder — pure extraction & attestation classification (#5882).
+ *
+ * The Atlas search index is VESUM-gated (every entry passes VESUM attestation
+ * before publication — see `docs/best-practices/audit-standards.md`), so it
+ * doubles as a client-side attestation source with zero extra bundle cost.
+ * A pasted word is "atlas_attested" only when it resolves to a real Atlas
+ * row; everything else is "unverified" and deselected by default so no
+ * unattested string is ever silently treated as confirmed vocabulary.
+ */
+
+import { CEFR_LEVELS, parseCefrLevel, type CefrLevel } from './levels';
+
+export type PasteCandidateStatus = 'atlas_attested' | 'unverified';
+
+/** Minimal shape this module needs from a search-index row (see search.ts SearchRow). */
+export interface AtlasAttestationRow {
+  l: string;
+  s: string;
+  g: string | null;
+  c?: string;
+}
+
+export interface PasteCandidate {
+  text: string;
+  cefr: CefrLevel | null;
+  status: PasteCandidateStatus;
+  atlasSlug: string | null;
+  gloss: string | null;
+  selected: boolean;
+}
+
+export interface PasteCandidateCounts {
+  total: number;
+  selected: number;
+  attested: number;
+  unverified: number;
+  byLevel: Record<CefrLevel, number>;
+}
+
+/** Index Atlas rows by lemma and slug (lowercased) for O(1) attestation lookup. */
+export function buildAtlasAttestationIndex(
+  rows: readonly AtlasAttestationRow[],
+): Map<string, AtlasAttestationRow> {
+  const index = new Map<string, AtlasAttestationRow>();
+  for (const row of rows) {
+    if (row.l) index.set(row.l.toLocaleLowerCase(), row);
+    if (row.s) index.set(row.s.toLocaleLowerCase(), row);
+  }
+  return index;
+}
+
+function cleanGloss(gloss: string | null): string | null {
+  if (!gloss) return null;
+  const trimmed = gloss.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Classify pasted-text candidate words against the Atlas attestation index.
+ * No candidate is ever assigned an invented CEFR level or gloss: both are
+ * `null` unless a real Atlas row backs them.
+ */
+export function classifyPasteCandidates(
+  lemmaKeys: readonly string[],
+  attestationIndex: ReadonlyMap<string, AtlasAttestationRow>,
+): PasteCandidate[] {
+  return lemmaKeys.map((text) => {
+    const row = attestationIndex.get(text.toLocaleLowerCase());
+    if (row) {
+      return {
+        text,
+        cefr: parseCefrLevel(row.c),
+        status: 'atlas_attested',
+        atlasSlug: row.s,
+        gloss: cleanGloss(row.g),
+        selected: true,
+      };
+    }
+    return {
+      text,
+      cefr: null,
+      status: 'unverified',
+      atlasSlug: null,
+      gloss: null,
+      selected: false,
+    };
+  });
+}
+
+/** Tally selection/attestation/CEFR counts for the wizard's review step. */
+export function summarizePasteCandidates(
+  candidates: readonly PasteCandidate[],
+): PasteCandidateCounts {
+  const byLevel = Object.fromEntries(CEFR_LEVELS.map((level) => [level, 0])) as Record<
+    CefrLevel,
+    number
+  >;
+  let selected = 0;
+  let attested = 0;
+  let unverified = 0;
+
+  for (const candidate of candidates) {
+    if (candidate.status === 'atlas_attested') attested++;
+    else unverified++;
+
+    if (candidate.selected) {
+      selected++;
+      if (candidate.cefr) byLevel[candidate.cefr]++;
+    }
+  }
+
+  return { total: candidates.length, selected, attested, unverified, byLevel };
+}

--- a/site/tests/unit/lexicon-custom-deck-manager-attestation-cache.test.ts
+++ b/site/tests/unit/lexicon-custom-deck-manager-attestation-cache.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { loadAttestationIndex } from '@site/src/components/LexiconCustomDeckManager';
+import type { AtlasAttestationRow } from '@site/src/lib/lexicon/paste-text-vocab';
+
+const ROWS: AtlasAttestationRow[] = [{ l: 'привіт', s: 'pryvit', g: 'hello', c: 'A1' }];
+
+function mockFetchOk() {
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => ROWS,
+  })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadAttestationIndex cache keying (F001)', () => {
+  test('fetches independently per distinct shardBaseUrl instead of sharing one global promise', async () => {
+    const fetchMock = mockFetchOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await loadAttestationIndex('/lexicon-cache-test-a');
+    await loadAttestationIndex('/lexicon-cache-test-b');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/lexicon-cache-test-a/search-index.json');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/lexicon-cache-test-b/search-index.json');
+  });
+
+  test('reuses the cached promise for the same shardBaseUrl', async () => {
+    const fetchMock = mockFetchOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const [first, second] = await Promise.all([
+      loadAttestationIndex('/lexicon-cache-test-c'),
+      loadAttestationIndex('/lexicon-cache-test-c'),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  test('normalizes a trailing slash so it hits the same cache entry', async () => {
+    const fetchMock = mockFetchOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await loadAttestationIndex('/lexicon-cache-test-d');
+    await loadAttestationIndex('/lexicon-cache-test-d/');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failed fetch for one shardBaseUrl does not evict or block a different shardBaseUrl', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).startsWith('/lexicon-cache-test-fail')) {
+        return { ok: false, status: 500, json: async () => [] } as Response;
+      }
+      return { ok: true, json: async () => ROWS } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadAttestationIndex('/lexicon-cache-test-fail')).rejects.toThrow();
+    const ok = await loadAttestationIndex('/lexicon-cache-test-ok');
+
+    expect(ok.get('pryvit')).toEqual(ROWS[0]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('a failed fetch clears its own cache entry so a retry re-fetches', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 500, json: async () => [] }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadAttestationIndex('/lexicon-cache-test-retry')).rejects.toThrow();
+    await expect(loadAttestationIndex('/lexicon-cache-test-retry')).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/site/tests/unit/paste-text-vocab.test.ts
+++ b/site/tests/unit/paste-text-vocab.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from 'vitest';
 import {
   buildAtlasAttestationIndex,
   classifyPasteCandidates,
+  isSaveEligiblePasteCandidate,
+  selectSaveEligiblePasteCandidates,
   summarizePasteCandidates,
   type AtlasAttestationRow,
+  type PasteCandidate,
 } from '@site/src/lib/lexicon/paste-text-vocab';
 import { parsePlainTextWithTranslations } from '@site/src/lib/lexicon/document-importer';
 
@@ -118,6 +121,50 @@ describe('summarizePasteCandidates', () => {
     const summary = summarizePasteCandidates(candidates);
     expect(summary.selected).toBe(0);
     expect(summary.byLevel.A1).toBe(0);
+  });
+});
+
+describe('isSaveEligiblePasteCandidate (#6073 F001 — fail-closed save gate)', () => {
+  const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+
+  test('an atlas-attested word with a real CEFR level is save-eligible', () => {
+    const [candidate] = classifyPasteCandidates(['привіт'], index);
+    expect(isSaveEligiblePasteCandidate(candidate)).toBe(true);
+  });
+
+  test('an unverified word is never save-eligible, even if manually selected', () => {
+    const [candidate] = classifyPasteCandidates(['вигаданеслово'], index);
+    expect(isSaveEligiblePasteCandidate({ ...candidate, selected: true })).toBe(false);
+  });
+
+  test('an atlas-attested word with no parseable CEFR level is never save-eligible, even if manually selected', () => {
+    const [candidate] = classifyPasteCandidates(['абракадабра'], index);
+    expect(isSaveEligiblePasteCandidate({ ...candidate, selected: true })).toBe(false);
+  });
+});
+
+describe('selectSaveEligiblePasteCandidates (#6073 F001 — final materialization gate)', () => {
+  const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+
+  test('keeps only selected candidates that are also save-eligible', () => {
+    const candidates: PasteCandidate[] = classifyPasteCandidates(
+      ['привіт', 'книжка', 'вигаданеслово', 'абракадабра'],
+      index,
+    );
+    // Simulate a bulk-select/individual-click bug upstream that force-selected
+    // ineligible rows anyway — the materialization gate must still reject them.
+    const corrupted = candidates.map((c) => ({ ...c, selected: true }));
+    const materialized = selectSaveEligiblePasteCandidates(corrupted);
+
+    expect(materialized.map((c) => c.text)).toEqual(['привіт', 'книжка']);
+  });
+
+  test('drops a save-eligible candidate the user deselected', () => {
+    const candidates = classifyPasteCandidates(['привіт'], index).map((c) => ({
+      ...c,
+      selected: false,
+    }));
+    expect(selectSaveEligiblePasteCandidates(candidates)).toEqual([]);
   });
 });
 

--- a/site/tests/unit/paste-text-vocab.test.ts
+++ b/site/tests/unit/paste-text-vocab.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildAtlasAttestationIndex,
+  classifyPasteCandidates,
+  summarizePasteCandidates,
+  type AtlasAttestationRow,
+} from '@site/src/lib/lexicon/paste-text-vocab';
+import { parsePlainTextWithTranslations } from '@site/src/lib/lexicon/document-importer';
+
+const SAMPLE_ROWS: AtlasAttestationRow[] = [
+  { l: 'привіт', s: 'pryvit', g: 'hello', c: 'A1' },
+  { l: 'книжка', s: 'knyzhka', g: 'book', c: 'A2' },
+  { l: 'абракадабра', s: 'abrakadabra-slug', g: null, c: undefined },
+];
+
+describe('buildAtlasAttestationIndex', () => {
+  test('indexes rows by lowercased lemma and slug', () => {
+    const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+    expect(index.get('привіт')).toBe(SAMPLE_ROWS[0]);
+    expect(index.get('pryvit')).toBe(SAMPLE_ROWS[0]);
+    expect(index.get('ПРИВІТ'.toLocaleLowerCase())).toBe(SAMPLE_ROWS[0]);
+  });
+
+  test('skips rows missing a lemma or slug key', () => {
+    const index = buildAtlasAttestationIndex([{ l: '', s: '', g: null }]);
+    expect(index.size).toBe(0);
+  });
+});
+
+describe('classifyPasteCandidates', () => {
+  const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+
+  test('marks an Atlas-attested word with real CEFR + gloss, selected by default', () => {
+    const [candidate] = classifyPasteCandidates(['привіт'], index);
+    expect(candidate).toMatchObject({
+      text: 'привіт',
+      status: 'atlas_attested',
+      cefr: 'A1',
+      atlasSlug: 'pryvit',
+      gloss: 'hello',
+      selected: true,
+    });
+  });
+
+  test('matches case-insensitively', () => {
+    const [candidate] = classifyPasteCandidates(['ПРИВІТ'], index);
+    expect(candidate.status).toBe('atlas_attested');
+  });
+
+  test('flags a word absent from the Atlas index as unverified, deselected, with no invented data', () => {
+    const [candidate] = classifyPasteCandidates(['вигаданеслово'], index);
+    expect(candidate).toEqual({
+      text: 'вигаданеслово',
+      cefr: null,
+      status: 'unverified',
+      atlasSlug: null,
+      gloss: null,
+      selected: false,
+    });
+  });
+
+  test('never invents a CEFR level for an Atlas row missing one', () => {
+    const [candidate] = classifyPasteCandidates(['абракадабра'], index);
+    expect(candidate.status).toBe('atlas_attested');
+    expect(candidate.cefr).toBeNull();
+    expect(candidate.gloss).toBeNull();
+  });
+
+  test('treats a blank Atlas gloss as null rather than an empty invented string', () => {
+    const rows: AtlasAttestationRow[] = [{ l: 'тест', s: 'test', g: '   ', c: 'B1' }];
+    const [candidate] = classifyPasteCandidates(['тест'], buildAtlasAttestationIndex(rows));
+    expect(candidate.gloss).toBeNull();
+  });
+});
+
+describe('summarizePasteCandidates', () => {
+  test('tallies selection, attestation, and per-level counts', () => {
+    const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+    const candidates = classifyPasteCandidates(
+      ['привіт', 'книжка', 'вигаданеслово'],
+      index,
+    );
+    const summary = summarizePasteCandidates(candidates);
+    expect(summary.total).toBe(3);
+    expect(summary.attested).toBe(2);
+    expect(summary.unverified).toBe(1);
+    // unverified candidates default to deselected, so only the two attested count
+    expect(summary.selected).toBe(2);
+    expect(summary.byLevel.A1).toBe(1);
+    expect(summary.byLevel.A2).toBe(1);
+    expect(summary.byLevel.B1).toBe(0);
+  });
+
+  test('excludes deselected candidates from the level tally even if attested', () => {
+    const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+    const candidates = classifyPasteCandidates(['привіт'], index).map((c) => ({
+      ...c,
+      selected: false,
+    }));
+    const summary = summarizePasteCandidates(candidates);
+    expect(summary.selected).toBe(0);
+    expect(summary.byLevel.A1).toBe(0);
+  });
+});
+
+describe('extraction feeds classification end-to-end', () => {
+  test('paste-text tokenization output classifies cleanly against an Atlas index', () => {
+    const { lemmaKeys } = parsePlainTextWithTranslations('Привіт! Це моя книжка.');
+    const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+    const candidates = classifyPasteCandidates(lemmaKeys, index);
+    const byText = new Map(candidates.map((c) => [c.text, c]));
+    expect(byText.get('привіт')?.status).toBe('atlas_attested');
+    expect(byText.get('книжка')?.status).toBe('atlas_attested');
+    // "це" and "моя" are not in the sample index, so must be flagged, never invented.
+    expect(byText.get('це')?.status).toBe('unverified');
+    expect(byText.get('моя')?.status).toBe('unverified');
+  });
+});

--- a/site/tests/unit/paste-text-vocab.test.ts
+++ b/site/tests/unit/paste-text-vocab.test.ts
@@ -59,11 +59,14 @@ describe('classifyPasteCandidates', () => {
     });
   });
 
-  test('never invents a CEFR level for an Atlas row missing one', () => {
+  test('never invents a CEFR level for an Atlas row missing one, and leaves it deselected', () => {
     const [candidate] = classifyPasteCandidates(['абракадабра'], index);
-    expect(candidate.status).toBe('atlas_attested');
-    expect(candidate.cefr).toBeNull();
-    expect(candidate.gloss).toBeNull();
+    expect(candidate).toMatchObject({
+      status: 'atlas_attested',
+      cefr: null,
+      gloss: null,
+      selected: false,
+    });
   });
 
   test('treats a blank Atlas gloss as null rather than an empty invented string', () => {
@@ -89,6 +92,21 @@ describe('summarizePasteCandidates', () => {
     expect(summary.byLevel.A1).toBe(1);
     expect(summary.byLevel.A2).toBe(1);
     expect(summary.byLevel.B1).toBe(0);
+  });
+
+  test('does not count an attested word with no CEFR level as selected or leveled', () => {
+    const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
+    const candidates = classifyPasteCandidates(
+      ['привіт', 'абракадабра'],
+      index,
+    );
+    const summary = summarizePasteCandidates(candidates);
+    expect(summary.total).toBe(2);
+    // both resolve to real Atlas rows, so both count as attested...
+    expect(summary.attested).toBe(2);
+    // ...but the one with no parseable CEFR level is deselected, not invented as A1
+    expect(summary.selected).toBe(1);
+    expect(summary.byLevel.A1).toBe(1);
   });
 
   test('excludes deselected candidates from the level tally even if attested', () => {


### PR DESCRIPTION
## Summary

Partial MVP for #5882 (paste-text → vocabulary → practice deck, enriched from lexicon).

The paste/upload wizard in `LexiconCustomDeckManager` (shipped with #5718's CustomSet model) already:
- let a user paste free text or upload a file,
- extracted Ukrainian word candidates,
- let the user confirm/edit selections before a local `CustomSet` materializes, and
- enriched cards from the Atlas at practice time (`ensureDeckCustomSetCoverage` in `LexiconPractice.tsx`) — untouched by this PR.

What was missing, per the operator vision: CEFR levels were a **word-length heuristic**, and every extracted string was **silently treated as confirmed vocabulary** — no attestation check at all.

This PR adds that check:
- New pure module `site/src/lib/lexicon/paste-text-vocab.ts`: classifies each candidate against the Atlas search index. Atlas entries are VESUM-gated before publication, so atlas-presence is used as the client-side attestation proxy (there's no full VESUM lemma list bundled to the browser). Attested words get their real CEFR level + gloss; everything else is `unverified` with `cefr: null`, `gloss: null` — nothing invented.
- Unverified candidates default to **deselected**, so a user has to consciously opt them in rather than silently ship them in a deck.
- Wizard review step (`LexiconCustomDeckManager.tsx`): real CEFR distribution bar (now includes C1/C2), an attestation banner (✅ in-dictionary / ❓ unverified counts), an "Unverified" filter chip, and per-group bulk toggles including unverified.
- `site/tests/unit/paste-text-vocab.test.ts`: unit tests for the classification/attestation pure functions (10 cases), including an end-to-end check that real tokenizer output classifies correctly against a sample index.

## What's residual for #5882

- **True VESUM form-level attestation** (beyond Atlas-lemma presence) — the full VESUM lemma set isn't bundled client-side; this PR uses Atlas-presence as a defensible proxy given the local-first, zero-backend architecture. Bundling a compact VESUM wordlist for stronger coverage is a follow-up.
- **Multiword residual** — explicitly out of scope per #6064.
- Dedicated component-level tests for the wizard UI — this sandbox's Node version (26.x) breaks `localStorage` in the existing happy-dom test harness for the whole `LexiconPractice.test.tsx` suite (confirmed pre-existing on `main`, unrelated to this diff); CI pins Node 22 where this doesn't reproduce. New pure-function tests were run and pass locally.

## Test plan
- [x] `npx vitest run tests/unit/paste-text-vocab.test.ts` — 10/10 passing
- [x] `npx tsc --noEmit` — no new errors introduced (3 pre-existing errors confirmed identical on `main` via `git stash` diff)
- [ ] CI (Node 22) full `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)