### PR TITLE
fix(acp): persist fleet conversations outside worktrees

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -168,6 +168,15 @@ append-only state/timeline events through fleet-comms and file handoffs, which
 remain authoritative. The task, participant responses, credentials, paths,
 sessions, tool data, and raw model content do not enter metadata APIs.
 
+Unless `FLEET_COMMS_ROOT` is explicitly set, fleet-comms storage resolves
+through Git's common directory to the primary checkout at
+`batch_state/fleet-comms/v1`. A discussion launched from a dispatch worktree
+therefore keeps its timeline after that worktree is removed. The SQLite store
+uses WAL journaling, full synchronous commits, a bounded busy timeout, and
+private owner-only filesystem modes. The standard data-backup run snapshots
+this database through SQLite's online backup mechanism and verifies the staged
+copy before encrypted retention; do not copy WAL files manually.
+
 Runtime exposes body-free, read-only observability only:
 `GET /api/runtime/acp/conversations` and
 `GET /api/runtime/acp/conversations/{conversation_id}`. The visual timeline is

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -1018,6 +1018,9 @@ def _import_message_plane() -> Any | None:
 def _plane_root() -> Path:
     if _PLANE_ROOT_OVERRIDE is not None:
         return _PLANE_ROOT_OVERRIDE
+    plane_mod = _import_message_plane()
+    if plane_mod is not None:
+        return Path(plane_mod.default_plane_root(repo_root=REPO_ROOT))
     env = os.environ.get("FLEET_COMMS_ROOT")
     if env:
         return Path(env)

--- a/scripts/fleet_comms/artifacts.py
+++ b/scripts/fleet_comms/artifacts.py
@@ -340,8 +340,24 @@ class ArtifactStore:
 
     @classmethod
     def _prepare_private_dir(cls, path: Path) -> None:
-        path.mkdir(mode=_PRIVATE_DIR_MODE, parents=True, exist_ok=True)
-        cls._tighten_owned_mode(path, _PRIVATE_DIR_MODE, require_dir=True)
+        missing: list[Path] = []
+        candidate = path
+        while not candidate.exists():
+            missing.append(candidate)
+            parent = candidate.parent
+            if parent == candidate:
+                break
+            candidate = parent
+
+        for directory in reversed(missing):
+            directory.mkdir(mode=_PRIVATE_DIR_MODE, exist_ok=True)
+            cls._tighten_owned_mode(
+                directory,
+                _PRIVATE_DIR_MODE,
+                require_dir=True,
+            )
+        if not missing:
+            cls._tighten_owned_mode(path, _PRIVATE_DIR_MODE, require_dir=True)
 
     @staticmethod
     def _tighten_owned_mode(path: Path, mode: int, *, require_dir: bool) -> None:

--- a/scripts/fleet_comms/artifacts.py
+++ b/scripts/fleet_comms/artifacts.py
@@ -85,11 +85,13 @@ class ArtifactStore:
         self._prepare_private_dir(self.blob_root)
         self._conn = sqlite3.connect(
             str(self.db_path),
-            timeout=_BUSY_TIMEOUT_MS / 1_000,
+            # WAL initialization owns its bounded retry loop below. Install
+            # the normal statement busy timeout only after WAL is established.
+            timeout=0,
         )
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
         self._enable_wal()
+        self._conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
         self._conn.execute("PRAGMA synchronous = FULL")
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._tighten_owned_mode(self.db_path, _PRIVATE_FILE_MODE, require_dir=False)

--- a/scripts/fleet_comms/artifacts.py
+++ b/scripts/fleet_comms/artifacts.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import sqlite3
 import tempfile
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -25,9 +26,13 @@ from typing import Any
 
 from scripts.fleet_comms.contracts import new_id
 from scripts.fleet_comms.migrations import apply_migrations
+from scripts.fleet_comms.paths import DEFAULT_ROOT_REL, default_plane_root
 
