### PR TITLE
fix(codex): route compact hydration through SessionStart

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -12,6 +12,18 @@
             "additionalContextLimit": 1200
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CODEX_COMPACT_SESSION_START=1 bash \"$(git rev-parse --show-toplevel)/.codex/hooks/post-compact.sh\"",
+            "timeout": 10,
+            "statusMessage": "Hydrating bound fleet-driver context",
+            "additionalContextLimit": 800
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -48,20 +60,6 @@
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" user-prompt-submit",
             "timeout": 5,
             "statusMessage": "Checking cross-agent inbox"
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "matcher": "manual|auto",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/post-compact.sh\"",
-            "timeout": 10,
-            "statusMessage": "Hydrating bound fleet-driver context",
-            "additionalContextLimit": 800
           }
         ]
       }

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Hook: PostCompact — fires after context compaction
-# Injects a concise context reminder so the agent doesn't lose track.
+# Hook: Claude invokes this as PostCompact after context compaction. Codex invokes
+# it from SessionStart(source=compact), because Codex PostCompact cannot emit
+# model-visible additionalContext. Inject a concise context reminder so the agent
+# doesn't lose track.
 
 # Skip in non-interactive mode
 if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
@@ -20,6 +22,16 @@ run_bounded() {
   "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
 }
 CONTEXT=""
+
+emit_context() {
+  local context="$1"
+  if [ "${CODEX_COMPACT_SESSION_START:-}" = "1" ]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}' \
+      "$(printf '%s' "$context" | jq -Rs '.')"
+  else
+    printf '{"additionalContext": %s}' "$(printf '%s' "$context" | jq -Rs '.')"
+  fi
+}
 
 # Ordinary Codex tasks use the runtime's native remote compaction and need no
 # repository-authored context replay. A launcher-bound fleet driver is the
@@ -59,7 +71,7 @@ ${HYDRATION:-Hydration helper unavailable.}
 Shadow diary: $DIARY_REL
 Do not select the next queue action until the stream lease or diary is repaired."
       fi
-      printf '{"additionalContext": %s}' "$(printf '%s' "$CONTEXT" | jq -Rs '.')"
+      emit_context "$CONTEXT"
       exit 0
     fi
     ;;
@@ -110,5 +122,5 @@ KEY REMINDERS:
   - Read audit/ and review/ files before fixing modules
   - MEMORY: ~/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian/memory/MEMORY.md"
 
-printf '{"additionalContext": %s}' "$(printf '%s' "CONTEXT RESTORED AFTER COMPACTION:$CONTEXT" | jq -Rs '.')"
+emit_context "CONTEXT RESTORED AFTER COMPACTION:$CONTEXT"
 exit 0

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -111,12 +111,18 @@ edit the separate user-level `~/.codex/hooks.json`.
 
 The project hook layer protects and augments **Codex CLI** sessions; native
 Codex still owns compaction. An ordinary Codex task receives a concise
-SessionStart capsule and has a silent `PostCompact`. Only a launcher-bound
-Codex epic may receive one bounded, exact-stream hydration capsule. That
-capsule requires `.claude/<epic>-epic/CODEX-DRIVER-HANDOFF.md`: the hook never
-substitutes `INTERIM-DRIVER-HANDOFF.md` or `CLAUDE-DRIVER-HANDOFF.md` into a
-Codex post-compaction response. A missing exact Codex handoff is a blocked
-capsule, not a generic replay.
+`SessionStart` capsule and remains silent after compaction. A launcher-bound
+Codex epic instead receives one bounded, exact-stream hydration capsule through
+the `SessionStart` `compact` matcher. That capsule requires
+`.claude/<epic>-epic/CODEX-DRIVER-HANDOFF.md`: the hook never substitutes
+`INTERIM-DRIVER-HANDOFF.md` or `CLAUDE-DRIVER-HANDOFF.md`. A missing exact
+Codex handoff is a blocked capsule, not a generic replay.
+
+Codex CLI 0.146 reports `ignoring additionalContextLimit for PostCompact hook
+... this event cannot emit additionalContext`. `PostCompact` may still run its
+command, but cannot deliver its stdout as model context. Do not use it for
+Codex hydration; keep the bounded launcher-bound capsule on `SessionStart`
+with matcher `compact`.
 
 The canonical checkout's `.venv/bin/python` must report exactly the version in
 the canonical `.python-version` file (currently `Python 3.12.8`). Linked
@@ -138,14 +144,17 @@ Codex Desktop is different: a recorded Desktop test showed hook commands and
 their UI labels run, but hook `additionalContext` was not delivered to the
 task. Do not use Desktop `SessionStart`, `PostCompact`, or inbox context output
 as continuity proof. Use a trusted dispatch worktree, native task context, and
