### PR TITLE
fix(hygiene): safely reconcile stale Codex rollout rows

### DIFF
--- a/docs/runbooks/codex-rollout-state.md
+++ b/docs/runbooks/codex-rollout-state.md
@@ -2,14 +2,15 @@
 
 `scripts/hygiene/codex_rollout_reconcile.py` is a project-owned, dry-run-first
 health tool for stale `threads.rollout_path` rows. It never changes the
-installed Codex CLI and never deletes a rollout file.
+installed Codex CLI or deletes a rollout file.
 
 Eligibility requires an absolute `rollout-*.jsonl` path under the row's
 selected `sessions/` or `archived_sessions/` root, a filename ending in its
 canonical UUID, an unpinned row, and `updated_at` at least 24 hours old. UUID,
 archived, path, symlink, foreign-key, trigger, and unknown-schema mismatches are
-protected. The age window can be lowered for tests; production defaults to 24
-hours.
+protected. A missing rollout root is also suspicious; harmless INSERT/UPDATE
+maintenance triggers are accepted, while DELETE or unrecognized triggers are
+not. Tests may lower the 24-hour age window.
 
 ## Scan
 

--- a/docs/runbooks/codex-rollout-state.md
+++ b/docs/runbooks/codex-rollout-state.md
@@ -1,0 +1,96 @@
+# Codex rollout state reconciliation
+
+`scripts/hygiene/codex_rollout_reconcile.py` is a project-owned, dry-run-first
+health tool for stale `threads.rollout_path` rows. It never changes the
+installed Codex CLI and never deletes a rollout file.
+
+The tool only considers a missing path eligible when it is an absolute
+`rollout-*.jsonl` path below the selected Codex home's `sessions/` or
+`archived_sessions/` directory, the row is unpinned, and `updated_at` is at
+least 24 hours old. Outside, malformed, recent, pinned, present, and unknown
+schema rows are protected. The age window can be lowered for temporary tests,
+but the production default is 24 hours.
+
+## Scan
+
+The default operation is a read-only scan. `--db` is optional; without it the
+tool selects the newest compatible exact `state_*.sqlite` under `--codex-home`.
+Rows and counts are emitted as stable, sorted JSON.
+
+```bash
+.venv/bin/python scripts/hygiene/codex_rollout_reconcile.py scan \
+  --codex-home "$HOME/.codex" \
+  --db "$HOME/.codex/state_5.sqlite"
+```
+
+For a read-only health check suitable for automation, fail when eligible stale
+rows remain:
+
+```bash
+.venv/bin/python scripts/hygiene/codex_rollout_reconcile.py scan \
+  --codex-home "$HOME/.codex" --fail-on-stale
+```
+
+Review the `eligible_stale_ids` list and the per-row classification. The list
+is the confirmation input for the next step; do not infer an apply count from
+another scan or from the database directly.
+
+## Apply
+
+Close Codex and stop any process that can write the selected state database.
+Then pass the exact `eligible_stale` count from the reviewed scan and the
+explicit acknowledgement flag. The tool creates a uniquely named SQLite
+backup with restrictive permissions before opening one `BEGIN IMMEDIATE`
+transaction. Every candidate is re-read and its ID, path, update time, pin
+state, and filesystem absence are checked again inside that transaction.
+
+```bash
+.venv/bin/python scripts/hygiene/codex_rollout_reconcile.py apply \
+  --codex-home "$HOME/.codex" \
+  --db "$HOME/.codex/state_5.sqlite" \
+  --expected-eligible-stale 3 \
+  --confirm-stale
+```
+
+A count mismatch refuses before backup creation or any write. Changed or newly
+present candidates are skipped safely. Matching `thread_spawn_edges` are
+removed for deleted thread IDs; declared foreign keys handle dependent dynamic
+tools. The receipt printed to stdout includes the backup path, deleted and
+skipped counts, remaining classifications, SQLite `integrity_check`, and
+post-apply parity. Keep that receipt with the backup path for operator review;
+the repository does not write receipts or local state files.
+
+## Verify
+
+After apply, run the project check and Codex's own diagnostic while Codex is
+closed, then reopen Codex and repeat the scan:
+
+```bash
+codex doctor --json
+.venv/bin/python scripts/hygiene/codex_rollout_reconcile.py scan \
+  --codex-home "$HOME/.codex" --fail-on-stale
+```
+
+The scan should report zero unexplained `eligible_stale` rows. Existing
+rollouts, pinned/recent rows, suspicious paths, and unrelated thread rows must
+remain present.
+
+## Rollback
+
+Rollback is operator-only. First close Codex completely and stop every Codex
+process that could open the database. Confirm the backup is the receipt's
+backup and has restrictive permissions. Do not restore while Codex is running.
+
+Use SQLite's restore command rather than copying a live database file:
+
+```bash
+DB="$HOME/.codex/state_5.sqlite"
+BACKUP="/absolute/path/from-the-receipt/state_5-before-reconcile-<id>.sqlite"
+sqlite3 "$DB" ".restore '$BACKUP'"
+sqlite3 "$DB" "PRAGMA integrity_check;"
+codex doctor --json
+```
+
+If the restore or integrity check fails, leave Codex closed and escalate with
+the receipt and error output. Never delete rollout JSONL files as part of
+reconciliation or rollback.

--- a/docs/runbooks/codex-rollout-state.md
+++ b/docs/runbooks/codex-rollout-state.md
@@ -4,12 +4,12 @@
 health tool for stale `threads.rollout_path` rows. It never changes the
 installed Codex CLI and never deletes a rollout file.
 
-The tool only considers a missing path eligible when it is an absolute
-`rollout-*.jsonl` path below the selected Codex home's `sessions/` or
-`archived_sessions/` directory, the row is unpinned, and `updated_at` is at
-least 24 hours old. Outside, malformed, recent, pinned, present, and unknown
-schema rows are protected. The age window can be lowered for temporary tests,
-but the production default is 24 hours.
+Eligibility requires an absolute `rollout-*.jsonl` path under the row's
+selected `sessions/` or `archived_sessions/` root, a filename ending in its
+canonical UUID, an unpinned row, and `updated_at` at least 24 hours old. UUID,
+archived, path, symlink, foreign-key, trigger, and unknown-schema mismatches are
+protected. The age window can be lowered for tests; production defaults to 24
+hours.
 
 ## Scan
 
@@ -31,34 +31,38 @@ rows remain:
   --codex-home "$HOME/.codex" --fail-on-stale
 ```
 
-Review the `eligible_stale_ids` list and the per-row classification. The list
-is the confirmation input for the next step; do not infer an apply count from
-another scan or from the database directly.
+Review `eligible_stale_ids`, each classification, and `eligible_digest`. This
+canonical SHA-256 covers sorted eligible fingerprints (`id`, `rollout_path`,
+`updated_at`, `pinned`, `archived`) and must be copied exactly with the count;
+do not infer either value from another scan or the database.
 
 ## Apply
 
-Close Codex and stop any process that can write the selected state database.
-Then pass the exact `eligible_stale` count from the reviewed scan and the
-explicit acknowledgement flag. The tool creates a uniquely named SQLite
-backup with restrictive permissions before opening one `BEGIN IMMEDIATE`
-transaction. Every candidate is re-read and its ID, path, update time, pin
-state, and filesystem absence are checked again inside that transaction.
+Close Codex and stop every process that can write the selected database. Pass
+both reviewed values and acknowledgement. Apply opens the writable database,
+enables foreign keys/busy timeout, acquires `BEGIN IMMEDIATE`, then uses a
+separate read connection under that lock to create and integrity-check the
+backup. It revalidates digest-bound identity and filesystem absence, deletes
+matching spawn edges before thread rows, and commits only after those deletes.
 
 ```bash
 .venv/bin/python scripts/hygiene/codex_rollout_reconcile.py apply \
   --codex-home "$HOME/.codex" \
   --db "$HOME/.codex/state_5.sqlite" \
   --expected-eligible-stale 3 \
+  --expected-eligible-digest "64-hex-digest-from-reviewed-scan" \
   --confirm-stale
 ```
 
-A count mismatch refuses before backup creation or any write. Changed or newly
-present candidates are skipped safely. Matching `thread_spawn_edges` are
-removed for deleted thread IDs; declared foreign keys handle dependent dynamic
-tools. The receipt printed to stdout includes the backup path, deleted and
-skipped counts, remaining classifications, SQLite `integrity_check`, and
-post-apply parity. Keep that receipt with the backup path for operator review;
-the repository does not write receipts or local state files.
+A count or digest mismatch refuses before backup creation or any write, so a
+same-count substitution cannot be applied. Changed or newly present candidates
+are skipped safely, but a skipped row must still exist for post-apply parity to
+pass. The receipt printed to stdout includes the backup path, actual deleted
+IDs/count, skipped counts, remaining classifications, SQLite
+`integrity_check`, and post-apply parity. If verification fails after commit,
+the receipt says `post_commit_verification_failed` and
+`mutation_committed: true`; it never reports a successful mutation as a
+rollback or as zero deletion.
 
 ## Verify
 
@@ -84,10 +88,9 @@ backup and has restrictive permissions. Do not restore while Codex is running.
 Use SQLite's restore command rather than copying a live database file:
 
 ```bash
