### PR TITLE
fix(hooks): reject bare Python without rewriting

### DIFF
--- a/agents_extensions/shared/hooks/enforce-venv.sh
+++ b/agents_extensions/shared/hooks/enforce-venv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Hook: PreToolUse (Bash) — Enforce .venv/bin/python usage
-# Rewrites bare `python3` or `python` commands to the canonical project venv.
-# Prevents accidentally using system Python instead of project venv.
+# Hook: PreToolUse (Bash) — Enforce .venv/bin/python usage.
+# Rejects bare `python3` or `python` commands with one copyable replacement.
+# It never rewrites a command behind the caller's back.
 
 # Read tool input from stdin
 INPUT=$(cat)
@@ -57,24 +57,15 @@ if echo "$COMMAND" | grep -qE '^python3?[[:space:]]'; then
     exit 2
   fi
 
+  printf -v QUOTED_PYTHON '%q' "$PYTHON_BIN"
   case "$COMMAND" in
-    python3*) FIXED="${PYTHON_BIN}${COMMAND#python3}" ;;
-    python*) FIXED="${PYTHON_BIN}${COMMAND#python}" ;;
+    python3*) FIXED="${QUOTED_PYTHON}${COMMAND#python3}" ;;
+    python*) FIXED="${QUOTED_PYTHON}${COMMAND#python}" ;;
   esac
 
-  if [ "${LEARN_UK_HOOK_PROVIDER:-claude}" = "codex" ]; then
-    jq -n --arg command "$FIXED" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "allow",
-        updatedInput: {command: $command}
-      }
-    }'
-  else
-    jq -n --arg command "$FIXED" '{modifiedInput: {command: $command}}'
-  fi
-  exit 0
+  printf 'Unqualified interpreter blocked. Run this command instead:\n  %s\n' "$FIXED" >&2
+  exit 2
 fi
 
-# No modification needed
+# Qualified commands pass through unchanged.
 exit 0

