### PR TITLE
feat(foundry): build disjoint model views and recipes

### DIFF
--- a/data/projects/open_model_data/contracts/continued_pretraining_view_v1.schema.json
+++ b/data/projects/open_model_data/contracts/continued_pretraining_view_v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/continued_pretraining_view_v1.schema.json",
+  "title": "Ukrainian Data Foundry continued-pretraining view v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "representation_view", "lineage", "origin", "payload", "permitted_destination", "denied_destinations", "eligibility"],
+  "properties": {
+    "schema_version": {"const": "continued_pretraining_view_v1"},
+    "record_id": {"type": "string", "pattern": "^pretrain:[a-f0-9]{64}$"},
+    "representation_view": {"enum": ["faithful_literary", "modern_literary_ukrainian"]},
+    "lineage": {"$ref": "#/$defs/lineage"},
+    "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic"]},
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "text_sha256", "character_mask_spans"],
+      "properties": {
+        "text": {"type": "string", "minLength": 1},
+        "text_sha256": {"$ref": "#/$defs/sha256"},
+        "character_mask_spans": {"type": "array", "items": {"$ref": "#/$defs/maskSpan"}}
+      }
+    },
+    "permitted_destination": {"const": "continued_pretraining"},
+    "denied_destinations": {"const": ["supervised_correction", "pairwise_preference", "quality_filter", "heldout_evaluation"]},
+    "eligibility": {"$ref": "#/$defs/eligibility"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "lineage": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source_record_id", "source_record_sha256", "source_content_sha256", "source_payload_id", "source_payload_sha256", "source_derivation_receipt_sha256", "normalization_receipt_sha256", "language_span_receipt_sha256"],
+      "properties": {
+        "source_record_id": {"type": "string", "minLength": 3},
+        "source_record_sha256": {"$ref": "#/$defs/sha256"},
+        "source_content_sha256": {"$ref": "#/$defs/sha256"},
+        "source_payload_id": {"type": "string", "minLength": 3},
+        "source_payload_sha256": {"$ref": "#/$defs/sha256"},
+        "source_derivation_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "normalization_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "language_span_receipt_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "maskSpan": {
+      "type": "object", "additionalProperties": false, "required": ["start_char", "end_char", "reason"],
+      "properties": {"start_char": {"type": "integer", "minimum": 0}, "end_char": {"type": "integer", "minimum": 1}, "reason": {"type": "string", "minLength": 1}}
+    },
+    "eligibility": {
+      "type": "object", "additionalProperties": false, "required": ["source_contract_admitted", "test_fixture", "model_training_eligible"],
+      "properties": {"source_contract_admitted": {"const": true}, "test_fixture": {"type": "boolean"}, "model_training_eligible": {"type": "boolean"}},
+      "allOf": [{"if": {"properties": {"test_fixture": {"const": true}}}, "then": {"properties": {"model_training_eligible": {"const": false}}}, "else": {"properties": {"model_training_eligible": {"const": true}}}}]
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/correction_instruction_view_v1.schema.json
+++ b/data/projects/open_model_data/contracts/correction_instruction_view_v1.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/correction_instruction_view_v1.schema.json",
+  "title": "Ukrainian Data Foundry correction/instruction view v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "lineage", "origin", "payload", "permitted_destination", "denied_destinations", "eligibility"],
+  "properties": {
+    "schema_version": {"const": "correction_instruction_view_v1"},
+    "record_id": {"type": "string", "pattern": "^correction-view:[a-f0-9]{64}$"},
+    "lineage": {"$ref": "#/$defs/lineage"},
+    "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic"]},
+    "payload": {
+      "type": "object", "additionalProperties": false,
+      "required": ["input_text", "target_text", "original_span", "accepted_correction", "acceptable_alternatives", "span_start_char", "span_end_char"],
+      "properties": {
+        "input_text": {"type": "string", "minLength": 1},
+        "target_text": {"type": "string", "minLength": 1},
+        "original_span": {"type": "string", "minLength": 1},
+        "accepted_correction": {"type": "string", "minLength": 1},
+        "acceptable_alternatives": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "span_start_char": {"type": "integer", "minimum": 0},
+        "span_end_char": {"type": "integer", "minimum": 1}
+      }
+    },
+    "permitted_destination": {"const": "supervised_correction"},
+    "denied_destinations": {"const": ["continued_pretraining", "pairwise_preference", "quality_filter", "heldout_evaluation"]},
+    "eligibility": {"$ref": "#/$defs/eligibility"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "lineage": {"type": "object", "additionalProperties": false, "required": ["source_record_id", "source_record_sha256", "source_content_sha256", "correction_record_id", "correction_record_sha256", "candidate_sha256", "decision_sha256"], "properties": {"source_record_id": {"type": "string", "minLength": 3}, "source_record_sha256": {"$ref": "#/$defs/sha256"}, "source_content_sha256": {"$ref": "#/$defs/sha256"}, "correction_record_id": {"type": "string", "minLength": 3}, "correction_record_sha256": {"$ref": "#/$defs/sha256"}, "candidate_sha256": {"$ref": "#/$defs/sha256"}, "decision_sha256": {"$ref": "#/$defs/sha256"}}},
+    "eligibility": {"type": "object", "additionalProperties": false, "required": ["source_contract_admitted", "qualified_adjudication", "test_fixture", "model_training_eligible"], "properties": {"source_contract_admitted": {"const": true}, "qualified_adjudication": {"const": true}, "test_fixture": {"type": "boolean"}, "model_training_eligible": {"type": "boolean"}}, "allOf": [{"if": {"properties": {"test_fixture": {"const": true}}}, "then": {"properties": {"model_training_eligible": {"const": false}}}, "else": {"properties": {"model_training_eligible": {"const": true}}}}]}
+  }
+}

--- a/data/projects/open_model_data/contracts/foundry_source_payload_v1.schema.json
+++ b/data/projects/open_model_data/contracts/foundry_source_payload_v1.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/foundry_source_payload_v1.schema.json",
+  "title": "Ukrainian Data Foundry source payload v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "payload_id", "source_record_id", "source_content_sha256", "derivation", "text", "text_sha256", "origin", "origin_evidence", "private_data", "private_data_review", "normalization", "language_span_review", "test_fixture"],
+  "properties": {
+    "schema_version": {"const": "foundry_source_payload_v1"},
+    "payload_id": {"$ref": "#/$defs/id"},
+    "source_record_id": {"$ref": "#/$defs/id"},
+    "source_content_sha256": {"$ref": "#/$defs/sha256"},
+    "derivation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "source_start_char", "source_end_char", "receipt_sha256"],
+          "properties": {
+            "kind": {"const": "full_source"},
+            "source_start_char": {"type": "null"},
+            "source_end_char": {"type": "null"},
+            "receipt_sha256": {"$ref": "#/$defs/sha256"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "source_start_char", "source_end_char", "receipt_sha256"],
+          "properties": {
+            "kind": {"const": "character_span"},
+            "source_start_char": {"type": "integer", "minimum": 0},
+            "source_end_char": {"type": "integer", "minimum": 1},
+            "receipt_sha256": {"$ref": "#/$defs/sha256"}
+          }
+        }
+      ]
+    },
+    "text": {"type": "string", "minLength": 1},
+    "text_sha256": {"$ref": "#/$defs/sha256"},
+    "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic", "unknown"]},
+    "origin_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "method", "receipt_sha256"],
+      "properties": {
+        "status": {"enum": ["verified", "unresolved"]},
+        "method": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "receipt_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]}
+      }
+    },
+    "private_data": {"enum": ["clear", "present", "unknown"]},
+    "private_data_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "method", "receipt_sha256"],
+      "properties": {
+        "status": {"enum": ["complete", "incomplete"]},
+        "method": {"type": "string", "minLength": 1},
+        "receipt_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]}
+      }
+    },
+    "normalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "version", "receipt_sha256"],
+      "properties": {
+        "status": {"enum": ["complete", "incomplete", "unknown"]},
+        "version": {"type": "string", "minLength": 1},
+        "receipt_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]}
+      }
+    },
+    "language_span_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reviewer_qualification", "receipt_sha256", "character_spans"],
+      "properties": {
+        "status": {"enum": ["complete", "incomplete", "unreviewed"]},
+        "reviewer_qualification": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "receipt_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "character_spans": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["start", "end", "language_identity", "representation", "discourse_role", "modern_loss_action", "reason"],
+            "properties": {
+              "start": {"type": "integer", "minimum": 0},
+              "end": {"type": "integer", "minimum": 1},
+              "language_identity": {"enum": ["ukrainian", "russian", "mixed_ukrainian_russian", "historical_east_slavic_unresolved", "church_slavonic_candidate", "other_language", "uncertain"]},
+              "representation": {"enum": ["standard_orthography", "ukrainian_phonetic_rendering_of_russian", "historical_orthography", "transliteration", "ocr_or_encoding_candidate", "unknown"]},
+              "discourse_role": {"enum": ["narration", "quotation", "dialogue", "epigraph", "title", "citation_or_document", "metalinguistic_example", "unknown"]},
+              "modern_loss_action": {"enum": ["retain", "mask_from_loss", "exclude_record"]},
+              "reason": {"enum": ["russian_or_mixed_language", "quoted_or_multilingual", "historical_or_heritage", "dialectal_or_regional", "marked_register", "ocr_or_encoding", "context_uncertain", "other_reviewed"]}
+            }
+          }
+        }
+      }
+    },
+    "test_fixture": {"type": "boolean"}
+  },
+  "$defs": {
+    "id": {"type": "string", "pattern": "^[a-z][a-z0-9_.:-]{2,127}$"},
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+  }
+}

--- a/data/projects/open_model_data/contracts/heldout_evaluation_view_v1.schema.json
+++ b/data/projects/open_model_data/contracts/heldout_evaluation_view_v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/heldout_evaluation_view_v1.schema.json",
+  "title": "Ukrainian Data Foundry held-out evaluation view v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "evaluation_release", "evaluation_state", "lineage", "payload", "permitted_destination", "denied_destinations", "model_training_eligible"],
+  "properties": {
+    "schema_version": {"const": "heldout_evaluation_view_v1"},
+    "record_id": {"type": "string", "pattern": "^evaluation-view:[a-f0-9]{64}$"},
+    "evaluation_release": {"enum": ["v0.1.1", "v0.2"]},
+    "evaluation_state": {"enum": ["frozen_public", "frozen_review_inventory"]},
+    "lineage": {"type": "object", "additionalProperties": false, "required": ["item_id", "artifact_logical_path", "artifact_sha256"], "properties": {"item_id": {"type": "string", "minLength": 1}, "artifact_logical_path": {"type": "string", "minLength": 1}, "artifact_sha256": {"$ref": "#/$defs/sha256"}}},
+    "payload": {"type": "object", "additionalProperties": false, "required": ["source", "source_sha256", "references"], "properties": {"source": {"type": "string", "minLength": 1}, "source_sha256": {"$ref": "#/$defs/sha256"}, "references": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["reference_id", "text", "sha256"], "properties": {"reference_id": {"type": "string", "minLength": 1}, "text": {"type": "string", "minLength": 1}, "sha256": {"$ref": "#/$defs/sha256"}}}}}},
+    "permitted_destination": {"const": "heldout_evaluation"},
+    "denied_destinations": {"const": ["continued_pretraining", "supervised_correction", "pairwise_preference", "quality_filter"]},
+    "model_training_eligible": {"const": false}
+  },
+  "$defs": {"sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}}
+}

--- a/data/projects/open_model_data/contracts/model_view_export_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/model_view_export_receipt_v1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/model_view_export_receipt_v1.schema.json",
+  "title": "Ukrainian Data Foundry model-view export receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "view_kind", "input_artifacts", "output", "schemas", "admission", "deduplication", "evaluation_exclusion_registry", "counts", "determinism", "safety"],
+  "properties": {
+    "schema_version": {"const": "model_view_export_receipt_v1"},
+    "view_kind": {"enum": ["continued_pretraining", "correction_instruction", "preference", "quality_filter", "heldout_evaluation"]},
+    "input_artifacts": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/artifact"}},
+    "output": {"$ref": "#/$defs/artifact"},
+    "schemas": {"type": "object", "minProperties": 2, "additionalProperties": {"$ref": "#/$defs/sha256"}},
+    "admission": {
+      "type": "object", "additionalProperties": false,
+      "required": ["applied", "policy", "source_records_total", "source_records_admitted", "source_records_denied"],
+      "properties": {
+        "applied": {"type": "boolean"},
+        "policy": {"const": "recompute source_record_v1 admission; unknown is denial"},
+        "source_records_total": {"type": "integer", "minimum": 0},
+        "source_records_admitted": {"type": "integer", "minimum": 0},
+        "source_records_denied": {"type": "integer", "minimum": 0}
+      }
+    },
+    "deduplication": {
+      "type": "object", "additionalProperties": false,
+      "required": ["applied", "algorithm_version", "partitioning", "normalization", "near_duplicate_threshold", "minimum_containment_characters", "candidate_anchor_characters", "maximum_character_anchors_per_text", "accepted_fingerprints"],
+      "properties": {
+        "applied": {"type": "boolean"},
+        "algorithm_version": {"const": "foundry-intra-view-dedup-v1"},
+        "partitioning": {"enum": ["source text", "exact destination semantic signature, then plain-text context", "not applicable"]},
+        "normalization": {"const": "NFKC; casefold; collapse whitespace"},
+        "near_duplicate_threshold": {"const": 0.9},
+        "minimum_containment_characters": {"const": 32},
+        "candidate_anchor_characters": {"const": 8},
+        "maximum_character_anchors_per_text": {"const": 64},
+        "accepted_fingerprints": {"type": "integer", "minimum": 0}
+      }
+    },
+    "evaluation_exclusion_registry": {
+      "type": "object", "additionalProperties": false,
+      "required": ["algorithm_version", "normalization", "near_duplicate_threshold", "minimum_containment_characters", "candidate_anchor_characters", "maximum_character_anchors_per_text", "artifacts", "exact_fingerprints", "near_fingerprints"],
+      "properties": {
+        "algorithm_version": {"const": "foundry-eval-exclusion-v1"},
+        "normalization": {"const": "NFKC; casefold; collapse whitespace"},
+        "near_duplicate_threshold": {"const": 0.9},
+        "minimum_containment_characters": {"const": 32},
+        "candidate_anchor_characters": {"const": 8},
+        "maximum_character_anchors_per_text": {"const": 64},
+        "artifacts": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["logical_path", "sha256"], "properties": {"logical_path": {"type": "string", "minLength": 1}, "sha256": {"$ref": "#/$defs/sha256"}}}},
+        "exact_fingerprints": {"type": "integer", "minimum": 1},
+        "near_fingerprints": {"type": "integer", "minimum": 1}
+      }
+    },
+    "counts": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 0}},
+    "determinism": {"type": "object", "additionalProperties": false, "required": ["serialization", "ordering", "timestamps_omitted"], "properties": {"serialization": {"const": "UTF-8 canonical JSON with sorted keys and LF"}, "ordering": {"enum": ["validated ascending source payload ID", "canonical upstream packet order; unique correction record ID", "evaluation release then item ID"]}, "timestamps_omitted": {"const": true}}},
+    "safety": {"type": "object", "additionalProperties": false, "required": ["local_artifact_written", "training_performed", "upload_performed", "publication_performed", "private_data_exported", "evaluation_data_entered_non_evaluation_view", "test_fixture_mode"], "properties": {"local_artifact_written": {"const": true}, "training_performed": {"const": false}, "upload_performed": {"const": false}, "publication_performed": {"const": false}, "private_data_exported": {"const": false}, "evaluation_data_entered_non_evaluation_view": {"const": false}, "test_fixture_mode": {"type": "boolean"}}}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"view_kind": {"const": "heldout_evaluation"}}, "required": ["view_kind"]},
+      "then": {"properties": {"admission": {"properties": {"applied": {"const": false}}}, "deduplication": {"properties": {"applied": {"const": false}}}}},
+      "else": {"properties": {"admission": {"properties": {"applied": {"const": true}}}, "deduplication": {"properties": {"applied": {"const": true}}}}}
+    }
+  ],
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "artifact": {"type": "object", "additionalProperties": false, "required": ["role", "records", "bytes", "sha256"], "properties": {"role": {"type": "string", "minLength": 1}, "records": {"type": "integer", "minimum": 0}, "bytes": {"type": "integer", "minimum": 0}, "sha256": {"$ref": "#/$defs/sha256"}}}
+  }
+}

--- a/data/projects/open_model_data/contracts/preference_view_v1.schema.json
+++ b/data/projects/open_model_data/contracts/preference_view_v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/preference_view_v1.schema.json",
+  "title": "Ukrainian Data Foundry pairwise preference view v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "lineage", "origin", "payload", "permitted_destination", "denied_destinations", "eligibility"],
+  "properties": {
+    "schema_version": {"const": "preference_view_v1"},
+    "record_id": {"type": "string", "pattern": "^preference-view:[a-f0-9]{64}$"},
+    "lineage": {"$ref": "#/$defs/lineage"},
+    "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic"]},
+    "payload": {"type": "object", "additionalProperties": false, "required": ["prompt", "chosen", "rejected", "acceptable_alternatives"], "properties": {"prompt": {"type": "string", "minLength": 1}, "chosen": {"type": "string", "minLength": 1}, "rejected": {"type": "string", "minLength": 1}, "acceptable_alternatives": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}}},
+    "permitted_destination": {"const": "pairwise_preference"},
+    "denied_destinations": {"const": ["continued_pretraining", "supervised_correction", "quality_filter", "heldout_evaluation"]},
+    "eligibility": {"$ref": "#/$defs/eligibility"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "lineage": {"type": "object", "additionalProperties": false, "required": ["source_record_id", "source_record_sha256", "source_content_sha256", "correction_record_id", "correction_record_sha256", "candidate_sha256", "decision_sha256"], "properties": {"source_record_id": {"type": "string", "minLength": 3}, "source_record_sha256": {"$ref": "#/$defs/sha256"}, "source_content_sha256": {"$ref": "#/$defs/sha256"}, "correction_record_id": {"type": "string", "minLength": 3}, "correction_record_sha256": {"$ref": "#/$defs/sha256"}, "candidate_sha256": {"$ref": "#/$defs/sha256"}, "decision_sha256": {"$ref": "#/$defs/sha256"}}},
+    "eligibility": {"type": "object", "additionalProperties": false, "required": ["source_contract_admitted", "qualified_adjudication", "test_fixture", "model_training_eligible"], "properties": {"source_contract_admitted": {"const": true}, "qualified_adjudication": {"const": true}, "test_fixture": {"type": "boolean"}, "model_training_eligible": {"type": "boolean"}}, "allOf": [{"if": {"properties": {"test_fixture": {"const": true}}}, "then": {"properties": {"model_training_eligible": {"const": false}}}, "else": {"properties": {"model_training_eligible": {"const": true}}}}]}
+  }
+}