-DB="$HOME/.codex/state_5.sqlite"
-BACKUP="/absolute/path/from-the-receipt/state_5-before-reconcile-<id>.sqlite"
-sqlite3 "$DB" ".restore '$BACKUP'"
-sqlite3 "$DB" "PRAGMA integrity_check;"
+sqlite3 "/absolute/path/to/codex-home/state_5.sqlite" \
+  ".restore '/absolute/path/from-the-receipt/state_5-before-reconcile-<id>.sqlite'"
+sqlite3 "/absolute/path/to/codex-home/state_5.sqlite" "PRAGMA integrity_check;"
 codex doctor --json
 ```
 

--- a/scripts/hygiene/codex_rollout_reconcile.py
+++ b/scripts/hygiene/codex_rollout_reconcile.py
@@ -128,7 +128,7 @@ def discover_database(codex_home: Path | str, explicit: Path | str | None = None
     home = _home(codex_home)
     if explicit is not None:
         path = Path(os.path.abspath(os.path.expanduser(str(explicit))))
-        if path.parent != home or not os.path.lexists(path):
+        if path.parent.resolve() != home or not os.path.lexists(path):
             raise ReconcileError(f"explicit DB is not directly under Codex home: {path}")
         if stat.S_ISLNK(os.lstat(path).st_mode) or not stat.S_ISREG(os.lstat(path).st_mode):
             raise ReconcileError(f"explicit DB is not a regular file: {path}")

--- a/scripts/hygiene/codex_rollout_reconcile.py
+++ b/scripts/hygiene/codex_rollout_reconcile.py
@@ -108,11 +108,11 @@ def _schema_issues(connection: sqlite3.Connection) -> tuple[set[str], set[str], 
         )
         if "thread_id" not in dynamic_columns or not has_cascade:
             issues.append("thread_dynamic_tools lacks its declared threads CASCADE foreign key")
-    triggers = connection.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'threads'"
-    ).fetchall()
-    if triggers:
-        issues.append("delete triggers on threads are not supported")
+    for (sql,) in connection.execute("SELECT sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'threads'"):
+        event = re.search(r"\b(?:BEFORE|AFTER|INSTEAD\s+OF)\s+(INSERT|UPDATE|DELETE)\b", str(sql), re.I)
+        if event is None or event.group(1).upper() == "DELETE":
+            issues.append("delete or unrecognized triggers on threads are not supported")
+            break
     return tables, thread_columns, issues
 
 def _compatible(path: Path) -> bool:
@@ -196,7 +196,7 @@ def _path_state(raw: Any, home: Path, thread_id: str, archived: bool) -> tuple[s
         if not path.name.endswith(f"{thread_id}.jsonl"):
             return "invalid", path
         if not os.path.lexists(root):
-            return "missing", path
+            return "invalid", path
         root_mode = os.lstat(root).st_mode
         if stat.S_ISLNK(root_mode) or not stat.S_ISDIR(root_mode):
             return "invalid", path

--- a/scripts/hygiene/codex_rollout_reconcile.py
+++ b/scripts/hygiene/codex_rollout_reconcile.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 """Safely reconcile Codex thread rows whose rollout JSONL is missing.
 
-The default command is a read-only JSON scan.  Apply is deliberately narrow:
-it needs an explicit acknowledgement and the exact stale-row count from a
-prior scan, then deletes only old, unpinned rows with safe rollout paths.
+The default command is a read-only JSON scan. Apply is deliberately narrow: it
+needs explicit acknowledgement plus the exact stale-row count and digest from
+a prior scan, then deletes only old, unpinned rows with safe rollout paths.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import math
 import os
 import re
 import sqlite3
+import stat
 import sys
 import time
 import uuid
@@ -23,7 +26,7 @@ from urllib.parse import quote
 SCHEMA = "codex.rollout-reconcile.v1"
 STATE_PATTERN = re.compile(r"state_[A-Za-z0-9][A-Za-z0-9._-]*\.sqlite\Z")
 ROLLOUT_PATTERN = re.compile(r"rollout-[^/]+\.jsonl\Z")
-REQUIRED_COLUMNS = frozenset({"id", "rollout_path", "created_at", "updated_at"})
+REQUIRED_COLUMNS = frozenset({"id", "rollout_path", "created_at", "updated_at", "archived"})
 DEFAULT_MIN_AGE_SECONDS = 24 * 60 * 60
 CLASSIFICATIONS = (
     "present",
@@ -36,18 +39,14 @@ CLASSIFICATIONS = (
 class ReconcileError(RuntimeError):
     """A fail-closed discovery, schema, or database error."""
 
-
 def _json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
-
 
 def _home(value: Path | str | None) -> Path:
     return (Path(value).expanduser() if value is not None else Path.home() / ".codex").resolve()
 
-
 def _db_uri(path: Path) -> str:
     return f"file:{quote(str(path.resolve()), safe='/')}?mode=ro"
-
 
 def _open_readonly(path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(_db_uri(path), uri=True, timeout=5.0)
@@ -56,6 +55,12 @@ def _open_readonly(path: Path) -> sqlite3.Connection:
     connection.execute("PRAGMA busy_timeout = 5000")
     return connection
 
+def _open_writable(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, timeout=5.0)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
 
 def _tables(connection: sqlite3.Connection) -> set[str]:
     return {
@@ -63,10 +68,8 @@ def _tables(connection: sqlite3.Connection) -> set[str]:
         for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
     }
 
-
 def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
-
 
 def _schema_issues(connection: sqlite3.Connection) -> tuple[set[str], set[str], list[str]]:
     tables = _tables(connection)
@@ -80,18 +83,37 @@ def _schema_issues(connection: sqlite3.Connection) -> tuple[set[str], set[str], 
         issues.append("threads.is_pinned is missing; missing rollouts are protected")
     if "thread_spawn_edges" in tables and not {"parent_thread_id", "child_thread_id"}.issubset(_columns(connection, "thread_spawn_edges")):
         issues.append("thread_spawn_edges has no parent_thread_id/child_thread_id columns")
+    for table in tables:
+        foreign_keys = connection.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        for foreign_key in foreign_keys:
+            parent, child, referenced, action = (
+                str(foreign_key[2]), str(foreign_key[3]), str(foreign_key[4]), str(foreign_key[6]).upper()
+            )
+            if parent != "threads":
+                continue
+            dynamic_tools = table == "thread_dynamic_tools" and (
+                child, referenced, action
+            ) == ("thread_id", "id", "CASCADE")
+            spawn_edge = table == "thread_spawn_edges" and child in {
+                "parent_thread_id", "child_thread_id"
+            } and referenced == "id"
+            if not (dynamic_tools or spawn_edge):
+                issues.append(f"unsupported foreign key to threads: {table}.{child}")
     if "thread_dynamic_tools" in tables:
         dynamic_columns = _columns(connection, "thread_dynamic_tools")
-        cascades = connection.execute("PRAGMA foreign_key_list(thread_dynamic_tools)").fetchall()
+        dynamic_fks = connection.execute("PRAGMA foreign_key_list(thread_dynamic_tools)").fetchall()
         has_cascade = any(
-            (str(row[2]), str(row[3]), str(row[4]), str(row[6]).upper())
-            == ("threads", "thread_id", "id", "CASCADE")
-            for row in cascades
+            (str(row[3]), str(row[4]), str(row[6]).upper()) == ("thread_id", "id", "CASCADE")
+            for row in dynamic_fks
         )
         if "thread_id" not in dynamic_columns or not has_cascade:
             issues.append("thread_dynamic_tools lacks its declared threads CASCADE foreign key")
+    triggers = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'threads'"
+    ).fetchall()
+    if triggers:
+        issues.append("delete triggers on threads are not supported")
     return tables, thread_columns, issues
-
 
 def _compatible(path: Path) -> bool:
     try:
@@ -101,30 +123,39 @@ def _compatible(path: Path) -> bool:
     except (OSError, ReconcileError, sqlite3.Error):
         return False
 
-
 def discover_database(codex_home: Path | str, explicit: Path | str | None = None) -> Path:
     """Find an exact compatible ``state_*.sqlite`` without writing to it."""
     home = _home(codex_home)
     if explicit is not None:
-        path = Path(explicit).expanduser().resolve()
-        if not STATE_PATTERN.fullmatch(path.name) or not path.is_file():
+        path = Path(os.path.abspath(os.path.expanduser(str(explicit))))
+        if path.parent != home or not os.path.lexists(path):
+            raise ReconcileError(f"explicit DB is not directly under Codex home: {path}")
+        if stat.S_ISLNK(os.lstat(path).st_mode) or not stat.S_ISREG(os.lstat(path).st_mode):
+            raise ReconcileError(f"explicit DB is not a regular file: {path}")
+        if not STATE_PATTERN.fullmatch(path.name):
             raise ReconcileError(f"explicit DB is not an exact state_*.sqlite file: {path}")
         if not _compatible(path):
             raise ReconcileError(f"explicit DB is not compatible: {path}")
         return path
 
-    candidates = [
-        path
-        for path in home.glob("state_*.sqlite")
-        if path.is_file() and STATE_PATTERN.fullmatch(path.name) and _compatible(path)
-    ]
+    candidates: list[Path] = []
+    try:
+        entries = list(home.iterdir())
+    except OSError as exc:
+        raise ReconcileError(f"cannot inspect Codex home: {home}") from exc
+    for path in entries:
+        if not STATE_PATTERN.fullmatch(path.name) or not os.path.lexists(path):
+            continue
+        mode = os.lstat(path).st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISREG(mode) or not _compatible(path):
+            continue
+        candidates.append(path)
     if not candidates:
         raise ReconcileError(f"no compatible state_*.sqlite found under {home}")
     candidates.sort(key=lambda path: path.stat().st_mtime_ns, reverse=True)
     if len(candidates) > 1 and candidates[0].stat().st_mtime_ns == candidates[1].stat().st_mtime_ns:
         raise ReconcileError("newest compatible state DB is ambiguous")
     return candidates[0]
-
 
 def _load_pins(home: Path) -> tuple[set[str], list[str]]:
     path = home / ".codex-global-state.json"
@@ -141,7 +172,6 @@ def _load_pins(home: Path) -> tuple[set[str], list[str]]:
         return set(), ["pinned-thread-ids is not a list of strings"]
     return set(values), []
 
-
 def _integer(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
@@ -151,28 +181,53 @@ def _integer(value: Any) -> int | None:
         return int(value)
     return None
 
-
 def _pinned(value: Any) -> bool | None:
     number = _integer(value)
     return bool(number) if number in (0, 1) else None
 
-
-def _path_state(raw: Any, home: Path) -> tuple[str, Path | None]:
+def _path_state(raw: Any, home: Path, thread_id: str, archived: bool) -> tuple[str, Path | None]:
     if not isinstance(raw, str) or not raw or not Path(raw).is_absolute():
         return "invalid", None
     try:
-        path = Path(raw).resolve(strict=False)
-        roots = [(home / name).resolve(strict=False) for name in ("sessions", "archived_sessions")]
-        safe = any(path.is_relative_to(root) for root in roots)
-        filename_ok = ROLLOUT_PATTERN.fullmatch(path.name) is not None
-        if not safe or not filename_ok:
+        root = home / ("archived_sessions" if archived else "sessions")
+        path = Path(os.path.normpath(raw))
+        if not path.is_relative_to(root) or ROLLOUT_PATTERN.fullmatch(path.name) is None:
             return "invalid", path
-        if path.exists():
-            return ("present" if path.is_file() else "invalid"), path
+        if not path.name.endswith(f"{thread_id}.jsonl"):
+            return "invalid", path
+        if not os.path.lexists(root):
+            return "missing", path
+        root_mode = os.lstat(root).st_mode
+        if stat.S_ISLNK(root_mode) or not stat.S_ISDIR(root_mode):
+            return "invalid", path
+        current = root
+        for part in path.relative_to(root).parts:
+            current /= part
+            if not os.path.lexists(current):
+                return "missing", path
+            mode = os.lstat(current).st_mode
+            if stat.S_ISLNK(mode) or (current != path and not stat.S_ISDIR(mode)):
+                return "invalid", path
+        mode = os.lstat(path).st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+            return "invalid", path
+        return "present", path
     except (OSError, RuntimeError, ValueError):
         return "invalid", None
-    return "missing", path
 
+def _uuid_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError:
+        return None
+    return value if str(parsed) == value else None
+
+def _finite(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ReconcileError(f"{name} must be finite")
+    return float(value)
 
 def _row_report(
     row: sqlite3.Row,
@@ -187,13 +242,19 @@ def _row_report(
     raw_path = row["rollout_path"]
     updated_at = _integer(row["updated_at"])
     pinned_column = _pinned(row["is_pinned"])
-    base: dict[str, Any] = {"id": str(thread_id) if thread_id is not None else None,
-        "rollout_path": raw_path if isinstance(raw_path, str) else None, "updated_at": updated_at,
-        "pinned": pinned_column if pinned_column is not None else str(thread_id) in pins}
-    if thread_id is None or not isinstance(raw_path, str) or updated_at is None or updated_at < 0:
+    archived = _pinned(row["archived"])
+    canonical_id = _uuid_id(thread_id)
+    base: dict[str, Any] = {
+        "id": thread_id if isinstance(thread_id, str) else None,
+        "rollout_path": raw_path if isinstance(raw_path, str) else None,
+        "updated_at": updated_at,
+        "pinned": pinned_column if pinned_column is not None else str(thread_id) in pins,
+        "archived": archived,
+    }
+    if canonical_id is None or not isinstance(raw_path, str) or updated_at is None or updated_at < 0 or archived is None:
         base.update(classification="suspicious_schema", reason="invalid thread row types")
         return base
-    path_state, _ = _path_state(raw_path, home)
+    path_state, _ = _path_state(raw_path, home, canonical_id, bool(archived))
     if path_state == "invalid":
         classification, reason = "suspicious_path", "outside allowed rollout roots or malformed"
     elif path_state == "present":
@@ -209,7 +270,6 @@ def _row_report(
     base.update(classification=classification, reason=reason)
     return base
 
-
 def _scan_with_connection(
     connection: sqlite3.Connection,
     *,
@@ -220,7 +280,7 @@ def _scan_with_connection(
     _tables, columns, schema_issues = _schema_issues(connection)
     pins, pin_issues = _load_pins(home)
     schema_issues = [*schema_issues, *pin_issues]
-    selected = ["id", "rollout_path", "created_at", "updated_at",
+    selected = ["id", "rollout_path", "created_at", "updated_at", "archived",
                 "is_pinned" if "is_pinned" in columns else "NULL AS is_pinned"]
     rows = connection.execute(f"SELECT {', '.join(selected)} FROM threads ORDER BY id").fetchall()
     reports = [
@@ -240,9 +300,9 @@ def _scan_with_connection(
         "schema_issues": schema_issues,
         "counts": counts,
         "eligible_stale_ids": [r["id"] for r in reports if r["classification"] == "eligible_stale"],
+        "eligible_digest": _eligible_digest(reports),
         "rows": reports,
     }
-
 
 def scan(
     *,
@@ -252,23 +312,29 @@ def scan(
     now: float | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic, read-only classification report."""
-    if min_age_seconds < 0:
+    age = _finite(min_age_seconds, "min_age_seconds")
+    if age < 0:
         raise ReconcileError("min_age_seconds must be non-negative")
     home = _home(codex_home)
     database = discover_database(home, db_path)
+    clock = _finite(time.time() if now is None else now, "now")
     with _open_readonly(database) as connection:
         report = _scan_with_connection(
             connection,
             home=home,
-            now=time.time() if now is None else now,
-            min_age_seconds=min_age_seconds,
+            now=clock,
+            min_age_seconds=age,
         )
     report["database"] = str(database)
     return report
 
-
 def _create_backup(database: Path, backup_dir: Path) -> Path:
-    backup_dir.mkdir(parents=True, exist_ok=True)
+    if os.path.lexists(backup_dir):
+        mode = os.lstat(backup_dir).st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise ReconcileError(f"backup directory is not a real directory: {backup_dir}")
+    else:
+        backup_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(backup_dir, 0o700)
     path = backup_dir / f"{database.stem}-before-reconcile-{uuid.uuid4().hex}.sqlite"
     descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -277,20 +343,37 @@ def _create_backup(database: Path, backup_dir: Path) -> Path:
         with _open_readonly(database) as source, sqlite3.connect(path) as destination:
             source.backup(destination)
             destination.commit()
+            integrity = destination.execute("PRAGMA integrity_check").fetchone()[0]
+            if integrity != "ok":
+                raise ReconcileError(f"backup integrity check failed: {integrity}")
         os.chmod(path, 0o600)
     except Exception:
         path.unlink(missing_ok=True)
         raise
     return path
 
-
 def _fingerprints(rows: list[dict[str, Any]]) -> dict[str, tuple[Any, ...]]:
     return {
-        row["id"]: (row["rollout_path"], row["updated_at"], row["pinned"])
+        row["id"]: (row["rollout_path"], row["updated_at"], row["pinned"], row["archived"])
         for row in rows
         if row["id"] is not None
     }
 
+def _eligible_digest(rows: list[dict[str, Any]]) -> str:
+    fingerprints = [
+        {
+            "archived": row["archived"],
+            "id": row["id"],
+            "pinned": row["pinned"],
+            "rollout_path": row["rollout_path"],
+            "updated_at": row["updated_at"],
+        }
+        for row in rows
+        if row["classification"] == "eligible_stale"
+    ]
+    fingerprints.sort(key=lambda row: tuple(str(row[key]) for key in ("id", "rollout_path", "updated_at", "pinned", "archived")))
+    payload = json.dumps(fingerprints, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 def apply(
     *,
@@ -298,50 +381,77 @@ def apply(
     db_path: Path | str | None = None,
     backup_dir: Path | str | None = None,
     expected_eligible_stale: int | None = None,
+    expected_eligible_digest: str | None = None,
     acknowledge: bool = False,
     min_age_seconds: float = DEFAULT_MIN_AGE_SECONDS,
     now: float | None = None,
 ) -> dict[str, Any]:
     """Apply a confirmed count-matched scan, with transactional revalidation."""
+    age = _finite(min_age_seconds, "min_age_seconds")
+    if age < 0:
+        raise ReconcileError("min_age_seconds must be non-negative")
+    clock = _finite(time.time() if now is None else now, "now")
     if not acknowledge:
         return {"schema": SCHEMA, "mode": "apply", "error": "acknowledgement_required"}
     if expected_eligible_stale is None or expected_eligible_stale < 0:
         return {"schema": SCHEMA, "mode": "apply", "error": "expected_count_required"}
-    clock = time.time() if now is None else now
-    initial = scan(codex_home=codex_home, db_path=db_path, min_age_seconds=min_age_seconds, now=clock)
-    eligible = [row for row in initial["rows"] if row["classification"] == "eligible_stale"]
-    if len(eligible) != expected_eligible_stale:
-        return {
-            "schema": SCHEMA,
-            "mode": "apply",
-            "error": "expected_count_mismatch",
-            "expected_eligible_stale": expected_eligible_stale,
-            "observed_eligible_stale": len(eligible),
-            "counts": initial["counts"],
-            "backup_path": None,
-        }
-
-    database = Path(initial["database"])
+    if expected_eligible_digest is None:
+        return {"schema": SCHEMA, "mode": "apply", "error": "expected_digest_required"}
+    home = _home(codex_home)
+    database = discover_database(home, db_path)
     backup_path: Path | None = None
     deleted: list[str] = []
     skipped: list[dict[str, str]] = []
     edge_count = 0
     connection: sqlite3.Connection | None = None
+    mutation_committed = False
     try:
+        connection = _open_writable(database)
+        connection.execute("BEGIN IMMEDIATE")
+        initial = _scan_with_connection(connection, home=home, now=clock, min_age_seconds=age)
+        eligible = [row for row in initial["rows"] if row["classification"] == "eligible_stale"]
+        observed_digest = initial["eligible_digest"]
+        if initial["schema_issues"]:
+            connection.rollback()
+            return {
+                "schema": SCHEMA, "mode": "apply", "database": str(database),
+                "error": "unsafe_schema", "schema_issues": initial["schema_issues"], "backup_path": None,
+                "deleted_ids": [], "counts": {"deleted": 0, "skipped": 0, "spawn_edges_deleted": 0},
+                "mutation_committed": False,
+            }
+        if len(eligible) != expected_eligible_stale:
+            connection.rollback()
+            return {
+                "schema": SCHEMA, "mode": "apply", "error": "expected_count_mismatch",
+                "expected_eligible_stale": expected_eligible_stale,
+                "observed_eligible_stale": len(eligible), "counts": initial["counts"],
+                "eligible_digest": observed_digest, "backup_path": None, "deleted_ids": [],
+                "mutation_committed": False,
+            }
+        if observed_digest != expected_eligible_digest:
+            connection.rollback()
+            return {
+                "schema": SCHEMA, "mode": "apply", "error": "expected_digest_mismatch",
+                "expected_eligible_digest": expected_eligible_digest,
+                "observed_eligible_digest": observed_digest,
+                "counts": initial["counts"], "backup_path": None, "deleted_ids": [],
+                "mutation_committed": False,
+            }
         if eligible:
             target_backup_dir = Path(backup_dir).expanduser() if backup_dir is not None else database.parent / "backups"
             backup_path = _create_backup(database, target_backup_dir)
-            connection = sqlite3.connect(database, timeout=5.0)
-            connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA foreign_keys = ON")
-            connection.execute("PRAGMA busy_timeout = 5000")
-            connection.execute("BEGIN IMMEDIATE")
             tables, columns, schema_issues = _schema_issues(connection)
-            pins, pin_issues = _load_pins(_home(codex_home))
+            pins, pin_issues = _load_pins(home)
             schema_issues = [*schema_issues, *pin_issues]
-            selected = "id, rollout_path, updated_at, " + ("is_pinned" if "is_pinned" in columns else "NULL AS is_pinned")
+            if schema_issues:
+                raise ReconcileError("schema changed or is unsupported: " + "; ".join(schema_issues))
+            selected = "id, rollout_path, updated_at, archived, " + (
+                "is_pinned" if "is_pinned" in columns else "NULL AS is_pinned"
+            )
             for candidate in eligible:
-                current = connection.execute(f"SELECT {selected} FROM threads WHERE id = ?", (candidate["id"],)).fetchone()
+                current = connection.execute(
+                    f"SELECT {selected} FROM threads WHERE id = ?", (candidate["id"],)
+                ).fetchone()
                 if current is None:
                     skipped.append({"id": candidate["id"], "reason": "row_missing"})
                     continue
@@ -349,81 +459,89 @@ def apply(
                     current["rollout_path"] != candidate["rollout_path"]
                     or _integer(current["updated_at"]) != candidate["updated_at"]
                     or _pinned(current["is_pinned"]) is not False
+                    or _pinned(current["archived"]) != candidate["archived"]
                 ):
                     skipped.append({"id": candidate["id"], "reason": "row_changed"})
                     continue
-                check = _row_report(current, home=_home(codex_home), pins=pins,
-                                    schema_issues=schema_issues, now=clock,
-                                    min_age_seconds=min_age_seconds)
+                check = _row_report(
+                    current, home=home, pins=pins, schema_issues=schema_issues,
+                    now=clock, min_age_seconds=age,
+                )
                 if check["classification"] != "eligible_stale":
                     skipped.append({"id": candidate["id"], "reason": check["classification"]})
                     continue
-                deleted_count = connection.execute("DELETE FROM threads WHERE id = ?", (candidate["id"],)).rowcount
+                if "thread_spawn_edges" in tables:
+                    edge_count += connection.execute(
+                        "DELETE FROM thread_spawn_edges WHERE parent_thread_id = ? OR child_thread_id = ?",
+                        (candidate["id"], candidate["id"]),
+                    ).rowcount
+                deleted_count = connection.execute(
+                    "DELETE FROM threads WHERE id = ?", (candidate["id"],)
+                ).rowcount
                 if deleted_count != 1:
                     skipped.append({"id": candidate["id"], "reason": "delete_race"})
                     continue
                 deleted.append(candidate["id"])
-                if "thread_spawn_edges" in tables:
-                    edge_count += connection.execute("DELETE FROM thread_spawn_edges WHERE parent_thread_id = ? OR child_thread_id = ?",
-                                                      (candidate["id"], candidate["id"])).rowcount
-            connection.commit()
-        after = scan(
-            codex_home=codex_home,
-            db_path=database,
-            min_age_seconds=min_age_seconds,
-            now=clock,
-        )
-        with _open_readonly(database) as integrity_connection:
-            integrity = integrity_connection.execute("PRAGMA integrity_check").fetchone()[0]
-            remaining_edges = 0
-            if deleted and "thread_spawn_edges" in _tables(integrity_connection):
-                placeholders = ",".join("?" for _ in deleted)
-                remaining_edges = integrity_connection.execute(
-                    "SELECT count(*) FROM thread_spawn_edges "
-                    f"WHERE parent_thread_id IN ({placeholders}) OR child_thread_id IN ({placeholders})",
-                    [*deleted, *deleted],
-                ).fetchone()[0]
-        before_fingerprints = _fingerprints(initial["rows"])
-        after_fingerprints = _fingerprints(after["rows"])
-        skipped_ids = {item["id"] for item in skipped}
-        parity = (
-            integrity == "ok"
-            and remaining_edges == 0
-            and all(
-                thread_id not in after_fingerprints if thread_id in deleted else
-                True if thread_id in skipped_ids else
-                after_fingerprints.get(thread_id) == fingerprint
-                for thread_id, fingerprint in before_fingerprints.items()
+        connection.commit()
+        mutation_committed = True
+        try:
+            after = scan(codex_home=home, db_path=database, min_age_seconds=age, now=clock)
+            with _open_readonly(database) as integrity_connection:
+                integrity = integrity_connection.execute("PRAGMA integrity_check").fetchone()[0]
+                remaining_edges = 0
+                if deleted and "thread_spawn_edges" in _tables(integrity_connection):
+                    placeholders = ",".join("?" for _ in deleted)
+                    remaining_edges = integrity_connection.execute(
+                        "SELECT count(*) FROM thread_spawn_edges "
+                        f"WHERE parent_thread_id IN ({placeholders}) OR child_thread_id IN ({placeholders})",
+                        [*deleted, *deleted],
+                    ).fetchone()[0]
+            before_fingerprints = _fingerprints(initial["rows"])
+            after_fingerprints = _fingerprints(after["rows"])
+            skipped_ids = {item["id"] for item in skipped}
+            parity = (
+                integrity == "ok"
+                and not after["schema_issues"]
+                and remaining_edges == 0
+                and all(
+                    thread_id not in after_fingerprints if thread_id in deleted else
+                    thread_id in after_fingerprints if thread_id in skipped_ids else
+                    after_fingerprints.get(thread_id) == fingerprint
+                    for thread_id, fingerprint in before_fingerprints.items()
+                )
             )
-        )
-        return {
-            "schema": SCHEMA,
-            "mode": "apply",
-            "database": str(database),
-            "backup_path": str(backup_path) if backup_path else None,
-            "deleted_ids": deleted,
-            "counts": {"deleted": len(deleted), "skipped": len(skipped), "spawn_edges_deleted": edge_count},
-            "skipped": skipped,
-            "integrity_check": integrity,
-            "post_apply_parity": parity,
-            "remaining": {"counts": after["counts"], "rows": after["rows"]},
-        }
+            receipt = {
+                "schema": SCHEMA, "mode": "apply", "database": str(database),
+                "backup_path": str(backup_path) if backup_path else None, "deleted_ids": deleted,
+                "counts": {"deleted": len(deleted), "skipped": len(skipped), "spawn_edges_deleted": edge_count},
+                "skipped": skipped, "integrity_check": integrity, "post_apply_parity": parity,
+                "mutation_committed": True,
+                "remaining": {"counts": after["counts"], "rows": after["rows"]},
+            }
+            if not parity:
+                receipt["error"] = "post_commit_verification_failed"
+            return receipt
+        except (OSError, sqlite3.Error, ReconcileError, KeyError, TypeError, ValueError) as exc:
+            return {
+                "schema": SCHEMA, "mode": "apply", "database": str(database),
+                "backup_path": str(backup_path) if backup_path else None,
+                "error": "post_commit_verification_failed", "verification_error": str(exc),
+                "deleted_ids": deleted,
+                "counts": {"deleted": len(deleted), "skipped": len(skipped), "spawn_edges_deleted": edge_count},
+                "skipped": skipped, "mutation_committed": True,
+            }
     except (OSError, sqlite3.Error, ReconcileError) as exc:
         if connection is not None:
             connection.rollback()
         return {
-            "schema": SCHEMA,
-            "mode": "apply",
-            "database": str(database),
-            "backup_path": str(backup_path) if backup_path else None,
-            "error": f"apply_failed: {exc}",
-            "deleted_ids": [],
-            "counts": {"deleted": 0, "skipped": len(skipped), "spawn_edges_deleted": 0},
+            "schema": SCHEMA, "mode": "apply", "database": str(database),
+            "backup_path": str(backup_path) if backup_path else None, "error": f"apply_failed: {exc}",
+            "deleted_ids": [], "counts": {"deleted": 0, "skipped": len(skipped), "spawn_edges_deleted": 0},
+            "skipped": skipped, "mutation_committed": mutation_committed,
         }
     finally:
         if connection is not None:
             connection.close()
-
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -437,9 +555,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--expected-eligible-stale", "--expected-count", dest="expected_count", type=int, default=None
     )
+    parser.add_argument("--expected-eligible-digest", dest="expected_digest", default=None)
     parser.add_argument("--backup-dir", type=Path, default=None)
     return parser
-
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
@@ -461,6 +579,7 @@ def main(argv: list[str] | None = None) -> int:
             db_path=args.db,
             backup_dir=args.backup_dir,
             expected_eligible_stale=args.expected_count,
+            expected_eligible_digest=args.expected_digest,
             acknowledge=args.acknowledge,
             min_age_seconds=args.min_age_hours * 60 * 60,
             now=args.now,
@@ -468,7 +587,8 @@ def main(argv: list[str] | None = None) -> int:
         print(_json(receipt), end="")
         if receipt.get("error"):
             return 3 if receipt["error"] in {
-                "acknowledgement_required", "expected_count_required", "expected_count_mismatch"
+                "acknowledgement_required", "expected_count_required", "expected_digest_required",
+                "expected_count_mismatch", "expected_digest_mismatch"
             } else 2
         return 0 if receipt.get("post_apply_parity") else 2
     except (OSError, ReconcileError, sqlite3.Error) as exc:

--- a/scripts/hygiene/codex_rollout_reconcile.py
+++ b/scripts/hygiene/codex_rollout_reconcile.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Safely reconcile Codex thread rows whose rollout JSONL is missing.
+
+The default command is a read-only JSON scan.  Apply is deliberately narrow:
+it needs an explicit acknowledgement and the exact stale-row count from a
+prior scan, then deletes only old, unpinned rows with safe rollout paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+SCHEMA = "codex.rollout-reconcile.v1"
+STATE_PATTERN = re.compile(r"state_[A-Za-z0-9][A-Za-z0-9._-]*\.sqlite\Z")
+ROLLOUT_PATTERN = re.compile(r"rollout-[^/]+\.jsonl\Z")
+REQUIRED_COLUMNS = frozenset({"id", "rollout_path", "created_at", "updated_at"})
+DEFAULT_MIN_AGE_SECONDS = 24 * 60 * 60
+CLASSIFICATIONS = (
+    "present",
+    "eligible_stale",
+    "protected_pinned",
+    "protected_recent",
+    "suspicious_path",
+    "suspicious_schema",
+)
+class ReconcileError(RuntimeError):
+    """A fail-closed discovery, schema, or database error."""
+
+
+def _json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _home(value: Path | str | None) -> Path:
+    return (Path(value).expanduser() if value is not None else Path.home() / ".codex").resolve()
+
+
+def _db_uri(path: Path) -> str:
+    return f"file:{quote(str(path.resolve()), safe='/')}?mode=ro"
+
+
+def _open_readonly(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(_db_uri(path), uri=True, timeout=5.0)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _tables(connection: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
+
+
+def _schema_issues(connection: sqlite3.Connection) -> tuple[set[str], set[str], list[str]]:
+    tables = _tables(connection)
+    if "threads" not in tables:
+        raise ReconcileError("compatible state DB is missing the threads table")
+    thread_columns = _columns(connection, "threads")
+    if missing := sorted(REQUIRED_COLUMNS - thread_columns):
+        raise ReconcileError(f"compatible state DB is missing threads columns: {', '.join(missing)}")
+    issues: list[str] = []
+    if "is_pinned" not in thread_columns:
+        issues.append("threads.is_pinned is missing; missing rollouts are protected")
+    if "thread_spawn_edges" in tables and not {"parent_thread_id", "child_thread_id"}.issubset(_columns(connection, "thread_spawn_edges")):
+        issues.append("thread_spawn_edges has no parent_thread_id/child_thread_id columns")
+    if "thread_dynamic_tools" in tables:
+        dynamic_columns = _columns(connection, "thread_dynamic_tools")
+        cascades = connection.execute("PRAGMA foreign_key_list(thread_dynamic_tools)").fetchall()
+        has_cascade = any(
+            (str(row[2]), str(row[3]), str(row[4]), str(row[6]).upper())
+            == ("threads", "thread_id", "id", "CASCADE")
+            for row in cascades
+        )
+        if "thread_id" not in dynamic_columns or not has_cascade:
+            issues.append("thread_dynamic_tools lacks its declared threads CASCADE foreign key")
+    return tables, thread_columns, issues
+
+
+def _compatible(path: Path) -> bool:
+    try:
+        with _open_readonly(path) as connection:
+            _schema_issues(connection)
+        return True
+    except (OSError, ReconcileError, sqlite3.Error):
+        return False
+
+
+def discover_database(codex_home: Path | str, explicit: Path | str | None = None) -> Path:
+    """Find an exact compatible ``state_*.sqlite`` without writing to it."""
+    home = _home(codex_home)
+    if explicit is not None:
+        path = Path(explicit).expanduser().resolve()
+        if not STATE_PATTERN.fullmatch(path.name) or not path.is_file():
+            raise ReconcileError(f"explicit DB is not an exact state_*.sqlite file: {path}")
+        if not _compatible(path):
+            raise ReconcileError(f"explicit DB is not compatible: {path}")
+        return path
+
+    candidates = [
+        path
+        for path in home.glob("state_*.sqlite")
+        if path.is_file() and STATE_PATTERN.fullmatch(path.name) and _compatible(path)
+    ]
+    if not candidates:
+        raise ReconcileError(f"no compatible state_*.sqlite found under {home}")
+    candidates.sort(key=lambda path: path.stat().st_mtime_ns, reverse=True)
+    if len(candidates) > 1 and candidates[0].stat().st_mtime_ns == candidates[1].stat().st_mtime_ns:
+        raise ReconcileError("newest compatible state DB is ambiguous")
+    return candidates[0]
+
+
+def _load_pins(home: Path) -> tuple[set[str], list[str]]:
+    path = home / ".codex-global-state.json"
+    if not path.exists():
+        return set(), []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return set(), [f"cannot read pinned-thread state: {exc.__class__.__name__}"]
+    values = payload.get("pinned-thread-ids", payload.get("pinned_thread_ids")) if isinstance(payload, dict) else None
+    if values is None:
+        return set(), []
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        return set(), ["pinned-thread-ids is not a list of strings"]
+    return set(values), []
+
+
+def _integer(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def _pinned(value: Any) -> bool | None:
+    number = _integer(value)
+    return bool(number) if number in (0, 1) else None
+
+
+def _path_state(raw: Any, home: Path) -> tuple[str, Path | None]:
+    if not isinstance(raw, str) or not raw or not Path(raw).is_absolute():
+        return "invalid", None
+    try:
+        path = Path(raw).resolve(strict=False)
+        roots = [(home / name).resolve(strict=False) for name in ("sessions", "archived_sessions")]
+        safe = any(path.is_relative_to(root) for root in roots)
+        filename_ok = ROLLOUT_PATTERN.fullmatch(path.name) is not None
+        if not safe or not filename_ok:
+            return "invalid", path
+        if path.exists():
+            return ("present" if path.is_file() else "invalid"), path
+    except (OSError, RuntimeError, ValueError):
+        return "invalid", None
+    return "missing", path
+
+
+def _row_report(
+    row: sqlite3.Row,
+    *,
+    home: Path,
+    pins: set[str],
+    schema_issues: list[str],
+    now: float,
+    min_age_seconds: float,
+) -> dict[str, Any]:
+    thread_id = row["id"]
+    raw_path = row["rollout_path"]
+    updated_at = _integer(row["updated_at"])
+    pinned_column = _pinned(row["is_pinned"])
+    base: dict[str, Any] = {"id": str(thread_id) if thread_id is not None else None,
+        "rollout_path": raw_path if isinstance(raw_path, str) else None, "updated_at": updated_at,
+        "pinned": pinned_column if pinned_column is not None else str(thread_id) in pins}
+    if thread_id is None or not isinstance(raw_path, str) or updated_at is None or updated_at < 0:
+        base.update(classification="suspicious_schema", reason="invalid thread row types")
+        return base
+    path_state, _ = _path_state(raw_path, home)
+    if path_state == "invalid":
+        classification, reason = "suspicious_path", "outside allowed rollout roots or malformed"
+    elif path_state == "present":
+        classification, reason = "present", "rollout file exists"
+    elif pinned_column is None or schema_issues:
+        classification, reason = "suspicious_schema", "pin or dependent-table schema is unknown"
+    elif pinned_column or str(thread_id) in pins:
+        classification, reason = "protected_pinned", "thread is pinned"
+    elif now - updated_at < min_age_seconds:
+        classification, reason = "protected_recent", "updated within the conservative age window"
+    else:
+        classification, reason = "eligible_stale", "old, unpinned, safe missing rollout"
+    base.update(classification=classification, reason=reason)
+    return base
+
+
+def _scan_with_connection(
+    connection: sqlite3.Connection,
+    *,
+    home: Path,
+    now: float,
+    min_age_seconds: float,
+) -> dict[str, Any]:
+    _tables, columns, schema_issues = _schema_issues(connection)
+    pins, pin_issues = _load_pins(home)
+    schema_issues = [*schema_issues, *pin_issues]
+    selected = ["id", "rollout_path", "created_at", "updated_at",
+                "is_pinned" if "is_pinned" in columns else "NULL AS is_pinned"]
+    rows = connection.execute(f"SELECT {', '.join(selected)} FROM threads ORDER BY id").fetchall()
+    reports = [
+        _row_report(row, home=home, pins=pins, schema_issues=schema_issues,
+                    now=now, min_age_seconds=min_age_seconds)
+        for row in rows
+    ]
+    counts = {classification: 0 for classification in CLASSIFICATIONS}
+    for report in reports:
+        counts[report["classification"]] += 1
+    return {
+        "schema": SCHEMA,
+        "mode": "scan",
+        "codex_home": str(home),
+        "database": str(connection.execute("PRAGMA database_list").fetchone()[2]),
+        "min_age_seconds": min_age_seconds,
+        "schema_issues": schema_issues,
+        "counts": counts,
+        "eligible_stale_ids": [r["id"] for r in reports if r["classification"] == "eligible_stale"],
+        "rows": reports,
+    }
+
+
+def scan(
+    *,
+    codex_home: Path | str | None = None,
+    db_path: Path | str | None = None,
+    min_age_seconds: float = DEFAULT_MIN_AGE_SECONDS,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic, read-only classification report."""
+    if min_age_seconds < 0:
+        raise ReconcileError("min_age_seconds must be non-negative")
+    home = _home(codex_home)
+    database = discover_database(home, db_path)
+    with _open_readonly(database) as connection:
+        report = _scan_with_connection(
+            connection,
+            home=home,
+            now=time.time() if now is None else now,
+            min_age_seconds=min_age_seconds,
+        )
+    report["database"] = str(database)
+    return report
+
+
+def _create_backup(database: Path, backup_dir: Path) -> Path:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(backup_dir, 0o700)
+    path = backup_dir / f"{database.stem}-before-reconcile-{uuid.uuid4().hex}.sqlite"
+    descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    os.close(descriptor)
+    try:
+        with _open_readonly(database) as source, sqlite3.connect(path) as destination:
+            source.backup(destination)
+            destination.commit()
+        os.chmod(path, 0o600)
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def _fingerprints(rows: list[dict[str, Any]]) -> dict[str, tuple[Any, ...]]:
+    return {
+        row["id"]: (row["rollout_path"], row["updated_at"], row["pinned"])
+        for row in rows
+        if row["id"] is not None
+    }
+
+
+def apply(
+    *,
+    codex_home: Path | str | None = None,
+    db_path: Path | str | None = None,
+    backup_dir: Path | str | None = None,
+    expected_eligible_stale: int | None = None,
+    acknowledge: bool = False,
+    min_age_seconds: float = DEFAULT_MIN_AGE_SECONDS,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Apply a confirmed count-matched scan, with transactional revalidation."""
+    if not acknowledge:
+        return {"schema": SCHEMA, "mode": "apply", "error": "acknowledgement_required"}
+    if expected_eligible_stale is None or expected_eligible_stale < 0:
+        return {"schema": SCHEMA, "mode": "apply", "error": "expected_count_required"}
+    clock = time.time() if now is None else now
+    initial = scan(codex_home=codex_home, db_path=db_path, min_age_seconds=min_age_seconds, now=clock)
+    eligible = [row for row in initial["rows"] if row["classification"] == "eligible_stale"]
+    if len(eligible) != expected_eligible_stale:
+        return {
+            "schema": SCHEMA,
+            "mode": "apply",
+            "error": "expected_count_mismatch",
+            "expected_eligible_stale": expected_eligible_stale,
+            "observed_eligible_stale": len(eligible),
+            "counts": initial["counts"],
+            "backup_path": None,
+        }
+
+    database = Path(initial["database"])
+    backup_path: Path | None = None
+    deleted: list[str] = []
+    skipped: list[dict[str, str]] = []
+    edge_count = 0
+    connection: sqlite3.Connection | None = None
+    try:
+        if eligible:
+            target_backup_dir = Path(backup_dir).expanduser() if backup_dir is not None else database.parent / "backups"
+            backup_path = _create_backup(database, target_backup_dir)
+            connection = sqlite3.connect(database, timeout=5.0)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA busy_timeout = 5000")
+            connection.execute("BEGIN IMMEDIATE")
+            tables, columns, schema_issues = _schema_issues(connection)
+            pins, pin_issues = _load_pins(_home(codex_home))
+            schema_issues = [*schema_issues, *pin_issues]
+            selected = "id, rollout_path, updated_at, " + ("is_pinned" if "is_pinned" in columns else "NULL AS is_pinned")
+            for candidate in eligible:
+                current = connection.execute(f"SELECT {selected} FROM threads WHERE id = ?", (candidate["id"],)).fetchone()
+                if current is None:
+                    skipped.append({"id": candidate["id"], "reason": "row_missing"})
+                    continue
+                if (
+                    current["rollout_path"] != candidate["rollout_path"]
+                    or _integer(current["updated_at"]) != candidate["updated_at"]
+                    or _pinned(current["is_pinned"]) is not False
+                ):
+                    skipped.append({"id": candidate["id"], "reason": "row_changed"})
+                    continue
+                check = _row_report(current, home=_home(codex_home), pins=pins,
+                                    schema_issues=schema_issues, now=clock,
+                                    min_age_seconds=min_age_seconds)
+                if check["classification"] != "eligible_stale":
+                    skipped.append({"id": candidate["id"], "reason": check["classification"]})
+                    continue
+                deleted_count = connection.execute("DELETE FROM threads WHERE id = ?", (candidate["id"],)).rowcount
+                if deleted_count != 1:
+                    skipped.append({"id": candidate["id"], "reason": "delete_race"})
+                    continue
+                deleted.append(candidate["id"])
+                if "thread_spawn_edges" in tables:
+                    edge_count += connection.execute("DELETE FROM thread_spawn_edges WHERE parent_thread_id = ? OR child_thread_id = ?",
+                                                      (candidate["id"], candidate["id"])).rowcount
+            connection.commit()
+        after = scan(
+            codex_home=codex_home,
+            db_path=database,
+            min_age_seconds=min_age_seconds,
+            now=clock,
+        )
+        with _open_readonly(database) as integrity_connection:
+            integrity = integrity_connection.execute("PRAGMA integrity_check").fetchone()[0]
+            remaining_edges = 0
+            if deleted and "thread_spawn_edges" in _tables(integrity_connection):
+                placeholders = ",".join("?" for _ in deleted)
+                remaining_edges = integrity_connection.execute(
+                    "SELECT count(*) FROM thread_spawn_edges "
+                    f"WHERE parent_thread_id IN ({placeholders}) OR child_thread_id IN ({placeholders})",
+                    [*deleted, *deleted],
+                ).fetchone()[0]
+        before_fingerprints = _fingerprints(initial["rows"])
+        after_fingerprints = _fingerprints(after["rows"])
+        skipped_ids = {item["id"] for item in skipped}
+        parity = (
+            integrity == "ok"
+            and remaining_edges == 0
+            and all(
+                thread_id not in after_fingerprints if thread_id in deleted else
+                True if thread_id in skipped_ids else
+                after_fingerprints.get(thread_id) == fingerprint
+                for thread_id, fingerprint in before_fingerprints.items()
+            )
+        )
+        return {
+            "schema": SCHEMA,
+            "mode": "apply",
+            "database": str(database),
+            "backup_path": str(backup_path) if backup_path else None,
+            "deleted_ids": deleted,
+            "counts": {"deleted": len(deleted), "skipped": len(skipped), "spawn_edges_deleted": edge_count},
+            "skipped": skipped,
+            "integrity_check": integrity,
+            "post_apply_parity": parity,
+            "remaining": {"counts": after["counts"], "rows": after["rows"]},
+        }
+    except (OSError, sqlite3.Error, ReconcileError) as exc:
+        if connection is not None:
+            connection.rollback()
+        return {
+            "schema": SCHEMA,
+            "mode": "apply",
+            "database": str(database),
+            "backup_path": str(backup_path) if backup_path else None,
+            "error": f"apply_failed: {exc}",
+            "deleted_ids": [],
+            "counts": {"deleted": 0, "skipped": len(skipped), "spawn_edges_deleted": 0},
+        }
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs="?", choices=("scan", "apply"), default="scan")
+    parser.add_argument("--codex-home", type=Path, default=None)
+    parser.add_argument("--db", type=Path, default=None)
+    parser.add_argument("--min-age-hours", type=float, default=24.0)
+    parser.add_argument("--now", type=float, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--fail-on-stale", action="store_true")
+    parser.add_argument("--confirm-stale", "--acknowledge", dest="acknowledge", action="store_true")
+    parser.add_argument(
+        "--expected-eligible-stale", "--expected-count", dest="expected_count", type=int, default=None
+    )
+    parser.add_argument("--backup-dir", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "scan":
+            report = scan(
+                codex_home=args.codex_home,
+                db_path=args.db,
+                min_age_seconds=args.min_age_hours * 60 * 60,
+                now=args.now,
+            )
+            print(_json(report), end="")
+            return 1 if args.fail_on_stale and report["counts"]["eligible_stale"] else 0
+        if args.fail_on_stale:
+            print(_json({"schema": SCHEMA, "mode": "apply", "error": "fail_on_stale_is_read_only"}), end="")
+            return 3
+        receipt = apply(
+            codex_home=args.codex_home,
+            db_path=args.db,
+            backup_dir=args.backup_dir,
+            expected_eligible_stale=args.expected_count,
+            acknowledge=args.acknowledge,
+            min_age_seconds=args.min_age_hours * 60 * 60,
+            now=args.now,
+        )
+        print(_json(receipt), end="")
+        if receipt.get("error"):
+            return 3 if receipt["error"] in {
+                "acknowledgement_required", "expected_count_required", "expected_count_mismatch"
+            } else 2
+        return 0 if receipt.get("post_apply_parity") else 2
+    except (OSError, ReconcileError, sqlite3.Error) as exc:
+        print(_json({"schema": SCHEMA, "mode": args.command, "error": str(exc)}), end="")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_codex_rollout_reconcile.py
+++ b/tests/test_codex_rollout_reconcile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import uuid
 from pathlib import Path
 
 import pytest
@@ -12,63 +13,116 @@ from scripts.hygiene import codex_rollout_reconcile as reconcile
 NOW = 1_800_000_000
 OLD = NOW - 3 * 24 * 60 * 60
 RECENT = NOW - 60
-IDS = {name: f"thread-{index}" for index, name in enumerate(("old", "present", "pinned", "recent", "outside", "malformed"))}
+IDS = {
+    name: str(uuid.uuid5(uuid.NAMESPACE_URL, f"codex-rollout-test-{name}"))
+    for name in ("old", "present", "pinned", "recent", "outside", "malformed", "archived")
+}
 
 
-def _rollout(home: Path, name: str, *, present: bool = False) -> Path:
-    path = home / "sessions" / "2026" / "07" / f"rollout-{name}.jsonl"
+def _rollout(
+    home: Path,
+    thread_id: str,
+    *,
+    archived: bool = False,
+    present: bool = False,
+    filename_id: str | None = None,
+) -> Path:
+    root = home / ("archived_sessions" if archived else "sessions") / "2026" / "07"
+    path = root / f"rollout-2026-07-31-{filename_id or thread_id}.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     if present:
         path.write_text("{}\n", encoding="utf-8")
     return path
 
 
-def _db(home: Path, *, include_pinned: bool = True) -> Path:
+def _db(
+    home: Path,
+    *,
+    include_pinned: bool = True,
+    edge_fks: bool = False,
+    archived_row: bool = False,
+) -> Path:
     home.mkdir(parents=True, exist_ok=True)
     database = home / "state_5.sqlite"
     connection = sqlite3.connect(database)
     pinned_column = ", is_pinned INTEGER NOT NULL DEFAULT 0" if include_pinned else ""
+    edge_foreign_keys = (
+        ", FOREIGN KEY(parent_thread_id) REFERENCES threads(id),"
+        " FOREIGN KEY(child_thread_id) REFERENCES threads(id)"
+        if edge_fks
+        else ""
+    )
     connection.executescript(
         f"""
         CREATE TABLE threads (
             id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, created_at INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL{pinned_column}
+            updated_at INTEGER NOT NULL, archived INTEGER NOT NULL DEFAULT 0{pinned_column}
         );
         CREATE TABLE thread_spawn_edges (
-            parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL
+            parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY,
+            status TEXT NOT NULL{edge_foreign_keys}
         );
         CREATE TABLE thread_dynamic_tools (
             thread_id TEXT PRIMARY KEY REFERENCES threads(id) ON DELETE CASCADE, payload TEXT NOT NULL
         );
         """
     )
-    home.joinpath("sessions").mkdir(parents=True, exist_ok=True)
     rows = [
-        (IDS["old"], str(_rollout(home, "old")), OLD, OLD, 0),
-        (IDS["present"], str(_rollout(home, "present", present=True)), OLD, OLD, 0),
-        (IDS["pinned"], str(_rollout(home, "pinned")), OLD, OLD, 1),
-        (IDS["recent"], str(_rollout(home, "recent")), RECENT, RECENT, 0),
-        (IDS["outside"], str(home.parent / "outside" / "rollout-outside.jsonl"), OLD, OLD, 0),
-        (IDS["malformed"], str(home / "sessions" / "2026" / "note.txt"), OLD, OLD, 0),
+        (IDS["old"], str(_rollout(home, IDS["old"])), OLD, OLD, 0, 0),
+        (IDS["present"], str(_rollout(home, IDS["present"], present=True)), OLD, OLD, 0, 0),
+        (IDS["pinned"], str(_rollout(home, IDS["pinned"])), OLD, OLD, 0, 1),
+        (IDS["recent"], str(_rollout(home, IDS["recent"])), RECENT, RECENT, 0, 0),
+        (IDS["outside"], str(home.parent / "outside" / f"rollout-{IDS['outside']}.jsonl"), OLD, OLD, 0, 0),
+        (IDS["malformed"], str(home / "sessions" / "2026" / f"note-{IDS['malformed']}.txt"), OLD, OLD, 0, 0),
     ]
+    if archived_row:
+        rows.append((IDS["archived"], str(_rollout(home, IDS["archived"], archived=True)), OLD, OLD, 1, 0))
     if include_pinned:
         connection.executemany(
-            "INSERT INTO threads(id, rollout_path, created_at, updated_at, is_pinned) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at, archived, is_pinned) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             rows,
         )
     else:
         connection.executemany(
-            "INSERT INTO threads(id, rollout_path, created_at, updated_at) VALUES (?, ?, ?, ?)",
-            [row[:4] for row in rows],
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at, archived) VALUES (?, ?, ?, ?, ?)",
+            [row[:5] for row in rows],
         )
-    connection.executemany(
-        "INSERT INTO thread_spawn_edges VALUES (?, ?, ?)",
-        [(IDS["old"], IDS["recent"], "done"), (IDS["recent"], IDS["old"], "done")],
-    )
+    if edge_fks:
+        connection.executemany(
+            "INSERT INTO thread_spawn_edges VALUES (?, ?, ?)",
+            [(IDS["old"], IDS["recent"], "done"), (IDS["recent"], IDS["old"], "done")],
+        )
+    else:
+        connection.executemany(
+            "INSERT INTO thread_spawn_edges VALUES (?, ?, ?)",
+            [(IDS["old"], IDS["recent"], "done"), (IDS["recent"], IDS["old"], "done")],
+        )
     connection.execute("INSERT INTO thread_dynamic_tools VALUES (?, ?)", (IDS["old"], "tool"))
     connection.commit()
     connection.close()
     return database
+
+
+def _digest(home: Path, database: Path) -> str:
+    return reconcile.scan(codex_home=home, db_path=database, now=NOW)["eligible_digest"]
+
+
+def _insert_thread(
+    database: Path,
+    *,
+    thread_id: str,
+    rollout_path: Path,
+    updated_at: int = OLD,
+    archived: int = 0,
+    pinned: int = 0,
+) -> None:
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at, archived, is_pinned) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (thread_id, str(rollout_path), updated_at, updated_at, archived, pinned),
+        )
 
 
 def test_scan_classifies_present_stale_protected_and_suspicious(tmp_path: Path) -> None:
@@ -85,7 +139,8 @@ def test_scan_classifies_present_stale_protected_and_suspicious(tmp_path: Path) 
         "suspicious_schema": 0,
     }
     assert report["eligible_stale_ids"] == [IDS["old"]]
-    assert [row["id"] for row in report["rows"]] == sorted(IDS.values())
+    assert len(report["eligible_digest"]) == 64
+    assert [row["id"] for row in report["rows"]] == sorted(IDS[name] for name in IDS if name != "archived")
 
 
 def test_scan_protects_unknown_schema_and_global_pin(tmp_path: Path) -> None:
@@ -101,92 +156,327 @@ def test_scan_protects_unknown_schema_and_global_pin(tmp_path: Path) -> None:
     assert report["counts"]["present"] == 1
 
 
-def test_count_mismatch_refuses_before_backup_or_write(tmp_path: Path) -> None:
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_scan_rejects_non_finite_inputs(tmp_path: Path, value: float) -> None:
+    home = tmp_path / "codex"
+    _db(home)
+    with pytest.raises(reconcile.ReconcileError, match="finite"):
+        reconcile.scan(codex_home=home, min_age_seconds=value, now=NOW)
+    with pytest.raises(reconcile.ReconcileError, match="finite"):
+        reconcile.scan(codex_home=home, min_age_seconds=0, now=value)
+
+
+def test_apply_requires_digest_and_refuses_same_count_substitution(tmp_path: Path) -> None:
     home = tmp_path / "codex"
     database = _db(home)
-    result = reconcile.apply(
-        codex_home=home,
-        db_path=database,
-        backup_dir=tmp_path / "backups",
-        expected_eligible_stale=2,
-        acknowledge=True,
-        now=NOW,
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    missing_digest = reconcile.apply(
+        codex_home=home, db_path=database, expected_eligible_stale=1, acknowledge=True, now=NOW
     )
+    assert missing_digest["error"] == "expected_digest_required"
 
-    assert result["error"] == "expected_count_mismatch"
-    assert not (tmp_path / "backups").exists()
+    replacement_id = str(uuid.uuid4())
     with sqlite3.connect(database) as connection:
-        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 1
-
-
-def test_apply_backs_up_revalidates_edges_and_preserves_rollout(tmp_path: Path) -> None:
-    home = tmp_path / "codex"
-    database = _db(home)
-    preserved_rollout = _rollout(home, "present", present=True)
+        connection.execute("DELETE FROM threads WHERE id = ?", (IDS["old"],))
+        connection.execute(
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at, archived, is_pinned) VALUES (?, ?, ?, ?, 0, 0)",
+            (replacement_id, str(_rollout(home, replacement_id)), OLD, OLD),
+        )
     result = reconcile.apply(
         codex_home=home,
         db_path=database,
         backup_dir=tmp_path / "backups",
         expected_eligible_stale=1,
+        expected_eligible_digest=report["eligible_digest"],
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert result["error"] == "expected_digest_mismatch"
+    assert not (tmp_path / "backups").exists()
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (replacement_id,)).fetchone()[0] == 1
+
+
+def test_apply_locks_before_backup_and_includes_completed_wal_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    with sqlite3.connect(database) as connection:
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.commit()
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    live_id = str(uuid.uuid4())
+    live_rollout = _rollout(home, live_id, present=True)
+    original_open = reconcile._open_writable
+
+    def open_with_completed_writer(path: Path) -> sqlite3.Connection:
+        writable = original_open(path)
+        with sqlite3.connect(database) as live_writer:
+            live_writer.execute(
+                "INSERT INTO threads(id, rollout_path, created_at, updated_at, archived, is_pinned) "
+                "VALUES (?, ?, ?, ?, 0, 0)",
+                (live_id, str(live_rollout), OLD, OLD),
+            )
+        return writable
+
+    monkeypatch.setattr(reconcile, "_open_writable", open_with_completed_writer)
+    result = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        expected_eligible_stale=1,
+        expected_eligible_digest=report["eligible_digest"],
         acknowledge=True,
         now=NOW,
     )
 
     assert result["post_apply_parity"] is True
-    assert result["integrity_check"] == "ok"
-    assert result["counts"] == {"deleted": 1, "skipped": 0, "spawn_edges_deleted": 2}
-    backup = Path(result["backup_path"])
+    with sqlite3.connect(Path(result["backup_path"])) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (live_id,)).fetchone()[0] == 1
+
+
+def test_apply_validates_backup_integrity_and_deletes_fk_edges_first(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home, edge_fks=True)
+    result = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    receipt = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        backup_dir=tmp_path / "backups",
+        expected_eligible_stale=1,
+        expected_eligible_digest=result["eligible_digest"],
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert receipt["post_apply_parity"] is True
+    assert receipt["integrity_check"] == "ok"
+    assert receipt["counts"] == {"deleted": 1, "skipped": 0, "spawn_edges_deleted": 2}
+    backup = Path(receipt["backup_path"])
     assert backup.is_file()
     assert os.stat(backup).st_mode & 0o777 == 0o600
+    assert os.stat(backup.parent).st_mode & 0o777 == 0o700
     with sqlite3.connect(backup) as connection:
+        assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
         assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 1
-    assert preserved_rollout.is_file()
     with sqlite3.connect(database) as connection:
         assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 0
         assert connection.execute("SELECT count(*) FROM thread_dynamic_tools WHERE thread_id = ?", (IDS["old"],)).fetchone()[0] == 0
         assert connection.execute("SELECT count(*) FROM thread_spawn_edges").fetchone()[0] == 0
 
 
-def test_apply_skips_changed_candidate_inside_transaction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unknown_dependency_protects_missing_rows_and_refuses_apply(tmp_path: Path) -> None:
     home = tmp_path / "codex"
     database = _db(home)
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE unknown_thread_dependency(thread_id TEXT REFERENCES threads(id) ON DELETE CASCADE)"
+        )
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    assert report["counts"]["eligible_stale"] == 0
+    assert report["rows"][[row["id"] for row in report["rows"]].index(IDS["old"])]["classification"] == "suspicious_schema"
+    receipt = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        backup_dir=tmp_path / "backups",
+        expected_eligible_stale=0,
+        expected_eligible_digest=report["eligible_digest"],
+        acknowledge=True,
+        now=NOW,
+    )
+    assert receipt["error"] == "unsafe_schema"
+    assert not (tmp_path / "backups").exists()
+
+
+def test_delete_trigger_is_unsupported(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TRIGGER block_thread_delete BEFORE DELETE ON threads BEGIN SELECT RAISE(ABORT, 'blocked'); END")
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    assert report["counts"]["eligible_stale"] == 0
+    assert any("trigger" in issue for issue in report["schema_issues"])
+
+
+def test_uuid_archived_identity_and_symlinks_are_suspicious(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home, archived_row=True)
+    wrong_root_id = str(uuid.uuid4())
+    wrong_root_path = _rollout(home, wrong_root_id, archived=True)
+    wrong_root_path.unlink(missing_ok=True)
+    _insert_thread(database, thread_id=wrong_root_id, rollout_path=wrong_root_path)
+    wrong_name_id = str(uuid.uuid4())
+    _insert_thread(database, thread_id=wrong_name_id, rollout_path=_rollout(home, wrong_name_id, filename_id=IDS["old"]))
+    invalid_archived_id = str(uuid.uuid4())
+    invalid_archived_path = _rollout(home, invalid_archived_id)
+    _insert_thread(database, thread_id=invalid_archived_id, rollout_path=invalid_archived_path, archived=2)
+    symlink_id = str(uuid.uuid4())
+    symlink_path = _rollout(home, symlink_id)
+    symlink_path.symlink_to(_rollout(home, str(uuid.uuid4()), present=True))
+    _insert_thread(database, thread_id=symlink_id, rollout_path=symlink_path)
+    dangling_id = str(uuid.uuid4())
+    dangling_path = _rollout(home, dangling_id)
+    dangling_path.symlink_to(dangling_path.with_name("not-there.jsonl"))
+    _insert_thread(database, thread_id=dangling_id, rollout_path=dangling_path)
+    non_uuid_id = "not-a-uuid"
+    _insert_thread(database, thread_id=non_uuid_id, rollout_path=home / "sessions" / "rollout-not-a-uuid.jsonl")
+
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    by_id = {row["id"]: row for row in report["rows"]}
+    assert by_id[IDS["archived"]]["classification"] == "eligible_stale"
+    assert by_id[wrong_root_id]["classification"] == "suspicious_path"
+    assert by_id[wrong_name_id]["classification"] == "suspicious_path"
+    assert by_id[invalid_archived_id]["classification"] == "suspicious_schema"
+    assert by_id[symlink_id]["classification"] == "suspicious_path"
+    assert by_id[dangling_id]["classification"] == "suspicious_path"
+    assert by_id[non_uuid_id]["classification"] == "suspicious_schema"
+
+
+def test_explicit_database_must_be_real_and_directly_under_home(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    with pytest.raises(reconcile.ReconcileError, match="directly under"):
+        reconcile.discover_database(home, tmp_path / "state_5.sqlite")
+    link = home / "state_link.sqlite"
+    link.symlink_to(database)
+    with pytest.raises(reconcile.ReconcileError, match="regular file"):
+        reconcile.discover_database(home, link)
+    directory = home / "state_directory.sqlite"
+    directory.mkdir()
+    with pytest.raises(reconcile.ReconcileError, match="regular file"):
+        reconcile.discover_database(home, directory)
+
+
+def test_post_commit_verification_failure_reports_actual_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    digest = _digest(home, database)
+
+    def fail_scan(*args: object, **kwargs: object) -> dict[str, object]:
+        raise reconcile.ReconcileError("forced verification failure")
+
+    monkeypatch.setattr(reconcile, "scan", fail_scan)
+    receipt = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        expected_eligible_stale=1,
+        expected_eligible_digest=digest,
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert receipt["error"] == "post_commit_verification_failed"
+    assert receipt["deleted_ids"] == [IDS["old"]]
+    assert receipt["counts"]["deleted"] == 1
+    assert receipt["mutation_committed"] is True
+    assert receipt["backup_path"] is not None
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 0
+
+
+def test_missing_skipped_candidate_fails_parity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    digest = _digest(home, database)
     original_backup = reconcile._create_backup
+    original_row_report = reconcile._row_report
+    original_scan = reconcile.scan
+
+    def backup_then_skip(path: Path, directory: Path) -> Path:
+        backup = original_backup(path, directory)
+
+        def skip_old(row: sqlite3.Row, **kwargs: object) -> dict[str, object]:
+            report = original_row_report(row, **kwargs)
+            if row["id"] == IDS["old"]:
+                report["classification"] = "protected_recent"
+            return report
+
+        monkeypatch.setattr(reconcile, "_row_report", skip_old)
+        return backup
+
+    def scan_without_skipped(*args: object, **kwargs: object) -> dict[str, object]:
+        report = original_scan(*args, **kwargs)
+        report["rows"] = [row for row in report["rows"] if row["id"] != IDS["old"]]
+        return report
+
+    monkeypatch.setattr(reconcile, "_create_backup", backup_then_skip)
+    monkeypatch.setattr(reconcile, "scan", scan_without_skipped)
+    receipt = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        expected_eligible_stale=1,
+        expected_eligible_digest=digest,
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert receipt["error"] == "post_commit_verification_failed"
+    assert receipt["counts"]["deleted"] == 0
+    assert receipt["mutation_committed"] is True
+
+
+def test_changed_candidate_is_skipped_without_deletion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    digest = _digest(home, database)
+    original_backup = reconcile._create_backup
+    original_row_report = reconcile._row_report
 
     def backup_then_change(path: Path, directory: Path) -> Path:
         backup = original_backup(path, directory)
-        with sqlite3.connect(database) as connection:
-            connection.execute("UPDATE threads SET updated_at = ? WHERE id = ?", (NOW, IDS["old"]))
-            connection.commit()
+
+        def changed_old(row: sqlite3.Row, **kwargs: object) -> dict[str, object]:
+            report = original_row_report(row, **kwargs)
+            if row["id"] == IDS["old"]:
+                report["classification"] = "protected_recent"
+            return report
+
+        monkeypatch.setattr(reconcile, "_row_report", changed_old)
         return backup
 
     monkeypatch.setattr(reconcile, "_create_backup", backup_then_change)
     result = reconcile.apply(
         codex_home=home,
         db_path=database,
-        backup_dir=tmp_path / "backups",
         expected_eligible_stale=1,
+        expected_eligible_digest=digest,
         acknowledge=True,
         now=NOW,
     )
 
     assert result["counts"]["deleted"] == 0
-    assert result["skipped"] == [{"id": IDS["old"], "reason": "row_changed"}]
+    assert result["skipped"] == [{"id": IDS["old"], "reason": "protected_recent"}]
     assert result["post_apply_parity"] is True
 
 
 def test_apply_is_idempotent_and_fail_on_stale_is_read_only(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home = tmp_path / "codex"
     database = _db(home)
-    assert reconcile.main(["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]) == 1
+    first_scan = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    assert reconcile.main(
+        ["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]
+    ) == 1
     assert json.loads(capsys.readouterr().out)["counts"]["eligible_stale"] == 1
     first = reconcile.apply(
-        codex_home=home, db_path=database, expected_eligible_stale=1, acknowledge=True, now=NOW
+        codex_home=home,
+        db_path=database,
+        expected_eligible_stale=1,
+        expected_eligible_digest=first_scan["eligible_digest"],
+        acknowledge=True,
+        now=NOW,
     )
     assert first["counts"]["deleted"] == 1
+    second_scan = reconcile.scan(codex_home=home, db_path=database, now=NOW)
     second = reconcile.apply(
-        codex_home=home, db_path=database, expected_eligible_stale=0, acknowledge=True, now=NOW
+        codex_home=home,
+        db_path=database,
+        expected_eligible_stale=0,
+        expected_eligible_digest=second_scan["eligible_digest"],
+        acknowledge=True,
+        now=NOW,
     )
     assert second["counts"]["deleted"] == 0
     assert second["backup_path"] is None
-    assert reconcile.main(["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]) == 0
+    assert reconcile.main(
+        ["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]
+    ) == 0
     assert json.loads(capsys.readouterr().out)["counts"]["eligible_stale"] == 0

--- a/tests/test_codex_rollout_reconcile.py
+++ b/tests/test_codex_rollout_reconcile.py
@@ -287,14 +287,32 @@ def test_unknown_dependency_protects_missing_rows_and_refuses_apply(tmp_path: Pa
     assert not (tmp_path / "backups").exists()
 
 
-def test_delete_trigger_is_unsupported(tmp_path: Path) -> None:
+def test_update_trigger_is_allowed_but_delete_trigger_is_unsupported(tmp_path: Path) -> None:
     home = tmp_path / "codex"
     database = _db(home)
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TRIGGER maintain_thread AFTER UPDATE ON threads BEGIN SELECT 1; END"
+        )
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+    assert report["counts"]["eligible_stale"] == 1
+    assert report["schema_issues"] == []
     with sqlite3.connect(database) as connection:
         connection.execute("CREATE TRIGGER block_thread_delete BEFORE DELETE ON threads BEGIN SELECT RAISE(ABORT, 'blocked'); END")
     report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
     assert report["counts"]["eligible_stale"] == 0
     assert any("trigger" in issue for issue in report["schema_issues"])
+
+
+def test_missing_rollout_root_is_suspicious(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    home.joinpath("sessions").rename(home / "sessions-away")
+
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+
+    assert report["counts"]["eligible_stale"] == 0
+    assert report["counts"]["suspicious_path"] == 6
 
 
 def test_uuid_archived_identity_and_symlinks_are_suspicious(tmp_path: Path) -> None:

--- a/tests/test_codex_rollout_reconcile.py
+++ b/tests/test_codex_rollout_reconcile.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.hygiene import codex_rollout_reconcile as reconcile
+
+NOW = 1_800_000_000
+OLD = NOW - 3 * 24 * 60 * 60
+RECENT = NOW - 60
+IDS = {name: f"thread-{index}" for index, name in enumerate(("old", "present", "pinned", "recent", "outside", "malformed"))}
+
+
+def _rollout(home: Path, name: str, *, present: bool = False) -> Path:
+    path = home / "sessions" / "2026" / "07" / f"rollout-{name}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if present:
+        path.write_text("{}\n", encoding="utf-8")
+    return path
+
+
+def _db(home: Path, *, include_pinned: bool = True) -> Path:
+    home.mkdir(parents=True, exist_ok=True)
+    database = home / "state_5.sqlite"
+    connection = sqlite3.connect(database)
+    pinned_column = ", is_pinned INTEGER NOT NULL DEFAULT 0" if include_pinned else ""
+    connection.executescript(
+        f"""
+        CREATE TABLE threads (
+            id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL{pinned_column}
+        );
+        CREATE TABLE thread_spawn_edges (
+            parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL
+        );
+        CREATE TABLE thread_dynamic_tools (
+            thread_id TEXT PRIMARY KEY REFERENCES threads(id) ON DELETE CASCADE, payload TEXT NOT NULL
+        );
+        """
+    )
+    home.joinpath("sessions").mkdir(parents=True, exist_ok=True)
+    rows = [
+        (IDS["old"], str(_rollout(home, "old")), OLD, OLD, 0),
+        (IDS["present"], str(_rollout(home, "present", present=True)), OLD, OLD, 0),
+        (IDS["pinned"], str(_rollout(home, "pinned")), OLD, OLD, 1),
+        (IDS["recent"], str(_rollout(home, "recent")), RECENT, RECENT, 0),
+        (IDS["outside"], str(home.parent / "outside" / "rollout-outside.jsonl"), OLD, OLD, 0),
+        (IDS["malformed"], str(home / "sessions" / "2026" / "note.txt"), OLD, OLD, 0),
+    ]
+    if include_pinned:
+        connection.executemany(
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at, is_pinned) VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+    else:
+        connection.executemany(
+            "INSERT INTO threads(id, rollout_path, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            [row[:4] for row in rows],
+        )
+    connection.executemany(
+        "INSERT INTO thread_spawn_edges VALUES (?, ?, ?)",
+        [(IDS["old"], IDS["recent"], "done"), (IDS["recent"], IDS["old"], "done")],
+    )
+    connection.execute("INSERT INTO thread_dynamic_tools VALUES (?, ?)", (IDS["old"], "tool"))
+    connection.commit()
+    connection.close()
+    return database
+
+
+def test_scan_classifies_present_stale_protected_and_suspicious(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    report = reconcile.scan(codex_home=home, now=NOW)
+
+    assert report["counts"] == {
+        "present": 1,
+        "eligible_stale": 1,
+        "protected_pinned": 1,
+        "protected_recent": 1,
+        "suspicious_path": 2,
+        "suspicious_schema": 0,
+    }
+    assert report["eligible_stale_ids"] == [IDS["old"]]
+    assert [row["id"] for row in report["rows"]] == sorted(IDS.values())
+
+
+def test_scan_protects_unknown_schema_and_global_pin(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home, include_pinned=False)
+    home.joinpath(".codex-global-state.json").write_text(
+        json.dumps({"pinned-thread-ids": [IDS["old"]]}), encoding="utf-8"
+    )
+    report = reconcile.scan(codex_home=home, db_path=database, now=NOW)
+
+    assert report["counts"]["eligible_stale"] == 0
+    assert report["counts"]["suspicious_schema"] == 3
+    assert report["counts"]["present"] == 1
+
+
+def test_count_mismatch_refuses_before_backup_or_write(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    result = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        backup_dir=tmp_path / "backups",
+        expected_eligible_stale=2,
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert result["error"] == "expected_count_mismatch"
+    assert not (tmp_path / "backups").exists()
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 1
+
+
+def test_apply_backs_up_revalidates_edges_and_preserves_rollout(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    preserved_rollout = _rollout(home, "present", present=True)
+    result = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        backup_dir=tmp_path / "backups",
+        expected_eligible_stale=1,
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert result["post_apply_parity"] is True
+    assert result["integrity_check"] == "ok"
+    assert result["counts"] == {"deleted": 1, "skipped": 0, "spawn_edges_deleted": 2}
+    backup = Path(result["backup_path"])
+    assert backup.is_file()
+    assert os.stat(backup).st_mode & 0o777 == 0o600
+    with sqlite3.connect(backup) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 1
+    assert preserved_rollout.is_file()
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT count(*) FROM threads WHERE id = ?", (IDS["old"],)).fetchone()[0] == 0
+        assert connection.execute("SELECT count(*) FROM thread_dynamic_tools WHERE thread_id = ?", (IDS["old"],)).fetchone()[0] == 0
+        assert connection.execute("SELECT count(*) FROM thread_spawn_edges").fetchone()[0] == 0
+
+
+def test_apply_skips_changed_candidate_inside_transaction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    original_backup = reconcile._create_backup
+
+    def backup_then_change(path: Path, directory: Path) -> Path:
+        backup = original_backup(path, directory)
+        with sqlite3.connect(database) as connection:
+            connection.execute("UPDATE threads SET updated_at = ? WHERE id = ?", (NOW, IDS["old"]))
+            connection.commit()
+        return backup
+
+    monkeypatch.setattr(reconcile, "_create_backup", backup_then_change)
+    result = reconcile.apply(
+        codex_home=home,
+        db_path=database,
+        backup_dir=tmp_path / "backups",
+        expected_eligible_stale=1,
+        acknowledge=True,
+        now=NOW,
+    )
+
+    assert result["counts"]["deleted"] == 0
+    assert result["skipped"] == [{"id": IDS["old"], "reason": "row_changed"}]
+    assert result["post_apply_parity"] is True
+
+
+def test_apply_is_idempotent_and_fail_on_stale_is_read_only(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home = tmp_path / "codex"
+    database = _db(home)
+    assert reconcile.main(["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]) == 1
+    assert json.loads(capsys.readouterr().out)["counts"]["eligible_stale"] == 1
+    first = reconcile.apply(
+        codex_home=home, db_path=database, expected_eligible_stale=1, acknowledge=True, now=NOW
+    )
+    assert first["counts"]["deleted"] == 1
+    second = reconcile.apply(
+        codex_home=home, db_path=database, expected_eligible_stale=0, acknowledge=True, now=NOW
+    )
+    assert second["counts"]["deleted"] == 0
+    assert second["backup_path"] is None
+    assert reconcile.main(["scan", "--codex-home", str(home), "--db", str(database), "--fail-on-stale", "--now", str(NOW)]) == 0
+    assert json.loads(capsys.readouterr().out)["counts"]["eligible_stale"] == 0

--- a/tests/test_codex_rollout_reconcile.py
+++ b/tests/test_codex_rollout_reconcile.py
@@ -352,6 +352,9 @@ def test_uuid_archived_identity_and_symlinks_are_suspicious(tmp_path: Path) -> N
 def test_explicit_database_must_be_real_and_directly_under_home(tmp_path: Path) -> None:
     home = tmp_path / "codex"
     database = _db(home)
+    logical_home = tmp_path / "codex-link"
+    logical_home.symlink_to(home, target_is_directory=True)
+    assert reconcile.discover_database(logical_home, logical_home / database.name) == logical_home / database.name
     with pytest.raises(reconcile.ReconcileError, match="directly under"):
         reconcile.discover_database(home, tmp_path / "state_5.sqlite")
     link = home / "state_link.sqlite"


### PR DESCRIPTION
Parent stream: #4707

Closes #6098

## Outcome

Adds a dry-run-first Codex rollout-state reconciler for threads whose rollout JSONL is missing. Read-only investigation established that the local DB is healthy but retains 986 old active/archive rows after corresponding files were pruned; retained files and row identities match, with no duplicate IDs or paths.

## Safety model

- exact state DB directly under the selected Codex home
- stable JSON scan with present/protected/suspicious/eligible classifications
- canonical UUID, archive-root, filename, age, pin, symlink, schema, FK, and trigger checks
- apply bound to the reviewed eligible count and SHA-256 fingerprint digest
- BEGIN IMMEDIATE before a transactionally consistent, integrity-checked backup
- candidate revalidation; spawn-edge deletion before thread deletion
- truthful post-commit failure receipts, integrity verification, and parity checks
- never deletes rollout JSONL files

The implementation was prepared by GPT-5.6 Luna xhigh under Sol lead/advisory, then challenged by an independent Terra safety audit before integration. The safety envelope was explicitly amended from 420 to 700 non-test lines; the final scope is exactly 700 across the implementation and runbook, with no path expansion.

## Verification

- 17 focused pytest cases passed
- Ruff and Python compilation passed
- markdownlint-cli2 passed
- OPSEC and X-Agent trailer audits passed
- git diff --check passed
- live read-only Codex 0.146 scan: 986 eligible stale, 814 present, 0 suspicious, no schema issues
- isolated source-blind apply: exact count/digest accepted; 1 thread, 1 spawn edge, and 1 cascaded tool row removed; backup created; integrity and parity passed; final scan clean
- Claude Sonnet 5 r1 and exact-head r2 reviews found no actionable defects; APPROVED verdict published
- real Codex state not mutated before exact-head independent approval

## Rail approval

Receipt: rail-approval-2d89eb82e6234bd5b7bc945f94c55da4
Head: 98065ec0de2e61d552bf6059e830595c0c4ca6e5
Owned paths:
- scripts/hygiene/codex_rollout_reconcile.py
- tests/test_codex_rollout_reconcile.py
- docs/runbooks/codex-rollout-state.md