### PR TITLE
fix(guardrails): make startup repair explicit

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -18,9 +18,9 @@ SESSION_START_STARTED_SECONDS=$SECONDS
 #    session) made every Claude Bash tool call take 60+ seconds for
 #    two days straight.
 #
-#    Defensive: if the sentinel is older than 1 minute, it is
-#    definitely stale (real rehashes complete in <1s) — delete it.
-#    The 1-minute threshold avoids racing against an active rehash.
+#    Diagnostic only: if the sentinel is older than 1 minute, report it and
+#    leave removal to the explicit operator repair command. Session startup
+#    must not delete machine state from an age heuristic.
 #
 #    Using `find -mmin +1` instead of `stat`: portable across BSD
 #    (macOS) and GNU (Homebrew coreutils) without flag-flavor
@@ -29,7 +29,7 @@ SESSION_START_STARTED_SECONDS=$SECONDS
 PYENV_SHIM_LOCK="${PYENV_ROOT:-$HOME/.pyenv}/shims/.pyenv-shim"
 if [ -f "$PYENV_SHIM_LOCK" ] && \
    [ -n "$(find "$PYENV_SHIM_LOCK" -mmin +1 -type f 2>/dev/null)" ]; then
-  rm -f "$PYENV_SHIM_LOCK"
+  echo "WARNING: pyenv rehash lock is older than one minute; inspect it, then remove it explicitly if stale: rm -f \"$PYENV_SHIM_LOCK\"" >&2
 fi
 
 # Repo-health canary: core.bare MUST be false on this working repo. A stray
@@ -49,13 +49,12 @@ fi
 # UPWARD and prepending every ancestor node_modules/.bin; resolving the loop
 # makes `spawn` return ELOOP, so EVERY npm build dies instantly with exit 194
 # and no output — looking like "Astro is broken" when it is not. Gitignored, so
-# CI can't catch it; only a local canary can. Auto-heal the exact absolute
-# self-link case here (the general loop case is healed by the API-orient Python
-# canary in scripts/api/main.py). See docs/bug-autopsies/node-modules-eloop-symlink.md.
+# CI can't catch it; only a local canary can. Detect the exact absolute
+# self-link here and leave repair to the explicit doctor command. See
+# docs/bug-autopsies/node-modules-eloop-symlink.md.
 for _nm in "$_LU_REPO/node_modules" "$_LU_REPO/site/node_modules"; do
   if [ -L "$_nm" ] && [ "$(readlink "$_nm" 2>/dev/null)" = "$_nm" ]; then
-    rm -f "$_nm" \
-      && echo "⚠️  repo-health: removed self-referential symlink $_nm (was breaking npm with spawn ELOOP)" >&2
+    echo "WARNING: self-referential symlink detected at $_nm (npm spawn ELOOP). Inspect it, then run: .venv/bin/python scripts/audit/check_self_symlinks.py --fix" >&2
   fi
 done
 
@@ -351,19 +350,13 @@ if [ "$CODEX_NORMAL_TASK" = "0" ]; then
   fi
 fi
 
-# Keep only the local protected-branch canary on the synchronous path.
+# Keep only the local protected-branch diagnostic on the synchronous path.
 if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
     && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
   if ! run_bounded 2 "$PROJECT_DIR/.venv/bin/python" \
       "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
       --cwd "$PROJECT_DIR" --quiet 2>/dev/null; then
-    if run_bounded 2 "$PROJECT_DIR/.venv/bin/python" \
-        "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
-        --cwd "$PROJECT_DIR" --heal 2>/dev/null; then
-      INFO+=("PRIMARY HEAD was off main/detached — auto-healed to main (#4857). Prefer worktrees for all branch work.")
-    else
-      ISSUES+=("PRIMARY HEAD is detached or not on main (#4857). Run: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal.")
-    fi
+    ISSUES+=("PRIMARY HEAD is detached or not on main (#4857). Inspect it, then run the explicit doctor if appropriate: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal.")
   fi
 fi
 