-DEFAULT_ROOT = Path("batch_state/fleet-comms/v1")
+DEFAULT_ROOT = DEFAULT_ROOT_REL
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9._@+=,-][A-Za-z0-9._@+=, -]{0,200}$")
+_PRIVATE_DIR_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+_BUSY_TIMEOUT_MS = 5_000
 
 
 def _utc_now() -> str:
@@ -68,16 +73,33 @@ class ArtifactStore:
     """SQLite metadata + content-addressed blob store."""
 
     def __init__(self, root: Path | None = None, *, repo_root: Path | None = None) -> None:
-        base = repo_root or Path.cwd()
-        self.root = (root if root is not None else base / DEFAULT_ROOT).resolve()
+        self.root = (
+            Path(root).resolve()
+            if root is not None
+            else default_plane_root(repo_root=repo_root)
+        )
         self.blob_root = self.root / "blobs" / "sha256"
         self.db_path = self.root / "comms.sqlite3"
-        self.root.mkdir(parents=True, exist_ok=True)
-        self.blob_root.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(self.db_path))
+        self._prepare_private_dir(self.root)
+        self._prepare_private_dir(self.root / "blobs")
+        self._prepare_private_dir(self.blob_root)
+        self._conn = sqlite3.connect(
+            str(self.db_path),
+            timeout=_BUSY_TIMEOUT_MS / 1_000,
+        )
         self._conn.row_factory = sqlite3.Row
+        self._conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        self._enable_wal()
+        self._conn.execute("PRAGMA synchronous = FULL")
         self._conn.execute("PRAGMA foreign_keys = ON")
+        self._tighten_owned_mode(self.db_path, _PRIVATE_FILE_MODE, require_dir=False)
         apply_migrations(self._conn)
+        for suffix in ("-wal", "-shm"):
+            self._tighten_owned_mode(
+                Path(f"{self.db_path}{suffix}"),
+                _PRIVATE_FILE_MODE,
+                require_dir=False,
+            )
 
     def close(self) -> None:
         self._conn.close()
@@ -114,7 +136,7 @@ class ArtifactStore:
             logical_filename = self._validate_filename(logical_filename)
         digest = hashlib.sha256(data).hexdigest()
         dest = self.blob_path_for(digest)
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        self._prepare_private_dir(dest.parent)
 
         existing = self._conn.execute(
             "SELECT * FROM artifacts WHERE sha256 = ?", (digest,)
@@ -308,10 +330,43 @@ class ArtifactStore:
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp_path, dest)
+            self._tighten_owned_mode(dest, _PRIVATE_FILE_MODE, require_dir=False)
         except Exception:
             with contextlib.suppress(OSError):
                 tmp_path.unlink(missing_ok=True)
             raise
+
+    @classmethod
+    def _prepare_private_dir(cls, path: Path) -> None:
+        path.mkdir(mode=_PRIVATE_DIR_MODE, parents=True, exist_ok=True)
+        cls._tighten_owned_mode(path, _PRIVATE_DIR_MODE, require_dir=True)
+
+    @staticmethod
+    def _tighten_owned_mode(path: Path, mode: int, *, require_dir: bool) -> None:
+        """Tighten only owned, non-symlink store paths."""
+        try:
+            stat_result = path.lstat()
+        except OSError:
+            return
+        if path.is_symlink() or stat_result.st_uid != os.getuid():
+            return
+        if require_dir != path.is_dir():
+            return
+        path.chmod(mode)
+
+    def _enable_wal(self) -> None:
+        """Establish WAL even when multiple first-openers race."""
+        deadline = time.monotonic() + (_BUSY_TIMEOUT_MS / 1_000)
+        while True:
+            try:
+                row = self._conn.execute("PRAGMA journal_mode = WAL").fetchone()
+                if row is None or str(row[0]).lower() != "wal":
+                    raise ArtifactStoreError("fleet communications database refused WAL mode")
+                return
+            except sqlite3.OperationalError as exc:
+                if "locked" not in str(exc).lower() or time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
 
     def _row_to_record(self, row: sqlite3.Row) -> ArtifactRecord:
         digest = str(row["sha256"])

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -32,8 +32,8 @@ from typing import Any, Literal
 
 from scripts.fleet_comms.contracts import CompletionState
 from scripts.fleet_comms.paths import (
-    DEFAULT_ROOT_REL,
-    ENV_ROOT,
+    DEFAULT_ROOT_REL,  # re-exported for compatibility
+    ENV_ROOT,  # re-exported for compatibility
     default_plane_root,
 )
 from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -31,18 +31,20 @@ from pathlib import Path
 from typing import Any, Literal
 
 from scripts.fleet_comms.contracts import CompletionState
