### PR TITLE
feat(lexicon): add 20k runner health probe

### DIFF
--- a/docs/runbooks/atlas-20k-runner-durability.md
+++ b/docs/runbooks/atlas-20k-runner-durability.md
@@ -69,6 +69,15 @@ ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
 scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # gate only, no sync
 ```
 
+`health_20k_runner.sh` is a status-only, fail-closed probe for atlas drivers:
+it requires `ATLAS_RUNNER_HOST`, checks the remote work-dir over SSH, then
+requires a fresh, restic-covered local mirror. It never starts enrichment or
+changes runner state:
+
+```bash
+ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/health_20k_runner.sh
+```
+
 ## Required workflow
 
 1. After every fetch/reduce/enrich phase on the VPS (or at minimum daily

--- a/scripts/lexicon/runner/README-offline-enrich.md
+++ b/scripts/lexicon/runner/README-offline-enrich.md
@@ -84,6 +84,13 @@ covers it:
 ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
 ```
 
+Atlas drivers can prove this run's remote work-dir and local durability state
+without starting enrichment by running:
+
+```bash
+ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/health_20k_runner.sh
+```
+
 Before any cleanup, execute the full durability order — **snapshot → restic
 backup → receipt gate → wipe**. The gate rejects a stale, missing, corrupt,
 or not-yet-backed-up mirror instead of guessing:

--- a/scripts/lexicon/runner/health_20k_runner.sh
+++ b/scripts/lexicon/runner/health_20k_runner.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fail-closed health probe for the Atlas 20k runner. This only reports state:
+# it never syncs a mirror, changes runner files, or starts enrichment (#6077).
+#
+# Required environment:
+#   ATLAS_RUNNER_HOST  ssh destination for the runner, for example ops@<runner-host>
+#
+# Optional environment follows mirror_20k_runner.sh:
+#   ATLAS_RUN_ROOT               remote run root (default /home/ops/atlas-runner)
+#   ATLAS_WORK_DIR_NAME          work-dir below the run root (default run-20k)
+#   ATLAS_MIRROR_DIR             local durable mirror directory
+#   ATLAS_MIRROR_MAX_AGE_HOURS   durable mirror age limit (default 24)
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK_DIR_NAME="${ATLAS_WORK_DIR_NAME:-run-20k}"
+RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+MIRROR_DIR="${ATLAS_MIRROR_DIR:-$REPO/data/lexicon/runner-mirror/$WORK_DIR_NAME}"
+MAX_AGE_HOURS="${ATLAS_MIRROR_MAX_AGE_HOURS:-24}"
+DURABLE_MIRROR=("$REPO/.venv/bin/python" "$REPO/scripts/lexicon/runner/durable_mirror.py")
+
+host_set=false
+mirror_present=false
+mirror_require_ok=false
+
+print_summary() {
+  printf 'host_set=%s\n' "$host_set"
+  printf 'mirror_present=%s\n' "$mirror_present"
+  printf 'mirror_require_ok=%s\n' "$mirror_require_ok"
+  printf 'mirror_age_hint=max_age_hours=%s\n' "$MAX_AGE_HOURS"
+}
+
+if [[ -z "${ATLAS_RUNNER_HOST:-}" ]]; then
+  printf 'ATLAS_RUNNER_HOST is required; see #6077 AC-HOST.\n' >&2
+  print_summary
+  exit 2
+fi
+host_set=true
+
+if ! command -v ssh >/dev/null 2>&1; then
+  printf 'runner SSH work-dir check failed: ssh is not available.\n' >&2
+  print_summary
+  exit 2
+fi
+
+remote_work_dir="$RUN_ROOT/$WORK_DIR_NAME"
+if ! ssh -o BatchMode=yes -- "$ATLAS_RUNNER_HOST" "test -d -- $(printf '%q' "$remote_work_dir")"; then
+  printf 'runner SSH work-dir check failed: remote work-dir is unavailable.\n' >&2
+  print_summary
+  exit 2
+fi
+
+if [[ -e "$MIRROR_DIR" ]]; then
+  mirror_present=true
+  if "${DURABLE_MIRROR[@]}" require --mirror-dir "$MIRROR_DIR" --max-age-hours "$MAX_AGE_HOURS"; then
+    mirror_require_ok=true
+  else
+    printf 'runner durable-mirror check failed; refresh and back up the mirror before cleanup.\n' >&2
+    print_summary
+    exit 2
+  fi
+else
+  printf 'runner durable-mirror check failed: no local mirror at %s.\n' "$MIRROR_DIR" >&2
+  print_summary
+  exit 2
+fi
+
+print_summary

--- a/scripts/lexicon/runner/health_20k_runner.sh
+++ b/scripts/lexicon/runner/health_20k_runner.sh
@@ -44,7 +44,7 @@ if ! command -v ssh >/dev/null 2>&1; then
 fi
 
 remote_work_dir="$RUN_ROOT/$WORK_DIR_NAME"
-if ! ssh -o BatchMode=yes -- "$ATLAS_RUNNER_HOST" "test -d -- $(printf '%q' "$remote_work_dir")"; then
+if ! ssh -o BatchMode=yes -o ConnectTimeout=10 -- "$ATLAS_RUNNER_HOST" "test -d -- $(printf '%q' "$remote_work_dir")"; then
   printf 'runner SSH work-dir check failed: remote work-dir is unavailable.\n' >&2
   print_summary
   exit 2

--- a/tests/test_health_20k_runner.py
+++ b/tests/test_health_20k_runner.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from scripts.lexicon.runner.durable_mirror import snapshot, write_restic_gate_receipt
+
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts/lexicon/runner/health_20k_runner.sh"
 
