### PR TITLE
fix(acp): persist message bodies atomically

### DIFF
--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -293,25 +293,39 @@ class AcpxDiscussionController:
         kind: str = "reply",
     ) -> str:
         """Persist directed content in the existing message/artifact mechanism."""
-        artifact = self.store.store_text(
-            body,
-            producer=f"acpx-discuss:{sender}",
-            retention_class="acpx-discussion",
-            logical_filename=f"{sender}-message.txt",
-        )
         message_id = new_id("message")
-        self.conn.execute(
-            """INSERT INTO comms_messages(
-                message_id, conversation_id, in_reply_to, kind, sender, recipient, body_inline,
-                body_artifact_id, content_sha256, metadata_json, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                message_id, conversation_id, reply_to, kind, sender, recipient, body,
-                artifact.artifact_id, artifact.sha256, json.dumps({"acpx_discussion": True}), _now(),
-            ),
-        )
-        self.conn.commit()
-        self.store.reference(message_id, artifact.artifact_id, relation="body")
+        try:
+            # The blob itself is durable before its SQLite row is created. Keep
+            # that row, the message, and its GC-visible reference in one SQLite
+            # transaction: a crash exposes either all three records or none.
+            self.conn.execute("BEGIN IMMEDIATE")
+            artifact = self.store.store_text(
+                body,
+                producer=f"acpx-discuss:{sender}",
+                retention_class="acpx-discussion",
+                logical_filename=f"{sender}-message.txt",
+                commit=False,
+            )
+            self.conn.execute(
+                """INSERT INTO comms_messages(
+                    message_id, conversation_id, in_reply_to, kind, sender, recipient, body_inline,
+                    body_artifact_id, content_sha256, metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    message_id, conversation_id, reply_to, kind, sender, recipient, body,
+                    artifact.artifact_id, artifact.sha256, json.dumps({"acpx_discussion": True}), _now(),
+                ),
+            )
+            self.store.reference(
+                message_id,
+                artifact.artifact_id,
+                relation="body",
+                commit=False,
+            )
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
         return message_id
 
     def _replay(self, conversation_id: str) -> dict[str, Any]:

--- a/scripts/fleet_comms/artifacts.py
+++ b/scripts/fleet_comms/artifacts.py
@@ -131,7 +131,11 @@ class ArtifactStore:
         mime_type: str | None = None,
         logical_filename: str | None = None,
         artifact_id: str | None = None,
+        commit: bool = True,
     ) -> ArtifactRecord:
+        """Store bytes; ``commit=False`` requires a caller-owned active transaction."""
+        if not commit:
+            self._require_active_transaction_for_deferred_commit()
         if not producer or not producer.strip():
             raise ArtifactStoreError("producer is required")
         if logical_filename is not None:
@@ -164,9 +168,11 @@ class ArtifactStore:
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 (aid, digest, len(data), mime, logical_filename, producer, retention_class, created),
             )
-            self._conn.commit()
+            if commit:
+                self._conn.commit()
         except Exception:
-            self._conn.rollback()
+            if commit:
+                self._conn.rollback()
             raise
         row = self._conn.execute(
             "SELECT * FROM artifacts WHERE artifact_id = ?", (aid,)
@@ -183,13 +189,18 @@ class ArtifactStore:
         retention_class: str = "default",
         logical_filename: str | None = None,
         mime_type: str = "text/plain; charset=utf-8",
+        commit: bool = True,
     ) -> ArtifactRecord:
+        """Store text; ``commit=False`` requires a caller-owned active transaction."""
+        if not commit:
+            self._require_active_transaction_for_deferred_commit()
         return self.store_bytes(
             text.encode("utf-8"),
             producer=producer,
             retention_class=retention_class,
             logical_filename=logical_filename,
             mime_type=mime_type,
+            commit=commit,
         )
 
     def import_path(
@@ -268,18 +279,37 @@ class ArtifactStore:
             raise ArtifactStoreError(f"blob digest mismatch for {artifact_id}")
         return data
 
-    def reference(self, message_id: str, artifact_id: str, relation: str = "body") -> None:
-        """Link artifact to a message so GC will not delete it."""
+    def reference(
+        self,
+        message_id: str,
+        artifact_id: str,
+        relation: str = "body",
+        *,
+        commit: bool = True,
+    ) -> None:
+        """Link artifact to a message so GC will not delete it.
+
+        ``commit=False`` is only safe when the caller owns an active transaction
+        and will commit or roll it back.
+        """
+        if not commit:
+            self._require_active_transaction_for_deferred_commit()
         if not message_id or not artifact_id:
             raise ArtifactStoreError("message_id and artifact_id required")
         self.get(artifact_id)  # ensure exists
-        self._ensure_message_stub(message_id)
-        self._conn.execute(
-            """INSERT OR IGNORE INTO message_artifacts(message_id, artifact_id, relation)
-               VALUES (?, ?, ?)""",
-            (message_id, artifact_id, relation),
-        )
-        self._conn.commit()
+        try:
+            self._ensure_message_stub(message_id)
+            self._conn.execute(
+                """INSERT OR IGNORE INTO message_artifacts(message_id, artifact_id, relation)
+                   VALUES (?, ?, ?)""",
+                (message_id, artifact_id, relation),
+            )
+            if commit:
+                self._conn.commit()
+        except Exception:
+            if commit:
+                self._conn.rollback()
+            raise
 
     def is_referenced(self, artifact_id: str) -> bool:
         row = self._conn.execute(
@@ -429,4 +459,9 @@ class ArtifactStore:
             ) VALUES (?, ?, 'note', 'artifact-store', '', ?)""",
             (message_id, conv, now),
         )
-        self._conn.commit()
+
+    def _require_active_transaction_for_deferred_commit(self) -> None:
+        if not self._conn.in_transaction:
+            raise ArtifactStoreError(
+                "commit=False requires a caller-owned active transaction"
+            )

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -142,6 +142,134 @@ def test_conversation_survives_dispatch_worktree_cleanup(tmp_path, monkeypatch):
         assert row[0] == "COMPLETE"
 
 
+class _InjectedPersistenceCrash(RuntimeError):
+    """Simulates process loss at a named ACP body-persistence boundary."""
+
+
+@pytest.mark.parametrize("boundary", ("blob", "artifact", "message", "link"))
+def test_message_persistence_rolls_back_every_precommit_boundary(
+    tmp_path, monkeypatch, boundary
+):
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda *_a, **_k: _result("codex", "unused"),
+        lambda *_a, **_k: _result("codex", "unused"),
+    )
+    conversation_id, replay = controller._reserve(
+        task_digest="task",
+        correlation_digest="correlation",
+        idempotency_digest=f"crash-{boundary}",
+        rounds=1,
+        deadline_at="2099-01-01T00:00:00Z",
+    )
+    assert replay is None
+
+    if boundary == "blob":
+        original_write = controller.store._write_blob_atomic
+
+        def crash_after_blob_write(dest, data):
+            original_write(dest, data)
+            raise _InjectedPersistenceCrash("after blob write")
+
+        monkeypatch.setattr(controller.store, "_write_blob_atomic", crash_after_blob_write)
+    elif boundary == "artifact":
+        original_store_text = controller.store.store_text
+
+        def crash_after_artifact(*args, **kwargs):
+            original_store_text(*args, **kwargs)
+            raise _InjectedPersistenceCrash("after artifact insert")
+
+        monkeypatch.setattr(controller.store, "store_text", crash_after_artifact)
+    elif boundary == "message":
+        def crash_before_link(*_args, **_kwargs):
+            raise _InjectedPersistenceCrash("after message insert")
+
+        monkeypatch.setattr(controller.store, "reference", crash_before_link)
+    else:
+        original_reference = controller.store.reference
+
+        def crash_after_link(*args, **kwargs):
+            original_reference(*args, **kwargs)
+            raise _InjectedPersistenceCrash("after link insert")
+
+        monkeypatch.setattr(controller.store, "reference", crash_after_link)
+
+    root = controller.store.root
+    try:
+        with pytest.raises(_InjectedPersistenceCrash):
+            controller._message(
+                conversation_id,
+                sender="codex",
+                recipient="root",
+                body="crash-boundary body",
+                reply_to=None,
+            )
+    finally:
+        controller.close()
+
+    with ArtifactStore(root=root) as reopened:
+        assert reopened.connection.execute(
+            "SELECT COUNT(*) FROM comms_messages WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()[0] == 0
+        assert reopened.connection.execute(
+            "SELECT COUNT(*) FROM message_artifacts",
+        ).fetchone()[0] == 0
+        assert reopened.connection.execute(
+            "SELECT COUNT(*) FROM artifacts",
+        ).fetchone()[0] == 0
+        assert reopened.garbage_collect_unreferenced(grace_seconds=0) == []
+
+
+def test_committed_message_body_is_gc_visible_after_zero_grace(tmp_path, monkeypatch):
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda *_a, **_k: _result("codex", "unused"),
+        lambda *_a, **_k: _result("codex", "unused"),
+    )
+    root = controller.store.root
+    try:
+        conversation_id, replay = controller._reserve(
+            task_digest="task",
+            correlation_digest="correlation",
+            idempotency_digest="committed-message",
+            rounds=1,
+            deadline_at="2099-01-01T00:00:00Z",
+        )
+        assert replay is None
+        message_id = controller._message(
+            conversation_id,
+            sender="codex",
+            recipient="root",
+            body="durable body",
+            reply_to=None,
+        )
+        artifact_id = controller.conn.execute(
+            "SELECT body_artifact_id FROM comms_messages WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()[0]
+        assert controller.conn.execute(
+            "SELECT 1 FROM message_artifacts WHERE message_id = ? AND artifact_id = ?",
+            (message_id, artifact_id),
+        ).fetchone() is not None
+    finally:
+        controller.close()
+
+    with ArtifactStore(root=root) as reopened:
+        assert reopened.connection.execute(
+            "SELECT 1 FROM comms_messages WHERE message_id = ?",
+            (message_id,),
+        ).fetchone() is not None
+        assert reopened.connection.execute(
+            "SELECT 1 FROM message_artifacts WHERE message_id = ? AND artifact_id = ?",
+            (message_id, artifact_id),
+        ).fetchone() is not None
+        assert reopened.garbage_collect_unreferenced(grace_seconds=0) == []
+        assert reopened.get(artifact_id).artifact_id == artifact_id
+
+
 def test_three_rounds_repeat_cross_exchange_and_complete(tmp_path, monkeypatch):
     calls: list[str] = []
 

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -97,6 +97,53 @@ def test_artifact_store_rejects_traversal_filename(tmp_path: Path) -> None:
             store.store_text("x", producer="t", logical_filename="/abs/name.txt")
 
 
+def test_artifact_store_deferred_commit_requires_active_transaction(tmp_path: Path) -> None:
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        persisted = store.store_text("persisted", producer="t")
+
+        with pytest.raises(ArtifactStoreError, match="caller-owned active transaction"):
+            store.store_text("uncommitted", producer="t", commit=False)
+        with pytest.raises(ArtifactStoreError, match="caller-owned active transaction"):
+            store.reference("message-uncommitted", persisted.artifact_id, commit=False)
+
+        store.connection.execute("BEGIN IMMEDIATE")
+        try:
+            deferred = store.store_text("deferred", producer="t", commit=False)
+            store.reference("message-deferred", deferred.artifact_id, commit=False)
+            store.connection.commit()
+        except Exception:
+            store.connection.rollback()
+            raise
+
+        assert store.connection.execute(
+            "SELECT 1 FROM message_artifacts WHERE message_id = ? AND artifact_id = ?",
+            ("message-deferred", deferred.artifact_id),
+        ).fetchone() is not None
+
+
+def test_artifact_reference_default_commit_rolls_back_failed_stub(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        persisted = store.store_text("persisted", producer="t")
+        original_stub = store._ensure_message_stub
+
+        def fail_after_stub(message_id: str) -> None:
+            original_stub(message_id)
+            raise sqlite3.IntegrityError("injected link failure")
+
+        monkeypatch.setattr(store, "_ensure_message_stub", fail_after_stub)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            store.reference("message-failed", persisted.artifact_id)
+
+        assert store.connection.in_transaction is False
+        assert store.connection.execute(
+            "SELECT 1 FROM comms_messages WHERE message_id = ?",
+            ("message-failed",),
+        ).fetchone() is None
+
+
 def test_artifact_import_materialize_and_gc(tmp_path: Path) -> None:
     src = tmp_path / "src.bin"
     src.write_bytes(b"payload-bytes")

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 import scripts.api.runtime_router as runtime_router
+from scripts.agent_runtime.acpx_discuss import AcpxDiscussionController
 from scripts.api.main import app
 
 client = TestClient(app, raise_server_exceptions=False)
@@ -365,6 +366,46 @@ def test_acp_conversation_api_is_ordered_allowlisted_and_read_only(tmp_path, mon
         "leg_key_digest", "must-not-leak", "leg-secret", "message-secret",
     ):
         assert private_value not in detail.text
+
+
+def test_acp_runtime_api_hides_persisted_message_content_and_references(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "plane"
+    controller = AcpxDiscussionController(root=root)
+    try:
+        conversation_id, replay = controller._reserve(
+            task_digest="task-digest",
+            correlation_digest="correlation-digest",
+            idempotency_digest="idempotency-digest",
+            rounds=1,
+            deadline_at="2099-01-01T00:00:00Z",
+        )
+        assert replay is None
+        message_id = controller._message(
+            conversation_id,
+            sender="codex",
+            recipient="root",
+            body="private ACP body must not leak",
+            reply_to=None,
+        )
+        artifact_id = controller.conn.execute(
+            "SELECT body_artifact_id FROM comms_messages WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()[0]
+    finally:
+        controller.close()
+
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(root))
+    response = client.get(f"/api/runtime/acp/conversations/{conversation_id}")
+
+    assert response.status_code == 200
+    for private_value in (
+        "private ACP body must not leak",
+        message_id,
+        artifact_id,
+    ):
+        assert private_value not in response.text
 
 
 def test_acp_conversations_refuse_poisoned_rows_and_hide_unavailable_storage(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #6089

Parent stream: #4707

## Summary

- persist the artifact metadata row, ACP message, and GC-visible message_artifacts link in one BEGIN IMMEDIATE transaction
- keep the filesystem blob atomic and roll back all database visibility at every pre-commit failure boundary
- make deferred ArtifactStore writes fail closed unless a caller-owned transaction is active
- preserve append-only conversation events and body-free Runtime API responses

## Crash-consistency proof

- injected failures after blob write, artifact insert, message insert, and link insert; every case closes and reopens storage and observes no partial database records
- post-commit close/reopen proves artifact, message, and reference survive and zero-grace GC retains the live body
- ordinary failed reference construction rolls back its helper-created message stub

## Verification

- 67 focused persistence/API tests passed
- 134 related fleet-comms/ACP tests passed
- Ruff, compilation, diff checks, staged OPSEC, protected-file checks, and commit-trailer checks passed

## Non-goals

No message-plane authority cutover, retention-policy change, participant rollout, API schema expansion, or UI change.