### PR TITLE
feat(guardrails): pin advisory consultations to Opus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ eats it. Full protocol: `agents_extensions/shared/rules/workflow.md` § Work int
 - Keep changes scoped to the requested files and behavior.
 - Run relevant verification before finalizing, or state why verification was not run.
 - Final reports must include changed files, verification performed, and final `git status --short --branch`.
+- New material blocking, mutating, network-dependent, or always-loaded guardrails must follow
+  `docs/best-practices/guardrail-lifecycle.md`; do not blanket-retrofit historical controls.
 
 ---
 

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -42,11 +42,12 @@ Record the harness fallback explicitly; it is a transport fallback, not a model 
   * **Codex seat**: `gpt-5.6-terra` (standard practical review)
   * **GLM seat**: `glm-5.2` (local-only)
   * **Gemini seat**: `gemini-3.6-flash-high`
-* **Complex Non-Advisory Tasks & Deep Reviews**:
-  * **Anthropic Opus seat**: `claude-opus-5` (complex coding, deep reasoning). NOT an
-    advisor seat — operator ruling 2026-07-26: weak in the advisor role and over-verbose
-    there; this REVERSES the 2026-07-24 "Opus replaces Fable as default Anthropic advisor"
-    ruling.
+* **Complex Tasks, Deep Reviews & Anthropic Advisory Consultations**:
+  * **Anthropic Opus seat**: `claude-opus-5` (complex coding, deep reasoning, and
+    non-binding advisory consultation). Operator directive 2026-07-31: when requesting
+    Anthropic advisory input, use `ab ask-claude --type advisory --to-model claude-opus-5`;
+    never substitute Sonnet. This consultation does not confer designated approval
+    authority and does not satisfy the formal cross-family review gate.
 * **Escalatory Advisor / Critical Authority Reviews** (reserved for architecture, security, or design escalation):
   * **Top advisors**: `claude-fable-5` · `gpt-5.6-sol` — the ONLY top-tier
     advisor seats. Sol starts at `high`; use `xhigh`/`max` only for an explicit
@@ -62,6 +63,11 @@ Record the harness fallback explicitly; it is a transport fallback, not a model 
 
 *Everyday routine PRs use practical seats (`sonnet` / `terra`). Do not burn advisor seats on routine work.*
 
+**Three-role boundary (operator directive 2026-07-31):** advisory consultation is
+non-binding model input (Anthropic → Opus); designated approval authority is the current
+identity roster in `operator-expectations.md`; formal review is selected independently by
+the canonical reviewer resolver. A routing-table change must never grant approval authority
+or count as a formal review.
 
 **Lane updates (user-reported 2026-07-18):**
 - **grok**: the lane now offers **grok-4.5 only**, with selectable reasoning effort

--- a/docs/best-practices/guardrail-lifecycle.md
+++ b/docs/best-practices/guardrail-lifecycle.md
@@ -1,0 +1,38 @@
+# Guardrail lifecycle
+
+Use this contract for a new material guardrail that blocks work, mutates repository state,
+depends on the network, changes merge authorization, or adds always-loaded instructions.
+Ordinary tests and narrow validators are not required to complete this process. Existing
+guardrails are assessed when touched; there is no blanket historical retrofit.
+
+## Proposal card
+
+Before implementation, record a compact card on the owning issue or PR:
+
+1. **Failure prevented:** the concrete incident or falsifiable failure mode.
+2. **Enforcement point:** why this is the narrowest reliable place to enforce it.
+3. **Owner:** the path, team, or issue responsible for maintenance.
+4. **False-positive budget:** the measurable blocking/error rate that triggers review.
+5. **Escape path:** a logged operator recovery route that cannot silently become the default.
+6. **Proof:** one expected pass and one deliberate failure exercised at the real boundary.
+7. **Sunset:** the replacement condition, deletion criterion, or review date.
+
+## Design constraints
+
+- Prefer server-side enforcement for shared authorization and local enforcement for local
+  secrets, checkout containment, and other failures the server cannot observe.
+- Do not silently rewrite user commands or mutate checkout state unless the state is
+  repository-fatal, the recovery is exact and bounded, and an explicit doctor path exists.
+- A replacement must block the same UI, API, and command-line path before the old control is
+  removed. A planned replacement is not proof.
+- Network failure must not block unrelated local work unless failing open would create the
+  specific high-impact failure named in the proposal card.
+- Default to annotation or shadow measurement when a new classifier would otherwise remove
+  an existing gate.
+
+## Closeout
+
+Record deterministic checks, independent review where required, and source-blind behavior
+proof. Compare observed false positives with the budget. Delete a redundant guardrail when
+its replacement proof and sunset criterion are satisfied; do not keep dual enforcement
+indefinitely for reassurance.

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -55,6 +55,32 @@ from ._review_worktree import (
 )
 
 VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+CLAUDE_DEFAULT_ASK_MODEL = "claude-sonnet-5"