-the durable launcher handoff/board for a bound driver. The CLI receives the
-same project hooks after trust; Desktop hook behavior remains manual and
-observational.
+the durable launcher handoff/board for a bound driver. The CLI can receive the
+bounded `SessionStart` `compact` capsule after trust; Desktop hook behavior
+remains manual and observational.
 
 After changing hook sources, run `npm run agents:deploy`, then re-trust the
 changed project hooks in the CLI/Desktop hook UI before testing. Verify a fresh
-CLI task, an ordinary PostCompact (silent), an exact Codex-driver hydration,
-and one repeated inbox prompt. The no-auth health check remains:
+CLI task, a `SessionStart` `compact` event for an exact Codex-driver hydration,
+an ordinary Codex compaction with no repository-authored context, and one
+repeated inbox prompt. Confirm that a CLI 0.146 startup no longer prints the
+`PostCompact` `additionalContextLimit` warning. The no-auth health check
+remains:
 
 ```bash
 .venv/bin/python -m scripts.orchestration.codex_transport_health status --json
@@ -177,8 +186,11 @@ audits were removed from the synchronous hook. The hook now points to
 a stop condition, but SessionStart renders the existing concise exact-identity
 inventory rather than injecting the full lease JSON.
 
-`PostCompact` remains read-only. Its curriculum scan and rollover-health read
-have separate two-second deadlines under the existing 10-second outer ceiling.
+`PostCompact` is not a Codex context-delivery boundary. The shared continuity
+script's underlying reads remain read-only and have separate two-second
+deadlines for the curriculum scan and rollover-health read under the existing
+10-second outer ceiling; Codex reaches that script through `SessionStart`
+`compact`.
 
 ## Pytest stamp and pre-push guard
 

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -274,6 +274,21 @@ def test_bound_codex_driver_hydrates_exact_stream_and_points_to_shadow_diary(
     assert ".claude/devops-epic/CODEX-DRIVER-HANDOFF.md" in context
     assert "continue only from the capsule's next_drive_boundary" in context
 
+    legacy = subprocess.run(
+        ["bash", os.fspath(compact_hook)],
+        input=json.dumps({"hook_event_name": "PostCompact", "model": "claude-sonnet-5"}),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert legacy.returncode == 0, legacy.stderr
+    legacy_output = json.loads(legacy.stdout)
+    assert "hookSpecificOutput" not in legacy_output
+    assert legacy_output["additionalContext"] == context
+
 
 def test_bound_codex_driver_without_exact_diary_is_blocked_without_fallback(
     tmp_path: Path,

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -122,16 +122,20 @@ def test_codex_project_config_leaves_root_model_user_selectable() -> None:
 
 def test_codex_compaction_has_one_bounded_hydration_path() -> None:
     hooks = _manifest()["hooks"]
-    session_group = hooks["SessionStart"][0]
-    compact_group = hooks["PostCompact"][0]
+    session_groups = hooks["SessionStart"]
+    session_group, compact_group = session_groups
 
     assert session_group["matcher"] == "startup|resume|clear"
     assert session_group["hooks"][0]["additionalContextLimit"] == 1200
-    assert compact_group["matcher"] == "manual|auto"
+    assert compact_group["matcher"] == "compact"
+    assert "CODEX_COMPACT_SESSION_START=1" in compact_group["hooks"][0]["command"]
+    assert 'post-compact.sh"' in compact_group["hooks"][0]["command"]
+    assert compact_group["hooks"][0]["timeout"] == 10
     assert compact_group["hooks"][0]["additionalContextLimit"] == 800
+    assert "PostCompact" not in hooks
 
 
-def test_ordinary_codex_start_is_concise_and_postcompact_is_silent(
+def test_ordinary_codex_start_is_concise_and_compact_session_start_is_silent(
     tmp_path: Path,
 ) -> None:
     deployed_hooks = tmp_path / ".codex" / "hooks"
@@ -178,17 +182,18 @@ def test_ordinary_codex_start_is_concise_and_postcompact_is_silent(
 
     compacted = subprocess.run(
         ["bash", os.fspath(compact_hook)],
+        input=json.dumps({"source": "compact", "model": "gpt-5.6-sol"}),
         text=True,
         capture_output=True,
         check=False,
-        env=environment,
+        env=environment | {"CODEX_COMPACT_SESSION_START": "1"},
         timeout=10,
     )
     assert compacted.returncode == 0, compacted.stderr
     assert compacted.stdout == ""
 
 
-def test_explicit_non_driver_codex_postcompact_is_silent(tmp_path: Path) -> None:
+def test_explicit_non_driver_codex_compact_session_start_is_silent(tmp_path: Path) -> None:
     compact_hook = tmp_path / ".codex" / "hooks" / "post-compact.sh"
     compact_hook.parent.mkdir(parents=True)
     shutil.copy2(POST_COMPACT_HOOK, compact_hook)
@@ -203,10 +208,11 @@ def test_explicit_non_driver_codex_postcompact_is_silent(tmp_path: Path) -> None
 
     completed = subprocess.run(
         ["bash", os.fspath(compact_hook)],
+        input=json.dumps({"source": "compact", "model": "gpt-5.6-sol"}),
         text=True,
         capture_output=True,
         check=False,
-        env=environment,
+        env=environment | {"CODEX_COMPACT_SESSION_START": "1"},
         timeout=10,
     )
 
@@ -251,15 +257,18 @@ def test_bound_codex_driver_hydrates_exact_stream_and_points_to_shadow_diary(
 
     compacted = subprocess.run(
         ["bash", os.fspath(compact_hook)],
+        input=json.dumps({"source": "compact", "model": "gpt-5.6-sol"}),
         text=True,
         capture_output=True,
         check=False,
-        env=environment,
+        env=environment | {"CODEX_COMPACT_SESSION_START": "1"},
         timeout=10,
     )
 
     assert compacted.returncode == 0, compacted.stderr
-    context = json.loads(compacted.stdout)["additionalContext"]
+    hook_output = json.loads(compacted.stdout)["hookSpecificOutput"]
+    assert hook_output["hookEventName"] == "SessionStart"
+    context = hook_output["additionalContext"]
     assert "CODEX FLEET-DRIVER HYDRATION" in context
     assert '"schema_name":"HydrationCapsuleV1"' in context
     assert ".claude/devops-epic/CODEX-DRIVER-HANDOFF.md" in context
@@ -287,15 +296,18 @@ def test_bound_codex_driver_without_exact_diary_is_blocked_without_fallback(
 
     completed = subprocess.run(
         ["bash", os.fspath(compact_hook)],
+        input=json.dumps({"source": "compact", "model": "gpt-5.6-sol"}),
         text=True,
         capture_output=True,
         check=False,
-        env=environment,
+        env=environment | {"CODEX_COMPACT_SESSION_START": "1"},
         timeout=10,
     )
 
     assert completed.returncode == 0, completed.stderr
-    context = json.loads(completed.stdout)["additionalContext"]
+    hook_output = json.loads(completed.stdout)["hookSpecificOutput"]
+    assert hook_output["hookEventName"] == "SessionStart"
+    context = hook_output["additionalContext"]
     assert "CODEX FLEET-DRIVER HYDRATION BLOCKED" in context
     assert "CODEX-DRIVER-HANDOFF.md" in context
     assert "CLAUDE-DRIVER-HANDOFF.md" not in context


### PR DESCRIPTION
## Summary

- remove the unsupported Codex `PostCompact` hook registration that causes `additionalContextLimit` warnings
- route compact-time fleet-driver hydration through `SessionStart` with matcher `compact`, the Codex event that supports `additionalContext`
- preserve the existing top-level `additionalContext` envelope for Claude's shared `PostCompact` consumer
- document deployment, re-trust, and TUI verification steps

## Design boundary

Ordinary Codex compaction remains runtime-owned and silent. Only launcher-bound epic driver sessions emit hydration context. Codex Desktop remains notification-only because it does not expose this context-delivery hook surface.

## Verification

- `34 passed`: Codex hook contract, extension deploy, and thread-restart lifecycle tests
- `19 passed`: focused Codex hook contract rerun after the review fix
- `bash scripts/audit/test_session_setup_hook.sh`
- `npm run agents:deploy` plus deployed-manifest equality and JSON inspection
- `jq empty`, `bash -n`, `shellcheck`, Ruff, markdownlint, `git diff --check`
- OPSEC audit and commit-trailer audit
- independent cross-family review: Claude Sonnet 5; follow-up verdict: no blocking findings

## Follow-up verification

After merge, deploy the primary checkout's generated hooks, re-trust the changed hook in TUI, restart TUI, and trigger a real compaction. Agents cannot mutate the primary checkout, and Codex resolves project hooks from that canonical checkout even when invoked from a linked worktree.

Fixes #6125

Rail-Approval-Receipt: rail-approval-3de4d3e38da2401da5c3a58ca9c3d9f7