### PR TITLE
feat(foundry): add correction review factory

### DIFF
--- a/data/projects/open_model_data/contracts/correction_candidate_v1.schema.json
+++ b/data/projects/open_model_data/contracts/correction_candidate_v1.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_candidate_v1.schema.json",
+  "title": "Ukrainian Data Foundry span-aware correction candidate v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "candidate_id", "upstream", "source", "span", "candidate_layers", "views", "evidence", "reconstructions", "safety", "uncertainty", "detector", "review_state"],
+  "properties": {
+    "schema_version": {"const": "correction_candidate_v1"},
+    "candidate_id": {"$ref": "#/$defs/id"},
+    "upstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "candidate_schema_version", "candidate_sha256"],
+      "properties": {
+        "profile_id": {"$ref": "#/$defs/id"},
+        "candidate_schema_version": {"const": "review_candidate_v1"},
+        "candidate_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_record_id", "source_family", "record_id", "locator", "content_sha256", "context", "period", "genre", "register", "region", "origin"],
+      "properties": {
+        "source_record_id": {"$ref": "#/$defs/id"},
+        "source_family": {"type": "string", "minLength": 1},
+        "record_id": {"type": "string", "minLength": 1},
+        "locator": {"type": "string", "minLength": 1},
+        "content_sha256": {"$ref": "#/$defs/sha256"},
+        "context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["text", "start", "end", "sha256"],
+          "properties": {
+            "text": {"type": "string", "minLength": 1},
+            "start": {"type": "integer", "minimum": 0},
+            "end": {"type": "integer", "minimum": 1},
+            "sha256": {"$ref": "#/$defs/sha256"}
+          }
+        },
+        "period": {"type": "string", "minLength": 1},
+        "genre": {"type": "string", "minLength": 1},
+        "register": {"type": "string", "minLength": 1},
+        "region": {"type": "string", "minLength": 1},
+        "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic", "unknown"]}
+      }
+    },
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "start", "end", "language_identity", "representation", "discourse_role", "downstream_disposition"],
+      "properties": {
+        "text": {"type": "string", "minLength": 1},
+        "start": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 1},
+        "language_identity": {"$ref": "#/$defs/languageIdentity"},
+        "representation": {"$ref": "#/$defs/representation"},
+        "discourse_role": {"$ref": "#/$defs/discourseRole"},
+        "downstream_disposition": {"enum": ["retain_faithful", "retain_with_language_metadata", "mask_from_modern_ukrainian_loss", "exclude_from_modern_ukrainian_view", "correction_candidate", "protected_historical_or_register_variation", "human_review_required", "unresolved"]}
+      }
+    },
+    "candidate_layers": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"enum": ["grammar", "semantic_calque", "collocation_or_government", "translation_like_phrasing", "russian_interference", "language_span", "protected_variation"]}
+    },
+    "views": {"$ref": "#/$defs/views"},
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/evidence"}
+    },
+    "reconstructions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/reconstruction"}
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provenance", "rights", "permitted_use", "origin", "private_data", "contamination"],
+      "properties": {
+        "provenance": {"enum": ["complete", "incomplete", "conflicting"]},
+        "rights": {"enum": ["granted", "unknown", "conflicting", "denied"]},
+        "permitted_use": {"enum": ["correction_eligible", "evaluation_only", "private_reference", "investigation", "excluded", "unknown"]},
+        "origin": {"enum": ["verified_human_authorship", "verified_synthetic", "unknown", "conflicting"]},
+        "private_data": {"enum": ["clear", "present", "unknown"]},
+        "contamination": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["v0_1_1_exact", "v0_1_1_near", "v0_2_exact", "v0_2_near", "registry_artifact_sha256"],
+          "properties": {
+            "v0_1_1_exact": {"$ref": "#/$defs/contaminationState"},
+            "v0_1_1_near": {"$ref": "#/$defs/contaminationState"},
+            "v0_2_exact": {"$ref": "#/$defs/contaminationState"},
+            "v0_2_near": {"$ref": "#/$defs/contaminationState"},
+            "registry_artifact_sha256": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["v0_1_1_manifest", "v0_2_packet"],
+              "properties": {
+                "v0_1_1_manifest": {"$ref": "#/$defs/sha256"},
+                "v0_2_packet": {"$ref": "#/$defs/sha256"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "uncertainty": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "detector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["producer", "kind", "automatic_error_label", "model_output_used_as_gold"],
+      "properties": {
+        "producer": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["rule", "dictionary", "model", "combined", "human_routing"]},
+        "automatic_error_label": {"const": false},
+        "model_output_used_as_gold": {"const": false}
+      }
+    },
+    "review_state": {"const": "unresolved"}
+  },
+  "$defs": {
+    "id": {"type": "string", "pattern": "^[a-z][a-z0-9_.:-]{2,127}$"},
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "languageIdentity": {"enum": ["ukrainian", "russian", "mixed_ukrainian_russian", "historical_east_slavic_unresolved", "church_slavonic_candidate", "other_language", "uncertain"]},
+    "representation": {"enum": ["standard_orthography", "ukrainian_phonetic_rendering_of_russian", "historical_orthography", "transliteration", "ocr_or_encoding_candidate", "unknown"]},
+    "discourseRole": {"enum": ["narration", "quotation", "dialogue", "epigraph", "title", "citation_or_document", "metalinguistic_example", "unknown"]},
+    "contaminationState": {"enum": ["clear", "match", "not_checked"]},
+    "views": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["faithful_literary", "modern_literary_ukrainian", "correction", "preference", "evaluation"],
+      "properties": {
+        "faithful_literary": {"const": "retain_original"},
+        "modern_literary_ukrainian": {"enum": ["retain_original", "mask_span_from_loss", "exclude_span_or_record", "protected", "unresolved"]},
+        "correction": {"enum": ["candidate", "not_applicable", "protected", "unresolved"]},
+        "preference": {"enum": ["candidate", "not_applicable", "protected", "unresolved"]},
+        "evaluation": {"const": "excluded_from_non_evaluation_views"}
+      }
+    },
+    "senseGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sense_or_group_id", "source_order", "terms", "register_labels", "citations"],
+      "properties": {
+        "sense_or_group_id": {"type": "string", "minLength": 1},
+        "source_order": {"type": "integer", "minimum": 0},
+        "terms": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "register_labels": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "citations": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "source_identity", "query", "status", "evidence_type", "supports", "period", "register", "locator", "official_url", "parser_version", "parser_status", "content_sha256", "rights_posture", "raw_payload_export_allowed", "sense_groups"],
+      "properties": {
+        "source": {"enum": ["vesum", "russian_morphology", "r2u", "ulif_dictua", "slovnyk_me", "heritage_dictionary", "ukrainian_corpus"]},
+        "source_identity": {"type": "string", "minLength": 2},
+        "query": {"type": "string", "minLength": 1},
+        "status": {"enum": ["attested", "not_found", "ambiguous", "incomplete", "parse_error", "transient_error"]},
+        "evidence_type": {"enum": ["form", "morphology", "translation_equivalent", "synonym_group", "definition", "usage_attestation", "corpus_context", "register_label"]},
+        "supports": {"enum": ["ukrainian_attestation", "russian_attestation", "alternative_candidate", "protected_variation", "context_only", "no_conclusion"]},
+        "period": {"type": "string", "minLength": 1},
+        "register": {"type": "string", "minLength": 1},
+        "locator": {"type": "string", "minLength": 1},
+        "official_url": {"anyOf": [{"type": "string", "format": "uri"}, {"type": "null"}]},
+        "parser_version": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "parser_status": {"enum": ["ok", "not_found", "parse_error", "transient_error", "not_applicable"]},
+        "content_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "rights_posture": {"enum": ["redistribution_granted", "bounded_internal_reference", "redistribution_unknown", "redistribution_denied"]},
+        "raw_payload_export_allowed": {"type": "boolean"},
+        "sense_groups": {"type": "array", "items": {"$ref": "#/$defs/senseGroup"}}
+      }
+    },
+    "reconstruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["original_surface", "candidate", "transformation_path", "score", "gate", "russian_morphology", "r2u"],
+      "properties": {
+        "original_surface": {"type": "string", "minLength": 1},
+        "candidate": {"type": "string", "minLength": 1},
+        "transformation_path": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "gate": {"enum": ["russian_anchor", "adjacent_joint_mapping", "discourse_context", "qualified_review_request"]},
+        "russian_morphology": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "lemma"],
+          "properties": {"status": {"const": "attested"}, "lemma": {"type": "string", "minLength": 1}}
+        },
+        "r2u": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "query"],
+          "properties": {"status": {"const": "attested"}, "query": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/correction_factory_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/correction_factory_receipt_v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_factory_receipt_v1.schema.json",
+  "title": "Ukrainian Data Foundry correction factory receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "operation", "input", "output", "schemas", "evaluation_registry", "counts", "determinism", "safety"],
+  "properties": {
+    "schema_version": {"const": "correction_factory_receipt_v1"},
+    "operation": {"enum": ["prepare_review_packet", "adjudicate"]},
+    "input": {"$ref": "#/$defs/artifact"},
+    "output": {"$ref": "#/$defs/artifact"},
+    "schemas": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/sha256"},
+      "minProperties": 2
+    },
+    "evaluation_registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["v0_1_1_manifest_sha256", "v0_2_packet_sha256", "source_fingerprint_count", "normalization", "near_duplicate_threshold"],
+      "properties": {
+        "v0_1_1_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "v0_2_packet_sha256": {"$ref": "#/$defs/sha256"},
+        "source_fingerprint_count": {"type": "integer", "minimum": 1},
+        "normalization": {"const": "NFKC; casefold; collapse whitespace"},
+        "near_duplicate_threshold": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": {"type": "integer", "minimum": 0}
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["serialization", "ordering", "timestamps_omitted"],
+      "properties": {
+        "serialization": {"const": "UTF-8 canonical JSON with sorted keys and LF"},
+        "ordering": {"const": "input packet order"},
+        "timestamps_omitted": {"const": true}
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automatic_gold_created", "model_training_performed", "dataset_export_or_publication_performed", "raw_dictionary_payload_exported"],
+      "properties": {
+        "automatic_gold_created": {"const": false},
+        "model_training_performed": {"const": false},
+        "dataset_export_or_publication_performed": {"const": false},
+        "raw_dictionary_payload_exported": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["records", "sha256"],
+      "properties": {"records": {"type": "integer", "minimum": 0}, "sha256": {"$ref": "#/$defs/sha256"}}
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/correction_record_v1.schema.json
+++ b/data/projects/open_model_data/contracts/correction_record_v1.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_record_v1.schema.json",
+  "title": "Ukrainian Data Foundry adjudicated correction record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "candidate_sha256", "decision_sha256", "candidate", "decision", "conflict_state", "safety_blockers", "export_control"],
+  "properties": {
+    "schema_version": {"const": "correction_record_v1"},
+    "record_id": {"type": "string", "pattern": "^correction:[a-f0-9]{64}$"},
+    "candidate_sha256": {"$ref": "#/$defs/sha256"},
+    "decision_sha256": {"$ref": "#/$defs/sha256"},
+    "candidate": {"$ref": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_candidate_v1.schema.json"},
+    "decision": {"$ref": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_reviewer_decision_v1.schema.json"},
+    "conflict_state": {"enum": ["none", "resolved_by_third_human", "unresolved"]},
+    "safety_blockers": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "export_control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["qualified_correction_intake", "handoff", "model_training_or_export_eligible", "owner_issue"],
+      "properties": {
+        "qualified_correction_intake": {"type": "boolean"},
+        "handoff": {"enum": ["correction_intake_ready", "faithful_or_protected_only", "excluded", "unresolved"]},
+        "model_training_or_export_eligible": {"const": false},
+        "owner_issue": {"const": 6122}
+      }
+    }
+  },
+  "$defs": {"sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}}
+}

--- a/data/projects/open_model_data/contracts/correction_reviewer_decision_v1.schema.json
+++ b/data/projects/open_model_data/contracts/correction_reviewer_decision_v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_reviewer_decision_v1.schema.json",
+  "title": "Ukrainian Data Foundry qualified correction review v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "candidate_id", "candidate_sha256", "review_state", "first_pass_reviews", "final_resolution", "final"],
+  "properties": {
+    "schema_version": {"const": "correction_reviewer_decision_v1"},
+    "candidate_id": {"$ref": "#/$defs/id"},
+    "candidate_sha256": {"$ref": "#/$defs/sha256"},
+    "review_state": {"enum": ["adjudicated", "unresolved"]},
+    "first_pass_reviews": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"$ref": "#/$defs/review"}},
+    "final_resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {"enum": ["first_pass_agreement", "third_human_adjudication", "unresolved_conflict"]},
+        "third_review": {"$ref": "#/$defs/review"}
+      }
+    },
+    "final": {"$ref": "#/$defs/projection"}
+  },
+  "$defs": {
+    "id": {"type": "string", "pattern": "^[a-z][a-z0-9_.:-]{2,127}$"},
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer_id", "human", "ukrainian_qualification", "qualification_evidence", "independence_attested", "test_fixture"],
+      "properties": {
+        "reviewer_id": {"$ref": "#/$defs/id"},
+        "human": {"const": true},
+        "ukrainian_qualification": {"enum": ["native_or_near_native_ukrainian_editor", "credentialed_ukrainian_linguist", "qualified_ukrainian_language_reviewer"]},
+        "qualification_evidence": {"type": "string", "minLength": 1},
+        "independence_attested": {"const": true},
+        "test_fixture": {"type": "boolean"}
+      }
+    },
+    "citation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_kind", "source_identity", "locator", "supports", "content_sha256"],
+      "properties": {
+        "source_kind": {"enum": ["primary_source", "dictionary", "grammar", "corpus", "editorial_policy", "other"]},
+        "source_identity": {"type": "string", "minLength": 2},
+        "locator": {"type": "string", "minLength": 1},
+        "supports": {"type": "string", "minLength": 1},
+        "content_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]}
+      }
+    },
+    "views": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["faithful_literary", "modern_literary_ukrainian", "correction", "preference", "evaluation"],
+      "properties": {
+        "faithful_literary": {"const": "retain_original"},
+        "modern_literary_ukrainian": {"enum": ["retain_original", "mask_span_from_loss", "exclude_span_or_record", "protected", "unresolved"]},
+        "correction": {"enum": ["eligible_intake", "not_applicable", "protected", "unresolved"]},
+        "preference": {"enum": ["eligible_intake", "not_applicable", "protected", "unresolved"]},
+        "evaluation": {"const": "excluded_from_non_evaluation_views"}
+      }
+    },
+    "projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "language_identity", "representation", "discourse_role", "accepted_correction", "acceptable_alternatives", "views", "uncertainty", "citations", "rationale"],
+      "properties": {
+        "decision": {"enum": ["correction", "acceptable_as_is", "protected_variation", "quoted_or_multilingual", "exclude", "unresolved"]},
+        "language_identity": {"enum": ["ukrainian", "russian", "mixed_ukrainian_russian", "historical_east_slavic_unresolved", "church_slavonic_candidate", "other_language", "uncertain"]},
+        "representation": {"enum": ["standard_orthography", "ukrainian_phonetic_rendering_of_russian", "historical_orthography", "transliteration", "ocr_or_encoding_candidate", "unknown"]},
+        "discourse_role": {"enum": ["narration", "quotation", "dialogue", "epigraph", "title", "citation_or_document", "metalinguistic_example", "unknown"]},
+        "accepted_correction": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "acceptable_alternatives": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "views": {"$ref": "#/$defs/views"},
+        "uncertainty": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "citations": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/citation"}},
+        "rationale": {"type": "string", "minLength": 1}
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer", "projection"],
+      "properties": {"reviewer": {"$ref": "#/$defs/reviewer"}, "projection": {"$ref": "#/$defs/projection"}}
+    }
+  }
+}