--- a/docs/best-practices/guardrail-lifecycle.md
+++ b/docs/best-practices/guardrail-lifecycle.md
@@ -36,3 +36,14 @@ Record deterministic checks, independent review where required, and source-blind
 proof. Compare observed false positives with the budget. Delete a redundant guardrail when
 its replacement proof and sunset criterion are satisfied; do not keep dual enforcement
 indefinitely for reassurance.
+
+## Startup mutation boundary
+
+Session startup and health-orientation paths diagnose machine and checkout drift; they do
+not switch branches, fetch, pull, remove symlinks, or delete age-classified lock files.
+Repairs remain explicit operator actions through the named `--fix` or `--heal` command.
+
+The sole automatic repair exception is `core.bare=true` in this non-bare primary layout.
+That value makes the primary and all linked worktrees unusable, while resetting the exact
+local Git key to `false` is bounded and preserves repository content. Any broader startup
+repair requires a new proposal card and present-tense operator or advisor approval.

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -670,8 +670,9 @@ def _self_symlink_canary() -> bool:
     the looping ancestor makes ``spawn`` return ``ELOOP``, so every npm build
     dies instantly with exit 194 and no output — looking like "Astro is broken"
     when it is not. The loop is gitignored so CI cannot catch it; only a local
-    canary can. On detection it auto-removes the looping link and logs an alert.
-    Never raises: the canary must not break health collection. See the autopsy
+    canary can. On detection it reports the link without removing it; repair is
+    an explicit doctor action. Never raises: the canary must not break health
+    collection. See the autopsy
     ``docs/bug-autopsies/node-modules-eloop-symlink.md``.
     """
     try:
@@ -679,24 +680,23 @@ def _self_symlink_canary() -> bool:
     except ImportError:  # path-flavoured import for test/script contexts
         from audit.check_self_symlinks import check_self_symlinks  # noqa: PLC0415 — script-path fallback
     try:
-        ok, message = check_self_symlinks(PROJECT_ROOT, fix=True)
+        ok, message = check_self_symlinks(PROJECT_ROOT, fix=False)
     except Exception:
         logger.exception("node_modules ELOOP canary failed to run")
         return True  # fail-open: don't raise a false alarm on canary error
-    if "removed" in message or not ok:
+    if not ok:
         logger.warning("node_modules ELOOP canary: %s", message)
     return ok
 
 
 def _primary_integrity_canary() -> bool:
-    """Detection + conservative repair canary for primary-checkout drift.
+    """Read-only checkout diagnostic for primary-checkout drift.
 
     #5803 follow-up: a worker detached the primary checkout (`checkout: moving
     from main to FETCH_HEAD`). Git-layer prevention was proven impossible
     against a same-UID process (design panel: gpt-5.6-sol + agy), so this
-    canary DETECTS and repairs ONLY detached+clean+idle drift; anything else
-    (dirty tree, op in progress, running dispatch, main moved unexpectedly)
-    alerts and preserves evidence without touching the human's checkout.
+    canary detects drift and records diagnostic evidence without switching,
+    fetching, or pulling the human's checkout.
     Never raises: the canary must not break health collection.
     """
     try:
@@ -708,13 +708,13 @@ def _primary_integrity_canary() -> bool:
     try:
         ok, message = check_primary_integrity(
             PROJECT_ROOT,
-            fix=True,
+            fix=False,
             tasks_dir=PROJECT_ROOT / "batch_state" / "tasks",
         )
     except Exception:
         logger.exception("primary-integrity canary failed to run")
         return True  # fail-open: don't raise a false alarm on canary error
-    if not ok or "repaired" in message:
+    if not ok:
         logger.warning("primary-integrity canary: %s", message)
     return ok
 

--- a/scripts/audit/check_primary_integrity.py
+++ b/scripts/audit/check_primary_integrity.py
@@ -32,9 +32,10 @@ Usage::
     python scripts/audit/check_primary_integrity.py          # check only
     python scripts/audit/check_primary_integrity.py --fix    # repair when safe
 