@@ -17,6 +19,37 @@ def _run_probe(*, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         text=True,
         check=False,
     )
+
+
+def _stub_ssh(tmp_path: Path, *, exit_code: int = 0) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ -n "${SSH_ARGS_FILE:-}" ]]; then\n'
+        '  printf "%s\\n" "$@" > "$SSH_ARGS_FILE"\n'
+        "fi\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    return fake_bin
+
+
+def _make_durable_mirror(tmp_path: Path) -> Path:
+    source = tmp_path / "runner-work"
+    source.mkdir()
+    (source / "ledger.sqlite").write_bytes(b"ledger")
+    mirror = tmp_path / "runner-mirror" / "run-20k"
+    snapshot(str(source), mirror, allow_live=True)
+    write_restic_gate_receipt(
+        mirror.parent,
+        restic_snapshot_id="a" * 64,
+        host="test-host",
+        git_sha="b" * 40,
+    )
+    return mirror
 
 
 def test_health_probe_requires_runner_host() -> None:
@@ -33,11 +66,7 @@ def test_health_probe_requires_runner_host() -> None:
 
 
 def test_health_probe_fails_closed_when_ssh_check_fails(tmp_path: Path) -> None:
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_ssh = fake_bin / "ssh"
-    fake_ssh.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
-    fake_ssh.chmod(0o755)
+    fake_bin = _stub_ssh(tmp_path, exit_code=1)
 
     result = _run_probe(
         env={
@@ -52,5 +81,81 @@ def test_health_probe_fails_closed_when_ssh_check_fails(tmp_path: Path) -> None:
         "host_set=true",
         "mirror_present=false",
         "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]
+
+
+def test_health_probe_fails_closed_without_local_mirror(tmp_path: Path) -> None:
+    fake_bin = _stub_ssh(tmp_path)
+    missing_mirror = tmp_path / "missing-mirror"
+
+    result = _run_probe(
+        env={
+            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_MIRROR_DIR": str(missing_mirror),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        }
+    )
+
+    assert result.returncode == 2
+    assert f"no local mirror at {missing_mirror}" in result.stderr
+    assert result.stdout.splitlines() == [
+        "host_set=true",
+        "mirror_present=false",
+        "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]
+
+
+def test_health_probe_fails_closed_when_mirror_is_not_durable(tmp_path: Path) -> None:
+    fake_bin = _stub_ssh(tmp_path)
+    mirror = tmp_path / "invalid-mirror"
+    mirror.mkdir()
+
+    result = _run_probe(
+        env={
+            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_MIRROR_DIR": str(mirror),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        }
+    )
+
+    assert result.returncode == 2
+    assert "runner durable-mirror check failed" in result.stderr
+    assert result.stdout.splitlines() == [
+        "host_set=true",
+        "mirror_present=true",
+        "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]
+
+
+def test_health_probe_succeeds_with_reachable_runner_and_durable_mirror(tmp_path: Path) -> None:
+    fake_bin = _stub_ssh(tmp_path)
+    mirror = _make_durable_mirror(tmp_path)
+    ssh_args = tmp_path / "ssh-args"
+
+    result = _run_probe(
+        env={
+            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_MIRROR_DIR": str(mirror),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "SSH_ARGS_FILE": str(ssh_args),
+        }
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert ssh_args.read_text(encoding="utf-8").splitlines()[:5] == [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "--",
+    ]
+    assert result.stdout.splitlines()[0].startswith(f"durable: {mirror} (1 files, generated_at=")
+    assert result.stdout.splitlines()[1:] == [
+        "host_set=true",
+        "mirror_present=true",
+        "mirror_require_ok=true",
         "mirror_age_hint=max_age_hours=24",
     ]

--- a/tests/test_health_20k_runner.py
+++ b/tests/test_health_20k_runner.py
@@ -1,0 +1,56 @@
+"""Black-box checks for the fail-closed Atlas 20k runner health probe."""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts/lexicon/runner/health_20k_runner.sh"
+
+
+def _run_probe(*, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO,
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_health_probe_requires_runner_host() -> None:
+    result = _run_probe(env={"ATLAS_RUNNER_HOST": ""})
+
+    assert result.returncode == 2
+    assert "ATLAS_RUNNER_HOST is required; see #6077 AC-HOST." in result.stderr
+    assert result.stdout.splitlines() == [
+        "host_set=false",
+        "mirror_present=false",
+        "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]
+
+
+def test_health_probe_fails_closed_when_ssh_check_fails(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+    fake_ssh.chmod(0o755)
+
+    result = _run_probe(
+        env={
+            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        }
+    )
+
+    assert result.returncode == 2
+    assert "runner SSH work-dir check failed" in result.stderr
+    assert result.stdout.splitlines() == [
+        "host_set=true",
+        "mirror_present=false",
+        "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]


### PR DESCRIPTION
## Summary

- add a fail-closed, status-only Atlas 20k runner health probe
- require host/work-dir reachability and a fresh restic-covered durable mirror
- document the probe and cover absent-host and SSH-failure paths

## Verification

- `bash -n scripts/lexicon/runner/health_20k_runner.sh`
- `shellcheck scripts/lexicon/runner/health_20k_runner.sh`
- `.venv/bin/ruff check tests/test_health_20k_runner.py`
- `.venv/bin/python -m pytest tests/test_health_20k_runner.py tests/test_lexicon_runner_durable_mirror.py -q`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Partially fixes #6077 (AC-WATCH tooling).

No auto-merge: requested by task brief.