### PR TITLE
fix(codex): preserve bridge context continuity

### DIFF
--- a/agents_extensions/shared/hooks/check-gemini-inbox.sh
+++ b/agents_extensions/shared/hooks/check-gemini-inbox.sh
@@ -10,6 +10,7 @@ if [ "${GEMINI_SESSION:-}" = "1" ] || [ "${LEARN_UKRAINIAN_PIPELINE:-}" = "1" ];
   exit 0
 fi
 
+HOOK_INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 DB="$PROJECT_DIR/.mcp/servers/message-broker/messages.db"
 RECIPIENT="${LEARN_UK_HOOK_RECIPIENT:-claude}"
@@ -25,11 +26,40 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
-# Count unclaimed, unacknowledged messages for this hook's provider.
-COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE to_llm='$RECIPIENT' AND acknowledged=0 AND claimed_by IS NULL" 2>/dev/null)
+# Count unclaimed, unacknowledged messages for this hook's provider. Keep the
+# pending IDs separate from previews: the session-local dedupe state may never
+# contain message content.
+PENDING_IDS=$(sqlite3 "$DB" "SELECT id FROM messages WHERE to_llm='$RECIPIENT' AND acknowledged=0 AND claimed_by IS NULL ORDER BY id ASC" 2>/dev/null)
+COUNT=$(printf '%s\n' "$PENDING_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
 
 if [ -z "$COUNT" ] || [ "$COUNT" -eq 0 ]; then
   exit 0
+fi
+
+# A UserPromptSubmit hook can fire repeatedly before another worker claims or
+# acknowledges its message. Suppress only an identical recipient/session ID
+# list. No session identity or unavailable state is deliberately fail-open.
+SESSION_ID="${LEARN_UK_HOOK_SESSION_ID:-${LEARN_UKRAINIAN_SESSION_ID:-${CODEX_THREAD_ID:-${CODEX_SESSION_ID:-}}}}"
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+fi
+if [ -n "$SESSION_ID" ]; then
+  STATE_DIR="$PROJECT_DIR/.agent/runtime"
+  STATE_KEY=$(printf '%s\n%s' "$RECIPIENT" "$SESSION_ID" | cksum | awk '{print $1 "-" $2}')
+  STATE_FILE="$STATE_DIR/inbox-${STATE_KEY}.ids"
+  if mkdir -p "$STATE_DIR" 2>/dev/null; then
+    STATE_TMP=$(mktemp "$STATE_DIR/.inbox-${STATE_KEY}.XXXXXX" 2>/dev/null || true)
+    if [ -n "$STATE_TMP" ]; then
+      printf '%s\n' "$PENDING_IDS" > "$STATE_TMP"
+      if [ -f "$STATE_FILE" ] && cmp -s "$STATE_TMP" "$STATE_FILE"; then
+        rm -f "$STATE_TMP"
+        exit 0
+      fi
+      if ! mv -f "$STATE_TMP" "$STATE_FILE" 2>/dev/null; then
+        rm -f "$STATE_TMP"
+      fi
+    fi
+  fi
 fi
 
 # Get message previews (only unclaimed)

--- a/agents_extensions/shared/hooks/check-gemini-inbox.sh
+++ b/agents_extensions/shared/hooks/check-gemini-inbox.sh
@@ -45,9 +45,12 @@ if [ -z "$SESSION_ID" ]; then
 fi
 if [ -n "$SESSION_ID" ]; then
   STATE_DIR="$PROJECT_DIR/.agent/runtime"
-  STATE_KEY=$(printf '%s\n%s' "$RECIPIENT" "$SESSION_ID" | cksum | awk '{print $1 "-" $2}')
+  STATE_KEY=""
+  if command -v shasum >/dev/null 2>&1; then
+    STATE_KEY=$(printf '%s\n%s' "$RECIPIENT" "$SESSION_ID" | shasum -a 256 | awk '{print $1}')
+  fi
   STATE_FILE="$STATE_DIR/inbox-${STATE_KEY}.ids"
-  if mkdir -p "$STATE_DIR" 2>/dev/null; then
+  if [ -n "$STATE_KEY" ] && mkdir -p "$STATE_DIR" 2>/dev/null; then
     STATE_TMP=$(mktemp "$STATE_DIR/.inbox-${STATE_KEY}.XXXXXX" 2>/dev/null || true)
     if [ -n "$STATE_TMP" ]; then
       printf '%s\n' "$PENDING_IDS" > "$STATE_TMP"

--- a/agents_extensions/shared/hooks/enforce-venv.sh
+++ b/agents_extensions/shared/hooks/enforce-venv.sh
@@ -42,6 +42,21 @@ if echo "$COMMAND" | grep -qE '^python3?[[:space:]]'; then
     exit 2
   fi
 
+  PYTHON_VERSION_FILE="${CANONICAL_ROOT:+$CANONICAL_ROOT/}.python-version"
+  if [ ! -f "$PYTHON_VERSION_FILE" ]; then
+    printf 'Unqualified interpreter blocked: project Python pin is missing at %s\n' \
+      "$PYTHON_VERSION_FILE" >&2
+    exit 2
+  fi
+  EXPECTED_PYTHON_VERSION=$(head -1 "$PYTHON_VERSION_FILE" | tr -d '[:space:]')
+  ACTUAL_PYTHON_VERSION=$("$PYTHON_BIN" --version 2>&1)
+  if [ -z "$EXPECTED_PYTHON_VERSION" ] \
+    || [ "$ACTUAL_PYTHON_VERSION" != "Python $EXPECTED_PYTHON_VERSION" ]; then
+    printf 'Unqualified interpreter blocked: expected Python %s, got %s\n' \
+      "${EXPECTED_PYTHON_VERSION:-<missing pin>}" "${ACTUAL_PYTHON_VERSION:-<unavailable>}" >&2
+    exit 2
+  fi
+
   case "$COMMAND" in
     python3*) FIXED="${PYTHON_BIN}${COMMAND#python3}" ;;
     python*) FIXED="${PYTHON_BIN}${COMMAND#python}" ;;

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -26,10 +26,6 @@ CONTEXT=""
 # exception: hydrate only its exact stream and point at the durable shadow
 # diary instead of scanning every rollover or curriculum artifact.
 POST_COMPACT_AGENT="${SESSION_HANDOFF_AGENT:-}"
-POST_COMPACT_AGENT_EXPLICIT=0
-if [ -n "$POST_COMPACT_AGENT" ]; then
-  POST_COMPACT_AGENT_EXPLICIT=1
-fi
 if [ -z "$POST_COMPACT_AGENT" ] \
   && { [[ "${0:-}" == *"/.codex/"* ]] || [ -n "${CODEX_THREAD_ID:-}${CODEX_SESSION_ID:-}${CODEX_SESSION:-}" ]; }; then
   POST_COMPACT_AGENT="codex"
@@ -37,26 +33,21 @@ fi
 case "$POST_COMPACT_AGENT" in
   codex|codex-*)
     if [ -z "${SESSION_EPIC:-}" ]; then
-      if [ "$POST_COMPACT_AGENT_EXPLICIT" = "0" ]; then
-        exit 0
-      fi
+      # Native Codex compaction is self-contained for non-driver tasks. This
+      # includes explicitly tagged Codex sessions: they must never fall through
+      # into the shared Claude-oriented replay below.
+      exit 0
     else
       DIARY_REL=".claude/${SESSION_EPIC}-epic/CODEX-DRIVER-HANDOFF.md"
       if [ ! -f "$PROJECT_DIR/$DIARY_REL" ]; then
-        for candidate in \
-          ".claude/${SESSION_EPIC}-epic/INTERIM-DRIVER-HANDOFF.md" \
-          ".claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md"; do
-          if [ -f "$PROJECT_DIR/$candidate" ]; then
-            DIARY_REL="$candidate"
-            break
-          fi
-        done
+        HYDRATION_RC=2
+        HYDRATION="Exact Codex driver handoff is missing: $DIARY_REL"
+      else
+        HYDRATION_RC=0
+        HYDRATION=$(run_bounded 2 "$BOUNDED_PYTHON" \
+          -m scripts.session_canary.codex_lane hydrate --epic "$SESSION_EPIC" 2>&1) \
+          || HYDRATION_RC=$?
       fi
-
-      HYDRATION_RC=0
-      HYDRATION=$(run_bounded 2 "$BOUNDED_PYTHON" \
-        -m scripts.session_canary.codex_lane hydrate --epic "$SESSION_EPIC" 2>&1) \
-        || HYDRATION_RC=$?
       if [ "$HYDRATION_RC" -eq 0 ]; then
         CONTEXT="CODEX FLEET-DRIVER HYDRATION
 $HYDRATION

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -252,15 +252,24 @@ if [ -n "${LEARN_UKRAINIAN_CLAUDEX_RUN_ID:-}" ]; then
   fi
 fi
 
-# 1. Check .venv exists and has correct Python
-if [ ! -f "$PROJECT_DIR/.venv/bin/python" ]; then
-  ISSUES+=("VENV MISSING: .venv/bin/python not found. Recreate: rm -rf .venv && ~/.pyenv/versions/3.12.8/bin/python -m venv .venv")
+# 1. Check the canonical venv against the repository's exact Python pin. Linked
+# worktrees deliberately do not carry a local .venv, so this must not inspect
+# PROJECT_DIR here.
+PYTHON_VERSION_FILE="$CANONICAL_ROOT/.python-version"
+CANONICAL_PYTHON="$CANONICAL_ROOT/.venv/bin/python"
+if [ ! -f "$PYTHON_VERSION_FILE" ]; then
+  ISSUES+=("PYTHON VERSION PIN MISSING: expected .python-version at $PYTHON_VERSION_FILE")
+elif [ ! -x "$CANONICAL_PYTHON" ]; then
+  ISSUES+=("VENV MISSING: canonical .venv/bin/python not found. Recreate it with the version in .python-version.")
 else
-  PY_VERSION=$(run_bounded 1 "$PROJECT_DIR/.venv/bin/python" --version 2>/dev/null)
-  if [[ "$PY_VERSION" != *"3.12"* ]]; then
-    ISSUES+=("VENV WRONG PYTHON: Expected 3.12.x, got $PY_VERSION")
+  EXPECTED_PYTHON_VERSION=$(head -1 "$PYTHON_VERSION_FILE" | tr -d '[:space:]')
+  PY_VERSION=$(run_bounded 1 "$CANONICAL_PYTHON" --version 2>&1)
+  if [ -z "$EXPECTED_PYTHON_VERSION" ] || [ "$PY_VERSION" != "Python $EXPECTED_PYTHON_VERSION" ]; then
+    ISSUES+=("VENV WRONG PYTHON: Expected Python ${EXPECTED_PYTHON_VERSION:-<missing pin>}, got ${PY_VERSION:-<unavailable>}")
   fi
+  unset EXPECTED_PYTHON_VERSION
 fi
+unset PYTHON_VERSION_FILE CANONICAL_PYTHON
 
 # 2. Claude-only environment diagnostics do not belong in Codex context.
 if [ "$IS_CODEX_SESSION" = "0" ] && [ -z "$CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS" ]; then

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -198,15 +198,23 @@ rate-limit headroom checks, mode validation, cwd enforcement.
 
 | Path | Resume? | Why |
 | --- | --- | --- |