--- a/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
@@ -209,6 +209,15 @@ profiled candidate
 An unresolved or protected record remains non-exportable. Synthetic fixtures
 and model outputs cannot stand in for qualified human decisions.
 
+The implemented #6121 boundary is the
+[correction-factory runbook](../runbooks/ukrainian-data-foundry-correction-factory.md).
+Its four versioned schemas and deterministic CLI enforce original span
+preservation, source-specific evidence, evaluation-contamination joins, two
+independent Ukrainian-human first passes, a distinct third-human conflict
+path, and fail-closed handoff. Every resulting record remains explicitly
+ineligible for model training or export; #6122 owns that separate consumer
+boundary.
+
 ### 6. Consumer views
 
 Continued-pretraining, correction/instruction, preference, quality-filter, and

--- a/docs/research/UKRAINIAN_DATA_FOUNDRY_LANGUAGE_SPAN_AND_LEXICAL_EVIDENCE.md
+++ b/docs/research/UKRAINIAN_DATA_FOUNDRY_LANGUAGE_SPAN_AND_LEXICAL_EVIDENCE.md
@@ -243,13 +243,17 @@ The repository already implements:
 - a sequential one-second fetch policy in
   `scripts/lexicon/runner/fetch_ulif_20k.py`.
 
-A live `query_ulif("дуже", sections=["paradigm", "synonyms"])` probe returned
-structured synonym groups, register labels, citations, parser version
-`ulif-dictua-v1`, and content hash
-`94da3fd742d98c87849f84fd90cf6b50c7cd31b9fc241d890ca74cb2d8c1da0b`, but
-the aggregate response status was `parse_error`. The adapter therefore exists
-but is not yet trustworthy for #6121. Implementation must reproduce and fix or
-correctly narrow that status before treating any response as complete.
+An initial live `query_ulif("дуже", sections=["paradigm", "synonyms"])` probe
+returned structured synonym groups, register labels, citations, and content
+hash `94da3fd742d98c87849f84fd90cf6b50c7cd31b9fc241d890ca74cb2d8c1da0b`,
+but parser version `ulif-dictua-v1` incorrectly assigned aggregate status
+`parse_error` because the adverb had no inflection table. Issue #6121 resolved
+that false requirement in `ulif-dictua-v2`. A live repeat over the same content
+hash returned `status: ok`, four synonym groups, and no paradigm, as expected.
+Missing WebForms state, malformed result lists, incomplete tab traversal, and
+transient failures still fail closed. The executable boundary and verification
+commands are in the
+[correction-factory runbook](../runbooks/ukrainian-data-foundry-correction-factory.md).
 
 The inspected landing page displays `© ULIF, 2001–2026`; no explicit open-data
 license for bulk redistribution was found there, and `/robots.txt` returned