-Wired into: ``cmd_dispatch`` pre-dispatch gate, ``_run_worker`` post-exit
-sweep (both in ``scripts/delegate.py``), and the Monitor API health-orient
-canary (``scripts/api/main.py``).
+Wired read-only into: ``cmd_dispatch`` pre-dispatch gate, ``_run_worker``
+post-exit sweep (both in ``scripts/delegate.py``), and the Monitor API
+health-orient canary (``scripts/api/main.py``). ``--fix`` is an explicit
+operator doctor action and is not called by those automatic paths.
 """
 
 from __future__ import annotations

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1299,10 +1299,10 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
 
     #5803 follow-up: a worker detached the primary (`checkout: moving from main
     to FETCH_HEAD`) and every worktree branched afterwards would inherit a
-    wrong base. The watchdog repairs detached+clean+idle drift conservatively
-    and reports anything else as unrepaired — in which case new dispatches must
-    stop (running ones are never killed). Read-only dispatches stay allowed for
-    preflight and diagnosis, same contract as the dirty-primary guard.
+    wrong base. The watchdog only diagnoses and records drift here; new
+    write-capable dispatches stop until an operator explicitly repairs the
+    checkout. Read-only dispatches stay allowed for preflight and diagnosis,
+    same contract as the dirty-primary guard.
     """
     if mode not in _WRITE_CAPABLE_MODES:
         return None
@@ -1313,7 +1313,7 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
         except ImportError:  # path-flavoured import for test/script contexts
             from audit.check_primary_integrity import check_primary_integrity
 