+from scripts.fleet_comms.paths import (
+    DEFAULT_ROOT_REL,
+    ENV_ROOT,
+    default_plane_root,
+)
 from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord
 
 logger = logging.getLogger(__name__)
 
 PlaneMode = Literal["off", "shadow", "dual_write"]
 ENV_MODE = "FLEET_COMMS_MESSAGE_PLANE"
-ENV_ROOT = "FLEET_COMMS_ROOT"
 ENV_TELEMETRY = "FLEET_COMMS_PLANE_TELEMETRY"
 # Max centrally configured continuation segments for length_limited (Sol).
 MAX_CONTINUATIONS = 2
-# Conventional relative layout under the plane root (batch_state/fleet-comms/v1).
-DEFAULT_ROOT_REL = Path("batch_state") / "fleet-comms" / "v1"
 DEFAULT_TELEMETRY_NAME = Path("telemetry") / "plane-parity.jsonl"
 _TELEMETRY_SUMMARY_LIMIT = 50
 
@@ -102,15 +104,6 @@ def resolve_plane_mode(raw: str | None = None) -> PlaneMode:
     if value in {"dual-write", "dualwrite"}:
         return "dual_write"
     raise ValueError(f"invalid FLEET_COMMS_MESSAGE_PLANE={value!r} (use off|shadow|dual_write)")
-
-
-def default_plane_root(*, repo_root: Path | None = None) -> Path:
-    """Resolve plane storage root (env override or batch_state/fleet-comms/v1)."""
-    env = os.environ.get(ENV_ROOT)
-    if env:
-        return Path(env).expanduser()
-    base = repo_root if repo_root is not None else Path.cwd()
-    return (base / DEFAULT_ROOT_REL).resolve()
 
 
 def default_parity_telemetry_path(root: Path | None = None) -> Path:

--- a/scripts/fleet_comms/paths.py
+++ b/scripts/fleet_comms/paths.py
@@ -1,0 +1,29 @@
+"""Canonical durable paths for fleet communications state."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scripts.guardrails.worktree_containment import (
+    NotAGitRepositoryError,
+    resolve_main_root,
+)
+
+ENV_ROOT = "FLEET_COMMS_ROOT"
+DEFAULT_ROOT_REL = Path("batch_state") / "fleet-comms" / "v1"
+
+
+def default_plane_root(*, repo_root: Path | None = None) -> Path:
+    """Resolve fleet state beneath the primary checkout, unless explicitly overridden."""
+    env = os.environ.get(ENV_ROOT)
+    if env:
+        return Path(env).expanduser()
+
+    candidate = repo_root if repo_root is not None else Path.cwd()
+    try:
+        base = resolve_main_root(candidate)
+    except NotAGitRepositoryError:
+        # Preserve support for isolated non-Git callers and test fixtures.
+        base = candidate.resolve()
+    return (base / DEFAULT_ROOT_REL).resolve()

--- a/scripts/fleet_comms/paths.py
+++ b/scripts/fleet_comms/paths.py
@@ -18,7 +18,7 @@ def default_plane_root(*, repo_root: Path | None = None) -> Path:
     """Resolve fleet state beneath the primary checkout, unless explicitly overridden."""
     env = os.environ.get(ENV_ROOT)
     if env:
-        return Path(env).expanduser()
+        return Path(env).expanduser().resolve()
 
     candidate = repo_root if repo_root is not None else Path.cwd()
     try:

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -123,7 +123,7 @@ def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
             check=False,
             env=sanitized_git_env(),
         )
-    except OSError as exc:
+    except FileNotFoundError as exc:
         # Root resolution promises an on-disk .git fallback when Git cannot
         # execute. Represent an unavailable subprocess as a failed probe so
         # callers reach that fallback rather than aborting.

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -114,13 +114,25 @@ class WriteDecision:
 
 def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run a read-only git command scoped to ``cwd`` with sanitized env."""