-| Your interactive Claude Code | not affected by runtime | Keep `--continue`, handoffs, etc. The runtime doesn't touch your session. |
-| Bridge `_claude.py` / `_gemini.py` | **yes** | Cache economics — 95% of our tokens are cache reads. Dropping resume here would reproduce the 2026-03-21 cost fiasco (5.8B tokens in 2 days, rate-limited for a week). |
-| Bridge `_codex.py` | **no** | Codex quota is per-message, not per-token. Resume saves nothing. And cross-worktree session carry-over is the #1 footgun (Codex's own warning, msg #28506). |
+| Native interactive task | not controlled by runtime | Resume the native task. Codex retains reasoning and owns compaction; do not rebuild it from visible messages. |
+| Bridge `_claude.py` / `_gemini.py` | **yes** | Cache warmth and multi-turn coherence inside the exact bridge identity. |
+| Bridge `_codex.py` | **yes** | Preserve native Codex reasoning and compaction for the exact `task_id`; `--new-session` is the explicit reset. |
+| Channel inbox | **yes** for resumable agents | Exact `agent + channel + thread_id`; resumed prompts contain only unseen deliveries. |
+| Sealed review | **no** | A review checkout is an isolation boundary and must not inherit a normal-worktree session. |
+| `/v1/chat/completions` proxy | **no** | Stateless compatibility endpoint; the caller owns and supplies the full message history. |
 | `delegate.py` (future, coding tasks) | **no** | Worktree is the isolation boundary. Resume across worktrees is an incoherence footgun. |
 | `dispatch.py` pipeline | **no** | Already fresh-session today. Don't regress. |
 
-Enforced at TWO layers:
-1. **Adapter-level** (defensive): `CodexAdapter.build_invocation()` ignores `session_id` even when passed. Belt.
-2. **Caller-level** (declarative): `runner.invoke()` raises `ValueError` if the caller's `entrypoint` is not "bridge" and the adapter's `resume_policy` is "bridge_only", or always if `resume_policy` is "never". Suspenders.
+The runner enforces the boundary: it raises `ValueError` if a caller passes a
+session to a `bridge_only` adapter from any entrypoint other than `bridge`, and
+always rejects a session for `resume_policy="never"`. Codex turns a permitted
+session into `codex exec resume <session-id>`.
+
+Do not infer proxy conversation identity from `user`, model, request ID, or
+prompt text. Do not automatically replay ambiguous bridge failures: a
+write-capable call may have completed side effects before transport failed.
 
 If you need to change this policy, edit `registry.py`, not the call site.
 

