### PR TITLE
fix(backup): preserve agent recovery state

### DIFF
--- a/docs/runbooks/data-backup.md
+++ b/docs/runbooks/data-backup.md
@@ -8,12 +8,13 @@ prune snapshots, or restore directly over live project data.
 Every snapshot contains these roots, in priority order:
 
 - every `.claude/*-epic/` directory, including driver plans and handoffs;
+- `.agent/`, including local agent recovery state and session-stream databases;
 - `batch_state/`;
 - `data/`, including SQLite databases, embeddings, and private inputs;
 - `GIT-WORKTREE.patch` when tracked changes have not been committed; and
 - `BACKUP-RECEIPT.json`.
 
-The script fails closed when `.claude/atlas-epic`, `batch_state`, `data`, or
+The script fails closed when `.claude/atlas-epic`, `.agent`, `batch_state`, `data`, or
 the destination configuration is missing. It also fails when a non-ignored
 untracked Git path is outside the declared recovery roots. This prevents a
 partial backup from appearing successful.
@@ -33,14 +34,17 @@ restic rclone path with that final directory name.
   copy-on-write staging; a cross-volume staging location fails closed.
 - On Linux filesystems without reflink support, only a bounded source tree of
   at most 64 MiB may fall back to a normal copy; larger trees fail closed.
-- Every `*.db`, `*.sqlite`, and `*.sqlite3` under the selected roots is rebuilt
+- Every `*.db`, `*.sqlite`, and `*.sqlite3` under the selected roots (including
+  `.agent/`) is rebuilt
   in staging with SQLite's online backup command and must pass
   `PRAGMA quick_check` before upload.
-- SQLite WAL/SHM files, `__pycache__`, `.DS_Store`, and retired `qdrant/` data
-  are excluded.
+- SQLite WAL/SHM sidecars for `*.db`, `*.sqlite`, and `*.sqlite3` databases,
+  plus `__pycache__`, `.DS_Store`, and retired `qdrant/` data, are excluded.
 - The legacy `data/textbooks` and `data/vesum` symlinks are excluded only when
   they resolve inside the old Drive backup. Other absolute or escaping
   symlinks stop the backup.
+- `.agent/` must be a real directory. Broken, absolute, or escaping symlinks
+  below it, and unsupported special files, stop the backup before restic runs.
 - Restore accepts only an absolute empty or nonexistent directory outside the
   project, cloud mounts, and the legacy backup.
 - There is intentionally no `forget`, `prune`, or snapshot-delete command.
@@ -180,7 +184,7 @@ mkdir -p /absolute/path/to/recovery-parent
   --execute
 ```
 
-The restored tree contains `.claude/`, `batch_state/`, `data/`, and the JSON
+The restored tree contains `.claude/`, `.agent/`, `batch_state/`, `data/`, and the JSON
 receipt. Validate the receipt and databases before any live import:
 
 ```bash
@@ -200,6 +204,12 @@ rsync -a "$RECOVERY_DIR/.claude/" "$PROJECT_DIR/.claude/"
 rsync -a "$RECOVERY_DIR/batch_state/" "$PROJECT_DIR/batch_state/"
 ```
 
+Before any selective `.agent/` import, stop every `.agent` writer. Never
+overwrite the live `.agent/` root as a whole, and never use `rsync --delete`.
+Review and import only the required recovery files after validating their
+databases and schema compatibility. Do not blindly reactivate stale locks,
+wake state, caches, deployed mirrors, hooks, or executables from a snapshot.
+
 If `GIT-WORKTREE.patch` exists, inspect it and run a check before deciding to
 apply it:
 
@@ -207,8 +217,8 @@ apply it:
 git -C "$PROJECT_DIR" apply --check "$RECOVERY_DIR/GIT-WORKTREE.patch"
 ```
 
-Do not use `rsync --delete`. Copy `data/` back only after validating the
-specific recovery target and stopping its writers.
+Copy `data/` back only after validating the specific recovery target and
+stopping its writers.
 
 For an incident:
 
