### PR TITLE
fix(monitor): expose GitHub CLI to launchd issue intake

### DIFF
--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -333,6 +333,7 @@ def status(*, home: Path) -> tuple[dict[str, object], int]:
                 and payload.get("Label") == LABEL
                 and payload.get("KeepAlive") == {"SuccessfulExit": False}
                 and payload.get("ThrottleInterval") == THROTTLE_INTERVAL_SECONDS
+                and payload.get("EnvironmentVariables") == {"PATH": _LAUNCHD_PATH}
             )
         except (OSError, ValueError, plistlib.InvalidFileException) as exc:
             parse_error = str(exc)

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -27,6 +27,7 @@ from scripts.api.release_snapshot import build_release, prune_releases
 LABEL = "com.learn-ukrainian.monitor-api"
 PORT = 8765
 THROTTLE_INTERVAL_SECONDS = 30
+_LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 _LOG_ROTATE_BYTES = 10 * 1024 * 1024
 _STOP_UNLOAD_TIMEOUT_SECONDS = 12.0
 _STOP_UNLOAD_POLL_SECONDS = 0.1
@@ -145,6 +146,7 @@ def build_plist(*, repo_root: Path) -> dict[str, object]:
         "KeepAlive": {"SuccessfulExit": False},
         # launchd applies this between restarts, preventing a crash-loop spin.
         "ThrottleInterval": THROTTLE_INTERVAL_SECONDS,
+        "EnvironmentVariables": {"PATH": _LAUNCHD_PATH},
         "StandardOutPath": str(_launchd_stdout_path(root)),
         "StandardErrorPath": str(_launchd_stderr_path(root)),
         "WorkingDirectory": str(root),

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -100,6 +100,32 @@ def test_install_and_uninstall_preserve_crash_evidence(tmp_path: Path, monkeypat
     assert evidence.exists()
 
 
+def test_status_rejects_plist_without_required_environment(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    destination = supervisor.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    legacy_payload = supervisor.build_plist(repo_root=repo)
+    legacy_payload.pop("EnvironmentVariables")
+    destination.write_bytes(plistlib.dumps(legacy_payload))
+    monkeypatch.setattr(
+        supervisor,
+        "_loaded_readback",
+        lambda: subprocess.CompletedProcess(["launchctl", "print"], 0, "", ""),
+    )
+
+    stale_status, stale_exit = supervisor.status(home=home)
+
+    assert stale_status["valid_plist"] is False
+    assert stale_exit == 1
+
+    destination.write_bytes(supervisor.render_plist(repo_root=repo))
+    current_status, current_exit = supervisor.status(home=home)
+
+    assert current_status["valid_plist"] is True
+    assert current_exit == 0
+
+
 def test_stop_disables_before_bootout(tmp_path: Path, monkeypatch) -> None:
     commands: list[list[str]] = []
 

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -21,6 +21,9 @@ def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> 
     assert payload["Label"] == supervisor.LABEL
     assert payload["KeepAlive"] == {"SuccessfulExit": False}
     assert payload["ThrottleInterval"] == supervisor.THROTTLE_INTERVAL_SECONDS
+    assert payload["EnvironmentVariables"] == {
+        "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    }
     assert payload["RunAtLoad"] is True
     assert payload["ProgramArguments"] == [
         str(repo / ".venv" / "bin" / "python"),


### PR DESCRIPTION
## Summary

- render an explicit launch-agent PATH containing Apple Silicon Homebrew, Intel Homebrew, and standard system directories
- prove the exact environment contract in the launchd supervisor test
- restore the prerequisite for Monitor issue intake to execute the installed gh CLI

## Root cause

The launchd Monitor process inherited PATH=/usr/bin:/bin:/usr/sbin:/sbin while gh is installed at /opt/homebrew/bin/gh. Full issue orientation failed, and detached issue-stream refreshes exited before updating the cache.

## Scope and rollout

This is the Sol-approved root environment fix from #6131. It leaves the separate refresh-state observability redesign out of scope.

Issue disposition: leaves #6131 open until an operator-authorized launchd reload proves full /api/orient issue collection and a fresh /api/issues/streams generation.

Refs #6131
Parent #4707

## Verification

- .venv/bin/python -m pytest tests/api/test_launchd_supervisor.py — 9 passed
- .venv/bin/ruff check scripts/api/launchd_supervisor.py tests/api/test_launchd_supervisor.py — passed
- git diff --check — passed
- staged OPSEC lint — zero leaks
- X-Agent trailer lint — passed
- env -i with the rendered PATH resolves gh

## Review and deployment

Independent cross-family review is required before auto-merge. The launchd agent will not be reloaded without explicit operator authorization.