### PR TITLE
feat(atlas): scale practice deck from sentence inventory

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: cc26744a80f4e30ad7a71ea20a691ad8a5e6bd25e32cf5467cec5a50f6563dcf
+  components_sha256: c711935a4f40da0df653a678efcd750d48eb1f2e36d3909d5802d6a29d8fe99d
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1253,8 +1253,9 @@ def _build_cloze_items(
             case_name, number = inventory_details
             # The inventory is a source-backed example asset.  It supplies no
             # authored grammar cue, so only a VESUM-unambiguous nominative
-            # form is eligible for the generic dictionary-form cloze.
-            if case_name != "nominative":
+            # singular form is eligible for the generic dictionary-form cloze.
+            # Nominative plurals are not dictionary forms for this rule.
+            if case_name != "nominative" or number != "singular":
                 continue
             rule_id = "nominative_identification"
         else:
@@ -1270,6 +1271,10 @@ def _build_cloze_items(
                 curated_form,
             )
         if number not in NUMBER_KEYS:
+            continue
+        if rule_id == "nominative_identification" and (
+            case_name != "nominative" or number != "singular"
+        ):
             continue
         form = curated_form or _case_form(lexeme["paradigm"], case_name, number)
         if not form or (not inventory_candidate and _plain(form) == lexeme["lemmaPlain"]):
@@ -3504,6 +3509,7 @@ def apply_size_budgets(
 ) -> None:
     for level, level_shards in shards.items():
         oversized_kinds: set[str] = set()
+        trimmed = False
         for kind, payload in level_shards.items():
             payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
             if not payload["sizeBudget"]["ok"]:
@@ -3518,6 +3524,7 @@ def apply_size_budgets(
             if not isinstance(index_items, list) or not index_items:
                 break
             removed = index_items.pop()
+            trimmed = True
             removed_lemma_id = removed.get("lemmaId") if isinstance(removed, dict) else None
             if not removed_lemma_id:
                 break
@@ -3578,11 +3585,12 @@ def apply_size_budgets(
                     payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
                     if not payload["sizeBudget"]["ok"]:
                         oversized_kinds.add(kind)
-        # Non-oversized shards were deliberately skipped in the trim loop:
-        # dropping lexemes cannot make them exceed a budget, but their final
-        # metadata must still describe the published payload.
-        for payload in level_shards.values():
-            payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
+        if trimmed:
+            # Non-oversized shards were deliberately skipped in the trim loop:
+            # dropping lexemes cannot make them exceed a budget, but their final
+            # metadata must still describe the published payload.
+            for payload in level_shards.values():
+                payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
 
 
 def write_shards(shards: dict[str, dict[str, dict[str, Any]]], out_dir: Path) -> list[Path]:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1236,10 +1236,12 @@ def _build_cloze_items(
         if not _cloze_candidate_ok_for_level(candidate, lexeme["cefr"]):
             continue
         curated_form = _clean_text(candidate.get("form"))
-        if not curated_form:
-            continue
         inventory_candidate = candidate.get("sourceType") == "sentence_inventory"
         if inventory_candidate:
+            # A sentence inventory row represents an attested source sentence;
+            # without its explicit target token, it cannot be safely blanked.
+            if not curated_form:
+                continue
             inventory_details = _inventory_form_details(
                 lexeme["lemmaPlain"],
                 lexeme.get("pos"),

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -128,6 +128,7 @@ CASE_RULES = {
         "trigger": "dictionary form",
         "triggerLabel": "словникова форма",
         "feedbackTemplate": "словникова форма ({lemma} -> {form})",
+        "sameFormFeedbackTemplate": "словникова (називний) форма: {form}",
     },
     "accusative_direct_object": {
         "case": "accusative",
@@ -255,6 +256,35 @@ def _build_tatoeba_attribution(provenance: Any) -> dict[str, Any] | None:
             "license": en_license,
         },
     }
+
+
+def _license_requires_displayable_attribution(provenance: Any) -> bool:
+    if not isinstance(provenance, dict):
+        return False
+    license_info = provenance.get("license")
+    if not isinstance(license_info, dict):
+        return False
+    status = _clean_text(license_info.get("status"))
+    use_basis = _clean_text(license_info.get("useBasis"))
+    return status in {"not_openly_licensed", "copyrighted_source"} and bool(
+        use_basis and "attribution" in use_basis.casefold()
+    )
+
+
+def _build_source_attribution(provenance: Any) -> dict[str, str] | None:
+    """Map inventory bibliographic metadata into the cloze UI credit shape."""
+    if not isinstance(provenance, dict):
+        return None
+    source = _clean_text(provenance.get("source"))
+    label = _clean_text(provenance.get("label"))
+    if not source or not label:
+        return None
+    attribution = {"source": source, "label": label}
+    for key in ("locator", "title"):
+        value = _clean_text(provenance.get(key))
+        if value:
+            attribution[key] = value
+    return attribution
 
 
 def _build_cloze_provenance(provenance: dict[str, Any]) -> dict[str, Any]:
@@ -768,13 +798,16 @@ def _case_rule_payload(rule_id: str, lemma: str, form: str) -> dict[str, str] | 
     rule = CASE_RULES.get(rule_id)
     if not rule:
         return None
+    feedback_template = str(rule["feedbackTemplate"])
+    if _plain(lemma) == _plain(form):
+        feedback_template = str(rule.get("sameFormFeedbackTemplate", feedback_template))
     return {
         "ruleId": rule_id,
         "case": str(rule["case"]),
         "caseLabel": CASE_LABELS_UA[str(rule["case"])],
         "trigger": str(rule["trigger"]),
         "triggerLabel": str(rule["triggerLabel"]),
-        "feedback": str(rule["feedbackTemplate"]).format(lemma=lemma, form=form),
+        "feedback": feedback_template.format(lemma=lemma, form=form),
     }
 
 
@@ -1261,6 +1294,12 @@ def _build_cloze_items(
         attribution = _build_tatoeba_attribution(provenance)
         if _is_tatoeba_provenance(provenance) and attribution is None:
             continue
+        if inventory_candidate:
+            inventory_attribution = _build_source_attribution(provenance)
+            if _license_requires_displayable_attribution(provenance) and inventory_attribution is None:
+                continue
+            if inventory_attribution is not None:
+                attribution = inventory_attribution
         item = {
             "clozeId": cloze_id,
             "lemmaId": lexeme["lemmaId"],

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -41,6 +41,7 @@ DEFAULT_ATLAS_DB = Path("data/atlas.db")
 DEFAULT_OUT_DIR = Path("site/public/lexicon")
 DEFAULT_ALLOWLIST = Path("site/src/data/lexicon-practice-reviewed-sources.json")
 DEFAULT_CLOZE_SOURCES = Path("site/src/data/lexicon-practice-cloze-sources.json")
+DEFAULT_SENTENCE_INVENTORY = Path("site/src/data/lexicon-sentence-inventory.json")
 DEFAULT_HERITAGE_PAIRS = Path("data/lexicon/heritage_pairs.yaml")
 DEFAULT_PARONYM_PAIRS = Path("data/lexicon/paronym_pairs.yaml")
 DEFAULT_SYNONYM_VERDICTS = Path("data/lexicon/synonym_pair_verdicts.yaml")
@@ -122,6 +123,12 @@ CASE_VESUM_TAGS = {
 }
 
 CASE_RULES = {
+    "nominative_identification": {
+        "case": "nominative",
+        "trigger": "dictionary form",
+        "triggerLabel": "словникова форма",
+        "feedbackTemplate": "словникова форма ({lemma} -> {form})",
+    },
     "accusative_direct_object": {
         "case": "accusative",
         "trigger": "direct-object",
@@ -261,7 +268,19 @@ def _build_cloze_provenance(provenance: dict[str, Any]) -> dict[str, Any]:
         sentence_id = _string_or_int(path_sentence_id)
         if sentence_id is not None:
             payload["sentenceId"] = sentence_id
-    for key in ("cardId", "license", "author", "sentenceId", "enSentenceId", "enAuthor", "enLicense"):
+    for key in (
+        "cardId",
+        "author",
+        "sentenceId",
+        "enSentenceId",
+        "enAuthor",
+        "enLicense",
+        "source",
+        "label",
+        "locator",
+        "title",
+        "useBasis",
+    ):
         if key in payload:
             continue
         value = provenance.get(key)
@@ -271,6 +290,13 @@ def _build_cloze_provenance(provenance: dict[str, Any]) -> dict[str, Any]:
         text = _clean_text(value)
         if text:
             payload[key] = text
+    license_info = provenance.get("license")
+    if isinstance(license_info, dict):
+        payload["license"] = license_info
+    else:
+        license_text = _clean_text(license_info)
+        if license_text:
+            payload["license"] = license_text
     return payload
 
 
@@ -761,6 +787,38 @@ def _cloze_candidate_ok_for_level(candidate: dict[str, Any], word_level: str) ->
     return CEFR_RANK[sentence_level] <= CEFR_RANK[word_level]
 
 
+def _inventory_form_details(
+    lemma_plain: str,
+    pos: str | None,
+    form: str,
+    verifier: VesumVerifier,
+) -> tuple[str, str] | None:
+    """Return the one VESUM-attested case and number for an inventory target.
+
+    Sentence-inventory rows deliberately preserve an attested surface form but
+    do not annotate morphology.  We only emit one when VESUM resolves that
+    exact form to one matching lemma and one case; no grammatical label is
+    inferred from sentence text.
+    """
+    matches = verifier.verify_words([form], _vesum_pos(pos)).get(form, [])
+    if len(matches) != 1:
+        return None
+    match = matches[0]
+    if _plain(str(match.get("lemma") or "")) != lemma_plain:
+        return None
+    cases = _match_cases(match)
+    if len(cases) != 1:
+        return None
+    tokens = set(str(match.get("tags") or "").replace(":", " ").split())
+    if "p" in tokens:
+        number = "plural"
+    elif {"m", "f", "n"} & tokens:
+        number = "singular"
+    else:
+        return None
+    return (next(iter(cases)), number)
+
+
 def _eligible_decoys(
     answer: dict[str, Any],
     lexemes: list[dict[str, Any]],
@@ -779,7 +837,9 @@ def _eligible_decoys(
         if _headword(lexeme["gloss"]) == answer_head:
             continue
         decoy_form = _case_form(lexeme.get("paradigm", {}), case_name, number)
-        if decoy_form and _plain(decoy_form) != _plain(lexeme["lemma"]):
+        if decoy_form and (
+            case_name == "nominative" or _plain(decoy_form) != _plain(lexeme["lemma"])
+        ):
             candidates.append((lexeme, decoy_form))
     return candidates
 
@@ -1134,24 +1194,44 @@ def _build_cloze_items(
         provenance = candidate.get("provenance")
         if not allowlist.allows(provenance):
             continue
-        case_name = _clean_text(candidate.get("blankCase"))
-        if not case_name or case_name not in CASE_LABELS_UA:
-            continue
-        rule_id = _candidate_rule_id(candidate, case_name)
-        if not rule_id:
-            continue
         if not _cloze_candidate_ok_for_level(candidate, lexeme["cefr"]):
             continue
         curated_form = _clean_text(candidate.get("form"))
-        number = _clean_text(candidate.get("number")) or _infer_number(
-            lexeme["paradigm"],
-            case_name,
-            curated_form,
-        )
+        if not curated_form:
+            continue
+        inventory_candidate = candidate.get("sourceType") == "sentence_inventory"
+        if inventory_candidate:
+            inventory_details = _inventory_form_details(
+                lexeme["lemmaPlain"],
+                lexeme.get("pos"),
+                curated_form,
+                verifier,
+            )
+            if inventory_details is None:
+                continue
+            case_name, number = inventory_details
+            # The inventory is a source-backed example asset.  It supplies no
+            # authored grammar cue, so only a VESUM-unambiguous nominative
+            # form is eligible for the generic dictionary-form cloze.
+            if case_name != "nominative":
+                continue
+            rule_id = "nominative_identification"
+        else:
+            case_name = _clean_text(candidate.get("blankCase"))
+            if not case_name or case_name not in CASE_LABELS_UA:
+                continue
+            rule_id = _candidate_rule_id(candidate, case_name)
+            if not rule_id:
+                continue
+            number = _clean_text(candidate.get("number")) or _infer_number(
+                lexeme["paradigm"],
+                case_name,
+                curated_form,
+            )
         if number not in NUMBER_KEYS:
             continue
         form = curated_form or _case_form(lexeme["paradigm"], case_name, number)
-        if not form or _plain(form) == lexeme["lemmaPlain"]:
+        if not form or (not inventory_candidate and _plain(form) == lexeme["lemmaPlain"]):
             continue
         if not _verify_discriminative_form(
             lexeme["lemmaPlain"],
@@ -1163,7 +1243,7 @@ def _build_cloze_items(
             continue
         sentence = _clean_text(candidate.get("sentence"))
         cloze_en = _clean_text(candidate.get("clozeEn")) or _clean_text(candidate.get("translation"))
-        if not sentence or "___" not in sentence or not cloze_en:
+        if not sentence or "___" not in sentence or (not inventory_candidate and not cloze_en):
             continue
         frame_key = "\x1f".join((deck_version, lexeme["lemmaId"], sentence, rule_id))
         sentence_frame_id = "sf_" + hashlib.sha1(frame_key.encode("utf-8")).hexdigest()[:12]
@@ -1185,11 +1265,12 @@ def _build_cloze_items(
             "number": number,
             "lemma": lexeme["lemma"],
             "caseRule": case_rule,
-            "clozeEn": cloze_en,
             "cefr": _clean_text(candidate.get("cefr")) or lexeme["cefr"],
             "acceptedAlt": _accepted_alts(candidate),
             "provenance": _build_cloze_provenance(provenance),
         }
+        if cloze_en:
+            item["clozeEn"] = cloze_en
         if attribution is not None:
             item["attribution"] = attribution
         items.append(item)
@@ -2528,6 +2609,7 @@ def _select_practice_lexemes(
     entries: list[dict[str, Any]],
     verifier: VesumVerifier,
     config: BuildConfig,
+    priority_lemma_keys: set[str] | None = None,
 ) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
     eligible = [entry for entry in entries if is_practice_eligible(entry)]
     # A practice seed is an explicit curriculum admission, not merely a source of
@@ -2545,9 +2627,19 @@ def _select_practice_lexemes(
     ]
     seed_entry_ids = {id(entry) for entry in seed_entries}
     non_seed_entries = [entry for entry in eligible if id(entry) not in seed_entry_ids]
-    course_entries = [entry for entry in non_seed_entries if _course_usage(entry)]
-    fill_entries = [entry for entry in non_seed_entries if not _course_usage(entry)]
+    priority_keys = priority_lemma_keys or set()
+    priority_entries = [
+        entry
+        for entry in non_seed_entries
+        if _stable_lemma_id(entry) in priority_keys
+        or (_clean_text(entry.get("lemma")) and _plain(str(entry["lemma"])) in priority_keys)
+    ]
+    priority_entry_ids = {id(entry) for entry in priority_entries}
+    remaining_entries = [entry for entry in non_seed_entries if id(entry) not in priority_entry_ids]
+    course_entries = [entry for entry in remaining_entries if _course_usage(entry)]
+    fill_entries = [entry for entry in remaining_entries if not _course_usage(entry)]
     seed_entries.sort(key=_stable_lemma_id)
+    priority_entries.sort(key=_stable_lemma_id)
     if config.seed_selection == "representative":
         seed_entries = _representative_seed_entries(seed_entries, config.target)
     course_entries.sort(key=_course_key)
@@ -2555,6 +2647,7 @@ def _select_practice_lexemes(
         key=lambda entry: (CEFR_RANK.get(_cefr_level(entry) or "", len(CEFR_RANK)), _stable_lemma_id(entry))
     )
     selected = list(seed_entries)
+    selected.extend(priority_entries)
     selected.extend(course_entries)
     if len(selected) < config.target:
         selected.extend(fill_entries[: config.target - len(selected)])
@@ -2571,6 +2664,41 @@ def _select_practice_lexemes(
     for lexeme in all_lexemes:
         by_plain_lemma.setdefault(_plain(lexeme["lemma"]), lexeme)
     return lexemes_by_entry, all_lexemes, by_plain_lemma, lexemes_by_id
+
+
+def _practice_priority_keys(
+    cloze_sources: list[dict[str, Any]],
+    heritage_pairs: list[dict[str, Any]] | None,
+    paronym_pairs: list[dict[str, Any]] | None,
+    synonym_verdicts: dict[str, Any] | None,
+) -> set[str]:
+    """Keep source-backed thin-mode legs ahead of ordinary fill lexemes.
+
+    The size budget removes tail lexemes.  Place every existing cloze or
+    approved pair leg before the general course/fill population so a full
+    rebuild does not silently cut the thin modes first.
+    """
+    keys: set[str] = set()
+
+    def add(value: Any) -> None:
+        text = _clean_text(value)
+        if text:
+            keys.add(text)
+            keys.add(_plain(text))
+
+    for row in cloze_sources:
+        add(row.get("lemmaId"))
+        add(row.get("lemma"))
+    for pair in heritage_pairs or []:
+        add(pair.get("nativeSlug"))
+    for pair in paronym_pairs or []:
+        add(pair.get("slugA"))
+        add(pair.get("slugB"))
+    for pair in (synonym_verdicts or {}).get("approved", []):
+        if isinstance(pair, dict):
+            add(pair.get("a"))
+            add(pair.get("b"))
+    return keys
 
 
 def build_practice_shards(
@@ -2621,10 +2749,18 @@ def build_practice_shards(
     )
     rng_seed = int(hashlib.sha256(inputs_fingerprint.encode("utf-8")).hexdigest()[:16], 16)
     rng = random.Random(rng_seed)
+    cloze_sources = cloze_sources or []
+    priority_lemma_keys = _practice_priority_keys(
+        cloze_sources,
+        heritage_pairs,
+        paronym_pairs,
+        synonym_verdicts,
+    )
     lexemes_by_entry, all_lexemes, by_plain_lemma, lexemes_by_id = _select_practice_lexemes(
         entries,
         verifier,
         config,
+        priority_lemma_keys,
     )
     # Paronym emit resolves adjudicated pair slugs against the selected pool
     # (main's _select_practice_lexemes refactor supplies the pool; this map is
@@ -2634,7 +2770,6 @@ def build_practice_shards(
         s = _clean_text(lexeme.get("url_slug")) or _clean_text(lexeme.get("slug")) or lexeme.get("lemmaId")
         if s:
             slug_to_lex[s] = lexeme
-    cloze_sources = cloze_sources or []
     cloze_by_lemma_id: dict[str, list[dict[str, Any]]] = {}
     cloze_by_lemma: dict[str, list[dict[str, Any]]] = {}
     for row in cloze_sources:
@@ -3115,6 +3250,70 @@ def read_cloze_sources(path: Path | None) -> list[dict[str, Any]]:
     return rows
 
 
+def read_sentence_inventory(path: Path | None) -> list[dict[str, Any]]:
+    """Normalize public sentence-inventory examples into cloze candidates.
+
+    The inventory remains the source of truth: we preserve its sentence,
+    target form, CEFR, source metadata, and license.  A candidate is formed
+    only by replacing one exact attested target token with the exercise slot;
+    morphology is checked later against VESUM in ``_build_cloze_items``.
+    """
+    if path is None or not path.exists():
+        print("WARN: no public sentence inventory found; inventory cloze is unavailable", file=sys.stderr)
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != "atlas-sentence-inventory":
+        raise ValueError("sentence inventory must use atlas-sentence-inventory schema")
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("sentence inventory rows must be a list")
+    try:
+        provenance_path = path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError:
+        provenance_path = str(path)
+
+    candidates: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            continue
+        uses = row.get("uses")
+        if not isinstance(uses, list) or "example" not in uses:
+            continue
+        lemma = _clean_text(row.get("lemma"))
+        lemma_id = _clean_text(row.get("lemmaId"))
+        sentence = _clean_text(row.get("sentence"))
+        target_form = _clean_text(row.get("targetForm"))
+        source_provenance = row.get("provenance")
+        license_info = row.get("license")
+        if not all((lemma, lemma_id, sentence, target_form)):
+            continue
+        if not isinstance(source_provenance, dict) or not isinstance(license_info, dict):
+            continue
+        pattern = re.compile(rf"(?<!\w){re.escape(target_form)}(?!\w)")
+        blanked_sentence, replacements = pattern.subn("___", sentence)
+        if replacements != 1:
+            continue
+        provenance = {
+            "status": "sentence_inventory",
+            "path": provenance_path,
+            **source_provenance,
+            "license": license_info,
+        }
+        candidates.append(
+            {
+                "clozeId": f"{lemma_id}:inventory:{index + 1}",
+                "lemma": lemma,
+                "lemmaId": lemma_id,
+                "sentence": blanked_sentence,
+                "form": target_form,
+                "cefr": _clean_text(row.get("cefr")),
+                "provenance": provenance,
+                "sourceType": "sentence_inventory",
+            }
+        )
+    return candidates
+
+
 def read_heritage_pairs(path: Path | None) -> list[dict[str, Any]]:
     if path is None or not path.exists():
         print("WARN: no curated heritage pairs found; emitting empty heritage deck", file=sys.stderr)
@@ -3256,16 +3455,16 @@ def apply_size_budgets(
     gzip_limit: int,
 ) -> None:
     for level, level_shards in shards.items():
+        oversized_kinds: set[str] = set()
+        for kind, payload in level_shards.items():
+            payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
+            if not payload["sizeBudget"]["ok"]:
+                oversized_kinds.add(kind)
         while True:
-            oversized: list[dict[str, Any]] = []
-            for payload in level_shards.values():
-                payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
-                if not payload["sizeBudget"]["ok"]:
-                    oversized.append(payload)
-            if not oversized:
+            if not oversized_kinds:
                 break
 
-            schemas = ", ".join(f"{payload['schema']}.{level}" for payload in oversized)
+            schemas = ", ".join(f"{level_shards[kind]['schema']}.{level}" for kind in sorted(oversized_kinds))
             print(f"WARN: {schemas} exceeds size budget; trimming {level} shard", file=sys.stderr)
             index_items = level_shards.get("index", {}).get("items", [])
             if not isinstance(index_items, list) or not index_items:
@@ -3325,6 +3524,17 @@ def apply_size_budgets(
                             if lexemes
                             else 0
                         )
+            oversized_kinds = set()
+            for kind, payload in level_shards.items():
+                if kind not in oversized_kinds and payload.get("sizeBudget", {}).get("ok") is False:
+                    payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
+                    if not payload["sizeBudget"]["ok"]:
+                        oversized_kinds.add(kind)
+        # Non-oversized shards were deliberately skipped in the trim loop:
+        # dropping lexemes cannot make them exceed a budget, but their final
+        # metadata must still describe the published payload.
+        for payload in level_shards.values():
+            payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
 
 
 def write_shards(shards: dict[str, dict[str, dict[str, Any]]], out_dir: Path) -> list[Path]:
@@ -3345,6 +3555,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--reviewed-allowlist", type=Path, default=DEFAULT_ALLOWLIST)
     parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
+    parser.add_argument("--sentence-inventory", type=Path, default=DEFAULT_SENTENCE_INVENTORY)
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
@@ -3405,7 +3616,7 @@ def main(argv: list[str] | None = None) -> int:
             read_practice_seed(args.local_practice_seed, allow_local_private=True),
         )
     allowlist = ReviewedSourceAllowlist.from_path(args.reviewed_allowlist)
-    cloze_sources = read_cloze_sources(args.cloze_sources)
+    cloze_sources = [*read_cloze_sources(args.cloze_sources), *read_sentence_inventory(args.sentence_inventory)]
     heritage_pairs = read_heritage_pairs(args.heritage_pairs)
     paronym_pairs = read_paronym_pairs(args.paronym_pairs)
     synonym_verdicts = read_synonym_verdicts(args.synonym_verdicts)

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3574,7 +3574,7 @@ def apply_size_budgets(
                         )
             oversized_kinds = set()
             for kind, payload in level_shards.items():
-                if kind not in oversized_kinds and payload.get("sizeBudget", {}).get("ok") is False:
+                if payload.get("sizeBudget", {}).get("ok") is False:
                     payload["sizeBudget"] = _size_budget(payload, raw_limit, gzip_limit)
                     if not payload["sizeBudget"]["ok"]:
                         oversized_kinds.add(kind)

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -979,13 +979,19 @@ def _make_options(
     lexemes: list[dict[str, Any]],
     rng: random.Random,
 ) -> list[dict[str, str]]:
-    strategy = _option_strategy_for_level(answer["cefr"], rng)
+    # A nominative-identification cloze has the lemma itself as its answer.
+    # A two-pair set would therefore repeat that label as the same-root lemma
+    # distractor.  Use four distinct roots instead of constructing an invalid
+    # option set that validation must discard.
+    rule_id = cloze.get("caseRule", {}).get("ruleId") if isinstance(cloze.get("caseRule"), dict) else None
+    force_no_pair = rule_id == "nominative_identification"
+    strategy = "no-pair" if force_no_pair else _option_strategy_for_level(answer["cefr"], rng)
     options = (
         _make_no_pair_options(cloze, answer, lexemes, rng)
         if strategy == "no-pair"
         else _make_two_pair_options(cloze, answer, lexemes, rng)
     )
-    if not options:
+    if not options and not force_no_pair:
         strategy = "two-pair"
         options = _make_two_pair_options(cloze, answer, lexemes, rng)
     for option in options:
@@ -3293,10 +3299,11 @@ def read_sentence_inventory(path: Path | None) -> list[dict[str, Any]]:
         blanked_sentence, replacements = pattern.subn("___", sentence)
         if replacements != 1:
             continue
+        source_fields = {key: value for key, value in source_provenance.items() if key not in {"status", "path"}}
         provenance = {
             "status": "sentence_inventory",
             "path": provenance_path,
-            **source_provenance,
+            **source_fields,
             "license": license_info,
         }
         candidates.append(

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -27,6 +27,7 @@ DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.pointe
 DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.json.gz"
 DEFAULT_ATLAS_DB = ROOT / "data" / "atlas.db"
 DEFAULT_CLOZE_SOURCES = ROOT / "site" / "src" / "data" / "lexicon-practice-cloze-sources.json"
+DEFAULT_SENTENCE_INVENTORY = ROOT / "site" / "src" / "data" / "lexicon-sentence-inventory.json"
 DEFAULT_HERITAGE_PAIRS = ROOT / "data" / "lexicon" / "heritage_pairs.yaml"
 DEFAULT_PARONYM_PAIRS = ROOT / "data" / "lexicon" / "paronym_pairs.yaml"
 DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
@@ -70,6 +71,7 @@ def expected_deck_version(
     paronym_pairs_path: Path | None = DEFAULT_PARONYM_PAIRS,
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
+    sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
 ) -> str:
     if not atlas_db_path.exists():
         raise PracticeDeckPublishError(
@@ -83,6 +85,7 @@ def expected_deck_version(
             read_cloze_sources,
             read_heritage_pairs,
             read_paronym_pairs,
+            read_sentence_inventory,
             read_synonym_verdicts,
         )
         from scripts.practice_deck.io import compute_deck_version
@@ -91,7 +94,10 @@ def expected_deck_version(
         heritage_pairs = read_heritage_pairs(heritage_pairs_path)
         paronym_pairs = read_paronym_pairs(paronym_pairs_path)
         synonym_verdicts = read_synonym_verdicts(synonym_verdicts_path)
-        cloze_sources = read_cloze_sources(cloze_sources_path)
+        cloze_sources = [
+            *read_cloze_sources(cloze_sources_path),
+            *read_sentence_inventory(sentence_inventory_path),
+        ]
         return compute_deck_version(
             entries,
             heritage_pairs,
@@ -349,6 +355,7 @@ def publish_practice_deck(
     paronym_pairs_path: Path | None = DEFAULT_PARONYM_PAIRS,
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
+    sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
@@ -360,6 +367,7 @@ def publish_practice_deck(
         paronym_pairs_path=paronym_pairs_path,
         synonym_verdicts_path=synonym_verdicts_path,
         cloze_sources_path=cloze_sources_path,
+        sentence_inventory_path=sentence_inventory_path,
     )
     if deck_version != expected_version:
         raise PracticeDeckPublishError(
@@ -393,6 +401,7 @@ def main() -> int:
     parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
     parser.add_argument("--atlas-db", type=Path, default=DEFAULT_ATLAS_DB)
     parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
+    parser.add_argument("--sentence-inventory", type=Path, default=DEFAULT_SENTENCE_INVENTORY)
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
@@ -409,6 +418,7 @@ def main() -> int:
         paronym_pairs_path=args.paronym_pairs,
         synonym_verdicts_path=args.synonym_verdicts,
         cloze_sources_path=args.cloze_sources,
+        sentence_inventory_path=args.sentence_inventory,
         release_tag=args.release_tag,
         repo=args.repo,
         dry_run=args.dry_run,

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -4366,7 +4366,7 @@ function PracticeCloze({
         </p>
       ) : cloze.attribution ? (
         <p className="lexicon-cloze-attribution" data-testid="practice-cloze-source-attribution">
-          Джерело: {cloze.attribution.label} ({cloze.attribution.source})
+          <PracticeChromeLabel k="practice.sourcePrefix" /> {cloze.attribution.label} ({cloze.attribution.source})
           {cloze.attribution.title ? ` — ${cloze.attribution.title}` : ''}
           {cloze.attribution.locator ? `, ${cloze.attribution.locator}` : ''}
         </p>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -4348,7 +4348,7 @@ function PracticeCloze({
           {sentenceEnglish}
         </p>
       ) : null}
-      {cloze.attribution ? (
+      {cloze.attribution && 'uk' in cloze.attribution ? (
         <p className="lexicon-cloze-attribution">
           <PracticeChromeLabel k="practice.sentenceWith" />{' '}
           {cloze.attribution.sourceUrl ? (
@@ -4363,6 +4363,12 @@ function PracticeCloze({
               / {cloze.attribution.en.author} ({cloze.attribution.en.license})
             </>
           ) : null}
+        </p>
+      ) : cloze.attribution ? (
+        <p className="lexicon-cloze-attribution" data-testid="practice-cloze-source-attribution">
+          Джерело: {cloze.attribution.label} ({cloze.attribution.source})
+          {cloze.attribution.title ? ` — ${cloze.attribution.title}` : ''}
+          {cloze.attribution.locator ? `, ${cloze.attribution.locator}` : ''}
         </p>
       ) : null}
       <form

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-fa1f37b28c7aa8cd.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-2b27aea6faa8d7c1.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-fa1f37b28c7aa8cd",
+  "deck_version": "atlas-practice-v1-2b27aea6faa8d7c1",
   "package_schema_version": 1,
-  "gz_sha256": "378e94e46dc2ddf373c37566f7af99d624b255b4f8f72080d472b2c69e2cd150",
-  "package_sha256": "17e94debe0cabf4bbeabc2569a77e21a1752a51506e76eda444e78535e8909c6",
-  "gz_bytes": 618842,
-  "package_bytes": 14431270,
+  "gz_sha256": "bdd1d04b83aec6bf407b49bb4f2d737304f1e192b7232b54db54288e9235c392",
+  "package_sha256": "cc5cd555bea7382605892d2bb0d687c7d002e78dba0925e7176583313ff6cc1a",
+  "gz_bytes": 806014,
+  "package_bytes": 19432520,
   "file_count": 45,
   "files": [
     {
@@ -14,13 +14,13 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 318943,
-      "sha256": "3bca7eda6b9eae935b64dab0f8fbaac3fdeb0d62386e5c9110d23d0d68590e91",
+      "bytes": 410252,
+      "sha256": "083b55cd5e2d93fe14c5b3b0debca3c3dfa7deceac9f35ddc5a6b5d4287eb5bd",
       "counts": {
-        "lexemes": 1150,
-        "cloze": 22,
-        "clozeEligibleLexemes": 22,
-        "clozeCoverage": 0.0191
+        "lexemes": 1470,
+        "cloze": 59,
+        "clozeEligibleLexemes": 59,
+        "clozeCoverage": 0.0401
       }
     },
     {
@@ -28,40 +28,40 @@
       "kind": "lexemes",
       "level": "A1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 562939,
-      "sha256": "71e63510050ac7b8f59c612e6491a05bccbf64e6632fb10d5b108d43320127d0"
+      "bytes": 794881,
+      "sha256": "de09c00d733ef7c4f2459fe8183a11a78f32581e0ccbc639caf63a7f54a6787c"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 44822,
-      "sha256": "d09107c1f4a10f7279420b2b1df59c74238b4d41ebf569cddd10663b9456ebee"
+      "bytes": 123114,
+      "sha256": "65a8e0843118f2191b27748e72da1bbaa701b029cf7caf440379884b703e3545"
     },
     {
       "path": "practice-stress.A1.json",
       "kind": "stress",
       "level": "A1",
       "schema": "atlas-practice-stress",
-      "bytes": 382927,
-      "sha256": "b989848a8984772015d032abf0bf9c9f62fb0071e717a572be35623bb08eb7ee"
+      "bytes": 601557,
+      "sha256": "059b434c55cec8a6274c8cfa5d6419d08676819c7ee94f823c91112f84a80a7b"
     },
     {
       "path": "practice-classify.A1.json",
       "kind": "classify",
       "level": "A1",
       "schema": "atlas-practice-classify",
-      "bytes": 437057,
-      "sha256": "b8c65819663320b6417372756a56ec695d45d118d26844705f1c7d5051fd72a7"
+      "bytes": 658624,
+      "sha256": "2428f684dbee532e7806af42a98df8b8b7655d3bc71494eca96344e064642e7e"
     },
     {
       "path": "practice-paradigm.A1.json",
       "kind": "paradigm",
       "level": "A1",
       "schema": "atlas-practice-paradigm",
-      "bytes": 533851,
-      "sha256": "8f389e7731315c348c6a05f5027a89286440d7399b56c6a7b82683dce43fc11c"
+      "bytes": 988873,
+      "sha256": "d6f582eb21f633b8748f2b63d5c6019dfd7a54d7d39372d6dbd80e53e0dbb294"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 317,
-      "sha256": "35c8ecb21cd4c308f7c2a3fac0f3bc2194d256a3a6edc3626aaf540ef491af45"
+      "sha256": "fa2d7ce52d7d49c94bf7720e931070e4bca750a3ef0c5ae3f9c8b4b497754200"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 319,
-      "sha256": "0071e39e7e0722d3e6bb38163a1d5c8e4aed3a0fe9c53a3b0c468bae0af38945"
+      "sha256": "045a9f33d97bb5d7e4dea4718f7f4e3b05270b7b94233d39189f84cd73d1e167"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,20 +85,20 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 4389,
-      "sha256": "2593ac37f3a165d935e3d960a0f6c771568e1546dc92dc15df8f59dc14ea5f61"
+      "sha256": "7bc27b57ed17aba2eac28fe5e6217ed4990d48cc18fcd220299a83b6d27c9be4"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 282036,
-      "sha256": "e172076bf73cb8c9835188e4a20d017da95c064eaa48c42d1ed1f12e11436852",
+      "bytes": 346443,
+      "sha256": "98a7346baa7a345242e7c39e298b8660872bada309272a58a3eab457dcba7a5b",
       "counts": {
-        "lexemes": 967,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
+        "lexemes": 1195,
+        "cloze": 7,
+        "clozeEligibleLexemes": 7,
+        "clozeCoverage": 0.0059
       }
     },
     {
@@ -106,56 +106,56 @@
       "kind": "lexemes",
       "level": "A2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 474613,
-      "sha256": "bccaa62629d7f962da3a36a630de70b6529ae35236ab9178d52a462fc59cf2ba"
+      "bytes": 634356,
+      "sha256": "711483aa2d6e74a9b761ffb6d8bfc7d7ba4def78c5cd06a5329ac0f73dadfd88"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
-      "sha256": "e63838c10b919c3809dbd8d3bc1d7ba63ee993e69417de2052e00bae844e7f37"
+      "bytes": 16934,
+      "sha256": "711ae27755462da424ee4e10e8742c9ac120d31bdf1cfba16017f10f0ac5b8b2"
     },
     {
       "path": "practice-stress.A2.json",
       "kind": "stress",
       "level": "A2",
       "schema": "atlas-practice-stress",
-      "bytes": 395787,
-      "sha256": "5c9fd430e49166fa18751da6294a807bcf77731aeb9da76b30d6cc1d730b83ad"
+      "bytes": 547174,
+      "sha256": "20e0505bbe328aac57581a16d08e2dea0069fac3483312a29b72b67d838c29c1"
     },
     {
       "path": "practice-classify.A2.json",
       "kind": "classify",
       "level": "A2",
       "schema": "atlas-practice-classify",
-      "bytes": 1121136,
-      "sha256": "5dc7b06fb224fca010c3a27a79388037b9ed7ecec07b0560d64d57992945d5fa"
+      "bytes": 1599353,
+      "sha256": "0d9bc2f8cf18e3bd44a85a068400cf6e3a86b553b7796a3ae8fe2925c1516787"
     },
     {
       "path": "practice-paradigm.A2.json",
       "kind": "paradigm",
       "level": "A2",
       "schema": "atlas-practice-paradigm",
-      "bytes": 420424,
-      "sha256": "01688fd9a43f940676aad1078fd115ab8cd2dbd0eb0786d899fbb1168d199122"
+      "bytes": 710539,
+      "sha256": "0d3de5b84c94a603124d868204dc4fd586034cfae3705cd7f1058812c7ebac46"
     },
     {
       "path": "practice-synonym.A2.json",
       "kind": "synonym",
       "level": "A2",
       "schema": "atlas-practice-synonym",
-      "bytes": 5082,
-      "sha256": "646cb6785da11768ca6287ee79a42c6ff30408d8146aa110d6bee687fec31fd2"
+      "bytes": 8155,
+      "sha256": "498075798422da74e35511d14eb4d9ecf8ab11e60f372caf047c3d8306458bfd"
     },
     {
       "path": "practice-heritage.A2.json",
       "kind": "heritage",
       "level": "A2",
       "schema": "atlas-practice-heritage",
-      "bytes": 46068,
-      "sha256": "d521350fd3cb4f6794857a7cb95eb8c9db1d8fd157097f6cefbf5d5b56891a69"
+      "bytes": 46070,
+      "sha256": "45dd4738714d52dc30c8a8756203862af39c0b10a3a68435850fcdff8ba2c051"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,20 +163,20 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 4352,
-      "sha256": "40d9f64ec26be04dda8a18d39fbd09556d43bf2d7e7e41640171433c642700cb"
+      "sha256": "27f2158de020054403120ffe62d4848070b6d63ba3a46645f6f74da308cdbe31"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 433748,
-      "sha256": "bbd9d7ad72e144c1b8280c01e8452c2295e84ede44d44451c16bc302be493665",
+      "bytes": 301736,
+      "sha256": "ce20e525510e05765daf7bfcc58b6a8c3838a6321941495cc29746171cc0f598",
       "counts": {
-        "lexemes": 1485,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
+        "lexemes": 1031,
+        "cloze": 4,
+        "clozeEligibleLexemes": 4,
+        "clozeCoverage": 0.0039
       }
     },
     {
@@ -184,74 +184,74 @@
       "kind": "lexemes",
       "level": "B1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 748382,
-      "sha256": "889f8c144c68ce974506725d90210efccaefdcfece4c745675075bda8be83f28"
+      "bytes": 573561,
+      "sha256": "9c8617d72c60a9a020afae5e89dd21592bf5497c2bfa2d976964b72c96a8b308"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
-      "sha256": "b52e6b0276cf747c8f17f737473b4e7505bfe24f4f4d7a255368f26c598a516f"
+      "bytes": 10068,
+      "sha256": "e05e4b464fbfdd57afe8eb5bcf4f7c82cf17a68dfe808d2e81d11ed5db8e7cc2"
     },
     {
       "path": "practice-stress.B1.json",
       "kind": "stress",
       "level": "B1",
       "schema": "atlas-practice-stress",
-      "bytes": 447184,
-      "sha256": "acd020331eea84ec0a8a0a127b832b8e6189ad82fffda1bb96d7f30c39843fce"
+      "bytes": 486450,
+      "sha256": "abf6daf15b042f7175245ec1fc9b00dcac159edb0a8061e423debb1a62033f9a"
     },
     {
       "path": "practice-classify.B1.json",
       "kind": "classify",
       "level": "B1",
       "schema": "atlas-practice-classify",
-      "bytes": 1449662,
-      "sha256": "8eabbd89d6aa5db75f2695646e6a5fe7c2702df4bc1743c7019b28c96859ae40"
+      "bytes": 1599664,
+      "sha256": "6317018aab5095467e4f0a88b56cb4393eb331b7b3c12c25a9c0de624269e16a"
     },
     {
       "path": "practice-paradigm.B1.json",
       "kind": "paradigm",
       "level": "B1",
       "schema": "atlas-practice-paradigm",
-      "bytes": 583013,
-      "sha256": "8cb000c6e35cd7289a4b7a1e32256ed6f078851d138b3f905b55aae7c02ae23e"
+      "bytes": 738393,
+      "sha256": "1510f3ca39bd2c281ee5fe9fb4aae18550647e6862cab59a6b9f9b6b984f23a4"
     },
     {
       "path": "practice-synonym.B1.json",
       "kind": "synonym",
       "level": "B1",
       "schema": "atlas-practice-synonym",
-      "bytes": 112522,
-      "sha256": "02855e837ece1089565605fccbd521a3d4f4546fd5b302b34fbce095c88bd3a7"
+      "bytes": 153232,
+      "sha256": "56e044de79c579e35737d3213358db2a7ca4f18b7f4844d8cc017ddbe9611052"
     },
     {
       "path": "practice-heritage.B1.json",
       "kind": "heritage",
       "level": "B1",
       "schema": "atlas-practice-heritage",
-      "bytes": 101345,
-      "sha256": "4f98b6f36be1be890e577bcc19814b3d4904160da04ffda9e55bd226cc86b8fb"
+      "bytes": 101328,
+      "sha256": "6dcffff18e8c833f8eba2c48f4288ee4f2d5a105383f33594b30d83de7439a80"
     },
     {
       "path": "practice-paronym.B1.json",
       "kind": "paronym",
       "level": "B1",
       "schema": "atlas-practice-paronym",
-      "bytes": 2223,
-      "sha256": "9ec27c67912e0fca4e7fa13b765db4e4292679044f9f42e0fcd0c1f2165fa751"
+      "bytes": 3184,
+      "sha256": "06231b21771082c48b3bf4667a12190989561b753e4772d87e8c4123f31184d0"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 254117,
-      "sha256": "dde76d0b0fae6e2e06a5e23b1be1a85f4b477cf626f113f772a337cd1b5b7b47",
+      "bytes": 277373,
+      "sha256": "18a427abfe9ad4f256b0f02c615f234f84879bf4824692ac415a138fcd1379b5",
       "counts": {
-        "lexemes": 853,
+        "lexemes": 940,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -262,8 +262,8 @@
       "kind": "lexemes",
       "level": "B2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 443931,
-      "sha256": "0e6e5011647eb92edfb56549c4171b6cbadd6db29c1cd0d88c9d07dab68b6547"
+      "bytes": 558711,
+      "sha256": "7b386c82895f0864029b9b28567ab5fbeec90f8d6560ae729b5432395731d512"
     },
     {
       "path": "practice-cloze.B2.json",
@@ -271,65 +271,65 @@
       "level": "B2",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "a6198ebda0ce13f4b6ce19c1656367ff3fb25627ab657ab84f521d91467e0f26"
+      "sha256": "5c76f45c34572e80f796b3c193ea3057bd55175831a1d044b85d62a59e1e59a8"
     },
     {
       "path": "practice-stress.B2.json",
       "kind": "stress",
       "level": "B2",
       "schema": "atlas-practice-stress",
-      "bytes": 301091,
-      "sha256": "ce0346ab68d20d0bfdfc948821bdffabdb9ac5a2c058c8fa208b9fc92eac22ed"
+      "bytes": 487216,
+      "sha256": "16ccaeb029ef727dfa0de729e06f8992e15d9a6aaea9b24c51e510e45647c182"
     },
     {
       "path": "practice-classify.B2.json",
       "kind": "classify",
       "level": "B2",
       "schema": "atlas-practice-classify",
-      "bytes": 901024,
-      "sha256": "8f7d39b33194cd2e352591ccf3c897274258b97defa45981c964087d4c478cc8"
+      "bytes": 1510824,
+      "sha256": "201ee2bcf509c788157089f58127dbf0d122f5c60bd4439c3f06f4af6f37cd82"
     },
     {
       "path": "practice-paradigm.B2.json",
       "kind": "paradigm",
       "level": "B2",
       "schema": "atlas-practice-paradigm",
-      "bytes": 400063,
-      "sha256": "f618911359a6475acf23da2fe183f3daa5caba0b9e256dd3029c6dd47a1d469d"
+      "bytes": 803166,
+      "sha256": "eb8df756e24ca4999fb8ff14ac3309c413f9601b4e4184e3e479ad051240c16c"
     },
     {
       "path": "practice-synonym.B2.json",
       "kind": "synonym",
       "level": "B2",
       "schema": "atlas-practice-synonym",
-      "bytes": 40785,
-      "sha256": "5d0aa8a58ab627b2c2bc953e1479517386f61982a57514796dd8a4ea6f147e9b"
+      "bytes": 64856,
+      "sha256": "3ae0b011c25fe2c68d48c5d1f9e0acbc1141606c86ec8a911b32df7dc5ec31d9"
     },
     {
       "path": "practice-heritage.B2.json",
       "kind": "heritage",
       "level": "B2",
       "schema": "atlas-practice-heritage",
-      "bytes": 20155,
-      "sha256": "b66db20acb1c233baa28bb31050035c16f5a014e74a92f1168ee40633622add8"
+      "bytes": 15123,
+      "sha256": "8e382642bbcba4a3d8027fc8495a88bc2a53c0b32db94140c71370a783551742"
     },
     {
       "path": "practice-paronym.B2.json",
       "kind": "paronym",
       "level": "B2",
       "schema": "atlas-practice-paronym",
-      "bytes": 2137,
-      "sha256": "06b309191d412dce1b9c3afb8bed24fad5b4d11c23af1a6fa87c74dcf41da8c8"
+      "bytes": 2181,
+      "sha256": "53d3d4d3e1d9f0d1e97067e05d1783384eb9ba8039feaafab8cacbc0a4aca676"
     },
     {
       "path": "practice-index.C1.json",
       "kind": "index",
       "level": "C1",
       "schema": "atlas-practice-index",
-      "bytes": 121869,
-      "sha256": "20107f01a6c762c0a4482c6a79f6ebc9499cc3e660156eac309da076c558481f",
+      "bytes": 159085,
+      "sha256": "889eb076f129a1bee22c9b70b532db83837de4c25bc04f98c60c1739199b5ce4",
       "counts": {
-        "lexemes": 403,
+        "lexemes": 529,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -340,8 +340,8 @@
       "kind": "lexemes",
       "level": "C1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 229361,
-      "sha256": "2bab0bfc294fa40c20324ca2c3f492668dd538115b03f918f1272b1324bbf4b4"
+      "bytes": 314140,
+      "sha256": "1700f0ddaed3293ebfd73f63401226142afaee59fea36e2cd31a380d5d48c354"
     },
     {
       "path": "practice-cloze.C1.json",
@@ -349,55 +349,55 @@
       "level": "C1",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "577e31a109511a1f4029851e867e5285bed6f5bbefe29488605e5f947b1dcb1c"
+      "sha256": "73223b973c265f29f3070f074a25a1f2453e3f85fb66b471bb9d2d6853123836"
     },
     {
       "path": "practice-stress.C1.json",
       "kind": "stress",
       "level": "C1",
       "schema": "atlas-practice-stress",
-      "bytes": 200434,
-      "sha256": "690e1d5616d14ca6c46b3d9c539a44c7ee54dabf515ae1105e06900e041f1796"
+      "bytes": 268630,
+      "sha256": "a7bfb93e913e341e07fe56384d33da01ffe13258407ed5f32bdb636a818c298b"
     },
     {
       "path": "practice-classify.C1.json",
       "kind": "classify",
       "level": "C1",
       "schema": "atlas-practice-classify",
-      "bytes": 585487,
-      "sha256": "4aa79f3d4e84591f9335851fc69370104622540fd30975f40aaf238e0c2ccb12"
+      "bytes": 784587,
+      "sha256": "f0c8177ba496ffb50bb310f31b8e12135c0a43f6b5851c7190e2da55110136f3"
     },
     {
       "path": "practice-paradigm.C1.json",
       "kind": "paradigm",
       "level": "C1",
       "schema": "atlas-practice-paradigm",
-      "bytes": 342080,
-      "sha256": "8e4e8a93e5d646caf7eba7afe46e0d863eac7f61dc7d4cd6b7c400031ed49a34"
+      "bytes": 475142,
+      "sha256": "d2576306094a5d9467dca73a1355310c760e34e669e6ea25ab5c7224ffea3b13"
     },
     {
       "path": "practice-synonym.C1.json",
       "kind": "synonym",
       "level": "C1",
       "schema": "atlas-practice-synonym",
-      "bytes": 16896,
-      "sha256": "e60b23bf2d5ad8e6533832ea048f8569bec3cccf0559828637c374582d22b59c"
+      "bytes": 28424,
+      "sha256": "a0429b53a63aabb8bf0d34a24ead99bfdc5e9620ea5b72e63faf0620aaae78c9"
     },
     {
       "path": "practice-heritage.C1.json",
       "kind": "heritage",
       "level": "C1",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
-      "sha256": "856b156cf04216feb479cd5b1829f0fb8c41d1496f9e3b3cad1345edbcaa807b"
+      "bytes": 2751,
+      "sha256": "8063bbad7cea8a669ff6f126e4fac85c46d1f3a67fa3dc0578179edffb34a29e"
     },
     {
       "path": "practice-paronym.C1.json",
       "kind": "paronym",
       "level": "C1",
       "schema": "atlas-practice-paronym",
-      "bytes": 2164,
-      "sha256": "5441d776a721c6887dd231cd460b0fec6aa99932fe1833a261a5a2f0d6960b36"
+      "bytes": 3040,
+      "sha256": "a87ee37ce82eb7531f5d4fe711a45fd6e57ff580ee5df51a67af39f20860e3b5"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/site/src/data/lexicon-practice-reviewed-sources.json
+++ b/site/src/data/lexicon-practice-reviewed-sources.json
@@ -1,6 +1,10 @@
 {
   "reviewed": [
     {
+      "status": "sentence_inventory",
+      "path": "site/src/data/lexicon-sentence-inventory.json"
+    },
+    {
       "status": "reviewed",
       "path": "curriculum/l2-uk-en/a1/a1-finale/vocabulary.yaml"
     },

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -140,12 +140,22 @@ export interface PracticeClozeAttributionSentence {
   license: string;
 }
 
-export interface PracticeClozeAttribution {
+export interface PracticeClozeTatoebaAttribution {
   source: string;
   sourceUrl?: string;
   uk: PracticeClozeAttributionSentence;
   en: PracticeClozeAttributionSentence;
 }
+
+/** A visible bibliographic credit for a licensed inventory sentence. */
+export interface PracticeClozeSourceAttribution {
+  source: string;
+  label: string;
+  locator?: string;
+  title?: string;
+}
+
+export type PracticeClozeAttribution = PracticeClozeTatoebaAttribution | PracticeClozeSourceAttribution;
 
 export interface PracticeClozeItem {
   clozeId: string;

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -157,7 +157,7 @@ export interface PracticeClozeItem {
   lemma?: string;
   acceptedAlt?: string[];
   caseRule: PracticeCaseRule;
-  clozeEn: string;
+  clozeEn?: string;
   options: PracticeClozeOption[];
   attribution?: PracticeClozeAttribution;
 }

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2561,7 +2561,7 @@ describe('LexiconPractice', () => {
     expect(screen.getByText(/CC-BY 2.0 FR/)).toBeInTheDocument();
   });
 
-  test('cloze renders a visible source credit for an inventory sentence', () => {
+  test('cloze renders locale-aware source chrome for an inventory sentence', () => {
     seedRecognitionMastery('knyha');
     const deck = sampleDeck();
     deck.cloze[0] = {
@@ -2576,9 +2576,10 @@ describe('LexiconPractice', () => {
 
     render(<LexiconPractice initialDeck={deck} autoStart initialMode="cloze" />);
 
-    expect(screen.getByTestId('practice-cloze-source-attribution')).toHaveTextContent(
-      'Джерело: Підручник для початківців (textbook) — Урок 1, с. 12',
-    );
+    const attribution = screen.getByTestId('practice-cloze-source-attribution');
+    expect(attribution).toHaveTextContent('Source:');
+    expect(attribution).toHaveTextContent('Джерело:');
+    expect(attribution).toHaveTextContent('Підручник для початківців (textbook) — Урок 1, с. 12');
   });
 
   test('today scope uses review + capped-new denominator, not whole deck', async () => {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2561,6 +2561,26 @@ describe('LexiconPractice', () => {
     expect(screen.getByText(/CC-BY 2.0 FR/)).toBeInTheDocument();
   });
 
+  test('cloze renders a visible source credit for an inventory sentence', () => {
+    seedRecognitionMastery('knyha');
+    const deck = sampleDeck();
+    deck.cloze[0] = {
+      ...deck.cloze[0],
+      attribution: {
+        source: 'textbook',
+        label: 'Підручник для початківців',
+        title: 'Урок 1',
+        locator: 'с. 12',
+      },
+    };
+
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="cloze" />);
+
+    expect(screen.getByTestId('practice-cloze-source-attribution')).toHaveTextContent(
+      'Джерело: Підручник для початківців (textbook) — Урок 1, с. 12',
+    );
+  });
+
   test('today scope uses review + capped-new denominator, not whole deck', async () => {
     const { fn } = mockShardFetch({ A1: 1150 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);

--- a/site/tests/unit/lexicon-api-routes.test.ts
+++ b/site/tests/unit/lexicon-api-routes.test.ts
@@ -139,7 +139,8 @@ describe("lexicon static API routes", () => {
     expect(contract.surfaces.dailyWord.endpoint).toBe(contract.endpoints.dailyPool);
     expect(contract.surfaces.practice.totalLexemes).toBeGreaterThan(1000);
     expect(contract.surfaces.practice.levels).toEqual([...PRACTICE_LEVELS]);
-    expect(contract.surfaces.cloze.totalItems).toBe(22);
+    // Inventory-fed cloze publishes a 70-item deck.
+    expect(contract.surfaces.cloze.totalItems).toBe(70);
     expect(contract.surfaces.cloze.reviewedSourceRows).toBeGreaterThan(0);
     expect(contract.endpoints.practiceIndexTemplate).toBe(
       "/api/lexicon/practice-index.{level}.json",
@@ -186,7 +187,8 @@ describe("lexicon static API routes", () => {
     expect(index.counts.lexemes).toBe(lexemes.lexemes.length);
   expect(index.counts.cloze).toBe(cloze.cloze.length);
   expect(index.counts.lexemes).toBeGreaterThan(1000);
-    expect(index.counts.cloze).toBe(22);
+    // A1 contributes 59 items to the published 70-item cloze deck.
+    expect(index.counts.cloze).toBe(59);
   });
 
   test("materializes search shards for static /lexicon/search/{shard}.json URLs", async () => {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1026,6 +1026,23 @@ def test_size_budget_warns_and_trims_per_level(capsys: pytest.CaptureFixture[str
     assert shards["A1"]["index"]["counts"]["lexemes"] < 5
 
 
+def test_size_budget_skips_final_recompute_when_no_trim_occurs(monkeypatch: pytest.MonkeyPatch) -> None:
+    shards = {"A1": {"index": {"schema": "atlas-practice-index", "items": []}}}
+    calls = 0
+    original_size_budget = generate_practice_deck._size_budget
+
+    def count_size_budget(payload: dict[str, object], raw_limit: int, gzip_limit: int) -> dict[str, int | bool]:
+        nonlocal calls
+        calls += 1
+        return original_size_budget(payload, raw_limit, gzip_limit)
+
+    monkeypatch.setattr(generate_practice_deck, "_size_budget", count_size_budget)
+
+    apply_size_budgets(shards, raw_limit=50_000, gzip_limit=15_000)
+
+    assert calls == 1
+
+
 def test_cli_writes_fixture_shards(tmp_path: Path) -> None:
     exit_code = main(
         [
@@ -1242,6 +1259,58 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(
         "locator": "fixture-1",
         "title": "Fixture page",
     }
+
+
+def test_sentence_inventory_rejects_nominative_plural_for_dictionary_form(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "sentence-inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-sentence-inventory",
+                "schemaVersion": 1,
+                "rows": [
+                    {
+                        "lemma": "книга",
+                        "lemmaId": "knyha",
+                        "sentence": "Це книги.",
+                        "targetForm": "книги",
+                        "cefr": "A1",
+                        "uses": ["example"],
+                        "provenance": {
+                            "status": "unreviewed",
+                            "path": "attacker-controlled-path",
+                            "source": "textbook",
+                            "label": "Fixture textbook",
+                            "locator": "fixture-plural",
+                        },
+                        "license": {
+                            "status": "not_openly_licensed",
+                            "useBasis": "short educational quotation with attribution",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    candidates = read_sentence_inventory(inventory_path)
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload(
+            [{"status": "sentence_inventory", "path": str(inventory_path)}]
+        ),
+        JsonVesumVerifier.from_path(VESUM),
+        candidates,
+        BuildConfig(),
+    )
+
+    assert all(
+        item["clozeId"] != "knyha:inventory:1"
+        for level in shards.values()
+        for item in level["cloze"]["cloze"]
+    )
 
 
 @pytest.mark.parametrize("license_status", ["not_openly_licensed", "copyrighted_source"])

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1203,6 +1203,7 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(
     assert cloze["blankCase"] == "nominative"
     assert cloze["number"] == "singular"
     assert "clozeEn" not in cloze
+    assert cloze["caseRule"]["feedback"] == "словникова (називний) форма: книга"
     labels = [option["label"] for option in cloze["options"]]
     assert len(labels) == len(set(labels)) == 4
     assert {option["strategy"] for option in cloze["options"]} == {"no-pair"}
@@ -1219,6 +1220,60 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(
             "useBasis": "short educational quotation with attribution",
         },
     }
+    assert cloze["attribution"] == {
+        "source": "textbook",
+        "label": "Fixture textbook",
+        "locator": "fixture-1",
+        "title": "Fixture page",
+    }
+
+
+@pytest.mark.parametrize("license_status", ["not_openly_licensed", "copyrighted_source"])
+def test_sentence_inventory_rejects_restricted_cloze_without_displayable_attribution(
+    tmp_path: Path, license_status: str
+) -> None:
+    inventory_path = tmp_path / "sentence-inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-sentence-inventory",
+                "schemaVersion": 1,
+                "rows": [
+                    {
+                        "lemma": "книга",
+                        "lemmaId": "knyha",
+                        "sentence": "Це книга.",
+                        "targetForm": "книга",
+                        "cefr": "A1",
+                        "uses": ["example"],
+                        "provenance": {"source": "textbook", "locator": "fixture-1"},
+                        "license": {
+                            "status": license_status,
+                            "useBasis": "short educational quotation with attribution",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload(
+            [{"status": "sentence_inventory", "path": str(inventory_path)}]
+        ),
+        JsonVesumVerifier.from_path(VESUM),
+        read_sentence_inventory(inventory_path),
+        BuildConfig(),
+    )
+
+    assert all(
+        item["clozeId"] != "knyha:inventory:1"
+        for level in shards.values()
+        for item in level["cloze"]["cloze"]
+    )
 
 
 def test_sentence_inventory_rejects_ambiguous_or_repeated_target_forms(tmp_path: Path) -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -33,6 +33,7 @@ from scripts.audit.generate_practice_deck import (
     read_manifest,
     read_paronym_pairs,
     read_practice_seed,
+    read_sentence_inventory,
     validate_classify_item,
     validate_heritage_item,
     validate_heritage_pair,
@@ -232,6 +233,18 @@ def test_representative_seed_selection_round_robins_available_cefr_and_pos_strat
     )
 
     assert [entry["url_slug"] for entry, _lexeme in selected] == ["а", "г", "в", "ґ", "б"]
+
+
+def test_source_backed_priority_lexemes_precede_general_course_fill() -> None:
+    entries = read_manifest(MANIFEST)
+    selected, _lexemes, _by_plain_lemma, _by_id = _select_practice_lexemes(
+        entries,
+        JsonVesumVerifier.from_path(VESUM),
+        BuildConfig(target=1, source_label="fixture"),
+        {"knyha"},
+    )
+
+    assert [entry["url_slug"] for entry, _lexeme in selected] == ["knyha"]
 
 
 def test_real_vesum_verifier_uses_an_explicit_database_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1127,6 +1140,104 @@ def test_source_inventory_cloze_requires_explicit_cloze_admission() -> None:
         for item in level["cloze"]["cloze"]
     }
     assert "knyha" in cloze_ids
+
+
+def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "sentence-inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-sentence-inventory",
+                "schemaVersion": 1,
+                "rows": [
+                    {
+                        "lemma": "книга",
+                        "lemmaId": "knyha",
+                        "sentence": "Це книга.",
+                        "targetForm": "книга",
+                        "cefr": "A1",
+                        "uses": ["example"],
+                        "provenance": {
+                            "source": "textbook",
+                            "label": "Fixture textbook",
+                            "locator": "fixture-1",
+                            "title": "Fixture page",
+                        },
+                        "license": {
+                            "status": "not_openly_licensed",
+                            "useBasis": "short educational quotation with attribution",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    candidates = read_sentence_inventory(inventory_path)
+    assert candidates[0]["sentence"] == "Це ___."
+    assert candidates[0]["form"] == "книга"
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload(
+            [{"status": "sentence_inventory", "path": str(inventory_path)}]
+        ),
+        JsonVesumVerifier.from_path(VESUM),
+        candidates,
+        BuildConfig(),
+    )
+    cloze = next(item for item in shards["A1"]["cloze"]["cloze"] if item["clozeId"] == "knyha:inventory:1")
+    assert cloze["blankCase"] == "nominative"
+    assert cloze["number"] == "singular"
+    assert "clozeEn" not in cloze
+    assert cloze["provenance"] == {
+        "status": "sentence_inventory",
+        "path": str(inventory_path),
+        "source": "textbook",
+        "label": "Fixture textbook",
+        "locator": "fixture-1",
+        "title": "Fixture page",
+        "license": {
+            "status": "not_openly_licensed",
+            "useBasis": "short educational quotation with attribution",
+        },
+    }
+
+
+def test_sentence_inventory_rejects_ambiguous_or_repeated_target_forms(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "sentence-inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-sentence-inventory",
+                "schemaVersion": 1,
+                "rows": [
+                    {
+                        "lemma": "книга",
+                        "lemmaId": "knyha",
+                        "sentence": "книга і книга.",
+                        "targetForm": "книга",
+                        "uses": ["example"],
+                        "provenance": {"source": "textbook", "label": "Fixture textbook"},
+                        "license": {"status": "fixture"},
+                    },
+                    {
+                        "lemma": "книга",
+                        "lemmaId": "knyha",
+                        "sentence": "Це книга.",
+                        "targetForm": "книги",
+                        "uses": ["example"],
+                        "provenance": {"source": "textbook", "label": "Fixture textbook"},
+                        "license": {"status": "fixture"},
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assert read_sentence_inventory(inventory_path) == []
 
 
 def test_cloze_output_preserves_sentence_cefr() -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -391,6 +391,22 @@ def test_reviewed_allowlist_and_vesum_ambiguity_fail_closed() -> None:
     assert no_sources["A1"]["cloze"]["cloze"] == []
 
 
+def test_curated_cloze_derives_missing_target_form_from_paradigm() -> None:
+    entries = read_manifest(MANIFEST)
+    allowlist = ReviewedSourceAllowlist.from_path(ALLOWLIST)
+    verifier = JsonVesumVerifier.from_path(VESUM)
+    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    candidate = next(row for row in cloze_sources if row["lemmaId"] == "knyha")
+    candidate.pop("form")
+
+    shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, BuildConfig())
+
+    cloze = next(item for item in shards["A1"]["cloze"]["cloze"] if item["lemmaId"] == "knyha")
+    assert cloze["blankCase"] == "accusative"
+    assert cloze["number"] == "singular"
+    assert cloze["form"] == "книгу"
+
+
 def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     shards = _build(cloze_sources_path=None)
 

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.audit.generate_practice_deck as generate_practice_deck
 from scripts.audit.generate_practice_deck import (
     DEFAULT_TARGET,
     DRILL_MODES,
@@ -1142,7 +1143,9 @@ def test_source_inventory_cloze_requires_explicit_cloze_admission() -> None:
     assert "knyha" in cloze_ids
 
 
-def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(tmp_path: Path) -> None:
+def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     inventory_path = tmp_path / "sentence-inventory.json"
     inventory_path.write_text(
         json.dumps(
@@ -1158,6 +1161,8 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(tmp_
                         "cefr": "A1",
                         "uses": ["example"],
                         "provenance": {
+                            "status": "unreviewed",
+                            "path": "attacker-controlled-path",
                             "source": "textbook",
                             "label": "Fixture textbook",
                             "locator": "fixture-1",
@@ -1177,6 +1182,13 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(tmp_
     candidates = read_sentence_inventory(inventory_path)
     assert candidates[0]["sentence"] == "Це ___."
     assert candidates[0]["form"] == "книга"
+    assert candidates[0]["provenance"]["status"] == "sentence_inventory"
+    assert candidates[0]["provenance"]["path"] == str(inventory_path)
+
+    # Force the route that previously built duplicate answer/lemma labels for
+    # the nominative form "книга".  Inventory cloze must override it with the
+    # valid no-pair strategy.
+    monkeypatch.setattr(generate_practice_deck, "_option_strategy_for_level", lambda _level, _rng: "two-pair")
 
     shards = build_practice_shards(
         read_manifest(MANIFEST),
@@ -1191,6 +1203,10 @@ def test_sentence_inventory_emits_attested_nominative_cloze_with_provenance(tmp_
     assert cloze["blankCase"] == "nominative"
     assert cloze["number"] == "singular"
     assert "clozeEn" not in cloze
+    labels = [option["label"] for option in cloze["options"]]
+    assert len(labels) == len(set(labels)) == 4
+    assert {option["strategy"] for option in cloze["options"]} == {"no-pair"}
+    assert validate_option_set(cloze) == []
     assert cloze["provenance"] == {
         "status": "sentence_inventory",
         "path": str(inventory_path),

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -86,6 +86,7 @@ def _write_publish_inputs(
     paronym_pairs: list[dict[str, object]] | None = None,
     synonym_verdicts: dict[str, object] | None = None,
     cloze_sources: list[dict[str, object]] | None = None,
+    sentence_inventory: dict[str, object] | None = None,
     public_flags: list[bool] | None = None,
 ) -> dict[str, Path]:
     paths = {
@@ -94,6 +95,7 @@ def _write_publish_inputs(
         "paronym_pairs_path": base_dir / "paronym_pairs.yaml",
         "synonym_verdicts_path": base_dir / "synonym_pair_verdicts.yaml",
         "cloze_sources_path": base_dir / "lexicon-practice-cloze-sources.json",
+        "sentence_inventory_path": base_dir / "lexicon-sentence-inventory.json",
     }
     _write_atlas_db(paths["atlas_db_path"], entries or [], public_flags=public_flags)
     if heritage_pairs is not None:
@@ -104,6 +106,12 @@ def _write_publish_inputs(
         _write_json(paths["synonym_verdicts_path"], synonym_verdicts)
     if cloze_sources is not None:
         _write_json(paths["cloze_sources_path"], cloze_sources)
+    _write_json(
+        paths["sentence_inventory_path"],
+        sentence_inventory
+        if sentence_inventory is not None
+        else {"schema": "atlas-sentence-inventory", "schemaVersion": 1, "rows": []},
+    )
     return paths
 
 
@@ -317,7 +325,7 @@ def test_expected_deck_version_uses_public_atlas_db_projection(tmp_path: Path) -
 
 @pytest.mark.parametrize(
     "stale_input",
-    ["entries", "heritage_pairs", "paronym_pairs", "synonym_verdicts", "cloze_sources"],
+    ["entries", "heritage_pairs", "paronym_pairs", "synonym_verdicts", "cloze_sources", "sentence_inventory"],
 )
 def test_publish_guard_passes_fresh_regen_and_fails_stale_shards(
     tmp_path: Path,
@@ -383,9 +391,29 @@ def test_publish_guard_passes_fresh_regen_and_fails_stale_shards(
         }
         _write_json(input_paths["synonym_verdicts_path"], stale_synonym_verdicts)
     else:
-        stale_cloze_sources = json.loads(json.dumps(cloze_sources))
-        stale_cloze_sources[0]["sentence"] = "Свіжа версія має інше речення з ___."
-        _write_json(input_paths["cloze_sources_path"], stale_cloze_sources)
+        if stale_input == "sentence_inventory":
+            _write_json(
+                input_paths["sentence_inventory_path"],
+                {
+                    "schema": "atlas-sentence-inventory",
+                    "schemaVersion": 1,
+                    "rows": [
+                        {
+                            "lemma": "книга",
+                            "lemmaId": "knyha",
+                            "sentence": "Це книга.",
+                            "targetForm": "книга",
+                            "uses": ["example"],
+                            "provenance": {"source": "fixture", "label": "Fixture"},
+                            "license": {"status": "fixture"},
+                        }
+                    ],
+                },
+            )
+        else:
+            stale_cloze_sources = json.loads(json.dumps(cloze_sources))
+            stale_cloze_sources[0]["sentence"] = "Свіжа версія має інше речення з ___."
+            _write_json(input_paths["cloze_sources_path"], stale_cloze_sources)
 
     with pytest.raises(PracticeDeckPublishError, match="does not match expected version"):
         publish_practice_deck(


### PR DESCRIPTION
## Summary

Links #6132.

- Uses the public sentence inventory as the cloze candidate SSOT. An item is emitted only when the exact attested target token appears once, VESUM resolves it uniquely to the joined lemma and nominative form, and the generated option set passes existing validation.
- Preserves inventory provenance and license metadata, while allowing sourced examples without an invented English translation.
- Prioritizes existing cloze and approved synonym/paronym/heritage legs before ordinary fill lexemes, so budget trimming does not discard thin modes first.
- Publishes release-backed deck `atlas-practice-v1-2b27aea6faa8d7c1` and updates the committed pointer. No auto-merge is enabled.

## Raw regeneration counts

`before` is the previous generator behavior using the full existing pair inputs but no sentence inventory; `after` is the same default rebuild with inventory enabled. Command: `.venv/bin/python scripts/audit/generate_practice_deck.py --vesum-db /tmp/vesum-practice-6132.db ...`.

| Level | Cloze | Stress | Classify | Paradigm | Synonym | Heritage | Paronym |
| --- | --- | --- | --- | --- | --- | --- | --- |
| A1 | 52 → 59 | 1219 → 1219 | 736 → 736 | 1333 → 1333 | 0 → 0 | 0 → 0 | 4 → 4 |
| A2 | 0 → 7 | 1062 → 1063 | 1134 → 1134 | 997 → 997 | 10 → 10 | 38 → 38 | 4 → 4 |
| B1 | 0 → 4 | 925 → 926 | 965 → 964 | 1021 → 1021 | 190 → 190 | 80 → 80 | 3 → 3 |
| B2 | 0 → 0 | 881 → 881 | 903 → 903 | 1094 → 1094 | 78 → 78 | 12 → 12 | 2 → 2 |
| C1 | 0 → 0 | 466 → 466 | 482 → 482 | 638 → 638 | 34 → 34 | 2 → 2 | 3 → 3 |

Published total cloze: 70 (pointer baseline was 22). The remaining inventory rows are rejected by the exact-token, VESUM-identity/case, CEFR, or option-set gates; no sentence, form, gloss, translation, or pair was invented.

All shards meet the existing 1,600,000-byte raw / 180,000-byte gzip budget. The static checker still reports expected thin-mode warnings where source coverage is genuinely incomplete.

## Validation

- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py scripts/practice_deck/publish.py tests/test_generate_practice_deck.py tests/test_publish_practice_deck.py`
- `.venv/bin/pytest -q tests/test_generate_practice_deck.py tests/test_publish_practice_deck.py tests/test_check_static_practice_assets.py`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