@@ -231,8 +241,8 @@ Drive backup, or another directory containing files.
   from committed configuration and release artifacts.
 - `_quarantine/`: incident evidence remains separately managed.
 - `data/qdrant/`: retired and rebuildable under ADR-005/006.
-- SQLite `*.db-wal` and `*.db-shm`: transient state incorporated into each
-  staged online database backup.
+- SQLite WAL/SHM sidecars for `*.db`, `*.sqlite`, and `*.sqlite3`: transient
+  state incorporated into each staged online database backup.
 - `data/textbooks` and `data/vesum` when they are legacy Drive symlinks. Their
   targets remain in the legacy backup until a separate migration is planned.
 

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -9,6 +9,7 @@
 #
 # Covers:
 #   .claude/*-epic/  Gitignored driver plans and handoffs
+#   .agent/          Gitignored agent recovery state
 #   batch_state/     Gitignored local fleet/delegate state
 #   data/            SQLite databases, embeddings, and private inputs
 #
@@ -96,7 +97,7 @@ Usage:
 
 Safety:
   - init, backup, and restore are previews unless --execute is supplied.
-  - backup requires epic state, batch_state/, data/, and full source coverage.
+  - backup requires epic state, .agent/, batch_state/, data/, and full source coverage.
   - successful snapshots contain BACKUP-RECEIPT.json and a restore command.
   - restore refuses non-empty, project, cloud, and legacy-backup targets.
   - no command prunes or deletes snapshots.