--- a/data/projects/open_model_data/contracts/quality_filter_view_v1.schema.json
+++ b/data/projects/open_model_data/contracts/quality_filter_view_v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/quality_filter_view_v1.schema.json",
+  "title": "Ukrainian Data Foundry quality-filter view v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "record_id", "lineage", "origin", "payload", "permitted_destination", "denied_destinations", "eligibility"],
+  "properties": {
+    "schema_version": {"const": "quality_filter_view_v1"},
+    "record_id": {"type": "string", "pattern": "^quality-view:[a-f0-9]{64}$"},
+    "lineage": {"$ref": "#/$defs/lineage"},
+    "origin": {"enum": ["human_authored", "machine_generated", "machine_translated", "human_revised_synthetic"]},
+    "payload": {"type": "object", "additionalProperties": false, "required": ["text", "label", "decision"], "properties": {"text": {"type": "string", "minLength": 1}, "label": {"enum": ["acceptable", "needs_correction"]}, "decision": {"enum": ["acceptable_as_is", "correction"]}}},
+    "permitted_destination": {"const": "quality_filter"},
+    "denied_destinations": {"const": ["continued_pretraining", "supervised_correction", "pairwise_preference", "heldout_evaluation"]},
+    "eligibility": {"$ref": "#/$defs/eligibility"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "lineage": {"type": "object", "additionalProperties": false, "required": ["source_record_id", "source_record_sha256", "source_content_sha256", "correction_record_id", "correction_record_sha256", "candidate_sha256", "decision_sha256"], "properties": {"source_record_id": {"type": "string", "minLength": 3}, "source_record_sha256": {"$ref": "#/$defs/sha256"}, "source_content_sha256": {"$ref": "#/$defs/sha256"}, "correction_record_id": {"type": "string", "minLength": 3}, "correction_record_sha256": {"$ref": "#/$defs/sha256"}, "candidate_sha256": {"$ref": "#/$defs/sha256"}, "decision_sha256": {"$ref": "#/$defs/sha256"}}},
+    "eligibility": {"type": "object", "additionalProperties": false, "required": ["source_contract_admitted", "qualified_adjudication", "test_fixture", "model_training_eligible"], "properties": {"source_contract_admitted": {"const": true}, "qualified_adjudication": {"const": true}, "test_fixture": {"type": "boolean"}, "model_training_eligible": {"type": "boolean"}}, "allOf": [{"if": {"properties": {"test_fixture": {"const": true}}}, "then": {"properties": {"model_training_eligible": {"const": false}}}, "else": {"properties": {"model_training_eligible": {"const": true}}}}]}
+  }
+}

--- a/data/projects/open_model_data/contracts/training_recipe_config_v1.schema.json
+++ b/data/projects/open_model_data/contracts/training_recipe_config_v1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/training_recipe_config_v1.schema.json",
+  "title": "Ukrainian Data Foundry preparation/training recipe config v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "recipe_id", "view_kind", "objective", "base_model", "tokenizer", "implementation", "data_preparation", "hyperparameters", "run_policy"],
+  "properties": {
+    "schema_version": {"const": "training_recipe_config_v1"},
+    "recipe_id": {"type": "string", "pattern": "^[a-z][a-z0-9_.:-]{2,127}$"},
+    "view_kind": {"enum": ["continued_pretraining", "correction_instruction", "preference", "quality_filter", "heldout_evaluation"]},
+    "objective": {"enum": ["causal_language_modeling", "supervised_correction", "pairwise_preference", "binary_quality_classification", "heldout_evaluation_only"]},
+    "base_model": {"$ref": "#/$defs/pinnedComponent"},
+    "tokenizer": {"$ref": "#/$defs/pinnedComponent"},
+    "implementation": {"type": "object", "additionalProperties": false, "required": ["framework", "framework_version", "code_revision", "dependency_lock_sha256"], "properties": {"framework": {"type": "string", "minLength": 1}, "framework_version": {"type": "string", "minLength": 1}, "code_revision": {"$ref": "#/$defs/revision"}, "dependency_lock_sha256": {"$ref": "#/$defs/sha256"}}},
+    "data_preparation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["rendering_template", "rendering_template_sha256", "target_loss_policy", "split"],
+      "properties": {
+        "rendering_template": {"type": "string", "minLength": 1},
+        "rendering_template_sha256": {"$ref": "#/$defs/sha256"},
+        "target_loss_policy": {"enum": ["unmasked_text_tokens", "target_fields_only", "no_training_evaluation_only"]},
+        "split": {
+          "type": "object", "additionalProperties": false,
+          "required": ["strategy", "namespace", "modulus", "validation_buckets"],
+          "properties": {
+            "strategy": {"enum": ["sha256_record_id_modulo", "preserve_evaluation_release"]},
+            "namespace": {"type": "string", "minLength": 1},
+            "modulus": {"anyOf": [{"type": "integer", "minimum": 2}, {"type": "null"}]},
+            "validation_buckets": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
+          }
+        }
+      }
+    },
+    "hyperparameters": {"type": "object", "additionalProperties": false, "required": ["seed", "sequence_length", "micro_batch_size", "gradient_accumulation_steps", "learning_rate", "weight_decay", "epochs", "precision", "packing"], "properties": {"seed": {"type": "integer", "minimum": 0}, "sequence_length": {"type": "integer", "minimum": 1}, "micro_batch_size": {"type": "integer", "minimum": 1}, "gradient_accumulation_steps": {"type": "integer", "minimum": 1}, "learning_rate": {"type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?([eE]-?[0-9]+)?$"}, "weight_decay": {"type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?([eE]-?[0-9]+)?$"}, "epochs": {"type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$"}, "precision": {"enum": ["fp32", "fp16", "bf16"]}, "packing": {"type": "boolean"}}},
+    "run_policy": {"type": "object", "additionalProperties": false, "required": ["training_authorized", "execution_state"], "properties": {"training_authorized": {"const": false}, "execution_state": {"const": "not_run"}}}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "revision": {"type": "string", "pattern": "^[a-f0-9]{40,64}$"},
+    "pinnedComponent": {"type": "object", "additionalProperties": false, "required": ["identifier", "revision"], "properties": {"identifier": {"type": "string", "minLength": 1}, "revision": {"$ref": "#/$defs/revision"}}}
+  }
+}

--- a/data/projects/open_model_data/contracts/training_recipe_manifest_v1.schema.json
+++ b/data/projects/open_model_data/contracts/training_recipe_manifest_v1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/training_recipe_manifest_v1.schema.json",
+  "title": "Ukrainian Data Foundry preparation/training recipe manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "manifest_id", "config", "config_sha256", "view_artifact", "view_receipt", "schema_hashes", "preparation", "execution", "determinism"],
+  "properties": {
+    "schema_version": {"const": "training_recipe_manifest_v1"},
+    "manifest_id": {"type": "string", "pattern": "^recipe:[a-f0-9]{64}$"},
+    "config": {"$ref": "https://learn-ukrainian.github.io/schemas/open-model-data/training_recipe_config_v1.schema.json"},
+    "config_sha256": {"$ref": "#/$defs/sha256"},
+    "view_artifact": {"$ref": "#/$defs/artifact"},
+    "view_receipt": {"$ref": "#/$defs/artifact"},
+    "schema_hashes": {"type": "object", "minProperties": 3, "additionalProperties": {"$ref": "#/$defs/sha256"}},
+    "preparation": {"type": "object", "additionalProperties": false, "required": ["record_order", "shuffle", "loss_mask_projection", "input_validation", "model_training_eligible_records", "test_fixture_records"], "properties": {"record_order": {"const": "view artifact order bound by export receipt"}, "shuffle": {"enum": ["SHA-256(seed || record_id), ascending digest", "not applicable; preserve held-out artifact order"]}, "loss_mask_projection": {"enum": ["tokenizer projects character_mask_spans after tokenization; masked tokens receive zero loss", "not applicable to this view"]}, "input_validation": {"const": "validate every JSONL row against the bound view schema before preparation"}, "model_training_eligible_records": {"type": "integer", "minimum": 0}, "test_fixture_records": {"type": "integer", "minimum": 0}}},
+    "execution": {"type": "object", "additionalProperties": false, "required": ["training_authorized", "execution_state", "model_call_performed", "training_performed", "test_fixture_mode"], "properties": {"training_authorized": {"const": false}, "execution_state": {"const": "not_run"}, "model_call_performed": {"const": false}, "training_performed": {"const": false}, "test_fixture_mode": {"type": "boolean"}}},
+    "determinism": {"type": "object", "additionalProperties": false, "required": ["serialization", "timestamps_omitted"], "properties": {"serialization": {"const": "UTF-8 canonical JSON with sorted keys and LF"}, "timestamps_omitted": {"const": true}}}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "artifact": {"type": "object", "additionalProperties": false, "required": ["records", "bytes", "sha256"], "properties": {"records": {"type": "integer", "minimum": 0}, "bytes": {"type": "integer", "minimum": 0}, "sha256": {"$ref": "#/$defs/sha256"}}}
+  }
+}

--- a/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
@@ -238,6 +238,22 @@ A non-evaluation view requires all of the following:
 Failure or absence at any gate yields an investigation, private, evaluation,
 unresolved, or excluded state—not `training_eligible`.
 
+The implemented #6122 boundary is the
+[model-view and recipe runbook](../runbooks/ukrainian-data-foundry-model-views.md).
+It provides separate schemas and commands for continued pretraining,
+correction/instruction, preference, quality-filter, and held-out evaluation
+artifacts. Non-evaluation views revalidate the source and correction contracts,
+all emitted text fields against the complete evaluation-exclusion registry,
+private/origin/rights state, and exact/near duplication inside each output.
+Modern-Ukrainian pretraining retains source bytes and exposes character-level
+loss masks; its payload contract binds every full source or segment to an
+explicit derivation receipt and parent content hash. Tokenizer-specific mask
+projection is part of the bound preparation recipe. Export receipts report
+recomputed source-admission and intra-view deduplication state. Recipe
+manifests pin exact view and receipt hashes, immutable model/tokenizer/code
+revisions, and positive training hyperparameters, while recording
+`training_authorized: false` and `execution_state: not_run`.
+
 ## Safety invariants
 
 ### Rights and provenance