-    return subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=sanitized_git_env(),
-    )
+    argv = ["git", "-C", str(cwd), *args]
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=sanitized_git_env(),
+        )
+    except OSError as exc:
+        # Root resolution promises an on-disk .git fallback when Git cannot
+        # execute. Represent an unavailable subprocess as a failed probe so
+        # callers reach that fallback rather than aborting.
+        return subprocess.CompletedProcess(
+            argv,
+            returncode=127,
+            stdout="",
+            stderr=str(exc),
+        )
 
 
 def _git_dir_for(path: Path) -> Path:

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sqlite3
 import threading
 from pathlib import Path
@@ -11,6 +12,8 @@ import pytest
 from scripts.agent_runtime import acpx_discuss
 from scripts.agent_runtime.errors import AgentTimeoutError
 from scripts.agent_runtime.result import Result
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.message_plane import default_plane_root
 
 
 def _result(agent: str, response: str, *, tokens: int = 5) -> Result:
@@ -90,6 +93,52 @@ def test_two_participants_are_parallel_and_completed_replay_makes_no_calls(tmp_p
     edges = {(str(row[0]), str(row[1])) for row in rows}
     assert {("root", "codex"), ("root", "grok"), ("codex", "root"), ("grok", "root"), ("codex", "grok"), ("grok", "codex")} <= edges
     assert any(row[2] is not None for row in rows)
+
+
+def test_conversation_survives_dispatch_worktree_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "active")
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    monkeypatch.setattr(acpx_discuss, "classify_repo_path", lambda *_a, **_k: "dispatch_worktree")
+    primary = tmp_path / "primary"
+    (primary / ".git").mkdir(parents=True)
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / "acp-proof"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(
+        f"gitdir: {primary / '.git' / 'worktrees' / 'acp-proof'}\n",
+        encoding="utf-8",
+    )
+    root = default_plane_root(repo_root=worktree)
+    with ArtifactStore(repo_root=worktree) as default_store:
+        assert default_store.root == root
+    controller = acpx_discuss.AcpxDiscussionController(
+        root=root,
+        participant_call=lambda agent, _prompt, **_kwargs: _result(agent, f"{agent} evidence"),
+        synthesis_call=lambda agent, _prompt, **_kwargs: _result(agent, "durable synthesis"),
+    )
+    try:
+        payload = controller.run(
+            prompt="Prove cleanup durability.",
+            cwd=worktree,
+            task_id="task-6087",
+            correlation_id="corr-6087",
+            idempotency_key="idem-6087",
+            rounds=1,
+        )
+    finally:
+        controller.close()
+
+    shutil.rmtree(primary / ".worktrees")
+
+    assert root == primary / "batch_state" / "fleet-comms" / "v1"
+    assert not worktree.exists()
+    with ArtifactStore(root=root) as reopened:
+        row = reopened.connection.execute(
+            "SELECT state FROM acp_conversation_events "
+            "WHERE conversation_id = ? ORDER BY sequence DESC LIMIT 1",
+            (payload["conversation_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "COMPLETE"
 
 
 def test_three_rounds_repeat_cross_exchange_and_complete(tmp_path, monkeypatch):

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -319,6 +319,20 @@ def _enable_plane(monkeypatch, tmp_path, mode: str) -> None:
     monkeypatch.setattr(lifecycle, "_PLANE_ROOT_OVERRIDE", tmp_path / "fleet-comms-v1")
 
 
+def test_plane_root_uses_shared_primary_root_resolver(monkeypatch, tmp_path):
+    resolved = tmp_path / "primary" / "batch_state" / "fleet-comms" / "v1"
+    plane_mod = Mock()
+    plane_mod.default_plane_root.return_value = resolved
+    monkeypatch.setattr(lifecycle, "_PLANE_ROOT_OVERRIDE", None)
+    monkeypatch.setattr(lifecycle, "_import_message_plane", lambda: plane_mod)
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path / "linked-worktree")
+
+    assert lifecycle._plane_root() == resolved
+    plane_mod.default_plane_root.assert_called_once_with(
+        repo_root=tmp_path / "linked-worktree"
+    )
+
+
 def test_message_plane_off_is_noop_for_register_and_reply(bridge_db, monkeypatch, tmp_path):
     """Default off: no fleet_request_id, reply path unchanged."""
     _enable_plane(monkeypatch, tmp_path, "off")

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -492,18 +492,24 @@ def test_execute_snapshots_sqlite3_database_from_batch_state(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
 ) -> None:
     environment, source, staging, _legacy = backup_environment
-    database = source.parent / "batch_state" / "monitor.sqlite3"
+    database = (
+        source.parent / "batch_state" / "fleet-comms" / "v1" / "comms.sqlite3"
+    )
+    database.parent.mkdir(parents=True)
     connection = sqlite3.connect(database)
     connection.execute("CREATE TABLE recovery_probe (value TEXT NOT NULL)")
     connection.execute("INSERT INTO recovery_probe VALUES ('batch')")
     connection.commit()
     connection.close()
-    environment["FAKE_DB_RELATIVE"] = "batch_state/monitor.sqlite3"
+    environment["FAKE_DB_RELATIVE"] = "batch_state/fleet-comms/v1/comms.sqlite3"
 
     result = _run(environment, "backup", "--execute")
 
     assert result.returncode == 0, result.stderr
-    assert "consistent SQLite snapshot: batch_state/monitor.sqlite3" in result.stdout
+    assert (
+        "consistent SQLite snapshot: batch_state/fleet-comms/v1/comms.sqlite3"
+        in result.stdout
+    )
     assert "db_rows=<1>" in _log(environment)
     assert list(staging.iterdir()) == []
 

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -72,6 +72,20 @@ def test_default_plane_root_preserves_override_and_non_git_fallback(
     )
 
 
+def test_default_plane_root_makes_relative_override_stable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller_root = tmp_path / "caller"
+    caller_root.mkdir()
+    monkeypatch.chdir(caller_root)
+    monkeypatch.setenv("FLEET_COMMS_ROOT", "relative-plane")
+
+    resolved = default_plane_root(repo_root=tmp_path / "ignored")
+
+    assert resolved == caller_root / "relative-plane"
+    assert resolved.is_absolute()
+
+
 def test_message_plane_preserves_public_root_constants() -> None:
     import scripts.fleet_comms.message_plane as message_plane
     from scripts.fleet_comms.paths import DEFAULT_ROOT_REL, ENV_ROOT

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -72,6 +72,14 @@ def test_default_plane_root_preserves_override_and_non_git_fallback(
     )
 
 
+def test_message_plane_preserves_public_root_constants() -> None:
+    import scripts.fleet_comms.message_plane as message_plane
+    from scripts.fleet_comms.paths import DEFAULT_ROOT_REL, ENV_ROOT
+
+    assert message_plane.DEFAULT_ROOT_REL is DEFAULT_ROOT_REL
+    assert message_plane.ENV_ROOT is ENV_ROOT
+
+
 def test_configured_default_fail_open_on_malformed_yaml(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -11,6 +11,7 @@ from scripts.fleet_comms.contracts import CompletionState
 from scripts.fleet_comms.message_plane import (
     MAX_CONTINUATIONS,
     MessagePlane,
+    default_plane_root,
     invocation_digest,
     resolve_plane_mode,
 )
@@ -36,6 +37,39 @@ def test_resolve_plane_mode_env_unset_uses_configured_default(
     assert resolve_plane_mode(None) == "off"
     monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "dual_write")
     assert resolve_plane_mode(None) == "dual_write"
+
+
+def test_default_plane_root_anchors_linked_worktree_to_primary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    primary = tmp_path / "primary"
+    (primary / ".git").mkdir(parents=True)
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / "proof"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(
+        f"gitdir: {primary / '.git' / 'worktrees' / 'proof'}\n",
+        encoding="utf-8",
+    )
+
+    expected = primary / "batch_state" / "fleet-comms" / "v1"
+    assert default_plane_root(repo_root=primary) == expected
+    assert default_plane_root(repo_root=worktree) == expected
+
+
+def test_default_plane_root_preserves_override_and_non_git_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    override = tmp_path / "explicit-plane"
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(override))
+    assert default_plane_root(repo_root=isolated) == override
+
+    monkeypatch.delenv("FLEET_COMMS_ROOT")
+    assert default_plane_root(repo_root=isolated) == (
+        isolated / "batch_state" / "fleet-comms" / "v1"
+    )
 
 
 def test_configured_default_fail_open_on_malformed_yaml(

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -35,13 +35,15 @@ def test_artifact_store_round_trip_and_dedup(tmp_path: Path) -> None:
 
 
 def test_artifact_store_uses_durable_sqlite_and_private_modes(tmp_path: Path) -> None:
-    root = tmp_path / "v1"
+    root = tmp_path / "fresh" / "fleet-comms" / "v1"
     with ArtifactStore(root=root) as store:
         store.store_text("private conversation", producer="test")
         assert store.connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert store.connection.execute("PRAGMA synchronous").fetchone()[0] == 2
         assert store.connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert store.connection.execute("PRAGMA busy_timeout").fetchone()[0] == 5_000
+        assert stat.S_IMODE((tmp_path / "fresh").stat().st_mode) == 0o700
+        assert stat.S_IMODE((tmp_path / "fresh" / "fleet-comms").stat().st_mode) == 0o700
         assert stat.S_IMODE(root.stat().st_mode) == 0o700
         assert stat.S_IMODE((root / "blobs").stat().st_mode) == 0o700
         assert stat.S_IMODE(store.blob_root.stat().st_mode) == 0o700

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import stat
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,29 @@ def test_artifact_store_round_trip_and_dedup(tmp_path: Path) -> None:
         b = store.store_bytes(b"hello fleet", producer="other")
         assert b.artifact_id == a.artifact_id  # content-addressed reuse
         assert b.sha256 == a.sha256
+
+
+def test_artifact_store_uses_durable_sqlite_and_private_modes(tmp_path: Path) -> None:
+    root = tmp_path / "v1"
+    with ArtifactStore(root=root) as store:
+        store.store_text("private conversation", producer="test")
+        assert store.connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert store.connection.execute("PRAGMA synchronous").fetchone()[0] == 2
+        assert store.connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert store.connection.execute("PRAGMA busy_timeout").fetchone()[0] == 5_000
+        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+        assert stat.S_IMODE((root / "blobs").stat().st_mode) == 0o700
+        assert stat.S_IMODE(store.blob_root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(store.db_path.stat().st_mode) == 0o600
+
+        with ArtifactStore(root=root) as reader:
+            store.connection.execute("BEGIN IMMEDIATE")
+            try:
+                assert reader.connection.execute(
+                    "SELECT COUNT(*) FROM artifacts"
+                ).fetchone()[0] == 1
+            finally:
+                store.connection.rollback()
 
 
 def test_artifact_store_rejects_traversal_filename(tmp_path: Path) -> None:

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sqlite3
 import stat
 from pathlib import Path
 
@@ -54,6 +55,36 @@ def test_artifact_store_uses_durable_sqlite_and_private_modes(tmp_path: Path) ->
                 ).fetchone()[0] == 1
             finally:
                 store.connection.rollback()
+
+
+def test_artifact_store_wal_setup_retries_fast_lock_failures(monkeypatch) -> None:
+    class FakeCursor:
+        def fetchone(self):
+            return ("wal",)
+
+    class RacingConnection:
+        calls = 0
+
+        def execute(self, _statement):
+            self.calls += 1
+            if self.calls < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return FakeCursor()
+
+    sleeps: list[float] = []
+    connection = RacingConnection()
+    store = ArtifactStore.__new__(ArtifactStore)
+    store._conn = connection
+    monkeypatch.setattr("scripts.fleet_comms.artifacts.time.monotonic", lambda: 0.0)
+    monkeypatch.setattr(
+        "scripts.fleet_comms.artifacts.time.sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
+
+    store._enable_wal()
+
+    assert connection.calls == 3
+    assert sleeps == [0.05, 0.05]
 
 
 def test_artifact_store_rejects_traversal_filename(tmp_path: Path) -> None:

--- a/tests/test_worktree_containment.py
+++ b/tests/test_worktree_containment.py
@@ -118,6 +118,18 @@ def test_resolve_main_root_uses_filesystem_fallback_when_git_cannot_execute(
     assert wc.resolve_main_root(layout.dispatch_wt) == layout.main
 
 
+def test_git_probe_propagates_non_missing_executable_errors(
+    layout: Layout, monkeypatch: pytest.MonkeyPatch
+):
+    def forbidden_git(*_args, **_kwargs):
+        raise PermissionError("git execution forbidden")
+
+    monkeypatch.setattr(wc.subprocess, "run", forbidden_git)
+
+    with pytest.raises(PermissionError, match="forbidden"):
+        wc.resolve_main_root(layout.main)
+
+
 # ---------------------------------------------------------------------------
 # classify_repo_path
 # ---------------------------------------------------------------------------

--- a/tests/test_worktree_containment.py
+++ b/tests/test_worktree_containment.py
@@ -106,6 +106,18 @@ def test_resolve_main_root_raises_outside_repo(layout: Layout):
         wc.resolve_main_root(layout.outside)
 
 
+def test_resolve_main_root_uses_filesystem_fallback_when_git_cannot_execute(
+    layout: Layout, monkeypatch: pytest.MonkeyPatch
+):
+    def missing_git(*_args, **_kwargs):
+        raise FileNotFoundError("git unavailable")
+
+    monkeypatch.setattr(wc.subprocess, "run", missing_git)
+
+    assert wc.resolve_main_root(layout.main) == layout.main
+    assert wc.resolve_main_root(layout.dispatch_wt) == layout.main
+
+
 # ---------------------------------------------------------------------------
 # classify_repo_path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- resolve the default fleet-comms root through Git common-dir so all linked worktrees share primary-checkout state
- route bridge and direct store defaults through the shared resolver while preserving explicit `FLEET_COMMS_ROOT`
- normalize configured overrides to a stable absolute path
- harden conversation SQLite with WAL, `synchronous=FULL`, a bounded busy timeout, and owner-only modes for every directory the store creates
- make the canonical Git-root resolver retain its on-disk fallback when Git is missing while other execution failures remain fail-loud
- prove dispatch-worktree cleanup survival and exact inclusion in the existing verified online backup

## Verification

- 183 targeted tests passed across fleet store/plane, ACP controller, bridge lifecycle, Runtime API, rollout acceptance, backup recovery, services lifecycle, and worktree containment
- Ruff, Python compilation, OPSEC diff scan, diff check, protected-file checks, and commit-trailer checks passed
- Authenticated one-round Codex↔Grok E2E completed as `conversation_5f05ed24208641b9af962ff7d2f3694b`; primary Runtime API/UI report `COMPLETE`
- Exact-head idempotent replay was suppressed without provider calls
- Four Claude review cycles produced six findings; all were fixed with regression coverage
- Final exact-head Claude Sonnet 5 review passed with no findings; formal verdict published `APPROVED`

## Scope

The artifact body-reference crash window discovered during this work is tracked separately in #6089. This PR does not change participant rollout, message-plane authority, retention policy, routing/failover, or formal-review eligibility.

Fixes #6087
Parent: #4707

Rail-Approval-Receipt: rail-approval-bcb4125e33a04bc1aa9f6b18eabdc9e4