@@ -387,6 +388,8 @@ validate_tree_symlinks() {
   while IFS= read -r -d '' link; do
     relative=${link#"$tree"/}
     target="$(readlink "$link")"
+    [[ -e "$link" ]] ||
+      die "Broken symlink in $label: $relative -> $target"
     resolved="$(realpath "$link" 2>/dev/null)" ||
       die "Broken symlink in $label: $relative -> $target"
     [[ "$target" != /* ]] ||
@@ -394,6 +397,17 @@ validate_tree_symlinks() {
     path_is_within "$resolved" "$tree_real" ||
       die "Symlink escapes $label: $relative -> $target"
   done < <(find "$tree" -type l -print0)
+}
+
+validate_tree_file_types() {
+  local tree=$1
+  local label=$2
+  local entry relative
+
+  while IFS= read -r -d '' entry; do
+    relative=${entry#"$tree"/}
+    die "Unsupported special file type in $label: $relative"
+  done < <(find "$tree" ! -type d ! -type f ! -type l -print0)
 }
 
 discover_backup_paths() {
@@ -410,6 +424,10 @@ discover_backup_paths() {
     die "Required recovery path is missing: batch_state"
   [[ ! -L "$PROJECT_ROOT/batch_state" ]] ||
     die "Required recovery path must not be a symlink: batch_state"
+  [[ -d "$PROJECT_ROOT/.agent" ]] ||
+    die "Required recovery path is missing: .agent"
+  [[ ! -L "$PROJECT_ROOT/.agent" ]] ||
+    die "Required recovery path must not be a symlink: .agent"
 
   for epic in "$PROJECT_ROOT"/.claude/*-epic; do
     [[ -d "$epic" ]] || continue
@@ -419,7 +437,7 @@ discover_backup_paths() {
       die "Epic recovery path has an unsafe label: $(basename "$epic")"
     BACKUP_PATHS+=(".claude/$(basename "$epic")")
   done
-  BACKUP_PATHS+=("batch_state" "data")
+  BACKUP_PATHS+=(".agent" "batch_state" "data")
 }
 
 path_has_backup_coverage() {
@@ -473,6 +491,7 @@ validate_source() {
     [[ "$relative" != "data" ]] || continue
     validate_tree_symlinks "$PROJECT_ROOT/$relative" "$relative"
   done
+  validate_tree_file_types "$PROJECT_ROOT/.agent" ".agent"
 }
 
 acquire_lock() {
@@ -647,7 +666,10 @@ remove_staged_exclusions() {
     remove_staged_path "$directory"
   done < <(find "$STAGED_ROOT" -type d -name __pycache__ -prune -print0)
   find "$STAGED_ROOT" -type f \
-    \( -name '*.db-wal' -o -name '*.db-shm' -o -name '.DS_Store' \) \
+    \( -name '*.db-wal' -o -name '*.db-shm' \
+      -o -name '*.sqlite-wal' -o -name '*.sqlite-shm' \
+      -o -name '*.sqlite3-wal' -o -name '*.sqlite3-shm' \
+      -o -name '.DS_Store' \) \
     -delete ||
     die "Could not remove excluded sidecars from the private staging tree."
 }
@@ -660,6 +682,10 @@ build_restic_excludes() {
     --exclude "$root/qdrant"
     --exclude '**/*.db-wal'
     --exclude '**/*.db-shm'
+    --exclude '**/*.sqlite-wal'
+    --exclude '**/*.sqlite-shm'
+    --exclude '**/*.sqlite3-wal'
+    --exclude '**/*.sqlite3-shm'
     --exclude '**/__pycache__/**'
     --exclude '**/.DS_Store'
   )
@@ -763,7 +789,7 @@ write_backup_receipt() {
     known_missing='[".claude/atlas-epic/plans/curated-seed"]'
   fi
   created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  exclusions_json='["data/qdrant", "*.db-wal", "*.db-shm", "__pycache__", ".DS_Store"]'
+  exclusions_json='["data/qdrant", "*.db-wal", "*.db-shm", "*.sqlite-wal", "*.sqlite-shm", "*.sqlite3-wal", "*.sqlite3-shm", "__pycache__", ".DS_Store"]'
   if ((${#LEGACY_EXCLUDES[@]} > 0)); then
     for relative in "${LEGACY_EXCLUDES[@]}"; do
       exclusions_json="$(

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -38,6 +38,7 @@ def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path
         fake_bin,
         source,
         project / ".claude" / "atlas-epic",
+        project / ".agent",
         project / "batch_state",
         staging,
         legacy,
@@ -45,6 +46,10 @@ def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path
     ):
         directory.mkdir(parents=True)
     (project / "README.md").write_text("fixture\n", encoding="utf-8")
+    (project / ".gitignore").write_text(
+        ".agent\n.claude\nbatch_state\n",
+        encoding="utf-8",
+    )
     (project / ".claude" / "atlas-epic" / "HANDOFF.md").write_text(
         "recover me\n",
         encoding="utf-8",
@@ -53,9 +58,13 @@ def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path
         "recover me too\n",
         encoding="utf-8",
     )
+    (project / ".agent" / "recovery-state.json").write_text(
+        '{"schema_version": 1}\n',
+        encoding="utf-8",
+    )
     subprocess.run(["git", "init", "-q", str(project)], check=True)
     subprocess.run(
-        ["git", "-C", str(project), "add", "README.md"],
+        ["git", "-C", str(project), "add", "README.md", ".gitignore"],
         check=True,
     )
     subprocess.run(
@@ -126,9 +135,34 @@ if [[ "${1:-}" == "backup" && -f "$PWD/BACKUP-RECEIPT.json" ]]; then
   jq -c '{
     status: .receipt_status,
     paths: [.paths[].path],
+    agent: (.paths[] | select(.path == ".agent")),
     data: (.paths[] | select(.path == "data"))
   }' \
     "$PWD/BACKUP-RECEIPT.json" >> "$FAKE_RESTIC_LOG"
+fi
+if [[ "${1:-}" == "backup" && -n "${FAKE_SNAPSHOT_DIR:-}" ]]; then
+  mkdir -p "$FAKE_SNAPSHOT_DIR"
+  cp -a "$PWD/." "$FAKE_SNAPSHOT_DIR/"
+fi
+if [[ "${1:-}" == "restore" && -n "${FAKE_SNAPSHOT_DIR:-}" ]]; then
+  dry_run=0
+  restore_target=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run) dry_run=1 ;;
+      --target)
+        shift
+        restore_target="${1:-}"
+        ;;
+    esac
+    shift
+  done
+  if [[ "$dry_run" == 0 ]]; then
+    test -n "$restore_target"
+    mkdir -p "$restore_target"
+    cp -a "$FAKE_SNAPSHOT_DIR/." "$restore_target/"
+  fi
 fi
 if [[ "${1:-}" == "backup" && -n "${FAKE_MUTATED_LIVE_STATE_SOURCE:-}" ]]; then
   cp "$FAKE_MUTATED_LIVE_STATE_SOURCE" "$FAKE_MUTATED_LIVE_STATE_DESTINATION"
@@ -228,6 +262,7 @@ def test_execute_stages_a_consistent_wal_database_and_cleans_up(
     assert "staged_required=<.claude/atlas-epic/HANDOFF.md>" in _log(environment)
     assert '"status":"prepared-before-snapshot-write"' in _log(environment)
     assert '".claude/atlas-epic"' in _log(environment)
+    assert '".agent"' in _log(environment)
     assert '"batch_state"' in _log(environment)
     assert list(staging.iterdir()) == []
 
@@ -430,12 +465,20 @@ def test_receipt_counts_match_post_exclusion_snapshot_contents(
     (source / "sidecar.db-wal").write_bytes(b"not recoverable")
     (source / ".DS_Store").write_bytes(b"not recoverable")
     (source / "keep.txt").write_bytes(b"keep\n")
-    environment["FAKE_FORBIDDEN_RELATIVES"] = "data/qdrant data/__pycache__ data/sidecar.db-wal data/.DS_Store"
+    (source / "keep-wal").write_bytes(b"keep\n")
+    environment.update(
+        {
+            "FAKE_FORBIDDEN_RELATIVES": (
+                "data/qdrant data/__pycache__ data/sidecar.db-wal data/.DS_Store"
+            ),
+            "FAKE_REQUIRED_RELATIVE": "data/keep-wal",
+        }
+    )
 
     result = _run(environment, "backup", "--execute")
 
     assert result.returncode == 0, result.stderr
-    assert '"data":{"path":"data","files":1,"bytes":5}' in _log(environment)
+    assert '"data":{"path":"data","files":2,"bytes":10}' in _log(environment)
     assert _log(environment).count("staged_excluded=<") == 4
     assert list(staging.iterdir()) == []
 
@@ -514,6 +557,91 @@ def test_execute_snapshots_sqlite3_database_from_batch_state(
     assert list(staging.iterdir()) == []
 
 
+def test_execute_restores_agent_wal_database_without_sidecars(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, source, staging, _legacy = backup_environment
+    database = (
+        source.parent
+        / ".agent"
+        / "session-streams"
+        / "v1"
+        / "session-streams.sqlite3"
+    )
+    database.parent.mkdir(parents=True)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute("CREATE TABLE recovery_probe (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO recovery_probe VALUES ('first')")
+        connection.commit()
+        connection.execute("INSERT INTO recovery_probe VALUES ('latest')")
+        connection.commit()
+        assert database.with_name("session-streams.sqlite3-wal").exists()
+        environment.update(
+            {
+                "FAKE_DB_RELATIVE": ".agent/session-streams/v1/session-streams.sqlite3",
+                "FAKE_FORBIDDEN_RELATIVES": " ".join(
+                    [
+                        ".agent/session-streams/v1/session-streams.sqlite3-wal",
+                        ".agent/session-streams/v1/session-streams.sqlite3-shm",
+                    ]
+                ),
+                "FAKE_SNAPSHOT_DIR": str(tmp_path / "snapshot"),
+            }
+        )
+
+        backed_up = _run(environment, "backup", "--execute")
+    finally:
+        connection.close()
+
+    assert backed_up.returncode == 0, backed_up.stderr
+    assert "db_rows=<2>" in _log(environment)
+    assert _log(environment).count("staged_excluded=<") == 2
+    assert list(staging.iterdir()) == []
+
+    restore_target = tmp_path / "separate-restore-target"
+    restored = _run(
+        environment,
+        "restore",
+        "latest",
+        "--to",
+        str(restore_target),
+        "--execute",
+    )
+
+    assert restored.returncode == 0, restored.stderr
+    restored_database = (
+        restore_target / ".agent" / "session-streams" / "v1" / database.name
+    )
+    assert not restored_database.with_name(f"{database.name}-wal").exists()
+    assert not restored_database.with_name(f"{database.name}-shm").exists()
+    with sqlite3.connect(f"file:{restored_database}?mode=ro", uri=True) as restored_connection:
+        rows = restored_connection.execute(
+            "SELECT value FROM recovery_probe ORDER BY rowid"
+        ).fetchall()
+    assert rows == [("first",), ("latest",)]
+    assert (restore_target / ".agent").is_dir()
+    assert restore_target != source.parent
+
+
+def test_execute_stages_agent_recovery_file_and_receipt_label(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, _source, staging, _legacy = backup_environment
+    environment["FAKE_REQUIRED_RELATIVE"] = ".agent/recovery-state.json"
+
+    result = _run(environment, "backup", "--execute")
+
+    assert result.returncode == 0, result.stderr
+    assert "staged_required=<.agent/recovery-state.json>" in _log(environment)
+    assert '"agent":{"path":".agent","files":1,"bytes":22}' in _log(environment)
+    assert '".agent/recovery-state.json"' not in _log(environment).splitlines()[-1]
+    assert list(staging.iterdir()) == []
+
+
 def test_execute_preserves_tracked_changes_as_a_patch(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
 ) -> None:
@@ -541,6 +669,83 @@ def test_backup_fails_closed_when_required_repo_state_is_missing(
 
     assert result.returncode != 0
     assert "Required recovery path is missing: .claude/atlas-epic" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_backup_fails_closed_when_agent_recovery_root_is_missing(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    agent_root = source.parent / ".agent"
+    (agent_root / "recovery-state.json").unlink()
+    agent_root.rmdir()
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Required recovery path is missing: .agent" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_backup_fails_closed_when_agent_recovery_root_is_a_symlink(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    agent_root = source.parent / ".agent"
+    external_root = tmp_path / "external-agent"
+    agent_root.rename(external_root)
+    agent_root.symlink_to(external_root, target_is_directory=True)
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Required recovery path must not be a symlink: .agent" in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_error"),
+    [
+        ("missing-target", "Broken symlink in .agent"),
+        ("/tmp/agent-outside", "Absolute symlink is not backup-safe in .agent"),
+        ("../agent-outside", "Symlink escapes .agent"),
+    ],
+)
+def test_backup_fails_closed_for_unsafe_agent_symlink(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
+    target: str,
+    expected_error: str,
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    agent_root = source.parent / ".agent"
+    if target == "../agent-outside":
+        (source.parent / "agent-outside").mkdir()
+    elif target == "/tmp/agent-outside":
+        external_root = tmp_path / "agent-outside"
+        external_root.mkdir()
+        target = str(external_root)
+    (agent_root / "unsafe-link").symlink_to(target)
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr
+    assert "arg=<backup>" not in _log(environment)
+
+
+def test_backup_fails_closed_for_agent_special_file(
+    backup_environment: tuple[dict[str, str], Path, Path, Path],
+) -> None:
+    environment, source, _staging, _legacy = backup_environment
+    fifo = source.parent / ".agent" / "writer.pipe"
+    os.mkfifo(fifo)
+
+    result = _run(environment, "backup")
+
+    assert result.returncode != 0
+    assert "Unsupported special file type in .agent: writer.pipe" in result.stderr
     assert "arg=<backup>" not in _log(environment)
 
 

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -629,16 +629,27 @@ def test_execute_restores_agent_wal_database_without_sidecars(
 
 def test_execute_stages_agent_recovery_file_and_receipt_label(
     backup_environment: tuple[dict[str, str], Path, Path, Path],
+    tmp_path: Path,
 ) -> None:
     environment, _source, staging, _legacy = backup_environment
     environment["FAKE_REQUIRED_RELATIVE"] = ".agent/recovery-state.json"
+    snapshot = tmp_path / "snapshot"
+    environment["FAKE_SNAPSHOT_DIR"] = str(snapshot)
 
     result = _run(environment, "backup", "--execute")
 
     assert result.returncode == 0, result.stderr
     assert "staged_required=<.agent/recovery-state.json>" in _log(environment)
     assert '"agent":{"path":".agent","files":1,"bytes":22}' in _log(environment)
-    assert '".agent/recovery-state.json"' not in _log(environment).splitlines()[-1]
+    receipt_path = snapshot / "BACKUP-RECEIPT.json"
+    receipt_text = receipt_path.read_text(encoding="utf-8")
+    receipt = json.loads(receipt_text)
+    assert next(path for path in receipt["paths"] if path["path"] == ".agent") == {
+        "path": ".agent",
+        "files": 1,
+        "bytes": 22,
+    }
+    assert ".agent/recovery-state.json" not in receipt_text
     assert list(staging.iterdir()) == []
 
 


### PR DESCRIPTION
## Summary

Closes the recovery-state coverage gap surfaced by #6013 without claiming that the deleting actor is known.

- adds the complete ignored `.agent/` tree as one required encrypted recovery root
- fails closed for a missing/symlinked root, broken/absolute/escaping nested symlinks, and special files
- includes `.agent` databases in the existing consistent SQLite staging path
- excludes WAL/SHM sidecars for the supported `.db`, `.sqlite`, and `.sqlite3` suffixes while preserving unrelated `*-wal` files
- records only top-level `.agent` aggregate counts in the backup receipt
- keeps restore staging-only and documents selective import after stopping writers

## Root cause

The encrypted restic job covered `.claude/*-epic`, `batch_state`, and `data`, but not `.agent`. Because `.agent` is ignored by Git, the existing uncovered-untracked guard cannot detect that omission. Confirmed rollover packets, task lifecycle state, review receipts, and the session-stream database could therefore be lost with the primary checkout even when the latest backup was healthy.

## Architecture gate

Present-tense Sol advisor decision: **GO, full `.agent` root**. A subpath allowlist was rejected because it would encode today's runtime schema and silently omit the next recovery-critical directory. The observed root is ~6.4 MiB; restic is encrypted and deduplicated; restore remains separate and non-overwriting.

The rclone shared-client-ID retirement warning is a different credential-owned dependency risk and is tracked separately in #6093.

## Validation

- `35 passed` — `tests/test_backup_data_script.py`
- `bash -n scripts/backup-data.sh`
- ShellCheck passed
- Ruff passed
- Markdownlint passed
- `git diff --check` passed
- staged OPSEC leak audit passed
- X-Agent trailer lint passed

The suite proves `.agent` staging and aggregate receipt inventory; missing/symlinked/unsafe/special-file rejection before upload; WAL-mode `.agent/session-streams/v1/session-streams.sqlite3` recovery with latest committed rows and no sidecars; preservation of unrelated `*-wal` files; and restore only beneath a separate target.

## Scope / disposition

Refs #6013 and #4707. This PR leaves #6013 open because the deleting actor remains unknown and other incident-hardening items may remain. It does not change retention/pruning, credentials, live in-place restore, `.agent` schema, `.git`, or worktree backups.

Independent cross-family code review is still required before auto-merge.