+CLAUDE_ADVISORY_MODEL = "claude-opus-5"
+
+
+def resolve_claude_ask_model(msg_type: str, to_model: str | None) -> str:
+    """Resolve one-shot Claude routing without conflating asks and reviews.
+
+    Advisory consultations are a distinct, non-binding message type.  The
+    operator pins that seat to Opus and forbids a silent Sonnet substitution;
+    ordinary asks keep the practical Sonnet default.  Formal review routing is
+    owned by the reviewer resolver and does not use this rule.
+    """
+    if msg_type.casefold() == "advisory":
+        if to_model not in (None, CLAUDE_ADVISORY_MODEL):
+            raise ValueError(
+                "Claude advisory consultations require "
+                f"--to-model {CLAUDE_ADVISORY_MODEL}; got {to_model}. "
+                "Do not substitute Sonnet for the advisory seat."
+            )
+        return CLAUDE_ADVISORY_MODEL
+    return resolve_model_selection(
+        lane="ask-claude",
+        to_model=to_model,
+        model=None,
+        default=CLAUDE_DEFAULT_ASK_MODEL,
+    )
 
 
 def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query",
@@ -83,9 +109,10 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
         formal_review=formal_review,
         has_target=has_target,
     )
-    effective_model = resolve_model_selection(
-        lane="ask-claude", to_model=to_model, model=None, default="claude-sonnet-5"
-    )
+    try:
+        effective_model = resolve_claude_ask_model(msg_type, to_model)
+    except ValueError as exc:
+        raise SystemExit(f"ask-claude: {exc}") from exc
     msg_id = send_message(
         content,
         task_id,

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -606,7 +606,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ask_claude_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     ask_claude_parser.add_argument("--task-id", required=True, help="Task ID (required for session tracking)")
-    ask_claude_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_claude_parser.add_argument(
+        "--type",
+        default="query",
+        help="Message type (default: query; use advisory to pin claude-opus-5)",
+    )
     ask_claude_parser.add_argument("--data", help="Path to data file to attach")
     ask_claude_parser.add_argument(
         "--new-session", dest="new_session", action="store_true", help="Force new session even if one exists"

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -133,7 +133,7 @@ models:
     family: anthropic
     tier: frontier_authority
     lifecycle: active
-    roles: [advisory, architecture, critical_review, security_review, orchestration, agentic_coding]
+    roles: [advisory_consultation, architecture, critical_review, security_review, agentic_coding]
     transports: [native_claude, cursor]
     strengths: [deep_reasoning, long_horizon_agentic, high_precision_and_recall_code_review]
     weaknesses: [verbose_by_default, over_delegates_to_subagents, elevated_refusal_surface]

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -133,20 +133,22 @@ models:
     family: anthropic
     tier: frontier_authority
     lifecycle: active
-    roles: [architecture, critical_review, security_review, orchestration, agentic_coding]
+    roles: [advisory, architecture, critical_review, security_review, orchestration, agentic_coding]
     transports: [native_claude, cursor]
     strengths: [deep_reasoning, long_horizon_agentic, high_precision_and_recall_code_review]
     weaknesses: [verbose_by_default, over_delegates_to_subagents, elevated_refusal_surface]
     notes: >-
-      Anthropic advisor + escalation TARGET seat (replaced Fable 5 on 2026-07-24 at half
-      the token cost). Effort ladder low..max; drive at high, xhigh for the hard turn.
-      Thinking is ON by default and disabling it is invalid above high effort.
-      Separate rate-limit bucket from the Opus 4.x pool.
+      Anthropic advisory-consultation seat (operator directive 2026-07-31). Advisory is
+      non-binding and does not confer designated approval authority or satisfy formal review.
+      Effort ladder low..max; use high for advisory and xhigh only for a documented hard turn.
+      Thinking is ON by default and disabling it is invalid above high effort. Separate
+      rate-limit bucket from the Opus 4.x pool.
     sources:
       - https://platform.claude.com/docs/en/about-claude/models/overview
-  # Retained alongside claude-opus-5 (which since 2026-07-26 is a coding seat, not an
-  # advisor — the advisor roster points at claude-fable-5 + gpt-5.6-sol), but
-  # this id is still referenced by scripts/context_canary.py, scripts/pipeline/dispatch.py,
+  # Retained alongside claude-opus-5. Opus is the non-binding Anthropic advisory-
+  # consultation seat; designated approval authority remains identity-scoped and the
+  # current advisor roster still points at claude-fable-5 + gpt-5.6-sol. This legacy id
+  # is still referenced by scripts/context_canary.py, scripts/pipeline/dispatch.py,
   # ai_agent_bridge/openai_proxy.py and _dispatch_wrappers.py. Removing the entry
   # broke collection with KeyError: 'claude-opus-4-8'.
   claude-opus-4-8:
@@ -590,16 +592,16 @@ orchestrator_seats:
     escalate_effort: xhigh
     escalate_when: deep_single_shot_or_architecture
     note: >-
-      Fable 5 is the Anthropic orchestration/judgment seat (operator 2026-07-26;
-      REVERSES the 2026-07-24 Opus-as-default ruling — operator: Opus 5 is weak in
-      the advisor role and over-verbose). Fable runs in the SUMMONED cadence, not
+      Fable 5 remains the Anthropic orchestration and designated-authority seat.
+      Non-binding Anthropic advisory consultations route separately to Opus 5 under
+      the operator's 2026-07-31 directive. Fable runs in the SUMMONED cadence, not
       as a resident daily driver: grok-4.5 owns the daily epic loops; Fable takes
       1-2 short scheduled judgment sessions/day (verdict reads, course corrections,
       design locks, briefs) driven dispatch-heavy, never inline-heavy — measured
       2026-07-26 at ~2 weekly-quota points per orchestration hour in that style.
       Escalation stays CROSS-FAMILY to Sol @ xhigh; Claude is an escalation TARGET,
-      not an escalator. Opus 5 remains a complex-coding/deep-reasoning seat only —
-      not an advisor, not an orchestrator. Driving is `high`, not `xhigh`.
+      not an escalator. Opus 5 is not an orchestrator and its advisory output does
+      not confer approval authority. Driving is `high`, not `xhigh`.
   codex:
     model_id: gpt-5.6-terra
     effort: high
@@ -649,7 +651,7 @@ formal_cf_defaults:
     model_id: claude-sonnet-5
     effort: high
     # Others escalate TO Claude: Fable 5 @ xhigh is the Anthropic advisor/authority
-    # seat (operator 2026-07-26 — Opus 5 de-advisored; reverses the 2026-07-24 swap).
+    # seat. Opus 5 advisory consultations are non-binding and separate from formal CF.
     escalate_model_id: claude-fable-5
     escalate_effort: xhigh
   glm:

--- a/tests/ai_agent_bridge/test_claude_advisory_routing.py
+++ b/tests/ai_agent_bridge/test_claude_advisory_routing.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.ai_agent_bridge._claude import (
+    CLAUDE_ADVISORY_MODEL,
+    CLAUDE_DEFAULT_ASK_MODEL,
+    resolve_claude_ask_model,
+)
+
+
+def test_advisory_defaults_to_opus() -> None:
+    assert resolve_claude_ask_model("advisory", None) == CLAUDE_ADVISORY_MODEL
+
+
+def test_advisory_rejects_sonnet_substitution() -> None:
+    with pytest.raises(ValueError, match="Do not substitute Sonnet"):
+        resolve_claude_ask_model("advisory", CLAUDE_DEFAULT_ASK_MODEL)
+
+
+def test_ordinary_query_keeps_practical_default() -> None:
+    assert resolve_claude_ask_model("query", None) == CLAUDE_DEFAULT_ASK_MODEL

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -367,10 +367,11 @@ def test_catalog_rejects_future_review_date():
 
 
 def test_critical_ladder_anthropic_authority_is_fable_not_opus():
-    """Operator 2026-07-26: Opus 5 is de-advisored. The critical (authority)
-    ladder must route Anthropic authority reviews to Fable and must not list
-    Opus at all — otherwise the resolver dispatches authority reviews to the
-    explicitly de-advisored model whenever the OpenAI rung is excluded."""
+    """Advisory consultation must not silently become approval authority.
+
+    The critical authority ladder routes Anthropic approval reviews to Fable.
+    Opus remains the separate, non-binding advisory-consultation seat.
+    """
     ladder = load_model_catalog()["review_ladders"]["critical"]
     flat = [model for rung in ladder for model in rung]
     assert "claude-fable-5" in flat

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -379,6 +379,13 @@ def test_critical_ladder_anthropic_authority_is_fable_not_opus():
     assert flat.index("claude-fable-5") < flat.index("claude-sonnet-5")
 
 
+def test_opus_advisory_capability_does_not_grant_orchestration() -> None:
+    """Model capability metadata must preserve the routing/authority boundary."""
+    roles = set(load_model_catalog()["models"]["claude-opus-5"]["roles"])
+    assert "advisory_consultation" in roles
+    assert "orchestration" not in roles
+
+
 def test_sol_advised_luna_execution_route_is_bounded_and_machine_readable():
     """The Sol→Luna lane must be explicit, bounded, and source-blind testable."""
     catalog = load_model_catalog()


### PR DESCRIPTION
## Summary

- pin ask-claude --type advisory to claude-opus-5
- reject explicit Sonnet substitution for advisory-type asks
- preserve Sonnet for ordinary queries and keep formal-review resolution separate
- distinguish non-binding advisory input from designated approval authority
- add a lightweight lifecycle contract for new material guardrails only

## Guardrail proposal card

- **Failure prevented:** Anthropic advisory requests silently routing to Sonnet and policy changes conflating model routing with approval authority.
- **Enforcement point:** the one-shot Claude bridge resolves the model before creating or invoking the ask.
- **Owner:** scripts/ai_agent_bridge/_claude.py and scripts/config/model_catalog.yaml.
- **False-positive budget:** zero blocked ordinary queries or formal reviews; only message_type=advisory is pinned.
- **Escape path:** choose a non-Anthropic advisory lane with an explicit substitution note; no silent Sonnet fallback.
- **Proof:** ordinary query resolves Sonnet; advisory resolves Opus; advisory plus Sonnet fails before provider invocation.
- **Sunset:** remove the special case only if advisory capabilities become first-class machine data enforced by a common router.

## Verification

- targeted bridge and catalog pytest suite — 110 passed
- model catalog lint — pass
- Ruff — pass
- lifecycle-document markdown lint — pass
- prompt deployment dry-run — pass
- OPSEC and agent-trailer lints — pass
- negative CLI probe with advisory plus Sonnet — rejected with the required Opus command before invocation

Refs #6108

X-Agent: codex/6108-guardrail-governance

Rail-Approval-Receipt: rail-approval-e811da91e1924e57b663dc996bf2c8d0
