### PR TITLE
feat(acp): make fleet conversations routine and readable

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -138,6 +138,21 @@ Discussion is never formal CF. Formal CF remains `review-pr` /
 `publish-review-verdict` only. ACPX is structured invocation transport, not a
 coordination authority. File dual-write stays authoritative in every plane mode.
 
+## Bounded ACP panel (approved selection)
+
+Every supported fleet orchestrator may explicitly invoke the fixed Codex↔Grok
+ACP panel for **one consequential, read-only design or risk comparison** when
+that direct cross-provider critique is materially useful. Its sole surface is
+`python -m scripts.fleet_comms acp-discuss`; do not add automatic launcher or
+`delegate.py` use. The default is two rounds and the hard maximum is three.
+
+Admission is one conversation repository-wide: return `busy` when occupied,
+with zero queue and zero automatic retry. On busy or when ACPX is unready, use
+the bounded bridge `discuss` path instead. ACP output is deliberation evidence:
+a typed partial outcome is valid evidence but never a successful discussion,
+formal review, or coordination authority. The exact command, primary-install
+and body-free `acp-verify` E2E/replay procedure are in the onboarding contract.
+
 ## Offline fallback path
 
 `agents_extensions/shared/rules/fleet-comms-coordination.md` (this file).

--- a/dashboards/acp.html
+++ b/dashboards/acp.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ACP Conversations - ukraine-ops</title>
+<link rel="icon" href="data:,">
+<style>
+:root { --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d; --text: #e6edf3; --text2: #8b949e; --text3: #6e7681; --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922; --purple: #bc8cff; --cyan: #39d2c0; }
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+a { color: var(--blue); }
+.topbar { display: flex; align-items: center; gap: 14px; padding: 16px 24px; border-bottom: 1px solid var(--border); background: var(--bg2); }
+.topbar h1 { margin: 0; font-size: 22px; }
+.sub, .muted { color: var(--text2); font-size: 13px; }
+.spacer { flex: 1; }
+.meta { text-align: right; color: var(--text3); font-size: 12px; }
+.container { max-width: 1480px; margin: 0 auto; padding: 24px; }
+.intro { display: flex; justify-content: space-between; gap: 24px; align-items: end; margin: 4px 0 20px; }
+.eyebrow { color: var(--cyan); font-size: 11px; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.intro h2 { margin: 5px 0 8px; font-size: clamp(24px, 3.2vw, 38px); letter-spacing: -.035em; }
+.intro p { max-width: 670px; margin: 0; color: var(--text2); line-height: 1.5; }
+.privacy { max-width: 350px; border-left: 3px solid var(--purple); background: rgba(188, 140, 255, .07); color: var(--text2); font-size: 12px; line-height: 1.5; padding: 12px 14px; }
+.privacy strong { color: var(--text); }
+.banner { display: none; margin: 0 0 16px; padding: 11px 13px; border: 1px solid rgba(248,81,73,.45); border-radius: 8px; background: rgba(248,81,73,.12); color: #ffaaa4; font-size: 13px; }
+.workspace { display: grid; grid-template-columns: minmax(280px, .8fr) minmax(0, 1.6fr); gap: 16px; align-items: start; }
+.ledger, .detail { min-width: 0; border: 1px solid var(--border); border-radius: 12px; background: var(--bg2); }
+.ledger { overflow: hidden; }
+.section-head { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 14px 16px; border-bottom: 1px solid var(--border); }
+.section-head h3 { margin: 0; font-size: 13px; letter-spacing: .02em; }
+.count { color: var(--text3); font-size: 12px; }
+.conversation-list { display: grid; gap: 1px; background: var(--border); }
+.conversation-row { display: block; padding: 14px 16px; background: var(--bg2); color: var(--text); text-decoration: none; border-left: 3px solid transparent; outline-offset: -3px; }
+.conversation-row:hover { background: var(--bg3); text-decoration: none; }
+.conversation-row:focus-visible { outline: 2px solid var(--blue); }
+.conversation-row[aria-current="true"] { border-left-color: var(--cyan); background: rgba(57,210,192,.08); }
+.row-top, .detail-title { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+.conversation-id { min-width: 0; overflow-wrap: anywhere; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 12px; font-weight: 750; }
+.row-meta { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; color: var(--text3); font-size: 11px; }
+.pill { display: inline-flex; align-items: center; border-radius: 999px; padding: 3px 8px; font-size: 11px; font-weight: 700; white-space: nowrap; }
+.pill.ok { color: var(--green); background: rgba(63,185,80,.14); }.pill.err { color: var(--red); background: rgba(248,81,73,.14); }.pill.warn { color: var(--yellow); background: rgba(210,153,34,.14); }.pill.gray { color: var(--text2); background: rgba(139,148,158,.12); }.pill.info { color: var(--cyan); background: rgba(57,210,192,.13); }
+.detail { min-height: 500px; padding: 20px; }
+.detail-empty { display: grid; place-items: center; min-height: 440px; color: var(--text3); text-align: center; line-height: 1.55; }
+.detail-title h3 { margin: 0; font-size: 16px; }
+.detail-sub { margin: 7px 0 0; color: var(--text3); font-size: 12px; }
+.facts { display: flex; flex-wrap: wrap; gap: 7px; margin: 16px 0 18px; }
+.participants { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding: 12px 0 18px; border-bottom: 1px solid var(--border); }
+.participants-label { color: var(--text3); font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.lane { color: var(--text2); border: 1px solid var(--border); border-radius: 6px; padding: 5px 8px; font-size: 11px; font-weight: 700; text-transform: uppercase; }
+.timeline-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin: 19px 0 12px; }.timeline-head h4 { margin: 0; font-size: 13px; }
+.timeline { position: relative; display: grid; gap: 0; padding-left: 28px; }.timeline::before { content: ""; position: absolute; left: 8px; top: 7px; bottom: 7px; width: 2px; background: linear-gradient(var(--cyan), rgba(57,210,192,.18)); }
+.event { position: relative; padding: 0 0 18px 14px; }.event:last-child { padding-bottom: 0; }.event::before { content: ""; position: absolute; left: -25px; top: 4px; width: 11px; height: 11px; border-radius: 50%; border: 2px solid var(--cyan); background: var(--bg2); box-shadow: 0 0 0 4px var(--bg2); }
+.event-top { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; }.event-flow { color: var(--cyan); font-size: 12px; font-weight: 800; }.event-time { color: var(--text3); font-size: 11px; }.event-type { color: var(--text); font-size: 12px; }.event-facts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.empty { padding: 18px 16px; color: var(--text3); font-size: 13px; line-height: 1.5; }
+@media (max-width: 880px) { .topbar, .intro { align-items: flex-start; flex-wrap: wrap; }.meta { text-align: left; }.workspace { grid-template-columns: 1fr; }.detail { min-height: 360px; }.privacy { max-width: none; }.conversation-row { padding: 13px; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; } }
+</style>
+<link rel="stylesheet" href="/monitor.css">
+</head>
+<body>
+<header class="topbar">
+  <div><h1>ACP Conversations</h1><div class="sub">Bounded conversation observability</div></div>
+  <div class="spacer"></div>
+  <div class="meta"><div>Read-only metadata</div><div id="last-refresh">Loading…</div></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a><a href="/orient.html">Orient</a><a href="/channels.html">Channels</a><a href="/comms.html">Comms</a><a href="/artifacts/">Artifacts</a><a href="/runtime.html">Runtime</a><a class="active" href="/acp.html">Conversations</a><a href="/docs">API</a>
+  </nav>
+</header>
+<main class="container">
+  <section class="intro" aria-labelledby="page-heading">
+    <div><div class="eyebrow">Conversation event rail</div><h2 id="page-heading">Follow the flow, not the payload.</h2><p>Recent bounded ACP conversations are shown as state transitions and allowlisted operational metadata. Select a conversation to inspect its chronological event rail.</p></div>
+    <aside class="privacy"><strong>Body-free by design.</strong> Prompts, responses, paths, credentials, commands, sessions, and artifact bodies never appear here. This page cannot send, start, retry, cancel, route, or review a conversation.</aside>
+  </section>
+  <div class="banner" id="error-banner" role="status"></div>
+  <section class="workspace" aria-label="ACP conversation browser">
+    <aside class="ledger" aria-labelledby="ledger-heading"><div class="section-head"><h3 id="ledger-heading">Recent conversations</h3><span class="count" id="conversation-count">Loading</span></div><div class="conversation-list" id="conversation-list" aria-live="polite"><div class="empty">Loading recent conversations…</div></div></aside>
+    <section class="detail" aria-labelledby="detail-heading"><div id="conversation-detail" class="detail-empty"><div><strong id="detail-heading">Select a conversation</strong><br>Its body-free timeline will appear here.</div></div></section>
+  </section>
+</main>
+<script>
+const LIST_URL = '/api/runtime/acp/conversations?limit=50';
+const DETAIL_URL = '/api/runtime/acp/conversations/';
+
+function escapeHtml(value) { const node = document.createElement('span'); node.textContent = value == null ? '' : String(value); return node.innerHTML; }
+function formatTs(value) { if (!value) return '—'; const date = new Date(value); return Number.isNaN(date.getTime()) ? escapeHtml(String(value)) : date.toLocaleString(); }
+function formatDurationMs(value) { return Number.isFinite(value) ? value >= 60000 ? `${(value / 60000).toFixed(1)}m` : `${(value / 1000).toFixed(1)}s` : '—'; }
+function label(value) { return String(value || 'unknown').replace(/[_-]+/g, ' ').replace(/\b\w/g, character => character.toUpperCase()); }
+function stateClass(state) { if (state === 'COMPLETE') return 'ok'; if (state === 'PARTIAL' || state === 'PARTIAL_COMPLETE') return 'warn'; if (state === 'FAILED' || state === 'CANCELLED') return 'err'; if (state === 'CREATED') return 'gray'; return 'info'; }
+function stateLabel(state) { if (state === 'COMPLETE') return 'Succeeded'; if (state === 'PARTIAL' || state === 'PARTIAL_COMPLETE') return 'Partial'; if (state === 'FAILED') return 'Failed'; if (state === 'CANCELLED') return 'Cancelled'; if (state === 'CREATED') return 'Queued'; return 'Running'; }
+function outcomeClass(outcome) { if (outcome === 'succeeded') return 'ok'; if (outcome === 'failed' || outcome === 'cancelled' || outcome === 'deadline_exceeded') return 'err'; if (outcome === 'partial' || outcome === 'budget_exhausted') return 'warn'; if (outcome === 'queued') return 'gray'; return 'info'; }
+function eventStatus(event) { return typeof event.outcome === 'string' && event.outcome ? { className: outcomeClass(event.outcome), text: label(event.outcome) } : { className: stateClass(event.state), text: stateLabel(event.state) }; }
+function selectedId() { return new URLSearchParams(location.search).get('conversation'); }
+function eventFacts(event) { const facts = []; if (Number.isFinite(event.duration_ms)) facts.push(`Duration ${formatDurationMs(event.duration_ms)}`); if (Number.isFinite(event.token_count)) facts.push(`Tokens ${event.token_count}`); return facts.map(fact => `<span class="pill gray">${escapeHtml(fact)}</span>`).join(''); }
+function eventFlow(event) { const sender = typeof event.sender === 'string' ? event.sender : 'system'; const recipient = typeof event.recipient === 'string' ? event.recipient : ''; return recipient ? `${sender} → ${recipient}` : sender; }
+async function fetchJson(url) { const response = await fetch(url); const text = await response.text(); let data = {}; try { data = text ? JSON.parse(text) : {}; } catch { data = { detail: text }; } if (!response.ok) throw new Error(data.detail || data.error || `HTTP ${response.status}`); return data; }
+function renderList(conversations, activeId) { const content = document.getElementById('conversation-list'); document.getElementById('conversation-count').textContent = `${conversations.length} recent`; if (!conversations.length) { content.innerHTML = '<div class="empty">No recent ACP conversations. Run no action from this page; it observes persisted metadata only.</div>'; return; } content.innerHTML = conversations.map(conversation => { const id = conversation && typeof conversation.conversation_id === 'string' ? conversation.conversation_id : null; if (!id) return ''; const selected = id === activeId; const href = `/acp.html?conversation=${encodeURIComponent(id)}`; return `<a class="conversation-row" href="${href}" ${selected ? 'aria-current="true"' : ''}><div class="row-top"><span class="conversation-id">${escapeHtml(id)}</span><span class="pill ${stateClass(conversation.current_state)}">${escapeHtml(stateLabel(conversation.current_state))}</span></div><div class="row-meta"><span>${escapeHtml((conversation.participants || []).map(label).join(' · ') || 'Participants unavailable')}</span><span>Rounds ${Number(conversation.rounds_completed) || 0}/${Number(conversation.rounds_requested) || 0}</span><span>Updated ${escapeHtml(formatTs(conversation.updated_at))}</span></div></a>`; }).join(''); }
+function renderDetail(conversation) { const detail = document.getElementById('conversation-detail'); const events = Array.isArray(conversation.events) ? conversation.events : []; const facts = [`Rounds ${Number(conversation.rounds_completed) || 0}/${Number(conversation.rounds_requested) || 0}`, `Started ${formatTs(conversation.created_at)}`, `Updated ${formatTs(conversation.updated_at)}`, `Duration ${formatDurationMs(conversation.total_duration_ms)}`, `Tokens ${Number.isFinite(conversation.total_tokens) ? conversation.total_tokens : '—'}`, `Synthesis ${label(conversation.synthesis_state)}`]; if (conversation.duplicate_suppressed) facts.push('Duplicate suppressed'); if (conversation.termination_reason) facts.push(`Ended ${label(conversation.termination_reason)}`); const participants = Array.isArray(conversation.participants) ? conversation.participants : []; const timeline = events.length ? `<div class="timeline">${events.map(event => { const status = eventStatus(event); return `<article class="event"><div class="event-top"><span class="event-flow">${escapeHtml(eventFlow(event))}</span><span class="event-type">${escapeHtml(label(event.event_type))}</span><span class="pill ${status.className}">${escapeHtml(status.text)}</span><span class="event-time">${escapeHtml(formatTs(event.created_at))}</span></div>${eventFacts(event) ? `<div class="event-facts">${eventFacts(event)}</div>` : ''}</article>`; }).join('')}</div>` : '<div class="empty">No allowlisted timeline events were recorded for this conversation.</div>'; detail.className = ''; detail.innerHTML = `<div class="detail-title"><div><h3 id="detail-heading" class="conversation-id">${escapeHtml(conversation.conversation_id || 'Conversation')}</h3><p class="detail-sub">Chronological, allowlisted event metadata</p></div><span class="pill ${stateClass(conversation.current_state)}">${escapeHtml(stateLabel(conversation.current_state))}</span></div><div class="facts">${facts.map(fact => `<span class="pill gray">${escapeHtml(fact)}</span>`).join('')}</div><div class="participants"><span class="participants-label">Participants</span>${participants.map(participant => `<span class="lane">${escapeHtml(label(participant))}</span>`).join('') || '<span class="muted">Not reported</span>'}</div><div class="timeline-head"><h4>Event flow</h4><span class="count">${events.length} allowlisted events</span></div>${timeline}`; }
+function showError(message) { const banner = document.getElementById('error-banner'); banner.textContent = message; banner.style.display = 'block'; }
+async function loadPage() { try { const snapshot = await fetchJson(LIST_URL); if (!snapshot || typeof snapshot !== 'object' || !Array.isArray(snapshot.conversations)) throw new Error('Malformed conversation data'); if (snapshot.availability === 'unavailable') { document.getElementById('conversation-count').textContent = 'Unavailable'; document.getElementById('conversation-list').innerHTML = '<div class="empty">Conversation storage is unavailable. No routing or provider health is inferred.</div>'; document.getElementById('conversation-detail').innerHTML = '<div><strong id="detail-heading">Timeline unavailable</strong><br>Restore read-only conversation storage, then refresh the page.</div>'; return; } const conversations = snapshot.conversations.filter(item => item && typeof item.conversation_id === 'string'); const activeId = conversations.some(item => item.conversation_id === selectedId()) ? selectedId() : conversations[0]?.conversation_id; renderList(conversations, activeId); if (!activeId) { document.getElementById('conversation-detail').innerHTML = '<div><strong id="detail-heading">No recent conversations</strong><br>There is no persisted body-free timeline to display.</div>'; return; } try { renderDetail(await fetchJson(`${DETAIL_URL}${encodeURIComponent(activeId)}`)); } catch (error) { document.getElementById('conversation-detail').innerHTML = '<div><strong id="detail-heading">Timeline unavailable</strong><br>The selected conversation could not be loaded.</div>'; showError(`Conversation detail unavailable: ${error.message}`); } } catch (error) { document.getElementById('conversation-count').textContent = 'Error'; document.getElementById('conversation-list').innerHTML = '<div class="empty">Recent conversations could not be loaded.</div>'; document.getElementById('conversation-detail').innerHTML = '<div><strong id="detail-heading">Timeline unavailable</strong><br>Check the read-only Runtime API and refresh.</div>'; showError(`ACP conversations unavailable: ${error.message}`); } finally { document.getElementById('last-refresh').textContent = `Updated ${new Date().toLocaleTimeString()}`; } }
+loadPage();
+</script>
+</body>
+</html>

--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -73,17 +73,6 @@ tr:last-child td { border-bottom: none; }
 .acpx-fact dt { color: var(--text3); font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
 .acpx-fact dd { margin: 5px 0 0; color: var(--text); font-size: 13px; overflow-wrap: anywhere; }
 .acpx-safety { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 12px; }
-.acp-card { border-left-color: var(--purple); }
-.acp-list { display: grid; gap: 12px; }
-.acp-conversation { background: var(--bg3); border: 1px solid var(--border); border-radius: 10px; padding: 14px; }
-.acp-conversation-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
-.acp-conversation-id { font-size: 13px; font-weight: 700; overflow-wrap: anywhere; }
-.acp-facts { display: flex; flex-wrap: wrap; gap: 7px; margin: 10px 0; }
-.acp-lanes { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 10px 0 8px; }
-.acp-lane { border: 1px solid var(--border); border-radius: 7px; color: var(--text2); font-size: 11px; font-weight: 700; padding: 6px 8px; text-align: center; text-transform: uppercase; }
-.acp-event { border-top: 1px solid var(--border); color: var(--text2); display: flex; flex-wrap: wrap; gap: 7px; padding: 8px 0; font-size: 12px; }
-.acp-arrow { color: var(--cyan); font-weight: 700; }
-.acp-event-meta { color: var(--text3); }
 @media (max-width: 820px) {
   .usage-row { grid-template-columns: 1fr; }
   .topbar { flex-wrap: wrap; }
@@ -91,7 +80,6 @@ tr:last-child td { border-bottom: none; }
   .acpx-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .acpx-spine { min-height: 110px; }
   .acpx-spine::before, .acpx-spine::after { width: 30px; height: 1px; }
-  .acp-lanes { grid-template-columns: 1fr; }
 }
 @media (max-width: 520px) {
   .acpx-summary { grid-template-columns: 1fr; }
@@ -129,10 +117,10 @@ tr:last-child td { border-bottom: none; }
     <div id="agents-content" class="empty">Loading...</div>
   </section>
 
-  <section class="card acp-card" aria-labelledby="acp-heading">
-    <div class="card-header"><h2 id="acp-heading">&#8646; Active ACP Conversations</h2><div class="muted">Read-only timeline · Root / Codex / Grok</div></div>
-    <div class="banner" id="acp-banner" role="status"></div>
-    <div id="acp-content" class="empty" aria-live="polite">Loading active conversations...</div>
+  <section class="card purple" aria-labelledby="acp-heading">
+    <div class="card-header"><h2 id="acp-heading">&#8646; ACP Conversations</h2><div class="muted">Read-only, body-free event history</div></div>
+    <p class="muted">Inspect recent conversations, participants, state transitions, and allowlisted operational metadata in the dedicated timeline.</p>
+    <p style="margin-top: 12px;"><a class="btn" href="/acp.html">Open ACP conversations →</a></p>
   </section>
 
   <section class="card acpx-card" aria-labelledby="acpx-heading">
@@ -340,90 +328,6 @@ function renderAcpx(snapshot) {
   ${safetyMarkup || inFlightMarkup ? `<div class="acpx-safety" aria-label="Reported safety boundaries">${inFlightMarkup}${safetyMarkup}</div>` : '<div class="empty">Safety boundaries not reported.</div>'}`;
 }
 
-function acpStateClass(state) {
-  if (state === 'COMPLETE') return 'ok';
-  if (state === 'PARTIAL' || state === 'PARTIAL_COMPLETE') return 'warn';
-  if (state === 'FAILED' || state === 'CANCELLED') return 'err';
-  if (state === 'CREATED') return 'gray';
-  return 'info';
-}
-
-function acpStateLabel(state) {
-  if (state === 'COMPLETE') return 'Succeeded';
-  if (state === 'PARTIAL' || state === 'PARTIAL_COMPLETE') return 'Partial';
-  if (state === 'CANCELLED') return 'Cancelled';
-  if (state === 'FAILED') return 'Failed';
-  if (state === 'CREATED') return 'Queued';
-  return 'Running';
-}
-
-function acpEventLabel(event) {
-  const sender = ['root', 'codex', 'grok'].includes(event.sender) ? event.sender : 'root';
-  const recipient = ['root', 'codex', 'grok'].includes(event.recipient) ? event.recipient : null;
-  const direction = recipient ? `${sender} → ${recipient}` : sender;
-  const round = Number.isInteger(event.round) ? `round ${event.round}` : 'round —';
-  const sequence = Number.isInteger(event.sequence) ? `seq ${event.sequence}` : 'seq —';
-  return `${direction} · ${round} · ${sequence}`;
-}
-
-function renderAcpConversation(conversation) {
-  const events = Array.isArray(conversation.events) ? conversation.events : [];
-  const state = typeof conversation.current_state === 'string' ? conversation.current_state : 'CREATED';
-  const facts = [
-    `Rounds ${Number(conversation.rounds_completed) || 0} / ${Number(conversation.rounds_requested) || 0}`,
-    `Duration ${formatDuration(Number(conversation.total_duration_ms) / 1000)}`,
-    `Tokens ${Number.isFinite(Number(conversation.total_tokens)) ? Number(conversation.total_tokens) : '—'}`,
-    `Synthesis ${displayLabel(conversation.synthesis_state)}`,
-  ];
-  if (conversation.duplicate_suppressed) facts.push('Duplicate suppressed');
-  if (conversation.termination_reason) facts.push(`Ended: ${displayLabel(conversation.termination_reason)}`);
-  const eventMarkup = events.length ? events.map(event => `<div class="acp-event">
-    <span class="acp-arrow">${escapeHtml(acpEventLabel(event))}</span>
-    <span>${escapeHtml(displayLabel(event.event_type))}</span>
-    <span class="pill ${acpStateClass(event.state)}">${escapeHtml(acpStateLabel(event.state))}</span>
-    <span class="acp-event-meta">${escapeHtml(formatTs(event.created_at))}</span>
-  </div>`).join('') : '<div class="empty">No allowlisted timeline events reported.</div>';
-  return `<article class="acp-conversation">
-    <div class="acp-conversation-header">
-      <div class="acp-conversation-id mono">${escapeHtml(conversation.conversation_id || 'Conversation')}</div>
-      <span class="pill ${acpStateClass(state)}">${escapeHtml(acpStateLabel(state))}</span>
-    </div>
-    <div class="acp-facts">${facts.map(fact => `<span class="pill gray">${escapeHtml(fact)}</span>`).join('')}</div>
-    <div class="acp-lanes" aria-label="Conversation lanes"><div class="acp-lane">Root</div><div class="acp-lane">Codex</div><div class="acp-lane">Grok</div></div>
-    ${eventMarkup}
-  </article>`;
-}
-
-async function loadAcpConversations() {
-  const content = document.getElementById('acp-content');
-  const snapshot = await fetchJson('/api/runtime/acp/conversations?limit=12');
-  if (!snapshot || typeof snapshot !== 'object' || !Array.isArray(snapshot.conversations)) {
-    throw new Error('Malformed conversation data');
-  }
-  if (snapshot.availability === 'unavailable') {
-    content.innerHTML = '<div class="empty">Conversation storage is unavailable. No routing or provider status is inferred.</div>';
-    return;
-  }
-  if (!snapshot.conversations.length) {
-    content.innerHTML = '<div class="empty">No active ACP conversations.</div>';
-    return;
-  }
-  const details = await Promise.all(snapshot.conversations.map(async summary => {
-    if (!summary || typeof summary.conversation_id !== 'string') return null;
-    try {
-      return await fetchJson(`/api/runtime/acp/conversations/${encodeURIComponent(summary.conversation_id)}`);
-    } catch {
-      return summary;
-    }
-  }));
-  const validDetails = details.filter(item => item && typeof item === 'object');
-  if (!validDetails.length) {
-    content.innerHTML = '<div class="empty">Conversation timeline data is unavailable.</div>';
-    return;
-  }
-  content.innerHTML = `<div class="acp-list">${validDetails.map(renderAcpConversation).join('')}</div>`;
-}
-
 function segment(count, total, cls, label) {
   if (!count) return '';
   const pct = total ? Math.max((count / total) * 100, 8) : 0;
@@ -500,14 +404,6 @@ function startRefresh() {
 
 async function loadRuntime() {
   let agents = [];
-
-  try {
-    await loadAcpConversations();
-    setBanner('acp-banner', '');
-  } catch (error) {
-    setBanner('acp-banner', `ACP conversations unavailable: ${error.message}`);
-    document.getElementById('acp-content').innerHTML = '<div class="empty">Active conversation timeline is unavailable.</div>';
-  }
 
   try {
     const data = await fetchJson('/api/runtime/acpx?days=7');

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -140,13 +140,23 @@ Approved boundary (#6027 Codex, #6043 Grok):
 
 ### Active ACP conversation: controller-owned and bounded
 
-Only the explicit controller accepts `LU_ACPX_TRANSPORT=active`. It accepts a
-task **on standard input**, never in argv, and schedules exactly the approved
-participants: `codex,grok`.
+Only the explicit `acp-discuss` command activates
+`LU_ACPX_TRANSPORT=active`, scoped to its controller call and restored on
+exit. It accepts a task **on standard input**, never in argv, and schedules
+exactly the approved participants: `codex,grok`.
+
+Every supported fleet orchestrator may explicitly select this fixed panel for
+one consequential read-only design or risk comparison when direct
+cross-provider critique is materially useful. `acp-discuss` is the sole
+surface: never invoke it automatically from a launcher or `delegate.py`.
+Admission is one conversation repository-wide; `busy` returns immediately with
+no queue or automatic retry, and bridge `discuss` is the fallback when ACPX is
+busy or unready. A typed partial result is inspectable evidence, not success,
+formal review, or coordination authority.
 
 ```bash
 printf '%s\n' 'Compare the two bounded options and name risks.' |
-  LU_ACPX_TRANSPORT=active ACPX_AUTH_CHAT_GPT=1 \
+  ACPX_AUTH_CHAT_GPT=1 \
   .venv/bin/python -m scripts.fleet_comms acp-discuss --cwd . \
   --task-id acp-6078 --correlation-id acp-6078-v1 \
   --idempotency-key acp-6078-v1 --rounds 2 --json
@@ -162,11 +172,30 @@ unrestricted loops, hidden failover, or retries. Each model call has a
 with a reliable-token budget of 160k or a 512 KiB content ceiling.
 
 Idempotency is durable: replay suppression occurs before scheduling and an
-orphaned reservation is terminal rather than retried. The controller never
-holds a lock across model I/O. It records typed partial results and
-append-only state/timeline events through fleet-comms and file handoffs, which
-remain authoritative. The task, participant responses, credentials, paths,
-sessions, tool data, and raw model content do not enter metadata APIs.
+orphaned reservation is terminal rather than retried. One single-host,
+repository-wide admission file lock is held for the conversation, including
+model I/O; no SQLite transaction is held across model I/O. It records typed
+partial results and append-only state/timeline events through fleet-comms and
+file handoffs, which remain authoritative. The task, participant responses,
+credentials, paths, sessions, tool data, and raw model content do not enter
+metadata APIs.
+
+The shared primary checkout owns the one pinned local `acpx@0.13.0` install;
+dispatch worktrees resolve that install rather than creating a global or
+floating copy. For E2E/replay verification, run the real stdin-only
+`acp-discuss` command once from a registered worktree, then repeat the
+identical task, correlation, and idempotency values. The second call must
+replay the recorded terminal disposition without scheduling model work.
+Finally verify the body-free receipt:
+
+```bash
+.venv/bin/python -m scripts.fleet_comms acp-verify \
+  --conversation-id conversation_<id> --require-replay --json
+```
+
+`verified: true` proves complete participant rounds, native synthesis, and the
+replay receipt without reading message bodies. Never reinterpret this check as
+permission to retry a failed or partial conversation.
 
 Unless `FLEET_COMMS_ROOT` is explicitly set, fleet-comms storage resolves
 through Git's common directory to the primary checkout at

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -23,7 +23,7 @@
 | **`discuss`** (bridge) | Bounded deliberation / design input | Never implementation; never the formal cross-family review gate |
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution | Worktree writes only; not durable fleet authority |
 | **Fleet-comms + file handoffs** | Durable coordination | **File dual-write remains authoritative in every current plane mode** — query `plane-status`, never hard-code live mode |
-| **ACPX** | Experimental structured invocation transport (default-off/shadow; one read-only/stateless Codex participant) | Not a second bus; correlation evidence ≠ authority; rollback = flag off + native transport |
+| **ACPX** | Explicit fixed Codex↔Grok panel for one consequential read-only design/risk comparison (default-off/shadow) | Sole surface `acp-discuss`; no automatic launcher/delegate use, queue, retry, formal review, or authority |
 | **Buzz** | **Deferred** | Relay-as-authority conflicts with the current model — out of scope |
 
 **Discussion is not formal review.** Design panels and same-family helpers do not
@@ -38,6 +38,12 @@ Use explicit project entrypoints (no bare `ab` — on many hosts that is ApacheB
 
 Full onboarding contract, budgets, troubleshooting, and no-auth smoke:
 [`agent-seat-onboarding.md`](../runbooks/agent-seat-onboarding.md).
+
+Use ACPX only when direct Codex↔Grok critique is materially useful; otherwise
+use bounded bridge `discuss`. The panel defaults to two rounds (three maximum),
+admits one repository-wide conversation, and returns `busy` rather than
+queueing or retrying. A partial result is evidence to inspect, never success or
+the independent review gate.
 
 ---
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -165,17 +165,52 @@ floating CLI surface.
 
 The active path is a **bounded fleet-comms-backed conversation**, not a new
 bus. It is accepted only by `.venv/bin/python -m scripts.fleet_comms
-acp-discuss` with `LU_ACPX_TRANSPORT=active`; generic runtime callers cannot
+acp-discuss`, which scopes `LU_ACPX_TRANSPORT=active` to the controller call
+and restores the prior environment on exit; generic runtime callers cannot
 turn it on. Pass the task on stdin and never place task or model-response data
 in argv:
 
 ```bash
 printf '%s\n' 'Compare the two bounded options and name risks.' |
-  LU_ACPX_TRANSPORT=active ACPX_AUTH_CHAT_GPT=1 \
+  ACPX_AUTH_CHAT_GPT=1 \
   .venv/bin/python -m scripts.fleet_comms acp-discuss --cwd . \
   --task-id acp-6078 --correlation-id acp-6078-v1 \
   --idempotency-key acp-6078-v1 --rounds 2 --json
 ```
+
+### When an orchestrator may use the ACP panel
+
+Every supported fleet orchestrator may **explicitly** use this fixed
+Codex↔Grok panel for one consequential, read-only design or risk comparison
+when direct cross-provider critique is materially useful. It is not an
+automatic launcher or `delegate.py` feature, and `acp-discuss` is the sole
+surface. Use the default two rounds; three is the hard maximum.
+
+Admission is one conversation repository-wide. If it is occupied, return
+`busy` immediately: there is no queue, wait, automatic retry, or hidden
+failover. On `busy`, unavailable ACPX, or an unready participant, use the
+bounded bridge `discuss` path instead. A typed partial ACP outcome is valid
+evidence to inspect, but not a successful discussion, formal review, or
+coordination authority.
+
+### Shared ACPX install and E2E/replay verification
+
+ACPX is installed once at the shared primary checkout as the pinned local
+`acpx@0.13.0`; a dispatch worktree resolves that primary install and must not
+create its own global or floating ACPX installation. For an E2E/replay check,
+run the real stdin-only `acp-discuss` command from a registered worktree with
+one bounded read-only task, then repeat the **identical** task, correlation,
+and idempotency values. The first terminal result is evidence; the second must
+be durable replay suppression, never another model run. Then run:
+
+```bash
+.venv/bin/python -m scripts.fleet_comms acp-verify \
+  --conversation-id conversation_<id> --require-replay --json
+```
+
+The verifier is read-only and body-free. `verified: true` requires the fixed
+participants to succeed in every requested round, successful native synthesis,
+terminal `COMPLETE`, and an observed replay. It never authorizes a retry.
 
 Participants are exactly `codex,grok`. Two rounds are the default and three is
 the hard maximum: parallel initial participant calls, a bounded peer
@@ -186,9 +221,10 @@ unrestricted loop, hidden failover, or retry. Each model call is capped at 300
 seconds, the whole conversation at 1,200 seconds, and content at 160k reliable
 tokens or 512 KiB.
 
-Replay suppression is durable and occurs before scheduling. An orphaned reservation
-is terminal: never retry it. Locks must not cover model I/O.
-Typed partial results, idempotency disposition, and append-only
+Replay suppression is durable and occurs before scheduling. An orphaned
+reservation is terminal: never retry it. The single-host repository admission
+file lock covers the conversation, including model I/O; no SQLite transaction
+may cover model I/O. Typed partial results, idempotency disposition, and append-only
 state/timeline events are durably recorded through existing fleet-comms and
 file handoffs; those handoffs retain authority. This conversation neither
 changes plane/retention state nor gains dispatch, routing, failover, or review

--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -7,15 +7,19 @@ direct-only ACPX seats, while the final synthesis is a fresh native Codex call.
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, wait
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -50,6 +54,8 @@ CONTENT_BUDGET_BYTES = 512 * 1024
 
 _TERMINAL = frozenset({"COMPLETE", "PARTIAL_COMPLETE", "FAILED", "CANCELLED"})
 _PARTICIPANT_SLOTS = threading.BoundedSemaphore(2)
+_LOCAL_ADMISSION = threading.Lock()
+_CONVERSATION_ID = re.compile(r"conversation_[0-9a-f]{32}")
 _NEXT = {
     # A CREATED reservation may be recovered after a crash only as terminal
     # partial; it is never re-executed.
@@ -65,6 +71,14 @@ _NEXT = {
 
 class AcpxDiscussionError(RuntimeError):
     """Typed refusal or state-machine failure for the bounded controller."""
+
+
+class AcpxDiscussionBusyError(AcpxDiscussionError):
+    """Another ACP discussion owns the repository-wide single-host admission."""
+
+
+class AcpxDiscussionNotFoundError(AcpxDiscussionError):
+    """The requested durable ACP discussion receipt does not exist."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -106,6 +120,26 @@ def _safe_tokens(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
+def _safe_receipt_timestamp(value: object) -> str | None:
+    """Allow only the controller's normalized UTC timestamp representation."""
+    if not isinstance(value, str):
+        return None
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return value
+
+
+def _safe_receipt_outcome(value: object) -> str:
+    """Collapse untrusted persisted outcomes into a fixed body-free vocabulary."""
+    if value == "ok":
+        return "ok"
+    if value in {"timeout", "rate_limited", "error", "busy", "orphan"}:
+        return str(value)
+    return "other_failure"
+
+
 def _expired_deadline(value: object) -> bool:
     """Fail closed unless a persisted UTC deadline is valid and in the past."""
     if not isinstance(value, str):
@@ -115,6 +149,45 @@ def _expired_deadline(value: object) -> bool:
     except ValueError:
         return False
     return datetime.now(UTC) > parsed
+
+
+@contextmanager
+def _discussion_admission(root: Path) -> Iterator[None]:
+    """Acquire one no-wait ACP slot for this repository on the current host.
+
+    The local mutex closes same-process platform differences in ``flock``
+    semantics. The file lock covers independent worktree processes sharing the
+    canonical fleet-comms root. A host crash releases both automatically; the
+    persistent lock file is only an inode and contains no runtime data.
+    """
+    if not _LOCAL_ADMISSION.acquire(blocking=False):
+        raise AcpxDiscussionBusyError("another ACP discussion is already running")
+    descriptor: int | None = None
+    locked = False
+    try:
+        flags = os.O_CREAT | os.O_RDWR
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(root / "acp-discuss.lock", flags, 0o600)
+            os.fchmod(descriptor, 0o600)
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            locked = True
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                raise AcpxDiscussionBusyError(
+                    "another ACP discussion is already running"
+                ) from None
+            raise AcpxDiscussionError(
+                f"unable to acquire the ACP admission lock: {exc}"
+            ) from exc
+        yield
+    finally:
+        if descriptor is not None:
+            if locked:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+        _LOCAL_ADMISSION.release()
 
 
 class AcpxDiscussionController:
@@ -438,6 +511,26 @@ class AcpxDiscussionController:
             return existing, self._replay(existing)
         return conversation_id, None
 
+    def _terminal_replay(self, idempotency_digest: str) -> dict[str, Any] | None:
+        """Replay completed work before admission so duplicates never report busy."""
+        row = self.conn.execute(
+            "SELECT conversation_id FROM acp_conversations WHERE idempotency_digest = ?",
+            (idempotency_digest,),
+        ).fetchone()
+        if row is None:
+            return None
+        conversation_id = str(row[0])
+        state = self._state(conversation_id)
+        if state not in _TERMINAL:
+            return None
+        self._append(
+            conversation_id,
+            event_type="DUPLICATE_SUPPRESSED",
+            state=state,
+            outcome="duplicate_suppressed",
+        )
+        return self._replay(conversation_id)
+
     def _call_wave(
         self,
         *,
@@ -551,7 +644,16 @@ class AcpxDiscussionController:
         pool.shutdown(wait=False, cancel_futures=True)
         return sorted(outcomes, key=lambda item: item.participant)
 
-    def run(self, *, prompt: str, cwd: Path, task_id: str, correlation_id: str, idempotency_key: str, rounds: int = DEFAULT_ROUNDS) -> dict[str, Any]:
+    def run(
+        self,
+        *,
+        prompt: str,
+        cwd: Path,
+        task_id: str,
+        correlation_id: str,
+        idempotency_key: str,
+        rounds: int = DEFAULT_ROUNDS,
+    ) -> dict[str, Any]:
         if os.environ.get(TRANSPORT_ENV, "off").strip().lower() != "active":
             raise AcpxDiscussionError("LU_ACPX_TRANSPORT=active is required by acp-discuss")
         if not prompt.strip():
@@ -566,10 +668,42 @@ class AcpxDiscussionController:
         task_id = _require_local_metadata_field("task_id", task_id, adapter_label="AcpxDiscuss")
         correlation_id = _require_local_metadata_field("correlation_id", correlation_id, adapter_label="AcpxDiscuss")
         idempotency_key = _require_local_metadata_field("idempotency_key", idempotency_key, adapter_label="AcpxDiscuss")
+        idempotency_digest = _digest(idempotency_key)
+        replay = self._terminal_replay(idempotency_digest)
+        if replay is not None:
+            return replay
+        with _discussion_admission(self.store.root):
+            return self._run_admitted(
+                prompt=prompt,
+                cwd=resolved_cwd,
+                task_id=task_id,
+                correlation_id=correlation_id,
+                idempotency_key=idempotency_key,
+                idempotency_digest=idempotency_digest,
+                rounds=rounds,
+            )
+
+    def _run_admitted(
+        self,
+        *,
+        prompt: str,
+        cwd: Path,
+        task_id: str,
+        correlation_id: str,
+        idempotency_key: str,
+        idempotency_digest: str,
+        rounds: int,
+    ) -> dict[str, Any]:
         started = self.clock()
         deadline = started + WHOLE_TIMEOUT_SECONDS
         deadline_at = (datetime.now(UTC) + timedelta(seconds=WHOLE_TIMEOUT_SECONDS)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        conversation_id, replay = self._reserve(task_digest=_digest(task_id), correlation_digest=_digest(correlation_id), idempotency_digest=_digest(idempotency_key), rounds=rounds, deadline_at=deadline_at)
+        conversation_id, replay = self._reserve(
+            task_digest=_digest(task_id),
+            correlation_digest=_digest(correlation_id),
+            idempotency_digest=idempotency_digest,
+            rounds=rounds,
+            deadline_at=deadline_at,
+        )
         if replay is not None:
             return replay
         if self.cancelled():
@@ -585,7 +719,7 @@ class AcpxDiscussionController:
         content_used = sum(len(prompt.encode("utf-8")) for _participant in PARTICIPANTS)
         outcomes = self._call_wave(
             conversation_id=conversation_id, task_id=task_id, correlation_id=correlation_id,
-            idempotency_key=idempotency_key, cwd=resolved_cwd, round_no=1,
+            idempotency_key=idempotency_key, cwd=cwd, round_no=1,
             prompts={p: prompt for p in PARTICIPANTS},
             deliveries={p: ("root", prompt, None) for p in PARTICIPANTS},
             state="INITIAL_FANOUT", deadline=deadline,
@@ -626,7 +760,7 @@ class AcpxDiscussionController:
             prior_messages = {item.participant: item.message_id for item in outcomes}
             outcomes = self._call_wave(
                 conversation_id=conversation_id, task_id=task_id, correlation_id=correlation_id,
-                idempotency_key=idempotency_key, cwd=resolved_cwd, round_no=round_no,
+                idempotency_key=idempotency_key, cwd=cwd, round_no=round_no,
                 prompts=prompts,
                 deliveries={
                     "codex": ("grok", prior.get("grok") or "[unavailable]", prior_messages.get("grok")),
@@ -686,7 +820,7 @@ class AcpxDiscussionController:
                 kind="request",
             )
             try:
-                synthesis_result = self.synthesis_call("codex", synthesis_prompt, mode="read-only", cwd=resolved_cwd, task_id=task_id, session_id=None, entrypoint="acpx-discuss-synthesis", hard_timeout=max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock()))))
+                synthesis_result = self.synthesis_call("codex", synthesis_prompt, mode="read-only", cwd=cwd, task_id=task_id, session_id=None, entrypoint="acpx-discuss-synthesis", hard_timeout=max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock()))))
                 if synthesis_result.ok:
                     synthesis = synthesis_result.response
             except BaseException as exc:
@@ -772,3 +906,156 @@ def run_discussion(**kwargs: Any) -> dict[str, Any]:
         return controller.run(**kwargs)
     finally:
         controller.close()
+
+
+def verify_discussion_receipt(
+    *,
+    root: Path,
+    conversation_id: str,
+    require_replay: bool = False,
+) -> dict[str, Any]:
+    """Verify a durable ACP receipt using metadata-only, read-only storage."""
+    if _CONVERSATION_ID.fullmatch(conversation_id) is None:
+        raise AcpxDiscussionError("conversation_id must be a canonical ACP conversation ID")
+    db_path = root.expanduser().resolve() / "comms.sqlite3"
+    if not db_path.is_file():
+        raise AcpxDiscussionNotFoundError("ACP conversation storage was not found")
+    try:
+        connection = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """SELECT conversation_id, rounds_requested, participants_json, created_at
+               FROM acp_conversations WHERE conversation_id = ?""",
+            (conversation_id,),
+        ).fetchone()
+        if row is None:
+            raise AcpxDiscussionNotFoundError(
+                f"ACP conversation {conversation_id} was not found"
+            )
+        events = connection.execute(
+            """SELECT sequence, event_type, state, sender, round, outcome,
+                      duration_ms, token_count, created_at
+               FROM acp_conversation_events
+               WHERE conversation_id = ? ORDER BY sequence""",
+            (conversation_id,),
+        ).fetchall()
+    except AcpxDiscussionNotFoundError:
+        raise
+    except sqlite3.Error as exc:
+        raise AcpxDiscussionError(f"unable to verify ACP conversation storage: {exc}") from exc
+    finally:
+        if "connection" in locals():
+            connection.close()
+
+    if not events:
+        raise AcpxDiscussionError("ACP conversation has no lifecycle events")
+    try:
+        participants = json.loads(str(row["participants_json"]))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        participants = None
+    rounds_value = row["rounds_requested"]
+    rounds_requested = (
+        rounds_value
+        if isinstance(rounds_value, int)
+        and not isinstance(rounds_value, bool)
+        and 1 <= rounds_value <= MAX_ROUNDS
+        else 0
+    )
+    created_at = _safe_receipt_timestamp(row["created_at"])
+    terminal_calls = [event for event in events if event["event_type"] == "CALL_TERMINAL"]
+    outcome_counts: dict[str, dict[str, int]] = {
+        participant: {} for participant in PARTICIPANTS
+    }
+    successful_legs: set[tuple[int, str]] = set()
+    rounds_observed = 0
+    for event in terminal_calls:
+        participant = str(event["sender"] or "")
+        round_no = event["round"]
+        outcome = _safe_receipt_outcome(event["outcome"])
+        if participant not in outcome_counts:
+            continue
+        outcome_counts[participant][outcome] = (
+            outcome_counts[participant].get(outcome, 0) + 1
+        )
+        if isinstance(round_no, int) and not isinstance(round_no, bool) and round_no > 0:
+            rounds_observed = max(rounds_observed, round_no)
+            if outcome == "ok":
+                successful_legs.add((round_no, participant))
+    successful_rounds = sum(
+        all((round_no, participant) in successful_legs for participant in PARTICIPANTS)
+        for round_no in range(1, rounds_requested + 1)
+    )
+    synthesis_events = [
+        event for event in events if event["event_type"] == "SYNTHESIS_TERMINAL"
+    ]
+    synthesis_outcome = (
+        _safe_receipt_outcome(synthesis_events[-1]["outcome"])
+        if synthesis_events
+        else "missing"
+    )
+    replay_count = sum(
+        event["event_type"] == "DUPLICATE_SUPPRESSED" for event in events
+    )
+    final_event = events[-1]
+    final_state = (
+        str(final_event["state"])
+        if final_event["state"] in _TERMINAL
+        else "UNKNOWN"
+    )
+    updated_at = _safe_receipt_timestamp(final_event["created_at"])
+    terminal_state_event = next(
+        (
+            event
+            for event in reversed(events)
+            if event["event_type"] == "STATE" and event["state"] in _TERMINAL
+        ),
+        None,
+    )
+    participants_exact = participants == list(PARTICIPANTS)
+    storage_metadata_valid = (
+        rounds_requested > 0
+        and created_at is not None
+        and updated_at is not None
+        and terminal_state_event is not None
+    )
+    terminal_complete = final_state == "COMPLETE"
+    rounds_complete = successful_rounds == rounds_requested
+    synthesis_complete = synthesis_outcome == "ok"
+    replay_complete = replay_count > 0 or not require_replay
+    checks = {
+        "storage_metadata_valid": storage_metadata_valid,
+        "fixed_participants": participants_exact,
+        "terminal_complete": terminal_complete,
+        "all_rounds_succeeded": rounds_complete,
+        "synthesis_succeeded": synthesis_complete,
+        "replay_observed": replay_complete,
+    }
+    reasons = [name for name, passed in checks.items() if not passed]
+    duration_ms = terminal_state_event["duration_ms"] if terminal_state_event else None
+    token_count = terminal_state_event["token_count"] if terminal_state_event else None
+    return {
+        "conversation_id": conversation_id,
+        "verified": not reasons,
+        "content_included": False,
+        "state": final_state,
+        "participants": list(PARTICIPANTS),
+        "rounds_requested": rounds_requested,
+        "rounds_observed": rounds_observed,
+        "successful_rounds": successful_rounds,
+        "participant_outcomes": [
+            {
+                "participant": participant,
+                "terminal_calls": sum(outcome_counts[participant].values()),
+                "outcomes": outcome_counts[participant],
+            }
+            for participant in PARTICIPANTS
+        ],
+        "synthesis_outcome": synthesis_outcome,
+        "duplicate_suppressed_count": replay_count,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "duration_ms": _safe_tokens(duration_ms),
+        "token_count": _safe_tokens(token_count),
+        "checks": checks,
+        "reasons": reasons,
+    }

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -87,8 +87,16 @@ from .base import InvocationPlan
 
 try:
     from scripts.guardrails import worktree_containment as _worktree_containment
+    from scripts.guardrails.worktree_containment import (
+        NotAGitRepositoryError,
+        resolve_main_root,
+    )
 except ImportError:  # pragma: no cover - stripped sys.path flavor
     from guardrails import worktree_containment as _worktree_containment  # type: ignore[import-not-found, no-redef]
+    from guardrails.worktree_containment import (  # type: ignore[import-not-found, no-redef]
+        NotAGitRepositoryError,
+        resolve_main_root,
+    )
 
 _logger = logging.getLogger(__name__)
 
@@ -107,7 +115,10 @@ PINNED_VERSION = "0.13.0"
 # install silently take over. "No global binary authority" per the approved
 # Stage 0/1 contract.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
+_DEFAULT_PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
+# Keep this separately patchable for hermetic adapter tests.  An explicit
+# override is authoritative and must never silently fall back to another tree.
+_PINNED_BINARY = _DEFAULT_PINNED_BINARY
 
 # Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
 # Built-in acpx ``grok-build`` is intentionally unused: it expands to
@@ -355,14 +366,45 @@ def _require_non_primary_worktree(cwd: Path, *, adapter_label: str) -> None:
         )
 
 
-def _require_pinned_acpx_binary(*, adapter_label: str) -> str:
-    if not _PINNED_BINARY.is_file():
+def _require_pinned_acpx_binary(*, adapter_label: str, cwd: Path) -> str:
+    """Resolve the exact local ACPX pin, sharing the primary install with worktrees.
+
+    A source worktree normally has no independent ``node_modules`` tree.  If
+    this module's default local candidate is absent, resolve the canonical
+    primary checkout from the invocation cwd and accept only that checkout's
+    identically pinned binary.  Never consult PATH or a global install.
+
+    Tests may explicitly patch :data:`_PINNED_BINARY`; an override remains
+    authoritative so an isolated test cannot accidentally borrow a developer
+    checkout's installation.
+    """
+    candidate = _PINNED_BINARY
+    if not candidate.is_file() and candidate == _DEFAULT_PINNED_BINARY:
+        try:
+            main_root = resolve_main_root(cwd)
+        except NotAGitRepositoryError:
+            main_root = None
+        if main_root is not None:
+            primary_candidate = main_root / "node_modules" / ".bin" / "acpx"
+            if primary_candidate.is_file():
+                candidate = primary_candidate
+
+    if not candidate.is_file():
+        primary_hint = ""
+        if _PINNED_BINARY == _DEFAULT_PINNED_BINARY:
+            try:
+                primary_hint = (
+                    f"; canonical primary candidate is "
+                    f"{resolve_main_root(cwd) / 'node_modules' / '.bin' / 'acpx'}"
+                )
+            except NotAGitRepositoryError:
+                primary_hint = "; cwd is not inside a Git checkout, so no canonical primary install is available"
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: pinned binary not found at {_PINNED_BINARY}; run "
-            f"`npm install acpx@{PINNED_VERSION} --save-exact --save-dev` first. "
+            f"{adapter_label}: pinned binary not found at {candidate}{primary_hint}; run "
+            f"`npm install acpx@{PINNED_VERSION} --save-exact --save-dev` in the canonical primary checkout. "
             "A global/PATH acpx binary is never used as a substitute."
         )
-    binary = str(_PINNED_BINARY)
+    binary = str(candidate)
     observed_version = _probe_acpx_version(binary)
     if observed_version != PINNED_VERSION:
         raise AcpxShadowRefusalError(
@@ -571,7 +613,7 @@ class AcpxAdapter:
             )
 
         _require_non_primary_worktree(cwd, adapter_label="AcpxAdapter")
-        binary = _require_pinned_acpx_binary(adapter_label="AcpxAdapter")
+        binary = _require_pinned_acpx_binary(adapter_label="AcpxAdapter", cwd=cwd)
 
         cmd: list[str] = _confinement_prefix_argv(binary, cwd)
         if model:
@@ -884,7 +926,7 @@ class AcpxGrokShadowAdapter:
             )
 
         _require_non_primary_worktree(cwd, adapter_label="AcpxGrokShadowAdapter")
-        acpx_binary = _require_pinned_acpx_binary(adapter_label="AcpxGrokShadowAdapter")
+        acpx_binary = _require_pinned_acpx_binary(adapter_label="AcpxGrokShadowAdapter", cwd=cwd)
 
         grok_binary = _resolve_grok_binary()
         observed_grok = _probe_grok_version(grok_binary)

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -949,7 +949,7 @@ PAGE_CONTRACTS: tuple[PageContract, ...] = (
         "/acp.html",
         "Readable, read-only ACP conversation ledger and event timeline.",
         "/api/runtime/acp/conversations*.",
-        "Live body-free reads from the shared fleet-comms SQLite store with a 5s client timeout.",
+        "Single-shot live body-free fetch on page load; the browser uses its platform-default request timeout and does not poll.",
         ("humans",),
         "Complements runtime and channels without exposing message composition.",
         "low",

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -945,6 +945,17 @@ PAGE_CONTRACTS: tuple[PageContract, ...] = (
         "keep",
     ),
     PageContract(
+        "acp.html",
+        "/acp.html",
+        "Readable, read-only ACP conversation ledger and event timeline.",
+        "/api/runtime/acp/conversations*.",
+        "Live body-free reads from the shared fleet-comms SQLite store with a 5s client timeout.",
+        ("humans",),
+        "Complements runtime and channels without exposing message composition.",
+        "low",
+        "keep as the canonical ACP conversation observer",
+    ),
+    PageContract(
         "cost.html",
         "/cost.html",
         "Cost reports.",

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -26,6 +26,8 @@ import json
 import os
 import sqlite3
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,21 @@ EXIT_ERROR = 3
 
 class FleetCommsCliError(RuntimeError):
     """CLI refused an operation."""
+
+
+@contextmanager
+def _active_acpx_transport() -> Iterator[None]:
+    """Authorize ACPX active mode only for the explicit ``acp-discuss`` call."""
+    variable = "LU_ACPX_TRANSPORT"
+    previous = os.environ.get(variable)
+    os.environ[variable] = "active"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(variable, None)
+        else:
+            os.environ[variable] = previous
 
 
 def _json_dump(payload: Any, *, indent: int | None = 2) -> str:
@@ -309,25 +326,72 @@ def cmd_github_metrics(args: argparse.Namespace) -> int:
 
 
 def cmd_acp_discuss(args: argparse.Namespace) -> int:
-    """Run the explicitly enabled bounded ACPX discussion (stdin-only prompt)."""
-    from scripts.agent_runtime.acpx_discuss import AcpxDiscussionError, run_discussion
+    """Run the explicitly authorized bounded ACPX discussion (stdin-only prompt)."""
+    from scripts.agent_runtime.acpx_discuss import (
+        AcpxDiscussionBusyError,
+        AcpxDiscussionError,
+        run_discussion,
+    )
 
     prompt = sys.stdin.read()
     try:
-        payload = run_discussion(
-            prompt=prompt,
-            cwd=Path(args.cwd),
-            task_id=args.task_id,
-            correlation_id=args.correlation_id,
-            idempotency_key=args.idempotency_key,
-            rounds=args.rounds,
-            root=Path(args.root).expanduser() if args.root else None,
+        with _active_acpx_transport():
+            payload = run_discussion(
+                prompt=prompt,
+                cwd=Path(args.cwd),
+                task_id=args.task_id,
+                correlation_id=args.correlation_id,
+                idempotency_key=args.idempotency_key,
+                rounds=args.rounds,
+                root=Path(args.root).expanduser() if args.root else None,
+            )
+    except AcpxDiscussionBusyError:
+        sys.stdout.write(
+            _json_dump(
+                {
+                    "classification": "busy",
+                    "state": "BUSY",
+                    "queued": False,
+                    "retryable": False,
+                },
+                indent=None,
+            )
         )
+        return EXIT_ERROR
     except AcpxDiscussionError as exc:
         sys.stderr.write(str(exc) + "\n")
         return EXIT_ERROR
     sys.stdout.write(_json_dump(payload, indent=None if args.json else 2))
     return EXIT_OK if payload["state"] == "COMPLETE" else EXIT_ERROR
+
+
+def cmd_acp_verify(args: argparse.Namespace) -> int:
+    """Verify one body-free durable ACP conversation receipt."""
+    from scripts.agent_runtime.acpx_discuss import (
+        AcpxDiscussionError,
+        AcpxDiscussionNotFoundError,
+        verify_discussion_receipt,
+    )
+
+    root = (
+        Path(args.root).expanduser()
+        if args.root
+        else default_plane_root(repo_root=Path.cwd())
+    )
+    try:
+        payload = verify_discussion_receipt(
+            root=root,
+            conversation_id=args.conversation_id,
+            require_replay=args.require_replay,
+        )
+    except AcpxDiscussionNotFoundError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_NOT_FOUND
+    except AcpxDiscussionError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_ERROR
+    sys.stdout.write(_json_dump(payload, indent=None if args.json else 2))
+    return EXIT_OK if payload["verified"] else EXIT_ERROR
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -547,6 +611,20 @@ def build_parser() -> argparse.ArgumentParser:
     acp.add_argument("--root", default=None, help="Fleet-comms storage root")
     acp.add_argument("--json", action="store_true", help="Emit compact JSON")
     acp.set_defaults(func=cmd_acp_discuss)
+
+    verify = sub.add_parser(
+        "acp-verify",
+        help="Read-only verification of one durable, body-free ACP receipt",
+    )
+    verify.add_argument("--conversation-id", required=True)
+    verify.add_argument("--root", default=None, help="Fleet-comms storage root")
+    verify.add_argument(
+        "--require-replay",
+        action="store_true",
+        help="Require an observed idempotent replay receipt",
+    )
+    verify.add_argument("--json", action="store_true", help="Emit compact JSON")
+    verify.set_defaults(func=cmd_acp_verify)
 
     return parser
 

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -480,6 +480,86 @@ def test_build_invocation_rejects_missing_binary(tmp_path, monkeypatch):
         _build(adapter, cwd=tmp_path)
 
 
+def _set_default_binary_candidate(monkeypatch, candidate: Path) -> None:
+    """Make a test-local module candidate eligible for primary fallback."""
+    monkeypatch.setattr(acpx_module, "_DEFAULT_PINNED_BINARY", candidate)
+    monkeypatch.setattr(acpx_module, "_PINNED_BINARY", candidate)
+
+
+def test_build_invocation_resolves_primary_pin_from_linked_worktree(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    primary = tmp_path / "primary"
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / "acp"
+    worktree.mkdir(parents=True)
+    module_candidate = worktree / "node_modules" / ".bin" / "acpx"
+    _set_default_binary_candidate(monkeypatch, module_candidate)
+    primary_binary = primary / "node_modules" / ".bin" / "acpx"
+    primary_binary.parent.mkdir(parents=True)
+    primary_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    primary_binary.chmod(0o755)
+    monkeypatch.setattr(acpx_module, "resolve_main_root", lambda cwd: primary)
+    monkeypatch.setattr(acpx_module, "_probe_acpx_version", lambda _binary: "0.13.0")
+
+    plan = _build(AcpxAdapter(), cwd=worktree)
+
+    assert plan.cmd[0] == str(primary_binary)
+
+
+def test_build_invocation_explicit_binary_override_never_uses_primary(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    override = _stub_binary(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        acpx_module,
+        "resolve_main_root",
+        lambda _cwd: pytest.fail("explicit binary override must remain authoritative"),
+    )
+
+    plan = _build(AcpxAdapter(), cwd=tmp_path)
+
+    assert plan.cmd[0] == str(override)
+
+
+def test_build_invocation_non_git_cwd_refuses_without_global_fallback(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    candidate = tmp_path / "worktree" / "node_modules" / ".bin" / "acpx"
+    _set_default_binary_candidate(monkeypatch, candidate)
+    monkeypatch.setattr(
+        acpx_module,
+        "resolve_main_root",
+        lambda cwd: (_ for _ in ()).throw(acpx_module.NotAGitRepositoryError(str(cwd))),
+    )
+
+    with pytest.raises(AcpxShadowRefusalError, match="no canonical primary install is available"):
+        _build(AcpxAdapter(), cwd=tmp_path)
+
+
+def test_build_invocation_refuses_when_primary_pin_is_missing(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    candidate = tmp_path / "worktree" / "node_modules" / ".bin" / "acpx"
+    primary = tmp_path / "primary"
+    _set_default_binary_candidate(monkeypatch, candidate)
+    monkeypatch.setattr(acpx_module, "resolve_main_root", lambda _cwd: primary)
+
+    with pytest.raises(AcpxShadowRefusalError, match=str(primary / "node_modules" / ".bin" / "acpx")):
+        _build(AcpxAdapter(), cwd=tmp_path)
+
+
+def test_build_invocation_rejects_primary_pin_version_mismatch(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    candidate = tmp_path / "worktree" / "node_modules" / ".bin" / "acpx"
+    primary = tmp_path / "primary"
+    primary_binary = primary / "node_modules" / ".bin" / "acpx"
+    primary_binary.parent.mkdir(parents=True)
+    primary_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    primary_binary.chmod(0o755)
+    _set_default_binary_candidate(monkeypatch, candidate)
+    monkeypatch.setattr(acpx_module, "resolve_main_root", lambda _cwd: primary)
+    monkeypatch.setattr(acpx_module, "_probe_acpx_version", lambda _binary: "0.12.1")
+
+    with pytest.raises(AcpxShadowRefusalError, match="version"):
+        _build(AcpxAdapter(), cwd=tmp_path)
+
+
 def test_build_invocation_rejects_unreadable_version_probe(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
     _stub_binary(monkeypatch, tmp_path, version="")

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+import subprocess
 import threading
 from pathlib import Path
 
@@ -532,27 +533,197 @@ def test_deadline_exceeded_is_partial_without_synthesis(tmp_path, monkeypatch):
     assert synthesis_called is False
 
 
-def test_process_wide_busy_rejects_without_queueing_or_retries(tmp_path, monkeypatch):
+def test_repository_wide_busy_rejects_without_queueing_or_retries(tmp_path, monkeypatch):
     calls = 0
 
     def participant(*_args, **_kwargs):
         nonlocal calls
         calls += 1
-        raise AssertionError("global capacity refusal must not invoke a participant")
+        raise AssertionError("repository admission refusal must not invoke a participant")
 
     controller = _controller(tmp_path, monkeypatch, participant, lambda *_a, **_k: _result("codex", "partial"))
-    assert acpx_discuss._PARTICIPANT_SLOTS.acquire(blocking=False)
-    assert acpx_discuss._PARTICIPANT_SLOTS.acquire(blocking=False)
     try:
-        payload = _run(controller, rounds=1)
+        with acpx_discuss._discussion_admission(controller.store.root):
+            with pytest.raises(acpx_discuss.AcpxDiscussionBusyError, match="already running"):
+                _run(controller, rounds=1)
     finally:
-        acpx_discuss._PARTICIPANT_SLOTS.release()
-        acpx_discuss._PARTICIPANT_SLOTS.release()
         controller.close()
 
-    assert payload["state"] == "PARTIAL_COMPLETE"
     assert calls == 0
-    assert {item["outcome"] for item in payload["participant_outcomes"]} == {"busy"}
+
+
+def test_terminal_replay_bypasses_repository_busy_admission(tmp_path, monkeypatch):
+    calls: list[str] = []
+
+    def participant(agent: str, _prompt: str, **_kwargs):
+        calls.append(agent)
+        return _result(agent, f"{agent} evidence")
+
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        participant,
+        lambda agent, _prompt, **_kwargs: _result(agent, "synthesis"),
+    )
+    try:
+        first = _run(controller, rounds=1)
+        with acpx_discuss._discussion_admission(controller.store.root):
+            replay = _run(controller, rounds=1)
+    finally:
+        controller.close()
+
+    assert first["state"] == "COMPLETE"
+    assert replay["conversation_id"] == first["conversation_id"]
+    assert replay["duplicate_suppressed"] is True
+    assert sorted(calls) == ["acpx-codex-shadow", "acpx-grok-shadow"]
+
+
+def test_crashed_process_releases_repository_admission_lock(tmp_path):
+    root = tmp_path / "plane"
+    root.mkdir()
+    repo_root = Path(__file__).resolve().parents[2]
+    code = """
+import os
+import sys
+from pathlib import Path
+from scripts.agent_runtime.acpx_discuss import _discussion_admission
+with _discussion_admission(Path(sys.argv[1])):
+    os._exit(17)
+"""
+    completed = subprocess.run(
+        [str(repo_root / ".venv" / "bin" / "python"), "-c", code, str(root)],
+        cwd=repo_root,
+        check=False,
+    )
+
+    assert completed.returncode == 17
+    with acpx_discuss._discussion_admission(root):
+        pass
+
+
+def test_body_free_receipt_verifies_complete_replayed_conversation(tmp_path, monkeypatch):
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda agent, _prompt, **_kwargs: _result(agent, "private participant body"),
+        lambda agent, _prompt, **_kwargs: _result(agent, "private synthesis body"),
+    )
+    try:
+        first = _run(controller, rounds=2)
+        replay = _run(controller, rounds=2)
+    finally:
+        controller.close()
+
+    receipt = acpx_discuss.verify_discussion_receipt(
+        root=tmp_path / "plane",
+        conversation_id=first["conversation_id"],
+        require_replay=True,
+    )
+
+    assert replay["duplicate_suppressed"] is True
+    assert receipt["verified"] is True
+    assert receipt["content_included"] is False
+    assert receipt["successful_rounds"] == 2
+    assert receipt["duplicate_suppressed_count"] == 1
+    assert receipt["checks"] == {
+        "storage_metadata_valid": True,
+        "fixed_participants": True,
+        "terminal_complete": True,
+        "all_rounds_succeeded": True,
+        "synthesis_succeeded": True,
+        "replay_observed": True,
+    }
+    serialized = str(receipt)
+    assert "private participant body" not in serialized
+    assert "private synthesis body" not in serialized
+
+
+def test_body_free_receipt_reports_partial_without_claiming_success(tmp_path, monkeypatch):
+    def participant(agent: str, _prompt: str, **_kwargs):
+        if agent.endswith("grok-shadow"):
+            raise AgentTimeoutError("fixture timeout")
+        return _result(agent, "private codex body")
+
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        participant,
+        lambda agent, _prompt, **_kwargs: _result(agent, "private partial synthesis"),
+    )
+    try:
+        result = _run(controller, rounds=1)
+    finally:
+        controller.close()
+
+    receipt = acpx_discuss.verify_discussion_receipt(
+        root=tmp_path / "plane",
+        conversation_id=result["conversation_id"],
+    )
+
+    assert result["state"] == "PARTIAL_COMPLETE"
+    assert receipt["verified"] is False
+    assert "terminal_complete" in receipt["reasons"]
+    assert "all_rounds_succeeded" in receipt["reasons"]
+    assert receipt["content_included"] is False
+
+
+def test_body_free_receipt_never_reflects_poisoned_storage_text(tmp_path, monkeypatch):
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda agent, _prompt, **_kwargs: _result(agent, "private participant body"),
+        lambda agent, _prompt, **_kwargs: _result(agent, "private synthesis body"),
+    )
+    try:
+        result = _run(controller, rounds=1)
+        controller.conn.execute(
+            """UPDATE acp_conversation_events
+               SET outcome = 'PRIVATE_PROMPT', created_at = 'PRIVATE_RESPONSE'
+               WHERE conversation_id = ? AND event_type = 'CALL_TERMINAL'
+                 AND sender = 'grok'""",
+            (result["conversation_id"],),
+        )
+        controller.conn.execute(
+            "UPDATE acp_conversations SET created_at = 'PRIVATE_TASK' WHERE conversation_id = ?",
+            (result["conversation_id"],),
+        )
+        controller.conn.execute(
+            """UPDATE acp_conversation_events SET created_at = 'PRIVATE_TERMINAL'
+               WHERE conversation_id = ? AND event_type = 'STATE' AND state = 'COMPLETE'""",
+            (result["conversation_id"],),
+        )
+        controller.conn.commit()
+    finally:
+        controller.close()
+
+    receipt = acpx_discuss.verify_discussion_receipt(
+        root=tmp_path / "plane",
+        conversation_id=result["conversation_id"],
+    )
+
+    serialized = str(receipt)
+    assert receipt["verified"] is False
+    assert receipt["checks"]["storage_metadata_valid"] is False
+    assert receipt["participant_outcomes"][1]["outcomes"] == {"other_failure": 1}
+    assert "PRIVATE_PROMPT" not in serialized
+    assert "PRIVATE_RESPONSE" not in serialized
+    assert "PRIVATE_TASK" not in serialized
+    assert "PRIVATE_TERMINAL" not in serialized
+    assert "private participant body" not in serialized
+    assert "private synthesis body" not in serialized
+
+
+def test_body_free_receipt_refuses_missing_or_invalid_conversation(tmp_path):
+    with pytest.raises(acpx_discuss.AcpxDiscussionError, match="canonical"):
+        acpx_discuss.verify_discussion_receipt(
+            root=tmp_path,
+            conversation_id="not-a-conversation",
+        )
+    with pytest.raises(acpx_discuss.AcpxDiscussionNotFoundError, match="storage"):
+        acpx_discuss.verify_discussion_receipt(
+            root=tmp_path,
+            conversation_id="conversation_" + ("a" * 32),
+        )
 
 
 def test_errors_are_terminal_once_per_leg_without_retry_or_failover(tmp_path, monkeypatch):

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -255,6 +255,39 @@ def test_acpx_default_off_rollback(onboarding: str, all_owned: dict[str, str]) -
     assert "rollback" in runtime or "flag off" in runtime or ("default" in runtime and "off" in runtime)
 
 
+def test_routine_acp_panel_is_explicit_bounded_and_non_authoritative(
+    onboarding: str, all_owned: dict[str, str]
+) -> None:
+    """The approved routine panel remains a finite deliberation, not a bus."""
+    lower = onboarding.lower()
+    assert "explicitly" in lower
+    assert "consequential" in lower
+    assert "read-only" in lower
+    assert "acp-discuss" in onboarding
+    assert "the sole\nsurface" in lower or "the sole surface" in lower
+    assert "default two rounds" in lower
+    assert "hard maximum" in lower
+    assert "repository-wide" in lower
+    assert "busy" in lower
+    assert "no queue" in lower
+    assert "automatic retry" in lower
+    assert "bridge `discuss`" in lower
+    assert "partial" in lower and "not a successful discussion" in lower
+    assert "shared primary checkout" in lower
+    assert "e2e/replay" in lower
+    assert "identical" in lower and "idempotency" in lower
+    assert "acp-verify" in onboarding
+    assert "body-free" in lower
+    assert "no sqlite transaction" in lower
+    for body in (
+        all_owned["docs/agent-runtime-guide.md"],
+        all_owned["docs/best-practices/agent-cooperation.md"],
+        all_owned["agents_extensions/shared/rules/fleet-comms-coordination.md"],
+    ):
+        assert "acp-discuss" in body
+        assert "formal review" in body.lower()
+
+
 def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned: dict[str, str]) -> None:
     """#6043 — Grok second pilot: broker evidence, two seats, not a new plane."""
     lower = onboarding.lower()

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import io
 import json
+import os
 import sqlite3
 from pathlib import Path
 
@@ -144,3 +146,147 @@ def test_formal_job_get_missing_db(tmp_path: Path, capsys) -> None:
 def test_get_formal_review_job_empty_id(tmp_path: Path) -> None:
     with pytest.raises(FleetCommsCliError, match="review_id is required"):
         get_formal_review_job("  ", root=tmp_path)
+
+
+def test_acp_discuss_cli_scopes_active_transport_and_restores_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    from scripts.agent_runtime import acpx_discuss
+
+    observed: list[str | None] = []
+
+    def fake_run_discussion(**_kwargs):
+        observed.append(os.environ.get("LU_ACPX_TRANSPORT"))
+        return {"state": "COMPLETE"}
+
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "shadow")
+    monkeypatch.setattr(acpx_discuss, "run_discussion", fake_run_discussion)
+    monkeypatch.setattr("sys.stdin", io.StringIO("bounded design question"))
+
+    rc = main(
+        [
+            "acp-discuss",
+            "--cwd",
+            str(tmp_path),
+            "--task-id",
+            "task-6094",
+            "--correlation-id",
+            "corr-6094",
+            "--idempotency-key",
+            "idem-6094",
+            "--rounds",
+            "2",
+            "--json",
+        ]
+    )
+
+    assert rc == EXIT_OK
+    assert observed == ["active"]
+    assert os.environ["LU_ACPX_TRANSPORT"] == "shadow"
+    assert json.loads(capsys.readouterr().out) == {"state": "COMPLETE"}
+
+
+def test_acp_discuss_cli_busy_is_body_free_no_queue_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    from scripts.agent_runtime import acpx_discuss
+
+    def refuse_busy(**_kwargs):
+        raise acpx_discuss.AcpxDiscussionBusyError("private holder details")
+
+    monkeypatch.setattr(acpx_discuss, "run_discussion", refuse_busy)
+    monkeypatch.setattr("sys.stdin", io.StringIO("bounded design question"))
+
+    rc = main(
+        [
+            "acp-discuss",
+            "--cwd",
+            str(tmp_path),
+            "--task-id",
+            "task-6094",
+            "--correlation-id",
+            "corr-6094",
+            "--idempotency-key",
+            "idem-6094",
+            "--json",
+        ]
+    )
+
+    output = capsys.readouterr()
+    assert rc == EXIT_ERROR
+    assert json.loads(output.out) == {
+        "classification": "busy",
+        "queued": False,
+        "retryable": False,
+        "state": "BUSY",
+    }
+    assert output.err == ""
+    assert "private holder details" not in output.out
+
+
+def test_acp_verify_cli_exit_codes_and_compact_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    from scripts.agent_runtime import acpx_discuss
+
+    conversation_id = "conversation_" + ("a" * 32)
+    monkeypatch.setattr(
+        acpx_discuss,
+        "verify_discussion_receipt",
+        lambda **_kwargs: {
+            "conversation_id": conversation_id,
+            "verified": True,
+            "content_included": False,
+        },
+    )
+
+    rc = main(
+        [
+            "acp-verify",
+            "--conversation-id",
+            conversation_id,
+            "--root",
+            str(tmp_path),
+            "--require-replay",
+            "--json",
+        ]
+    )
+
+    assert rc == EXIT_OK
+    assert json.loads(capsys.readouterr().out) == {
+        "content_included": False,
+        "conversation_id": conversation_id,
+        "verified": True,
+    }
+
+
+def test_acp_verify_cli_maps_missing_receipt_to_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    from scripts.agent_runtime import acpx_discuss
+
+    def missing(**_kwargs):
+        raise acpx_discuss.AcpxDiscussionNotFoundError("receipt missing")
+
+    monkeypatch.setattr(acpx_discuss, "verify_discussion_receipt", missing)
+
+    rc = main(
+        [
+            "acp-verify",
+            "--conversation-id",
+            "conversation_" + ("b" * 32),
+            "--root",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == EXIT_NOT_FOUND
+    assert "receipt missing" in capsys.readouterr().err

--- a/tests/test_monitor_route_contracts.py
+++ b/tests/test_monitor_route_contracts.py
@@ -89,3 +89,4 @@ def test_contract_endpoint_exposes_route_and_page_contracts():
     assert any(item["pattern"] == "/api/worktrees" for item in data["route_contracts"])
     assert any(item["pattern"] == "/ws/batch" and item["kind"] == "websocket" for item in data["route_contracts"])
     assert any(item["file"] == "routing.html" and item["url"] == "/routing.html" for item in data["page_contracts"])
+    assert any(item["file"] == "acp.html" and item["url"] == "/acp.html" for item in data["page_contracts"])

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -135,6 +135,72 @@ def test_runtime_page_acpx_panel_has_no_mutating_transport_controls():
         assert prohibited not in acpx_panel
 
 
+def test_runtime_page_renders_recent_body_free_acp_observability_without_controls():
+    html = (DASHBOARDS / "runtime.html").read_text(encoding="utf-8")
+    acp_panel = html[html.index('id="acp-heading"') : html.index('id="acpx-heading"')]
+
+    assert "ACP Conversations" in acp_panel
+    assert "Read-only, body-free event history" in acp_panel
+    assert 'href="/acp.html"' in acp_panel
+    assert "Open ACP conversations" in acp_panel
+    assert "/api/runtime/acp/conversations" not in html
+
+    for prohibited in [
+        "<form",
+        "acp-send",
+        "acp-post",
+        "acp-session",
+        "acp-toggle",
+        "acp-retry",
+        "acp-cancel",
+        "acp-route",
+        "acp-review",
+        "acp-config",
+    ]:
+        assert prohibited not in acp_panel
+
+
+def test_acp_page_is_a_read_only_master_detail_event_timeline():
+    html = (DASHBOARDS / "acp.html").read_text(encoding="utf-8")
+
+    assert '<link rel="stylesheet" href="/monitor.css">' in html
+    assert '<a class="active" href="/acp.html">Conversations</a>' in html
+    assert "/api/runtime/acp/conversations?limit=50" in html
+    assert "/api/runtime/acp/conversations/" in html
+    assert "new URLSearchParams(location.search).get('conversation')" in html
+    assert "Recent conversations" in html
+    assert "Event flow" in html
+    assert "Body-free by design." in html
+    assert "conversation.updated_at" in html
+    assert "event.outcome" in html
+    assert "event.duration_ms" in html
+    assert "event.token_count" in html
+    assert "Conversation storage is unavailable." in html
+    assert "Malformed conversation data" in html
+    assert "No recent ACP conversations." in html
+    assert "@media (max-width: 880px)" in html
+    assert ":focus-visible" in html
+    assert "prefers-reduced-motion" in html
+    for href in PRIMARY_NAV_HREFS:
+        assert f'href="{href}"' in html
+
+    for prohibited in [
+        "<form",
+        "acp-send",
+        "acp-post",
+        "acp-start",
+        "acp-session",
+        "acp-toggle",
+        "acp-retry",
+        "acp-cancel",
+        "acp-route",
+        "acp-review",
+        "acp-config",
+        "fetch(url, { method:",
+    ]:
+        assert prohibited not in html
+
+
 def test_routing_page_uses_live_monitor_sources():
     html = (DASHBOARDS / "routing.html").read_text(encoding="utf-8")
     assert "Static snapshot" not in html

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -448,33 +448,23 @@ def test_acp_summary_prefers_terminal_wall_duration_and_token_total(tmp_path, mo
     assert summary["total_tokens"] == 5
 
 
-def test_runtime_page_has_a_separate_read_only_active_acp_timeline():
+def test_runtime_page_links_to_the_dedicated_read_only_acp_conversations_page():
     html = (DASHBOARDS / "runtime.html").read_text(encoding="utf-8")
     acp_panel = html[html.index('id="acp-heading"') : html.index('id="acpx-heading"')]
 
-    assert "Active ACP Conversations" in acp_panel
-    assert "/api/runtime/acp/conversations?limit=12" in html
-    assert "/api/runtime/acp/conversations/${encodeURIComponent(summary.conversation_id)}" in html
-    assert "Loading active conversations..." in acp_panel
-    assert "No active ACP conversations." in html
-    assert "Conversation storage is unavailable." in html
-    assert "Malformed conversation data" in html
-    assert "Root</div><div class=\"acp-lane\">Codex</div><div class=\"acp-lane\">Grok" in html
-    assert "round ${event.round}" in html
-    assert "seq ${event.sequence}" in html
-    assert "Duplicate suppressed" in html
-    assert "Ended: ${displayLabel(conversation.termination_reason)}" in html
-    assert "acpStateClass" in html
-    assert "acpStateLabel" in html
-    for label in ["Queued", "Running", "Succeeded", "Partial", "Cancelled", "Failed"]:
-        assert label in html
-    for state in ["COMPLETE", "PARTIAL_COMPLETE", "CANCELLED", "FAILED", "CREATED"]:
-        assert state in html
+    assert "ACP Conversations" in acp_panel
+    assert "Read-only, body-free event history" in acp_panel
+    assert 'href="/acp.html"' in acp_panel
+    assert "/api/runtime/acp/conversations" not in html
+    assert (DASHBOARDS / "acp.html").is_file()
 
     for prohibited in [
         "<form",
         "acp-send",
         "acp-post",
+        "acp-start",
+        "acp-session",
+        "acp-toggle",
         "acp-retry",
         "acp-cancel",
         "acp-route",


### PR DESCRIPTION
Closes #6094.

## What changed

- Makes the fixed Codex↔Grok `acp-discuss` panel a documented routine cooperation path for consequential read-only design/risk comparisons, while keeping invocation explicit and bounded to 1–3 rounds.
- Adds one nonblocking repository-wide admission guard with no queue or retry; terminal idempotent replay bypasses admission.
- Scopes `LU_ACPX_TRANSPORT=active` to the explicit CLI call and restores the prior environment.
- Resolves exact `acpx@0.13.0` from the canonical primary install for worktrees when the worktree has no local install; no PATH/global fallback.
- Adds a read-only, body-free `acp-verify` receipt command with poisoned-row reflection defenses.
- Adds `/acp.html`, a dedicated read-only master/detail ACP Conversations page. Runtime now links to it instead of rendering every timeline in one card.
- Updates binding coordination/onboarding/runtime documentation. ACP remains deliberation evidence only; file dual-write stays authoritative and ACP never satisfies formal review.

## Validation

- 226 scoped ACP/fleet/API/UI tests passed after rebase.
- Ruff, Python compilation, diff integrity, OPSEC, and X-Agent trailer checks passed.
- Shared primary runtime proof: a worktree with local `node_modules` temporarily absent resolved `/node_modules/.bin/acpx` from the canonical primary and confirmed version `0.13.0`.
- Authenticated exact-head E2E completed: `conversation_1b70f9c6ac924c66bed8a30178fa9dfd`, both Codex and Grok succeeded, native synthesis completed, 61,693 reliable tokens, 129.095 seconds.
- Identical replay returned immediately without provider scheduling; `acp-verify --require-replay` returned `verified=true` and `content_included=false`.
- Browser verification covered two persisted conversations, selection/URL state, complete and partial event timelines, terminal outcome labels, and absence of mutating controls.
- CI-discovered dashboard route-contract coverage was added; 42 focused API/UI/route-contract tests pass.

## Independent review and approval

- Exact-head Claude Sonnet 5 high-effort review of `0fdd51c7e37199d4d723cb6c8da0575baa3a3b5a`: APPROVED, no material findings.
- Freshness-contract review finding on the CI fix was corrected to describe the actual single-shot browser fetch; exact-head re-review is in progress.
- Rail approval receipt: `rail-approval-61c3e3bb80af4692b99a66894b7b013a` (advisor, exact head, binding coordination rule path).

Rail-Approval-Receipt: rail-approval-61c3e3bb80af4692b99a66894b7b013a

CI-Receipt-Refresh: fresh exact-head event after review finding resolution