--- a/docs/runbooks/ukrainian-data-foundry-correction-factory.md
+++ b/docs/runbooks/ukrainian-data-foundry-correction-factory.md
@@ -121,9 +121,11 @@ Every record still carries:
 }
 ```
 
-Issue #6122 owns the separate consumer schemas and model-ready exporters. It
-must revalidate rights, contamination, view separation, and this handoff; it
-must not reinterpret an unresolved or protected record as correction data.
+Issue #6122 implements that separate consumer boundary in the
+[model-view and recipe runbook](ukrainian-data-foundry-model-views.md). Its
+exporter revalidates rights, contamination, view separation, and this handoff;
+it does not reinterpret an unresolved or protected record as correction data.
+The upstream `model_training_or_export_eligible: false` remains unchanged.
 
 ## ULIF completeness
 

--- a/docs/runbooks/ukrainian-data-foundry-model-views.md
+++ b/docs/runbooks/ukrainian-data-foundry-model-views.md
@@ -1,0 +1,259 @@
+# Ukrainian Data Foundry Model Views and Recipes
+
+> **Owner:** [#6122](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6122)
+> under [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
+> **Boundary:** local view construction and reproducible manifests, not training
+> or publication
+
+## What this component does
+
+The model-view exporter turns already governed Foundry inputs into five
+mechanically separate local artifacts:
+
+| View | Schema | Only permitted destination |
+| --- | --- | --- |
+| Continued pretraining | `continued_pretraining_view_v1.schema.json` | `continued_pretraining` |
+| Correction/instruction | `correction_instruction_view_v1.schema.json` | `supervised_correction` |
+| Preference | `preference_view_v1.schema.json` | `pairwise_preference` |
+| Quality filter | `quality_filter_view_v1.schema.json` | `quality_filter` |
+| Held-out evaluation | `heldout_evaluation_view_v1.schema.json` | `heldout_evaluation` |
+
+Each command validates and writes only one schema. There is no mixed export to
+filter or rename later. Every non-evaluation row carries its source-record
+lineage, destination, origin class, and eligibility decision. The evaluation
+schema denies every training destination.
+
+Before a non-evaluation row is written, the exporter applies destination-aware
+deduplication. Continued-pretraining compares source text. Correction-family
+views first group rows by an exact semantic signature—the corrected/rejected
+span, accepted form, alternatives, offsets, or label as applicable—and only
+then compare their plain-text contexts for exact or near duplication. Shared
+context alone therefore cannot erase two distinct corrections. Exclusions are
+counted and never cross separate origin artifacts.
+
+The CLI writes local artifacts. It does not upload, publish, redistribute, call
+a model, or run training.
+
+## Required inputs
+
+### Continued-pretraining source payloads
+
+`foundry_source_payload_v1.schema.json` is a local, uncommitted content
+envelope. It binds a prepared text segment to an admitted
+`source_record_v1` parent through:
+
+- source record ID and parent content SHA-256;
+- explicit full-source or character-span derivation and receipt;
+- segment text and segment SHA-256;
+- explicit human, generated, translated, or human-revised-synthetic origin
+  with a verification method and receipt;
+- private-data disposition with a completed screening method and receipt;
+- normalization version and receipt;
+- complete language-span review and receipt; and
+- a gap-free, full-text partition of classified character spans with
+  modern-loss actions.
+
+Normalization applies to the full source before segmentation. A payload can
+then be a deterministic character span of that normalized source; its declared
+span width must exactly equal the emitted segment length. The parent hash,
+normalized-source character bounds, and derivation, normalization, and span
+receipts preserve that chain without requiring the source record to duplicate
+copyrighted content. Full-source payloads explicitly use null source bounds.
+
+A modern-literary-Ukrainian view keeps the original text bytes and emits
+tokenizer-independent `start_char`/`end_char` mask ranges. Russian quotation,
+mixed-language material, Ukrainian-phonetic Russian, historical orthography,
+dialectal or regional material, marked register, and uncertain spans cannot be
+silently retained in modern-Ukrainian loss. An `exclude_record` decision omits
+the whole payload and increments an explicit receipt count. The faithful view
+retains the original text and emits no loss masks.
+
+Each artifact is homogeneous by origin. Machine-generated, translated,
+human-revised-synthetic, and human-authored material must be exported in
+separate invocations.
+
+### Correction, preference, and quality-filter inputs
+
+These commands consume the canonical `correction_record_v1` handoff plus the
+exact admitted `source_record_v1` join. The #6121 field
+`model_training_or_export_eligible` intentionally remains `false`; #6122 never
+expects or mutates it. Instead, the correction and preference exporters
+recompute the canonical handoff and require:
+
+- `qualified_correction_intake: true`;
+- `handoff: correction_intake_ready`;
+- `owner_issue: 6122`;
+- no safety blockers;
+- a resolved correction with an accepted form;
+- an admitted source record with all required rights granted; and
+- clear private-data, origin, and contamination states.
+
+The correction view reconstructs the corrected context from the preserved
+span offsets. The preference view keeps the context as the prompt and the
+accepted/original span as the chosen/rejected pair. Every emitted text field,
+including alternatives and reconstructed targets, is checked again for
+evaluation contamination.
+
+The quality-filter view accepts only resolved `correction` or
+`acceptable_as_is` decisions after the same independent safety checks.
+Protected, quoted, multilingual, unresolved, contaminated, or rights-unclear
+records do not become quality labels.
+
+Correction-family exporters preserve canonical upstream packet order and
+require unique correction-record IDs. They do not sort or require lexical
+ordering of the hash-derived correction IDs. Continued-pretraining payloads,
+by contrast, require caller-assigned payload IDs in strictly ascending order.
+The receipt records the ordering rule actually applied.
+
+## Evaluation exclusion registry
+
+Every non-evaluation invocation rebuilds an in-memory exclusion registry from:
+
+- the frozen v0.1.1 held-out manifest;
+- the frozen v0.2 review inventory;
+- `evalset_v1.jsonl`;
+- v0.1.1 item-level evidence;
+- scoring dispositions;
+- the evaluation taxonomy; and
+- the frozen minimal-edit prompt.
+
+Additional evaluation-only or derived-rule artifacts may be supplied with a
+repeatable `--extra-evaluation-artifact` argument. Missing or unreadable
+artifacts fail closed.
+
+The frozen algorithm combines normalized exact hashes, 32-character
+containment, character-sequence comparison, and three-token shingle Jaccard at
+`0.90`. Each text contributes at most 64 deterministic, evenly spaced
+eight-character anchors (including both endpoints) to the character candidate
+index. This keeps index growth bounded by record count rather than total
+character count; exact hashes and three-token shingles provide the primary
+exact and near-duplicate candidate paths. Raw evaluation text remains in memory
+only. Receipts record logical artifact paths, artifact hashes, algorithm
+version, thresholds, the anchor cap, and fingerprint counts—not evaluation
+content or private filesystem paths.
+
+The same matching primitives power a separate intra-view deduplication gate.
+The export receipt distinguishes that gate from evaluation contamination and
+records whether it ran, its frozen algorithm and thresholds, and the number of
+accepted fingerprints. It also records the recomputed source-contract totals:
+admitted, denied, and total source records. Evaluation-only exports mark both
+source admission and intra-view deduplication as not applicable.
+
+The view and receipt are prepared in temporary files. Existing outputs are
+moved atomically over still-reserved same-directory backup files, so another
+process cannot claim a released backup pathname. If either final rename fails,
+the exporter restores both previous files (or removes both new files) and
+deletes rollback temporaries before propagating the failure. A successful
+return therefore cannot leave a newly written view paired with a stale receipt.
+
+## Build one view
+
+Run from the worktree root. Inputs and outputs shown below are local paths and
+must not be committed merely because the command succeeds.
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.model_view_exporter \
+  continued-pretraining \
+  --source-records /local/source-records.jsonl \
+  --payloads /local/source-payloads.jsonl \
+  --origin human_authored \
+  --representation-view modern_literary_ukrainian \
+  --output /local/modern-pretraining.jsonl \
+  --receipt-output /local/modern-pretraining.receipt.json
+```
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.model_view_exporter \
+  correction \
+  --source-records /local/source-records.jsonl \
+  --correction-records /local/correction-records.jsonl \
+  --origin human_authored \
+  --output /local/correction-view.jsonl \
+  --receipt-output /local/correction-view.receipt.json
+```
+
+Replace `correction` with `preference` or `quality-filter` to build those
+separate schemas. The same input cannot create a mixed artifact.
+
+The held-out view has its own command and schema:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.model_view_exporter \
+  evaluation \
+  --release all \
+  --output /local/heldout-evaluation.jsonl \
+  --receipt-output /local/heldout-evaluation.receipt.json
+```
+
+This copies frozen evaluation inputs into a local evaluation-only interface. It
+does not make the v0.2 review inventory a public release.
+
+## Build a reproducible recipe manifest
+
+`training_recipe_config_v1.schema.json` requires immutable base-model,
+tokenizer, code, dependency, framework, seed, precision, and hyperparameter
+pins. Its objective must match the view. A moving revision such as `main` is
+invalid. Learning rate and epochs must be greater than zero; weight decay must
+not be negative.
+
+The config also embeds the exact record-rendering template and its SHA-256,
+the destination-specific loss policy, and the data split rule. Training views
+use a named SHA-256 record-ID modulo partition with a fixed modulus and number
+of validation buckets. Evaluation recipes instead preserve the frozen release
+and cannot declare training partitions or loss.
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.model_view_exporter \
+  recipe \
+  --config /local/recipe-config.json \
+  --view-artifact /local/modern-pretraining.jsonl \
+  --view-receipt /local/modern-pretraining.receipt.json \
+  --output /local/modern-pretraining.recipe.json
+```
+
+The manifest revalidates every view row, verifies the receipt's record count,
+byte count, and SHA-256, and binds both exact artifact digests. It freezes
+destination-specific preparation and deterministic shuffle rules. Character
+mask projection applies only to continued pretraining; other views record it
+as not applicable. Held-out evaluation preserves its artifact order and is
+never shuffled. Every manifest records:
+
+```json
+{
+  "execution_state": "not_run",
+  "model_call_performed": false,
+  "training_authorized": false,
+  "training_performed": false
+}
+```
+
+Recipes do not authorize a training run. A future run needs a named research
+question, a decision the run can change, and separate present-tense operator
+authorization.
+
+## Fixture boundary
+
+Synthetic fixtures are rejected unless `--allow-test-fixtures` is explicit.
+Fixture mode exercises schema, join, reconstruction, contamination, receipt,
+and recipe behavior while forcing every non-evaluation row to
+`model_training_eligible: false`. Fixture and genuinely eligible records cannot
+share a recipe-bound view.
+
+No real source record or qualified human correction has been admitted by this
+implementation. The exporter makes the missing evidence executable and
+auditable; it does not convert the existing zero-admission corpus inventory
+into permission.
+
+## Verification
+
+```bash
+.venv/bin/python -m pytest -q \
+  tests/test_open_model_view_exporter.py \
+  tests/test_open_model_correction_factory.py \
+  tests/test_open_model_source_record_contract.py
+
+.venv/bin/ruff check \
+  scripts/projects/open_model_data/model_view_exporter.py \
+  scripts/projects/open_model_data/correction_factory.py \
+  tests/test_open_model_view_exporter.py
+```

--- a/scripts/projects/open_model_data/correction_factory.py
+++ b/scripts/projects/open_model_data/correction_factory.py
@@ -538,7 +538,14 @@ def _handoff(candidate: Mapping[str, Any], decision: Mapping[str, Any], blockers
     return "unresolved"
 
 
-def _record(candidate: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
+def build_correction_record(
+    candidate: dict[str, Any], decision: dict[str, Any]
+) -> dict[str, Any]:
+    """Build the canonical non-exportable #6121 handoff record.
+
+    Issue #6122 imports this function to recompute the handoff rather than
+    trusting caller-supplied blockers or export-control fields.
+    """
     candidate_hash = sha256_text(canonical_json(candidate))
     decision_hash = sha256_text(canonical_json(decision))
     blockers = _safety_blockers(candidate, decision)
@@ -564,6 +571,11 @@ def _record(candidate: dict[str, Any], decision: dict[str, Any]) -> dict[str, An
         "safety_blockers": blockers,
         "schema_version": "correction_record_v1",
     }
+
+
+def _record(candidate: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
+    """Backward-compatible internal alias for existing focused tests."""
+    return build_correction_record(candidate, decision)
 
 
 def _jsonl_bytes(rows: Sequence[Mapping[str, Any]]) -> bytes:
@@ -726,7 +738,7 @@ def adjudicate(
             validator=decision_validator,
             allow_test_fixtures=allow_test_fixtures,
         )
-        record = _record(candidate, decision)
+        record = build_correction_record(candidate, decision)
         _validate_schema(record, record_validator, label="correction record")
         records.append(record)
         counts["candidate_records"] += 1

--- a/scripts/projects/open_model_data/model_view_exporter.py
+++ b/scripts/projects/open_model_data/model_view_exporter.py
@@ -1,0 +1,1808 @@
+#!/usr/bin/env python3
+"""Build disjoint, lineage-preserving Ukrainian model-consumer views.
+
+The exporter is the #6122 admission boundary. It revalidates source contracts,
+qualified correction handoffs, privacy/origin state, and evaluation
+contamination before writing one homogeneous local artifact. It never runs a
+model, starts training, uploads data, or publishes an artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import unicodedata
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, TextIO
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+from scripts.projects.open_model_data import correction_factory
+from scripts.projects.open_model_data import validate_source_records as source_contract
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
+
+SOURCE_PAYLOAD_SCHEMA = CONTRACTS / "foundry_source_payload_v1.schema.json"
+PRETRAIN_SCHEMA = CONTRACTS / "continued_pretraining_view_v1.schema.json"
+CORRECTION_VIEW_SCHEMA = CONTRACTS / "correction_instruction_view_v1.schema.json"
+PREFERENCE_SCHEMA = CONTRACTS / "preference_view_v1.schema.json"
+QUALITY_SCHEMA = CONTRACTS / "quality_filter_view_v1.schema.json"
+EVALUATION_SCHEMA = CONTRACTS / "heldout_evaluation_view_v1.schema.json"
+EXPORT_RECEIPT_SCHEMA = CONTRACTS / "model_view_export_receipt_v1.schema.json"
+RECIPE_CONFIG_SCHEMA = CONTRACTS / "training_recipe_config_v1.schema.json"
+RECIPE_MANIFEST_SCHEMA = CONTRACTS / "training_recipe_manifest_v1.schema.json"
+
+CANDIDATE_SCHEMA = CONTRACTS / "correction_candidate_v1.schema.json"
+DECISION_SCHEMA = CONTRACTS / "correction_reviewer_decision_v1.schema.json"
+CORRECTION_RECORD_SCHEMA = CONTRACTS / "correction_record_v1.schema.json"
+SOURCE_RECORD_SCHEMA = CONTRACTS / "source_record_v1.schema.json"
+
+NEW_SCHEMA_PATHS = (
+    SOURCE_PAYLOAD_SCHEMA,
+    PRETRAIN_SCHEMA,
+    CORRECTION_VIEW_SCHEMA,
+    PREFERENCE_SCHEMA,
+    QUALITY_SCHEMA,
+    EVALUATION_SCHEMA,
+    EXPORT_RECEIPT_SCHEMA,
+    RECIPE_CONFIG_SCHEMA,
+    RECIPE_MANIFEST_SCHEMA,
+)
+DEPENDENCY_SCHEMA_PATHS = (
+    CANDIDATE_SCHEMA,
+    DECISION_SCHEMA,
+    CORRECTION_RECORD_SCHEMA,
+    SOURCE_RECORD_SCHEMA,
+)
+ALL_SCHEMA_PATHS = NEW_SCHEMA_PATHS + DEPENDENCY_SCHEMA_PATHS
+
+DEFAULT_V011_MANIFEST = ROOT / "data/projects/ua_eval_harness/heldout_manifest_v1.json"
+DEFAULT_V02_PACKET = ROOT / "data/projects/ua_eval_harness/v0.2/review_packet_priority_v1.jsonl"
+DEFAULT_EVALUATION_ARTIFACTS = (
+    DEFAULT_V011_MANIFEST,
+    DEFAULT_V02_PACKET,
+    ROOT / "data/projects/ua_eval_harness/evalset_v1.jsonl",
+    ROOT / "data/projects/ua_eval_harness/analysis/v0.1.1/item_evidence.jsonl",
+    ROOT / "data/projects/ua_eval_harness/scoring_dispositions_v1.json",
+    ROOT / "data/projects/ua_eval_harness/development/taxonomy.yaml",
+    ROOT / "data/projects/ua_eval_harness/minimal_edit_prompt_v1.txt",
+)
+
+VIEW_SCHEMAS = {
+    "continued_pretraining": PRETRAIN_SCHEMA,
+    "correction_instruction": CORRECTION_VIEW_SCHEMA,
+    "preference": PREFERENCE_SCHEMA,
+    "quality_filter": QUALITY_SCHEMA,
+    "heldout_evaluation": EVALUATION_SCHEMA,
+}
+OBJECTIVES = {
+    "continued_pretraining": "causal_language_modeling",
+    "correction_instruction": "supervised_correction",
+    "preference": "pairwise_preference",
+    "quality_filter": "binary_quality_classification",
+    "heldout_evaluation": "heldout_evaluation_only",
+}
+TARGET_LOSS_POLICIES = {
+    "continued_pretraining": "unmasked_text_tokens",
+    "correction_instruction": "target_fields_only",
+    "preference": "target_fields_only",
+    "quality_filter": "target_fields_only",
+    "heldout_evaluation": "no_training_evaluation_only",
+}
+ORIGINS = (
+    "human_authored",
+    "machine_generated",
+    "machine_translated",
+    "human_revised_synthetic",
+)
+
+NEAR_DUPLICATE_THRESHOLD = 0.90
+MIN_CONTAINMENT_CHARACTERS = 32
+CANDIDATE_ANCHOR_CHARACTERS = 8
+MAX_CHARACTER_ANCHORS_PER_TEXT = 64
+MIN_DERIVED_RULE_CHARACTERS = 16
+SHINGLE_WIDTH = 3
+PROTECTED_REASONS = frozenset(
+    {
+        "russian_or_mixed_language",
+        "quoted_or_multilingual",
+        "historical_or_heritage",
+        "dialectal_or_regional",
+        "marked_register",
+        "ocr_or_encoding",
+        "context_uncertain",
+    }
+)
+
+
+class ExportError(ValueError):
+    """An input or requested export violates the Foundry contract."""
+
+
+@dataclass(frozen=True)
+class SourceAdmission:
+    record: dict[str, Any]
+    sha256: str
+    admitted: bool
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExclusionMatch:
+    matched: bool
+    method: str | None = None
+
+
+@dataclass
+class EvaluationExclusionRegistry:
+    exact_hashes: set[str]
+    near_texts: list[str]
+    near_shingles: list[frozenset[str]]
+    shingle_index: dict[str, set[int]]
+    character_index: dict[str, set[int]]
+    artifacts: list[dict[str, str]]
+
+    def add_text(self, text: str, *, explicit_evaluation_text: bool) -> None:
+        normalized = normalize_text(text)
+        if not normalized:
+            return
+        if explicit_evaluation_text or len(normalized) >= MIN_DERIVED_RULE_CHARACTERS:
+            self.exact_hashes.add(sha256_text(normalized))
+        if len(normalized) < MIN_CONTAINMENT_CHARACTERS:
+            return
+        if not explicit_evaluation_text and len(normalized.split()) < SHINGLE_WIDTH:
+            return
+        index = len(self.near_texts)
+        shingles = frozenset(word_shingles(normalized))
+        self.near_texts.append(normalized)
+        self.near_shingles.append(shingles)
+        for shingle in shingles:
+            self.shingle_index[shingle].add(index)
+        for offset in character_anchor_offsets(normalized):
+            self.character_index[normalized[offset : offset + CANDIDATE_ANCHOR_CHARACTERS]].add(index)
+
+    def match(self, text: str) -> ExclusionMatch:
+        normalized = normalize_text(text)
+        if not normalized:
+            return ExclusionMatch(False)
+        if sha256_text(normalized) in self.exact_hashes:
+            return ExclusionMatch(True, "exact_normalized")
+
+        candidate_indexes: set[int] = set()
+        shingles = frozenset(word_shingles(normalized))
+        for shingle in shingles:
+            candidate_indexes.update(self.shingle_index.get(shingle, ()))
+        if len(normalized) >= CANDIDATE_ANCHOR_CHARACTERS:
+            for offset in character_anchor_offsets(normalized):
+                candidate_indexes.update(
+                    self.character_index.get(normalized[offset : offset + CANDIDATE_ANCHOR_CHARACTERS], ())
+                )
+
+        for index in sorted(candidate_indexes):
+            reference = self.near_texts[index]
+            if min(len(normalized), len(reference)) >= MIN_CONTAINMENT_CHARACTERS and (
+                normalized in reference or reference in normalized
+            ):
+                return ExclusionMatch(True, "character_containment")
+            reference_shingles = self.near_shingles[index]
+            union = shingles | reference_shingles
+            if union and len(shingles & reference_shingles) / len(union) >= NEAR_DUPLICATE_THRESHOLD:
+                return ExclusionMatch(True, "word_shingle_jaccard")
+            length_ratio = min(len(normalized), len(reference)) / max(len(normalized), len(reference))
+            if (
+                length_ratio >= NEAR_DUPLICATE_THRESHOLD
+                and SequenceMatcher(None, normalized, reference, autojunk=False).ratio() >= NEAR_DUPLICATE_THRESHOLD
+            ):
+                return ExclusionMatch(True, "character_sequence")
+        return ExclusionMatch(False)
+
+
+def character_anchor_offsets(normalized: str) -> tuple[int, ...]:
+    """Return deterministic, evenly spaced anchors with bounded index growth."""
+    windows = len(normalized) - CANDIDATE_ANCHOR_CHARACTERS + 1
+    if windows <= 0:
+        return ()
+    if windows <= MAX_CHARACTER_ANCHORS_PER_TEXT:
+        return tuple(range(windows))
+    final_offset = windows - 1
+    return tuple(
+        (anchor * final_offset) // (MAX_CHARACTER_ANCHORS_PER_TEXT - 1)
+        for anchor in range(MAX_CHARACTER_ANCHORS_PER_TEXT)
+    )
+
+
+def empty_text_registry() -> EvaluationExclusionRegistry:
+    return EvaluationExclusionRegistry(
+        exact_hashes=set(),
+        near_texts=[],
+        near_shingles=[],
+        shingle_index=defaultdict(set),
+        character_index=defaultdict(set),
+        artifacts=[],
+    )
+
+
+@dataclass
+class AtomicJsonl:
+    output: Path
+    handle: TextIO
+    temporary: Path
+    digest: Any
+    records: int = 0
+    bytes_written: int = 0
+
+    @classmethod
+    def open(cls, output: Path) -> AtomicJsonl:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        handle = tempfile.NamedTemporaryFile(  # noqa: SIM115 - closed by finish/abort
+            mode="w",
+            encoding="utf-8",
+            newline="",
+            dir=output.parent,
+            prefix=output.name,
+            suffix=".tmp",
+            delete=False,
+        )
+        return cls(output, handle, Path(handle.name), hashlib.sha256())
+
+    def write(self, row: Mapping[str, Any]) -> None:
+        encoded = (canonical_json(row) + "\n").encode("utf-8")
+        self.handle.write(encoded.decode("utf-8"))
+        self.digest.update(encoded)
+        self.records += 1
+        self.bytes_written += len(encoded)
+
+    def finish(self) -> dict[str, Any]:
+        self.handle.flush()
+        os.fsync(self.handle.fileno())
+        self.handle.close()
+        return {
+            "bytes": self.bytes_written,
+            "records": self.records,
+            "sha256": self.digest.hexdigest(),
+        }
+
+    def replace(self) -> None:
+        os.replace(self.temporary, self.output)
+
+    def abort(self) -> None:
+        if not self.handle.closed:
+            self.handle.close()
+        self.temporary.unlink(missing_ok=True)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_text(value: str) -> str:
+    return sha256_bytes(value.encode("utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise ExportError(f"cannot hash {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def normalize_text(value: str) -> str:
+    return " ".join(unicodedata.normalize("NFKC", value).casefold().split())
+
+
+def word_shingles(value: str) -> Iterator[str]:
+    tokens = value.split()
+    for index in range(len(tokens) - SHINGLE_WIDTH + 1):
+        yield " ".join(tokens[index : index + SHINGLE_WIDTH])
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ExportError(message)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExportError(f"cannot read JSON {path}: {exc}") from exc
+    require(isinstance(value, dict), f"expected JSON object: {path}")
+    return value
+
+
+def iter_jsonl(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
+    try:
+        handle = path.open(encoding="utf-8")
+    except OSError as exc:
+        raise ExportError(f"cannot read JSONL {path}: {exc}") from exc
+    with handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ExportError(f"invalid JSONL at {path}:{line_number}: {exc}") from exc
+            require(isinstance(row, dict), f"expected object at {path}:{line_number}")
+            yield line_number, row
+
+
+def artifact(path: Path, *, role: str, records: int) -> dict[str, Any]:
+    try:
+        byte_count = path.stat().st_size
+    except OSError as exc:
+        raise ExportError(f"cannot stat {path}: {exc}") from exc
+    return {
+        "bytes": byte_count,
+        "records": records,
+        "role": role,
+        "sha256": sha256_file(path),
+    }
+
+
+def schema_bundle() -> tuple[dict[Path, dict[str, Any]], Registry]:
+    schemas = {path: read_json(path) for path in ALL_SCHEMA_PATHS}
+    registry = Registry()
+    for schema in schemas.values():
+        Draft202012Validator.check_schema(schema)
+        registry = registry.with_resource(str(schema["$id"]), Resource.from_contents(schema))
+    return schemas, registry
+
+
+def validator_for(
+    path: Path,
+    *,
+    schemas: Mapping[Path, dict[str, Any]],
+    registry: Registry,
+    format_checker: bool = False,
+) -> Draft202012Validator:
+    return Draft202012Validator(
+        schemas[path],
+        registry=registry,
+        format_checker=FormatChecker() if format_checker else None,
+    )
+
+
+def validate_schema(value: Mapping[str, Any], validator: Draft202012Validator, *, label: str) -> None:
+    errors = sorted(validator.iter_errors(value), key=lambda error: list(error.path))
+    if errors:
+        location = ".".join(str(part) for part in errors[0].path) or "<root>"
+        raise ExportError(f"{label} schema violation at {location}: {errors[0].message}")
+
+
+def logical_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(ROOT.resolve()).as_posix()
+    except ValueError:
+        return f"external:{sha256_text(str(resolved))[:16]}"
+
+
+def recursive_strings(value: Any) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from recursive_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from recursive_strings(item)
+
+
+def jsonl_values(path: Path) -> Iterator[dict[str, Any]]:
+    for _line_number, row in iter_jsonl(path):
+        yield row
+
+
+def artifact_strings(path: Path) -> Iterator[str]:
+    if path.suffix == ".jsonl":
+        for row in jsonl_values(path):
+            yield from recursive_strings(row)
+        return
+    if path.suffix == ".json":
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ExportError(f"cannot parse evaluation artifact {path}: {exc}") from exc
+        yield from recursive_strings(value)
+        return
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ExportError(f"cannot read evaluation artifact {path}: {exc}") from exc
+    yield raw
+    yield from (line for line in raw.splitlines() if line.strip())
+
+
+def v011_items(path: Path) -> list[dict[str, Any]]:
+    manifest = read_json(path)
+    layouts = manifest.get("record_layouts", {})
+    item_layout = layouts.get("item")
+    reference_layout = layouts.get("reference")
+    items = manifest.get("items")
+    require(
+        isinstance(item_layout, list) and isinstance(reference_layout, list) and isinstance(items, list),
+        "invalid v0.1.1 manifest layouts",
+    )
+    required_item_fields = {"id", "source", "source_sha256", "references"}
+    require(
+        required_item_fields.issubset(item_layout),
+        "v0.1.1 item layout lacks required fields",
+    )
+    required_reference_fields = {"annotator_index", "target", "target_sha256"}
+    require(
+        required_reference_fields.issubset(reference_layout),
+        "v0.1.1 reference layout lacks required fields",
+    )
+    rows: list[dict[str, Any]] = []
+    for packed in items:
+        require(
+            isinstance(packed, list) and len(packed) == len(item_layout),
+            "invalid v0.1.1 item",
+        )
+        item = dict(zip(item_layout, packed, strict=True))
+        source = item["source"]
+        source_hash = item["source_sha256"]
+        require(
+            isinstance(source, str) and isinstance(source_hash, str) and sha256_text(source) == source_hash,
+            "v0.1.1 source hash mismatch",
+        )
+        references: list[dict[str, str]] = []
+        for packed_reference in item["references"]:
+            require(
+                isinstance(packed_reference, list) and len(packed_reference) == len(reference_layout),
+                "invalid v0.1.1 reference",
+            )
+            reference = dict(zip(reference_layout, packed_reference, strict=True))
+            target = reference["target"]
+            target_hash = reference["target_sha256"]
+            require(
+                isinstance(target, str) and isinstance(target_hash, str) and sha256_text(target) == target_hash,
+                "v0.1.1 reference hash mismatch",
+            )
+            references.append(
+                {
+                    "reference_id": str(reference["annotator_index"]),
+                    "sha256": target_hash,
+                    "text": target,
+                }
+            )
+        require(references, "v0.1.1 evaluation item lacks references")
+        rows.append(
+            {
+                "item_id": str(item["id"]),
+                "references": references,
+                "source": source,
+                "source_sha256": source_hash,
+            }
+        )
+    require(rows, "empty v0.1.1 manifest")
+    return rows
+
+
+def v02_items(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for _line_number, row in iter_jsonl(path):
+        blind = row.get("blind_reviewer_view")
+        receipts = row.get("frozen_receipts")
+        require(
+            isinstance(blind, Mapping) and isinstance(receipts, Mapping),
+            "invalid v0.2 packet row",
+        )
+        source = blind.get("source")
+        source_hash = receipts.get("source_sha256")
+        require(
+            isinstance(source, str) and isinstance(source_hash, str) and sha256_text(source) == source_hash,
+            "v0.2 source hash mismatch",
+        )
+        references: list[dict[str, str]] = []
+        for reference in blind.get("references", []):
+            require(
+                isinstance(reference, list) and len(reference) >= 3,
+                "invalid v0.2 reference",
+            )
+            reference_id, text, target_hash = reference[:3]
+            require(
+                isinstance(text, str) and isinstance(target_hash, str) and sha256_text(text) == target_hash,
+                "v0.2 reference hash mismatch",
+            )
+            references.append(
+                {
+                    "reference_id": str(reference_id),
+                    "sha256": target_hash,
+                    "text": text,
+                }
+            )
+        require(references, "v0.2 evaluation item lacks references")
+        rows.append(
+            {
+                "item_id": str(row["item_id"]),
+                "references": references,
+                "source": source,
+                "source_sha256": source_hash,
+            }
+        )
+    require(rows, "empty v0.2 packet")
+    return rows
+
+
+def build_exclusion_registry(
+    *,
+    v011_manifest: Path,
+    v02_packet: Path,
+    extra_artifacts: Sequence[Path] = (),
+) -> EvaluationExclusionRegistry:
+    registry = empty_text_registry()
+    defaults = [
+        v011_manifest,
+        v02_packet,
+        *(path for path in DEFAULT_EVALUATION_ARTIFACTS if path not in {DEFAULT_V011_MANIFEST, DEFAULT_V02_PACKET}),
+    ]
+    paths: list[Path] = []
+    seen_paths: set[Path] = set()
+    for path in (*defaults, *extra_artifacts):
+        resolved = path.resolve()
+        if resolved in seen_paths:
+            continue
+        require(path.is_file(), f"missing evaluation exclusion artifact: {path}")
+        seen_paths.add(resolved)
+        paths.append(path)
+
+    for item in v011_items(v011_manifest):
+        registry.add_text(item["source"], explicit_evaluation_text=True)
+        for reference in item["references"]:
+            registry.add_text(reference["text"], explicit_evaluation_text=True)
+    for item in v02_items(v02_packet):
+        registry.add_text(item["source"], explicit_evaluation_text=True)
+        for reference in item["references"]:
+            registry.add_text(reference["text"], explicit_evaluation_text=True)
+
+    for path in paths:
+        registry.artifacts.append({"logical_path": logical_path(path), "sha256": sha256_file(path)})
+        if path.resolve() in {v011_manifest.resolve(), v02_packet.resolve()}:
+            continue
+        for text in artifact_strings(path):
+            registry.add_text(text, explicit_evaluation_text=False)
+
+    registry.artifacts.sort(key=lambda item: item["logical_path"])
+    require(registry.exact_hashes, "empty exact evaluation exclusion registry")
+    require(registry.near_texts, "empty near-duplicate evaluation exclusion registry")
+    return registry
+
+
+def registry_receipt(registry: EvaluationExclusionRegistry) -> dict[str, Any]:
+    return {
+        "algorithm_version": "foundry-eval-exclusion-v1",
+        "artifacts": registry.artifacts,
+        "candidate_anchor_characters": CANDIDATE_ANCHOR_CHARACTERS,
+        "maximum_character_anchors_per_text": MAX_CHARACTER_ANCHORS_PER_TEXT,
+        "exact_fingerprints": len(registry.exact_hashes),
+        "minimum_containment_characters": MIN_CONTAINMENT_CHARACTERS,
+        "near_duplicate_threshold": NEAR_DUPLICATE_THRESHOLD,
+        "near_fingerprints": len(registry.near_texts),
+        "normalization": "NFKC; casefold; collapse whitespace",
+    }
+
+
+def admission_receipt(
+    admissions: Mapping[str, SourceAdmission] | None,
+) -> dict[str, Any]:
+    total = len(admissions) if admissions is not None else 0
+    admitted = sum(1 for admission in admissions.values() if admission.admitted) if admissions is not None else 0
+    return {
+        "applied": admissions is not None,
+        "policy": "recompute source_record_v1 admission; unknown is denial",
+        "source_records_admitted": admitted,
+        "source_records_denied": total - admitted,
+        "source_records_total": total,
+    }
+
+
+def deduplication_receipt(accepted_fingerprints: int | None, *, partitioning: str) -> dict[str, Any]:
+    return {
+        "accepted_fingerprints": accepted_fingerprints or 0,
+        "algorithm_version": "foundry-intra-view-dedup-v1",
+        "applied": accepted_fingerprints is not None,
+        "candidate_anchor_characters": CANDIDATE_ANCHOR_CHARACTERS,
+        "maximum_character_anchors_per_text": MAX_CHARACTER_ANCHORS_PER_TEXT,
+        "minimum_containment_characters": MIN_CONTAINMENT_CHARACTERS,
+        "near_duplicate_threshold": NEAR_DUPLICATE_THRESHOLD,
+        "normalization": "NFKC; casefold; collapse whitespace",
+        "partitioning": partitioning,
+    }
+
+
+def load_source_admissions(path: Path) -> tuple[dict[str, SourceAdmission], int]:
+    schema, schema_hash = source_contract.load_schema()
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    try:
+        rows = source_contract.load_records(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExportError(f"cannot read source records {path}: {exc}") from exc
+    admissions: dict[str, SourceAdmission] = {}
+    for index, row in enumerate(rows, 1):
+        require(isinstance(row, dict), f"source record {index} is not an object")
+        record_id = row.get("record_id")
+        require(isinstance(record_id, str), f"source record {index} lacks record_id")
+        require(record_id not in admissions, f"duplicate source record ID: {record_id}")
+        result = source_contract.validate_record(row, validator, schema_hash)
+        admissions[record_id] = SourceAdmission(
+            record=row,
+            sha256=sha256_text(canonical_json(row)),
+            admitted=bool(result["admitted"]),
+            reasons=tuple(result["reasons"]),
+        )
+    require(rows, "empty source-record input")
+    return admissions, len(rows)
+
+
+def source_lineage(
+    admission: SourceAdmission,
+    *,
+    correction_record: Mapping[str, Any] | None = None,
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    base = {
+        "source_content_sha256": admission.record["content"]["sha256"],
+        "source_record_id": admission.record["record_id"],
+        "source_record_sha256": admission.sha256,
+    }
+    if correction_record is not None:
+        base.update(
+            {
+                "candidate_sha256": correction_record["candidate_sha256"],
+                "correction_record_id": correction_record["record_id"],
+                "correction_record_sha256": sha256_text(canonical_json(correction_record)),
+                "decision_sha256": correction_record["decision_sha256"],
+            }
+        )
+    if payload is not None:
+        base.update(
+            {
+                "language_span_receipt_sha256": payload["language_span_review"]["receipt_sha256"],
+                "source_derivation_receipt_sha256": payload["derivation"]["receipt_sha256"],
+                "normalization_receipt_sha256": payload["normalization"]["receipt_sha256"],
+                "source_payload_id": payload["payload_id"],
+                "source_payload_sha256": sha256_text(canonical_json(payload)),
+            }
+        )
+    return base
+
+
+def eligibility(*, test_fixture: bool, qualified: bool | None = None) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "model_training_eligible": not test_fixture,
+        "source_contract_admitted": True,
+        "test_fixture": test_fixture,
+    }
+    if qualified is not None:
+        value["qualified_adjudication"] = qualified
+    return value
+
+
+def require_stable_order(current: str, previous: str | None, *, label: str) -> str:
+    require(previous is None or current > previous, f"{label} IDs must be unique and strictly ascending")
+    return current
+
+
+def validate_source_payload_semantics(payload: Mapping[str, Any]) -> None:
+    require(payload["text_sha256"] == sha256_text(payload["text"]), "source payload text hash mismatch")
+    derivation = payload["derivation"]
+    if derivation["kind"] == "character_span":
+        require(
+            derivation["source_start_char"] < derivation["source_end_char"],
+            "source payload derivation span is empty or reversed",
+        )
+        require(
+            derivation["source_end_char"] - derivation["source_start_char"] == len(payload["text"]),
+            "source payload derivation span length does not match segment text",
+        )
+    spans = payload["language_span_review"]["character_spans"]
+    previous_end = 0
+    for span in spans:
+        require(0 <= span["start"] < span["end"] <= len(payload["text"]), "language span lies outside payload text")
+        require(
+            span["start"] == previous_end,
+            "language spans must form a gap-free ordered partition",
+        )
+        previous_end = span["end"]
+        protected = (
+            span["language_identity"] != "ukrainian"
+            or span["representation"] != "standard_orthography"
+            or span["reason"] in PROTECTED_REASONS
+        )
+        if protected:
+            require(
+                span["modern_loss_action"] in {"mask_from_loss", "exclude_record"},
+                "protected/non-Ukrainian span cannot be retained in modern loss",
+            )
+    require(
+        previous_end == len(payload["text"]),
+        "language spans must cover the complete payload text",
+    )
+
+
+def safety_reason_for_source_payload(
+    payload: Mapping[str, Any],
+    admission: SourceAdmission | None,
+    registry: EvaluationExclusionRegistry,
+) -> str | None:
+    if admission is None:
+        return "source_record_missing"
+    if not admission.admitted:
+        return "source_record_not_admitted"
+    if payload["source_content_sha256"] != admission.record["content"]["sha256"]:
+        raise ExportError("source payload parent content hash does not match source record")
+    if payload["origin"] == "unknown":
+        return "origin_unknown"
+    origin_evidence = payload["origin_evidence"]
+    if (
+        origin_evidence["status"] != "verified"
+        or origin_evidence["method"] is None
+        or origin_evidence["receipt_sha256"] is None
+    ):
+        return "origin_unverified"
+    if payload["private_data"] != "clear":
+        return "private_data_not_clear"
+    private_review = payload["private_data_review"]
+    if private_review["status"] != "complete" or private_review["receipt_sha256"] is None:
+        return "private_data_review_incomplete"
+    normalization = payload["normalization"]
+    if normalization["status"] != "complete" or normalization["receipt_sha256"] is None:
+        return "normalization_incomplete"
+    span_review = payload["language_span_review"]
+    if (
+        span_review["status"] != "complete"
+        or span_review["reviewer_qualification"] is None
+        or span_review["receipt_sha256"] is None
+    ):
+        return "language_span_review_incomplete"
+    contamination = registry.match(payload["text"])
+    if contamination.matched:
+        return f"evaluation_contamination_{contamination.method}"
+    return None
+
+
+def correction_fixture_state(record: Mapping[str, Any]) -> bool:
+    reviewers = [item["reviewer"] for item in record["decision"]["first_pass_reviews"]]
+    third = record["decision"]["final_resolution"].get("third_review")
+    if isinstance(third, Mapping):
+        reviewers.append(third["reviewer"])
+    return any(reviewer["test_fixture"] for reviewer in reviewers)
+
+
+def validate_correction_handoff(
+    record: Mapping[str, Any],
+    *,
+    candidate_validator: Draft202012Validator,
+    decision_validator: Draft202012Validator,
+    record_validator: Draft202012Validator,
+    evaluation_registry: correction_factory.EvaluationRegistry,
+    allow_test_fixtures: bool,
+) -> None:
+    validate_schema(record, record_validator, label="correction record")
+    candidate = record["candidate"]
+    decision = record["decision"]
+    correction_factory.validate_candidate(
+        candidate,
+        validator=candidate_validator,
+        evaluation_registry=evaluation_registry,
+    )
+    correction_factory.validate_decision(
+        decision,
+        candidate,
+        validator=decision_validator,
+        allow_test_fixtures=allow_test_fixtures,
+    )
+    expected = correction_factory.build_correction_record(candidate, decision)
+    require(record == expected, "correction record does not equal canonical #6121 handoff")
+    require(
+        record["export_control"]["model_training_or_export_eligible"] is False,
+        "#6121 handoff flag must remain false at the #6122 boundary",
+    )
+    require(record["export_control"]["owner_issue"] == 6122, "wrong correction handoff owner")
+
+
+def correction_source_reason(record: Mapping[str, Any], admission: SourceAdmission | None) -> str | None:
+    if admission is None:
+        return "source_record_missing"
+    if not admission.admitted:
+        return "source_record_not_admitted"
+    candidate = record["candidate"]
+    if candidate["source"]["content_sha256"] != admission.record["content"]["sha256"]:
+        raise ExportError("correction/source-record content hash mismatch")
+    safety = candidate["safety"]
+    checks = (
+        (safety["provenance"] == "complete", "provenance_not_complete"),
+        (safety["rights"] == "granted", "rights_not_granted"),
+        (safety["permitted_use"] == "correction_eligible", "permitted_use_not_eligible"),
+        (safety["origin"] in {"verified_human_authorship", "verified_synthetic"}, "origin_not_verified"),
+        (safety["private_data"] == "clear", "private_data_not_clear"),
+    )
+    for passed, reason in checks:
+        if not passed:
+            return reason
+    if any(
+        safety["contamination"][field] != "clear"
+        for field in ("v0_1_1_exact", "v0_1_1_near", "v0_2_exact", "v0_2_near")
+    ):
+        return "evaluation_contamination_upstream"
+    return None
+
+
+def corrected_context(record: Mapping[str, Any]) -> tuple[str, int, int]:
+    candidate = record["candidate"]
+    context = candidate["source"]["context"]
+    span = candidate["span"]
+    correction = record["decision"]["final"]["accepted_correction"]
+    require(isinstance(correction, str), "correction handoff lacks accepted correction")
+    local_start = span["start"] - context["start"]
+    local_end = span["end"] - context["start"]
+    target = context["text"][:local_start] + correction + context["text"][local_end:]
+    return target, local_start, local_end
+
+
+def any_contamination(values: Iterable[str], registry: EvaluationExclusionRegistry) -> ExclusionMatch:
+    for value in values:
+        match = registry.match(value)
+        if match.matched:
+            return match
+    return ExclusionMatch(False)
+
+
+def correction_deduplication_parts(view_kind: str, row: Mapping[str, Any]) -> tuple[str, str]:
+    payload = row["payload"]
+    if view_kind == "correction_instruction":
+        signature = {
+            "acceptable_alternatives": payload["acceptable_alternatives"],
+            "accepted_correction": payload["accepted_correction"],
+            "original_span": payload["original_span"],
+            "span_end_char": payload["span_end_char"],
+            "span_start_char": payload["span_start_char"],
+        }
+        return canonical_json(signature), payload["input_text"]
+    if view_kind == "preference":
+        signature = {
+            "acceptable_alternatives": payload["acceptable_alternatives"],
+            "chosen": payload["chosen"],
+            "rejected": payload["rejected"],
+        }
+        return canonical_json(signature), payload["prompt"]
+    signature = {"decision": payload["decision"], "label": payload["label"]}
+    return canonical_json(signature), payload["text"]
+
+
+def reserved_rollback_path(path: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f"{path.name}.rollback-",
+        suffix=".bak",
+        delete=False,
+    ) as handle:
+        rollback = Path(handle.name)
+    return rollback
+
+
+def replace_output_pair(*, writer: AtomicJsonl, receipt_temporary: Path, receipt_output: Path) -> None:
+    require(
+        writer.output.resolve() != receipt_output.resolve(),
+        "view output and receipt output must be different paths",
+    )
+    output_backup: Path | None = None
+    receipt_backup: Path | None = None
+    output_backed_up = False
+    receipt_backed_up = False
+    output_installed = False
+    receipt_installed = False
+    try:
+        if writer.output.exists():
+            output_backup = reserved_rollback_path(writer.output)
+            os.replace(writer.output, output_backup)
+            output_backed_up = True
+        if receipt_output.exists():
+            receipt_backup = reserved_rollback_path(receipt_output)
+            os.replace(receipt_output, receipt_backup)
+            receipt_backed_up = True
+        writer.replace()
+        output_installed = True
+        os.replace(receipt_temporary, receipt_output)
+        receipt_installed = True
+    except Exception as exc:
+        rollback_errors: list[OSError] = []
+        for installed, path in (
+            (output_installed, writer.output),
+            (receipt_installed, receipt_output),
+        ):
+            if installed:
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as rollback_exc:
+                    rollback_errors.append(rollback_exc)
+        for backed_up, backup, destination in (
+            (output_backed_up, output_backup, writer.output),
+            (receipt_backed_up, receipt_backup, receipt_output),
+        ):
+            if backed_up and backup is not None:
+                try:
+                    os.replace(backup, destination)
+                except OSError as rollback_exc:
+                    rollback_errors.append(rollback_exc)
+        if rollback_errors:
+            raise ExportError(f"view/receipt commit failed and rollback failed: {rollback_errors[0]}") from exc
+        raise
+    finally:
+        writer.abort()
+        receipt_temporary.unlink(missing_ok=True)
+        if output_backup is not None:
+            output_backup.unlink(missing_ok=True)
+        if receipt_backup is not None:
+            receipt_backup.unlink(missing_ok=True)
+
+
+def finalize_export(
+    *,
+    writer: AtomicJsonl,
+    receipt_output: Path,
+    view_kind: str,
+    input_artifacts: list[dict[str, Any]],
+    counts: Counter[str],
+    registry: EvaluationExclusionRegistry,
+    schemas_used: Sequence[Path],
+    receipt_validator: Draft202012Validator,
+    admissions: Mapping[str, SourceAdmission] | None,
+    deduplication_fingerprints: int | None,
+    deduplication_partitioning: str,
+    ordering: str,
+) -> dict[str, Any]:
+    receipt_temporary: Path | None = None
+    try:
+        output_artifact = writer.finish()
+        output_artifact["role"] = f"{view_kind}_view"
+        receipt = {
+            "admission": admission_receipt(admissions),
+            "counts": dict(sorted(counts.items())),
+            "deduplication": deduplication_receipt(
+                deduplication_fingerprints,
+                partitioning=deduplication_partitioning,
+            ),
+            "determinism": {
+                "ordering": ordering,
+                "serialization": "UTF-8 canonical JSON with sorted keys and LF",
+                "timestamps_omitted": True,
+            },
+            "evaluation_exclusion_registry": registry_receipt(registry),
+            "input_artifacts": input_artifacts,
+            "output": output_artifact,
+            "safety": {
+                "evaluation_data_entered_non_evaluation_view": False,
+                "local_artifact_written": True,
+                "private_data_exported": False,
+                "publication_performed": False,
+                "test_fixture_mode": bool(counts.get("fixture_records", 0)),
+                "training_performed": False,
+                "upload_performed": False,
+            },
+            "schema_version": "model_view_export_receipt_v1",
+            "schemas": {path.name: sha256_file(path) for path in sorted(set(schemas_used), key=lambda item: item.name)},
+            "view_kind": view_kind,
+        }
+        validate_schema(receipt, receipt_validator, label="model-view receipt")
+        receipt_bytes = (canonical_json(receipt) + "\n").encode("utf-8")
+        receipt_output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            dir=receipt_output.parent,
+            prefix=receipt_output.name,
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            receipt_temporary = Path(handle.name)
+            handle.write(receipt_bytes)
+            handle.flush()
+            os.fsync(handle.fileno())
+        replace_output_pair(
+            writer=writer,
+            receipt_temporary=receipt_temporary,
+            receipt_output=receipt_output,
+        )
+        return receipt
+    except Exception:
+        writer.abort()
+        if receipt_temporary is not None:
+            receipt_temporary.unlink(missing_ok=True)
+        raise
+
+
+def export_pretraining(
+    *,
+    source_records_path: Path,
+    payloads_path: Path,
+    origin: str,
+    representation_view: str,
+    output: Path,
+    receipt_output: Path,
+    allow_test_fixtures: bool,
+    v011_manifest: Path,
+    v02_packet: Path,
+    extra_evaluation_artifacts: Sequence[Path],
+) -> dict[str, Any]:
+    schemas, schema_registry = schema_bundle()
+    payload_validator = validator_for(SOURCE_PAYLOAD_SCHEMA, schemas=schemas, registry=schema_registry)
+    output_validator = validator_for(PRETRAIN_SCHEMA, schemas=schemas, registry=schema_registry)
+    receipt_validator = validator_for(EXPORT_RECEIPT_SCHEMA, schemas=schemas, registry=schema_registry)
+    admissions, source_count = load_source_admissions(source_records_path)
+    exclusion_registry = build_exclusion_registry(
+        v011_manifest=v011_manifest,
+        v02_packet=v02_packet,
+        extra_artifacts=extra_evaluation_artifacts,
+    )
+    writer = AtomicJsonl.open(output)
+    deduplication_registry = empty_text_registry()
+    counts: Counter[str] = Counter()
+    previous_id: str | None = None
+    try:
+        for line_number, payload in iter_jsonl(payloads_path):
+            counts["input_records"] += 1
+            validate_schema(payload, payload_validator, label=f"source payload line {line_number}")
+            validate_source_payload_semantics(payload)
+            previous_id = require_stable_order(payload["payload_id"], previous_id, label="source payload")
+            if payload["test_fixture"] and not allow_test_fixtures:
+                raise ExportError("test fixture source payload requires --allow-test-fixtures")
+            require(payload["origin"] == origin, "source payload origin differs from homogeneous export origin")
+            admission = admissions.get(payload["source_record_id"])
+            reason = safety_reason_for_source_payload(payload, admission, exclusion_registry)
+            if (
+                reason is None
+                and representation_view == "modern_literary_ukrainian"
+                and any(
+                    span["modern_loss_action"] == "exclude_record"
+                    for span in payload["language_span_review"]["character_spans"]
+                )
+            ):
+                reason = "modern_view_record_excluded"
+            if reason is not None:
+                counts["excluded_records"] += 1
+                counts[f"excluded_{reason}"] += 1
+                continue
+            duplicate = deduplication_registry.match(payload["text"])
+            if duplicate.matched:
+                counts["excluded_records"] += 1
+                counts[f"excluded_intra_view_duplicate_{duplicate.method}"] += 1
+                continue
+            assert admission is not None
+            mask_spans = []
+            if representation_view == "modern_literary_ukrainian":
+                mask_spans = [
+                    {
+                        "end_char": span["end"],
+                        "reason": span["reason"],
+                        "start_char": span["start"],
+                    }
+                    for span in payload["language_span_review"]["character_spans"]
+                    if span["modern_loss_action"] == "mask_from_loss"
+                ]
+            lineage = source_lineage(admission, payload=payload)
+            record_id = "pretrain:" + sha256_text(
+                canonical_json(
+                    {
+                        "lineage": lineage,
+                        "representation_view": representation_view,
+                        "text_sha256": payload["text_sha256"],
+                    }
+                )
+            )
+            row = {
+                "denied_destinations": [
+                    "supervised_correction",
+                    "pairwise_preference",
+                    "quality_filter",
+                    "heldout_evaluation",
+                ],
+                "eligibility": eligibility(test_fixture=payload["test_fixture"]),
+                "lineage": lineage,
+                "origin": origin,
+                "payload": {
+                    "character_mask_spans": mask_spans,
+                    "text": payload["text"],
+                    "text_sha256": payload["text_sha256"],
+                },
+                "permitted_destination": "continued_pretraining",
+                "record_id": record_id,
+                "representation_view": representation_view,
+                "schema_version": "continued_pretraining_view_v1",
+            }
+            validate_schema(row, output_validator, label="continued-pretraining output")
+            deduplication_registry.add_text(payload["text"], explicit_evaluation_text=True)
+            writer.write(row)
+            counts["exported_records"] += 1
+            counts["fixture_records" if payload["test_fixture"] else "model_training_eligible_records"] += 1
+        require(counts["input_records"] > 0, "empty source-payload input")
+        return finalize_export(
+            writer=writer,
+            receipt_output=receipt_output,
+            view_kind="continued_pretraining",
+            input_artifacts=[
+                artifact(source_records_path, role="source_records", records=source_count),
+                artifact(payloads_path, role="source_payloads", records=counts["input_records"]),
+            ],
+            counts=counts,
+            registry=exclusion_registry,
+            schemas_used=(SOURCE_RECORD_SCHEMA, SOURCE_PAYLOAD_SCHEMA, PRETRAIN_SCHEMA, EXPORT_RECEIPT_SCHEMA),
+            receipt_validator=receipt_validator,
+            admissions=admissions,
+            deduplication_fingerprints=len(deduplication_registry.exact_hashes),
+            deduplication_partitioning="source text",
+            ordering="validated ascending source payload ID",
+        )
+    except Exception:
+        writer.abort()
+        raise
+
+
+def correction_output_row(
+    *,
+    view_kind: str,
+    record: Mapping[str, Any],
+    admission: SourceAdmission,
+    origin: str,
+    test_fixture: bool,
+) -> tuple[dict[str, Any], list[str]]:
+    candidate = record["candidate"]
+    decision = record["decision"]
+    final = decision["final"]
+    context = candidate["source"]["context"]
+    span = candidate["span"]
+    target, local_start, local_end = (
+        corrected_context(record)
+        if final["decision"] == "correction"
+        else (context["text"], span["start"] - context["start"], span["end"] - context["start"])
+    )
+    lineage = source_lineage(admission, correction_record=record)
+    common = {
+        "eligibility": eligibility(test_fixture=test_fixture, qualified=True),
+        "lineage": lineage,
+        "origin": origin,
+    }
+    alternatives = final["acceptable_alternatives"]
+    if view_kind == "correction_instruction":
+        payload = {
+            "acceptable_alternatives": alternatives,
+            "accepted_correction": final["accepted_correction"],
+            "input_text": context["text"],
+            "original_span": span["text"],
+            "span_end_char": local_end,
+            "span_start_char": local_start,
+            "target_text": target,
+        }
+        identity = {"lineage": lineage, "payload": payload}
+        row = {
+            **common,
+            "denied_destinations": [
+                "continued_pretraining",
+                "pairwise_preference",
+                "quality_filter",
+                "heldout_evaluation",
+            ],
+            "payload": payload,
+            "permitted_destination": "supervised_correction",
+            "record_id": "correction-view:" + sha256_text(canonical_json(identity)),
+            "schema_version": "correction_instruction_view_v1",
+        }
+        texts = [context["text"], target, span["text"], final["accepted_correction"], *alternatives]
+        return row, texts
+    if view_kind == "preference":
+        payload = {
+            "acceptable_alternatives": alternatives,
+            "chosen": final["accepted_correction"],
+            "prompt": context["text"],
+            "rejected": span["text"],
+        }
+        identity = {"lineage": lineage, "payload": payload}
+        row = {
+            **common,
+            "denied_destinations": [
+                "continued_pretraining",
+                "supervised_correction",
+                "quality_filter",
+                "heldout_evaluation",
+            ],
+            "payload": payload,
+            "permitted_destination": "pairwise_preference",
+            "record_id": "preference-view:" + sha256_text(canonical_json(identity)),
+            "schema_version": "preference_view_v1",
+        }
+        texts = [context["text"], final["accepted_correction"], span["text"], *alternatives]
+        return row, texts
+    label = "needs_correction" if final["decision"] == "correction" else "acceptable"
+    payload = {
+        "decision": final["decision"],
+        "label": label,
+        "text": context["text"],
+    }
+    identity = {"lineage": lineage, "payload": payload}
+    row = {
+        **common,
+        "denied_destinations": [
+            "continued_pretraining",
+            "supervised_correction",
+            "pairwise_preference",
+            "heldout_evaluation",
+        ],
+        "payload": payload,
+        "permitted_destination": "quality_filter",
+        "record_id": "quality-view:" + sha256_text(canonical_json(identity)),
+        "schema_version": "quality_filter_view_v1",
+    }
+    return row, [context["text"]]
+
+
+def export_correction_family(
+    *,
+    view_kind: str,
+    source_records_path: Path,
+    correction_records_path: Path,
+    origin: str,
+    output: Path,
+    receipt_output: Path,
+    allow_test_fixtures: bool,
+    v011_manifest: Path,
+    v02_packet: Path,
+    extra_evaluation_artifacts: Sequence[Path],
+) -> dict[str, Any]:
+    require(view_kind in {"correction_instruction", "preference", "quality_filter"}, "invalid correction-family view")
+    schemas, schema_registry = schema_bundle()
+    candidate_validator = validator_for(CANDIDATE_SCHEMA, schemas=schemas, registry=schema_registry)
+    decision_validator = validator_for(DECISION_SCHEMA, schemas=schemas, registry=schema_registry)
+    correction_validator = validator_for(CORRECTION_RECORD_SCHEMA, schemas=schemas, registry=schema_registry)
+    output_validator = validator_for(VIEW_SCHEMAS[view_kind], schemas=schemas, registry=schema_registry)
+    receipt_validator = validator_for(EXPORT_RECEIPT_SCHEMA, schemas=schemas, registry=schema_registry)
+    admissions, source_count = load_source_admissions(source_records_path)
+    exclusion_registry = build_exclusion_registry(
+        v011_manifest=v011_manifest,
+        v02_packet=v02_packet,
+        extra_artifacts=extra_evaluation_artifacts,
+    )
+    evaluation_registry = correction_factory.load_evaluation_registry(
+        v011_manifest_path=v011_manifest,
+        v02_packet_path=v02_packet,
+    )
+    writer = AtomicJsonl.open(output)
+    deduplication_registries: dict[str, EvaluationExclusionRegistry] = {}
+    counts: Counter[str] = Counter()
+    seen_record_ids: set[str] = set()
+    try:
+        for _line_number, record in iter_jsonl(correction_records_path):
+            counts["input_records"] += 1
+            record_id = record.get("record_id", "")
+            require(
+                record_id not in seen_record_ids,
+                "correction record IDs must be unique",
+            )
+            seen_record_ids.add(record_id)
+            validate_correction_handoff(
+                record,
+                candidate_validator=candidate_validator,
+                decision_validator=decision_validator,
+                record_validator=correction_validator,
+                evaluation_registry=evaluation_registry,
+                allow_test_fixtures=allow_test_fixtures,
+            )
+            fixture = correction_fixture_state(record)
+            if fixture and not allow_test_fixtures:
+                raise ExportError("fixture reviewer requires --allow-test-fixtures")
+            candidate = record["candidate"]
+            require(
+                candidate["source"]["origin"] == origin,
+                "correction record origin differs from homogeneous export origin",
+            )
+            admission = admissions.get(candidate["source"]["source_record_id"])
+            reason = correction_source_reason(record, admission)
+            final_decision = record["decision"]["final"]["decision"]
+            if reason is None and view_kind in {"correction_instruction", "preference"}:
+                export_control = record["export_control"]
+                production_handoff = (
+                    export_control["qualified_correction_intake"] is True
+                    and export_control["handoff"] == "correction_intake_ready"
+                    and record["safety_blockers"] == []
+                    and final_decision == "correction"
+                )
+                fixture_proof_handoff = (
+                    fixture
+                    and allow_test_fixtures
+                    and record["safety_blockers"] == ["test_fixture_reviewer"]
+                    and record["decision"]["review_state"] == "adjudicated"
+                    and final_decision == "correction"
+                )
+                if not (production_handoff or fixture_proof_handoff):
+                    reason = "qualified_correction_handoff_missing"
+            if reason is None and view_kind == "quality_filter":
+                if final_decision not in {"correction", "acceptable_as_is"}:
+                    reason = "quality_decision_not_eligible"
+                else:
+                    allowed_blockers = set()
+                    if final_decision == "acceptable_as_is":
+                        allowed_blockers.add("decision_not_correction")
+                    if fixture and allow_test_fixtures:
+                        allowed_blockers.add("test_fixture_reviewer")
+                    unexpected = set(record["safety_blockers"]) - allowed_blockers
+                    if unexpected:
+                        reason = "quality_safety_blocker"
+                    elif record["decision"]["review_state"] != "adjudicated":
+                        reason = "quality_review_unresolved"
+            if reason is not None:
+                counts["excluded_records"] += 1
+                counts[f"excluded_{reason}"] += 1
+                continue
+            assert admission is not None
+            row, text_fields = correction_output_row(
+                view_kind=view_kind,
+                record=record,
+                admission=admission,
+                origin=origin,
+                test_fixture=fixture,
+            )
+            contamination = any_contamination(text_fields, exclusion_registry)
+            if contamination.matched:
+                counts["excluded_records"] += 1
+                counts[f"excluded_evaluation_contamination_{contamination.method}"] += 1
+                continue
+            deduplication_signature, deduplication_text = correction_deduplication_parts(view_kind, row)
+            deduplication_registry = deduplication_registries.setdefault(deduplication_signature, empty_text_registry())
+            duplicate = deduplication_registry.match(deduplication_text)
+            if duplicate.matched:
+                counts["excluded_records"] += 1
+                counts[f"excluded_intra_view_duplicate_{duplicate.method}"] += 1
+                continue
+            validate_schema(row, output_validator, label=f"{view_kind} output")
+            deduplication_registry.add_text(deduplication_text, explicit_evaluation_text=True)
+            writer.write(row)
+            counts["exported_records"] += 1
+            counts["fixture_records" if fixture else "model_training_eligible_records"] += 1
+        require(counts["input_records"] > 0, "empty correction-record input")
+        return finalize_export(
+            writer=writer,
+            receipt_output=receipt_output,
+            view_kind=view_kind,
+            input_artifacts=[
+                artifact(source_records_path, role="source_records", records=source_count),
+                artifact(correction_records_path, role="correction_records", records=counts["input_records"]),
+            ],
+            counts=counts,
+            registry=exclusion_registry,
+            schemas_used=(
+                SOURCE_RECORD_SCHEMA,
+                CANDIDATE_SCHEMA,
+                DECISION_SCHEMA,
+                CORRECTION_RECORD_SCHEMA,
+                VIEW_SCHEMAS[view_kind],
+                EXPORT_RECEIPT_SCHEMA,
+            ),
+            receipt_validator=receipt_validator,
+            admissions=admissions,
+            deduplication_fingerprints=sum(
+                len(registry.exact_hashes) for registry in deduplication_registries.values()
+            ),
+            deduplication_partitioning=("exact destination semantic signature, then plain-text context"),
+            ordering="canonical upstream packet order; unique correction record ID",
+        )
+    except Exception:
+        writer.abort()
+        raise
+
+
+def evaluation_rows(*, v011_manifest: Path, v02_packet: Path, release: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    artifacts = {
+        "v0.1.1": (v011_manifest, "frozen_public", v011_items(v011_manifest)),
+        "v0.2": (v02_packet, "frozen_review_inventory", v02_items(v02_packet)),
+    }
+    selected = ("v0.1.1", "v0.2") if release == "all" else (release,)
+    for version in selected:
+        path, state, items = artifacts[version]
+        artifact_hash = sha256_file(path)
+        for item in items:
+            identity = {"item_id": item["item_id"], "release": version, "source_sha256": item["source_sha256"]}
+            rows.append(
+                {
+                    "denied_destinations": [
+                        "continued_pretraining",
+                        "supervised_correction",
+                        "pairwise_preference",
+                        "quality_filter",
+                    ],
+                    "evaluation_release": version,
+                    "evaluation_state": state,
+                    "lineage": {
+                        "artifact_logical_path": logical_path(path),
+                        "artifact_sha256": artifact_hash,
+                        "item_id": item["item_id"],
+                    },
+                    "model_training_eligible": False,
+                    "payload": {
+                        "references": item["references"],
+                        "source": item["source"],
+                        "source_sha256": item["source_sha256"],
+                    },
+                    "permitted_destination": "heldout_evaluation",
+                    "record_id": "evaluation-view:" + sha256_text(canonical_json(identity)),
+                    "schema_version": "heldout_evaluation_view_v1",
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            row["evaluation_release"],
+            row["lineage"]["item_id"],
+        ),
+    )
+
+
+def export_evaluation(
+    *,
+    release: str,
+    output: Path,
+    receipt_output: Path,
+    v011_manifest: Path,
+    v02_packet: Path,
+    extra_evaluation_artifacts: Sequence[Path],
+) -> dict[str, Any]:
+    schemas, schema_registry = schema_bundle()
+    output_validator = validator_for(EVALUATION_SCHEMA, schemas=schemas, registry=schema_registry)
+    receipt_validator = validator_for(EXPORT_RECEIPT_SCHEMA, schemas=schemas, registry=schema_registry)
+    exclusion_registry = build_exclusion_registry(
+        v011_manifest=v011_manifest,
+        v02_packet=v02_packet,
+        extra_artifacts=extra_evaluation_artifacts,
+    )
+    rows = evaluation_rows(v011_manifest=v011_manifest, v02_packet=v02_packet, release=release)
+    writer = AtomicJsonl.open(output)
+    counts: Counter[str] = Counter()
+    try:
+        for row in rows:
+            validate_schema(row, output_validator, label="held-out evaluation output")
+            writer.write(row)
+            counts["exported_records"] += 1
+            counts[f"release_{row['evaluation_release']}"] += 1
+        input_artifacts = []
+        if release in {"v0.1.1", "all"}:
+            input_artifacts.append(
+                artifact(v011_manifest, role="v0.1.1_manifest", records=len(v011_items(v011_manifest)))
+            )
+        if release in {"v0.2", "all"}:
+            input_artifacts.append(artifact(v02_packet, role="v0.2_packet", records=len(v02_items(v02_packet))))
+        return finalize_export(
+            writer=writer,
+            receipt_output=receipt_output,
+            view_kind="heldout_evaluation",
+            input_artifacts=input_artifacts,
+            counts=counts,
+            registry=exclusion_registry,
+            schemas_used=(EVALUATION_SCHEMA, EXPORT_RECEIPT_SCHEMA),
+            receipt_validator=receipt_validator,
+            admissions=None,
+            deduplication_fingerprints=None,
+            deduplication_partitioning="not applicable",
+            ordering="evaluation release then item ID",
+        )
+    except Exception:
+        writer.abort()
+        raise
+
+
+def validate_view_artifact(
+    *,
+    view_path: Path,
+    view_kind: str,
+    validator: Draft202012Validator,
+) -> tuple[int, int, int]:
+    seen_ids: set[str] = set()
+    total = 0
+    eligible = 0
+    fixtures = 0
+    for line_number, row in iter_jsonl(view_path):
+        validate_schema(row, validator, label=f"view artifact line {line_number}")
+        require(row["record_id"] not in seen_ids, "view artifact contains duplicate record IDs")
+        seen_ids.add(row["record_id"])
+        total += 1
+        if view_kind == "heldout_evaluation":
+            continue
+        row_eligibility = row["eligibility"]
+        eligible += int(row_eligibility["model_training_eligible"])
+        fixtures += int(row_eligibility["test_fixture"])
+    return total, eligible, fixtures
+
+
+def build_recipe_manifest(
+    *,
+    config_path: Path,
+    view_path: Path,
+    view_receipt_path: Path,
+    output: Path,
+    allow_test_fixtures: bool,
+) -> dict[str, Any]:
+    schemas, schema_registry = schema_bundle()
+    config_validator = validator_for(RECIPE_CONFIG_SCHEMA, schemas=schemas, registry=schema_registry)
+    manifest_validator = validator_for(RECIPE_MANIFEST_SCHEMA, schemas=schemas, registry=schema_registry)
+    receipt_validator = validator_for(EXPORT_RECEIPT_SCHEMA, schemas=schemas, registry=schema_registry)
+    config = read_json(config_path)
+    validate_schema(config, config_validator, label="training recipe config")
+    view_kind = config["view_kind"]
+    require(config["objective"] == OBJECTIVES[view_kind], "recipe objective does not match view")
+    preparation = config["data_preparation"]
+    require(
+        preparation["rendering_template_sha256"] == sha256_text(preparation["rendering_template"]),
+        "recipe rendering template hash mismatch",
+    )
+    require(
+        preparation["target_loss_policy"] == TARGET_LOSS_POLICIES[view_kind],
+        "recipe target-loss policy does not match view",
+    )
+    split = preparation["split"]
+    if view_kind == "heldout_evaluation":
+        require(
+            split["strategy"] == "preserve_evaluation_release"
+            and split["modulus"] is None
+            and split["validation_buckets"] is None,
+            "evaluation recipe must preserve the frozen evaluation release",
+        )
+    else:
+        require(
+            split["strategy"] == "sha256_record_id_modulo"
+            and isinstance(split["modulus"], int)
+            and isinstance(split["validation_buckets"], int)
+            and split["validation_buckets"] < split["modulus"],
+            "training recipe requires a valid deterministic validation split",
+        )
+    hyperparameters = config["hyperparameters"]
+    require(
+        Decimal(hyperparameters["learning_rate"]) > 0,
+        "recipe learning_rate must be greater than zero",
+    )
+    require(
+        Decimal(hyperparameters["weight_decay"]) >= 0,
+        "recipe weight_decay must not be negative",
+    )
+    require(
+        Decimal(hyperparameters["epochs"]) > 0,
+        "recipe epochs must be greater than zero",
+    )
+    view_receipt = read_json(view_receipt_path)
+    validate_schema(view_receipt, receipt_validator, label="view receipt")
+    require(view_receipt["view_kind"] == view_kind, "view receipt kind does not match recipe")
+    view_validator = validator_for(VIEW_SCHEMAS[view_kind], schemas=schemas, registry=schema_registry)
+    records, eligible_records, fixture_records = validate_view_artifact(
+        view_path=view_path,
+        view_kind=view_kind,
+        validator=view_validator,
+    )
+    view_artifact = {
+        "bytes": view_path.stat().st_size,
+        "records": records,
+        "sha256": sha256_file(view_path),
+    }
+    require(view_receipt["output"]["records"] == records, "view receipt record count mismatch")
+    require(view_receipt["output"]["bytes"] == view_artifact["bytes"], "view receipt byte count mismatch")
+    require(view_receipt["output"]["sha256"] == view_artifact["sha256"], "view receipt hash mismatch")
+    if view_kind != "heldout_evaluation":
+        require(records > 0, "training recipe cannot bind an empty non-evaluation view")
+        if fixture_records and not allow_test_fixtures:
+            raise ExportError("fixture view requires --allow-test-fixtures for recipe proof")
+        require(
+            fixture_records == 0 or eligible_records == 0,
+            "fixture and model-training-eligible rows cannot share a view",
+        )
+    config_hash = sha256_text(canonical_json(config))
+    view_receipt_artifact = {
+        "bytes": view_receipt_path.stat().st_size,
+        "records": 1,
+        "sha256": sha256_file(view_receipt_path),
+    }
+    manifest_identity = {
+        "config_sha256": config_hash,
+        "view_receipt_sha256": view_receipt_artifact["sha256"],
+        "view_sha256": view_artifact["sha256"],
+    }
+    manifest = {
+        "config": config,
+        "config_sha256": config_hash,
+        "determinism": {
+            "serialization": "UTF-8 canonical JSON with sorted keys and LF",
+            "timestamps_omitted": True,
+        },
+        "execution": {
+            "execution_state": "not_run",
+            "model_call_performed": False,
+            "test_fixture_mode": bool(fixture_records),
+            "training_authorized": False,
+            "training_performed": False,
+        },
+        "manifest_id": "recipe:" + sha256_text(canonical_json(manifest_identity)),
+        "preparation": {
+            "input_validation": "validate every JSONL row against the bound view schema before preparation",
+            "loss_mask_projection": (
+                "tokenizer projects character_mask_spans after tokenization; masked tokens receive zero loss"
+                if view_kind == "continued_pretraining"
+                else "not applicable to this view"
+            ),
+            "model_training_eligible_records": eligible_records,
+            "record_order": "view artifact order bound by export receipt",
+            "shuffle": (
+                "not applicable; preserve held-out artifact order"
+                if view_kind == "heldout_evaluation"
+                else "SHA-256(seed || record_id), ascending digest"
+            ),
+            "test_fixture_records": fixture_records,
+        },
+        "schema_hashes": {
+            path.name: sha256_file(path)
+            for path in sorted(
+                {RECIPE_CONFIG_SCHEMA, RECIPE_MANIFEST_SCHEMA, EXPORT_RECEIPT_SCHEMA, VIEW_SCHEMAS[view_kind]},
+                key=lambda item: item.name,
+            )
+        },
+        "schema_version": "training_recipe_manifest_v1",
+        "view_artifact": view_artifact,
+        "view_receipt": view_receipt_artifact,
+    }
+    validate_schema(manifest, manifest_validator, label="training recipe manifest")
+    output_bytes = (canonical_json(manifest) + "\n").encode("utf-8")
+    write_json_atomic(output, output_bytes)
+    return manifest
+
+
+def write_json_atomic(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=path.name,
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def add_evaluation_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--v011-manifest", type=Path, default=DEFAULT_V011_MANIFEST)
+    parser.add_argument("--v02-packet", type=Path, default=DEFAULT_V02_PACKET)
+    parser.add_argument(
+        "--extra-evaluation-artifact",
+        action="append",
+        type=Path,
+        default=[],
+        help="Additional evaluation-only or derived-rule artifact to fingerprint",
+    )
+
+
+def add_common_export_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--source-records", type=Path, required=True)
+    parser.add_argument("--origin", choices=ORIGINS, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--receipt-output", type=Path, required=True)
+    parser.add_argument("--allow-test-fixtures", action="store_true")
+    add_evaluation_options(parser)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build disjoint Ukrainian Data Foundry model-consumer views")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    pretraining = subparsers.add_parser("continued-pretraining")
+    add_common_export_options(pretraining)
+    pretraining.add_argument("--payloads", type=Path, required=True)
+    pretraining.add_argument(
+        "--representation-view",
+        choices=("faithful_literary", "modern_literary_ukrainian"),
+        required=True,
+    )
+
+    for command in ("correction", "preference", "quality-filter"):
+        child = subparsers.add_parser(command)
+        add_common_export_options(child)
+        child.add_argument("--correction-records", type=Path, required=True)
+
+    evaluation = subparsers.add_parser("evaluation")
+    evaluation.add_argument("--release", choices=("v0.1.1", "v0.2", "all"), default="all")
+    evaluation.add_argument("--output", type=Path, required=True)
+    evaluation.add_argument("--receipt-output", type=Path, required=True)
+    add_evaluation_options(evaluation)
+
+    recipe = subparsers.add_parser("recipe")
+    recipe.add_argument("--config", type=Path, required=True)
+    recipe.add_argument("--view-artifact", type=Path, required=True)
+    recipe.add_argument("--view-receipt", type=Path, required=True)
+    recipe.add_argument("--output", type=Path, required=True)
+    recipe.add_argument("--allow-test-fixtures", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "continued-pretraining":
+            receipt = export_pretraining(
+                source_records_path=args.source_records,
+                payloads_path=args.payloads,
+                origin=args.origin,
+                representation_view=args.representation_view,
+                output=args.output,
+                receipt_output=args.receipt_output,
+                allow_test_fixtures=args.allow_test_fixtures,
+                v011_manifest=args.v011_manifest,
+                v02_packet=args.v02_packet,
+                extra_evaluation_artifacts=args.extra_evaluation_artifact,
+            )
+            print(canonical_json(receipt))
+            return 0
+        if args.command in {"correction", "preference", "quality-filter"}:
+            view_kind = {
+                "correction": "correction_instruction",
+                "preference": "preference",
+                "quality-filter": "quality_filter",
+            }[args.command]
+            receipt = export_correction_family(
+                view_kind=view_kind,
+                source_records_path=args.source_records,
+                correction_records_path=args.correction_records,
+                origin=args.origin,
+                output=args.output,
+                receipt_output=args.receipt_output,
+                allow_test_fixtures=args.allow_test_fixtures,
+                v011_manifest=args.v011_manifest,
+                v02_packet=args.v02_packet,
+                extra_evaluation_artifacts=args.extra_evaluation_artifact,
+            )
+            print(canonical_json(receipt))
+            return 0
+        if args.command == "evaluation":
+            receipt = export_evaluation(
+                release=args.release,
+                output=args.output,
+                receipt_output=args.receipt_output,
+                v011_manifest=args.v011_manifest,
+                v02_packet=args.v02_packet,
+                extra_evaluation_artifacts=args.extra_evaluation_artifact,
+            )
+            print(canonical_json(receipt))
+            return 0
+        manifest = build_recipe_manifest(
+            config_path=args.config,
+            view_path=args.view_artifact,
+            view_receipt_path=args.view_receipt,
+            output=args.output,
+            allow_test_fixtures=args.allow_test_fixtures,
+        )
+        print(canonical_json(manifest))
+        return 0
+    except (ExportError, correction_factory.FactoryError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_open_model_view_exporter.py
+++ b/tests/test_open_model_view_exporter.py
@@ -1,0 +1,1213 @@
+"""Safety and determinism tests for Foundry model-consumer views."""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import correction_factory
+from scripts.projects.open_model_data import model_view_exporter as exporter
+from scripts.projects.open_model_data import validate_source_records as source_contract
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_EXAMPLE = ROOT / "data/projects/open_model_data/contracts/source_record_v1.example.json"
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(exporter.canonical_json(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def source_record(text: str, *, record_id: str = "record.synthetic-001") -> dict[str, Any]:
+    record = json.loads(SOURCE_EXAMPLE.read_text(encoding="utf-8"))
+    record["contract_schema_sha256"] = source_contract.load_schema()[1]
+    record["record_id"] = record_id
+    record["source_id"] = record_id.replace("record.", "source.")
+    record["work_id"] = record_id.replace("record.", "work.")
+    record["content"]["sha256"] = exporter.sha256_text(text)
+    return record
+
+
+def source_payload(
+    text: str,
+    *,
+    payload_id: str = "payload.synthetic-001",
+    record_id: str = "record.synthetic-001",
+    private_data: str = "clear",
+    spans: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    complete_spans = spans
+    if complete_spans is None:
+        complete_spans = [
+            {
+                "discourse_role": "narration",
+                "end": len(text),
+                "language_identity": "ukrainian",
+                "modern_loss_action": "retain",
+                "reason": "other_reviewed",
+                "representation": "standard_orthography",
+                "start": 0,
+            }
+        ]
+    return {
+        "derivation": {
+            "kind": "full_source",
+            "receipt_sha256": "c" * 64,
+            "source_end_char": None,
+            "source_start_char": None,
+        },
+        "language_span_review": {
+            "character_spans": complete_spans,
+            "receipt_sha256": "b" * 64,
+            "reviewer_qualification": "Synthetic structural fixture reviewer",
+            "status": "complete",
+        },
+        "normalization": {
+            "receipt_sha256": "a" * 64,
+            "status": "complete",
+            "version": "fixture-normalization-v1",
+        },
+        "origin": "machine_generated",
+        "origin_evidence": {
+            "method": "synthetic-fixture-lineage",
+            "receipt_sha256": "d" * 64,
+            "status": "verified",
+        },
+        "payload_id": payload_id,
+        "private_data": private_data,
+        "private_data_review": {
+            "method": "synthetic-fixture-screen",
+            "receipt_sha256": "e" * 64,
+            "status": "complete",
+        },
+        "schema_version": "foundry_source_payload_v1",
+        "source_content_sha256": exporter.sha256_text(text),
+        "source_record_id": record_id,
+        "test_fixture": True,
+        "text": text,
+        "text_sha256": exporter.sha256_text(text),
+    }
+
+
+def evidence(query: str = "помилку") -> dict[str, Any]:
+    return {
+        "content_sha256": exporter.sha256_text("vesum-fixture"),
+        "evidence_type": "form",
+        "locator": "fixture:vesum",
+        "official_url": None,
+        "parser_status": "ok",
+        "parser_version": "vesum-fixture-v1",
+        "period": "modern",
+        "query": query,
+        "raw_payload_export_allowed": False,
+        "register": "neutral",
+        "rights_posture": "bounded_internal_reference",
+        "sense_groups": [],
+        "source": "vesum",
+        "source_identity": "vesum-fixture",
+        "status": "attested",
+        "supports": "ukrainian_attestation",
+    }
+
+
+def candidate(
+    text: str,
+    *,
+    candidate_id: str = "candidate.synthetic-001",
+    source_record_id: str = "record.synthetic-001",
+    span_text: str = "помилку",
+) -> dict[str, Any]:
+    registry = correction_factory.load_evaluation_registry()
+    span_start = text.index(span_text)
+    contamination = correction_factory.contamination_states(text, registry)
+    contamination["registry_artifact_sha256"] = {
+        "v0_1_1_manifest": registry.v011_manifest_sha256,
+        "v0_2_packet": registry.v02_packet_sha256,
+    }
+    return {
+        "candidate_id": candidate_id,
+        "candidate_layers": ["grammar"],
+        "detector": {
+            "automatic_error_label": False,
+            "kind": "combined",
+            "model_output_used_as_gold": False,
+            "producer": "fixture-detector-v1",
+        },
+        "evidence": [evidence(span_text)],
+        "reconstructions": [],
+        "review_state": "unresolved",
+        "safety": {
+            "contamination": contamination,
+            "origin": "verified_synthetic",
+            "permitted_use": "correction_eligible",
+            "private_data": "clear",
+            "provenance": "complete",
+            "rights": "granted",
+        },
+        "schema_version": "correction_candidate_v1",
+        "source": {
+            "content_sha256": exporter.sha256_text(text),
+            "context": {
+                "end": len(text),
+                "sha256": exporter.sha256_text(text),
+                "start": 0,
+                "text": text,
+            },
+            "genre": "fixture",
+            "locator": f"fixture:{candidate_id}",
+            "origin": "machine_generated",
+            "period": "modern",
+            "record_id": candidate_id.replace("candidate.", "row."),
+            "region": "synthetic",
+            "register": "neutral",
+            "source_family": "fixture",
+            "source_record_id": source_record_id,
+        },
+        "span": {
+            "discourse_role": "narration",
+            "downstream_disposition": "human_review_required",
+            "end": span_start + len(span_text),
+            "language_identity": "ukrainian",
+            "representation": "standard_orthography",
+            "start": span_start,
+            "text": span_text,
+        },
+        "uncertainty": ["fixture_review_not_real_gold"],
+        "upstream": {
+            "candidate_schema_version": "review_candidate_v1",
+            "candidate_sha256": exporter.sha256_text(f"upstream:{candidate_id}"),
+            "profile_id": "fixture-profile-v1",
+        },
+        "views": {
+            "correction": "candidate",
+            "evaluation": "excluded_from_non_evaluation_views",
+            "faithful_literary": "retain_original",
+            "modern_literary_ukrainian": "retain_original",
+            "preference": "candidate",
+        },
+    }
+
+
+def projection(decision: str, correction: str | None = None) -> dict[str, Any]:
+    is_correction = decision == "correction"
+    return {
+        "acceptable_alternatives": [correction] if correction else [],
+        "accepted_correction": correction,
+        "citations": [
+            {
+                "content_sha256": exporter.sha256_text("fixture-citation"),
+                "locator": "fixture:review-source",
+                "source_identity": "fixture-source",
+                "source_kind": "dictionary",
+                "supports": "Synthetic structural review evidence.",
+            }
+        ],
+        "decision": decision,
+        "discourse_role": "narration",
+        "language_identity": "ukrainian",
+        "rationale": "Synthetic structural review rationale; never human gold.",
+        "representation": "standard_orthography",
+        "uncertainty": ["fixture_review_not_real_gold"],
+        "views": {
+            "correction": "eligible_intake" if is_correction else "not_applicable",
+            "evaluation": "excluded_from_non_evaluation_views",
+            "faithful_literary": "retain_original",
+            "modern_literary_ukrainian": "retain_original",
+            "preference": "eligible_intake" if is_correction else "not_applicable",
+        },
+    }
+
+
+def review(reviewer_id: str, final: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "projection": copy.deepcopy(final),
+        "reviewer": {
+            "human": True,
+            "independence_attested": True,
+            "qualification_evidence": "Synthetic test fixture; never real qualification.",
+            "reviewer_id": reviewer_id,
+            "test_fixture": True,
+            "ukrainian_qualification": "qualified_ukrainian_language_reviewer",
+        },
+    }
+
+
+def correction_record(
+    text: str,
+    *,
+    candidate_id: str = "candidate.synthetic-001",
+    source_record_id: str = "record.synthetic-001",
+    span_text: str = "помилку",
+    decision_name: str = "correction",
+    correction: str | None = "похибку",
+) -> dict[str, Any]:
+    candidate_row = candidate(
+        text,
+        candidate_id=candidate_id,
+        source_record_id=source_record_id,
+        span_text=span_text,
+    )
+    final = projection(decision_name, correction)
+    decision = {
+        "candidate_id": candidate_row["candidate_id"],
+        "candidate_sha256": exporter.sha256_text(exporter.canonical_json(candidate_row)),
+        "final": copy.deepcopy(final),
+        "final_resolution": {"kind": "first_pass_agreement"},
+        "first_pass_reviews": [
+            review("fixture-reviewer-a", final),
+            review("fixture-reviewer-b", final),
+        ],
+        "review_state": "adjudicated",
+        "schema_version": "correction_reviewer_decision_v1",
+    }
+    return correction_factory.build_correction_record(candidate_row, decision)
+
+
+def recipe_config(view_kind: str = "continued_pretraining") -> dict[str, Any]:
+    template = "{{text}}" if view_kind == "continued_pretraining" else "{{payload}}"
+    evaluation = view_kind == "heldout_evaluation"
+    return {
+        "base_model": {"identifier": "fixture/base-model", "revision": "1" * 40},
+        "data_preparation": {
+            "rendering_template": template,
+            "rendering_template_sha256": exporter.sha256_text(template),
+            "split": {
+                "modulus": None if evaluation else 10_000,
+                "namespace": "fixture-split-v1",
+                "strategy": ("preserve_evaluation_release" if evaluation else "sha256_record_id_modulo"),
+                "validation_buckets": None if evaluation else 100,
+            },
+            "target_loss_policy": exporter.TARGET_LOSS_POLICIES[view_kind],
+        },
+        "hyperparameters": {
+            "epochs": "1",
+            "gradient_accumulation_steps": 2,
+            "learning_rate": "2e-5",
+            "micro_batch_size": 1,
+            "packing": False,
+            "precision": "bf16",
+            "seed": 42,
+            "sequence_length": 1024,
+            "weight_decay": "0.1",
+        },
+        "implementation": {
+            "code_revision": "2" * 40,
+            "dependency_lock_sha256": "3" * 64,
+            "framework": "fixture-trainer",
+            "framework_version": "1.0.0",
+        },
+        "objective": exporter.OBJECTIVES[view_kind],
+        "recipe_id": "recipe.fixture-v1",
+        "run_policy": {"execution_state": "not_run", "training_authorized": False},
+        "schema_version": "training_recipe_config_v1",
+        "tokenizer": {"identifier": "fixture/tokenizer", "revision": "4" * 40},
+        "view_kind": view_kind,
+    }
+
+
+def export_fixture_pretraining(tmp_path: Path) -> tuple[Path, Path]:
+    text = "Це синтетичний приклад для перевірки окремого тренувального виду."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "pretraining.jsonl"
+    receipt = tmp_path / "pretraining.receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [source_payload(text)])
+    exporter.export_pretraining(
+        source_records_path=source_path,
+        payloads_path=payload_path,
+        origin="machine_generated",
+        representation_view="faithful_literary",
+        output=output,
+        receipt_output=receipt,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    return output, receipt
+
+
+def test_new_schemas_are_strict_and_meta_valid() -> None:
+    schemas, _registry = exporter.schema_bundle()
+    for path in exporter.NEW_SCHEMA_PATHS:
+        Draft202012Validator.check_schema(schemas[path])
+        assert schemas[path]["additionalProperties"] is False
+
+
+def test_evaluation_view_is_separate_and_byte_stable(tmp_path: Path) -> None:
+    outputs = []
+    receipts = []
+    for suffix in ("a", "b"):
+        output = tmp_path / f"evaluation-{suffix}.jsonl"
+        receipt = tmp_path / f"evaluation-{suffix}.receipt.json"
+        exporter.export_evaluation(
+            release="all",
+            output=output,
+            receipt_output=receipt,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+        outputs.append(output.read_bytes())
+        receipts.append(receipt.read_bytes())
+    assert outputs[0] == outputs[1]
+    assert receipts[0] == receipts[1]
+    rows = [json.loads(line) for line in outputs[0].decode().splitlines()]
+    assert len(rows) == 691
+    assert {row["schema_version"] for row in rows} == {"heldout_evaluation_view_v1"}
+    assert all(row["model_training_eligible"] is False for row in rows)
+    assert all("continued_pretraining" in row["denied_destinations"] for row in rows)
+    receipt = json.loads(receipts[0])
+    assert receipt["safety"]["test_fixture_mode"] is False
+
+
+def test_v011_manifest_item_must_have_a_reference(tmp_path: Path) -> None:
+    manifest = json.loads(exporter.DEFAULT_V011_MANIFEST.read_text(encoding="utf-8"))
+    references_index = manifest["record_layouts"]["item"].index("references")
+    manifest["items"][0][references_index] = []
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    with pytest.raises(
+        exporter.ExportError,
+        match=r"v0\.1\.1 evaluation item lacks references",
+    ):
+        exporter.v011_items(path)
+
+
+def test_evaluation_recipe_preserves_order_and_never_projects_training_loss(
+    tmp_path: Path,
+) -> None:
+    view = tmp_path / "evaluation.jsonl"
+    receipt = tmp_path / "evaluation.receipt.json"
+    exporter.export_evaluation(
+        release="all",
+        output=view,
+        receipt_output=receipt,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    config_path = tmp_path / "recipe-config.json"
+    config_path.write_text(json.dumps(recipe_config("heldout_evaluation")), encoding="utf-8")
+    manifest = exporter.build_recipe_manifest(
+        config_path=config_path,
+        view_path=view,
+        view_receipt_path=receipt,
+        output=tmp_path / "recipe-manifest.json",
+        allow_test_fixtures=False,
+    )
+    assert manifest["preparation"]["shuffle"] == ("not applicable; preserve held-out artifact order")
+    assert manifest["preparation"]["loss_mask_projection"] == ("not applicable to this view")
+    assert manifest["preparation"]["model_training_eligible_records"] == 0
+    assert manifest["execution"]["training_authorized"] is False
+
+
+def test_pretraining_preserves_faithful_text_and_masks_modern_loss(tmp_path: Path) -> None:
+    text = "Він сказав «привет», а потім продовжив українською."
+    start = text.index("привет")
+    end = start + len("привет")
+    spans = [
+        {
+            "discourse_role": "narration",
+            "end": start,
+            "language_identity": "ukrainian",
+            "modern_loss_action": "retain",
+            "reason": "other_reviewed",
+            "representation": "standard_orthography",
+            "start": 0,
+        },
+        {
+            "discourse_role": "quotation",
+            "end": end,
+            "language_identity": "russian",
+            "modern_loss_action": "mask_from_loss",
+            "reason": "quoted_or_multilingual",
+            "representation": "standard_orthography",
+            "start": start,
+        },
+        {
+            "discourse_role": "narration",
+            "end": len(text),
+            "language_identity": "ukrainian",
+            "modern_loss_action": "retain",
+            "reason": "other_reviewed",
+            "representation": "standard_orthography",
+            "start": end,
+        },
+    ]
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [source_payload(text, spans=spans)])
+    results = {}
+    for view in ("faithful_literary", "modern_literary_ukrainian"):
+        output = tmp_path / f"{view}.jsonl"
+        receipt = tmp_path / f"{view}.receipt.json"
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view=view,
+            output=output,
+            receipt_output=receipt,
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+        results[view] = read_jsonl(output)[0]
+    assert results["faithful_literary"]["payload"]["text"] == text
+    assert results["faithful_literary"]["payload"]["character_mask_spans"] == []
+    assert results["modern_literary_ukrainian"]["payload"]["character_mask_spans"] == [
+        {"end_char": end, "reason": "quoted_or_multilingual", "start_char": start}
+    ]
+    assert results["modern_literary_ukrainian"]["eligibility"] == {
+        "model_training_eligible": False,
+        "source_contract_admitted": True,
+        "test_fixture": True,
+    }
+
+
+def test_complete_language_review_cannot_leave_unclassified_text(
+    tmp_path: Path,
+) -> None:
+    text = "Увесь рядок мусить мати явну мовну класифікацію."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    payload = source_payload(text)
+    payload["language_span_review"]["character_spans"][0]["start"] = 1
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [payload])
+    with pytest.raises(exporter.ExportError, match="gap-free"):
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="modern_literary_ukrainian",
+            output=tmp_path / "output.jsonl",
+            receipt_output=tmp_path / "receipt.json",
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+
+
+def test_character_span_width_must_match_emitted_segment(tmp_path: Path) -> None:
+    text = "Сегмент мусить відповідати оголошеним межам нормалізованого джерела."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    payload = source_payload(text)
+    payload["derivation"] = {
+        "kind": "character_span",
+        "receipt_sha256": "c" * 64,
+        "source_end_char": len(text) + 1,
+        "source_start_char": 0,
+    }
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [payload])
+    with pytest.raises(exporter.ExportError, match="span length"):
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="faithful_literary",
+            output=tmp_path / "output.jsonl",
+            receipt_output=tmp_path / "receipt.json",
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_reason"),
+    [
+        (
+            lambda record, payload: record["rights"]["model_training"].update(status="unknown"),
+            "excluded_source_record_not_admitted",
+        ),
+        (lambda _record, payload: payload.update(private_data="present"), "excluded_private_data_not_clear"),
+        (
+            lambda _record, payload: payload["origin_evidence"].update(
+                status="unresolved", method=None, receipt_sha256=None
+            ),
+            "excluded_origin_unverified",
+        ),
+        (
+            lambda _record, payload: payload["private_data_review"].update(status="incomplete", receipt_sha256=None),
+            "excluded_private_data_review_incomplete",
+        ),
+        (
+            lambda _record, payload: payload["normalization"].update(status="incomplete", receipt_sha256=None),
+            "excluded_normalization_incomplete",
+        ),
+    ],
+)
+def test_pretraining_denies_source_rights_private_and_incomplete_inputs(
+    tmp_path: Path, mutation, expected_reason: str
+) -> None:
+    text = "Окремий синтетичний рядок для перевірки заборон експорту."
+    record = source_record(text)
+    payload = source_payload(text)
+    mutation(record, payload)
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, [record])
+    write_jsonl(payload_path, [payload])
+    receipt = exporter.export_pretraining(
+        source_records_path=source_path,
+        payloads_path=payload_path,
+        origin="machine_generated",
+        representation_view="faithful_literary",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    assert output.read_bytes() == b""
+    assert receipt["counts"][expected_reason] == 1
+    assert receipt["safety"]["test_fixture_mode"] is False
+
+
+def test_exact_and_near_evaluation_text_never_enter_pretraining(tmp_path: Path) -> None:
+    evaluation_text = exporter.v011_items(exporter.DEFAULT_V011_MANIFEST)[0]["source"]
+    near_text = evaluation_text[:-1] + ("!" if evaluation_text[-1] != "!" else ".")
+    for index, text in enumerate((evaluation_text, near_text)):
+        source_path = tmp_path / f"source-{index}.jsonl"
+        payload_path = tmp_path / f"payload-{index}.jsonl"
+        output = tmp_path / f"output-{index}.jsonl"
+        receipt_path = tmp_path / f"receipt-{index}.json"
+        write_jsonl(source_path, [source_record(text)])
+        write_jsonl(payload_path, [source_payload(text)])
+        receipt = exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="faithful_literary",
+            output=output,
+            receipt_output=receipt_path,
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+        assert output.read_bytes() == b""
+        assert receipt["counts"]["excluded_records"] == 1
+        assert any(key.startswith("excluded_evaluation_contamination_") for key in receipt["counts"])
+
+
+def test_extensionless_evaluation_artifact_text_is_excluded(tmp_path: Path) -> None:
+    text = "Розширення назви файла не повинно вимикати захист оцінювальних даних."
+    evaluation_artifact = tmp_path / "HELDOUT"
+    evaluation_artifact.write_text(text, encoding="utf-8")
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [source_payload(text)])
+    receipt = exporter.export_pretraining(
+        source_records_path=source_path,
+        payloads_path=payload_path,
+        origin="machine_generated",
+        representation_view="faithful_literary",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(evaluation_artifact,),
+    )
+    assert output.read_bytes() == b""
+    assert receipt["counts"]["excluded_evaluation_contamination_exact_normalized"] == 1
+    assert any(
+        artifact["logical_path"].startswith("external:")
+        for artifact in receipt["evaluation_exclusion_registry"]["artifacts"]
+    )
+
+
+def test_distributed_edits_still_reach_character_sequence_check() -> None:
+    reference = "".join(chr(ord("а") + index % 20) for index in range(240))
+    candidate = "".join("я" if index % 20 == 19 else character for index, character in enumerate(reference))
+    registry = exporter.EvaluationExclusionRegistry(
+        exact_hashes=set(),
+        near_texts=[],
+        near_shingles=[],
+        shingle_index=defaultdict(set),
+        character_index=defaultdict(set),
+        artifacts=[],
+    )
+    registry.add_text(reference, explicit_evaluation_text=True)
+    match = registry.match(candidate)
+    assert match.matched is True
+    assert match.method == "character_sequence"
+
+
+def test_character_anchor_index_is_bounded_and_keeps_endpoints() -> None:
+    normalized = "".join(chr(0x400 + index) for index in range(400))
+    offsets = exporter.character_anchor_offsets(normalized)
+    assert len(offsets) == exporter.MAX_CHARACTER_ANCHORS_PER_TEXT
+    assert offsets[0] == 0
+    assert offsets[-1] == len(normalized) - exporter.CANDIDATE_ANCHOR_CHARACTERS
+    assert offsets == tuple(sorted(set(offsets)))
+
+    registry = exporter.empty_text_registry()
+    registry.add_text(normalized, explicit_evaluation_text=True)
+    assert sum(len(indexes) for indexes in registry.character_index.values()) <= 64
+
+
+def test_rollback_backup_path_remains_reserved(tmp_path: Path) -> None:
+    destination = tmp_path / "view.jsonl"
+    backup = exporter.reserved_rollback_path(destination)
+    try:
+        assert backup.exists()
+        assert backup.parent == destination.parent
+        assert backup.read_bytes() == b""
+    finally:
+        backup.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    "second_text",
+    [
+        "Повторний синтетичний запис не повинен двічі входити до одного виду.",
+        "Повторний синтетичний запис не повинен двічі входити до одного виду!",
+    ],
+)
+def test_intra_view_exact_and_near_duplicates_are_excluded(
+    tmp_path: Path,
+    second_text: str,
+) -> None:
+    first_text = "Повторний синтетичний запис не повинен двічі входити до одного виду."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(
+        source_path,
+        [
+            source_record(first_text, record_id="record.synthetic-001"),
+            source_record(second_text, record_id="record.synthetic-002"),
+        ],
+    )
+    write_jsonl(
+        payload_path,
+        [
+            source_payload(
+                first_text,
+                payload_id="payload.synthetic-001",
+                record_id="record.synthetic-001",
+            ),
+            source_payload(
+                second_text,
+                payload_id="payload.synthetic-002",
+                record_id="record.synthetic-002",
+            ),
+        ],
+    )
+    receipt = exporter.export_pretraining(
+        source_records_path=source_path,
+        payloads_path=payload_path,
+        origin="machine_generated",
+        representation_view="faithful_literary",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    assert len(read_jsonl(output)) == 1
+    assert receipt["counts"]["excluded_records"] == 1
+    assert (
+        sum(count for reason, count in receipt["counts"].items() if reason.startswith("excluded_intra_view_duplicate_"))
+        == 1
+    )
+    assert receipt["admission"] == {
+        "applied": True,
+        "policy": "recompute source_record_v1 admission; unknown is denial",
+        "source_records_admitted": 2,
+        "source_records_denied": 0,
+        "source_records_total": 2,
+    }
+    assert receipt["deduplication"]["accepted_fingerprints"] == 1
+    assert receipt["safety"]["test_fixture_mode"] is True
+
+
+def test_production_mode_rejects_fixtures_and_preserves_existing_output(
+    tmp_path: Path,
+) -> None:
+    text = "Синтетичний рядок не є реально допущеним тренувальним записом."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    good = source_payload(text, payload_id="payload.synthetic-001")
+    bad = source_payload(text, payload_id="payload.synthetic-002")
+    bad["text_sha256"] = "0" * 64
+    write_jsonl(payload_path, [good, bad])
+    output.write_text("sentinel\n", encoding="utf-8")
+    receipt.write_text("sentinel-receipt\n", encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="test fixture"):
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="faithful_literary",
+            output=output,
+            receipt_output=receipt,
+            allow_test_fixtures=False,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+    assert output.read_text(encoding="utf-8") == "sentinel\n"
+    assert receipt.read_text(encoding="utf-8") == "sentinel-receipt\n"
+
+
+def test_late_row_validation_failure_preserves_existing_output_and_receipt(
+    tmp_path: Path,
+) -> None:
+    text = "Синтетичний рядок не є реально допущеним тренувальним записом."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    good = source_payload(text, payload_id="payload.synthetic-001")
+    bad = source_payload(text, payload_id="payload.synthetic-002")
+    bad["text_sha256"] = "0" * 64
+    write_jsonl(payload_path, [good, bad])
+    output.write_text("sentinel\n", encoding="utf-8")
+    receipt.write_text("sentinel-receipt\n", encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="text hash mismatch"):
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="faithful_literary",
+            output=output,
+            receipt_output=receipt,
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+    assert output.read_text(encoding="utf-8") == "sentinel\n"
+    assert receipt.read_text(encoding="utf-8") == "sentinel-receipt\n"
+
+
+def test_receipt_commit_failure_rolls_back_view_and_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text = "Синтетичний рядок перевіряє відновлення пари артефактів."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [source_payload(text)])
+    output.write_text("sentinel\n", encoding="utf-8")
+    receipt.write_text("sentinel-receipt\n", encoding="utf-8")
+    original_replace = exporter.os.replace
+
+    def fail_receipt_commit(source, destination) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if source_path.suffix == ".tmp" and destination_path == receipt:
+            raise OSError("synthetic receipt rename failure")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(exporter.os, "replace", fail_receipt_commit)
+    with pytest.raises(OSError, match="synthetic receipt rename failure"):
+        exporter.export_pretraining(
+            source_records_path=source_path,
+            payloads_path=payload_path,
+            origin="machine_generated",
+            representation_view="faithful_literary",
+            output=output,
+            receipt_output=receipt,
+            allow_test_fixtures=True,
+            v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+            v02_packet=exporter.DEFAULT_V02_PACKET,
+            extra_evaluation_artifacts=(),
+        )
+    assert output.read_text(encoding="utf-8") == "sentinel\n"
+    assert receipt.read_text(encoding="utf-8") == "sentinel-receipt\n"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob("*.bak"))
+
+
+@pytest.mark.parametrize(
+    ("view_kind", "expected_schema", "expected_destination"),
+    [
+        ("correction_instruction", "correction_instruction_view_v1", "supervised_correction"),
+        ("preference", "preference_view_v1", "pairwise_preference"),
+        ("quality_filter", "quality_filter_view_v1", "quality_filter"),
+    ],
+)
+def test_correction_family_views_are_disjoint_and_fixture_ineligible(
+    tmp_path: Path,
+    view_kind: str,
+    expected_schema: str,
+    expected_destination: str,
+) -> None:
+    text = "У цьому синтетичному реченні є помилку для перевірки."
+    source_path = tmp_path / f"source-{view_kind}.jsonl"
+    correction_path = tmp_path / f"correction-{view_kind}.jsonl"
+    output = tmp_path / f"output-{view_kind}.jsonl"
+    receipt_path = tmp_path / f"receipt-{view_kind}.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(correction_path, [correction_record(text)])
+    receipt = exporter.export_correction_family(
+        view_kind=view_kind,
+        source_records_path=source_path,
+        correction_records_path=correction_path,
+        origin="machine_generated",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    row = read_jsonl(output)[0]
+    assert row["schema_version"] == expected_schema
+    assert row["permitted_destination"] == expected_destination
+    assert row["eligibility"]["model_training_eligible"] is False
+    assert receipt["counts"]["fixture_records"] == 1
+    if view_kind == "correction_instruction":
+        assert row["payload"]["target_text"] == text.replace("помилку", "похибку")
+    if view_kind == "preference":
+        assert row["payload"]["chosen"] == "похибку"
+        assert row["payload"]["rejected"] == "помилку"
+    if view_kind == "quality_filter":
+        assert row["payload"]["label"] == "needs_correction"
+
+
+def test_correction_export_preserves_packet_order_for_hash_derived_ids(
+    tmp_path: Path,
+) -> None:
+    inputs = [
+        (
+            "У першому короткому прикладі є помилку.",
+            "candidate.synthetic-001",
+            "record.synthetic-001",
+        ),
+        (
+            "Цілком інший контекст також містить помилку для окремої перевірки.",
+            "candidate.synthetic-002",
+            "record.synthetic-002",
+        ),
+    ]
+    source_rows = [source_record(text, record_id=source_record_id) for text, _candidate_id, source_record_id in inputs]
+    correction_rows = [
+        correction_record(
+            text,
+            candidate_id=candidate_id,
+            source_record_id=source_record_id,
+        )
+        for text, candidate_id, source_record_id in inputs
+    ]
+    correction_rows.sort(key=lambda row: row["record_id"], reverse=True)
+    assert correction_rows[0]["record_id"] > correction_rows[1]["record_id"]
+
+    source_path = tmp_path / "source.jsonl"
+    correction_path = tmp_path / "correction.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, source_rows)
+    write_jsonl(correction_path, correction_rows)
+    receipt = exporter.export_correction_family(
+        view_kind="correction_instruction",
+        source_records_path=source_path,
+        correction_records_path=correction_path,
+        origin="machine_generated",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    output_rows = read_jsonl(output)
+    assert [row["lineage"]["correction_record_id"] for row in output_rows] == [
+        row["record_id"] for row in correction_rows
+    ]
+    assert receipt["counts"]["exported_records"] == 2
+    assert receipt["determinism"]["ordering"] == ("canonical upstream packet order; unique correction record ID")
+
+
+def test_distinct_corrections_sharing_long_context_are_not_near_deduplicated(
+    tmp_path: Path,
+) -> None:
+    text = (
+        "У розгорнутому навчальному реченні навмисно залишено помилку, щоб "
+        "перевірити перше незалежне виправлення, а наприкінці додано окремий "
+        "недолік для другого незалежного виправлення в тому самому контексті."
+    )
+    correction_rows = [
+        correction_record(
+            text,
+            candidate_id="candidate.synthetic-001",
+            span_text="помилку",
+            correction="похибку",
+        ),
+        correction_record(
+            text,
+            candidate_id="candidate.synthetic-002",
+            span_text="недолік",
+            correction="ваду",
+        ),
+    ]
+    source_path = tmp_path / "source.jsonl"
+    correction_path = tmp_path / "correction.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(correction_path, correction_rows)
+    receipt = exporter.export_correction_family(
+        view_kind="correction_instruction",
+        source_records_path=source_path,
+        correction_records_path=correction_path,
+        origin="machine_generated",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    assert len(read_jsonl(output)) == 2
+    assert receipt["counts"]["exported_records"] == 2
+    assert not any(reason.startswith("excluded_intra_view_duplicate_") for reason in receipt["counts"])
+
+
+def test_quality_filter_accepts_resolved_acceptable_fixture_only_as_fixture(
+    tmp_path: Path,
+) -> None:
+    text = "У цьому синтетичному реченні є помилку для перевірки."
+    source_path = tmp_path / "source.jsonl"
+    correction_path = tmp_path / "correction.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(
+        correction_path,
+        [correction_record(text, decision_name="acceptable_as_is", correction=None)],
+    )
+    exporter.export_correction_family(
+        view_kind="quality_filter",
+        source_records_path=source_path,
+        correction_records_path=correction_path,
+        origin="machine_generated",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    row = read_jsonl(output)[0]
+    assert row["payload"] == {
+        "decision": "acceptable_as_is",
+        "label": "acceptable",
+        "text": text,
+    }
+    assert row["eligibility"]["model_training_eligible"] is False
+
+
+def test_derived_correction_target_is_checked_for_evaluation_contamination(
+    tmp_path: Path,
+) -> None:
+    text = "У цьому синтетичному реченні є помилку для перевірки."
+    evaluation_text = exporter.v011_items(exporter.DEFAULT_V011_MANIFEST)[0]["source"]
+    record = correction_record(text, correction=evaluation_text)
+    source_path = tmp_path / "source.jsonl"
+    correction_path = tmp_path / "correction.jsonl"
+    output = tmp_path / "output.jsonl"
+    receipt_path = tmp_path / "receipt.json"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(correction_path, [record])
+    receipt = exporter.export_correction_family(
+        view_kind="correction_instruction",
+        source_records_path=source_path,
+        correction_records_path=correction_path,
+        origin="machine_generated",
+        output=output,
+        receipt_output=receipt_path,
+        allow_test_fixtures=True,
+        v011_manifest=exporter.DEFAULT_V011_MANIFEST,
+        v02_packet=exporter.DEFAULT_V02_PACKET,
+        extra_evaluation_artifacts=(),
+    )
+    assert output.read_bytes() == b""
+    assert receipt["counts"]["excluded_records"] == 1
+    assert any(key.startswith("excluded_evaluation_contamination_") for key in receipt["counts"])
+
+
+def test_recipe_binds_exact_fixture_view_but_never_authorizes_training(
+    tmp_path: Path,
+) -> None:
+    view, receipt = export_fixture_pretraining(tmp_path)
+    config_path = tmp_path / "recipe-config.json"
+    output = tmp_path / "recipe-manifest.json"
+    config_path.write_text(json.dumps(recipe_config()), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="fixture view"):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=output,
+            allow_test_fixtures=False,
+        )
+    manifest = exporter.build_recipe_manifest(
+        config_path=config_path,
+        view_path=view,
+        view_receipt_path=receipt,
+        output=output,
+        allow_test_fixtures=True,
+    )
+    assert manifest["view_artifact"]["sha256"] == exporter.sha256_file(view)
+    assert manifest["view_receipt"]["sha256"] == exporter.sha256_file(receipt)
+    assert manifest["execution"] == {
+        "execution_state": "not_run",
+        "model_call_performed": False,
+        "test_fixture_mode": True,
+        "training_authorized": False,
+        "training_performed": False,
+    }
+    assert manifest["preparation"]["model_training_eligible_records"] == 0
+    assert manifest["preparation"]["test_fixture_records"] == 1
+
+
+def test_recipe_rejects_wrong_objective_and_moving_revision(tmp_path: Path) -> None:
+    view, receipt = export_fixture_pretraining(tmp_path)
+    config = recipe_config()
+    config["objective"] = "pairwise_preference"
+    config_path = tmp_path / "wrong-objective.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="objective"):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=tmp_path / "manifest.json",
+            allow_test_fixtures=True,
+        )
+    config = recipe_config()
+    config["base_model"]["revision"] = "main"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="schema violation"):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=tmp_path / "manifest.json",
+            allow_test_fixtures=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("learning_rate", "0", "learning_rate"),
+        ("epochs", "0", "epochs"),
+    ],
+)
+def test_recipe_rejects_non_positive_training_values(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    view, receipt = export_fixture_pretraining(tmp_path)
+    config = recipe_config()
+    config["hyperparameters"][field] = value
+    config_path = tmp_path / "invalid-hyperparameter.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match=message):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=tmp_path / "manifest.json",
+            allow_test_fixtures=True,
+        )
+
+
+def test_recipe_rejects_unbound_template_and_invalid_split(tmp_path: Path) -> None:
+    view, receipt = export_fixture_pretraining(tmp_path)
+    config = recipe_config()
+    config_path = tmp_path / "invalid-preparation.json"
+    config["data_preparation"]["rendering_template"] = "{{different_text}}"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="template hash"):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=tmp_path / "manifest.json",
+            allow_test_fixtures=True,
+        )
+    config = recipe_config()
+    config["data_preparation"]["split"]["validation_buckets"] = 10_000
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(exporter.ExportError, match="validation split"):
+        exporter.build_recipe_manifest(
+            config_path=config_path,
+            view_path=view,
+            view_receipt_path=receipt,
+            output=tmp_path / "manifest.json",
+            allow_test_fixtures=True,
+        )
+
+
+def test_cli_returns_exit_two_for_fixture_without_explicit_switch(
+    tmp_path: Path,
+) -> None:
+    text = "Синтетичний рядок для перевірки коду завершення."
+    source_path = tmp_path / "source.jsonl"
+    payload_path = tmp_path / "payload.jsonl"
+    write_jsonl(source_path, [source_record(text)])
+    write_jsonl(payload_path, [source_payload(text)])
+    with pytest.raises(SystemExit) as exc:
+        exporter.main(
+            [
+                "continued-pretraining",
+                "--source-records",
+                str(source_path),
+                "--payloads",
+                str(payload_path),
+                "--origin",
+                "machine_generated",
+                "--representation-view",
+                "faithful_literary",
+                "--output",
+                str(tmp_path / "output.jsonl"),
+                "--receipt-output",
+                str(tmp_path / "receipt.json"),
+            ]
+        )
+    assert exc.value.code == 2


### PR DESCRIPTION
Closes #6122\n\n## Outcome\n\nAdds the Foundry consumer boundary for five mechanically disjoint local views:\n- continued pretraining, with faithful and modern-literary-Ukrainian representations\n- supervised correction/instruction\n- pairwise preference\n- quality filtering\n- held-out evaluation\n\nAlso adds deterministic, hash-bound preparation/training recipe manifests. No model call, training, upload, publication, redistribution, outreach, OCR, or private-data export occurs.\n\n## Safety and reproducibility\n\n- Recomputes source_record_v1 admission and the canonical #6121 handoff.\n- Requires evidence-backed authorship origin, private-data screening, normalization, and gap-free language-span classification.\n- Preserves Russian quotations and other protected variation in the faithful view while masking or excluding it from modern-Ukrainian loss.\n- Blocks exact and near evaluation contamination across frozen v0.1.1, v0.2, other evaluation artifacts, and derived rules.\n- Applies separate exact/near intra-view deduplication.\n- Keeps human-authored, generated, translated, and human-revised-synthetic outputs homogeneous.\n- Pins exact view and receipt hashes, rendering template, split rule, model/tokenizer/code revisions, dependencies, objective, and hyperparameters.\n- Keeps all fixture rows training-ineligible and every recipe at training_authorized false / execution_state not_run.\n\n## Verification\n\n- 57 focused and integration tests\n- 13 JSON Schemas meta-valid and registry-resolvable\n- Ruff and Python compilation\n- Markdownlint\n- two byte-identical 691-record held-out exports\n- OPSEC, public-identifier, gitleaks, protected-file, diff, and X-Agent trailer checks\n\nIndependent exact-head cross-family review and GitHub CI remain required before merge.