--- a/docs/CLAUDE-CODE-FEATURES.md
+++ b/docs/CLAUDE-CODE-FEATURES.md
@@ -11,7 +11,7 @@ Hooks run automatically on specific events. Configured in `claude_extensions/set
 | Event | Hook script | Timeout | What it does |
 |-------|------------|---------|--------------|
 | **SessionStart** | `session-setup.sh` | 10s | Validates environment: venv, env vars, MCP sources server, gemini-cli auth, stale builds, MEMORY.md line count, deploy drift, open GH issues |
-| **PreToolUse** (Bash) | `enforce-venv.sh` | 3s | Rewrites bare `python3`/`python` → `.venv/bin/python` before every Bash call |
+| **PreToolUse** (Bash) | `enforce-venv.sh` | 3s | Rejects bare `python3`/`python` and prints a copyable `.venv/bin/python` replacement |
 | **UserPromptSubmit** | `check-gemini-inbox.sh` | 5s | Checks message broker DB for unread Gemini messages, injects alert |
 | **PostCompact** | `post-compact.sh` | 10s | After context compaction: restores in-progress modules, open issues, key reminders |
 | **FileChanged** (`curriculum/l2-uk-en/**/*.md`) | `auto-audit.sh` | 30s | Auto-runs `audit_module.py` on changed curriculum files (skips orchestration/audit/review) |
@@ -194,7 +194,7 @@ User types message
   └── check-gemini-inbox.sh → alerts on unread Gemini messages
 
 Claude runs Bash command
-  └── enforce-venv.sh → rewrites python → .venv/bin/python
+  └── enforce-venv.sh → rejects bare python and prints the project interpreter command
 
 Curriculum .md file changes
   └── auto-audit.sh → runs audit_module.py

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -257,7 +257,8 @@ Runs on every session start, new or resumed.
 
 ### `enforce-venv.sh`
 
-Intercepts bare `python` and `python3` shell calls and rewrites them to `.venv/bin/python`.
+Rejects bare `python` and `python3` shell calls and prints one shell-quoted,
+copyable command using the canonical checkout's `.venv/bin/python`.
 
 ### `check-gemini-inbox.sh`
 

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -67,7 +67,7 @@ Re-verified against the current OpenAI Codex Hooks reference on 2026-07-26:
 
 The Codex manifest therefore sends each tool event through one tracked,
 deterministic entry point:
-`scripts/agent_runtime/codex_hook_entry.sh`. The Bash-command venv rewrite has
+`scripts/agent_runtime/codex_hook_entry.sh`. The Bash-command venv guard has
 its own 3-second fail-closed deadline. `PreToolUse` local policy checks then run
 sequentially with their former 3–5 second individual deadlines. The two
 independent, network-backed merge guards run concurrently with separate
@@ -79,12 +79,12 @@ without letting one slow merge guard starve the other.
 `codex_hook_policy.py` converts an individual guard timeout into exit code `2`
 with a concrete reason. Per the Codex `PreToolUse` contract, exit `2` blocks the
 tool call; a timeout therefore fails closed. The manifest's 45-second outer
-timeout remains a last-resort ceiling above the 3-second rewrite, local-chain,
+timeout remains a last-resort ceiling above the 3-second venv guard, local-chain,
 and concurrent network-guard budgets.
 
-Only the venv rewrite may write the final Codex JSON response to stdout.
-Unexpected stdout from any policy guard is redirected to diagnostics and
-fails closed, preventing multiple payloads from corrupting the hook response.
+No policy guard writes a Codex JSON response to stdout. Unexpected stdout is
+redirected to diagnostics and fails closed, preventing multiple payloads from
+corrupting the hook response.
 
 Merge commands must name the PR explicitly. This removes the preliminary
 current-branch discovery call and prevents the guard from checking one PR while
@@ -95,9 +95,9 @@ after those results identify the exact base.
 The entry point resolves the exact tool worktree from structured hook input and
 the canonical checkout from Git's common directory. Python policies use the
 canonical checkout's `.venv/bin/python`, so a linked worktree does not need its
-own `.venv` symlink. Bare `python`/`python3` calls are rewritten to that absolute
-project interpreter using the Codex `updatedInput` schema. If the project
-interpreter is genuinely absent, the policy blocks instead of falling back to a
+own `.venv` symlink. Bare `python`/`python3` calls are rejected with one
+shell-quoted, copyable command using that absolute project interpreter. If the
+project interpreter is genuinely absent, the policy blocks instead of falling back to a
 system interpreter.
 
 `UserPromptSubmit` invokes the inbox hook with recipient `codex`; the shared

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -122,7 +122,6 @@ def _run_enforce_venv(
     payload: str,
 ) -> GuardResult:
     environment = os.environ.copy()
-    environment["LEARN_UK_HOOK_PROVIDER"] = "codex"
     environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical_root)
     guard = hooks_dir / "enforce-venv.sh"
     try:
@@ -183,16 +182,16 @@ def main() -> int:
     args = parser.parse_args()
     payload = sys.stdin.read()
     tool_name = _tool_name(payload)
-    rewrite_result = None
+    venv_result = None
     if tool_name == "Bash":
-        rewrite_result = _run_enforce_venv(
+        venv_result = _run_enforce_venv(
             args.hooks_dir,
             args.canonical_root,
             payload,
         )
-        if rewrite_result.returncode:
-            _emit(rewrite_result)
-            return rewrite_result.returncode
+        if venv_result.returncode:
+            _emit(venv_result)
+            return venv_result.returncode
 
     local_specs = LOCAL_BASH_GUARDS if tool_name == "Bash" else ()
     local_results = _run_specs(
@@ -209,8 +208,8 @@ def main() -> int:
         merge_code = _result_code(_run_merge_guards(args.python_bin, args.hooks_dir, payload))
         if merge_code:
             return merge_code
-        if rewrite_result is not None:
-            _emit(rewrite_result)
+        if venv_result is not None:
+            _emit(venv_result)
     return 0
 
 

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -182,7 +182,6 @@ def main() -> int:
     args = parser.parse_args()
     payload = sys.stdin.read()
     tool_name = _tool_name(payload)
-    venv_result = None
     if tool_name == "Bash":
         venv_result = _run_enforce_venv(
             args.hooks_dir,
@@ -208,8 +207,6 @@ def main() -> int:
         merge_code = _result_code(_run_merge_guards(args.python_bin, args.hooks_dir, payload))
         if merge_code:
             return merge_code
-        if venv_result is not None:
-            _emit(venv_result)
     return 0
 
 

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -368,7 +368,7 @@ def test_non_rewrite_guard_stdout_fails_closed(
     assert "not-json" in captured.err
 
 
-def test_codex_policy_venv_rewrite_timeout_fails_closed(
+def test_codex_policy_venv_guard_timeout_fails_closed(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -384,7 +384,7 @@ def test_codex_policy_venv_rewrite_timeout_fails_closed(
     assert "blocking the tool call fail-closed" in result.stderr
 
 
-def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(
+def test_codex_entry_rejects_bare_python_from_worktree_with_copyable_command(
     tmp_path: Path,
 ) -> None:
     primary, worktree = _make_linked_worktree(tmp_path)
@@ -409,15 +409,13 @@ def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(
         timeout=30,
     )
 
-    assert completed.returncode == 0, completed.stderr
-    output = json.loads(completed.stdout)
-    specific = output["hookSpecificOutput"]
-    assert specific["hookEventName"] == "PreToolUse"
-    assert specific["permissionDecision"] == "allow"
-    assert specific["updatedInput"]["command"] == (f'{primary}/.venv/bin/python -c "print(1)"')
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert "Unqualified interpreter blocked" in completed.stderr
+    assert f'{primary}/.venv/bin/python -c "print(1)"' in completed.stderr
 
 
-def test_claude_python_rewrite_shape_remains_compatible(tmp_path: Path) -> None:
+def test_claude_bare_python_is_rejected_without_rewrite_output(tmp_path: Path) -> None:
     canonical = tmp_path / "canonical"
     canonical.mkdir()
     _make_exact_python_checkout(canonical)
@@ -442,15 +440,12 @@ def test_claude_python_rewrite_shape_remains_compatible(tmp_path: Path) -> None:
         timeout=10,
     )
 
-    assert completed.returncode == 0, completed.stderr
-    assert json.loads(completed.stdout) == {
-        "modifiedInput": {
-            "command": f"{canonical}/.venv/bin/python --version",
-        }
-    }
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert f"{canonical}/.venv/bin/python --version" in completed.stderr
 
 
-def test_python_rewrite_preserves_checkout_path_metacharacters(tmp_path: Path) -> None:
+def test_python_rejection_shell_quotes_checkout_path_metacharacters(tmp_path: Path) -> None:
     canonical = tmp_path / "checkout&pipe|root"
     canonical.mkdir()
     _make_exact_python_checkout(canonical)
@@ -475,12 +470,41 @@ def test_python_rewrite_preserves_checkout_path_metacharacters(tmp_path: Path) -
         timeout=10,
     )
 
-    assert completed.returncode == 0, completed.stderr
-    updated = json.loads(completed.stdout)["hookSpecificOutput"]["updatedInput"]
-    assert updated["command"] == (f'{canonical}/.venv/bin/python -c "print(1)"')
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert r'checkout\&pipe\|root/.venv/bin/python -c "print(1)"' in completed.stderr
 
 
-def test_bare_python_rewrite_blocks_a_canonical_version_mismatch(tmp_path: Path) -> None:
+def test_qualified_project_python_passes_without_output(tmp_path: Path) -> None:
+    canonical = tmp_path / "checkout"
+    canonical.mkdir()
+    _make_exact_python_checkout(canonical)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(canonical),
+        "tool_name": "Bash",
+        "tool_input": {"command": ".venv/bin/python --version"},
+    }
+    environment = os.environ.copy()
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical)
+
+    completed = subprocess.run(
+        ["bash", str(VENV_HOOK)],
+        cwd=canonical,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+
+
+def test_bare_python_rejection_blocks_a_canonical_version_mismatch(tmp_path: Path) -> None:
     canonical = tmp_path / "checkout"
     canonical.mkdir()
     _make_exact_python_checkout(canonical)


### PR DESCRIPTION
## Summary

- stop silently rewriting bare python/python3 commands
- reject each bare invocation with one shell-quoted, copyable project-interpreter command
- keep qualified .venv/bin/python calls unchanged
- remove the provider-specific response path and the final deferred-rewrite remnant

## Guardrail proposal card

- **Failure prevented:** hidden command mutation executes a different command than the caller supplied and can mishandle shell metacharacters.
- **Enforcement point:** the existing PreToolUse venv guard rejects before Bash execution.
- **Owner:** agents_extensions/shared/hooks/enforce-venv.sh and scripts/agent_runtime/codex_hook_policy.py.
- **False-positive budget:** zero blocks for qualified project interpreters; every genuinely bare python/python3 prefix remains blocked.
- **Escape path:** copy the exact shell-quoted command printed by the rejection.
- **Proof:** bare python3 exits 2 with one replacement and no stdout; .venv/bin/python exits 0 unchanged.
- **Sunset:** remove the hook when every supported harness natively enforces the repository interpreter without command mutation.

## Verification

- 19 Codex hook contract tests passed
- direct bare-command probe rejected with exit 2 and an actionable command
- direct qualified-command probe passed with no output
- Bash syntax, ShellCheck, Ruff, OPSEC lint, agent-trailer lint, deploy dry-run, and diff checks passed

Refs #6108

Rail-Approval-Receipt: rail-approval-aed7b31fac4c48c28f0edeead95317dd