--- a/docs/design/agent-runtime.md
+++ b/docs/design/agent-runtime.md
@@ -181,11 +181,11 @@ class Result:
 AGENTS: dict[str, dict] = {
     "codex": {
         "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",
-        "default_model": "gpt-5.5",
+        "default_model": "gpt-5.6-terra",
         "cost_tier": "medium",
         "capabilities": {"code_writing", "code_review", "debugging", "adversarial_review"},
         "cli_available": True,
-        "resume_policy": "never",      # §6.3 — Codex is fresh-session-only always
+        "resume_policy": "bridge_only", # §6.3 — exact bridge identity only
     },
     "claude": {
         "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
@@ -402,30 +402,62 @@ Keep these names. They already match the shape the code uses (`_codex.py:16`, `d
 - The worst 2-day stretch (Mar 20–21) hit 5.8B tokens and rate-limited the account for a week.
 - Top-cost sessions were multi-subagent interactive sessions with cold-cache reloads of SESSION-HANDOFF docs.
 
-**The runtime's impact on cache economics** (Session B in §6.3.1) is different for each provider:
+**The runtime's impact on continuity and cache economics** (Session B in
+§6.3.1) is different for each provider:
 
-| Provider | Resume saves cost? | Resume causes harm? |
+| Provider | Resume benefit | Resume boundary |
 | --- | --- | --- |
-| Anthropic (Claude) | **YES** — warm prompt cache reused across bridge calls on same task_id | No — Claude `-p --resume <uuid>` is well-scoped to a session |
-| Google (Gemini) | Likely yes (caching mechanics unclear but similar model) | No — multi-turn bridge coherence |
-| OpenAI (Codex) | **NO** — Codex quota is per-message, not per-token; resume doesn't save slots | **YES** — resume + `-C` flag limitation = cross-worktree contamination (see Codex's consultation, footgun #5) |
+| Anthropic (Claude) | Warm prompt cache and multi-turn coherence | Exact bridge task/thread |
+| Google (Gemini) | Multi-turn coherence; provider caching may also help | Exact bridge task/thread |
+| OpenAI (Codex) | Retains native reasoning state and compaction across turns | Exact bridge task/thread only; never a dispatch/review worktree |
 
-**Policy (enforced in two layers):**
+For Codex, continuity is a quality requirement, not merely a token-cost
+optimization. OpenAI's
+[ARC-AGI-3 harness analysis](https://openai.com/index/how-two-settings-tripled-our-arc-agi-3-scores/)
+demonstrated the failure caused by replaying visible history while discarding
+reasoning state. The
+[Responses API](https://developers.openai.com/blog/responses-api) and
+[compaction guidance](https://developers.openai.com/api/docs/guides/compaction)
+describe the platform-native state model that `codex exec resume` preserves.
 
-Layer 1 — adapter default (`resume_policy` in registry):
-- `CodexAdapter` has `resume_policy="never"` and **ignores `session_id` even if passed**. Belt + suspenders.
-- `ClaudeAdapter` / `GeminiAdapter` have `resume_policy="bridge_only"`.
+**Policy (enforced at the runtime boundary):**
 
-Layer 2 — caller enforcement:
-- `_claude.py`, `_gemini.py`, `_codex.py` (bridge messaging) → may pass `session_id` from the existing SQLite `sessions` table.
-- `scripts/delegate.py` (future) → hard-refuses to pass `session_id`; asserts runtime-side that `resume_policy != "bridge_only" OR entrypoint != "delegate"`.
-- `scripts/build/dispatch.py` → never passes `session_id` (already true today).
+- `CodexAdapter`, `ClaudeAdapter`, and resumable bridge agents use
+  `resume_policy="bridge_only"`.
+- `runner.invoke()` accepts their session IDs only when
+  `entrypoint="bridge"`.
+- Delegate, dispatch, consult, and sealed review calls pass no session ID. A
+  worktree or sealed review checkout is an isolation boundary, never a
+  continuation boundary.
+
+Bridge identities are deliberately narrow:
+
+| Surface | Continuity identity | Contract |
+| --- | --- | --- |
+| Direct `ask-codex` | Exact `task_id` | Resume unless `--new-session` is requested. A sealed review is always fresh. |
+| Channel inbox | Exact `agent + channel + thread_id` | Resume within the thread; a resumed prompt contains only unseen deliveries. |
+| `discuss` | Discussion-local session | Reuse only inside the bounded discussion. |
+| Delegate/dispatch/review | None | Always fresh. |
+| `/v1/chat/completions` proxy | None | Stateless; the caller supplies the complete visible history. |
+
+Do not infer proxy continuity from `user`, model, request ID, or prompt text.
+That would risk cross-client session leakage and duplicate history. A failed
+bridge invocation does not overwrite a known-good session and is not
+automatically replayed: a write-capable call may have completed side effects
+before transport failure. Direct callers use `--new-session` for an explicit
+reset.
 
 #### 6.3.1 Clarification: two different meanings of "session"
 
-**Session A** = the user's interactive Claude Code workflow (this terminal, `--continue`, handoff docs, autocompact). **Unaffected by the runtime.** Keep doing handoffs; they are necessary when context gets heavy. Separate optimization work can shrink handoff docs to reduce cold-reload cost, but that is not this issue.
+**Session A** = the user's native interactive agent task. For Codex TUI/App,
+resume the existing task and let native compaction manage long context.
+Repository PostCompact hooks stay silent for ordinary Codex tasks; only a
+launcher-bound epic driver receives its exact bounded hydration capsule.
 
-**Session B** = bridge subprocess `claude -p --resume <uuid>` invocations. **This is what the resume policy above applies to.** Each Session B invocation is a short-lived subprocess that runs for seconds; the UUID lets Anthropic's prompt cache hit across multiple bridge calls on the same `task_id`.
+**Session B** = short-lived bridge subprocess invocations. This is what the
+resume policy above applies to. Claude resumes with its provider session ID;
+Codex uses `codex exec resume <session-id>` so native reasoning and compaction
+continue across bridge turns without crossing into a worktree.
 
 ### 6.4 Headroom check semantics
 
@@ -447,9 +479,9 @@ Load loudly — `GrokAdapter.build_invocation()` raises `NotImplementedError` wi
 | Concurrent usage log corruption | `os.open(O_APPEND\|O_CREAT\|O_WRONLY) + os.write()` — POSIX atomicity guarantee for sub-PIPE_BUF writes. No filelock. |
 | Stall detection missing (kills healthy slow calls) | Streaming stdout watchdog (primary) + `liveness_signal_paths()` mtime polling (fallback). New `"stalled"` outcome distinguishes from hard timeout. |
 | Protocol drift as we add agents | `_template.py` living adapter as canonical reference. Protocol tests assert every registered adapter implements the protocol correctly. `mypy --strict` on the `agent_runtime` package. |
-| Resume footgun in coding tasks (Codex) | Enforced at two layers: adapter `resume_policy="never"` + caller-side enforcement in `delegate.py` and `dispatch.py`. Codex adapter defensively ignores `session_id` even if passed. |
+| Resume footgun across coding worktrees | Registry policy plus `runner.invoke()` allow session IDs only at `entrypoint="bridge"`; delegate, dispatch, consult, and review stay fresh. |
 | MCP tool restrictions lost during migration | `tool_config` in protocol. Phase 3 AC explicitly asserts dispatch.py reviewer paths still carry only the reviewer tool list. Integration test locks this. |
-| Cost regression from breaking resume | Data-driven policy: Claude/Gemini bridge paths KEEP resume for cache warmth. Only Codex and delegate/dispatch paths go fresh-only. |
+| Quality/cost regression from breaking resume | Claude/Gemini keep bridge continuity; Codex keeps exact bridge continuity for native reasoning/compaction; delegate/dispatch/review remain fresh. |
 | Future agents add features we can't handle | `tool_config: dict[str, Any]` is deliberately untyped. Adapters ignore keys they don't understand. Forward-compatible. |
 | Rate-limit false positives from "429" in URLs | `\b429\b` regex boundaries + specific phrases (`"HTTP 429"`, `"status 429"`). Applied to both new runtime and existing `dispatch.py` as free cleanup. |
 | Error signal loss when Gemini call fails with empty stderr | Runner auto-tails the newest liveness file into the error log on failure. Free feature given liveness_signal_paths is already in play. |
@@ -542,7 +574,7 @@ This is AC #11 on #1184. The guide is shipped in the same PR as the runtime code
 | 10 | User feedback | NEW §10 documentation requirements — 4 artifacts shipped in Phase 1, AC-gated |
 | 11 | User feedback + both reviewers | NEW §7 vulnerabilities + mitigations table |
 | 12 | User feedback (Session A/B clarification) | Added §6.3.1 distinguishing interactive Claude Code sessions from bridge subprocess resume |
-| 13 | Token-usage data (HIGH) | §6.3 resume policy is data-driven: Claude/Gemini bridge keep resume for cache warmth, Codex always fresh, delegate/dispatch always fresh |
+| 13 | Token-usage and continuity data (HIGH) | §6.3 resume policy is data-driven: bridge-only agents retain exact bridge continuity; delegate/dispatch/review always start fresh |
 
 **Deliberately cut from v1 (ship in v2 if needed):**
 

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -107,6 +107,55 @@ queries Codex-addressed messages rather than silently reporting Claude's inbox.
 The repository deploy manages project-local `.codex/hooks.json`; it does not
 edit the separate user-level `~/.codex/hooks.json`.
 
+## Continuity boundaries: native CLI and Desktop
+
+The project hook layer protects and augments **Codex CLI** sessions; native
+Codex still owns compaction. An ordinary Codex task receives a concise
+SessionStart capsule and has a silent `PostCompact`. Only a launcher-bound
+Codex epic may receive one bounded, exact-stream hydration capsule. That
+capsule requires `.claude/<epic>-epic/CODEX-DRIVER-HANDOFF.md`: the hook never
+substitutes `INTERIM-DRIVER-HANDOFF.md` or `CLAUDE-DRIVER-HANDOFF.md` into a
+Codex post-compaction response. A missing exact Codex handoff is a blocked
+capsule, not a generic replay.
+
+The canonical checkout's `.venv/bin/python` must report exactly the version in
+the canonical `.python-version` file (currently `Python 3.12.8`). Linked
+worktrees intentionally have no local `.venv`; `SessionStart` and bare
+`python`/`python3` rewrites use the canonical interpreter. A missing or
+mismatched canonical interpreter blocks a bare-interpreter rewrite instead of
+silently using a system Python. Qualified interpreter commands keep their
+existing behavior.
+
+`UserPromptSubmit` inbox notices are recipient-and-native-session scoped. The
+hook stores only the sorted pending message-ID list under ignored
+`.agent/runtime/`, atomically replacing it when the list changes. Identical
+pending IDs are shown once per session; a new pending ID is shown again. It
+does not store message text, claim, or acknowledge broker messages. If a hook
+cannot establish a session identity or write this local state, it fails open
+and reports the notice rather than suppressing it.
+
+Codex Desktop is different: a recorded Desktop test showed hook commands and
+their UI labels run, but hook `additionalContext` was not delivered to the
+task. Do not use Desktop `SessionStart`, `PostCompact`, or inbox context output
+as continuity proof. Use a trusted dispatch worktree, native task context, and
+the durable launcher handoff/board for a bound driver. The CLI receives the
+same project hooks after trust; Desktop hook behavior remains manual and
+observational.
+
+After changing hook sources, run `npm run agents:deploy`, then re-trust the
+changed project hooks in the CLI/Desktop hook UI before testing. Verify a fresh
+CLI task, an ordinary PostCompact (silent), an exact Codex-driver hydration,
+and one repeated inbox prompt. The no-auth health check remains:
+
+```bash
+.venv/bin/python -m scripts.orchestration.codex_transport_health status --json
+```
+
+To roll back, revert the tracked source change and rerun `npm run agents:deploy`;
+then re-trust the deployed commands. Do not delete `.agent/runtime/` inbox
+watermarks, rollover packets, or local state databases as part of rollback:
+old ID-only watermarks are harmless and naturally cease to match a new session.
+
 ## Session availability and rollover deadlines
 
 `SessionStart` is an availability path with a 15-second outer ceiling. Its

--- a/scripts/agent_runtime/__init__.py
+++ b/scripts/agent_runtime/__init__.py
@@ -31,9 +31,9 @@ DESIGN PRINCIPLES:
   to batch_state/api_usage/ so the existing /api/batch/usage endpoint
   surfaces per-agent + per-entrypoint cost data automatically.
 - Resume policy is data-driven. See docs/design/agent-runtime.md § 6.3.
-  Claude/Gemini bridge paths keep resume for cache warmth (cost economics);
-  Codex always fresh-session (coherence footgun); delegate/dispatch always
-  fresh (worktree is the isolation boundary).
+  Bridge-only agents, including Codex, may keep task-scoped bridge continuity;
+  delegate/dispatch always start fresh because the worktree is the isolation
+  boundary.
 
 HOW TO ADD A NEW AGENT:
 

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -152,6 +152,7 @@ class CodexAdapter:
     # ``_candidate_rollout_dirs`` so the post-call rollout scan looks in
     # the scoped sessions/ dir, not the user's real ``~/.codex/sessions/``.
     _codex_home_scope: str | None = None
+    _resume_session_id: str | None = None
 
     def build_invocation(
         self,
@@ -210,6 +211,7 @@ class CodexAdapter:
         # between consecutive calls on the same adapter instance).
         # Codex 2026-04-10 audit.
         self._reset_per_invocation_state()
+        self._resume_session_id = session_id
 
         discussion_readonly = _discussion_readonly_requested(tool_config)
         if discussion_readonly and mode != "read-only":
@@ -783,6 +785,7 @@ class CodexAdapter:
         self._last_early_reap_mtime = 0.0
         self._rollout_snapshot = self._snapshot_preexisting_rollouts()
         self._bound_rollout = None
+        self._resume_session_id = None
 
     def _read_latest_rollout_task_complete(
         self,
@@ -864,15 +867,31 @@ class CodexAdapter:
                 all_candidates.extend(directory.glob("rollout-*.jsonl"))
             except OSError:
                 continue
-        new_candidates = [path for path in all_candidates if path not in snapshot]
-        if not new_candidates:
-            return None
 
         def mtime(path: Path) -> float:
             try:
                 return path.stat().st_mtime
             except OSError:
                 return 0.0
+
+        # Current Codex appends every resumed turn to the original session
+        # rollout instead of creating a new file. That exact file is therefore
+        # present in the pre-invocation snapshot. Bind it by BOTH the trusted
+        # stored session ID and this invocation's normalized prompt before
+        # applying the fresh-call snapshot exclusion below.
+        resume_session_id = getattr(self, "_resume_session_id", None)
+        if resume_session_id:
+            for candidate in sorted(all_candidates, key=mtime, reverse=True):
+                if (
+                    self._read_rollout_session_id(candidate) == resume_session_id
+                    and self._rollout_matches_plan(candidate, plan)
+                ):
+                    self._bound_rollout = candidate
+                    return candidate
+
+        new_candidates = [path for path in all_candidates if path not in snapshot]
+        if not new_candidates:
+            return None
 
         for candidate in sorted(new_candidates, key=mtime, reverse=True):
             if self._rollout_matches_plan(candidate, plan):
@@ -901,6 +920,11 @@ class CodexAdapter:
         rollout = self._select_rollout_for_plan(plan)
         if rollout is None:
             return None
+        return self._read_rollout_session_id(rollout)
+
+    @staticmethod
+    def _read_rollout_session_id(rollout: Path) -> str | None:
+        """Read one validated session UUID from a rollout's opening metadata."""
         try:
             with open(rollout, encoding="utf-8", errors="replace") as stream:
                 for line_number, line in enumerate(stream, start=1):

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -776,14 +776,20 @@ class CodexAdapter:
         Taking the snapshot eagerly (in build_invocation) instead of
         lazily (on the first check_early_reap call) is correct: we
         want to capture the state of the sessions dir at the MOMENT
-        the call begins, not at some arbitrary later time when the
-        new rollout may already have been created. Any file present
-        when build_invocation runs is "pre-existing" and therefore
-        cannot be the current call's rollout.
+        the call begins, not at some arbitrary later time when a fresh
+        rollout may already have been created. For resumed sessions, Codex
+        appends to a pre-existing rollout; its captured byte length is the
+        current invocation's safe scan boundary.
         """
         self._last_early_reap_check = 0.0
         self._last_early_reap_mtime = 0.0
         self._rollout_snapshot = self._snapshot_preexisting_rollouts()
+        self._rollout_start_offsets = {}
+        for rollout in self._rollout_snapshot:
+            try:
+                self._rollout_start_offsets[rollout] = rollout.stat().st_size
+            except OSError:
+                continue
         self._bound_rollout = None
         self._resume_session_id = None
 
@@ -801,17 +807,13 @@ class CodexAdapter:
         because concurrent Codex runs in the same repo would
         cross-contaminate. Instead we:
 
-        1. Snapshot the set of rollout files that existed at the
-           moment check_early_reap first runs (stored on the adapter
-           as ``_rollout_snapshot``).
-        2. On every scan, ignore any file in the snapshot.
-        3. From the non-snapshot candidates, pick the one with the
-           newest mtime. This is guaranteed to be a file Codex created
-           AFTER our call started.
-        4. Once we find a candidate, we cache it as ``_bound_rollout``
-           — any future calls return the SAME file, so the runner's
-           parse_response always sees the rollout scoped to THIS
-           invocation.
+        1. Fresh calls ignore files in the build-time snapshot and prompt-bind
+           one newly created candidate.
+        2. Resumed calls session-ID-bind the original rollout and prompt-match
+           only bytes appended after its build-time length.
+        3. Once bound, later scans keep the same file and the same byte
+           boundary, so prior turns cannot satisfy task completion or pollute
+           current-turn tool telemetry.
 
         Also checks yesterday's sessions dir for UTC-midnight rollover.
 
@@ -826,23 +828,22 @@ class CodexAdapter:
 
             # 4. Scan our bound rollout for task_complete
             last_message = ""
-            with open(rollout_to_scan, encoding="utf-8", errors="replace") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        event = _json.loads(line)
-                    except _json.JSONDecodeError:
-                        continue
-                    if event.get("type") != "event_msg":
-                        continue
-                    payload = event.get("payload") or {}
-                    if payload.get("type") != "task_complete":
-                        continue
-                    msg = payload.get("last_agent_message")
-                    if isinstance(msg, str) and msg:
-                        last_message = msg
+            for line in self._read_rollout_segment(rollout_to_scan).splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                if event.get("type") != "event_msg":
+                    continue
+                payload = event.get("payload") or {}
+                if payload.get("type") != "task_complete":
+                    continue
+                msg = payload.get("last_agent_message")
+                if isinstance(msg, str) and msg:
+                    last_message = msg
 
             return last_message
         except Exception:
@@ -904,18 +905,31 @@ class CodexAdapter:
         rollout = self._select_rollout_for_plan(plan)
         if rollout is None:
             return ""
+        return self._read_rollout_segment(rollout)
+
+    def _read_rollout_segment(self, rollout: Path) -> str:
+        """Read only bytes appended during the current invocation.
+
+        A fresh invocation owns a newly created rollout and starts at byte zero.
+        A resumed invocation appends to a pre-existing session rollout, whose
+        starting length was captured synchronously in ``build_invocation``.
+        """
+        offsets: dict[Path, int] = getattr(self, "_rollout_start_offsets", {})
+        start_offset = offsets.get(rollout, 0)
         try:
-            return rollout.read_text(encoding="utf-8", errors="replace")
+            with open(rollout, "rb") as stream:
+                stream.seek(start_offset)
+                return stream.read().decode("utf-8", errors="replace")
         except OSError:
             return ""
 
     def _read_session_id_from_rollout(self, plan: InvocationPlan) -> str | None:
         """Read the exact invocation's session id from ``session_meta``.
 
-        The rollout selector first proves that the file contains this plan's
-        normalized user prompt and was created after the invocation snapshot.
-        Never take an ID from the globally newest rollout: concurrent Codex
-        calls may share the same date directory.
+        The rollout selector first proves that a fresh file or the exact
+        resumed session contains this plan's normalized prompt in the current
+        invocation segment. Never take an ID from the globally newest rollout:
+        concurrent Codex calls may share the same date directory.
         """
         rollout = self._select_rollout_for_plan(plan)
         if rollout is None:
@@ -961,48 +975,47 @@ class CodexAdapter:
             return True
 
         try:
-            with open(rollout_path, encoding="utf-8", errors="replace") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        event = _json.loads(line)
-                    except _json.JSONDecodeError:
-                        continue
+            for line in self._read_rollout_segment(rollout_path).splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
 
-                    payload = event.get("payload") or {}
-                    if not isinstance(payload, dict):
-                        continue
+                payload = event.get("payload") or {}
+                if not isinstance(payload, dict):
+                    continue
 
-                    if (
-                        event.get("type") == "event_msg"
-                        and payload.get("type") == "user_message"
-                        and isinstance(payload.get("message"), str)
-                        and _normalize_payload_for_rollout_match(payload["message"]) == expected
-                    ):
-                        return True
+                if (
+                    event.get("type") == "event_msg"
+                    and payload.get("type") == "user_message"
+                    and isinstance(payload.get("message"), str)
+                    and _normalize_payload_for_rollout_match(payload["message"]) == expected
+                ):
+                    return True
 
-                    if (
-                        event.get("type") == "response_item"
-                        and payload.get("type") == "message"
-                        and payload.get("role") == "user"
-                    ):
-                        content = payload.get("content")
-                        if isinstance(content, list):
-                            parts: list[str] = []
-                            for item in content:
-                                if isinstance(item, dict):
-                                    text = item.get("text")
-                                    if isinstance(text, str):
-                                        parts.append(text)
-                            if parts:
-                                candidates = [*parts, "\n".join(parts)]
-                                if any(
-                                    _normalize_payload_for_rollout_match(candidate) == expected
-                                    for candidate in candidates
-                                ):
-                                    return True
+                if (
+                    event.get("type") == "response_item"
+                    and payload.get("type") == "message"
+                    and payload.get("role") == "user"
+                ):
+                    content = payload.get("content")
+                    if isinstance(content, list):
+                        parts: list[str] = []
+                        for item in content:
+                            if isinstance(item, dict):
+                                text = item.get("text")
+                                if isinstance(text, str):
+                                    parts.append(text)
+                        if parts:
+                            candidates = [*parts, "\n".join(parts)]
+                            if any(
+                                _normalize_payload_for_rollout_match(candidate) == expected
+                                for candidate in candidates
+                            ):
+                                return True
             return False
         except Exception:
             return False

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -9,8 +9,8 @@ Key design points:
 
 - **Bridge-only warm resume.** CodexAdapter has ``resume_policy="bridge_only"``
   in the registry: dispatch/delegate invocations stay fresh-session via the
-  runner policy gate, while ``ab discuss`` bridge rounds may resume a prior
-  Codex CLI session for prompt-cache reuse (#1894).
+  runner policy gate, while an exact bridge task/thread may resume its prior
+  Codex CLI session and retain native reasoning/compaction state (#1894).
 - **All three modes supported:** read-only, workspace-write, danger.
   Mode → flag mapping matches ``_codex.py::_codex_bridge_flags`` and
   ``dispatch.py::_codex_dispatch_flags``.
@@ -18,9 +18,10 @@ Key design points:
   agent message to a file; we read it in ``parse_response``. The file path
   goes into ``liveness_signal_paths`` so the runner's mtime poller catches
   Codex writing progress even when stdout is quiet.
-- **Session ID parsed from stdout.** The CLI prints "session id: <uuid>"
-  somewhere in stdout; we extract it so bridge callers can feed it into
-  later rounds.
+- **Session ID bound to the invocation.** Older CLIs printed
+  ``session id: <uuid>`` on stdout. Current CLIs persist it in the matched
+  rollout's ``session_meta`` event. We accept either source so bridge callers
+  can feed the exact session into later rounds.
 
 Issue: #1184
 """
@@ -47,6 +48,10 @@ _logger = logging.getLogger(__name__)
 
 # Matches the session id line in Codex stdout. Case-insensitive.
 _SESSION_RE = re.compile(r"session id:\s*([0-9a-f-]{8,})", re.IGNORECASE)
+_SESSION_ID_VALUE_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 # Stderr phrases that indicate the provider rate-limited us. Ordered
 # roughly by specificity — specific phrases first, generic last.
@@ -274,19 +279,13 @@ class CodexAdapter:
         if effort is not None:
             # Per-invocation override of ~/.codex/config.toml (#1396).
             cmd.extend(["-c", f"model_reasoning_effort={effort}"])
-        cmd.extend(
-            [
-                "--skip-git-repo-check",
-                "-C",
-                str(execution_cwd),
-                "--color",
-                "never",
-                "-o",
-                str(output_path),
-                "-m",
-                model or self.default_model,
-            ]
-        )
+        cmd.append("--skip-git-repo-check")
+        if not has_session_to_resume:
+            # ``codex exec resume`` does not accept -C or --color. It resumes
+            # the original session boundary and the subprocess itself still
+            # runs from execution_cwd.
+            cmd.extend(["-C", str(execution_cwd), "--color", "never"])
+        cmd.extend(["-o", str(output_path), "-m", model or self.default_model])
         # Review isolation (#5285): ignore user/project config when the bridge
         # marks the invocation as a fail-closed review. Missing flags on an
         # older binary are the caller's responsibility to feature-detect; the
@@ -305,12 +304,19 @@ class CodexAdapter:
         # after the enable to actually suppress ``multi_agent``. The 2026-05-22
         # ab ask-codex `codex-node-repl-leak-2026-05-22` diagnosis flagged
         # this ordering as a secondary leak path (see PR #2230 follow-up).
+        if has_session_to_resume and tc.get("review_isolation"):
+            raise ValueError("CodexAdapter: sealed review sessions cannot resume")
         if tc.get("review_isolation"):
             # Codex's internal read-only mode cancels stdio MCP calls even
             # when approval_policy=never. The verified parent OS sandbox is
             # the review boundary, so bypass only the nested Codex sandbox to
             # keep the sole sealed read-only MCP tool usable.
             cmd.append("--dangerously-bypass-approvals-and-sandbox")
+        elif has_session_to_resume and mode == "read-only":
+            # ``resume`` has no -s/--sandbox flag, but accepts config
+            # overrides. Reassert the requested boundary instead of inheriting
+            # a broader mode if a caller changes delivery metadata mid-thread.
+            cmd.extend(["-c", 'sandbox_mode="read-only"'])
         else:
             cmd.extend(self._mode_flags(mode))
         cmd.extend(self._tool_config_flags(tool_config))
@@ -543,11 +549,15 @@ class CodexAdapter:
             call_failed = returncode != 0 or not durable_output
             rate_limited = pattern_hit and call_failed
 
-        # Session id comes from stdout in Codex.
+        # Older Codex CLIs printed the session id on stdout. Current CLIs keep
+        # stdout quiet and persist it in the invocation-matched rollout's
+        # session_meta record.
         session_id: str | None = None
         session_match = _SESSION_RE.search(stdout or "")
         if session_match:
             session_id = session_match.group(1)
+        elif plan is not None:
+            session_id = self._read_session_id_from_rollout(plan)
 
         rollout_trace = ""
         if plan is not None:
@@ -879,6 +889,40 @@ class CodexAdapter:
             return rollout.read_text(encoding="utf-8", errors="replace")
         except OSError:
             return ""
+
+    def _read_session_id_from_rollout(self, plan: InvocationPlan) -> str | None:
+        """Read the exact invocation's session id from ``session_meta``.
+
+        The rollout selector first proves that the file contains this plan's
+        normalized user prompt and was created after the invocation snapshot.
+        Never take an ID from the globally newest rollout: concurrent Codex
+        calls may share the same date directory.
+        """
+        rollout = self._select_rollout_for_plan(plan)
+        if rollout is None:
+            return None
+        try:
+            with open(rollout, encoding="utf-8", errors="replace") as stream:
+                for line_number, line in enumerate(stream, start=1):
+                    if line_number > 25:
+                        break
+                    try:
+                        event = _json.loads(line)
+                    except (TypeError, ValueError):
+                        continue
+                    if event.get("type") != "session_meta":
+                        continue
+                    payload = event.get("payload")
+                    if not isinstance(payload, dict):
+                        return None
+                    for key in ("session_id", "id"):
+                        candidate = payload.get(key)
+                        if isinstance(candidate, str) and _SESSION_ID_VALUE_RE.fullmatch(candidate):
+                            return candidate
+                    return None
+        except OSError:
+            return None
+        return None
 
     def _rollout_matches_plan(self, rollout_path: Path, plan: InvocationPlan) -> bool:
         """Return True when a rollout's user prompt matches this invocation.

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -8,13 +8,12 @@ Resume policy is data-driven (see docs/design/agent-runtime.md § 6.3):
 
 - ``bridge_only`` — Session resume allowed ONLY when caller is the bridge
   (multi-turn task_id messaging). Forbidden for delegate/dispatch. Claude
-  and Gemini use this policy because their providers charge per cache-read
-  token; dropping resume would reproduce the March 20-21 cost fiasco.
-- ``never`` — No resume ever. Codex uses this because (a) its quota is
-  per-message so resume saves nothing, and (b) session-across-worktree
-  contamination is the #1 footgun flagged in Codex's own consultation.
-- The runner does NOT enforce resume policy — callers do. The policy is
-  stored here for documentation and for delegate.py's assertion layer.
+  and Gemini use it for cache warmth; Codex uses it to preserve its native
+  conversation reasoning and compaction without exposing sessions to worktrees.
+- ``never`` — No resume ever. Use this for agents whose sessions cannot be
+  safely continued by the runtime.
+- The runner enforces resume policy at its invocation boundary. This keeps
+  bridge-only continuity out of delegate, dispatch, and consult worktrees.
 
 Issue: #1184
 """

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -640,9 +640,9 @@ def _enforce_resume_policy(
 ) -> None:
     """Enforce resume policy from the registry.
 
-    Design doc § 6.3: Codex is always fresh-session. Claude/Gemini bridge
-    paths may keep resume (cache economics). delegate/dispatch never use
-    resume (worktree is the isolation boundary).
+    Design doc § 6.3: bridge-only agents may resume through the bridge.
+    Delegate, dispatch, and consult never resume because a worktree is the
+    isolation boundary.
 
     If a caller tries to pass ``session_id`` when policy forbids it, we
     raise ValueError. This is a hard invariant — we'd rather crash loudly

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -1,8 +1,9 @@
 """Codex interaction: ask_codex and process_for_codex.
 
 Phase 4 of #1184 migrated the bridge subprocess path onto
-scripts.agent_runtime. Codex bridge calls now always start fresh,
-consistent with the runtime's resume_policy="never" for Codex.
+scripts.agent_runtime. Normal bridge calls may resume their task-scoped Codex
+conversation; the runtime's ``bridge_only`` policy keeps every non-bridge
+entrypoint fresh.
 """
 
 import json
@@ -21,7 +22,7 @@ from agent_runtime.errors import (
 from ._ask_contract import resolve_model_selection, response_provenance
 from ._ask_lifecycle import launch_background_ask, record_ask_failure, record_ask_reply, register_ask
 from ._config import REPO_ROOT
-from ._db import get_db, set_session
+from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_codex_prompt
 from ._review_safety import (
@@ -285,16 +286,17 @@ def _render_codex_chain_content(content_template: str, issue_num: int, task_id: 
 def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bool = False, review: bool = False):
     """Read message addressed to Codex, invoke via agent_runtime, send response.
 
-    Phase 4: routes through scripts.agent_runtime.runner.invoke(). Resume
-    is dropped (Codex resume_policy="never" in the registry); new_session
-    parameter is accepted for backward compatibility but now always True
-    in effect.
+    Phase 4: routes through scripts.agent_runtime.runner.invoke(). Normal
+    bridge calls resume the task-scoped Codex session when one exists;
+    ``new_session`` and sealed reviews always start a fresh session.
     """
     msg = _fetch_codex_message(message_id)
     if not msg:
         return
 
-    _ = new_session  # No-op: Codex always starts fresh (resume_policy="never")
+    codex_session_id = None
+    if msg["task_id"] and not new_session and not review:
+        codex_session_id = get_session(msg["task_id"])["codex"]
     timeout_val = _resolve_codex_bridge_timeout(no_timeout)
     model = _extract_target_model(msg)
     effort = _extract_effort(msg)
@@ -311,7 +313,12 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         print(f"   Model: {model}")
     if effort:
         print(f"   Effort: {effort}")
-    print("   Session: NEW (Codex runtime always fresh)")
+    if review:
+        print("   Session: EPHEMERAL (sealed review)")
+    elif codex_session_id:
+        print(f"   Session: RESUME ({codex_session_id[:8]}...)")
+    else:
+        print("   Session: NEW")
     if timeout_val == _NO_TIMEOUT_CODEX_BRIDGE_TIMEOUT_SECONDS:
         print("   Hard timeout: no-timeout requested (24h ceiling)")
     else:
@@ -354,7 +361,7 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
                 model=model,
                 effort=effort,
                 task_id=msg["task_id"],
-                session_id=None,  # Codex resume_policy="never"
+                session_id=codex_session_id,
                 tool_config=review_tool_config,
                 entrypoint="bridge",
                 hard_timeout=timeout_val,
@@ -392,7 +399,7 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         )
         return
 
-    # Persist session ID for observability (though we never reuse it).
+    # Persist a successful session ID for later task-scoped bridge continuity.
     if result.session_id and msg["task_id"]:
         set_session(msg["task_id"], "codex", result.session_id)
 

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -508,7 +508,7 @@ def _build_thread_prompt(
 
     latest_message = unseen[-1]
     review_prefix = review_protocol_prefix() if _uses_review_protocol(thread_messages) else ""
-    if agent == "claude" and has_session:
+    if agent in {"claude", "codex"} and has_session:
         sections = [
             review_prefix,
             f"Continue the existing bridge session for channel #{claimed.channel}.",
@@ -708,7 +708,8 @@ def _invoke_thread(
     gemini_auth_mode: str | None = None,
 ) -> Any:
     task_id = _thread_session_key(claimed.channel, claimed.thread_id)
-    existing_session = _get_session_id(task_id, agent) if agent == "claude" else None
+    resumable_agent = agent in {"claude", "codex"}
+    existing_session = _get_session_id(task_id, agent) if resumable_agent else None
     has_session = existing_session is not None
     prompt = _build_thread_prompt(agent, claimed, has_session=has_session)
     session_id = existing_session
@@ -772,7 +773,7 @@ def _invoke_thread(
                 cwd=REPO_ROOT,
                 model=requested_model,
                 task_id=task_id,
-                session_id=session_id if agent == "claude" else None,
+                session_id=session_id if resumable_agent else None,
                 tool_config=_with_discussion_readonly_tool_config(
                     tool_config,
                     mode=mode,
@@ -785,7 +786,7 @@ def _invoke_thread(
         stop_heartbeats.set()
         heartbeat_thread.join(timeout=1.0)
 
-    if agent == "claude" and result.ok:
+    if resumable_agent and result.ok:
         persisted_session = result.session_id or session_to_store or existing_session
         if persisted_session:
             _set_session_id(task_id, agent, persisted_session)

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -5,6 +5,9 @@ unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_DIR GIT_INDEX_FILE
 unset GIT_OBJECT_DIRECTORY GIT_PREFIX GIT_WORK_TREE
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GIT_COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+CANONICAL_ROOT="$(dirname "$GIT_COMMON_DIR")"
+VENV_PYTHON="$CANONICAL_ROOT/.venv/bin/python"
 HOOK="$REPO_ROOT/agents_extensions/shared/hooks/session-setup.sh"
 POST_COMPACT_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/post-compact.sh"
 TMP_ROOT="$(mktemp -d)"
@@ -61,6 +64,7 @@ fi
 printf "Python 3.12.8\n"
 PYEOF
   printf 'fixture db\n' > "$root/.mcp/servers/message-broker/messages.db"
+  printf '3.12.8\n' > "$root/.python-version"
   chmod +x "$root/.venv/bin/python"
   mkdir -p "$root/scripts/orchestration"
   touch "$root/scripts/orchestration/thread_handoff.py"
@@ -102,14 +106,14 @@ run_hook() {
     CLAUDEX_SUPERVISOR_TEST_STATE_ROOT="$root" \
     CLAUDE_PROFILE_RESOLVER_SH="$REPO_ROOT/scripts/lib/profile_resolver.sh" \
     CLAUDE_PROFILE_RESOLVER_PY="$REPO_ROOT/scripts/lib/context_profiles.py" \
-    CLAUDE_PROFILE_RESOLVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    CLAUDE_PROFILE_RESOLVER_PYTHON="$VENV_PYTHON" \
     CLAUDE_HANDOFF_IDENTITY_SH="$REPO_ROOT/scripts/lib/handoff_identity.sh" \
     CLAUDE_SESSION_RECORD_SCRIPT="$REPO_ROOT/scripts/lib/session_record.py" \
-    CLAUDE_SESSION_RECORD_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    CLAUDE_SESSION_RECORD_PYTHON="$VENV_PYTHON" \
     SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     CLAUDEX_SUPERVISOR_SCRIPT="$REPO_ROOT/scripts/orchestration/claudex_supervisor.py" \
-    CLAUDEX_SUPERVISOR_PYTHON="$REPO_ROOT/.venv/bin/python" \
-    THREAD_ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$REPO_ROOT/.venv/bin/python}" \
+    CLAUDEX_SUPERVISOR_PYTHON="$VENV_PYTHON" \
+    THREAD_ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$VENV_PYTHON}" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_HANDOFF_AGENT="$handoff_agent" \
     SESSION_EPIC="$session_epic" \
@@ -124,7 +128,7 @@ prepare_fixture() {
 
   HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" \
     CODEX_CANONICAL_REPO_ROOT="$root" PATH="/usr/bin:/bin" \
-    "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 prepare --agent "$agent" --active-thread-id "$thread_id" >/dev/null
 }
 
@@ -145,18 +149,18 @@ resume_fixture() {
   local intended_title
   local db_path
 
-  rollover_id=$("$REPO_ROOT/.venv/bin/python" -c \
+  rollover_id=$("$VENV_PYTHON" -c \
     'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["replacement"]["rollover_id"])' \
     "$state_file")
-  source_thread_id=$("$REPO_ROOT/.venv/bin/python" -c \
+  source_thread_id=$("$VENV_PYTHON" -c \
     'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["active"]["thread_id"])' \
     "$state_file")
-  intended_title=$("$REPO_ROOT/.venv/bin/python" -c \
+  intended_title=$("$VENV_PYTHON" -c \
     'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["replacement"]["display"]["title"])' \
     "$state_file")
   db_path="$root/state_session-fixture.sqlite"
 
-  "$REPO_ROOT/.venv/bin/python" - "$db_path" "$source_thread_id" "$replacement_thread_id" "$root" <<'PYEOF'
+  "$VENV_PYTHON" - "$db_path" "$source_thread_id" "$replacement_thread_id" "$root" <<'PYEOF'
 import sqlite3
 import sys
 
@@ -175,21 +179,21 @@ with sqlite3.connect(db_path) as connection:
     )
 PYEOF
 
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 native-action --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --action create >/dev/null
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 record-native-result --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --action create --succeeded \
     --evidence "fixture create_thread returned $replacement_thread_id" >/dev/null
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 register-created --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --replacement-thread-id "$replacement_thread_id" \
     --db "$db_path" --evidence "fixture exact native create result" >/dev/null
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 native-action --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --action title --db "$db_path" >/dev/null
-  "$REPO_ROOT/.venv/bin/python" - "$db_path" "$replacement_thread_id" "$intended_title" <<'PYEOF'
+  "$VENV_PYTHON" - "$db_path" "$replacement_thread_id" "$intended_title" <<'PYEOF'
 import sqlite3
 import sys
 
@@ -197,16 +201,16 @@ db_path, replacement_id, intended_title = sys.argv[1:]
 with sqlite3.connect(db_path) as connection:
     connection.execute("UPDATE threads SET title = ? WHERE id = ?", (intended_title, replacement_id))
 PYEOF
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 record-native-result --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --action title --succeeded \
     --evidence "fixture set_thread_title acknowledged" >/dev/null
-  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+  "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 reconcile-native --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" --action title --db "$db_path" >/dev/null
 
   HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" PATH="/usr/bin:/bin" \
-    "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    "$VENV_PYTHON" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     --repo-root "$root" --monitor-base-url http://127.0.0.1:1 resume --agent "$agent" \
     --state-file "$state_file" --rollover-id "$rollover_id" \
     --replacement-thread-id "$replacement_thread_id" >/dev/null
@@ -216,7 +220,7 @@ run_post_compact() {
   local root="$1"
   HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" \
     CLAUDE_PROJECT_DIR="$root" SESSION_HANDOFF_AGENT="codex" CODEX_CANONICAL_REPO_ROOT="$root" \
-    THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    THREAD_ROLLOVER_PYTHON="$VENV_PYTHON" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     "$POST_COMPACT_HOOK"
@@ -457,13 +461,11 @@ output="$(run_hook "$fixture_root" 0 codex "$other_thread_id")"
 assert_contains "$output" "live rollover is already bound to a different replacement thread" "resumed bound other thread"
 assert_contains "$output" "$replacement_thread_id" "resumed bound other thread"
 
-# 16. PostCompact remains read-only and surfaces packet health only.
+# 16. An explicit Codex non-driver stays silent after native compaction.
 setup_fixture "$fixture_root"
 prepare_fixture "$fixture_root" codex old-thread
 output="$(run_post_compact "$fixture_root")"
-assert_contains "$output" "Thread rollover health (read-only)" "post compact health"
-assert_contains "$output" '\"status\": \"pending_start\"' "post compact packet"
-assert_not_contains "$output" "confirm-started" "post compact no confirmation"
+[ "$output" = "" ] || fail "explicit Codex non-driver PostCompact: expected no context"
 
 # 17. #5201: --epic harness resolves to the claude-infra slot. A live
 #     pending_start packet under claude-infra MUST surface at SessionStart —
@@ -533,7 +535,7 @@ native_record="$fixture_root/.agent/sessions/official-native-session.json"
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/transcripts"
 sol_transcript="$fixture_root/transcripts/sol.jsonl"
-supervisor_run_id=$("$REPO_ROOT/.venv/bin/python" - "$fixture_root" "$REPO_ROOT" <<'PYEOF'
+supervisor_run_id=$("$VENV_PYTHON" - "$fixture_root" "$REPO_ROOT" <<'PYEOF'
 import os
 import sys
 from pathlib import Path

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -253,6 +253,47 @@ def test_message_flatten_preserves_role_order(monkeypatch):
     assert prompt.index("[assistant]: first assistant") < prompt.index("[user]: second user")
 
 
+def test_codex_proxy_is_stateless_and_uses_caller_supplied_history(monkeypatch):
+    prompts = []
+    backend_kwargs = []
+
+    def backend(model, messages, **kwargs):
+        prompts.append(kwargs["prompt"])
+        backend_kwargs.append(kwargs)
+        return proxy.CompletionResponse(content="ok")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
+
+    first = _client().post(
+        "/v1/chat/completions",
+        json={
+            "model": "codex",
+            "user": "same-user",
+            "messages": [{"role": "user", "content": "first"}],
+        },
+    )
+    second = _client().post(
+        "/v1/chat/completions",
+        json={
+            "model": "codex",
+            "user": "same-user",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": "second"},
+            ],
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(prompts) == 2
+    assert all("session_id" not in kwargs for kwargs in backend_kwargs)
+    assert prompts[0] == "--- Round 1 ---\n[user]: first"
+    assert "[assistant]: answer" in prompts[1]
+    assert "[user]: second" in prompts[1]
+
+
 def test_healthz_endpoint_returns_backend_status(monkeypatch):
     # Clear any cached state from other tests to keep this test isolated
     with proxy._healthz_cache_lock:

--- a/tests/test_bridge_inbox.py
+++ b/tests/test_bridge_inbox.py
@@ -87,6 +87,7 @@ def _ok_result(
     stderr_excerpt: str | None = None,
     rate_limited: bool = False,
     returncode: int | None = 0,
+    session_id: str | None = None,
 ) -> Result:
     return Result(
         ok=ok,
@@ -96,7 +97,7 @@ def _ok_result(
         response=response,
         stderr_excerpt=stderr_excerpt,
         duration_s=0.1,
-        session_id=None,
+        session_id=session_id,
         rate_limited=rate_limited,
         stalled=False,
         returncode=returncode,
@@ -122,6 +123,94 @@ def test_run_inbox_single_thread_single_delivery(mock_invoke):
     assert len(messages) == 2
     assert messages[-1]["from_agent"] == "claude"
     assert messages[-1]["parent_id"] == thread[0]["message_id"]
+
+
+@patch("ai_agent_bridge._inbox.runtime_invoke")
+def test_run_inbox_codex_cold_call_persists_runtime_session(mock_invoke):
+    thread = _make_thread("codex", count=1)
+    mock_invoke.return_value = _ok_result(
+        "codex",
+        session_id="codex-session-one",
+    )
+
+    summary = _inbox.run_inbox("codex")
+
+    assert summary.deliveries_delivered == 1
+    assert mock_invoke.call_args.kwargs["session_id"] is None
+    task_id = _inbox._thread_session_key("topic", str(thread[0]["thread_id"]))
+    assert _inbox._get_session_id(task_id, "codex") == "codex-session-one"
+
+
+@patch("ai_agent_bridge._inbox.runtime_invoke")
+def test_run_inbox_codex_same_thread_resumes_with_unseen_only_prompt(mock_invoke):
+    thread = _make_thread("codex", count=1)
+    mock_invoke.return_value = _ok_result(
+        "codex",
+        session_id="codex-session-one",
+    )
+    _inbox.run_inbox("codex")
+
+    follow_up = _channels.post(
+        "topic",
+        "user",
+        "message-2",
+        to_agents=["codex"],
+        parent_id=str(thread[0]["message_id"]),
+        auto_snapshot=False,
+    )
+    mock_invoke.reset_mock()
+    mock_invoke.return_value = _ok_result("codex", session_id="codex-session-one")
+
+    summary = _inbox.run_inbox("codex")
+
+    assert summary.deliveries_delivered == 1
+    assert mock_invoke.call_args.kwargs["session_id"] == "codex-session-one"
+    prompt = mock_invoke.call_args.args[1]
+    assert "Continue the existing bridge session" in prompt
+    assert "message-2" in prompt
+    assert "message-1" not in prompt
+    assert str(follow_up["message_id"]) not in prompt
+
+
+@patch("ai_agent_bridge._inbox.runtime_invoke")
+def test_run_inbox_codex_sessions_are_isolated_by_thread(mock_invoke):
+    first = _make_thread("codex", channel="first", count=1)
+    second = _make_thread("codex", channel="second", count=1)
+    first_task_id = _inbox._thread_session_key("first", str(first[0]["thread_id"]))
+    _inbox._set_session_id(first_task_id, "codex", "first-session")
+    mock_invoke.return_value = _ok_result("codex", session_id="second-session")
+
+    summary = _inbox.run_inbox("codex")
+
+    assert summary.threads_processed == 2
+    calls_by_channel = {
+        "first" if "#first" in call.args[1] else "second": call
+        for call in mock_invoke.call_args_list
+    }
+    assert calls_by_channel["first"].kwargs["session_id"] == "first-session"
+    assert calls_by_channel["second"].kwargs["session_id"] is None
+    second_task_id = _inbox._thread_session_key("second", str(second[0]["thread_id"]))
+    assert _inbox._get_session_id(second_task_id, "codex") == "second-session"
+
+
+@patch("ai_agent_bridge._inbox.runtime_invoke")
+def test_run_inbox_failed_codex_result_does_not_overwrite_session(mock_invoke):
+    thread = _make_thread("codex", count=1)
+    task_id = _inbox._thread_session_key("topic", str(thread[0]["thread_id"]))
+    _inbox._set_session_id(task_id, "codex", "existing-session")
+    mock_invoke.return_value = _ok_result(
+        "codex",
+        ok=False,
+        response="",
+        stderr_excerpt="backend failed",
+        session_id="unexpected-session",
+        returncode=1,
+    )
+
+    _inbox.run_inbox("codex")
+
+    assert mock_invoke.call_args.kwargs["session_id"] == "existing-session"
+    assert _inbox._get_session_id(task_id, "codex") == "existing-session"
 
 
 @patch("ai_agent_bridge._inbox.runtime_invoke")

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -18,6 +18,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from agent_runtime.adapters.codex import CodexAdapter
 from agent_runtime.errors import AgentStalledError, RateLimitedError
 from agent_runtime.result import Result
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
@@ -261,6 +262,7 @@ def test_codex_bridge_runtime_mode_invalid_mode_falls_back_read_only():
 @patch("ai_agent_bridge._codex.acknowledge")
 @patch("ai_agent_bridge._codex.send_message", return_value=99)
 @patch("ai_agent_bridge._codex.set_session")
+@patch("ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
 @patch("ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
 @patch(
     "ai_agent_bridge._codex._fetch_codex_message",
@@ -280,6 +282,7 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
     mock_invoke,
     mock_fetch_message,
     mock_build_prompt,
+    mock_get_session,
     mock_set_session,
     mock_send_message,
     mock_acknowledge,
@@ -303,13 +306,14 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
         process_for_codex(7)
 
     mock_fetch_message.assert_called_once_with(7)
+    mock_get_session.assert_called_once_with("issue-1177")
     mock_build_prompt.assert_called_once()
     kwargs = mock_invoke.call_args.kwargs
     assert kwargs["mode"] == "read-only"
     assert kwargs["model"] == "gpt-5.4"
     assert kwargs["entrypoint"] == "bridge"
     assert kwargs["tool_config"] is None
-    assert kwargs["session_id"] is None
+    assert kwargs["session_id"] == "session-existing"
     assert kwargs["hard_timeout"] == 900
     assert kwargs["stall_timeout"] == 600
     mock_set_session.assert_called_once_with("issue-1177", "codex", "session-123")
@@ -334,6 +338,7 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
 @patch("ai_agent_bridge._codex.acknowledge")
 @patch("ai_agent_bridge._codex.send_message", return_value=100)
 @patch("ai_agent_bridge._codex.set_session")
+@patch("ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
 @patch("ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
 @patch(
     "ai_agent_bridge._codex._fetch_codex_message",
@@ -349,10 +354,11 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
     },
 )
 @patch("agent_runtime.runner.invoke")
-def test_process_for_codex_uses_workspace_write_mode_and_never_resumes(
+def test_process_for_codex_new_session_starts_cold_even_when_session_exists(
     mock_invoke,
     mock_fetch_message,
     mock_build_prompt,
+    mock_get_session,
     mock_set_session,
     mock_send_message,
     mock_acknowledge,
@@ -373,9 +379,10 @@ def test_process_for_codex_uses_workspace_write_mode_and_never_resumes(
     )
 
     with patch.dict(os.environ, {"CODEX_BRIDGE_MODE": "workspace-write"}, clear=True):
-        process_for_codex(8, new_session=False)
+        process_for_codex(8, new_session=True)
 
     mock_fetch_message.assert_called_once_with(8)
+    mock_get_session.assert_not_called()
     mock_build_prompt.assert_called_once()
     kwargs = mock_invoke.call_args.kwargs
     assert kwargs["mode"] == "workspace-write"
@@ -405,6 +412,124 @@ def test_process_for_codex_uses_workspace_write_mode_and_never_resumes(
     mock_acknowledge.assert_called_once_with(8)
 
 
+def test_process_for_codex_cold_starts_without_stored_session(monkeypatch):
+    captured: dict[str, object] = {}
+    message = {
+        "id": 10,
+        "task_id": "issue-1179",
+        "from": "gemini",
+        "to": "codex",
+        "type": "query",
+        "content": "bridge content",
+        "data": None,
+        "timestamp": "2026-04-10T12:00:00Z",
+    }
+    result = Result(
+        ok=True,
+        agent="codex",
+        model="gpt-5.6-terra",
+        mode="read-only",
+        response="Codex response",
+        stderr_excerpt=None,
+        duration_s=1.0,
+        session_id=None,
+        rate_limited=False,
+        stalled=False,
+        returncode=0,
+        usage_record={},
+    )
+    monkeypatch.setattr("ai_agent_bridge._codex._fetch_codex_message", lambda _message_id: message)
+    monkeypatch.setattr("ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": None})
+    monkeypatch.setattr("ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
+    monkeypatch.setattr("ai_agent_bridge._codex.build_codex_prompt", lambda *_args, **_kwargs: "bridge prompt")
+    monkeypatch.setattr("ai_agent_bridge._codex.agent_runner.invoke", lambda *_args, **kwargs: captured.update(kwargs) or result)
+    monkeypatch.setattr("ai_agent_bridge._codex.send_message", lambda **_kwargs: 11)
+    monkeypatch.setattr("ai_agent_bridge._codex.acknowledge", lambda *_args: None)
+    monkeypatch.setattr("ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
+
+    process_for_codex(10)
+
+    assert captured["session_id"] is None
+
+
+def test_codex_adapter_reads_session_id_from_matching_rollout(tmp_path, monkeypatch):
+    adapter = CodexAdapter()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    today = datetime.now(UTC)
+    sessions_today = (
+        fake_home
+        / ".codex"
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    sessions_today.mkdir(parents=True)
+
+    plan = adapter.build_invocation(
+        prompt="continuity probe",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="continuity-probe",
+        session_id=None,
+        tool_config=None,
+    )
+    session_id = "019fb7cd-8344-7440-a3ff-a60c45f62b73"
+    rollout = sessions_today / f"rollout-2026-07-31T12-52-06-{session_id}.jsonl"
+    rollout.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {"id": session_id, "session_id": session_id},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {"type": "user_message", "message": "continuity probe"},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output_file = tmp_path / "output.txt"
+    output_file.write_text("done", encoding="utf-8")
+
+    result = adapter.parse_response(
+        stdout="",
+        stderr="",
+        returncode=0,
+        output_file=output_file,
+        plan=plan,
+    )
+
+    assert result.ok is True
+    assert result.session_id == session_id
+
+    resumed = adapter.build_invocation(
+        prompt="continuity follow-up",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="continuity-probe",
+        session_id=session_id,
+        tool_config=None,
+    )
+    assert resumed.cmd[1:3] == ["exec", "resume"]
+    assert resumed.cmd[-2:] == [session_id, "-"]
+    assert "-C" not in resumed.cmd
+    assert "--color" not in resumed.cmd
+    assert "-s" not in resumed.cmd
+    assert 'sandbox_mode="read-only"' in resumed.cmd
+
+
 def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):
     checkout = ProvisionedReviewWorktree(
         path=tmp_path / "review-checkout",
@@ -431,6 +556,7 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
         },
     )
     monkeypatch.setattr("ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
+    monkeypatch.setattr("ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": "session-existing"})
     monkeypatch.setattr("ai_agent_bridge._codex.provision_review_worktree", fake_checkout)
     monkeypatch.setattr(
         ProvisionedReviewWorktree,
@@ -475,6 +601,7 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
     process_for_codex(9, review=True)
 
     assert captured["cwd"] == checkout.path
+    assert captured["session_id"] is None
     assert str(captured["prompt"]).endswith("SEALED_DOSSIER")
 
 

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -529,6 +529,59 @@ def test_codex_adapter_reads_session_id_from_matching_rollout(tmp_path, monkeypa
     assert "-s" not in resumed.cmd
     assert 'sandbox_mode="read-only"' in resumed.cmd
 
+    with rollout.open("a", encoding="utf-8") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "user_message",
+                        "message": "continuity follow-up",
+                    },
+                }
+            )
+            + "\n"
+        )
+        stream.write(
+            json.dumps(
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_complete",
+                        "last_agent_message": "follow-up done",
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    resumed_output = tmp_path / "resumed-output.txt"
+    resumed_output.write_text("follow-up done", encoding="utf-8")
+    resumed_result = adapter.parse_response(
+        stdout="",
+        stderr="",
+        returncode=0,
+        output_file=resumed_output,
+        plan=resumed,
+    )
+    assert resumed_result.session_id == session_id
+    assert adapter._read_latest_rollout_task_complete(resumed) == "follow-up done"
+
+    for mode in ("workspace-write", "danger"):
+        resumed_write = adapter.build_invocation(
+            prompt=f"{mode} follow-up",
+            mode=mode,
+            cwd=tmp_path,
+            model=None,
+            task_id="continuity-probe",
+            session_id=session_id,
+            tool_config=None,
+        )
+        assert "--dangerously-bypass-approvals-and-sandbox" in resumed_write.cmd
+        assert "--enable" in resumed_write.cmd
+        assert "multi_agent" in resumed_write.cmd
+        assert "-s" not in resumed_write.cmd
+
 
 def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):
     checkout = ProvisionedReviewWorktree(

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -494,6 +494,15 @@ def test_codex_adapter_reads_session_id_from_matching_rollout(tmp_path, monkeypa
                         "payload": {"type": "user_message", "message": "continuity probe"},
                     }
                 ),
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_complete",
+                            "last_agent_message": "initial turn done",
+                        },
+                    }
+                ),
             ]
         )
         + "\n",
@@ -542,6 +551,10 @@ def test_codex_adapter_reads_session_id_from_matching_rollout(tmp_path, monkeypa
             )
             + "\n"
         )
+
+    assert adapter._read_latest_rollout_task_complete(resumed) == ""
+
+    with rollout.open("a", encoding="utf-8") as stream:
         stream.write(
             json.dumps(
                 {
@@ -566,6 +579,9 @@ def test_codex_adapter_reads_session_id_from_matching_rollout(tmp_path, monkeypa
     )
     assert resumed_result.session_id == session_id
     assert adapter._read_latest_rollout_task_complete(resumed) == "follow-up done"
+    resumed_trace = adapter._read_latest_rollout_trace(resumed)
+    assert "initial turn done" not in resumed_trace
+    assert "follow-up done" in resumed_trace
 
     for mode in ("workspace-write", "danger"):
         resumed_write = adapter.build_invocation(

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -600,3 +600,16 @@ def test_inbox_dedupes_by_recipient_and_native_session_and_reemits_new_ids(
     assert provider_isolation.returncode == 0
     provider_context = json.loads(provider_isolation.stdout)["hookSpecificOutput"]["additionalContext"]
     assert "CLAUDE INBOX: 1 unread message(s)" in provider_context
+
+    new_session_environment = environment | {"CODEX_THREAD_ID": "another-codex-session"}
+    session_isolation = subprocess.run(
+        ["bash", str(INBOX_HOOK)], input="{}", text=True, capture_output=True,
+        check=False, env=new_session_environment, timeout=10,
+    )
+    assert session_isolation.returncode == 0
+    session_context = json.loads(session_isolation.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "CODEX INBOX: 2 unread message(s)" in session_context
+
+    state_files = list((tmp_path / ".agent" / "runtime").glob("inbox-*.ids"))
+    assert len(state_files) == 3
+    assert all(len(path.stem.removeprefix("inbox-")) == 64 for path in state_files)

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -48,6 +48,14 @@ def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _make_exact_python_checkout(root: Path) -> None:
+    python = root / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/bash\nprintf 'Python 3.12.8\\n'\n", encoding="utf-8")
+    python.chmod(0o755)
+    (root / ".python-version").write_text("3.12.8\n", encoding="utf-8")
+
+
 def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
     primary = tmp_path / "primary"
     worktree = tmp_path / "linked"
@@ -56,6 +64,7 @@ def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
     _run(["git", "config", "user.email", "hooks@example.invalid"], cwd=primary)
     _run(["git", "config", "user.name", "Hook Tests"], cwd=primary)
     (primary / "README.md").write_text("hook test\n", encoding="utf-8")
+    (primary / ".python-version").write_text("3.12.8\n", encoding="utf-8")
     _run(["git", "add", "README.md"], cwd=primary)
     _run(["git", "commit", "-m", "test fixture"], cwd=primary)
     (primary / ".venv").symlink_to(PRIMARY_ROOT / ".venv", target_is_directory=True)
@@ -166,6 +175,32 @@ def test_ordinary_codex_start_is_concise_and_postcompact_is_silent(
     assert compacted.stdout == ""
 
 
+def test_explicit_non_driver_codex_postcompact_is_silent(tmp_path: Path) -> None:
+    compact_hook = tmp_path / ".codex" / "hooks" / "post-compact.sh"
+    compact_hook.parent.mkdir(parents=True)
+    shutil.copy2(POST_COMPACT_HOOK, compact_hook)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CLAUDE_PROJECT_DIR": os.fspath(tmp_path),
+            "CODEX_CANONICAL_REPO_ROOT": os.fspath(tmp_path),
+            "SESSION_HANDOFF_AGENT": "codex",
+        }
+    )
+
+    completed = subprocess.run(
+        ["bash", os.fspath(compact_hook)],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+
+
 def test_bound_codex_driver_hydrates_exact_stream_and_points_to_shadow_diary(
     tmp_path: Path,
 ) -> None:
@@ -173,7 +208,7 @@ def test_bound_codex_driver_hydrates_exact_stream_and_points_to_shadow_diary(
     deployed_hooks.mkdir(parents=True)
     compact_hook = deployed_hooks / "post-compact.sh"
     shutil.copy2(POST_COMPACT_HOOK, compact_hook)
-    diary = tmp_path / ".claude" / "devops-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    diary = tmp_path / ".claude" / "devops-epic" / "CODEX-DRIVER-HANDOFF.md"
     diary.parent.mkdir(parents=True)
     diary.write_text("# durable driver state\n", encoding="utf-8")
     bounded_runner = tmp_path / "bounded_command.py"
@@ -214,8 +249,43 @@ def test_bound_codex_driver_hydrates_exact_stream_and_points_to_shadow_diary(
     context = json.loads(compacted.stdout)["additionalContext"]
     assert "CODEX FLEET-DRIVER HYDRATION" in context
     assert '"schema_name":"HydrationCapsuleV1"' in context
-    assert ".claude/devops-epic/CLAUDE-DRIVER-HANDOFF.md" in context
+    assert ".claude/devops-epic/CODEX-DRIVER-HANDOFF.md" in context
     assert "continue only from the capsule's next_drive_boundary" in context
+
+
+def test_bound_codex_driver_without_exact_diary_is_blocked_without_fallback(
+    tmp_path: Path,
+) -> None:
+    compact_hook = tmp_path / ".codex" / "hooks" / "post-compact.sh"
+    compact_hook.parent.mkdir(parents=True)
+    shutil.copy2(POST_COMPACT_HOOK, compact_hook)
+    fallback = tmp_path / ".claude" / "devops-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    fallback.parent.mkdir(parents=True)
+    fallback.write_text("# shared driver state\n", encoding="utf-8")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CLAUDE_PROJECT_DIR": os.fspath(tmp_path),
+            "CODEX_CANONICAL_REPO_ROOT": os.fspath(tmp_path),
+            "SESSION_HANDOFF_AGENT": "codex-devops",
+            "SESSION_EPIC": "devops",
+        }
+    )
+
+    completed = subprocess.run(
+        ["bash", os.fspath(compact_hook)],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    context = json.loads(completed.stdout)["additionalContext"]
+    assert "CODEX FLEET-DRIVER HYDRATION BLOCKED" in context
+    assert "CODEX-DRIVER-HANDOFF.md" in context
+    assert "CLAUDE-DRIVER-HANDOFF.md" not in context
 
 
 def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
@@ -334,15 +404,18 @@ def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(
     assert specific["updatedInput"]["command"] == (f'{primary}/.venv/bin/python -c "print(1)"')
 
 
-def test_claude_python_rewrite_shape_remains_compatible() -> None:
+def test_claude_python_rewrite_shape_remains_compatible(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    _make_exact_python_checkout(canonical)
     payload = {
         "hook_event_name": "PreToolUse",
-        "cwd": str(PRIMARY_ROOT),
+        "cwd": str(canonical),
         "tool_name": "Bash",
         "tool_input": {"command": "python --version"},
     }
     environment = os.environ.copy()
-    environment["LEARN_UK_CANONICAL_ROOT"] = str(PRIMARY_ROOT)
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical)
     environment.pop("LEARN_UK_HOOK_PROVIDER", None)
 
     completed = subprocess.run(
@@ -359,7 +432,7 @@ def test_claude_python_rewrite_shape_remains_compatible() -> None:
     assert completed.returncode == 0, completed.stderr
     assert json.loads(completed.stdout) == {
         "modifiedInput": {
-            "command": f"{PRIMARY_ROOT}/.venv/bin/python --version",
+            "command": f"{canonical}/.venv/bin/python --version",
         }
     }
 
@@ -367,10 +440,7 @@ def test_claude_python_rewrite_shape_remains_compatible() -> None:
 def test_python_rewrite_preserves_checkout_path_metacharacters(tmp_path: Path) -> None:
     canonical = tmp_path / "checkout&pipe|root"
     canonical.mkdir()
-    (canonical / ".venv").symlink_to(
-        PRIMARY_ROOT / ".venv",
-        target_is_directory=True,
-    )
+    _make_exact_python_checkout(canonical)
     payload = {
         "hook_event_name": "PreToolUse",
         "cwd": str(canonical),
@@ -395,6 +465,36 @@ def test_python_rewrite_preserves_checkout_path_metacharacters(tmp_path: Path) -
     assert completed.returncode == 0, completed.stderr
     updated = json.loads(completed.stdout)["hookSpecificOutput"]["updatedInput"]
     assert updated["command"] == (f'{canonical}/.venv/bin/python -c "print(1)"')
+
+
+def test_bare_python_rewrite_blocks_a_canonical_version_mismatch(tmp_path: Path) -> None:
+    canonical = tmp_path / "checkout"
+    canonical.mkdir()
+    _make_exact_python_checkout(canonical)
+    (canonical / ".python-version").write_text("3.12.7\n", encoding="utf-8")
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(canonical),
+        "tool_name": "Bash",
+        "tool_input": {"command": "python --version"},
+    }
+    environment = os.environ.copy()
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical)
+    environment["LEARN_UK_HOOK_PROVIDER"] = "codex"
+
+    completed = subprocess.run(
+        ["bash", str(VENV_HOOK)],
+        cwd=canonical,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 2
+    assert "expected Python 3.12.7" in completed.stderr
 
 
 def _make_inbox_db(project: Path) -> None:
@@ -451,3 +551,52 @@ def test_inbox_hook_targets_requested_provider(tmp_path: Path) -> None:
     assert "CODEX INBOX: 1 unread message" in context
     assert "codex-only message" in context
     assert "claude-only message" not in context
+
+
+def test_inbox_dedupes_by_recipient_and_native_session_and_reemits_new_ids(
+    tmp_path: Path,
+) -> None:
+    _make_inbox_db(tmp_path)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+            "LEARN_UK_HOOK_RECIPIENT": "codex",
+            "CODEX_THREAD_ID": "codex-native-session",
+        }
+    )
+
+    first = subprocess.run(
+        ["bash", str(INBOX_HOOK)], input="{}", text=True, capture_output=True,
+        check=False, env=environment, timeout=10,
+    )
+    second = subprocess.run(
+        ["bash", str(INBOX_HOOK)], input="{}", text=True, capture_output=True,
+        check=False, env=environment, timeout=10,
+    )
+    assert first.returncode == second.returncode == 0
+    assert "CODEX INBOX: 1 unread message" in first.stdout
+    assert second.stdout == ""
+
+    db = tmp_path / ".mcp" / "servers" / "message-broker" / "messages.db"
+    with sqlite3.connect(db) as connection:
+        connection.execute(
+            "INSERT INTO messages (from_llm, to_llm, message_type, task_id, content, timestamp, acknowledged, claimed_by) VALUES (?, ?, 'status', 'hooks', ?, '2026-07-26T00:00:00Z', 0, NULL)",
+            ("claude", "codex", "new codex message"),
+        )
+    third = subprocess.run(
+        ["bash", str(INBOX_HOOK)], input="{}", text=True, capture_output=True,
+        check=False, env=environment, timeout=10,
+    )
+    assert third.returncode == 0
+    third_context = json.loads(third.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "CODEX INBOX: 2 unread message(s)" in third_context
+
+    claude_environment = environment | {"LEARN_UK_HOOK_RECIPIENT": "claude"}
+    provider_isolation = subprocess.run(
+        ["bash", str(INBOX_HOOK)], input="{}", text=True, capture_output=True,
+        check=False, env=claude_environment, timeout=10,
+    )
+    assert provider_isolation.returncode == 0
+    provider_context = json.loads(provider_isolation.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "CLAUDE INBOX: 1 unread message(s)" in provider_context

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -48,10 +49,20 @@ def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _make_exact_python_checkout(root: Path) -> None:
+def _make_exact_python_checkout(root: Path, *, delegate: Path | None = None) -> None:
     python = root / ".venv" / "bin" / "python"
     python.parent.mkdir(parents=True)
-    python.write_text("#!/bin/bash\nprintf 'Python 3.12.8\\n'\n", encoding="utf-8")
+    script = "#!/bin/bash\nprintf 'Python 3.12.8\\n'\n"
+    if delegate is not None:
+        script = (
+            "#!/bin/bash\n"
+            "if [ \"${1:-}\" = \"--version\" ]; then\n"
+            "  printf 'Python 3.12.8\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            f"exec {shlex.quote(os.fspath(delegate))} \"$@\"\n"
+        )
+    python.write_text(script, encoding="utf-8")
     python.chmod(0o755)
     (root / ".python-version").write_text("3.12.8\n", encoding="utf-8")
 
@@ -64,10 +75,12 @@ def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
     _run(["git", "config", "user.email", "hooks@example.invalid"], cwd=primary)
     _run(["git", "config", "user.name", "Hook Tests"], cwd=primary)
     (primary / "README.md").write_text("hook test\n", encoding="utf-8")
-    (primary / ".python-version").write_text("3.12.8\n", encoding="utf-8")
+    _make_exact_python_checkout(
+        primary,
+        delegate=PRIMARY_ROOT / ".venv" / "bin" / "python",
+    )
     _run(["git", "add", "README.md"], cwd=primary)
     _run(["git", "commit", "-m", "test fixture"], cwd=primary)
-    (primary / ".venv").symlink_to(PRIMARY_ROOT / ".venv", target_is_directory=True)
     _run(["git", "worktree", "add", "-b", "codex/hooks-test", str(worktree)], cwd=primary)
     return primary, worktree
 

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -20,6 +20,17 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_session_setup_hook.sh"
 
 
+def _canonical_python() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return Path(result.stdout.strip()).parent / ".venv" / "bin" / "python"
+
+
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
 def test_session_setup_hook_handoff_fixtures() -> None:
     assert _HOOK_TEST.is_file(), f"missing hook test: {_HOOK_TEST}"
@@ -86,11 +97,15 @@ def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
     agent_dir.mkdir()
     (agent_dir / "canary-x.json").write_text("{}", encoding="utf-8")
 
-    # Mock other things to avoid unrelated warnings/issues
-    venv_bin = project_dir / ".venv" / "bin"
+    # Linked worktrees do not have a local venv: SessionStart must resolve the
+    # canonical checkout interpreter and exact pin instead.
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    venv_bin = canonical_dir / ".venv" / "bin"
     venv_bin.mkdir(parents=True)
     (venv_bin / "python").write_text("#!/bin/sh\necho 'Python 3.12.8'", encoding="utf-8")
     (venv_bin / "python").chmod(0o755)
+    (canonical_dir / ".python-version").write_text("3.12.8\n", encoding="utf-8")
 
     db_dir = project_dir / ".mcp" / "servers" / "message-broker"
     db_dir.mkdir(parents=True)
@@ -116,7 +131,8 @@ def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
         "XDG_STATE_HOME": str(tmp_path / "xdg-state"),
         "GH_CONFIG_DIR": str(tmp_path / "gh-config"),
         "PATH": f"{venv_bin}:{os.environ.get('PATH', '')}",
-        "CODEX_CANONICAL_REPO_ROOT": str(project_dir),
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        "CODEX_CANONICAL_REPO_ROOT": str(canonical_dir),
         "LEARN_UKRAINIAN_REQUESTED_PROFILE_ID": "native_claude",
         "CLAUDE_PROFILE_RESOLVER_SH": str(
             _REPO_ROOT / "scripts/lib/profile_resolver.sh"
@@ -124,11 +140,14 @@ def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
         "CLAUDE_PROFILE_RESOLVER_PY": str(
             _REPO_ROOT / "scripts/lib/context_profiles.py"
         ),
-        "CLAUDE_PROFILE_RESOLVER_PYTHON": str(_REPO_ROOT / ".venv/bin/python"),
+        "CLAUDE_PROFILE_RESOLVER_PYTHON": str(_canonical_python()),
         "CLAUDE_SESSION_RECORD_SCRIPT": str(
             _REPO_ROOT / "scripts/lib/session_record.py"
         ),
-        "CLAUDE_SESSION_RECORD_PYTHON": str(_REPO_ROOT / ".venv/bin/python"),
+        "CLAUDE_SESSION_RECORD_PYTHON": str(_canonical_python()),
+        "SESSION_BOUNDED_RUNNER": str(
+            _REPO_ROOT / "scripts" / "agent_runtime" / "bounded_command.py"
+        ),
     }
 
     result = subprocess.run(
@@ -148,3 +167,5 @@ def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
         pytest.fail(f"Failed to parse JSON output: {e}\nStdout: {result.stdout}\nStderr: {result.stderr}")
 
     assert "DEPLOY DRIFT" not in context, f"False positive drift detected! Context:\n{context}"
+    assert "VENV MISSING" not in context
+    assert "VENV WRONG PYTHON" not in context


### PR DESCRIPTION
## Summary

- resume native Codex sessions only within an exact direct bridge `task_id` or channel `agent + channel + thread_id`
- keep sealed reviews, delegate/dispatch worktrees, and the chat-completions proxy fresh/stateless
- recover session IDs from invocation-matched Codex rollout metadata for current CLIs, and emit valid `codex exec resume` commands
- harden canonical Python pin checks, Codex PostCompact routing, and per-session inbox notification deduplication
- document TUI/Desktop continuity boundaries, deployment, trust, health checks, rollback, and local profile practices

## Root cause

The registry already described Codex as bridge-resumable, but the direct and inbox callers discarded its stored session ID. The adapter also relied on an older CLI stdout session-ID format and built resume commands with flags unsupported by `codex exec resume`. This reproduced the failure mode described in OpenAI's ARC-AGI-3 harness analysis: visible messages survived while native reasoning state did not.

## Impact

Direct bridge and inbox conversations now retain Codex's native reasoning and compaction state without allowing that state to cross worktree or review boundaries. Ordinary native Codex compaction remains runtime-owned; only an explicitly bound epic driver receives its exact Codex handoff capsule.

## Validation

- `252 passed, 1 skipped` across bridge, adapter, inbox, proxy, hook, and linked-worktree tests on Python 3.12.8
- Ruff, shell syntax, Markdown lint, `git diff --check`, deploy, agent trailer, and staged OPSEC checks passed
- source-blind direct smoke retained one session ID across four resumed turns, including a turn beyond the early-reap window
- source-blind isolated inbox smoke retained one session ID across two unseen-message deliveries and returned `INBOX-A` then `INBOX-B`
- cross-family Claude review resolved four findings and returned clean on the preceding runtime head; the exact final head is being re-reviewed after the CI-only hermetic fixture correction

Rail-Approval-Receipt: rail-approval-e2f9cbbbeef94786831a2b69d47607d9

Fixes #6088