-        ok, message = check_primary_integrity(_REPO_ROOT, fix=True, tasks_dir=_TASKS_DIR)
+        ok, message = check_primary_integrity(_REPO_ROOT, fix=False, tasks_dir=_TASKS_DIR)
     except Exception as exc:
         print(
             f"⚠️  primary-integrity watchdog errored ({type(exc).__name__}: {exc}); "
@@ -1323,8 +1323,6 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
         return None
 
     if ok:
-        if "repaired" in message:
-            _append_dispatch_event("primary_integrity_repaired_pre_dispatch", detail=message)
         return None
 
     return (
@@ -1332,10 +1330,9 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
         "write-capable dispatch (it would branch from a wrong base). Running "
         "dispatches are not touched.\n"
         f"   watchdog: {message}\n"
-        "   The first detection only records a baseline — if the drift is "
-        "detached+clean+idle and main is stable, simply retry the dispatch and "
-        "the watchdog re-attaches HEAD automatically. Otherwise inspect the "
-        "primary checkout manually; evidence is under "
+        "   Inspect the primary checkout and run the explicit doctor only when "
+        "appropriate: .venv/bin/python scripts/audit/check_primary_integrity.py "
+        "--fix. Evidence is under "
         "data/telemetry/primary-integrity/events.jsonl."
     )
 
@@ -3537,17 +3534,16 @@ def _run_worker(
     # Post-worker primary-integrity sweep (#5803 follow-up): if THIS worker
     # touched the primary checkout, the drift is caught here while its
     # task_id/agent/pid are still known, so the drift event names the likely
-    # actor. Conservative: repairs only detached+clean+idle drift and never
-    # raises into teardown. Runs after final_state is persisted, so this task
-    # no longer counts as a running dispatch for the repair gate.
+    # actor. Diagnostic only: never switches the human's checkout. Runs after
+    # final_state is persisted.
     try:
         try:
             from scripts.audit.check_primary_integrity import check_primary_integrity
         except ImportError:  # path-flavoured import for test/script contexts
             from audit.check_primary_integrity import check_primary_integrity
 
-        pi_ok, pi_message = check_primary_integrity(_REPO_ROOT, fix=True, tasks_dir=_TASKS_DIR)
-        if not pi_ok or "repaired" in pi_message:
+        pi_ok, pi_message = check_primary_integrity(_REPO_ROOT, fix=False, tasks_dir=_TASKS_DIR)
+        if not pi_ok:
             _append_dispatch_event(
                 "primary_integrity_post_worker",
                 task_id=task_id,

--- a/scripts/guardrails/primary_post_checkout_heal.sh
+++ b/scripts/guardrails/primary_post_checkout_heal.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Git post-checkout hook fragment: keep the PRIMARY worktree on main.
+# Git post-checkout hook fragment: diagnose a PRIMARY worktree off main.
 #
 # Git has already moved HEAD when this runs. If the main worktree is detached
-# or on a non-main branch, heal immediately and warn. Added worktrees are
-# ignored (feature branches are expected there).
+# or on a non-main branch, warn without moving HEAD, fetching, or pulling.
+# Added worktrees are ignored (feature branches are expected there).
 #
 # Install via scripts/install_git_hooks.sh. Safe to re-run.
 
@@ -40,14 +40,14 @@ if [ ! -x "$PY" ]; then
   PY="$(cd "$GIT_COMMON/.." && pwd)/.venv/bin/python"
 fi
 if [ ! -x "$PY" ]; then
-  echo "WARNING: primary-on-main heal skipped; project .venv/bin/python is unavailable." >&2
+  echo "WARNING: primary-on-main diagnostic skipped; project .venv/bin/python is unavailable." >&2
   exit 0
 fi
 
-# Heal quietly if broken; always allow the checkout to complete (we already moved).
+# Diagnose quietly if broken; always allow the checkout to complete (Git has
+# already moved it). Repair remains an explicit operator action.
 if ! "$PY" "$ROOT/scripts/guardrails/assert_primary_on_main.py" --cwd "$ROOT" --quiet 2>/dev/null; then
-  echo "WARNING: primary left main/detached — auto-healing to main…" >&2
-  "$PY" "$ROOT/scripts/guardrails/assert_primary_on_main.py" --cwd "$ROOT" --heal || true
+  echo "WARNING: primary is off main/detached. Inspect it, then run the explicit doctor if appropriate: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal" >&2
 fi
 
 exit 0

--- a/tests/test_assert_primary_on_main.py
+++ b/tests/test_assert_primary_on_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -128,3 +129,27 @@ def test_cli_heal_still_heals_operator_context(primary_repo: Path) -> None:
     assert _is_detached(primary_repo) is False
     state = primary_head_state(primary_repo)
     assert state["ok"] is True and state["branch"] == "main"
+
+
+def test_post_checkout_hook_diagnoses_without_reattaching(primary_repo: Path) -> None:
+    guardrails = primary_repo / "scripts" / "guardrails"
+    guardrails.mkdir(parents=True)
+    for name in ("assert_primary_on_main.py", "worktree_containment.py"):
+        shutil.copy2(_REPO_ROOT / "scripts" / "guardrails" / name, guardrails / name)
+    hook = guardrails / "primary_post_checkout_heal.sh"
+    shutil.copy2(
+        _REPO_ROOT / "scripts" / "guardrails" / "primary_post_checkout_heal.sh",
+        hook,
+    )
+    hook.chmod(0o755)
+    venv_bin = primary_repo / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_bin.joinpath("python").symlink_to(_REPO_ROOT / ".venv" / "bin" / "python")
+
+    assert _run(primary_repo, "git", "switch", "--detach", "HEAD").returncode == 0
+    result = _run(primary_repo, "bash", str(hook))
+
+    assert result.returncode == 0
+    assert _is_detached(primary_repo)
+    assert "explicit doctor" in result.stderr
+    assert "assert_primary_on_main.py --heal" in result.stderr

--- a/tests/test_delegate_primary_integrity.py
+++ b/tests/test_delegate_primary_integrity.py
@@ -106,18 +106,16 @@ def test_gate_blocks_unrepaired_drift(primary_repo):
     assert (primary_repo / "README.md").read_text() == "human work\n"
 
 
-def test_gate_repairs_safe_drift_then_allows(primary_repo):
+def test_gate_never_repairs_safe_drift_implicitly(primary_repo):
     _git(primary_repo, "checkout", "-q", "--detach", "HEAD")
 
-    # First call records the stable-main baseline and blocks.
-    error = delegate._resolve_primary_integrity_error(mode="danger")
-    assert error is not None
-    assert "baseline" in error
+    first = delegate._resolve_primary_integrity_error(mode="danger")
+    second = delegate._resolve_primary_integrity_error(mode="danger")
 
-    # Second call: main observed stable → watchdog repairs → dispatch allowed.
-    assert delegate._resolve_primary_integrity_error(mode="danger") is None
-    proc = _git(primary_repo, "symbolic-ref", "-q", "HEAD")
-    assert proc.stdout.strip() == "refs/heads/main"
+    assert first is not None and second is not None
+    assert "explicit doctor" in second
+    proc = _git(primary_repo, "symbolic-ref", "-q", "HEAD", check=False)
+    assert proc.returncode != 0
 
 
 def test_gate_defers_while_dispatch_running(primary_repo):

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -247,6 +247,29 @@ def test_health_includes_core_bare_canary():
     assert health["git_core_bare_ok"] is True
 
 
+def test_health_canaries_do_not_apply_general_repairs(monkeypatch):
+    import scripts.audit.check_primary_integrity as primary_check
+    import scripts.audit.check_self_symlinks as symlink_check
+
+    fix_values: list[bool] = []
+
+    def check_symlinks(_repo: Path, *, fix: bool):
+        fix_values.append(fix)
+        return False, "loop detected"
+
+    def check_primary(_repo: Path, *, fix: bool, tasks_dir: Path):
+        assert tasks_dir.name == "tasks"
+        fix_values.append(fix)
+        return False, "primary detached"
+
+    monkeypatch.setattr(symlink_check, "check_self_symlinks", check_symlinks)
+    monkeypatch.setattr(primary_check, "check_primary_integrity", check_primary)
+
+    assert api_main._self_symlink_canary() is False
+    assert api_main._primary_integrity_canary() is False
+    assert fix_values == [False, False]
+
+
 def test_orient_swallows_failing_subquery(monkeypatch):
     _patch_orient_sources(monkeypatch)
 

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -10,8 +10,10 @@ makes the guard load-bearing: it runs in the required ``Test (pytest)`` job.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -58,9 +60,62 @@ def test_legacy_table_parser_avoids_gnu_sed_anchor_escape() -> None:
     assert "\\`" not in parser_line
 
 
+def test_session_setup_reports_machine_repairs_without_applying_them(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q", str(project)], check=True, timeout=30)
+    subprocess.run(
+        ["git", "-C", str(project), "config", "--local", "core.bare", "true"],
+        check=True,
+        timeout=30,
+    )
+
+    pyenv_root = tmp_path / "pyenv"
+    lock = pyenv_root / "shims" / ".pyenv-shim"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("", encoding="utf-8")
+    old = time.time() - 180
+    lock.touch()
+    os.utime(lock, (old, old))
+
+    node_modules = project / "node_modules"
+    node_modules.symlink_to(node_modules)
+    env = os.environ.copy()
+    env.update(
+        {
+            "CLAUDE_PROJECT_DIR": str(project),
+            "CLAUDE_NON_INTERACTIVE": "1",
+            "PYENV_ROOT": str(pyenv_root),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(_REPO_ROOT / "agents_extensions/shared/hooks/session-setup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert lock.is_file(), "startup must not delete a heuristic-age pyenv lock"
+    assert node_modules.is_symlink(), "startup must not remove machine state"
+    core_bare = subprocess.run(
+        ["git", "-C", str(project), "config", "--get", "core.bare"],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    assert core_bare.stdout.strip() == "false", "core.bare is the bounded repair exception"
+    assert "inspect it" in result.stderr
+    assert "check_self_symlinks.py --fix" in result.stderr
+
+
 def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
     import json
-    import os
 
     # 1. Setup the project structure
     project_dir = tmp_path / "project"


### PR DESCRIPTION
## Summary

- stop SessionStart and post-checkout hooks from deleting lock/symlink state or switching, fetching, and pulling the primary checkout
- make Monitor health and delegate sweeps diagnostic-only while keeping write-capable dispatch fail-loud on primary drift
- retain only the bounded core.bare=false automatic repair and document explicit doctor commands

## Verification

- 51 focused startup, primary-integrity, launcher, and orient tests passed
- deployment sync/drift check, shellcheck, Ruff, markdown lint, and git diff checks passed

Part of #6108.

Rail-Approval-Receipt: rail-approval-23c36d1c4d7b46c3a61cc1fe76272b6a