### PR TITLE
feat(practice): add session and deck variety controls

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 2c223b2d808a9549b49a09e1e5d0e0fe71fb7c77b1fafa8f844696fe44fcbd81
+  components_sha256: cc26744a80f4e30ad7a71ea20a691ad8a5e6bd25e32cf5467cec5a50f6563dcf
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1654,6 +1654,10 @@ components:
       - name: deckTitleEn
         type: string | null
         description: deckTitleEn prop.
+        ukrainian_text: 'false'
+      - name: onReRoll
+        type: () => void
+        description: onReRoll prop.
         ukrainian_text: 'false'
     nested_types: {}
     example:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1517,15 +1517,46 @@ function LexiconPracticeIsland({
   const [dailyLexemes, setDailyLexemes] = useState<Map<string, PracticeLexeme>>(() => new Map());
   const [dailySnapshotLoading, setDailySnapshotLoading] = useState(false);
   const [dailyReRollCount, setDailyReRollCount] = useState(() => readDailyReRollCount(todayKey()));
+  // #6146: the calendar day `dailyReRollCount` was established for. `useState`'s
+  // initializer only runs at mount, so a tab left open across local midnight would
+  // otherwise keep applying yesterday's re-roll offset to today's `dateSeed` — the
+  // picks-fetch effect below and the midnight timer both compare against this to
+  // catch the rollover and reset the count back to the day's default draw (0).
+  const dailyReRollDateRef = useRef(todayKey());
   // #6132: explicit re-draw of today's featured set — see the effect below that folds
   // this count into the pickDaily seed via `reRollSeed`.
   const reRollDailyPicks = useCallback(() => {
     const dateKey = todayKey();
+    // #6146: a tap landing before the day-rollover reset has run (midnight timer not
+    // yet fired, effect not yet re-run) must not continue incrementing yesterday's
+    // count — start the new day's re-roll sequence at 1, not stale-count + 1.
+    const dayChanged = dailyReRollDateRef.current !== dateKey;
+    dailyReRollDateRef.current = dateKey;
     setDailyReRollCount((count) => {
-      const next = count + 1;
+      const next = (dayChanged ? 0 : count) + 1;
       writeDailyReRollCount(dateKey, next);
       return next;
     });
+  }, []);
+  // #6146: catch a day rollover while the tab stays open (idle, no props changing) by
+  // arming a timer for the next local midnight rather than polling. On fire, reset the
+  // re-roll count if the day actually advanced, then rearm for the following midnight.
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const armForNextMidnight = () => {
+      const now = new Date();
+      const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 5);
+      timeoutId = setTimeout(() => {
+        const currentDateKey = todayKey();
+        if (dailyReRollDateRef.current !== currentDateKey) {
+          dailyReRollDateRef.current = currentDateKey;
+          setDailyReRollCount(0);
+        }
+        armForNextMidnight();
+      }, Math.max(0, nextMidnight.getTime() - now.getTime()));
+    };
+    armForNextMidnight();
+    return () => clearTimeout(timeoutId);
   }, []);
   const [hoveredMode, setHoveredMode] = useState<VisiblePracticeModeFilter | null>(null);
   const [publishedLevels] = useState<Set<CefrLevel>>(
@@ -1779,6 +1810,20 @@ function LexiconPracticeIsland({
   // still produces a deterministic, testable draw, it just adds a third seed term.
   useEffect(() => {
     if (sessionPhase !== 'idle') return;
+
+    // #6146: defends against the midnight timer not having fired yet (e.g. this effect
+    // re-runs from an unrelated dependency change in the first seconds of a new day) —
+    // re-check the rollover here too rather than trusting the timer alone. Bail this run;
+    // the reset below re-triggers the effect (dailyReRollCount is a dependency) with the
+    // correct day-zero count.
+    const currentDateKey = todayKey();
+    if (dailyReRollDateRef.current !== currentDateKey) {
+      dailyReRollDateRef.current = currentDateKey;
+      if (dailyReRollCount !== 0) {
+        setDailyReRollCount(0);
+        return;
+      }
+    }
 
     let cancelled = false;
     setDailySnapshotLoading(true);

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -33,6 +33,7 @@ import {
   parseCardKey,
   previewRatingIntervals,
   rateCard,
+  recentSessionHistory,
   resolveSessionCompletion,
   readNewCardsDailyState,
   readPracticeSessionSnapshots,
@@ -82,7 +83,7 @@ import {
   normalizeCefrLevel,
   type CefrLevel,
 } from '../lib/lexicon/levels';
-import { dateSeed, deckSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
+import { dateSeed, deckSeed, pickDaily, reRollSeed, type DailyWord } from '../lib/lexicon/daily';
 import {
   filterTeacherClozeItems,
   getTeacherLessonVirtualDeck,
@@ -381,6 +382,7 @@ interface CompletionOutcome {
 }
 
 const STREAK_KEY = 'lu-lexicon-practice-streak';
+const DAILY_REROLL_KEY = 'lu-lexicon-daily-reroll';
 const MASTERED_THRESHOLD = 21;
 type SessionPhase = 'idle' | 'active' | 'summary';
 
@@ -732,6 +734,33 @@ function previousDayKey(date = new Date()): string {
   return todayKey(previous);
 }
 
+/**
+ * #6132: re-roll count for today's featured/daily pick set — how many times the
+ * learner has tapped «Перемішати» since the calendar day started. Scoped to
+ * `dateKey` so a day change (not just a page reload) resets the draw back to the
+ * default (count 0), matching the existing dateSeed(today) behavior it composes with.
+ */
+function readDailyReRollCount(dateKey: string): number {
+  if (typeof window === 'undefined') return 0;
+  try {
+    const raw = window.localStorage.getItem(DAILY_REROLL_KEY);
+    if (!raw) return 0;
+    const parsed = JSON.parse(raw) as { date?: string; count?: number };
+    return parsed.date === dateKey && typeof parsed.count === 'number' ? parsed.count : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeDailyReRollCount(dateKey: string, count: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DAILY_REROLL_KEY, JSON.stringify({ date: dateKey, count }));
+  } catch {
+    // Persisting the re-roll count is best-effort; the in-memory count still applies.
+  }
+}
+
 function readStreak(): StreakState {
   try {
     const raw = window.localStorage.getItem(STREAK_KEY);
@@ -894,6 +923,16 @@ function historyFromSelection(selection: PracticeSelection): SelectionHistoryIte
     choicePolarity: selection.choicePolarity,
     lapsed: selection.lapsed,
   };
+}
+
+/**
+ * #6132: a fresh session's `history` starts from the learner's most recent same-day
+ * reviews instead of always `[]`, so `selectNextPracticeItem`'s spacing/anti-monotony
+ * logic reacts immediately — without this, starting a second same-day session opened
+ * with the exact same opening picks as the first.
+ */
+function seedCrossSessionHistory(now: Date): SelectionHistoryItem[] {
+  return recentSessionHistory(loadState().reviews, now.getTime());
 }
 
 function reviewLemmaId(selection: PracticeSelection): string {
@@ -1477,6 +1516,17 @@ function LexiconPracticeIsland({
   const [dailySnapshot, setDailySnapshot] = useState<DailyPracticeDeckSnapshot | null>(null);
   const [dailyLexemes, setDailyLexemes] = useState<Map<string, PracticeLexeme>>(() => new Map());
   const [dailySnapshotLoading, setDailySnapshotLoading] = useState(false);
+  const [dailyReRollCount, setDailyReRollCount] = useState(() => readDailyReRollCount(todayKey()));
+  // #6132: explicit re-draw of today's featured set — see the effect below that folds
+  // this count into the pickDaily seed via `reRollSeed`.
+  const reRollDailyPicks = useCallback(() => {
+    const dateKey = todayKey();
+    setDailyReRollCount((count) => {
+      const next = count + 1;
+      writeDailyReRollCount(dateKey, next);
+      return next;
+    });
+  }, []);
   const [hoveredMode, setHoveredMode] = useState<VisiblePracticeModeFilter | null>(null);
   const [publishedLevels] = useState<Set<CefrLevel>>(
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
@@ -1624,11 +1674,12 @@ function LexiconPracticeIsland({
     const nextSeed = makePracticeSessionSeed();
     setSessionSeed(nextSeed);
     sessionStartedAtRef.current = Date.now();
-    setHistory([]);
+    const seededHistory = seedCrossSessionHistory(new Date());
+    setHistory(seededHistory);
     const reviewSlots = sessionBudget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, sessionBudget);
     const snapshot: PracticeSessionSnapshot = {
       sessionSeed: nextSeed,
-      history: [],
+      history: seededHistory,
       budget: sessionBudget,
       completed: 0,
       modeFilter: mode,
@@ -1721,6 +1772,11 @@ function LexiconPracticeIsland({
   // deck filter draws the daily picks FROM THAT DECK instead — pickDaily(deckPool,
   // dateSeed(now) + deckSeed(deckId), 12) — so the featured zone (and its default
   // session) react to the learner's deck choice, not just the atlas-global pool.
+  //
+  // #6132: the operator's complaint was the SAME 12 every session that day, with no
+  // way to see a different set without waiting for UTC midnight. `dailyReRollCount`
+  // (persisted per calendar day) folds into the seed via `reRollSeed` — a re-roll tap
+  // still produces a deterministic, testable draw, it just adds a third seed term.
   useEffect(() => {
     if (sessionPhase !== 'idle') return;
 
@@ -1744,7 +1800,11 @@ function LexiconPracticeIsland({
             shardJsonCacheRef.current,
           );
           const eligiblePool = filterByCumulativeLevel(pool, learnerLevel);
-          picks = pickDaily(eligiblePool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+          picks = pickDaily(
+            eligiblePool,
+            dateSeed(now) + reRollSeed(dailyReRollCount),
+            DAILY_PRACTICE_DECK_SIZE,
+          );
 
           // Fetch lexeme cores only for levels represented among today's picks —
           // or all selected-level cores for the defined fallback when the daily
@@ -1845,7 +1905,7 @@ function LexiconPracticeIsland({
           });
           displayablePicks = pickDaily(
             deckPool,
-            dateSeed(now) + deckSeed(selectedDeckFilter),
+            dateSeed(now) + deckSeed(selectedDeckFilter) + reRollSeed(dailyReRollCount),
             DAILY_PRACTICE_DECK_SIZE,
           );
         } else {
@@ -1879,7 +1939,7 @@ function LexiconPracticeIsland({
           }));
           displayablePicks = picks.length > 0
             ? picks
-            : pickDaily(fallbackPool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+            : pickDaily(fallbackPool, dateSeed(now) + reRollSeed(dailyReRollCount), DAILY_PRACTICE_DECK_SIZE);
         }
 
         const snapshot: DailyPracticeDeckSnapshot = {
@@ -1925,11 +1985,27 @@ function LexiconPracticeIsland({
     shardBaseUrl,
     selectedDeckFilter,
     customSets,
+    dailyReRollCount,
   ]);
 
   const indexForStats = (deck?.index ?? dueIndex ?? []).filter(
     (item) => !focusedLemmaId || item.lemmaId === focusedLemmaId
   );
+
+  // #6132 mode honesty: the lightweight index shard (`dueIndex`, or `deck.index` once
+  // loaded) already carries each lemma's available modes, so the mode grid can show a
+  // real per-mode count for the ACTIVE deck filter before the learner ever taps a card
+  // — instead of mixed silently collapsing toward whichever modes happen to have
+  // content and leaving an empty tap as the only way to discover a mode has nothing.
+  const modeCounts = useMemo(() => {
+    const filtered = filterIndexByDeckFilter(indexForStats, selectedDeckFilter, customSets);
+    const counts: Partial<Record<VisiblePracticeModeFilter, number>> = { mixed: filtered.length };
+    for (const visibleMode of MODE_CARD_ORDER) {
+      if (visibleMode === 'mixed') continue;
+      counts[visibleMode] = filtered.filter((item) => item.modes.includes(visibleMode)).length;
+    }
+    return counts;
+  }, [indexForStats, selectedDeckFilter, customSets]);
 
   const sessionPoolConstraints = useMemo(
     () =>
@@ -2544,10 +2620,11 @@ function LexiconPracticeIsland({
     );
     const plan = computeSessionScope(index, budget, { dailyNewCount });
     const nextSeed = resume?.sessionSeed ?? makePracticeSessionSeed();
+    const seededHistory = resume ? resume.history : seedCrossSessionHistory(new Date());
     if (resume) {
       sessionStartedAtRef.current = resume.startedAt;
       setSessionSeed(nextSeed);
-      setHistory(resume.history);
+      setHistory(seededHistory);
       setSessionCompleted(resume.completed);
       setPlannedReviews(resume.plannedReviews ?? plan.dueReviews);
       setPlannedTotal(resume.plannedTotal ?? plan.plannedTotal);
@@ -2559,14 +2636,14 @@ function LexiconPracticeIsland({
     } else {
       sessionStartedAtRef.current = Date.now();
       setSessionSeed(nextSeed);
-      setHistory([]);
+      setHistory(seededHistory);
       resetSessionTracking(plan, budget);
     }
     setSessionPhase('active');
     const reviewSlots = budget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, budget);
     const snapshot: PracticeSessionSnapshot = {
       sessionSeed: nextSeed,
-      history: resume?.history ?? [],
+      history: seededHistory,
       budget,
       completed: resume?.completed ?? 0,
       modeFilter: nextMode,
@@ -3314,6 +3391,7 @@ function LexiconPracticeIsland({
                   learnerLevel={learnerLevel}
                   deckTitleUk={activeDeckTitles?.uk}
                   deckTitleEn={activeDeckTitles?.en}
+                  onReRoll={reRollDailyPicks}
                 />
               )}
             </div>
@@ -3424,6 +3502,8 @@ function LexiconPracticeIsland({
               >
                 {MODE_CARD_ORDER.map((practiceMode) => {
                   const meta = MODE_META[practiceMode];
+                  const modeCount = modeCounts[practiceMode] ?? 0;
+                  const modeEmpty = practiceMode !== 'mixed' && modeCount === 0;
                   return (
                     <button
                       key={practiceMode}
@@ -3431,6 +3511,8 @@ function LexiconPracticeIsland({
                       className="k3-mode-card"
                       data-mode={practiceMode}
                       data-accent={meta.accent}
+                      data-mode-count={modeCount}
+                      data-mode-empty={modeEmpty ? 'true' : undefined}
                       aria-describedby="mode-detail-line"
                       onMouseEnter={() => setHoveredMode(practiceMode)}
                       onMouseLeave={() => setHoveredMode(null)}
@@ -3440,6 +3522,13 @@ function LexiconPracticeIsland({
                     >
                       <span className="k3-mode-title">{chromeLocale === 'uk' ? meta.title : meta.en}</span>
                       <span className="k3-mode-step">{chromeLocale === 'uk' ? meta.step : meta.stepEn}</span>
+                      <span
+                        className="k3-mode-count"
+                        aria-hidden="true"
+                        data-testid={`practice-mode-count-${practiceMode}`}
+                      >
+                        {modeCount}
+                      </span>
                     </button>
                   );
                 })}

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -24,6 +24,8 @@ export interface PracticeDailyDeckProps {
   /** D10: independently localized active-deck titles, or undefined for All Words. */
   deckTitleUk?: string | null;
   deckTitleEn?: string | null;
+  /** #6132: re-draw today's pick set without waiting for the calendar day to change. */
+  onReRoll?: () => void;
 }
 
 const STATUS_META = {
@@ -45,6 +47,7 @@ export default function PracticeDailyDeck({
   learnerLevel,
   deckTitleUk = null,
   deckTitleEn = null,
+  onReRoll,
 }: PracticeDailyDeckProps) {
   const [previewIndex, setPreviewIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
@@ -110,6 +113,20 @@ export default function PracticeDailyDeck({
             en={`${previewIndex + 1} / ${total}`}
           />
         </span>
+        {onReRoll ? (
+          <button
+            type="button"
+            className="daily-deck-reroll"
+            data-testid="practice-daily-reroll"
+            onClick={() => {
+              setPreviewIndex(0);
+              setFlipped(false);
+              onReRoll();
+            }}
+          >
+            <span aria-hidden="true">🔀</span> <ChromeText k="practice.reRoll" />
+          </button>
+        ) : null}
       </div>
 
       <div className="daily-deck-preview-shell">

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -288,6 +288,7 @@ const en = {
   'practice.verdict.wrong': 'Wrong',
   'practice.verdict.calque': 'Calque',
   'practice.wordsTitle': 'Words of the day',
+  'practice.reRoll': 'Shuffle words',
 
   // Practice session chrome residuals (#5355)
   'practice.sessionComplete': 'Session complete',
@@ -590,6 +591,7 @@ const uk: Record<ChromeKey, string> = {
   'practice.verdict.wrong': 'Неправильно',
   'practice.verdict.calque': 'Калька',
   'practice.wordsTitle': 'Слова дня',
+  'practice.reRoll': 'Перемішати слова',
 
   // Practice session chrome residuals (#5355)
   'practice.sessionComplete': 'Сесію завершено',

--- a/site/src/lib/lexicon/daily.ts
+++ b/site/src/lib/lexicon/daily.ts
@@ -64,3 +64,15 @@ export function deckSeed(deckId: string): number {
   }
   return hash >>> 0;
 }
+
+/**
+ * #6132: deterministic contribution for an explicit re-roll (the learner asking to
+ * see a different pick set without waiting for the calendar day to change).
+ * Combines additively with `dateSeed`/`deckSeed` the same way they combine with each
+ * other. `count` is 0 for the day's default draw and increments once per re-roll tap;
+ * multiplying by a large prime keeps consecutive counts from producing near-identical
+ * permutations under `pickDaily`'s mulberry32-style generator.
+ */
+export function reRollSeed(count: number): number {
+  return (count * 104729) >>> 0;
+}

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -439,6 +439,37 @@ export interface SelectionHistoryItem {
   lapsed?: boolean;
 }
 
+/**
+ * #6132: seed for a freshly started session's spacing/anti-monotony history — the
+ * learner's most recent SAME LOCAL CALENDAR DAY reviews, converted from the
+ * persisted (cross-session) `reviews` log. `selectNextPracticeItem`'s history param
+ * resets to `[]` at the start of every new session; without a seed, `applySpacingFilters`
+ * (word-repeat window) and `candidatePenalty` (mode anti-monotony) start blind, so a
+ * second same-day session opened with the same opening picks as the first. `reviews` is
+ * append-only chronological, so the tail is already the most recent.
+ */
+export function recentSessionHistory(
+  reviews: ReviewLogEntry[],
+  nowTime: number,
+  limit = 12,
+): SelectionHistoryItem[] {
+  const now = new Date(nowTime);
+  const sameDay = reviews.filter((entry) => {
+    const at = new Date(entry.review);
+    return (
+      at.getFullYear() === now.getFullYear() &&
+      at.getMonth() === now.getMonth() &&
+      at.getDate() === now.getDate()
+    );
+  });
+  return sameDay.slice(-limit).map((entry) => ({
+    itemId: `${entry.lemmaId}:${entry.mode}`,
+    lemmaId: entry.lemmaId,
+    mode: entry.mode,
+    blankCase: entry.blankCase,
+  }));
+}
+
 export interface PracticeSelection {
   itemId: string;
   lemma: PracticeLexeme;

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1377,6 +1377,25 @@ const frontmatter = {
     font-size: 0.9rem;
     font-weight: 800;
   }
+  :global(.daily-deck-reroll) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 999px;
+    background: var(--lu-surface);
+    color: var(--lu-text);
+    font-size: 0.85rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  :global(.daily-deck-reroll:hover),
+  :global(.daily-deck-reroll:focus-visible) {
+    border-color: var(--lu-primary);
+    outline: 2px solid var(--lu-primary);
+    outline-offset: 2px;
+  }
   :global(.daily-deck-preview-shell) {
     display: flex;
     align-items: center;
@@ -1587,6 +1606,7 @@ const frontmatter = {
     }
   }
   :global(.k3-mode-card) {
+    position: relative;
     display: flex;
     min-height: 48px;
     flex-direction: column;
@@ -1606,6 +1626,9 @@ const frontmatter = {
     outline: none;
     box-shadow: 0 0 0 3px var(--lu-state-active);
   }
+  :global(.k3-mode-card[data-mode-empty='true']) {
+    opacity: 0.55;
+  }
   :global(.k3-mode-title) {
     font-size: 1rem;
     font-weight: 900;
@@ -1616,6 +1639,24 @@ const frontmatter = {
     font-weight: 900;
     letter-spacing: 0.04em;
     text-transform: uppercase;
+  }
+  :global(.k3-mode-count) {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.6rem;
+    min-width: 1.4em;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--lu-surface-raised);
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-align: center;
+  }
+  :global(.k3-mode-card[data-mode-empty='true'] .k3-mode-count) {
+    color: var(--lu-text-muted);
+    background: transparent;
+    border: 1px solid var(--lu-border);
   }
 
   /* Chunk 5 — generalized form rail and N-vowel stress */

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -27,7 +27,7 @@ import {
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
 import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
-import { filterTeacherClozeItems, type CustomSet } from '@site/src/lib/lexicon/custom-decks';
+import { CUSTOM_SETS_STORAGE_KEY, filterTeacherClozeItems, type CustomSet } from '@site/src/lib/lexicon/custom-decks';
 import { type DailyWord } from '@site/src/lib/lexicon/daily';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
@@ -476,6 +476,23 @@ function sampleDeckWithOnlyMode(lemmaId: string, mode: PracticeMode): PracticeDe
       clozeIds: [],
     })),
     cloze: [],
+  };
+}
+
+/**
+ * #6132: two possible modes only (flashcards on every lemma, cloze on `knyha` alone) —
+ * deliberately excludes matching/choice, whose distractor pools are drawn from the
+ * WHOLE deck by design (`meaningDistractors`/`orderedChoiceOptions`), which would make
+ * "no forbidden lemma anywhere in the DOM" an invalid assertion for those modes.
+ */
+function customDeckMixedFixture(): PracticeDeckData {
+  const baseDeck = sampleDeck();
+  return {
+    ...baseDeck,
+    index: baseDeck.index.map((item) => ({
+      ...item,
+      modes: (item.lemmaId === 'knyha' ? ['flashcards', 'cloze'] : ['flashcards']) as PracticeMode[],
+    })),
   };
 }
 
@@ -4086,6 +4103,83 @@ describe('LexiconPractice', () => {
       await waitFor(() =>
         expect(screen.getByTestId('practice-session-scope')).toHaveTextContent(/3 нових/),
       );
+    });
+
+    test('#6132 mixed-mode session started from a custom deck never draws a lemma outside it', async () => {
+      // 'knyha'/'robota' are IN the deck; 'misto'/'shkola' (sampleDeck's other two
+      // lemmas) are NOT. Only 'knyha' carries cloze — proving the MIXED path (not
+      // just a single mode card, already covered above) respects the deck filter
+      // whichever of its modes gets drawn.
+      const customSet: CustomSet = {
+        id: 'test_custom_deck_mixed',
+        title: 'Дві слова',
+        lemma_keys: ['книга', 'робота'],
+        cloze_items: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        device_id: 'test_device',
+        revision: 1,
+      };
+      localStorage.setItem(CUSTOM_SETS_STORAGE_KEY, JSON.stringify([customSet]));
+
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        const user = userEvent.setup();
+        const { container, unmount } = render(
+          <LexiconPractice initialDeck={customDeckMixedFixture()} autoStart={false} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /Дві слова/i }));
+        await user.click(container.querySelector<HTMLButtonElement>('[data-mode="mixed"]')!);
+
+        const clozeStage = screen.queryByTestId('practice-cloze');
+        if (clozeStage) {
+          expect(clozeStage.textContent).not.toMatch(/місто|школа/);
+        } else {
+          const flashcardWord = container.querySelector('.flashcard-word')?.textContent ?? '';
+          expect(['книга', 'робота']).toContain(flashcardWord);
+        }
+
+        unmount();
+      }
+    });
+
+    test('#6132 mode grid shows a real per-mode count, honest about which modes are empty', async () => {
+      // Custom sets load once at mount (`useState(() => readLocalCustomSets())`), so seed
+      // localStorage BEFORE render — matching the established pattern in the other
+      // Custom Set tests above (e.g. "dashboard session estimate narrows...").
+      const customSet: CustomSet = {
+        id: 'test_custom_deck_mode_counts',
+        title: 'Лічильник',
+        lemma_keys: ['робота'],
+        cloze_items: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        device_id: 'test_device',
+        revision: 1,
+      };
+      localStorage.setItem(CUSTOM_SETS_STORAGE_KEY, JSON.stringify([customSet]));
+
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice initialDeck={sampleDeck()} autoStart={false} />);
+
+      // sampleDeck: 4 lemmas carry flashcards/matching/choice, only 'книга' carries cloze,
+      // and no lemma carries heritage — the grid must say so BEFORE any tap, not just
+      // fail closed with an empty-state message after the learner has already committed.
+      expect(screen.getByTestId('practice-mode-count-flashcards')).toHaveTextContent('4');
+      expect(screen.getByTestId('practice-mode-count-cloze')).toHaveTextContent('1');
+      expect(screen.getByTestId('practice-mode-count-heritage')).toHaveTextContent('0');
+      expect(container.querySelector('[data-mode="heritage"]')).toHaveAttribute('data-mode-empty', 'true');
+      expect(container.querySelector('[data-mode="flashcards"]')).not.toHaveAttribute('data-mode-empty');
+
+      // Narrowing to a 1-word custom deck (no cloze) must narrow the counts too, not just
+      // the session-size estimate — a mixed session from this deck has nothing to draw
+      // from cloze, and the grid should say so for THIS deck, not the full level.
+      await user.click(screen.getByRole('button', { name: /Лічильник/i }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('practice-mode-count-flashcards')).toHaveTextContent('1'),
+      );
+      expect(screen.getByTestId('practice-mode-count-cloze')).toHaveTextContent('0');
     });
   });
 });

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -13,6 +13,7 @@ import PracticeSessionSummary, { type SessionSummaryStats } from '@site/src/comp
 import PracticeErrorBoundary from '@site/src/components/PracticeErrorBoundary';
 import {
   SRS_STORAGE_KEY,
+  DAILY_PRACTICE_DECK_SIZE,
   cardKey,
   loadState,
   saveState,
@@ -26,9 +27,9 @@ import {
   type PracticeRating,
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
-import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
+import { LEARNER_LEVEL_STORAGE_KEY, filterByCumulativeLevel, type CefrLevel } from '@site/src/lib/lexicon/levels';
 import { CUSTOM_SETS_STORAGE_KEY, filterTeacherClozeItems, type CustomSet } from '@site/src/lib/lexicon/custom-decks';
-import { type DailyWord } from '@site/src/lib/lexicon/daily';
+import { dateSeed, pickDaily, type DailyWord } from '@site/src/lib/lexicon/daily';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
 
@@ -1206,6 +1207,69 @@ describe('LexiconPractice', () => {
     expect(requested.some((u) => u.includes('practice-synonym'))).toBe(false);
     expect(requested.some((u) => u.includes('practice-paronym'))).toBe(false);
     expect(requested.some((u) => u.includes('practice-heritage'))).toBe(false);
+  });
+
+  test('resets the daily re-roll offset when the local calendar day changes while the tab stays open (#6146)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { fn } = mockShardFetch({ A1: 24 });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+      const dayOneNoon = new Date(2026, 5, 23, 12, 0, 0);
+      vi.setSystemTime(dayOneNoon);
+
+      const user = userEvent.setup({ delay: null });
+      render(<LexiconPractice />);
+      await screen.findByTestId('practice-daily-deck');
+
+      const readFeaturedLemmaIds = async () => {
+        const summary = screen.getByTestId('practice-daily-summary');
+        if (summary.getAttribute('aria-expanded') !== 'true') {
+          await user.click(summary);
+        }
+        return Array.from(document.querySelectorAll('.daily-deck-row'))
+          .map((row) => row.querySelector('[data-testid^="practice-daily-why-"]')?.getAttribute('data-testid'))
+          .filter((id): id is string => Boolean(id))
+          .map((id) => id.replace('practice-daily-why-', ''))
+          .sort();
+      };
+
+      const dayOneDefaultIds = await readFeaturedLemmaIds();
+
+      // Re-roll on day one so the featured set diverges from the day's default draw.
+      await user.click(screen.getByTestId('practice-daily-reroll'));
+      let rolledIds: string[] = [];
+      await waitFor(async () => {
+        rolledIds = await readFeaturedLemmaIds();
+        expect(rolledIds).not.toEqual(dayOneDefaultIds);
+      });
+
+      // Jump the clock past local midnight with NO further interaction — this is the
+      // "tab stayed open overnight" scenario the fix targets. Only the armed midnight
+      // timer (not a click) can catch this rollover.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(13 * 60 * 60 * 1000);
+      });
+
+      const dayOnePool = dailyPoolFixture({ A1: 24 });
+      const eligiblePool = filterByCumulativeLevel(dayOnePool, 'A1');
+      const expectedDayTwoDefaultIds = pickDaily(
+        eligiblePool,
+        dateSeed(new Date(2026, 5, 24)),
+        DAILY_PRACTICE_DECK_SIZE,
+      )
+        .map((word) => word.slug)
+        .sort();
+
+      await waitFor(async () => {
+        expect(await readFeaturedLemmaIds()).toEqual(expectedDayTwoDefaultIds);
+      });
+      // Sanity: the reset actually changed the draw — day two's default is not merely
+      // coincidentally equal to what the still-elevated day-one re-roll count produced.
+      expect(rolledIds).not.toEqual(expectedDayTwoDefaultIds);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('a real regenerated daily-pool row with pos renders on the card (#5856 fix-round-2)', async () => {

--- a/site/tests/unit/lexicon-daily.test.ts
+++ b/site/tests/unit/lexicon-daily.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { dateSeed, deckSeed, pickDaily } from '@site/src/lib/lexicon/daily';
+import { dateSeed, deckSeed, pickDaily, reRollSeed } from '@site/src/lib/lexicon/daily';
 
 describe('dateSeed', () => {
   test('uses the local calendar date', () => {
@@ -55,5 +55,31 @@ describe('deckSeed', () => {
 
     expect(pickDaily(pool, day1 + seed, 12)).toEqual(pickDaily(pool, day1 + seed, 12));
     expect(pickDaily(pool, day1 + seed, 12)).not.toEqual(pickDaily(pool, day2 + seed, 12));
+  });
+});
+
+describe('reRollSeed', () => {
+  test('is zero for the default (un-re-rolled) draw', () => {
+    expect(reRollSeed(0)).toBe(0);
+  });
+
+  test('#6132: re-rolling draws a different set without changing the day', () => {
+    const pool = Array.from({ length: 30 }, (_, i) => `word-${i}`);
+    const day = dateSeed(new Date(2026, 5, 23));
+
+    const first = pickDaily(pool, day + reRollSeed(0), 12);
+    const second = pickDaily(pool, day + reRollSeed(1), 12);
+    const third = pickDaily(pool, day + reRollSeed(2), 12);
+
+    expect(second).not.toEqual(first);
+    expect(third).not.toEqual(first);
+    expect(third).not.toEqual(second);
+  });
+
+  test('is deterministic for a given count, so the same re-roll replays identically', () => {
+    const pool = Array.from({ length: 30 }, (_, i) => `word-${i}`);
+    const day = dateSeed(new Date(2026, 5, 23));
+
+    expect(pickDaily(pool, day + reRollSeed(3), 12)).toEqual(pickDaily(pool, day + reRollSeed(3), 12));
   });
 });

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -22,6 +22,7 @@ import {
   parseCardKey,
   rateCard,
   readDailyPracticeDeckSnapshot,
+  recentSessionHistory,
   refillDailyPracticeDeckSnapshot,
   saveState,
   selectDailyPracticeDeckItems,
@@ -1209,6 +1210,48 @@ describe('lexicon SRS facade', () => {
     expect(uaPlural(5)).toBe('правильних');
     expect(uaPlural(11)).toBe('правильних');
     expect(uaPlural(21)).toBe('правильна');
+  });
+});
+
+describe('recentSessionHistory (#6132 cross-session anti-repeat)', () => {
+  test('seeds from the same-day tail of the persisted review log', () => {
+    const reviews = [reviewEntry(0, 'alpha'), reviewEntry(1, 'beta'), reviewEntry(2, 'gamma')];
+    const history = recentSessionHistory(reviews, NOW.getTime());
+
+    expect(history).toHaveLength(3);
+    expect(history.map((item) => item.lemmaId)).toEqual(['alpha', 'beta', 'gamma']);
+    expect(history.every((item) => item.mode === 'flashcards')).toBe(true);
+  });
+
+  test('drops reviews from a different local calendar day', () => {
+    const yesterday: ReviewLogEntry = {
+      ...reviewEntry(0, 'stale'),
+      review: NOW.getTime() - DAY_MS,
+    };
+    const today = reviewEntry(1, 'fresh');
+
+    const history = recentSessionHistory([yesterday, today], NOW.getTime());
+
+    expect(history.map((item) => item.lemmaId)).toEqual(['fresh']);
+  });
+
+  test('caps to the most recent `limit` entries, keeping chronological order', () => {
+    const reviews = Array.from({ length: 20 }, (_, index) => reviewEntry(index, `word-${index}`));
+
+    const history = recentSessionHistory(reviews, NOW.getTime(), 5);
+
+    expect(history).toHaveLength(5);
+    expect(history.map((item) => item.lemmaId)).toEqual([
+      'word-15',
+      'word-16',
+      'word-17',
+      'word-18',
+      'word-19',
+    ]);
+  });
+
+  test('an empty review log seeds an empty history (first-ever session)', () => {
+    expect(recentSessionHistory([], NOW.getTime())).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes/addresses #6132 — the operator's complaint was seeing the same practices every new local session, and custom/paste decks not clearly showing which modes have content.

- **Re-roll control**: learners can now tap «Перемішати слова» / "Shuffle words" on the Words-of-the-Day card to re-draw the daily/featured pick set without waiting for the calendar day to change. Implemented via a new `reRollSeed(count)` term that composes additively with the existing `dateSeed`/`deckSeed` formula (`site/src/lib/lexicon/daily.ts`), so the draw stays deterministic and testable per tap.
- **Cross-session anti-repeat**: a freshly started session now seeds its spacing/anti-monotony `history` from the same-day tail of the persisted SRS review log (`recentSessionHistory` in `site/src/lib/lexicon/srs.ts`) instead of always starting from `[]`. A second same-day session now reacts to what the first one just covered.
- **Deck-scoped session start**: audited the existing `filterIndexByDeckFilter`/`deckFilterAllowsLemma`/`ensureDeckCustomSetCoverage` machinery — it already applies uniformly across all practice modes including `mixed`. Added a dedicated test proving a `mixed`-mode session started from a 2-lemma custom deck never draws a lemma outside it, across both of its available modes (flashcards, cloze).
- **Mode honesty**: the mode grid now shows a real per-mode item count for the active deck filter *before* the learner taps a card (`data-mode-count`, `data-mode-empty`), computed from the lightweight index shard that's already loaded. No more silent "mixed" collapse with no visibility into which modes actually have content.

## Test plan
- [x] `vitest run tests/unit/lexicon-daily.test.ts tests/unit/lexicon-srs.test.ts tests/unit/practice-session.test.ts tests/unit/LexiconPractice.test.tsx` — 207/207 passing
- [x] `astro check` — zero new type errors (25 pre-existing errors, all in files/lines untouched by this PR)
- [x] New unit coverage: `reRollSeed` determinism (daily.ts), `recentSessionHistory` same-day filtering/cap (srs.ts), mixed-mode custom-deck filtering, mode-count grid narrowing to a custom deck

🤖 Generated with [Claude Code](https://claude.com/claude-code)