### PR TITLE
fix(rail): use one receipt authorization clock

### DIFF
--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -542,7 +542,12 @@ class ApprovedRailApprovalReceiptResolver:
         self.store = store
         self.now = now
 
-    def fetch(self, receipt_id: str) -> VerifiedRailApprovalReceipt:
+    def fetch(
+        self,
+        receipt_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> VerifiedRailApprovalReceipt:
         """Re-fetch a receipt; any unreadable store is an authorization failure."""
         if not RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id):
             raise RailApprovalReceiptError(
@@ -565,7 +570,8 @@ class ApprovedRailApprovalReceiptResolver:
             raise RailApprovalReceiptError(
                 f"rail approval receipt issuer {receipt['issuer']!r} is not approved"
             )
-        if _parse_time(receipt["expires_at"], field="expires_at") <= self.now().astimezone(UTC):
+        checked_at = (now or self.now()).astimezone(UTC)
+        if _parse_time(receipt["expires_at"], field="expires_at") <= checked_at:
             raise RailApprovalReceiptError("rail approval receipt has expired")
         return VerifiedRailApprovalReceipt(
             payload=receipt,
@@ -686,7 +692,7 @@ def decide_rail_path_mutation_with_production_receipt(
     receipt_id: str | None,
     resolver: ApprovedRailApprovalReceiptResolver | None = None,
     path_binding: RailApprovalPathBinding = RailApprovalPathBinding.MUTATION_CONTAINMENT,
-    now: Callable[[], datetime] = _utc_now,
+    now: Callable[[], datetime] | None = None,
 ) -> RailPathDecision:
     """Resolve a receipt from the fixed source, then make the normal decision.
 
@@ -699,14 +705,19 @@ def decide_rail_path_mutation_with_production_receipt(
         candidate_paths=candidate_paths,
         head_sha=head_sha,
         path_binding=path_binding,
-        now=now,
+        now=now or _utc_now,
     )
     if preliminary.allowed or preliminary.reason != "rail_approval_receipt_required":
         return preliminary
     if receipt_id is None:
         return preliminary
+    receipt_resolver = resolver or build_production_rail_approval_receipt_resolver()
+    # Freeze one as-of time so resolution cannot accept a receipt that the
+    # immediately following authorization treats as expired.
+    clock = now or receipt_resolver.now
+    checked_at = clock()
     try:
-        receipt = (resolver or build_production_rail_approval_receipt_resolver()).fetch(receipt_id)
+        receipt = receipt_resolver.fetch(receipt_id, now=checked_at)
     except RailApprovalValidatorUnavailableError:
         return RailPathDecision(
             RailPathDecisionKind.DENY,
@@ -726,5 +737,5 @@ def decide_rail_path_mutation_with_production_receipt(
         head_sha=head_sha,
         receipt=receipt,
         path_binding=path_binding,
-        now=now,
+        now=lambda: checked_at,
     )

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -140,6 +140,32 @@ def test_non_rail_paths_are_unaffected_without_receipt() -> None:
     assert decision.rail_paths == ()
 
 
+def test_production_receipt_uses_one_clock_for_resolution_and_authorization() -> None:
+    calls = 0
+
+    def clock() -> datetime:
+        nonlocal calls
+        calls += 1
+        return NOW
+
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _ReceiptStore({RECEIPT_ID: _receipt()}),
+        now=clock,
+    )
+
+    decision = guard.decide_rail_path_mutation_with_production_receipt(
+        task_id=TASK,
+        candidate_paths=[OWNED_RAIL_PATH],
+        head_sha=HEAD,
+        receipt_id=RECEIPT_ID,
+        resolver=resolver,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "rail_approval_verified"
+    assert calls == 1
+
+
 def test_path_classification_imports_without_jsonschema_but_receipt_validation_denies(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -166,6 +166,40 @@ def test_production_receipt_uses_one_clock_for_resolution_and_authorization() ->
     assert calls == 1
 
 
+def test_production_receipt_explicit_clock_overrides_resolver_clock() -> None:
+    resolver_calls = 0
+    explicit_calls = 0
+
+    def resolver_clock() -> datetime:
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return datetime(2026, 7, 30, tzinfo=UTC)
+
+    def explicit_clock() -> datetime:
+        nonlocal explicit_calls
+        explicit_calls += 1
+        return NOW
+
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _ReceiptStore({RECEIPT_ID: _receipt()}),
+        now=resolver_clock,
+    )
+
+    decision = guard.decide_rail_path_mutation_with_production_receipt(
+        task_id=TASK,
+        candidate_paths=[OWNED_RAIL_PATH],
+        head_sha=HEAD,
+        receipt_id=RECEIPT_ID,
+        resolver=resolver,
+        now=explicit_clock,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "rail_approval_verified"
+    assert explicit_calls == 1
+    assert resolver_calls == 0
+
+
 def test_path_classification_imports_without_jsonschema_but_receipt_validation_denies(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- freeze one authorization timestamp for production rail-receipt fetch and final policy validation
- preserve fail-closed expiry, issuer, task, head, and path checks
- add regression coverage proving the resolver clock is read exactly once

## Verification

- 47 focused tests passed, including the repository-wide CI reproducer
- Ruff passed
- OPSEC, diff, and X-Agent trailer checks passed
- broader rail-adjacent run: 262 passed; one unrelated worktree-venv assumption failed (tests/test_guard_pr_merge.py::test_hook_loader_reaches_default_receipt_store_from_outside_repo)

Rail-Approval-Receipt: rail-approval-30ef627c9c324922b46cf59266c0beec

Fixes #6153