--- a/docs/runbooks/ukrainian-data-foundry-correction-factory.md
+++ b/docs/runbooks/ukrainian-data-foundry-correction-factory.md
@@ -1,0 +1,161 @@
+# Ukrainian Data Foundry Correction Factory
+
+> **Owner:** [#6121](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6121)
+> under [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
+> **Boundary:** review intake and adjudication, not model-ready export
+
+## What this component produces
+
+The correction factory takes span-aware, unresolved candidates from a local
+detector or enrichment stage and produces two deterministic artifacts:
+
+1. a review packet that preserves the original bounded context, offsets,
+   language/representation/discourse axes, source-specific evidence, and
+   separate view dispositions; and
+2. an adjudicated correction record that preserves the complete candidate and
+   qualified-human decision while remaining ineligible for training or export.
+
+The component does not infer corrections. A detector, VESUM miss, Russian
+morphology result, `r2u` hit, dictionary result, exact mismatch, or model vote
+remains evidence until the qualified-human review contract is satisfied.
+
+## Contracts
+
+| Interface | Contract |
+| --- | --- |
+| Unresolved span candidate | `correction_candidate_v1.schema.json` |
+| Qualified reviewer decision | `correction_reviewer_decision_v1.schema.json` |
+| Adjudicated record | `correction_record_v1.schema.json` |
+| Deterministic receipt | `correction_factory_receipt_v1.schema.json` |
+
+All contracts are in `data/projects/open_model_data/contracts/`. The runtime
+validates the schemas before writing output and replaces existing artifacts
+only after all rows and receipts pass validation.
+
+## Prepare a review packet
+
+Run from the repository root with local, non-published paths:
+
+```bash
+.venv/bin/python scripts/projects/open_model_data/correction_factory.py prepare \
+  --candidates /local/path/correction-candidates.jsonl \
+  --packet-output /local/path/review-packet.jsonl \
+  --receipt-output /local/path/review-packet.receipt.json
+```
+
+The command binds every candidate to the committed v0.1.1 held-out manifest
+and v0.2 review packet. It recomputes exact and near-duplicate dispositions,
+checks the frozen manifest/packet hashes, validates original text and offsets,
+and rejects stale or falsely cleared contamination fields.
+
+A candidate producer must supply:
+
+- the upstream profiler candidate hash and profile identifier;
+- bounded source context plus exact span offsets without rewriting the text;
+- language identity, representation, discourse role, and proposed downstream
+  disposition as independent axes;
+- separate faithful, modern-Ukrainian, correction, preference, and evaluation
+  view dispositions;
+- source-specific lexical evidence with source identity, locator, period,
+  register, parser status/version, content hash, and rights posture; and
+- unresolved detector state with `automatic_error_label: false` and
+  `model_output_used_as_gold: false`.
+
+When VESUM does not attest a form, the packet must record completed routing to
+ULIF, a heritage dictionary, one named underlying `slovnyk.me` dictionary, and
+Ukrainian corpus context. Missing results are valid evidence; omitted routes
+are not. `slovnyk.me` itself is never accepted as the dictionary identity.
+
+Ukrainian-phonetic Russian requires a suspicious bounded span and at least one
+preserved reconstruction. Each reconstruction records its gate,
+transformation path, score, Russian morphology result, and `r2u` result. A
+global character substitution is not an accepted input.
+
+## Import adjudication
+
+```bash
+.venv/bin/python scripts/projects/open_model_data/correction_factory.py adjudicate \
+  --packet /local/path/review-packet.jsonl \
+  --decisions /local/path/reviewer-decisions.jsonl \
+  --records-output /local/path/correction-records.jsonl \
+  --receipt-output /local/path/correction-records.receipt.json
+```
+
+The decisions must be in exact packet order and carry the canonical candidate
+hash. Two different qualified Ukrainian humans must make independent first
+passes. Matching projections are preserved exactly. A conflict either remains
+unresolved or is resolved by a third, distinct qualified Ukrainian human;
+the final projection must equal that third review.
+
+Synthetic reviewers are supported only by the explicit
+`--allow-test-fixtures` test switch. They always add a safety blocker and can
+never produce qualified correction intake.
+
+## Fail-closed promotion
+
+A record is marked `qualified_correction_intake: true` only when all of these
+are true:
+
+- the human final decision is `correction` and includes an accepted form;
+- review is adjudicated through the required independent-human path;
+- provenance and destination-specific rights are complete and granted;
+- intended use and human/synthetic origin are known;
+- private-data screening is clear;
+- exact and near-duplicate checks are clear against both evaluation versions;
+- no dictionary request is incomplete or in a parser/transient-error state;
+- the span is not historical, heritage, dialectal, regional, archaic, rare,
+  slang/marked, quoted Russian, multilingual, or otherwise protected; and
+- no test-fixture reviewer participated.
+
+Russian quotations and dialogue retain their source bytes in the faithful
+view and are masked or excluded from modern-Ukrainian loss. Historical and
+protected variation remains faithful/protected. The canonical source is never
+silently translated or rewritten.
+
+Every record still carries:
+
+```json
+{
+  "model_training_or_export_eligible": false,
+  "owner_issue": 6122
+}
+```
+
+Issue #6122 owns the separate consumer schemas and model-ready exporters. It
+must revalidate rights, contamination, view separation, and this handoff; it
+must not reinterpret an unresolved or protected record as correction data.
+
+## ULIF completeness
+
+Parser version `ulif-dictua-v2` treats an exact DictUA headword match with a
+complete WebForms/tab traversal as successful even when no inflection table
+exists. This covers non-inflecting headwords that expose synonym or other
+relation data. Missing WebForms state, a malformed result list, an interrupted
+tab sequence, or a transient network failure still fails closed.
+
+ULIF synonym evidence retains ordered sense groups, register labels,
+citations, parser status/version, locator, and content hash. Raw HTML is not a
+correction-packet field and remains non-exportable without permission.
+
+## Required verification
+
+```bash
+.venv/bin/python -m pytest -q \
+  tests/test_open_model_correction_factory.py \
+  tests/test_ulif_dictua.py \
+  tests/test_lexicon_runner_offline_reduce.py
+
+.venv/bin/ruff check \
+  scripts/projects/open_model_data/correction_factory.py \
+  scripts/rag/source_query.py \
+  scripts/lexicon/runner/ulif_dictua_parse.py \
+  tests/test_open_model_correction_factory.py \
+  tests/test_ulif_dictua.py \
+  tests/test_lexicon_runner_offline_reduce.py
+```
+
+The focused regression suite covers Russian quotation and dash dialogue,
+phonetic Russian, VESUM-presence ambiguity, historical protection,
+`перекличка`, shared Ukrainian/Russian forms, ULIF completeness, per-dictionary
+source identity, contamination and rights gates, deterministic bytes, and the
+detector-not-gold boundary.

--- a/scripts/lexicon/runner/ulif_dictua_parse.py
+++ b/scripts/lexicon/runner/ulif_dictua_parse.py
@@ -283,11 +283,11 @@ def parse_dictua_envelope(
     if status == "not_found":
         sections = {}
 
-    # A successful fetch can legitimately have no paradigm: non-inflecting
-    # headwords may expose only synonym/antonym/phraseology tabs, or no
-    # structured section at all.  The fetch envelope owns completeness; this
-    # reducer must not turn a source ``ok`` into ``parse_error`` merely because
-    # an inflection table is absent.
+    # A successful fetch can legitimately have no paradigm when at least one
+    # relation section was parsed.  A content-empty envelope remains unusable
+    # evidence and must fail closed even if its source status says ``ok``.
+    if status == "ok" and not sections:
+        status = "parse_error"
 
     return {
         "body_sha256": body_sha256 or "",

--- a/scripts/lexicon/runner/ulif_dictua_parse.py
+++ b/scripts/lexicon/runner/ulif_dictua_parse.py
@@ -29,7 +29,7 @@ from bs4 import BeautifulSoup, Tag
 # Structured reduce schema (independent of fetch status stubs).
 ULIF_STRUCTURED_SCHEMA_VERSION = "ulif-structured-v1"
 # Keep in lockstep with scripts.rag.source_query.ULIF_PARSER_VERSION.
-ULIF_PARSER_VERSION = "ulif-dictua-v1"
+ULIF_PARSER_VERSION = "ulif-dictua-v2"
 ULIF_NORMALIZER_VERSION = "ulif-strip-raw-html-v1"
 ULIF_SOURCE_ID = "ulif_dictua"
 ULIF_OFFICIAL_URL = "https://lcorp.ulif.org.ua/dictua/"
@@ -280,15 +280,14 @@ def parse_dictua_envelope(
         if groups:
             sections[section_name] = groups if include_raw_html else strip_raw_html(groups)
 
-    if status == "ok":
-        if "paradigm" not in sections and source_status == "ok" and paradigm_html:
-            status = "parse_error"
-    elif status == "not_found":
+    if status == "not_found":
         sections = {}
 
-    # Antonyms-only / partial envelopes with source ok and no paradigm stage keep sections.
-    if status == "ok" and not paradigm_html and not sections:
-        status = "parse_error"
+    # A successful fetch can legitimately have no paradigm: non-inflecting
+    # headwords may expose only synonym/antonym/phraseology tabs, or no
+    # structured section at all.  The fetch envelope owns completeness; this
+    # reducer must not turn a source ``ok`` into ``parse_error`` merely because
+    # an inflection table is absent.
 
     return {
         "body_sha256": body_sha256 or "",

--- a/scripts/projects/open_model_data/correction_factory.py
+++ b/scripts/projects/open_model_data/correction_factory.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python3
+"""Build deterministic Ukrainian correction-review packets and adjudications.
+
+This module is an intake and control boundary.  It validates span/evidence
+records, binds them to the frozen evaluation inventories, enforces qualified
+human review, and writes non-exportable correction records.  It never turns a
+detector result into gold and never produces a model-training export.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
+CANDIDATE_SCHEMA_PATH = CONTRACTS / "correction_candidate_v1.schema.json"
+DECISION_SCHEMA_PATH = CONTRACTS / "correction_reviewer_decision_v1.schema.json"
+RECORD_SCHEMA_PATH = CONTRACTS / "correction_record_v1.schema.json"
+RECEIPT_SCHEMA_PATH = CONTRACTS / "correction_factory_receipt_v1.schema.json"
+SCHEMA_PATHS = (
+    CANDIDATE_SCHEMA_PATH,
+    DECISION_SCHEMA_PATH,
+    RECORD_SCHEMA_PATH,
+    RECEIPT_SCHEMA_PATH,
+)
+DEFAULT_EVALUATION_MANIFEST = (
+    ROOT / "data/projects/ua_eval_harness/heldout_manifest_v1.json"
+)
+DEFAULT_V02_PACKET = (
+    ROOT / "data/projects/ua_eval_harness/v0.2/review_packet_priority_v1.jsonl"
+)
+
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+NEAR_DUPLICATE_THRESHOLD = 0.90
+PROTECTED_PERIOD_MARKERS = (
+    "historical",
+    "middle_ukrainian",
+    "old_east_slavic",
+    "archaic",
+)
+PROTECTED_REGISTER_MARKERS = (
+    "dialect",
+    "folk",
+    "heritage",
+    "regional",
+    "archaic",
+    "rare",
+    "slang",
+    "marked",
+)
+UKRAINIAN_ESCALATION_SOURCES = frozenset(
+    {"ulif_dictua", "heritage_dictionary", "slovnyk_me", "ukrainian_corpus"}
+)
+
+
+class FactoryError(ValueError):
+    """A packet, review, or safety state violates the correction contract."""
+
+
+@dataclass(frozen=True)
+class EvaluationRegistry:
+    """Frozen source fingerprints used to prevent evaluation contamination."""
+
+    v011_exact: frozenset[str]
+    v011_texts: tuple[str, ...]
+    v02_exact: frozenset[str]
+    v02_texts: tuple[str, ...]
+    v011_manifest_sha256: str
+    v02_packet_sha256: str
+
+    @property
+    def source_fingerprint_count(self) -> int:
+        return len(self.v011_exact | self.v02_exact)
+
+
+def canonical_json(value: Any) -> str:
+    """Return the byte-stable JSON representation used by every artifact."""
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_text(value: str) -> str:
+    return sha256_bytes(value.encode("utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def normalize_evaluation_text(value: str) -> str:
+    """Normalize only for duplicate comparison; never mutate source payloads."""
+    return " ".join(unicodedata.normalize("NFKC", value).casefold().split())
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FactoryError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise FactoryError(f"expected JSON object: {path}")
+    return value
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load non-empty JSONL records with attributable line failures."""
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise FactoryError(f"cannot read JSONL {path}: {exc}") from exc
+    for line_number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise FactoryError(f"invalid JSONL at {path}:{line_number}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise FactoryError(f"expected object at {path}:{line_number}")
+        rows.append(row)
+    return rows
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise FactoryError(message)
+
+
+def _schema_bundle() -> tuple[dict[Path, dict[str, Any]], Registry]:
+    schemas = {path: _read_json(path) for path in SCHEMA_PATHS}
+    registry = Registry()
+    for schema in schemas.values():
+        Draft202012Validator.check_schema(schema)
+        registry = registry.with_resource(
+            str(schema["$id"]), Resource.from_contents(schema)
+        )
+    return schemas, registry
+
+
+def _validator(
+    path: Path,
+    *,
+    schemas: Mapping[Path, dict[str, Any]],
+    registry: Registry,
+) -> Draft202012Validator:
+    return Draft202012Validator(schemas[path], registry=registry)
+
+
+def _validate_schema(
+    value: Mapping[str, Any],
+    validator: Draft202012Validator,
+    *,
+    label: str,
+) -> None:
+    errors = sorted(validator.iter_errors(value), key=lambda error: list(error.path))
+    if errors:
+        path = ".".join(str(part) for part in errors[0].path) or "<root>"
+        raise FactoryError(f"{label} schema violation at {path}: {errors[0].message}")
+
+
+def _expanded_manifest_sources(manifest: Mapping[str, Any]) -> list[tuple[str, str]]:
+    layout = manifest.get("record_layouts", {}).get("item")
+    items = manifest.get("items")
+    _require(isinstance(layout, list) and isinstance(items, list), "invalid evaluation manifest layout")
+    _require("source" in layout and "source_sha256" in layout, "evaluation manifest lacks source fields")
+    source_index = layout.index("source")
+    hash_index = layout.index("source_sha256")
+    result: list[tuple[str, str]] = []
+    for row in items:
+        _require(isinstance(row, list) and len(row) == len(layout), "invalid evaluation manifest item")
+        source, source_hash = row[source_index], row[hash_index]
+        _require(isinstance(source, str) and isinstance(source_hash, str), "invalid evaluation source")
+        _require(sha256_text(source) == source_hash, "evaluation source hash mismatch")
+        result.append((source, source_hash))
+    return result
+
+
+def _v02_sources(rows: Sequence[Mapping[str, Any]]) -> list[tuple[str, str]]:
+    result: list[tuple[str, str]] = []
+    for row in rows:
+        blind = row.get("blind_reviewer_view")
+        receipts = row.get("frozen_receipts")
+        _require(isinstance(blind, Mapping) and isinstance(receipts, Mapping), "invalid v0.2 packet row")
+        source, source_hash = blind.get("source"), receipts.get("source_sha256")
+        _require(isinstance(source, str) and isinstance(source_hash, str), "invalid v0.2 source")
+        _require(sha256_text(source) == source_hash, "v0.2 source hash mismatch")
+        result.append((source, source_hash))
+        references = blind.get("references")
+        _require(isinstance(references, list), "invalid v0.2 reference list")
+        for reference in references:
+            _require(isinstance(reference, list) and len(reference) >= 3, "invalid v0.2 reference")
+            text, reference_hash = reference[1], reference[2]
+            _require(isinstance(text, str) and isinstance(reference_hash, str), "invalid v0.2 reference fields")
+            _require(sha256_text(text) == reference_hash, "v0.2 reference hash mismatch")
+            result.append((text, reference_hash))
+    return result
+
+
+def load_evaluation_registry(
+    *,
+    v011_manifest_path: Path = DEFAULT_EVALUATION_MANIFEST,
+    v02_packet_path: Path = DEFAULT_V02_PACKET,
+) -> EvaluationRegistry:
+    """Load v0.1.1 and v0.2 source/gold fingerprints fail closed."""
+    v011_rows = _expanded_manifest_sources(_read_json(v011_manifest_path))
+    v02_rows_raw = read_jsonl(v02_packet_path)
+    _require(v02_rows_raw, "empty v0.2 review packet")
+    v02_rows = _v02_sources(v02_rows_raw)
+    return EvaluationRegistry(
+        v011_exact=frozenset(item[1] for item in v011_rows),
+        v011_texts=tuple(sorted({normalize_evaluation_text(item[0]) for item in v011_rows})),
+        v02_exact=frozenset(item[1] for item in v02_rows),
+        v02_texts=tuple(sorted({normalize_evaluation_text(item[0]) for item in v02_rows})),
+        v011_manifest_sha256=sha256_file(v011_manifest_path),
+        v02_packet_sha256=sha256_file(v02_packet_path),
+    )
+
+
+def _near_duplicate(text: str, reference_texts: Sequence[str]) -> bool:
+    normalized = normalize_evaluation_text(text)
+    if not normalized:
+        return False
+    for reference in reference_texts:
+        if normalized == reference:
+            return True
+        length_ratio = min(len(normalized), len(reference)) / max(len(normalized), len(reference))
+        if length_ratio < NEAR_DUPLICATE_THRESHOLD:
+            continue
+        if SequenceMatcher(None, normalized, reference, autojunk=False).ratio() >= NEAR_DUPLICATE_THRESHOLD:
+            return True
+    return False
+
+
+def contamination_states(text: str, registry: EvaluationRegistry) -> dict[str, str]:
+    """Compute exact and near-duplicate dispositions for one bounded context."""
+    raw_hash = sha256_text(text)
+    return {
+        "v0_1_1_exact": "match" if raw_hash in registry.v011_exact else "clear",
+        "v0_1_1_near": "match" if _near_duplicate(text, registry.v011_texts) else "clear",
+        "v0_2_exact": "match" if raw_hash in registry.v02_exact else "clear",
+        "v0_2_near": "match" if _near_duplicate(text, registry.v02_texts) else "clear",
+    }
+
+
+def _is_protected(candidate: Mapping[str, Any]) -> bool:
+    source = candidate["source"]
+    span = candidate["span"]
+    period = str(source["period"]).casefold()
+    register = str(source["register"]).casefold()
+    return (
+        any(marker in period for marker in PROTECTED_PERIOD_MARKERS)
+        or any(marker in register for marker in PROTECTED_REGISTER_MARKERS)
+        or "protected_variation" in candidate["candidate_layers"]
+        or span["language_identity"] in {
+            "historical_east_slavic_unresolved",
+            "church_slavonic_candidate",
+        }
+        or span["downstream_disposition"]
+        == "protected_historical_or_register_variation"
+    )
+
+
+def _validate_evidence(candidate: Mapping[str, Any]) -> None:
+    evidence = candidate["evidence"]
+    sources = {item["source"] for item in evidence}
+    identities = {(item["source"], item["source_identity"], item["locator"]) for item in evidence}
+    _require(len(identities) == len(evidence), "duplicate source-specific evidence")
+
+    vesum_miss = any(
+        item["source"] == "vesum" and item["status"] == "not_found"
+        for item in evidence
+    )
+    if vesum_miss:
+        missing = sorted(UKRAINIAN_ESCALATION_SOURCES - sources)
+        _require(not missing, f"VESUM miss lacks Ukrainian escalation sources: {', '.join(missing)}")
+
+    for item in evidence:
+        if item["source"] == "slovnyk_me":
+            normalized_identity = item["source_identity"].casefold().replace(" ", "")
+            _require(
+                normalized_identity not in {"slovnyk.me", "slovnykme", "aggregator"},
+                "slovnyk.me evidence must name the underlying dictionary",
+            )
+            _require(not item["raw_payload_export_allowed"], "slovnyk.me raw payload cannot enter the packet")
+        if item["source"] == "ulif_dictua":
+            _require(not item["raw_payload_export_allowed"], "ULIF raw payload cannot enter the packet")
+            if item["status"] == "attested":
+                _require(item["parser_status"] == "ok", "attested ULIF evidence requires parser status ok")
+                _require(item["content_sha256"] is not None, "attested ULIF evidence requires a content hash")
+            if item["evidence_type"] == "synonym_group" and item["status"] == "attested":
+                _require(item["sense_groups"], "ULIF synonym evidence lacks sense groups")
+
+    phonetic = candidate["span"]["representation"] == "ukrainian_phonetic_rendering_of_russian"
+    reconstructions = candidate["reconstructions"]
+    _require(phonetic == bool(reconstructions), "phonetic-Russian classification and reconstructions must agree")
+    for reconstruction in reconstructions:
+        _require(
+            reconstruction["original_surface"] in candidate["span"]["text"],
+            "reconstruction surface is absent from the preserved span",
+        )
+
+    if "russian_interference" in candidate["candidate_layers"]:
+        _require("r2u" in sources and "russian_morphology" in sources, "Russian-interference candidate lacks r2u or morphology evidence")
+
+    shared_form_only = (
+        any(item["source"] == "vesum" and item["status"] == "attested" for item in evidence)
+        and any(item["source"] == "r2u" and item["status"] == "attested" for item in evidence)
+        and sources <= {"vesum", "r2u", "russian_morphology"}
+        and not reconstructions
+        and not phonetic
+    )
+    if shared_form_only:
+        _require(candidate["span"]["language_identity"] == "uncertain", "bare r2u hit cannot decide a shared form")
+        _require(candidate["views"]["correction"] == "unresolved", "shared form must remain unresolved")
+
+
+def validate_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    validator: Draft202012Validator,
+    evaluation_registry: EvaluationRegistry,
+) -> None:
+    """Validate schema, offsets, evidence routing, views, and safety joins."""
+    _validate_schema(candidate, validator, label="correction candidate")
+    source = candidate["source"]
+    context = source["context"]
+    span = candidate["span"]
+    _require(context["end"] - context["start"] == len(context["text"]), "context offsets do not match text")
+    _require(context["sha256"] == sha256_text(context["text"]), "context hash mismatch")
+    _require(context["start"] <= span["start"] < span["end"] <= context["end"], "span lies outside context")
+    local_start = span["start"] - context["start"]
+    local_end = span["end"] - context["start"]
+    _require(context["text"][local_start:local_end] == span["text"], "span offsets do not reproduce original text")
+
+    _validate_evidence(candidate)
+    views = candidate["views"]
+    role = span["discourse_role"]
+    if span["language_identity"] == "russian" and role in {"quotation", "dialogue"}:
+        _require(views["faithful_literary"] == "retain_original", "Russian speech must remain source-faithful")
+        _require(views["modern_literary_ukrainian"] in {"mask_span_from_loss", "exclude_span_or_record"}, "Russian speech must be masked or excluded from modern loss")
+        _require(views["correction"] in {"not_applicable", "protected"}, "Russian speech is not correction gold")
+    if _is_protected(candidate):
+        _require(views["correction"] in {"protected", "not_applicable", "unresolved"}, "protected variation cannot be a correction candidate")
+
+    contamination = candidate["safety"]["contamination"]
+    expected_states = contamination_states(context["text"], evaluation_registry)
+    for field, expected in expected_states.items():
+        _require(contamination[field] == expected, f"stale or false contamination state: {field}")
+    expected_artifacts = {
+        "v0_1_1_manifest": evaluation_registry.v011_manifest_sha256,
+        "v0_2_packet": evaluation_registry.v02_packet_sha256,
+    }
+    _require(contamination["registry_artifact_sha256"] == expected_artifacts, "evaluation registry receipt mismatch")
+
+
+def _projection(review: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = review.get("projection")
+    _require(isinstance(value, Mapping), "review lacks projection")
+    return value
+
+
+def validate_decision(
+    decision: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    validator: Draft202012Validator,
+    allow_test_fixtures: bool,
+) -> None:
+    """Enforce two-person review and a distinct third-person conflict path."""
+    _validate_schema(decision, validator, label="reviewer decision")
+    _require(decision["candidate_id"] == candidate["candidate_id"], "decision candidate ID mismatch")
+    candidate_hash = sha256_text(canonical_json(candidate))
+    _require(decision["candidate_sha256"] == candidate_hash, "decision candidate hash mismatch")
+
+    first = decision["first_pass_reviews"]
+    first_ids = [item["reviewer"]["reviewer_id"] for item in first]
+    _require(len(set(first_ids)) == 2, "first-pass reviewers must be distinct")
+    first_fixtures = [item["reviewer"]["test_fixture"] for item in first]
+    _require(allow_test_fixtures or not any(first_fixtures), "fixture reviewer cannot be a real adjudicator")
+    projections = [_projection(item) for item in first]
+    resolution = decision["final_resolution"]
+    final = decision["final"]
+
+    if projections[0] == projections[1]:
+        _require(resolution["kind"] == "first_pass_agreement", "matching first passes require agreement resolution")
+        _require("third_review" not in resolution, "agreement resolution cannot contain a third review")
+        _require(final == projections[0], "final projection must preserve first-pass agreement")
+    elif resolution["kind"] == "unresolved_conflict":
+        _require("third_review" not in resolution, "unresolved conflict cannot contain a third review")
+        _require(final["decision"] == "unresolved", "unresolved conflict requires unresolved final decision")
+    else:
+        _require(resolution["kind"] == "third_human_adjudication", "conflict needs a third human or unresolved state")
+        third = resolution.get("third_review")
+        _require(isinstance(third, Mapping), "third-human adjudication lacks a review")
+        reviewer = third["reviewer"]
+        _require(reviewer["reviewer_id"] not in first_ids, "third reviewer must be distinct")
+        _require(allow_test_fixtures or not reviewer["test_fixture"], "fixture third reviewer cannot be a real adjudicator")
+        _require(_projection(third)["decision"] != "unresolved", "unresolved third review cannot adjudicate")
+        _require(final == _projection(third), "final projection must equal third-human adjudication")
+
+    unresolved = final["decision"] == "unresolved"
+    _require((decision["review_state"] == "unresolved") == unresolved, "review state contradicts final decision")
+    if final["decision"] == "correction":
+        _require(final["accepted_correction"] is not None, "correction decision lacks accepted correction")
+    else:
+        _require(final["accepted_correction"] is None, "non-correction decision cannot carry accepted correction")
+
+    span = candidate["span"]
+    if _is_protected(candidate):
+        _require(final["decision"] != "correction", "protected variation cannot be adjudicated as correction")
+    if span["language_identity"] == "russian" and span["discourse_role"] in {"quotation", "dialogue"}:
+        _require(final["decision"] in {"quoted_or_multilingual", "protected_variation", "exclude", "unresolved"}, "source-faithful Russian speech cannot become a correction")
+        _require(final["views"]["faithful_literary"] == "retain_original", "final review must preserve quotation bytes")
+        _require(final["views"]["modern_literary_ukrainian"] in {"mask_span_from_loss", "exclude_span_or_record"}, "final review must mask or exclude Russian speech")
+
+
+def _evidence_incomplete(candidate: Mapping[str, Any]) -> bool:
+    return any(
+        item["status"] in {"incomplete", "parse_error", "transient_error"}
+        or item["parser_status"] in {"parse_error", "transient_error"}
+        for item in candidate["evidence"]
+    )
+
+
+def _safety_blockers(
+    candidate: Mapping[str, Any],
+    decision: Mapping[str, Any],
+) -> list[str]:
+    safety = candidate["safety"]
+    blockers: list[str] = []
+    checks = (
+        (safety["provenance"] == "complete", "provenance_not_complete"),
+        (safety["rights"] == "granted", "rights_not_granted"),
+        (safety["permitted_use"] == "correction_eligible", "permitted_use_not_correction_eligible"),
+        (safety["origin"] in {"verified_human_authorship", "verified_synthetic"}, "origin_not_verified"),
+        (safety["private_data"] == "clear", "private_data_not_clear"),
+    )
+    blockers.extend(reason for passed, reason in checks if not passed)
+    for field in ("v0_1_1_exact", "v0_1_1_near", "v0_2_exact", "v0_2_near"):
+        if safety["contamination"][field] != "clear":
+            blockers.append(f"contamination_{field}")
+    if _evidence_incomplete(candidate):
+        blockers.append("evidence_incomplete")
+    if _is_protected(candidate):
+        blockers.append("protected_variation")
+    if decision["review_state"] != "adjudicated":
+        blockers.append("review_unresolved")
+    if decision["final"]["decision"] != "correction":
+        blockers.append("decision_not_correction")
+    reviewers = [item["reviewer"] for item in decision["first_pass_reviews"]]
+    third = decision["final_resolution"].get("third_review")
+    if isinstance(third, Mapping):
+        reviewers.append(third["reviewer"])
+    if any(reviewer["test_fixture"] for reviewer in reviewers):
+        blockers.append("test_fixture_reviewer")
+    return sorted(set(blockers))
+
+
+def _handoff(candidate: Mapping[str, Any], decision: Mapping[str, Any], blockers: Sequence[str]) -> str:
+    final_decision = decision["final"]["decision"]
+    if not blockers:
+        return "correction_intake_ready"
+    if final_decision in {"acceptable_as_is", "protected_variation", "quoted_or_multilingual"} or _is_protected(candidate):
+        return "faithful_or_protected_only"
+    if final_decision == "exclude" or any(
+        blocker.startswith("contamination_") or blocker in {"rights_not_granted", "private_data_not_clear"}
+        for blocker in blockers
+    ):
+        return "excluded"
+    return "unresolved"
+
+
+def _record(candidate: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
+    candidate_hash = sha256_text(canonical_json(candidate))
+    decision_hash = sha256_text(canonical_json(decision))
+    blockers = _safety_blockers(candidate, decision)
+    resolution_kind = decision["final_resolution"]["kind"]
+    conflict_state = {
+        "first_pass_agreement": "none",
+        "third_human_adjudication": "resolved_by_third_human",
+        "unresolved_conflict": "unresolved",
+    }[resolution_kind]
+    return {
+        "candidate": candidate,
+        "candidate_sha256": candidate_hash,
+        "conflict_state": conflict_state,
+        "decision": decision,
+        "decision_sha256": decision_hash,
+        "export_control": {
+            "handoff": _handoff(candidate, decision, blockers),
+            "model_training_or_export_eligible": False,
+            "owner_issue": 6122,
+            "qualified_correction_intake": not blockers,
+        },
+        "record_id": f"correction:{sha256_text(candidate_hash + decision_hash)}",
+        "safety_blockers": blockers,
+        "schema_version": "correction_record_v1",
+    }
+
+
+def _jsonl_bytes(rows: Sequence[Mapping[str, Any]]) -> bytes:
+    return "".join(canonical_json(row) + "\n" for row in rows).encode("utf-8")
+
+
+def _write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=path.name,
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _schema_hashes() -> dict[str, str]:
+    return {path.name: sha256_file(path) for path in SCHEMA_PATHS}
+
+
+def _receipt(
+    *,
+    operation: str,
+    input_records: int,
+    input_hash: str,
+    output_rows: Sequence[Mapping[str, Any]],
+    registry: EvaluationRegistry,
+    counts: Mapping[str, int],
+) -> dict[str, Any]:
+    output_bytes = _jsonl_bytes(output_rows)
+    return {
+        "counts": dict(sorted(counts.items())),
+        "determinism": {
+            "ordering": "input packet order",
+            "serialization": "UTF-8 canonical JSON with sorted keys and LF",
+            "timestamps_omitted": True,
+        },
+        "evaluation_registry": {
+            "near_duplicate_threshold": NEAR_DUPLICATE_THRESHOLD,
+            "normalization": "NFKC; casefold; collapse whitespace",
+            "source_fingerprint_count": registry.source_fingerprint_count,
+            "v0_1_1_manifest_sha256": registry.v011_manifest_sha256,
+            "v0_2_packet_sha256": registry.v02_packet_sha256,
+        },
+        "input": {"records": input_records, "sha256": input_hash},
+        "operation": operation,
+        "output": {"records": len(output_rows), "sha256": sha256_bytes(output_bytes)},
+        "safety": {
+            "automatic_gold_created": False,
+            "dataset_export_or_publication_performed": False,
+            "model_training_performed": False,
+            "raw_dictionary_payload_exported": False,
+        },
+        "schema_version": "correction_factory_receipt_v1",
+        "schemas": _schema_hashes(),
+    }
+
+
+def prepare_review_packet(
+    *,
+    candidates_path: Path,
+    packet_output: Path,
+    receipt_output: Path,
+    evaluation_registry: EvaluationRegistry,
+) -> dict[str, Any]:
+    """Validate unresolved candidates and write a deterministic review packet."""
+    rows = read_jsonl(candidates_path)
+    _require(rows, "empty correction candidate input")
+    schemas, schema_registry = _schema_bundle()
+    candidate_validator = _validator(
+        CANDIDATE_SCHEMA_PATH, schemas=schemas, registry=schema_registry
+    )
+    receipt_validator = _validator(
+        RECEIPT_SCHEMA_PATH, schemas=schemas, registry=schema_registry
+    )
+    seen: set[str] = set()
+    counts: Counter[str] = Counter()
+    for line_number, candidate in enumerate(rows, 1):
+        validate_candidate(
+            candidate,
+            validator=candidate_validator,
+            evaluation_registry=evaluation_registry,
+        )
+        candidate_id = candidate["candidate_id"]
+        _require(candidate_id not in seen, f"duplicate candidate ID at line {line_number}: {candidate_id}")
+        seen.add(candidate_id)
+        counts["candidate_records"] += 1
+        counts["unresolved_records"] += 1
+        for layer in candidate["candidate_layers"]:
+            counts[f"layer_{layer}"] += 1
+
+    input_hash = sha256_file(candidates_path)
+    receipt = _receipt(
+        operation="prepare_review_packet",
+        input_records=len(rows),
+        input_hash=input_hash,
+        output_rows=rows,
+        registry=evaluation_registry,
+        counts=counts,
+    )
+    _validate_schema(receipt, receipt_validator, label="factory receipt")
+    packet_bytes = _jsonl_bytes(rows)
+    _require(receipt["output"]["sha256"] == sha256_bytes(packet_bytes), "internal packet hash mismatch")
+    _write_atomic(packet_output, packet_bytes)
+    _write_atomic(receipt_output, (canonical_json(receipt) + "\n").encode("utf-8"))
+    return receipt
+
+
+def adjudicate(
+    *,
+    packet_path: Path,
+    decisions_path: Path,
+    records_output: Path,
+    receipt_output: Path,
+    evaluation_registry: EvaluationRegistry,
+    allow_test_fixtures: bool = False,
+) -> dict[str, Any]:
+    """Join an exact packet to qualified reviews and emit controlled records."""
+    candidates = read_jsonl(packet_path)
+    decisions = read_jsonl(decisions_path)
+    _require(candidates, "empty correction review packet")
+    _require(len(candidates) == len(decisions), "missing or extra reviewer decisions")
+    schemas, schema_registry = _schema_bundle()
+    candidate_validator = _validator(
+        CANDIDATE_SCHEMA_PATH, schemas=schemas, registry=schema_registry
+    )
+    decision_validator = _validator(
+        DECISION_SCHEMA_PATH, schemas=schemas, registry=schema_registry
+    )
+    record_validator = _validator(RECORD_SCHEMA_PATH, schemas=schemas, registry=schema_registry)
+    receipt_validator = _validator(
+        RECEIPT_SCHEMA_PATH, schemas=schemas, registry=schema_registry
+    )
+
+    records: list[dict[str, Any]] = []
+    counts: Counter[str] = Counter()
+    seen_candidates: set[str] = set()
+    for candidate, decision in zip(candidates, decisions, strict=True):
+        validate_candidate(
+            candidate,
+            validator=candidate_validator,
+            evaluation_registry=evaluation_registry,
+        )
+        candidate_id = candidate["candidate_id"]
+        _require(candidate_id not in seen_candidates, f"duplicate packet candidate: {candidate_id}")
+        seen_candidates.add(candidate_id)
+        validate_decision(
+            decision,
+            candidate,
+            validator=decision_validator,
+            allow_test_fixtures=allow_test_fixtures,
+        )
+        record = _record(candidate, decision)
+        _validate_schema(record, record_validator, label="correction record")
+        records.append(record)
+        counts["candidate_records"] += 1
+        counts[f"decision_{decision['final']['decision']}"] += 1
+        counts[f"handoff_{record['export_control']['handoff']}"] += 1
+        if record["export_control"]["qualified_correction_intake"]:
+            counts["qualified_correction_intake"] += 1
+        else:
+            counts["blocked_records"] += 1
+
+    combined_input_hash = sha256_text(
+        canonical_json(
+            {
+                "decisions_sha256": sha256_file(decisions_path),
+                "packet_sha256": sha256_file(packet_path),
+            }
+        )
+    )
+    receipt = _receipt(
+        operation="adjudicate",
+        input_records=len(candidates),
+        input_hash=combined_input_hash,
+        output_rows=records,
+        registry=evaluation_registry,
+        counts=counts,
+    )
+    _validate_schema(receipt, receipt_validator, label="factory receipt")
+    records_bytes = _jsonl_bytes(records)
+    _require(receipt["output"]["sha256"] == sha256_bytes(records_bytes), "internal record hash mismatch")
+    _write_atomic(records_output, records_bytes)
+    _write_atomic(receipt_output, (canonical_json(receipt) + "\n").encode("utf-8"))
+    return receipt
+
+
+def _evaluation_registry_from_args(args: argparse.Namespace) -> EvaluationRegistry:
+    return load_evaluation_registry(
+        v011_manifest_path=args.evaluation_manifest,
+        v02_packet_path=args.v02_packet,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evaluation-manifest",
+        type=Path,
+        default=DEFAULT_EVALUATION_MANIFEST,
+    )
+    parser.add_argument("--v02-packet", type=Path, default=DEFAULT_V02_PACKET)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare", help="validate and freeze a review packet")
+    prepare_parser.add_argument("--candidates", required=True, type=Path)
+    prepare_parser.add_argument("--packet-output", required=True, type=Path)
+    prepare_parser.add_argument("--receipt-output", required=True, type=Path)
+
+    adjudicate_parser = subparsers.add_parser("adjudicate", help="join qualified decisions")
+    adjudicate_parser.add_argument("--packet", required=True, type=Path)
+    adjudicate_parser.add_argument("--decisions", required=True, type=Path)
+    adjudicate_parser.add_argument("--records-output", required=True, type=Path)
+    adjudicate_parser.add_argument("--receipt-output", required=True, type=Path)
+    adjudicate_parser.add_argument(
+        "--allow-test-fixtures",
+        action="store_true",
+        help="tests only; fixture reviewers remain blocked from qualified intake",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        registry = _evaluation_registry_from_args(args)
+        if args.command == "prepare":
+            receipt = prepare_review_packet(
+                candidates_path=args.candidates,
+                packet_output=args.packet_output,
+                receipt_output=args.receipt_output,
+                evaluation_registry=registry,
+            )
+        else:
+            receipt = adjudicate(
+                packet_path=args.packet,
+                decisions_path=args.decisions,
+                records_output=args.records_output,
+                receipt_output=args.receipt_output,
+                evaluation_registry=registry,
+                allow_test_fixtures=args.allow_test_fixtures,
+            )
+    except FactoryError as exc:
+        parser.error(str(exc))
+    print(canonical_json(receipt))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/correction_factory.py
+++ b/scripts/projects/open_model_data/correction_factory.py
@@ -50,6 +50,7 @@ SLOVNYK_DICTIONARY_LOCATOR_RE = re.compile(
     r"^https://slovnyk\.me/dict/(?P<dictionary_slug>[A-Za-z0-9_-]+)/.+$"
 )
 NEAR_DUPLICATE_THRESHOLD = 0.90
+MIN_CONTAINMENT_CHARACTERS = 32
 PROTECTED_PERIOD_MARKERS = (
     "historical",
     "middle_ukrainian",
@@ -249,6 +250,10 @@ def _near_duplicate(text: str, reference_texts: Sequence[str]) -> bool:
     for reference in reference_texts:
         if normalized == reference:
             return True
+        if min(len(normalized), len(reference)) >= MIN_CONTAINMENT_CHARACTERS and (
+            normalized in reference or reference in normalized
+        ):
+            return True
         length_ratio = min(len(normalized), len(reference)) / max(len(normalized), len(reference))
         if length_ratio < NEAR_DUPLICATE_THRESHOLD:
             continue
@@ -257,13 +262,22 @@ def _near_duplicate(text: str, reference_texts: Sequence[str]) -> bool:
     return False
 
 
-def contamination_states(text: str, registry: EvaluationRegistry) -> dict[str, str]:
+def contamination_states(
+    text: str,
+    registry: EvaluationRegistry,
+    *,
+    additional_sha256: Sequence[str] = (),
+) -> dict[str, str]:
     """Compute exact and near-duplicate dispositions for one bounded context."""
-    raw_hash = sha256_text(text)
+    exact_hashes = {sha256_text(text), *additional_sha256}
+    _require(
+        all(SHA256_RE.fullmatch(value) for value in exact_hashes),
+        "invalid additional contamination hash",
+    )
     return {
-        "v0_1_1_exact": "match" if raw_hash in registry.v011_exact else "clear",
+        "v0_1_1_exact": "match" if exact_hashes & registry.v011_exact else "clear",
         "v0_1_1_near": "match" if _near_duplicate(text, registry.v011_texts) else "clear",
-        "v0_2_exact": "match" if raw_hash in registry.v02_exact else "clear",
+        "v0_2_exact": "match" if exact_hashes & registry.v02_exact else "clear",
         "v0_2_near": "match" if _near_duplicate(text, registry.v02_texts) else "clear",
     }
 
@@ -374,7 +388,11 @@ def validate_candidate(
         _require(views["correction"] in {"protected", "not_applicable", "unresolved"}, "protected variation cannot be a correction candidate")
 
     contamination = candidate["safety"]["contamination"]
-    expected_states = contamination_states(context["text"], evaluation_registry)
+    expected_states = contamination_states(
+        context["text"],
+        evaluation_registry,
+        additional_sha256=(source["content_sha256"],),
+    )
     for field, expected in expected_states.items():
         _require(contamination[field] == expected, f"stale or false contamination state: {field}")
     expected_artifacts = {
@@ -382,6 +400,25 @@ def validate_candidate(
         "v0_2_packet": evaluation_registry.v02_packet_sha256,
     }
     _require(contamination["registry_artifact_sha256"] == expected_artifacts, "evaluation registry receipt mismatch")
+
+    source_origin = source["origin"]
+    safety_origin = candidate["safety"]["origin"]
+    expected_origin = {
+        "human_authored": "verified_human_authorship",
+        "machine_generated": "verified_synthetic",
+        "machine_translated": "verified_synthetic",
+        "human_revised_synthetic": "verified_synthetic",
+    }.get(source_origin)
+    if expected_origin is None:
+        _require(
+            safety_origin in {"unknown", "conflicting"},
+            "unknown source origin cannot be marked verified",
+        )
+    else:
+        _require(
+            safety_origin == expected_origin,
+            "source origin and safety evidence contradict each other",
+        )
 
 
 def _projection(review: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/scripts/projects/open_model_data/correction_factory.py
+++ b/scripts/projects/open_model_data/correction_factory.py
@@ -46,6 +46,9 @@ DEFAULT_V02_PACKET = (
 )
 
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+SLOVNYK_DICTIONARY_LOCATOR_RE = re.compile(
+    r"^https://slovnyk\.me/dict/(?P<dictionary_slug>[A-Za-z0-9_-]+)/.+$"
+)
 NEAR_DUPLICATE_THRESHOLD = 0.90
 PROTECTED_PERIOD_MARKERS = (
     "historical",
@@ -299,10 +302,15 @@ def _validate_evidence(candidate: Mapping[str, Any]) -> None:
 
     for item in evidence:
         if item["source"] == "slovnyk_me":
-            normalized_identity = item["source_identity"].casefold().replace(" ", "")
+            locator_match = SLOVNYK_DICTIONARY_LOCATOR_RE.fullmatch(item["locator"])
             _require(
-                normalized_identity not in {"slovnyk.me", "slovnykme", "aggregator"},
-                "slovnyk.me evidence must name the underlying dictionary",
+                locator_match is not None,
+                "slovnyk.me evidence requires a per-dictionary /dict/<slug>/ locator",
+            )
+            _require(
+                item["source_identity"].casefold()
+                == locator_match.group("dictionary_slug").casefold(),
+                "slovnyk.me source identity must equal the underlying dictionary slug",
             )
             _require(not item["raw_payload_export_allowed"], "slovnyk.me raw payload cannot enter the packet")
         if item["source"] == "ulif_dictua":

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -780,12 +780,10 @@ def ulif_lookup(word: str) -> dict[str, object]:
 
         # A confirmed registry hit does not have to expose an inflection table:
         # adverbs and other non-inflecting headwords can legitimately return
-        # relation data only.  Search-list membership establishes the hit;
-        # reaching this point with valid WebForms state establishes that every
-        # available tab was consumed.  Reserve ``parse_error`` for malformed or
-        # incomplete responses handled above, rather than inventing a missing
-        # paradigm requirement.
-        status = "ok"
+        # relation data only.  Some structured content is still required; a
+        # content-empty response is not usable lexical evidence and therefore
+        # fails closed instead of being cached as a successful lookup.
+        status = "ok" if sections else "parse_error"
         stored = sources_db.store_ulif_dictua_entry(
             word=requested_word,
             canonical_headword=canonical_headword,

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -402,7 +402,7 @@ def grac_collocations(
 # ══════════════════════════════════════════════════════════════════
 
 ULIF_BASE = "https://lcorp.ulif.org.ua/dictua"
-ULIF_PARSER_VERSION = "ulif-dictua-v1"
+ULIF_PARSER_VERSION = "ulif-dictua-v2"
 # DictUA returns 403 under aggressive access patterns; a cache miss makes at
 # most four POSTs, each spaced far enough apart to keep that sequence polite.
 ULIF_REQUEST_DELAY_SECONDS = 1.0
@@ -778,12 +778,14 @@ def ulif_lookup(word: str) -> dict[str, object]:
             # earlier page's token remaining valid in the same ASP.NET session.
             tab_tokens = next_tokens
 
-        if not sections:
-            status = "not_found"
-        elif "paradigm" not in sections:
-            status = "parse_error"
-        else:
-            status = "ok"
+        # A confirmed registry hit does not have to expose an inflection table:
+        # adverbs and other non-inflecting headwords can legitimately return
+        # relation data only.  Search-list membership establishes the hit;
+        # reaching this point with valid WebForms state establishes that every
+        # available tab was consumed.  Reserve ``parse_error`` for malformed or
+        # incomplete responses handled above, rather than inventing a missing
+        # paradigm requirement.
+        status = "ok"
         stored = sources_db.store_ulif_dictua_entry(
             word=requested_word,
             canonical_headword=canonical_headword,

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -374,7 +374,9 @@ def _rail_resolver(path: str) -> rail_path_guard.ApprovedRailApprovalReceiptReso
         "receipt_id": "rail-approval-" + "1" * 32,
         "issuer": "operator",
         "issued_at": "2026-07-31T00:00:00Z",
-        "expires_at": "2026-08-01T00:00:00Z",
+        # Keep this success-path fixture independent of wall-clock time. Expiry
+        # behavior has dedicated coverage in the rail approval test suite.
+        "expires_at": "2099-08-01T00:00:00Z",
         "action": "rail-path-mutation",
         "task_id": "pr-5512",
         "head_sha": _SHA_A,

--- a/tests/test_lexicon_runner_offline_reduce.py
+++ b/tests/test_lexicon_runner_offline_reduce.py
@@ -187,6 +187,23 @@ def test_parse_dictua_envelope_ok_and_not_found(sample_envelopes):
     assert len(ant["sections"]["antonyms"]) >= 1
 
 
+def test_reduce_accepts_confirmed_headword_without_inflection_table():
+    envelope = _envelope(
+        "привіт",
+        "ok",
+        [
+            ("paradigm", "privit-synonyms.html"),
+            ("synonyms", "privit-synonyms.html"),
+        ],
+    )
+
+    artifact = parse_dictua_envelope(envelope)
+
+    assert artifact["status"] == "ok"
+    assert "paradigm" not in artifact["sections"]
+    assert artifact["sections"]["synonyms"]
+
+
 def test_strip_raw_html_removes_nested_keys():
     payload = {"rows": [[{"raw_html": "<b>x</b>", "text": "x"}]], "raw_html": "<table/>"}
     cleaned = strip_raw_html(payload)

--- a/tests/test_lexicon_runner_offline_reduce.py
+++ b/tests/test_lexicon_runner_offline_reduce.py
@@ -204,6 +204,15 @@ def test_reduce_accepts_confirmed_headword_without_inflection_table():
     assert artifact["sections"]["synonyms"]
 
 
+def test_reduce_rejects_content_empty_ok_envelope():
+    artifact = parse_dictua_envelope(
+        {"lemma": "дуже", "status": "ok", "responses": []}
+    )
+
+    assert artifact["status"] == "parse_error"
+    assert artifact["sections"] == {}
+
+
 def test_strip_raw_html_removes_nested_keys():
     payload = {"rows": [[{"raw_html": "<b>x</b>", "text": "x"}]], "raw_html": "<table/>"}
     cleaned = strip_raw_html(payload)

--- a/tests/test_open_model_correction_factory.py
+++ b/tests/test_open_model_correction_factory.py
@@ -562,6 +562,30 @@ def test_evaluation_rights_and_private_data_gates_fail_closed(evaluation_registr
     blockers = factory._safety_blockers(near, decision)
     assert {"rights_not_granted", "private_data_not_clear"} <= set(blockers)
 
+    containing_context = f"Передмова до фрагмента. {source} Післямова до фрагмента."
+    contained = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-evaluation-contained",
+        text=containing_context,
+        span_text=source,
+    )
+    _validate(contained, evaluation_registry)
+    assert contained["safety"]["contamination"]["v0_1_1_near"] == "match"
+
+
+def test_source_origin_and_safety_evidence_cannot_contradict(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-origin-consistency",
+        text="Синтетичний приклад потребує перевірки.",
+        span_text="потребує перевірки",
+        origin="machine_generated",
+    )
+    _validate(candidate, evaluation_registry)
+    candidate["safety"]["origin"] = "verified_human_authorship"
+    with pytest.raises(factory.FactoryError, match="source origin"):
+        _validate(candidate, evaluation_registry)
+
 
 def test_packet_and_receipt_are_byte_stable(evaluation_registry, tmp_path: Path) -> None:
     candidate = _candidate(

--- a/tests/test_open_model_correction_factory.py
+++ b/tests/test_open_model_correction_factory.py
@@ -1,0 +1,729 @@
+"""Regression and safety tests for the Ukrainian correction-data factory."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.projects.open_model_data import correction_factory as factory
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _hash(text: str) -> str:
+    return factory.sha256_text(text)
+
+
+def _evidence(
+    source: str,
+    *,
+    status: str,
+    supports: str,
+    source_identity: str | None = None,
+    evidence_type: str = "form",
+    parser_status: str = "ok",
+    sense_groups: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    identity = source_identity or {
+        "vesum": "vesum-pinned-snapshot",
+        "russian_morphology": "pymorphy3-russian-dictionary",
+        "r2u": "r2u.org.ua",
+        "ulif_dictua": "ulif-dictua",
+        "slovnyk_me": "sum20",
+        "heritage_dictionary": "esum",
+        "ukrainian_corpus": "foundry-corpus-snapshot",
+    }[source]
+    return {
+        "content_sha256": _hash(f"{source}:{identity}:{status}"),
+        "evidence_type": evidence_type,
+        "locator": f"fixture:{source}/{identity}",
+        "official_url": None,
+        "parser_status": parser_status,
+        "parser_version": f"{source}-fixture-v1",
+        "period": "modern_or_source_specific",
+        "query": "fixture-query",
+        "raw_payload_export_allowed": False,
+        "register": "source_specific",
+        "rights_posture": "bounded_internal_reference",
+        "sense_groups": sense_groups or [],
+        "source": source,
+        "source_identity": identity,
+        "status": status,
+        "supports": supports,
+    }
+
+
+def _russian_evidence(*, vesum_status: str = "not_found") -> list[dict[str, Any]]:
+    rows = [
+        _evidence("vesum", status=vesum_status, supports="no_conclusion"),
+        _evidence("russian_morphology", status="attested", supports="russian_attestation", evidence_type="morphology"),
+        _evidence("r2u", status="attested", supports="russian_attestation", evidence_type="translation_equivalent"),
+    ]
+    if vesum_status == "not_found":
+        rows.extend(
+            [
+                _evidence("ulif_dictua", status="not_found", supports="no_conclusion"),
+                _evidence("heritage_dictionary", status="not_found", supports="no_conclusion"),
+                _evidence("slovnyk_me", status="not_found", supports="no_conclusion"),
+                _evidence("ukrainian_corpus", status="attested", supports="context_only", evidence_type="corpus_context"),
+            ]
+        )
+    return rows
+
+
+def _views(
+    *,
+    modern: str = "unresolved",
+    correction: str = "unresolved",
+    preference: str = "unresolved",
+) -> dict[str, str]:
+    return {
+        "correction": correction,
+        "evaluation": "excluded_from_non_evaluation_views",
+        "faithful_literary": "retain_original",
+        "modern_literary_ukrainian": modern,
+        "preference": preference,
+    }
+
+
+@pytest.fixture(scope="module")
+def evaluation_registry() -> factory.EvaluationRegistry:
+    return factory.load_evaluation_registry()
+
+
+def _candidate(
+    registry: factory.EvaluationRegistry,
+    *,
+    candidate_id: str,
+    text: str,
+    span_text: str,
+    language: str = "ukrainian",
+    representation: str = "standard_orthography",
+    role: str = "narration",
+    disposition: str = "human_review_required",
+    period: str = "modern",
+    register: str = "neutral",
+    origin: str = "human_authored",
+    layers: list[str] | None = None,
+    views: dict[str, str] | None = None,
+    evidence: list[dict[str, Any]] | None = None,
+    reconstructions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    context_start = 100
+    relative_start = text.index(span_text)
+    span_start = context_start + relative_start
+    contamination = factory.contamination_states(text, registry)
+    contamination["registry_artifact_sha256"] = {
+        "v0_1_1_manifest": registry.v011_manifest_sha256,
+        "v0_2_packet": registry.v02_packet_sha256,
+    }
+    return {
+        "candidate_id": candidate_id,
+        "candidate_layers": layers or ["grammar"],
+        "detector": {
+            "automatic_error_label": False,
+            "kind": "combined",
+            "model_output_used_as_gold": False,
+            "producer": "fixture-detector-v1",
+        },
+        "evidence": evidence or [_evidence("vesum", status="attested", supports="ukrainian_attestation")],
+        "reconstructions": reconstructions or [],
+        "review_state": "unresolved",
+        "safety": {
+            "contamination": contamination,
+            "origin": "verified_synthetic" if origin != "human_authored" else "verified_human_authorship",
+            "permitted_use": "correction_eligible",
+            "private_data": "clear",
+            "provenance": "complete",
+            "rights": "granted",
+        },
+        "schema_version": "correction_candidate_v1",
+        "source": {
+            "content_sha256": _hash(text),
+            "context": {
+                "end": context_start + len(text),
+                "sha256": _hash(text),
+                "start": context_start,
+                "text": text,
+            },
+            "genre": "fixture",
+            "locator": f"fixture:{candidate_id}",
+            "origin": origin,
+            "period": period,
+            "record_id": f"record-{candidate_id}",
+            "region": "unknown",
+            "register": register,
+            "source_family": "fixture",
+            "source_record_id": f"source:{candidate_id}",
+        },
+        "span": {
+            "discourse_role": role,
+            "downstream_disposition": disposition,
+            "end": span_start + len(span_text),
+            "language_identity": language,
+            "representation": representation,
+            "start": span_start,
+            "text": span_text,
+        },
+        "uncertainty": ["qualified_ukrainian_review_required"],
+        "upstream": {
+            "candidate_schema_version": "review_candidate_v1",
+            "candidate_sha256": _hash(f"upstream:{candidate_id}"),
+            "profile_id": "fixture-profile-v1",
+        },
+        "views": views or _views(),
+    }
+
+
+def _validators():
+    schemas, registry = factory._schema_bundle()
+    return (
+        factory._validator(factory.CANDIDATE_SCHEMA_PATH, schemas=schemas, registry=registry),
+        factory._validator(factory.DECISION_SCHEMA_PATH, schemas=schemas, registry=registry),
+    )
+
+
+def _validate(candidate: dict[str, Any], registry: factory.EvaluationRegistry) -> None:
+    candidate_validator, _ = _validators()
+    factory.validate_candidate(
+        candidate,
+        validator=candidate_validator,
+        evaluation_registry=registry,
+    )
+
+
+def _reconstruction(original: str, russian: str) -> dict[str, Any]:
+    return {
+        "candidate": russian,
+        "gate": "discourse_context",
+        "original_surface": original,
+        "r2u": {"query": russian, "status": "attested"},
+        "russian_morphology": {"lemma": russian, "status": "attested"},
+        "score": 0.95,
+        "transformation_path": [f"bounded:{original}->{russian}"],
+    }
+
+
+def _projection(
+    *,
+    decision: str,
+    language: str,
+    representation: str,
+    role: str,
+    correction: str | None = None,
+) -> dict[str, Any]:
+    is_correction = decision == "correction"
+    return {
+        "acceptable_alternatives": [correction] if correction else [],
+        "accepted_correction": correction,
+        "citations": [
+            {
+                "content_sha256": _hash("fixture-citation"),
+                "locator": "fixture:review-source",
+                "source_identity": "fixture-source",
+                "source_kind": "dictionary",
+                "supports": "The cited source supports the human decision.",
+            }
+        ],
+        "decision": decision,
+        "discourse_role": role,
+        "language_identity": language,
+        "rationale": "Qualified fixture review rationale for contract testing.",
+        "representation": representation,
+        "uncertainty": ["fixture_review_not_real_gold"],
+        "views": {
+            "correction": "eligible_intake" if is_correction else ("unresolved" if decision == "unresolved" else "not_applicable"),
+            "evaluation": "excluded_from_non_evaluation_views",
+            "faithful_literary": "retain_original",
+            "modern_literary_ukrainian": (
+                "mask_span_from_loss"
+                if decision == "quoted_or_multilingual"
+                else ("unresolved" if decision == "unresolved" else "retain_original")
+            ),
+            "preference": "eligible_intake" if is_correction else ("unresolved" if decision == "unresolved" else "not_applicable"),
+        },
+    }
+
+
+def _review(reviewer_id: str, projection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "projection": copy.deepcopy(projection),
+        "reviewer": {
+            "human": True,
+            "independence_attested": True,
+            "qualification_evidence": "Synthetic test fixture; never valid as real qualification evidence.",
+            "reviewer_id": reviewer_id,
+            "test_fixture": True,
+            "ukrainian_qualification": "qualified_ukrainian_language_reviewer",
+        },
+    }
+
+
+def _decision(candidate: dict[str, Any], projection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_id": candidate["candidate_id"],
+        "candidate_sha256": _hash(factory.canonical_json(candidate)),
+        "final": copy.deepcopy(projection),
+        "final_resolution": {"kind": "first_pass_agreement"},
+        "first_pass_reviews": [
+            _review("fixture-reviewer-a", projection),
+            _review("fixture-reviewer-b", projection),
+        ],
+        "review_state": "unresolved" if projection["decision"] == "unresolved" else "adjudicated",
+        "schema_version": "correction_reviewer_decision_v1",
+    }
+
+
+def test_standard_russian_quotation_is_preserved_and_masked(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-russian-quotation",
+        text="Автор згадує: «что вызвало смуту», а потім пояснює контекст.",
+        span_text="что вызвало смуту",
+        language="russian",
+        role="quotation",
+        disposition="retain_with_language_metadata",
+        layers=["russian_interference", "language_span"],
+        views=_views(modern="mask_span_from_loss", correction="not_applicable", preference="not_applicable"),
+        evidence=_russian_evidence(),
+    )
+    _validate(candidate, evaluation_registry)
+    projection = _projection(
+        decision="quoted_or_multilingual",
+        language="russian",
+        representation="standard_orthography",
+        role="quotation",
+    )
+    decision = _decision(candidate, projection)
+    _, decision_validator = _validators()
+    factory.validate_decision(
+        decision,
+        candidate,
+        validator=decision_validator,
+        allow_test_fixtures=True,
+    )
+    assert factory._record(candidate, decision)["export_control"]["handoff"] == "faithful_or_protected_only"
+
+
+def test_dash_led_russian_dialogue_does_not_require_guillemets(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-dash-dialogue",
+        text="— Они что, не разговаривают? — спитав герой.",
+        span_text="Они что, не разговаривают?",
+        language="russian",
+        role="dialogue",
+        disposition="retain_with_language_metadata",
+        layers=["russian_interference", "language_span"],
+        views=_views(modern="exclude_span_or_record", correction="not_applicable", preference="not_applicable"),
+        evidence=_russian_evidence(),
+    )
+    _validate(candidate, evaluation_registry)
+
+
+def test_phonetic_russian_requires_bounded_morphology_and_r2u_reconstruction(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-phonetic-russian",
+        text="— Вот, что значіт цівілізація! — вигукнув персонаж.",
+        span_text="значіт цівілізація",
+        language="russian",
+        representation="ukrainian_phonetic_rendering_of_russian",
+        role="dialogue",
+        disposition="retain_with_language_metadata",
+        layers=["russian_interference", "language_span"],
+        views=_views(modern="mask_span_from_loss", correction="not_applicable", preference="not_applicable"),
+        evidence=_russian_evidence(),
+        reconstructions=[
+            _reconstruction("значіт", "значит"),
+            _reconstruction("цівілізація", "цивилизация"),
+        ],
+    )
+    _validate(candidate, evaluation_registry)
+    broken = copy.deepcopy(candidate)
+    broken["reconstructions"] = []
+    with pytest.raises(factory.FactoryError, match="reconstructions must agree"):
+        _validate(broken, evaluation_registry)
+
+
+def test_vesum_slang_presence_does_not_override_phonetic_russian_span(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-ochen-context",
+        text="Він відповів: «очєнь вєжліви с нєй».",
+        span_text="очєнь вєжліви с нєй",
+        language="russian",
+        representation="ukrainian_phonetic_rendering_of_russian",
+        role="quotation",
+        disposition="retain_with_language_metadata",
+        layers=["russian_interference", "language_span"],
+        views=_views(modern="mask_span_from_loss", correction="not_applicable", preference="not_applicable"),
+        evidence=_russian_evidence(vesum_status="attested"),
+        reconstructions=[_reconstruction("очєнь", "очень"), _reconstruction("вєжліви", "вежливы")],
+    )
+    _validate(candidate, evaluation_registry)
+    assert candidate["span"]["language_identity"] == "russian"
+    assert candidate["review_state"] == "unresolved"
+
+
+def test_historical_span_is_protected_from_modern_error_gold(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-historical-span",
+        text="У документі читаємо: что вас порушило.",
+        span_text="что вас порушило",
+        language="historical_east_slavic_unresolved",
+        representation="historical_orthography",
+        role="citation_or_document",
+        disposition="protected_historical_or_register_variation",
+        period="historical_documents",
+        layers=["language_span", "protected_variation"],
+        views=_views(modern="protected", correction="protected", preference="protected"),
+        evidence=_russian_evidence(),
+    )
+    _validate(candidate, evaluation_registry)
+    correction = _projection(
+        decision="correction",
+        correction="що вас порушило",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="citation_or_document",
+    )
+    decision = _decision(candidate, correction)
+    _, decision_validator = _validators()
+    with pytest.raises(factory.FactoryError, match="protected variation"):
+        factory.validate_decision(
+            decision,
+            candidate,
+            validator=decision_validator,
+            allow_test_fixtures=True,
+        )
+
+
+def test_pereklychka_is_rescued_by_source_specific_ukrainian_evidence(evaluation_registry) -> None:
+    evidence = _russian_evidence()
+    for item in evidence:
+        if item["source"] == "heritage_dictionary":
+            item.update(status="attested", supports="ukrainian_attestation", source_identity="esum-etymological-dictionary")
+        if item["source"] == "slovnyk_me":
+            item.update(status="attested", supports="ukrainian_attestation", source_identity="sum20")
+        if item["source"] == "ukrainian_corpus":
+            item.update(status="attested", supports="ukrainian_attestation")
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-pereklychka-rescue",
+        text="Почалася перекличка учасників.",
+        span_text="перекличка",
+        disposition="human_review_required",
+        layers=["russian_interference", "protected_variation"],
+        views=_views(modern="protected", correction="protected", preference="protected"),
+        evidence=evidence,
+    )
+    _validate(candidate, evaluation_registry)
+    assert {item["source_identity"] for item in evidence if item["status"] == "attested"} >= {
+        "esum-etymological-dictionary",
+        "sum20",
+    }
+
+
+def test_shared_ukrainian_russian_surface_stays_unresolved_on_bare_r2u_hit(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-shared-form",
+        text="Контекст містить форму, спільну для двох мов.",
+        span_text="форму",
+        language="uncertain",
+        disposition="unresolved",
+        layers=["russian_interference"],
+        views=_views(),
+        evidence=_russian_evidence(vesum_status="attested"),
+    )
+    _validate(candidate, evaluation_registry)
+    broken = copy.deepcopy(candidate)
+    broken["span"]["language_identity"] = "russian"
+    with pytest.raises(factory.FactoryError, match="bare r2u hit"):
+        _validate(broken, evaluation_registry)
+
+
+def test_ulif_synonyms_retain_groups_and_incomplete_status_blocks_intake(evaluation_registry) -> None:
+    sense_group = {
+        "citations": ["Словник синонімів української мови, т. 1"],
+        "register_labels": ["розм."],
+        "sense_or_group_id": "synonyms:1",
+        "source_order": 0,
+        "terms": ["вітання", "привітання"],
+    }
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-ulif-synonyms",
+        text="Це звучить неприродно в цьому контексті.",
+        span_text="звучить неприродно",
+        evidence=[
+            _evidence("vesum", status="attested", supports="ukrainian_attestation"),
+            _evidence(
+                "ulif_dictua",
+                status="attested",
+                supports="alternative_candidate",
+                evidence_type="synonym_group",
+                parser_status="ok",
+                sense_groups=[sense_group],
+            ),
+        ],
+        layers=["collocation_or_government"],
+        views=_views(correction="candidate", preference="candidate"),
+        disposition="correction_candidate",
+    )
+    _validate(candidate, evaluation_registry)
+    assert candidate["evidence"][1]["sense_groups"][0]["register_labels"] == ["розм."]
+    incomplete = copy.deepcopy(candidate)
+    incomplete["evidence"][1].update(status="parse_error", parser_status="parse_error")
+    projection = _projection(
+        decision="correction",
+        correction="Це неприродно звучить",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="narration",
+    )
+    decision = _decision(incomplete, projection)
+    assert "evidence_incomplete" in factory._safety_blockers(incomplete, decision)
+
+
+def test_slovnyk_me_must_retain_underlying_dictionary_identity(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-slovnyk-source",
+        text="Потрібне джерельне підтвердження слова.",
+        span_text="підтвердження",
+        evidence=[
+            _evidence("vesum", status="attested", supports="ukrainian_attestation"),
+            _evidence("slovnyk_me", status="attested", supports="ukrainian_attestation", source_identity="slovnyk.me"),
+        ],
+    )
+    with pytest.raises(factory.FactoryError, match="underlying dictionary"):
+        _validate(candidate, evaluation_registry)
+    candidate["evidence"][1]["source_identity"] = "sum20"
+    _validate(candidate, evaluation_registry)
+
+
+def test_evaluation_rights_and_private_data_gates_fail_closed(evaluation_registry) -> None:
+    manifest = json.loads(factory.DEFAULT_EVALUATION_MANIFEST.read_text(encoding="utf-8"))
+    layout = manifest["record_layouts"]["item"]
+    source = manifest["items"][0][layout.index("source")]
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-evaluation-match",
+        text=source,
+        span_text=source.split()[0],
+    )
+    _validate(candidate, evaluation_registry)
+    projection = _projection(
+        decision="correction",
+        correction="Виправлений тестовий варіант",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="narration",
+    )
+    decision = _decision(candidate, projection)
+    blockers = factory._safety_blockers(candidate, decision)
+    assert "contamination_v0_1_1_exact" in blockers
+
+    near_source = source[:-1] + ("!" if not source.endswith("!") else ".")
+    near = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-evaluation-near",
+        text=near_source,
+        span_text=near_source.split()[0],
+    )
+    _validate(near, evaluation_registry)
+    assert near["safety"]["contamination"]["v0_1_1_near"] == "match"
+    near["safety"].update(rights="unknown", private_data="present")
+    decision = _decision(near, projection | {"accepted_correction": "Виправлено", "acceptable_alternatives": ["Виправлено"]})
+    blockers = factory._safety_blockers(near, decision)
+    assert {"rights_not_granted", "private_data_not_clear"} <= set(blockers)
+
+
+def test_packet_and_receipt_are_byte_stable(evaluation_registry, tmp_path: Path) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-determinism",
+        text="Модель ужила невдалу конструкцію.",
+        span_text="невдалу конструкцію",
+        origin="machine_generated",
+        disposition="correction_candidate",
+        views=_views(correction="candidate", preference="candidate"),
+    )
+    candidate_input = tmp_path / "candidates.jsonl"
+    candidate_input.write_text(factory.canonical_json(candidate) + "\n", encoding="utf-8")
+
+    first_packet, second_packet = tmp_path / "packet-1.jsonl", tmp_path / "packet-2.jsonl"
+    first_receipt, second_receipt = tmp_path / "receipt-1.json", tmp_path / "receipt-2.json"
+    factory.prepare_review_packet(
+        candidates_path=candidate_input,
+        packet_output=first_packet,
+        receipt_output=first_receipt,
+        evaluation_registry=evaluation_registry,
+    )
+    factory.prepare_review_packet(
+        candidates_path=candidate_input,
+        packet_output=second_packet,
+        receipt_output=second_receipt,
+        evaluation_registry=evaluation_registry,
+    )
+    assert first_packet.read_bytes() == second_packet.read_bytes()
+    assert first_receipt.read_bytes() == second_receipt.read_bytes()
+
+    projection = _projection(
+        decision="correction",
+        correction="Модель використала невдалу конструкцію.",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="narration",
+    )
+    decisions = tmp_path / "decisions.jsonl"
+    decisions.write_text(
+        factory.canonical_json(_decision(candidate, projection)) + "\n",
+        encoding="utf-8",
+    )
+    first_records, second_records = tmp_path / "records-1.jsonl", tmp_path / "records-2.jsonl"
+    first_adjudication, second_adjudication = (
+        tmp_path / "adjudication-1.json",
+        tmp_path / "adjudication-2.json",
+    )
+    factory.adjudicate(
+        packet_path=first_packet,
+        decisions_path=decisions,
+        records_output=first_records,
+        receipt_output=first_adjudication,
+        evaluation_registry=evaluation_registry,
+        allow_test_fixtures=True,
+    )
+    factory.adjudicate(
+        packet_path=second_packet,
+        decisions_path=decisions,
+        records_output=second_records,
+        receipt_output=second_adjudication,
+        evaluation_registry=evaluation_registry,
+        allow_test_fixtures=True,
+    )
+    assert first_records.read_bytes() == second_records.read_bytes()
+    assert first_adjudication.read_bytes() == second_adjudication.read_bytes()
+    record = json.loads(first_records.read_text(encoding="utf-8"))
+    assert record["export_control"]["model_training_or_export_eligible"] is False
+    assert record["export_control"]["qualified_correction_intake"] is False
+
+
+def test_detector_or_model_cannot_emit_gold(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-not-gold",
+        text="Так звучит неправильно.",
+        span_text="звучит",
+        language="uncertain",
+        layers=["russian_interference"],
+        evidence=_russian_evidence(),
+    )
+    _validate(candidate, evaluation_registry)
+    broken = copy.deepcopy(candidate)
+    broken["detector"]["automatic_error_label"] = True
+    with pytest.raises(factory.FactoryError, match="automatic_error_label"):
+        _validate(broken, evaluation_registry)
+
+
+def test_two_humans_and_distinct_third_reviewer_are_enforced(evaluation_registry) -> None:
+    candidate = _candidate(
+        evaluation_registry,
+        candidate_id="candidate-human-conflict",
+        text="Модель створила сумнівний вислів.",
+        span_text="сумнівний вислів",
+        origin="machine_generated",
+        disposition="correction_candidate",
+        views=_views(correction="candidate", preference="candidate"),
+    )
+    correction = _projection(
+        decision="correction",
+        correction="невдалий вислів",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="narration",
+    )
+    acceptable = _projection(
+        decision="acceptable_as_is",
+        language="ukrainian",
+        representation="standard_orthography",
+        role="narration",
+    )
+    decision = _decision(candidate, correction)
+    decision["first_pass_reviews"][1] = _review("fixture-reviewer-b", acceptable)
+    decision["final_resolution"] = {
+        "kind": "third_human_adjudication",
+        "third_review": _review("fixture-reviewer-c", correction),
+    }
+    _, validator = _validators()
+    factory.validate_decision(
+        decision,
+        candidate,
+        validator=validator,
+        allow_test_fixtures=True,
+    )
+    record = factory._record(candidate, decision)
+    assert record["conflict_state"] == "resolved_by_third_human"
+    assert record["export_control"] == {
+        "handoff": "unresolved",
+        "model_training_or_export_eligible": False,
+        "owner_issue": 6122,
+        "qualified_correction_intake": False,
+    }
+    assert "test_fixture_reviewer" in record["safety_blockers"]
+
+    decision["final_resolution"]["third_review"]["reviewer"]["reviewer_id"] = "fixture-reviewer-a"
+    with pytest.raises(factory.FactoryError, match="third reviewer must be distinct"):
+        factory.validate_decision(
+            decision,
+            candidate,
+            validator=validator,
+            allow_test_fixtures=True,
+        )
+
+
+def test_adjudication_rejects_reordered_or_mismatched_decisions(evaluation_registry, tmp_path: Path) -> None:
+    candidates = [
+        _candidate(
+            evaluation_registry,
+            candidate_id=f"candidate-order-{suffix}",
+            text=f"Контекст для кандидата {suffix}.",
+            span_text="кандидата",
+        )
+        for suffix in ("one", "two")
+    ]
+    packet = tmp_path / "packet.jsonl"
+    packet.write_text("".join(factory.canonical_json(row) + "\n" for row in candidates), encoding="utf-8")
+    decisions = [
+        _decision(
+            candidate,
+            _projection(
+                decision="acceptable_as_is",
+                language="ukrainian",
+                representation="standard_orthography",
+                role="narration",
+            ),
+        )
+        for candidate in reversed(candidates)
+    ]
+    decision_path = tmp_path / "decisions.jsonl"
+    decision_path.write_text("".join(factory.canonical_json(row) + "\n" for row in decisions), encoding="utf-8")
+    output = tmp_path / "records.jsonl"
+    output.write_text("prior-output\n", encoding="utf-8")
+    with pytest.raises(factory.FactoryError, match="decision candidate ID mismatch"):
+        factory.adjudicate(
+            packet_path=packet,
+            decisions_path=decision_path,
+            records_output=output,
+            receipt_output=tmp_path / "receipt.json",
+            evaluation_registry=evaluation_registry,
+            allow_test_fixtures=True,
+        )
+    assert output.read_text(encoding="utf-8") == "prior-output\n"

--- a/tests/test_open_model_correction_factory.py
+++ b/tests/test_open_model_correction_factory.py
@@ -37,10 +37,15 @@ def _evidence(
         "heritage_dictionary": "esum",
         "ukrainian_corpus": "foundry-corpus-snapshot",
     }[source]
+    locator = (
+        f"https://slovnyk.me/dict/{identity}/fixture-query"
+        if source == "slovnyk_me"
+        else f"fixture:{source}/{identity}"
+    )
     return {
         "content_sha256": _hash(f"{source}:{identity}:{status}"),
         "evidence_type": evidence_type,
-        "locator": f"fixture:{source}/{identity}",
+        "locator": locator,
         "official_url": None,
         "parser_status": parser_status,
         "parser_version": f"{source}-fixture-v1",
@@ -503,10 +508,22 @@ def test_slovnyk_me_must_retain_underlying_dictionary_identity(evaluation_regist
             _evidence("slovnyk_me", status="attested", supports="ukrainian_attestation", source_identity="slovnyk.me"),
         ],
     )
-    with pytest.raises(factory.FactoryError, match="underlying dictionary"):
+    with pytest.raises(factory.FactoryError, match="per-dictionary"):
         _validate(candidate, evaluation_registry)
-    candidate["evidence"][1]["source_identity"] = "sum20"
+    candidate["evidence"][1] = _evidence(
+        "slovnyk_me",
+        status="attested",
+        supports="ukrainian_attestation",
+        source_identity="sum20",
+    )
     _validate(candidate, evaluation_registry)
+
+    mismatch = copy.deepcopy(candidate)
+    mismatch["evidence"][1]["locator"] = (
+        "https://slovnyk.me/dict/newsum/fixture-query"
+    )
+    with pytest.raises(factory.FactoryError, match="must equal"):
+        _validate(mismatch, evaluation_registry)
 
 
 def test_evaluation_rights_and_private_data_gates_fail_closed(evaluation_registry) -> None:

--- a/tests/test_ulif_dictua.py
+++ b/tests/test_ulif_dictua.py
@@ -209,6 +209,25 @@ def test_confirmed_relation_only_headword_is_complete_without_paradigm(tmp_path,
     assert record["parser_version"] == "ulif-dictua-v2"
 
 
+def test_confirmed_but_content_empty_headword_fails_closed(tmp_path, monkeypatch):
+    db_path = tmp_path / "sources.db"
+    monkeypatch.setattr(sources_db, "SOURCES_DB_PATH", db_path)
+    monkeypatch.setattr(source_query, "ULIF_REQUEST_DELAY_SECONDS", 0)
+    empty_html = _without_paradigm(_fixture("privit-paradigm.html"))
+    monkeypatch.setattr(source_query, "_get", lambda *args, **kwargs: _Response(empty_html))
+    monkeypatch.setattr(
+        source_query._SESSION,
+        "post",
+        lambda *args, **kwargs: _Response(empty_html),
+    )
+
+    record = source_query.query_ulif("привіт", source_query.ULIF_SECTIONS)
+
+    assert record["status"] == "parse_error"
+    assert record["sections"] == {}
+    assert sources_db.get_ulif_dictua_entry("привіт")["status"] == "parse_error"
+
+
 def test_transient_error_is_not_persisted_as_a_negative_cache(tmp_path, monkeypatch):
     db_path = tmp_path / "sources.db"
     monkeypatch.setattr(sources_db, "SOURCES_DB_PATH", db_path)

--- a/tests/test_ulif_dictua.py
+++ b/tests/test_ulif_dictua.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import requests
+from bs4 import BeautifulSoup
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -21,6 +22,16 @@ FIXTURES = ROOT / "tests" / "fixtures" / "ulif_dictua"
 
 def _fixture(name: str) -> str:
     return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _without_paradigm(html: str) -> str:
+    """Keep a valid matched DictUA page while removing its inflection table."""
+    soup = BeautifulSoup(html, "html.parser")
+    for table in soup.find_all("table"):
+        labels = table.get_text(" ", strip=True).casefold()
+        if table.find("table") is None and ("називний" in labels or "інфінітив" in labels):
+            table.decompose()
+    return str(soup)
 
 
 class _Response:
@@ -169,6 +180,33 @@ def test_empty_available_relation_tab_is_not_a_parse_error(tmp_path, monkeypatch
     record = source_query.query_ulif("говорити", source_query.ULIF_SECTIONS)
     assert record["status"] == "ok"
     assert "phraseology" not in record["sections"]
+
+
+def test_confirmed_relation_only_headword_is_complete_without_paradigm(tmp_path, monkeypatch):
+    """An adverb-like headword must not be failed solely for lacking inflection."""
+    db_path = tmp_path / "sources.db"
+    monkeypatch.setattr(sources_db, "SOURCES_DB_PATH", db_path)
+    monkeypatch.setattr(source_query, "ULIF_REQUEST_DELAY_SECONDS", 0)
+    search_html = _without_paradigm(_fixture("privit-paradigm.html"))
+    monkeypatch.setattr(source_query, "_get", lambda *args, **kwargs: _Response(search_html))
+
+    def post(_url: str, data: dict[str, str], timeout: int) -> _Response:
+        if "ctl00$ContentPlaceHolder1$search.x" in data:
+            return _Response(search_html)
+        if "ctl00$ContentPlaceHolder1$syn.x" in data:
+            return _Response(_fixture("privit-synonyms.html"))
+        if "ctl00$ContentPlaceHolder1$phras.x" in data:
+            return _Response(_fixture("privit-phraseology.html"))
+        raise AssertionError(f"Unexpected DictUA POST: {data}")
+
+    monkeypatch.setattr(source_query._SESSION, "post", post)
+
+    record = source_query.query_ulif("привіт", ("paradigm", "synonyms"))
+    assert record["status"] == "ok"
+    assert "paradigm" not in record["sections"]
+    assert record["sections"]["synonyms"][0]["sense_or_group_id"] == "synonyms:1"
+    assert record["content_sha256"]
+    assert record["parser_version"] == "ulif-dictua-v2"
 
 
 def test_transient_error_is_not_persisted_as_a_negative_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #6121.

## Outcome

Implements the span-aware Ukrainian correction-data intake and qualified-human adjudication boundary required by the #6056 Foundry control plane.

- Adds strict candidate, reviewer-decision, correction-record, and deterministic-receipt schemas.
- Preserves original context and offsets plus independent language, representation, discourse, and view dispositions.
- Enforces VESUM-miss escalation, source-specific ULIF/r2u/Russian-morphology/slovnyk.me/heritage/corpus evidence, bounded phonetic-Russian reconstruction, and protected literary/historical handling.
- Recomputes exact and near-duplicate contamination against v0.1.1 and v0.2 evaluation sources and reference gold.
- Enforces two independent qualified Ukrainian-human first passes and a distinct third-human conflict path.
- Keeps every resulting record explicitly ineligible for model training/export; #6122 owns that later boundary.
- Fixes the ULIF false parse_error for valid relation-only headwords and bumps the parser to ulif-dictua-v2.

## Verification

- 44 focused Foundry/profiler/ULIF tests pass; the CI-expiry repair also passes 42 rail-path guard tests.
- Ruff, Python compilation, JSON Schema meta-validation, Markdownlint, OPSEC, gitleaks, agent-trailer, protected-file, generated-artifact, and diff checks pass.
- Live ULIF reproduction: дуже returns status ok, four synonym groups, no paradigm, and the same previously observed content hash under parser v2.

## Safety

No human decisions were fabricated. No model inference, training, dataset export/upload/publication, bulk dictionary redistribution, private-data disclosure, OCR, or outreach occurred.

X-Agent: codex/6121-correction-factory

