### PR TITLE
fix(atlas): publish no-CEFR residual CEFR coverage

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,32 +1,32 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-3718247a2304.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-45e1b7bba8a3.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
   "manifest_fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-07-31T01:18:09+00:00",
-  "gz_sha256": "15b954c3c522ecc2311d6545477a1315e803acca900bf683e1a738c34791f0aa",
-  "json_sha256": "3718247a23045b67503d1b8486d0f2c02d888d97b644ff666e50f10c5f72898e",
-  "gz_bytes": 13822030,
-  "json_bytes": 99338809,
+  "generated_at": "2026-07-31T21:44:34Z",
+  "gz_sha256": "0755c37001be516c81777879f7d6219b77ff17f7d122ddb93b843ce1cedae952",
+  "json_sha256": "45e1b7bba8a37d235530bffe07bd8e8b1817d68490df036d56b28679769ffe7f",
+  "gz_bytes": 13866622,
+  "json_bytes": 99616768,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 672,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 43
+      "old_gate_no_english_anchor": 50
     },
     "candidate": {
-      "poc_thin_pages": 672,
+      "poc_thin_pages": 678,
       "search_no_visible_gloss": 43,
       "old_gate_no_english_anchor": 50
     },
     "regressions": {
-      "old_gate_no_english_anchor": {
-        "baseline": 43,
-        "candidate": 50
+      "poc_thin_pages": {
+        "baseline": 672,
+        "candidate": 678
       }
     },
-    "override_reason": "#6064 PULS residual work: the candidate is 43→50; the five affected PULS-backed teacher lemmas remain explicitly scoped for follow-up enrichment.",
+    "override_reason": "#6064 no_cefr residual complete: 37 teacher lemmas pipeline CEFR (GRAC estimate); POC-thin 672→678 (+6 listed thin heads with no available relations/etymology/wiki). Practice admit 612→649. missing_route still open (169).",
     "bootstrap": false
   },
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."


### PR DESCRIPTION
## Published Atlas pointer

Publishes the immutable Atlas manifest release asset and advances the tracked pointer for the #6064 no-CEFR residual slice.

| Residual | Before | Published result |
| --- | ---: | ---: |
| no_cefr | 37 | 0 |
| practice_admitted_rows | 612 | 649 |
| missing_route | 169 | 169 |

The 37 teacher lemmas received pipeline CEFR through estimated (GRAC frequency); no CEFR, gloss, or route was invented.

## Richness override

POC-thin changed from 672 to 678. The six thin heads are:

- млявий
- знахар
- безліч
- ерудиція
- порічка
- всіляко

Recorded pointer reason:

> #6064 no_cefr residual complete: 37 teacher lemmas pipeline CEFR (GRAC estimate); POC-thin 672→678 (+6 listed thin heads with no available relations/etymology/wiki). Practice admit 612→649. missing_route still open (169).

## Scope and verification

This PR does **not** claim #6064 is fully closed: missing_route=169 remains the next mandate.

- node site/scripts/hydrate-manifest.mjs
- scripts/atlas/residual_teacher_lists.py after hydration: no_cefr=0, practice_admitted_rows=649, missing_route=169
- pytest -q tests/test_publish_manifest.py tests/test_residual_teacher_lists.py tests/test_curated_seed_atlas_admission.py — 46 passed
- node site/scripts/verify-consumed-artifacts.mjs
- staged OPSEC and diff checks passed

Links #6064.