### PR TITLE
feat(agent-runtime): complete ACP fleet participant coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Keep the ACP protocol test's Node runtime deterministic regardless of
+      # which round-robin shard owns its test file.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
       - name: Restore Atlas lexicon manifest cache
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,13 @@ jobs:
           mapfile -t shard_files < <(.venv/bin/python -c "$split_py" "$SHARD")
           echo "shard $SHARD: ${#shard_files[@]} test files"
           if [ "${#shard_files[@]}" -eq 0 ]; then echo "::error::empty shard"; exit 1; fi
+          # The text ACP protocol test executes the project-owned Node server,
+          # which imports the exact SDK pinned in package-lock.json. Install
+          # Node dependencies only in the shard that owns that test file.
+          if printf '%s\n' "${shard_files[@]}" | grep -Fxq \
+            'tests/agent_runtime/test_acp_text_agent.py'; then
+            npm ci --ignore-scripts
+          fi
           # shellcheck disable=SC2086  # cov_args is a deliberate word-split argument list
           .venv/bin/python -m pytest "${shard_files[@]}" -n auto --strict-markers \
             --timeout=120 --timeout-method=thread --durations=25 $cov_args \

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1336,11 +1336,11 @@ Claude, Gemini, and Codex coordinate through distinct primitives. Pick the right
 | Need | Tool | Write access? |
 | --- | --- | --- |
 | Sustained topic-scoped discussion, multi-turn, pinned context | **`ai_agent_bridge post` / `ai_agent_bridge discuss`** (channel bridge) | No (Q&A only; **not** formal CF) |
-| One-off drive-by question to another agent | **`ask-claude` / `ask-agy` / `ask-codex`** | No by default; opt-in via `--allow-write` |
+| One-off drive-by question to another agent | **Legacy `ask-*` compatibility command** pending single-seat ACP cutover | No by default; opt-in via `--allow-write` only on legacy paths |
 | Fire-and-forget execution — run code, commit, push | **`scripts/delegate.py dispatch`** | Yes |
 | Durable fleet coordination / topology | **`scripts.fleet_comms`** (`plane-status`, …) + **file dual-write handoffs** (authoritative in every plane mode) | Hand-off files only as existing lane diaries; never invent a third bus |
 | Formal cross-family PR review | **`review-pr` / `publish-review-verdict`** | No (review evidence) |
-| Experimental structured Codex / Grok invocation | **ACPX adapters** `acpx-codex-shadow` + `acpx-grok-shadow` (feature-flagged, default-off/shadow; not a coordination plane) | **No** (read-only/stateless; see onboarding runbook) |
+| Structured two-seat agent conversation | **ACPX adapters** for Codex, Grok (`acpx-grok-shadow`), Claude, Kimi/K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek (feature-flagged, default-off; not a coordination plane) | **No** (read-only/stateless; see onboarding runbook) |
 | Buzz relay coordination | **Deferred** — not in this rollout | N/A |
 | Watch a long-running process (builds, reviews) emit events — **Claude only** | **`Monitor` tool** (Claude Code built-in) | N/A |
 | Watch a long-running process — **Gemini / Codex** | Shell-poll the Monitor API | N/A |
@@ -1348,11 +1348,18 @@ Claude, Gemini, and Codex coordinate through distinct primitives. Pick the right
 
 **Rules of thumb:**
 - Channel-first for anything >1 turn. The pinned `context.md` eliminates re-pasting project setup on every round.
-- `ask-*` is not deprecated for genuine one-shots. `ask-gemini` is retired; use `ask-agy` for Gemini-family one-shots.
+- Supported two-seat `discuss` calls delegate to ACP; the command name is a
+  compatibility surface, not a second provider-launch engine.
+- `ask-*` remains a temporary compatibility path only until single-seat ACP
+  and initiator/quota telemetry land. Do not add new provider launch logic
+  there. `ask-gemini` is retired; AGY is the Gemini-family route.
 - `ai_agent_bridge` is for **communication**. `delegate.py dispatch` is for **execution**. Don't confuse them.
 - **`discuss` is not formal review.** Use `review-pr` / `publish-review-verdict` for CF.
 - Query `.venv/bin/python -m scripts.fleet_comms plane-status` — never hard-code a live plane mode.
-- ACPX is optional experimental transport only (two direct-only seats: Codex pilot + Grok second pilot on broker-centrality evidence with limited direct-runtime sample); rollback is feature-flag off + native runtime. Grok + Codex ACPX is not a new coordination plane.
+- ACPX is the structured transport for supported bounded two-seat panels;
+  rollback is feature-flag off + native runtime. It is
+  not a new coordination plane, and fleet-comms/file handoffs remain durable
+  authority.
 - Never run a polling loop to check a background task — use `Monitor` or the bash `run_in_background` completion notification.
 
 ### Channel bridge — preferred for multi-turn

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -66,43 +66,34 @@ interactive launcher, this stateless `--bare` route does not install an
 Ownership matrix, troubleshooting, and seat smoke (including ACPX scope):
 [`docs/runbooks/agent-seat-onboarding.md`](runbooks/agent-seat-onboarding.md).
 
-## ACPX experimental transport (runtime boundary)
+## ACPX structured transport (runtime boundary)
 
-ACPX is an **experimental, feature-flagged structured invocation transport** —
-not a coordination plane and not a replacement for `discuss`, fleet-comms, or
-authoritative file handoffs. **Grok + Codex ACPX is not a new coordination plane.**
-The shadow pilot remains transport evidence only; the separately
-approved active path is a controller-scheduled, bounded conversation DAG whose
-durable state and timeline are written through existing fleet-comms and file
-handoffs.
+ACPX is a **feature-flagged structured invocation transport** — not a
+coordination plane and not a replacement for fleet-comms or authoritative file
+handoffs. Supported two-seat `discuss` calls use ACPX as their execution
+engine; the CLI name remains a compatibility surface. The active path is a
+controller-scheduled bounded conversation DAG whose durable state and timeline
+are written through existing fleet-comms. The expanded participant registry is
+not a new coordination plane.
 
-**Why Grok is the second pilot (#6043, API-backed):** in the 2026-07-30
-snapshot from `/api/comms/live-activity?limit=500&minutes=120`, all **95**
-broker dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
-**Claude 22** among the three busiest senders; the remaining **22** were
-**Gemini 11**, **OpenCode 6**, **GLM 4**, and **AGY 1**. The same-day
-30-day sample from
-`/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
-Broker centrality is high; direct-runtime evidence is still limited — hence
-a thin second shadow pilot, not fleet-wide enablement. These are dated
-selection-evidence snapshots, not permanent routing weights.
-
-Approved boundary (#6027 Codex, #6043 Grok):
+Approved boundary (#6027, #6043, #6078, #6130, #6158):
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow|active`, **default `off`**.
   `shadow` retains the comparison pilot below. `active` is accepted only by
   the explicit fleet-comms `acp-discuss` controller; it is never a generic
   runner, routing, dispatch, failover, or review setting. Rollback is setting
   the flag to `off` (or unsetting it) and using native transport.
-- Direct-only seats:
-  - `acpx-codex-shadow` (`scripts/agent_runtime/adapters/acpx.py:AcpxAdapter`)
-  - `acpx-grok-shadow` (`scripts/agent_runtime/adapters/acpx.py:AcpxGrokShadowAdapter`)
-  — never returned by `available_agents()`, never dispatch/routing/review/
-  failover candidates.
-- Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); both adapters refuse to
+- Direct-only seats cover Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool,
+  AGY/Gemini, GLM, and DeepSeek through the fixed registry in
+  `scripts/agent_runtime/adapters/acpx.py` (including `acpx-codex-shadow`,
+  `acpx-grok-shadow` via `AcpxGrokShadowAdapter`, `acpx-agy-shadow`,
+  `acpx-glm-shadow`, and `acpx-deepseek-shadow`). They are never returned by
+  `available_agents()` and never become dispatch/routing/review/failover
+  candidates.
+- Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); every adapter refuses to
   spawn on any other resolved version.
-- Grok seat also preflights the installed native Grok CLI at exact semver
-  `0.2.117` (wrong/missing/unparseable → refuse before prompt).
+- Custom seats also pin their provider CLIs: Grok `0.2.117`, AGY `1.1.9`,
+  OpenCode/GLM `1.17.13`, and Hermes/DeepSeek `0.18.2`.
 - Codex participant:
   `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
 - Grok participant:
@@ -113,6 +104,10 @@ Approved boundary (#6027 Codex, #6043 Grok):
   <hash-pinned-project-no-tool-profile> --no-leader stdio`. The project-owned
   profile is digest-checked before every spawn and removes write, shell,
   subagent, memory, web, MCP, and LSP tools at the Grok server boundary.
+- AGY and DeepSeek use `scripts/agent_runtime/acp_text_agent.mjs`: one text
+  prompt, source-blind temporary cwd, provider-local sandbox/isolation, and
+  cleanup after the turn. GLM uses native `opencode acp --pure` with a fixed
+  Z.AI subscription model plus deny-all permissions and disabled tools.
 - Adapter safety contract: one in-flight prompt, zero backlog, zero automatic
   prompt retries, bounded timeout/cancellation, required non-empty/bounded
   `task_id`, `correlation_id`, and `idempotency_key` (local runtime metadata

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -93,7 +93,9 @@ Approved boundary (#6027, #6043, #6078, #6130, #6158):
 - Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); every adapter refuses to
   spawn on any other resolved version.
 - Custom seats also pin their provider CLIs: Grok `0.2.117`, AGY `1.1.9`,
-  OpenCode/GLM `1.17.13`, and Hermes/DeepSeek `0.18.2`.
+  OpenCode/GLM `1.17.13`, and Hermes/DeepSeek `0.18.2`. Provider version
+  parsing is anchored to each reviewed CLI output format, and the project text
+  ACP server is SHA-256 digest-checked before spawn.
 - Codex participant:
   `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
 - Grok participant:

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -153,7 +153,8 @@ not permanent routing weights and do not override current CodexBar headroom.
   resolved binary version.
 - Custom participant commands additionally preflight their reviewed provider
   CLI versions: Grok `0.2.117`, AGY `1.1.9`, OpenCode/GLM `1.17.13`, and
-  Hermes/DeepSeek `0.18.2`.
+  Hermes/DeepSeek `0.18.2`. Each version is parsed only from its reviewed CLI
+  output shape, and the project text ACP server is digest-checked before use.
 - Every invocation requires a non-empty, bounded, local `task_id`,
   `correlation_id`, and `idempotency_key`, a fixed target from the participant
   registry, and a read-only, non-primary worktree.

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -39,7 +39,7 @@ caps or live modes.
 | **`discuss`** (bridge) | An observable exception for agent communication that ACP cannot serve; bounded multi-agent deliberation and design input | Implementation, merge authority, or the formal cross-family review gate |
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution in a worktree | Durable fleet authority or formal CF |
 | **Fleet-comms + file handoffs** | Durable coordination and authority today; **file dual-write remains authoritative in every current plane mode** | Competing message buses; silent plane/retention/eligibility flips |
-| **ACPX** | Routine first-choice structured transport for eligible two-seat read-only communication; fleet launchers make `ab discuss` select it automatically for Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, and Pool; not a coordination plane | Persistent sessions, backlog, auto-retries, unrestricted chat, plane flips, review eligibility |
+| **ACPX** | Routine first-choice structured transport for eligible two-seat read-only communication; fleet launchers make `discuss` select it automatically for Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek; not a coordination plane | Persistent sessions, backlog, auto-retries, unrestricted chat, plane flips, review eligibility |
 | **Buzz** | **Explicitly deferred** | Anything in this rollout — relay-as-authority conflicts with the current authority model |
 
 ### Human overview pages
@@ -124,48 +124,46 @@ to Sol or the accountable orchestrator before making a consequential decision.
 - Plane / retention-apply / `formal_review_eligible` flips belong to the
   infra/harness lane after parity + present-tense operator/advisor GO.
 
-### ACPX — experimental transport boundary
+### ACPX — structured transport boundary
 
 ACPX is **not** a coordination product and **not** a second fleet bus.
-Two direct-only shadow seats (Codex + Grok) are **not a new coordination plane** —
-fleet-comms + file dual-write stay authoritative, and native Codex / native
-Grok stay authoritative under shadow compare.
+Direct-only participant seats are **not a new coordination plane**:
+fleet-comms + file dual-write stay authoritative. The Codex/Grok shadow
+comparison remains available, while the active bounded controller may use
+any enabled participant from the fixed registry.
 
-**Seat-selection evidence (#6043, API-backed):** in the 2026-07-30 snapshot
-from `/api/comms/live-activity?limit=500&minutes=120`, all **95** broker
-dispatches had sender counts **Codex 26**, **grok-atlas 25**, and
-**Claude 22** among the three busiest senders; the remaining **22** were
-**Gemini 11**, **OpenCode 6**, **GLM 4**, and **AGY 1**. The same-day
-30-day runtime sample from
-`/api/runtime/usage?days=30` had **Codex 20**, **Claude 15**, and **Grok 1**.
-Broker centrality is therefore strong for Grok, while **direct-runtime
-evidence remains limited** — Grok is a deliberately conservative second
-pilot, not fleet-wide enablement. These are dated selection-evidence
-snapshots, not permanent routing weights.
+**Historical Grok pilot evidence (#6043):** the 2026-07-30 snapshot from
+`/api/comms/live-activity?limit=500&minutes=120` contained 95 broker
+dispatches: Codex 26, grok-atlas 25, Claude 22, and the remaining **22** from
+Gemini 11, OpenCode 6, GLM 4, and AGY 1. The same-day direct-runtime sample
+had Grok 1. This dated evidence justified the second pilot. These are
+not permanent routing weights and do not override current CodexBar headroom.
 
-**Exact contract (#6027 Codex pilot, #6043 Grok second pilot):**
+**Exact contract (#6027, #6043, #6078, #6130, #6158):**
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow|active`, **default `off`**.
   `shadow` is the unchanged comparison pilot. `active` is accepted only by the
   explicit `acp-discuss` controller described below.
-- Direct-only seat names `acpx-codex-shadow` and `acpx-grok-shadow`; never
-  registered for dispatch, routing, review, or failover.
+- Direct-only seat names include `acpx-codex-shadow`, `acpx-grok-shadow`,
+  `acpx-claude-shadow`, `acpx-kimi-shadow`, `acpx-kimicc-shadow`,
+  `acpx-cursor-shadow`, `acpx-pool-shadow`, `acpx-agy-shadow`,
+  `acpx-glm-shadow`, and `acpx-deepseek-shadow`; never registered for
+  dispatch, routing, review, or failover.
 - Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
   resolved binary version.
-- Grok seat additionally preflights the installed native Grok CLI at exact
-  semver `0.2.117` and refuses wrong/missing/unparseable versions before
-  prompt.
+- Custom participant commands additionally preflight their reviewed provider
+  CLI versions: Grok `0.2.117`, AGY `1.1.9`, OpenCode/GLM `1.17.13`, and
+  Hermes/DeepSeek `0.18.2`.
 - Every invocation requires a non-empty, bounded, local `task_id`,
-  `correlation_id`, and `idempotency_key`, plus
-  `tool_config={"acpx_shadow": True, "target_agent": "codex"|"grok"}`, and
-  runs against a read-only, non-primary worktree.
+  `correlation_id`, and `idempotency_key`, a fixed target from the participant
+  registry, and a read-only, non-primary worktree.
 
 **In scope (approved):**
 
-- Feature-flagged adapters (default off / shadow comparison).
-- Exactly one read-only/stateless **Codex** ACP participant
-  (`acpx-codex-shadow`) and exactly one read-only/stateless **Grok** ACP
-  participant (`acpx-grok-shadow`) for structured invocation.
+- Feature-flagged adapters (default off / shadow comparison / bounded active
+  controller).
+- Exactly one read-only/stateless participant per enabled route: Codex, Grok,
+  Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek.
 - Grok fixed effective model/effort: `grok-4.5` / `high` (caller may pass
   only `None` or those exact values; metadata never fabricates otherwise).
 - Grok ACP server command (single custom agent argument; never built-in
@@ -178,6 +176,14 @@ snapshots, not permanent routing weights.
   memory, web, MCP, and LSP tools inside the Grok ACP server. This is required
   in addition to ACPX `--deny-all --no-fs --no-terminal --allowed-tools ""`:
   ACPX client flags alone do not remove native Grok tools.
+- AGY and DeepSeek use the project-owned text ACP server. It accepts one text
+  prompt, runs source-blind in a fresh temporary directory, and removes that
+  directory after the turn. AGY runs `plan` + sandbox without permission
+  bypasses. DeepSeek runs Hermes against an isolated empty-tool/no-fallback
+  config while reusing only the existing local credential files.
+- GLM uses native `opencode acp --pure`, pinned to
+  `zai-coding-plan/glm-5.2`, with both `permission.*=deny` and `tools.*=false`.
+  GLM and first-party DeepSeek retain their local-only/never-CI egress guards.
 - Correlation / idempotency fields recorded as **evidence** (local runtime
   metadata only — never ACP protocol flags, argv, or stdin; never published
   to fleet-comms, dispatch authority, or review evidence), not as a new
@@ -193,13 +199,13 @@ snapshots, not permanent routing weights.
 - Plane-mode or retention changes via ACPX
 - Review-eligibility changes via ACPX
 - Primary-checkout writes or write-mode ACP work
-- Treating Grok + Codex ACPX as a coordination plane, review bus, or
+- Treating ACPX as a coordination plane, review bus, or
   fleet-comms replacement
 
 **Do not invent CLI flags, endpoints, or review eligibility here.** The
 adapter's argv is fully confined and callers only ever set the `tool_config`
-keys it allowlists (`acpx_shadow`, `target_agent`, `correlation_id`,
-`idempotency_key`); this runbook describes ownership and safety, not a
+keys it allowlists (`acpx_shadow`/`acpx_discussion`, `target_agent`,
+`correlation_id`, `idempotency_key`); this runbook describes ownership and safety, not a
 floating CLI surface.
 
 #### Active controller-backed ACP conversation
@@ -224,7 +230,7 @@ printf '%s\n' 'Compare the two bounded options and name risks.' |
 Every fleet launcher exports ACP as the routine transport. The project
 `discuss` command automatically selects the durable ACP controller when the request names
 exactly two enabled participants: Codex, Grok, Claude, Kimi, KimiCC K3,
-Cursor, or Pool. The direct `acp-discuss` command remains available for
+Cursor, Pool, AGY/Gemini, GLM, or DeepSeek. The direct `acp-discuss` command remains available for
 operators and tests. Selection starts no process at cold start and does not
 change `delegate.py`. Use the default two rounds; three is the hard maximum.
 
@@ -237,6 +243,16 @@ silently fall back. Admission is one conversation repository-wide. If it is
 occupied, return `busy` immediately: there is no queue, wait, automatic retry,
 or hidden failover. A typed partial ACP outcome is valid evidence to inspect,
 but not a successful discussion, formal review, or coordination authority.
+
+The legacy `discuss` CLI is now a compatibility surface, not a second
+execution engine, for supported two-seat panels: it delegates to ACP and
+records the durable ACP conversation. Legacy `ask-*` one-shots remain only
+until the single-recipient ACP controller and initiator/quota telemetry land;
+do not add new provider launch logic to those modules. The retirement order is
+compatibility shim → deprecation event → measured zero direct launches → code
+removal. Fleet-comms persistence, leases, inbox delivery, formal verdicts,
+and crash recovery are durable-plane responsibilities and are not retired by
+this transport migration.
 
 Fleet-wide means caller-access parity plus the enabled participant set above.
 The live caller classes below may request any supported two-seat panel when
@@ -386,8 +402,8 @@ counts and outcomes.
    native Codex and native Grok remain the authoritative paths.
 3. Leave fleet-comms plane mode and formal-review eligibility unchanged.
 4. Keep file dual-write handoffs current.
-5. Grok + Codex ACPX seats are independent observability pilots only; turning
-   either (or both) off is not a plane cutover.
+5. Direct-only ACPX seats are transport adapters only; turning any or all off
+   is not a plane cutover.
 
 ### Buzz — deferred
 
@@ -427,9 +443,10 @@ printf '%s\n' 'Bounded read-only task.' | ACPX_AUTH_CHAT_GPT=1 \
 .venv/bin/python scripts/ai_agent_bridge/__main__.py discuss <channel> "..." \
   --with claude,kimicc
 
-# The same command uses bridge only for a named exception.
+# Three participants remain a named bridge exception until the bounded
+# controller supports that count.
 .venv/bin/python scripts/ai_agent_bridge/__main__.py discuss <channel> "..." \
-  --with agy,codex
+  --with agy,codex,cursor
 
 # Formal CF
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR_NUMBER> --reviewer codex

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "showdown": "^2.1.0"
       },
       "devDependencies": {
+        "@agentclientprotocol/sdk": "1.3.0",
         "@dagger.io/dagger": "^0.19.8",
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "homepage": "https://github.com/krisztiankoos/learn-ukrainian#readme",
   "devDependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@dagger.io/dagger": "^0.19.8",
     "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "^30.0.0",

--- a/scripts/agent_runtime/acp_text_agent.mjs
+++ b/scripts/agent_runtime/acp_text_agent.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+
+/**
+ * Text-only ACP server for fleet CLIs that do not expose a suitably confined
+ * native ACP endpoint.
+ *
+ * The server accepts exactly one text prompt per ACP session and returns one
+ * text response. Provider CLIs run in a fresh temporary directory with no
+ * repository files. AGY uses plan+sandbox mode without permission bypasses;
+ * Hermes uses an isolated config with an explicit empty CLI toolset, no
+ * fallbacks, no MCP, no plugins, and no injected project rules.
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable, Writable } from 'node:stream';
+
+const MAX_PROMPT_BYTES = 512 * 1024;
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024;
+const CHILD_TIMEOUT_MS = 270_000;
+const CONFINEMENT_NOTICE = [
+  'This is a bounded text-only advisory turn.',
+  'Do not invoke tools, inspect files, browse, execute commands, or modify state.',
+  'Answer only from the text in this prompt.',
+].join(' ');
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith('--') || value == null) {
+      throw new Error('usage: acp_text_agent.mjs --provider NAME --model MODEL --binary PATH');
+    }
+    values[flag.slice(2)] = value;
+  }
+  if (!['agy', 'deepseek'].includes(values.provider)) {
+    throw new Error(`unsupported provider ${JSON.stringify(values.provider)}`);
+  }
+  if (!values.model || !values.binary) {
+    throw new Error('--model and --binary are required');
+  }
+  return values;
+}
+
+function textPrompt(blocks) {
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    throw new Error('a non-empty text prompt is required');
+  }
+  if (blocks.some((block) => block?.type !== 'text' || typeof block.text !== 'string')) {
+    throw new Error('this ACP adapter accepts text content blocks only');
+  }
+  const prompt = blocks
+    .map((block) => block.text)
+    .join('\n')
+    .trim();
+  if (!prompt) {
+    throw new Error('a non-empty text prompt is required');
+  }
+  if (Buffer.byteLength(prompt, 'utf8') > MAX_PROMPT_BYTES) {
+    throw new Error(`prompt exceeds the ${MAX_PROMPT_BYTES}-byte limit`);
+  }
+  return `${CONFINEMENT_NOTICE}\n\n${prompt}`;
+}
+
+async function linkIfPresent(source, destination) {
+  try {
+    await symlink(source, destination);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+}
+
+function boundedAppend(current, chunk, child) {
+  const next = current + chunk.toString('utf8');
+  if (Buffer.byteLength(next, 'utf8') > MAX_OUTPUT_BYTES) {
+    child.kill('SIGTERM');
+    throw new Error(`provider output exceeds the ${MAX_OUTPUT_BYTES}-byte limit`);
+  }
+  return next;
+}
+
+function runChild(binary, args, { cwd, env, session }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    session.child = child;
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      session.child = null;
+      callback();
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish(() => reject(new Error(`provider exceeded ${CHILD_TIMEOUT_MS}ms`)));
+    }, CHILD_TIMEOUT_MS);
+
+    child.stdout.on('data', (chunk) => {
+      try {
+        stdout = boundedAppend(stdout, chunk, child);
+      } catch (error) {
+        finish(() => reject(error));
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      try {
+        stderr = boundedAppend(stderr, chunk, child);
+      } catch (error) {
+        finish(() => reject(error));
+      }
+    });
+    child.on('error', (error) => finish(() => reject(error)));
+    child.on('close', (code, signal) => {
+      finish(() => {
+        const response = stdout.trim();
+        if (code === 0 && response) {
+          resolve(response);
+          return;
+        }
+        const detail = stderr.trim().slice(-500);
+        reject(
+          new Error(
+            `provider exited without a usable response (code=${code}, signal=${signal ?? 'none'})` +
+              (detail ? `: ${detail}` : ''),
+          ),
+        );
+      });
+    });
+  });
+}
+
+async function runAgy(options, prompt, session, workRoot) {
+  const appData = join(workRoot, 'agy-data');
+  await mkdir(appData, { recursive: true });
+  return runChild(
+    options.binary,
+    [
+      '-p',
+      prompt,
+      '--mode',
+      'plan',
+      '--sandbox',
+      '--disable-slash-commands',
+      '--print-timeout',
+      '5m',
+      '--output-format',
+      'text',
+      '--model',
+      options.model,
+      '--log-file',
+      join(workRoot, 'agy.log'),
+    ],
+    {
+      cwd: workRoot,
+      env: { ...process.env, AGY_APP_DATA_DIR: appData },
+      session,
+    },
+  );
+}
+
+async function runDeepSeek(options, prompt, session, workRoot) {
+  const hermesHome = join(workRoot, 'hermes-home');
+  await mkdir(hermesHome, { recursive: true });
+  await writeFile(
+    join(hermesHome, 'config.yaml'),
+    [
+      'model:',
+      '  provider: deepseek',
+      `  default: ${options.model}`,
+      'platform_toolsets:',
+      '  cli: []',
+      'fallback_providers: []',
+      'mcp_servers: {}',
+      'plugins:',
+      '  enabled: []',
+      '  disabled: []',
+      'hooks: []',
+      '',
+    ].join('\n'),
+    { encoding: 'utf8', mode: 0o600 },
+  );
+
+  const sourceHome = join(homedir(), '.hermes');
+  for (const name of ['.env', 'auth.json', 'auth.lock']) {
+    await linkIfPresent(join(sourceHome, name), join(hermesHome, name));
+  }
+
+  return runChild(
+    options.binary,
+    ['--ignore-rules', '-z', prompt, '-m', options.model, '--provider', 'deepseek'],
+    {
+      cwd: workRoot,
+      env: {
+        ...process.env,
+        HERMES_HOME: hermesHome,
+        HERMES_SAFE_MODE: '1',
+        HERMES_IGNORE_RULES: '1',
+      },
+      session,
+    },
+  );
+}
+
+const options = parseArgs(process.argv.slice(2));
+const sessions = new Map();
+
+const input = Writable.toWeb(process.stdout);
+const output = Readable.toWeb(process.stdin);
+const stream = acp.ndJsonStream(input, output);
+
+acp
+  .agent({ name: `learn-ukrainian-${options.provider}-text-agent` })
+  .onRequest(acp.methods.agent.initialize, () => ({
+    protocolVersion: acp.PROTOCOL_VERSION,
+    agentCapabilities: { loadSession: false },
+  }))
+  .onRequest(acp.methods.agent.session.new, () => {
+    const sessionId = globalThis.crypto.randomUUID();
+    sessions.set(sessionId, { child: null, prompted: false });
+    return { sessionId };
+  })
+  .onRequest(acp.methods.agent.authenticate, () => ({}))
+  .onRequest(acp.methods.agent.session.setMode, () => ({}))
+  .onRequest(acp.methods.agent.session.prompt, async (context) => {
+    const session = sessions.get(context.params.sessionId);
+    if (!session) throw new Error('unknown ACP session');
+    if (session.prompted) throw new Error('this text-only ACP session accepts one prompt');
+    session.prompted = true;
+    const prompt = textPrompt(context.params.prompt);
+    const workRoot = await mkdtemp(join(tmpdir(), `lu-acp-${options.provider}-`));
+    try {
+      const response =
+        options.provider === 'agy'
+          ? await runAgy(options, prompt, session, workRoot)
+          : await runDeepSeek(options, prompt, session, workRoot);
+      await context.client.notify(acp.methods.client.session.update, {
+        sessionId: context.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: response },
+        },
+      });
+      return { stopReason: 'end_turn' };
+    } finally {
+      await rm(workRoot, { recursive: true, force: true });
+    }
+  })
+  .onNotification(acp.methods.agent.session.cancel, (context) => {
+    sessions.get(context.params.sessionId)?.child?.kill('SIGTERM');
+  })
+  .connect(stream);

--- a/scripts/agent_runtime/acp_text_agent.mjs
+++ b/scripts/agent_runtime/acp_text_agent.mjs
@@ -21,6 +21,17 @@ import { Readable, Writable } from 'node:stream';
 const MAX_PROMPT_BYTES = 512 * 1024;
 const MAX_OUTPUT_BYTES = 2 * 1024 * 1024;
 const CHILD_TIMEOUT_MS = 270_000;
+const FORCE_KILL_GRACE_MS = 1_000;
+const CHILD_ENV_KEYS = [
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'NODE_EXTRA_CA_CERTS',
+  'PATH',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  'TMPDIR',
+];
 const CONFINEMENT_NOTICE = [
   'This is a bounded text-only advisory turn.',
   'Do not invoke tools, inspect files, browse, execute commands, or modify state.',
@@ -74,10 +85,29 @@ async function linkIfPresent(source, destination) {
   }
 }
 
-function boundedAppend(current, chunk, child) {
+function childBaseEnv() {
+  const env = {};
+  for (const name of CHILD_ENV_KEYS) {
+    if (process.env[name] != null) env[name] = process.env[name];
+  }
+  return env;
+}
+
+function signalProcessTree(child, signal) {
+  try {
+    if (process.platform !== 'win32' && child.pid != null) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
+function boundedAppend(current, chunk) {
   const next = current + chunk.toString('utf8');
   if (Buffer.byteLength(next, 'utf8') > MAX_OUTPUT_BYTES) {
-    child.kill('SIGTERM');
     throw new Error(`provider output exceeds the ${MAX_OUTPUT_BYTES}-byte limit`);
   }
   return next;
@@ -88,6 +118,7 @@ function runChild(binary, args, { cwd, env, session }) {
     const child = spawn(binary, args, {
       cwd,
       env,
+      detached: process.platform !== 'win32',
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -95,36 +126,53 @@ function runChild(binary, args, { cwd, env, session }) {
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let terminalError = null;
+    let forceKillTimer = null;
+    let timeoutTimer = null;
 
     const finish = (callback) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
       session.child = null;
+      session.terminate = null;
       callback();
     };
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      finish(() => reject(new Error(`provider exceeded ${CHILD_TIMEOUT_MS}ms`)));
+    const terminate = (error) => {
+      if (settled) return;
+      terminalError ??= error;
+      signalProcessTree(child, 'SIGTERM');
+      forceKillTimer ??= setTimeout(() => {
+        signalProcessTree(child, 'SIGKILL');
+      }, FORCE_KILL_GRACE_MS);
+    };
+    session.terminate = terminate;
+    timeoutTimer = setTimeout(() => {
+      terminate(new Error(`provider exceeded ${CHILD_TIMEOUT_MS}ms`));
     }, CHILD_TIMEOUT_MS);
 
     child.stdout.on('data', (chunk) => {
       try {
-        stdout = boundedAppend(stdout, chunk, child);
+        stdout = boundedAppend(stdout, chunk);
       } catch (error) {
-        finish(() => reject(error));
+        terminate(error);
       }
     });
     child.stderr.on('data', (chunk) => {
       try {
-        stderr = boundedAppend(stderr, chunk, child);
+        stderr = boundedAppend(stderr, chunk);
       } catch (error) {
-        finish(() => reject(error));
+        terminate(error);
       }
     });
     child.on('error', (error) => finish(() => reject(error)));
     child.on('close', (code, signal) => {
       finish(() => {
+        if (terminalError != null) {
+          reject(terminalError);
+          return;
+        }
         const response = stdout.trim();
         if (code === 0 && response) {
           resolve(response);
@@ -165,7 +213,7 @@ async function runAgy(options, prompt, session, workRoot) {
     ],
     {
       cwd: workRoot,
-      env: { ...process.env, AGY_APP_DATA_DIR: appData },
+      env: { ...childBaseEnv(), AGY_APP_DATA_DIR: appData },
       session,
     },
   );
@@ -204,7 +252,7 @@ async function runDeepSeek(options, prompt, session, workRoot) {
     {
       cwd: workRoot,
       env: {
-        ...process.env,
+        ...childBaseEnv(),
         HERMES_HOME: hermesHome,
         HERMES_SAFE_MODE: '1',
         HERMES_IGNORE_RULES: '1',
@@ -259,6 +307,8 @@ acp
     }
   })
   .onNotification(acp.methods.agent.session.cancel, (context) => {
-    sessions.get(context.params.sessionId)?.child?.kill('SIGTERM');
+    sessions
+      .get(context.params.sessionId)
+      ?.terminate?.(new Error('provider cancelled by ACP client'));
   })
   .connect(stream);

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -1,9 +1,9 @@
-"""ACPX experimental read-only shadow transport (#6027, #6043).
+"""ACPX bounded read-only transport (#6027, #6043, #6078, #6130, #6158).
 
 Wraps the project-local ``acpx@0.13.0`` headless CLI
 (https://www.npmjs.com/package/acpx) for the Agent Client Protocol (ACP).
 
-Two **separate** direct-only seats share this module:
+Direct-only seats in this module cover the fixed participant registry:
 
 - ``AcpxAdapter`` / ``acpx-codex-shadow`` (#6027) — fixed Codex participant
   via ``acpx … codex exec``
@@ -12,10 +12,13 @@ Two **separate** direct-only seats share this module:
   ``agent … --agent-profile <hash-pinned-no-tool-profile> --no-leader stdio``
   (never the built-in ``grok-build`` name, which cannot place parent flags
   before ``stdio``)
+- built-in ACP participants for Claude, Kimi, KimiCC K3, Cursor, and Pool
+- source-blind project ACP wrappers for AGY and DeepSeek
+- native OpenCode ACP for the Z.AI GLM subscription route
 
-Neither seat is registered for model selection, catalog, review eligibility,
-or failover (``cli_available: False``). They are not a second coordination
-plane: native Codex/Grok remain authoritative under shadow compare.
+No seat is registered for model selection, catalog, review eligibility, or
+failover (``cli_available: False``). They are not a second coordination plane:
+fleet-comms remains the durable authority and shadow comparison stays optional.
 
 Contract captured empirically from the pinned local ``acpx@0.13.0`` install
 (``node_modules/acpx``), not guessed:
@@ -63,7 +66,7 @@ any of these — a caller cannot pass permission/tool overrides through
 markers plus local correlation/idempotency metadata — and rejects anything
 else before spawn).
 
-Issues: #6027 (Codex pilot), #6043 (second Grok pilot).
+Issues: #6027, #6043, #6078, #6130, #6158.
 """
 
 from __future__ import annotations
@@ -83,7 +86,9 @@ from pathlib import Path
 from typing import Any
 
 from ..result import ParseResult
+from ..routes import deepseek_first_party_error, is_deepseek_first_party_forbidden_in_ci
 from .base import InvocationPlan
+from .glm import assert_glm_egress_allowed
 
 try:
     from scripts.guardrails import worktree_containment as _worktree_containment
@@ -100,15 +105,29 @@ except ImportError:  # pragma: no cover - stripped sys.path flavor
 
 _logger = logging.getLogger(__name__)
 
-# Env var gating the experimental transport. Anything other than exactly
-# "shadow" (including unset, "off", or an unrecognized value) refuses to
-# spawn. There is deliberately no "on"/"live" value in Stage 0/1 — this seat
-# is observability-only.
+# Env var gating the transport. ``shadow`` is the comparison path; ``active``
+# is accepted only inside the controller-owned context below. Unset, ``off``,
+# and unrecognized values refuse to spawn.
 TRANSPORT_ENV = "LU_ACPX_TRANSPORT"
 
 # Exact reviewed version. AC-PIN requires resolving ACPX at one exact
 # version with a deterministic preflight — never a floating "latest".
 PINNED_VERSION = "0.13.0"
+
+# Provider CLI versions validated with the text-only/native ACP participant
+# recipes introduced in #6158. These custom commands are part of the protocol
+# boundary, so an unreviewed CLI update fails before the prompt leaves ACPX.
+PINNED_AGY_VERSION = "1.1.9"
+PINNED_OPENCODE_VERSION = "1.17.13"
+PINNED_HERMES_VERSION = "0.18.2"
+AGY_ACP_MODEL = "gemini-3.6-flash-high"
+GLM_ACP_MODEL = "glm-5.2"
+GLM_ACP_INVOCATION_MODEL = "zai-coding-plan/glm-5.2"
+DEEPSEEK_ACP_MODEL = "deepseek-v4-pro"
+# OpenCode advertises its existing local login as ACP auth method
+# ``opencode-login``. ACPX maps that method ID deterministically to this
+# non-secret selector; the value is never a credential.
+GLM_AUTH_OPENCODE_LOGIN_ENV = "ACPX_AUTH_OPENCODE_LOGIN"
 
 # Project-local pinned binary. Deliberately NOT `shutil.which("acpx")`:
 # global/PATH resolution would let an unrelated or unreviewed global acpx
@@ -119,6 +138,12 @@ _DEFAULT_PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 # Keep this separately patchable for hermetic adapter tests.  An explicit
 # override is authoritative and must never silently fall back to another tree.
 _PINNED_BINARY = _DEFAULT_PINNED_BINARY
+_TEXT_AGENT_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "acp_text_agent.mjs"
+_OPENCODE_DENY_ALL_CONFIG = json.dumps(
+    {"permission": {"*": "deny"}, "tools": {"*": False}},
+    separators=(",", ":"),
+    sort_keys=True,
+)
 
 # Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
 # Built-in acpx ``grok-build`` is intentionally unused: it expands to
@@ -145,8 +170,8 @@ _GROK_XAI_API_KEY_ENV_UNSETS: tuple[str, ...] = (
 # tool_config allowlist. Anything outside this set is rejected before spawn
 # — this is the enforcement point for "unsupported permission/tool config"
 # in the approved reject-before-spawn list. No key here can loosen
-# confinement; each seat re-affirms its own fixed target_agent ("codex" or
-# "grok"). "correlation_id"/"idempotency_key" are local runtime metadata only
+# confinement; each seat re-affirms its own fixed target_agent.
+# "correlation_id"/"idempotency_key" are local runtime metadata only
 # (see _require_local_metadata_field): never forwarded to the ACP wire protocol.
 _ALLOWED_TOOL_CONFIG_KEYS = frozenset(
     {"acpx_shadow", "acpx_discussion", "target_agent", "correlation_id", "idempotency_key"}
@@ -165,6 +190,13 @@ ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},
     "cursor": {"seat": "acpx-cursor-shadow", "agent": "cursor", "model": None},
     "pool": {"seat": "acpx-pool-shadow", "agent": "pool", "model": None},
+    "agy": {"seat": "acpx-agy-shadow", "agent": "agy", "model": AGY_ACP_MODEL},
+    "glm": {"seat": "acpx-glm-shadow", "agent": "glm", "model": GLM_ACP_MODEL},
+    "deepseek": {
+        "seat": "acpx-deepseek-shadow",
+        "agent": "deepseek",
+        "model": DEEPSEEK_ACP_MODEL,
+    },
 }
 
 # Active ACPX is deliberately not a generally selectable adapter mode.  The
@@ -576,6 +608,103 @@ def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
     )
 
 
+_SEMVER_RE = re.compile(r"(?<!\d)(\d+\.\d+\.\d+)(?![\d.])")
+
+
+@lru_cache(maxsize=16)
+def _probe_participant_cli_version(binary: str) -> str:
+    """Return the first exact semver from ``<binary> --version``."""
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    match = _SEMVER_RE.search(f"{proc.stdout or ''}\n{proc.stderr or ''}")
+    return match.group(1) if match else ""
+
+
+def _resolve_participant_binary(
+    executable: str,
+    *,
+    adapter_label: str,
+    expected_version: str,
+) -> str:
+    """Resolve and version-check one provider CLI before constructing argv."""
+    found = shutil.which(executable)
+    if not found:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: {executable} binary not found on PATH; expected exact "
+            f"version {expected_version!r}"
+        )
+    resolved = Path(found).resolve()
+    if not resolved.is_file():
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: resolved {executable} path {resolved} is not a file"
+        )
+    observed = _probe_participant_cli_version(str(resolved))
+    if observed != expected_version:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: resolved {executable} binary reports version {observed!r} "
+            f"(expected pinned {expected_version!r}); refusing to spawn on a version mismatch"
+        )
+    return str(resolved)
+
+
+def _require_text_agent(*, adapter_label: str) -> str:
+    """Return the project-owned text ACP server path, or fail closed."""
+    if not _TEXT_AGENT_PATH.is_file():
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: required text-only ACP server missing at {_TEXT_AGENT_PATH}"
+        )
+    return str(_TEXT_AGENT_PATH)
+
+
+def _build_text_agent_command(
+    *,
+    adapter_label: str,
+    provider: str,
+    model: str,
+    executable: str,
+    expected_version: str,
+) -> tuple[str, str]:
+    """Return shell-safe custom ACP command plus observed provider binary."""
+    provider_binary = _resolve_participant_binary(
+        executable,
+        adapter_label=adapter_label,
+        expected_version=expected_version,
+    )
+    node_binary = shutil.which("node")
+    if not node_binary:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: node binary not found on PATH; required by the text ACP server"
+        )
+    node_path = Path(node_binary).resolve()
+    if not node_path.is_file():
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: resolved node path {node_path} is not a file"
+        )
+    command = shlex.join(
+        [
+            str(node_path),
+            _require_text_agent(adapter_label=adapter_label),
+            "--provider",
+            provider,
+            "--model",
+            model,
+            "--binary",
+            provider_binary,
+        ]
+    )
+    return command, provider_binary
+
+
 class AcpxAdapter:
     """Adapter for ``acpx codex exec`` — read-only, stateless, shadow-only.
 
@@ -872,19 +1001,36 @@ class AcpxAdapter:
         return ()
 
 
-class _AcpxBuiltinDiscussionAdapter:
-    """Shared implementation for one fixed built-in ACPX discussion seat.
+class _AcpxDiscussionAdapter:
+    """Shared implementation for one fixed ACPX discussion seat.
 
-    Subclasses set constants only; callers cannot choose an ACP participant,
-    permissions, session, or (where pinned) model through this base class.
+    A subclass either names one ACPX built-in or returns one reviewed custom
+    ACP command. Callers cannot choose a participant, permissions, session,
+    or pinned model through this base class.
     """
 
     name: str
     target_agent: str
     fixed_model: str | None = None
+    acpx_model: str | None = None
+    fixed_effort: str | None = None
+    forward_model_to_acpx: bool = True
     auth_env: str | None = None
     default_model: str = "acpx-built-in-default"
     supported_modes: frozenset[str] = frozenset({"read-only"})
+
+    def _custom_agent_command(self, cwd: Path) -> str | None:
+        _ = cwd
+        return None
+
+    def _env_overrides(self) -> dict[str, str]:
+        return {} if self.auth_env is None else {self.auth_env: "1"}
+
+    def _env_unsets(self) -> tuple[str, ...]:
+        return ()
+
+    def _extra_metadata(self) -> dict[str, Any]:
+        return {}
 
     def build_invocation(
         self,
@@ -912,6 +1058,11 @@ class _AcpxBuiltinDiscussionAdapter:
                 f"{type(self).__name__}: model={model!r} rejected; caller may only pass None "
                 f"or {self.fixed_model!r}"
             )
+        if self.fixed_effort is not None and effort not in {None, self.fixed_effort}:
+            raise AcpxShadowRefusalError(
+                f"{type(self).__name__}: effort={effort!r} rejected; caller may only pass None "
+                f"or {self.fixed_effort!r}"
+            )
         if session_id is not None:
             raise AcpxShadowRefusalError(
                 f"{type(self).__name__}: session_id must be None; this seat is one-shot `exec` only"
@@ -928,9 +1079,13 @@ class _AcpxBuiltinDiscussionAdapter:
         _require_non_primary_worktree(cwd, adapter_label=type(self).__name__)
         binary = _require_pinned_acpx_binary(adapter_label=type(self).__name__, cwd=cwd)
         cmd = _confinement_prefix_argv(binary, cwd)
-        if self.fixed_model is not None:
-            cmd.extend(["--model", self.fixed_model])
-        cmd.extend([self.target_agent, "exec", "-f", "-"])
+        if self.fixed_model is not None and self.forward_model_to_acpx:
+            cmd.extend(["--model", self.acpx_model or self.fixed_model])
+        custom_agent = self._custom_agent_command(cwd)
+        if custom_agent is None:
+            cmd.extend([self.target_agent, "exec", "-f", "-"])
+        else:
+            cmd.extend(["--agent", custom_agent, "exec", "-f", "-"])
         metadata: dict[str, Any] = {
             "acpx_discussion": True,
             "acpx_pinned_version": PINNED_VERSION,
@@ -941,14 +1096,18 @@ class _AcpxBuiltinDiscussionAdapter:
         }
         if self.fixed_model is not None:
             metadata["model"] = self.fixed_model
-        if effort is not None:
+        if self.fixed_effort is not None:
+            metadata["effort"] = self.fixed_effort
+        metadata.update(self._extra_metadata())
+        if effort is not None and self.fixed_effort is None:
             _logger.debug("%s: effort=%r has no ACPX flag equivalent; ignoring", type(self).__name__, effort)
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
             stdin_payload=prompt,
             output_file=None,
-            env_overrides={} if self.auth_env is None else {self.auth_env: "1"},
+            env_overrides=self._env_overrides(),
+            env_unsets=self._env_unsets(),
             liveness_paths=(),
             metadata=metadata,
         )
@@ -962,18 +1121,18 @@ class _AcpxBuiltinDiscussionAdapter:
         return ()
 
 
-class AcpxClaudeShadowAdapter(_AcpxBuiltinDiscussionAdapter):
+class AcpxClaudeShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-claude-shadow"
     target_agent = "claude"
 
 
-class AcpxKimiShadowAdapter(_AcpxBuiltinDiscussionAdapter):
+class AcpxKimiShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-kimi-shadow"
     target_agent = "kimi"
     auth_env = "ACPX_AUTH_LOGIN"
 
 
-class AcpxKimiCcShadowAdapter(_AcpxBuiltinDiscussionAdapter):
+class AcpxKimiCcShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-kimicc-shadow"
     target_agent = "kimi"
     fixed_model = "kimi-code/k3"
@@ -981,15 +1140,115 @@ class AcpxKimiCcShadowAdapter(_AcpxBuiltinDiscussionAdapter):
     auth_env = "ACPX_AUTH_LOGIN"
 
 
-class AcpxCursorShadowAdapter(_AcpxBuiltinDiscussionAdapter):
+class AcpxCursorShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-cursor-shadow"
     target_agent = "cursor"
     auth_env = "ACPX_AUTH_CURSOR_LOGIN"
 
 
-class AcpxPoolShadowAdapter(_AcpxBuiltinDiscussionAdapter):
+class AcpxPoolShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-pool-shadow"
     target_agent = "pool"
+
+
+class AcpxAgyShadowAdapter(_AcpxDiscussionAdapter):
+    """Text-only AGY/Gemini-family ACP participant (#6158)."""
+
+    name = "acpx-agy-shadow"
+    target_agent = "agy"
+    fixed_model = AGY_ACP_MODEL
+    default_model = fixed_model
+    fixed_effort = "high"
+    forward_model_to_acpx = False
+
+    def _custom_agent_command(self, cwd: Path) -> str:
+        _ = cwd
+        command, _binary = _build_text_agent_command(
+            adapter_label=type(self).__name__,
+            provider="agy",
+            model=AGY_ACP_MODEL,
+            executable="agy",
+            expected_version=PINNED_AGY_VERSION,
+        )
+        return command
+
+    def _extra_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_cli": "agy",
+            "provider_cli_pinned_version": PINNED_AGY_VERSION,
+            "text_only_adapter": True,
+        }
+
+
+class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
+    """Native OpenCode ACP participant pinned to the Z.AI GLM subscription."""
+
+    name = "acpx-glm-shadow"
+    target_agent = "glm"
+    fixed_model = GLM_ACP_MODEL
+    acpx_model = GLM_ACP_INVOCATION_MODEL
+    default_model = fixed_model
+
+    def _custom_agent_command(self, cwd: Path) -> str:
+        _ = cwd
+        assert_glm_egress_allowed(type(self).__name__)
+        binary = _resolve_participant_binary(
+            "opencode",
+            adapter_label=type(self).__name__,
+            expected_version=PINNED_OPENCODE_VERSION,
+        )
+        return shlex.join([binary, "acp", "--pure"])
+
+    def _env_overrides(self) -> dict[str, str]:
+        return {
+            GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
+            "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
+        }
+
+    def _extra_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_cli": "opencode",
+            "provider_cli_pinned_version": PINNED_OPENCODE_VERSION,
+            "provider_route": GLM_ACP_INVOCATION_MODEL,
+            "tool_policy": "deny-all",
+        }
+
+
+class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
+    """Text-only, first-party DeepSeek ACP participant via isolated Hermes."""
+
+    name = "acpx-deepseek-shadow"
+    target_agent = "deepseek"
+    fixed_model = DEEPSEEK_ACP_MODEL
+    default_model = fixed_model
+    forward_model_to_acpx = False
+
+    def _custom_agent_command(self, cwd: Path) -> str:
+        _ = cwd
+        if is_deepseek_first_party_forbidden_in_ci("deepseek", DEEPSEEK_ACP_MODEL):
+            raise AcpxShadowRefusalError(
+                deepseek_first_party_error(
+                    provider="deepseek",
+                    model=DEEPSEEK_ACP_MODEL,
+                    source=type(self).__name__,
+                )
+            )
+        command, _binary = _build_text_agent_command(
+            adapter_label=type(self).__name__,
+            provider="deepseek",
+            model=DEEPSEEK_ACP_MODEL,
+            executable="hermes",
+            expected_version=PINNED_HERMES_VERSION,
+        )
+        return command
+
+    def _extra_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_cli": "hermes",
+            "provider_cli_pinned_version": PINNED_HERMES_VERSION,
+            "provider_route": "deepseek",
+            "text_only_adapter": True,
+        }
 
 
 class AcpxGrokShadowAdapter:

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -139,6 +139,7 @@ _DEFAULT_PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 # override is authoritative and must never silently fall back to another tree.
 _PINNED_BINARY = _DEFAULT_PINNED_BINARY
 _TEXT_AGENT_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "acp_text_agent.mjs"
+_TEXT_AGENT_SHA256 = "42761e2bd9ab0e66f5e5779826777b46bd0761cc4673e13285e1fc37418ea679"
 _OPENCODE_DENY_ALL_CONFIG = json.dumps(
     {"permission": {"*": "deny"}, "tools": {"*": False}},
     separators=(",", ":"),
@@ -608,12 +609,16 @@ def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
     )
 
 
-_SEMVER_RE = re.compile(r"(?<!\d)(\d+\.\d+\.\d+)(?![\d.])")
+_PROVIDER_VERSION_PATTERNS = {
+    "agy": re.compile(r"^\s*(\d+\.\d+\.\d+)\s*$", re.MULTILINE),
+    "opencode": re.compile(r"^\s*(\d+\.\d+\.\d+)\s*$", re.MULTILINE),
+    "hermes": re.compile(r"^\s*Hermes Agent v(\d+\.\d+\.\d+)(?:\s|$)", re.MULTILINE),
+}
 
 
 @lru_cache(maxsize=16)
-def _probe_participant_cli_version(binary: str) -> str:
-    """Return the first exact semver from ``<binary> --version``."""
+def _probe_participant_cli_version(binary: str, executable: str) -> str:
+    """Return a version anchored to the reviewed provider output format."""
     try:
         proc = subprocess.run(
             [binary, "--version"],
@@ -626,7 +631,10 @@ def _probe_participant_cli_version(binary: str) -> str:
         return ""
     if proc.returncode != 0:
         return ""
-    match = _SEMVER_RE.search(f"{proc.stdout or ''}\n{proc.stderr or ''}")
+    pattern = _PROVIDER_VERSION_PATTERNS.get(executable)
+    if pattern is None:
+        return ""
+    match = pattern.search(f"{proc.stdout or ''}\n{proc.stderr or ''}")
     return match.group(1) if match else ""
 
 
@@ -648,7 +656,7 @@ def _resolve_participant_binary(
         raise AcpxShadowRefusalError(
             f"{adapter_label}: resolved {executable} path {resolved} is not a file"
         )
-    observed = _probe_participant_cli_version(str(resolved))
+    observed = _probe_participant_cli_version(str(resolved), executable)
     if observed != expected_version:
         raise AcpxShadowRefusalError(
             f"{adapter_label}: resolved {executable} binary reports version {observed!r} "
@@ -662,6 +670,17 @@ def _require_text_agent(*, adapter_label: str) -> str:
     if not _TEXT_AGENT_PATH.is_file():
         raise AcpxShadowRefusalError(
             f"{adapter_label}: required text-only ACP server missing at {_TEXT_AGENT_PATH}"
+        )
+    try:
+        observed = hashlib.sha256(_TEXT_AGENT_PATH.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: unable to read text-only ACP server at {_TEXT_AGENT_PATH}: {exc}"
+        ) from exc
+    if observed != _TEXT_AGENT_SHA256:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: text-only ACP server digest mismatch; refusing unreviewed "
+            "confinement code"
         )
     return str(_TEXT_AGENT_PATH)
 

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -128,6 +128,15 @@ _PROVIDER_SAFE_NAME_ALLOWLIST = {
         # Non-secret acpx auth-method selector for the existing Cursor login.
         "ACPX_AUTH_CURSOR_LOGIN",
     },
+    "acpx-glm-shadow": {
+        # Non-secret selector for OpenCode's advertised ACP method ID
+        # ``opencode-login``. The literal value is constrained to ``1`` by
+        # build_agent_env below and carries no credential material.
+        "ACPX_AUTH_OPENCODE_LOGIN",
+        # Fixed non-secret OpenCode policy JSON: all tools and permissions are
+        # denied for the native ACP participant.
+        "OPENCODE_CONFIG_CONTENT",
+    },
     "gemini": {
         "GEMINI_AUTH_MODE",
     },

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -349,6 +349,33 @@ AGENTS: dict[str, AgentEntry] = {
         "direct_only": True,
         "resume_policy": "never",
     },
+    "acpx-agy-shadow": {
+        "adapter": "scripts.agent_runtime.adapters.acpx:AcpxAgyShadowAdapter",
+        "default_model": "gemini-3.6-flash-high",
+        "cost_tier": "unknown",
+        "capabilities": frozenset(),
+        "cli_available": False,
+        "direct_only": True,
+        "resume_policy": "never",
+    },
+    "acpx-glm-shadow": {
+        "adapter": "scripts.agent_runtime.adapters.acpx:AcpxGlmShadowAdapter",
+        "default_model": "glm-5.2",
+        "cost_tier": "unknown",
+        "capabilities": frozenset(),
+        "cli_available": False,
+        "direct_only": True,
+        "resume_policy": "never",
+    },
+    "acpx-deepseek-shadow": {
+        "adapter": "scripts.agent_runtime.adapters.acpx:AcpxDeepSeekShadowAdapter",
+        "default_model": "deepseek-v4-pro",
+        "cost_tier": "unknown",
+        "capabilities": frozenset(),
+        "cli_available": False,
+        "direct_only": True,
+        "resume_policy": "never",
+    },
     "agy": {
         # Antigravity CLI shipping Gemini Flash 3.6 (was 3.5) on a separate meter from
         # gemini-cli. Added 2026-05-20 for the seminar-writer ADR bakeoff

--- a/tests/agent_runtime/test_acp_text_agent.py
+++ b/tests/agent_runtime/test_acp_text_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import selectors
+import shlex
 import shutil
 import subprocess
 import time
@@ -38,16 +39,15 @@ def _request(process: subprocess.Popen[str], payload: dict) -> None:
     process.stdin.flush()
 
 
-def _run_protocol(tmp_path: Path, *, provider: str, model: str, binary: Path) -> tuple[str, str]:
+def _launch_server(
+    *, provider: str, model: str, binary: Path, extra_env: dict[str, str] | None = None
+) -> subprocess.Popen[str]:
     node = shutil.which("node")
     if node is None:
         pytest.skip("node is required for the ACP protocol test")
-    capture = tmp_path / f"{provider}-capture.txt"
-    config_capture = tmp_path / f"{provider}-config.yaml"
     env = dict(os.environ)
-    env["LU_ACP_FAKE_CAPTURE"] = str(capture)
-    env["LU_ACP_FAKE_CONFIG_CAPTURE"] = str(config_capture)
-    process = subprocess.Popen(
+    env.update(extra_env or {})
+    return subprocess.Popen(
         [
             node,
             str(_SERVER),
@@ -66,34 +66,47 @@ def _run_protocol(tmp_path: Path, *, provider: str, model: str, binary: Path) ->
         text=True,
         bufsize=1,
     )
-    try:
-        _request(
-            process,
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": 1,
-                    "clientCapabilities": {},
-                    "clientInfo": {"name": "pytest", "version": "1"},
-                },
-            },
-        )
-        initialized = _read_json_line(process)
-        assert initialized["id"] == 1
-        assert initialized["result"]["protocolVersion"] == 1
 
-        _request(
-            process,
-            {
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "session/new",
-                "params": {"cwd": str(_ROOT), "mcpServers": []},
+
+def _initialize_session(process: subprocess.Popen[str]) -> str:
+    _request(
+        process,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+                "clientCapabilities": {},
+                "clientInfo": {"name": "pytest", "version": "1"},
             },
-        )
-        session = _read_json_line(process)["result"]["sessionId"]
+        },
+    )
+    initialized = _read_json_line(process)
+    assert initialized["id"] == 1
+    assert initialized["result"]["protocolVersion"] == 1
+    _request(
+        process,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {"cwd": str(_ROOT), "mcpServers": []},
+        },
+    )
+    return _read_json_line(process)["result"]["sessionId"]
+
+
+def _run_protocol(tmp_path: Path, *, provider: str, model: str, binary: Path) -> tuple[str, str]:
+    capture = tmp_path / f"{binary.name}-capture.txt"
+    process = _launch_server(
+        provider=provider,
+        model=model,
+        binary=binary,
+        extra_env={"UNRELATED_API_KEY": "must-not-reach-provider"},
+    )
+    try:
+        session = _initialize_session(process)
         _request(
             process,
             {
@@ -135,11 +148,13 @@ def _run_protocol(tmp_path: Path, *, provider: str, model: str, binary: Path) ->
 
 def _fake_binary(tmp_path: Path, name: str, response: str) -> Path:
     binary = tmp_path / name
+    capture = shlex.quote(str(tmp_path / f"{name}-capture.txt"))
+    config_capture = shlex.quote(str(tmp_path / f"{name}-config.yaml"))
     binary.write_text(
         "#!/bin/sh\n"
-        "printf '%s\\n' \"$PWD|${AGY_APP_DATA_DIR:-}|${HERMES_HOME:-}|$*\" > \"$LU_ACP_FAKE_CAPTURE\"\n"
+        f"printf '%s\\n' \"$PWD|${{AGY_APP_DATA_DIR:-}}|${{HERMES_HOME:-}}|$*|${{UNRELATED_API_KEY:-}}\" > {capture}\n"
         "if [ -n \"${HERMES_HOME:-}\" ]; then\n"
-        "  /bin/cp \"$HERMES_HOME/config.yaml\" \"$LU_ACP_FAKE_CONFIG_CAPTURE\"\n"
+        f"  /bin/cp \"$HERMES_HOME/config.yaml\" {config_capture}\n"
         "fi\n"
         f"printf '%s' {json.dumps(response)}\n",
         encoding="utf-8",
@@ -156,7 +171,7 @@ def test_agy_text_agent_is_source_blind_sandboxed_and_ephemeral(tmp_path):
         model="gemini-3.6-flash-high",
         binary=binary,
     )
-    cwd, app_data, hermes_home, args = capture.strip().split("|", 3)
+    cwd, app_data, hermes_home, args, unrelated_secret = capture.strip().split("|", 4)
     assert response == "agy fake response"
     assert cwd != str(_ROOT)
     assert not Path(cwd).exists()
@@ -167,6 +182,7 @@ def test_agy_text_agent_is_source_blind_sandboxed_and_ephemeral(tmp_path):
     assert "--sandbox" in args
     assert "--disable-slash-commands" in args
     assert "--dangerously-skip-permissions" not in args
+    assert unrelated_secret == ""
 
 
 def test_deepseek_text_agent_has_empty_tools_no_fallbacks_and_ephemeral_home(tmp_path):
@@ -177,7 +193,7 @@ def test_deepseek_text_agent_has_empty_tools_no_fallbacks_and_ephemeral_home(tmp
         model="deepseek-v4-pro",
         binary=binary,
     )
-    cwd, app_data, hermes_home, args = capture.strip().split("|", 3)
+    cwd, app_data, hermes_home, args, unrelated_secret = capture.strip().split("|", 4)
     assert response == "deepseek fake response"
     assert cwd != str(_ROOT)
     assert app_data == ""
@@ -185,7 +201,66 @@ def test_deepseek_text_agent_has_empty_tools_no_fallbacks_and_ephemeral_home(tmp
     assert not Path(hermes_home).exists()
     assert "--ignore-rules -z" in args
     assert "-m deepseek-v4-pro --provider deepseek" in args
-    config = (tmp_path / "deepseek-config.yaml").read_text(encoding="utf-8")
+    config = (tmp_path / "hermes-config.yaml").read_text(encoding="utf-8")
     assert "platform_toolsets:\n  cli: []" in config
     assert "fallback_providers: []" in config
     assert "mcp_servers: {}" in config
+    assert unrelated_secret == ""
+
+
+def test_cancel_force_kills_provider_process_group_before_cleanup(tmp_path):
+    binary = tmp_path / "agy"
+    capture = tmp_path / "cancel-capture.txt"
+    binary.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$$|$PWD\" > {shlex.quote(str(capture))}\n"
+        "trap '' TERM\n"
+        "while :; do sleep 30; done\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    process = _launch_server(provider="agy", model="gemini-3.6-flash-high", binary=binary)
+    try:
+        session = _initialize_session(process)
+        _request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session,
+                    "prompt": [{"type": "text", "text": "Wait."}],
+                },
+            },
+        )
+        deadline = time.monotonic() + 3
+        while not capture.is_file() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert capture.is_file()
+        child_pid_text, child_cwd = capture.read_text(encoding="utf-8").strip().split("|", 1)
+        child_pid = int(child_pid_text)
+        started = time.monotonic()
+        _request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/cancel",
+                "params": {"sessionId": session},
+            },
+        )
+        cancelled = _read_json_line(process, timeout=5)
+        assert cancelled["id"] == 3
+        assert "error" in cancelled
+        assert time.monotonic() - started < 3
+        assert not Path(child_cwd).exists()
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
+    finally:
+        if process.stdin:
+            process.stdin.close()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.wait(timeout=5)

--- a/tests/agent_runtime/test_acp_text_agent.py
+++ b/tests/agent_runtime/test_acp_text_agent.py
@@ -1,0 +1,191 @@
+"""Protocol and confinement tests for the project-owned text ACP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SERVER = _ROOT / "scripts" / "agent_runtime" / "acp_text_agent.mjs"
+
+
+def _read_json_line(process: subprocess.Popen[str], timeout: float = 10.0) -> dict:
+    selector = selectors.DefaultSelector()
+    assert process.stdout is not None
+    selector.register(process.stdout, selectors.EVENT_READ)
+    try:
+        ready = selector.select(timeout)
+        if not ready:
+            stderr = process.stderr.read() if process.poll() is not None and process.stderr else ""
+            raise AssertionError(f"timed out waiting for ACP output; stderr={stderr!r}")
+        line = process.stdout.readline()
+    finally:
+        selector.close()
+    assert line, f"ACP server exited early with code {process.poll()}"
+    return json.loads(line)
+
+
+def _request(process: subprocess.Popen[str], payload: dict) -> None:
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+
+
+def _run_protocol(tmp_path: Path, *, provider: str, model: str, binary: Path) -> tuple[str, str]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the ACP protocol test")
+    capture = tmp_path / f"{provider}-capture.txt"
+    config_capture = tmp_path / f"{provider}-config.yaml"
+    env = dict(os.environ)
+    env["LU_ACP_FAKE_CAPTURE"] = str(capture)
+    env["LU_ACP_FAKE_CONFIG_CAPTURE"] = str(config_capture)
+    process = subprocess.Popen(
+        [
+            node,
+            str(_SERVER),
+            "--provider",
+            provider,
+            "--model",
+            model,
+            "--binary",
+            str(binary),
+        ],
+        cwd=_ROOT,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        _request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "1"},
+                },
+            },
+        )
+        initialized = _read_json_line(process)
+        assert initialized["id"] == 1
+        assert initialized["result"]["protocolVersion"] == 1
+
+        _request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(_ROOT), "mcpServers": []},
+            },
+        )
+        session = _read_json_line(process)["result"]["sessionId"]
+        _request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session,
+                    "prompt": [{"type": "text", "text": "Give one sentence."}],
+                },
+            },
+        )
+
+        response = ""
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            message = _read_json_line(process, timeout=max(0.1, deadline - time.monotonic()))
+            if message.get("method") == "session/update":
+                update = message["params"]["update"]
+                if update.get("sessionUpdate") == "agent_message_chunk":
+                    response += update["content"]["text"]
+            if message.get("id") == 3:
+                assert message["result"]["stopReason"] == "end_turn"
+                break
+        else:  # pragma: no cover - defensive deadline branch
+            raise AssertionError("prompt response never completed")
+
+        assert capture.is_file()
+        return response, capture.read_text(encoding="utf-8")
+    finally:
+        if process.stdin:
+            process.stdin.close()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.wait(timeout=5)
+
+
+def _fake_binary(tmp_path: Path, name: str, response: str) -> Path:
+    binary = tmp_path / name
+    binary.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$PWD|${AGY_APP_DATA_DIR:-}|${HERMES_HOME:-}|$*\" > \"$LU_ACP_FAKE_CAPTURE\"\n"
+        "if [ -n \"${HERMES_HOME:-}\" ]; then\n"
+        "  /bin/cp \"$HERMES_HOME/config.yaml\" \"$LU_ACP_FAKE_CONFIG_CAPTURE\"\n"
+        "fi\n"
+        f"printf '%s' {json.dumps(response)}\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    return binary
+
+
+def test_agy_text_agent_is_source_blind_sandboxed_and_ephemeral(tmp_path):
+    binary = _fake_binary(tmp_path, "agy", "agy fake response")
+    response, capture = _run_protocol(
+        tmp_path,
+        provider="agy",
+        model="gemini-3.6-flash-high",
+        binary=binary,
+    )
+    cwd, app_data, hermes_home, args = capture.strip().split("|", 3)
+    assert response == "agy fake response"
+    assert cwd != str(_ROOT)
+    assert not Path(cwd).exists()
+    assert Path(app_data).resolve().is_relative_to(Path(cwd).resolve())
+    assert not Path(app_data).exists()
+    assert hermes_home == ""
+    assert "--mode plan" in args
+    assert "--sandbox" in args
+    assert "--disable-slash-commands" in args
+    assert "--dangerously-skip-permissions" not in args
+
+
+def test_deepseek_text_agent_has_empty_tools_no_fallbacks_and_ephemeral_home(tmp_path):
+    binary = _fake_binary(tmp_path, "hermes", "deepseek fake response")
+    response, capture = _run_protocol(
+        tmp_path,
+        provider="deepseek",
+        model="deepseek-v4-pro",
+        binary=binary,
+    )
+    cwd, app_data, hermes_home, args = capture.strip().split("|", 3)
+    assert response == "deepseek fake response"
+    assert cwd != str(_ROOT)
+    assert app_data == ""
+    assert Path(hermes_home).resolve().is_relative_to(Path(cwd).resolve())
+    assert not Path(hermes_home).exists()
+    assert "--ignore-rules -z" in args
+    assert "-m deepseek-v4-pro --provider deepseek" in args
+    config = (tmp_path / "deepseek-config.yaml").read_text(encoding="utf-8")
+    assert "platform_toolsets:\n  cli: []" in config
+    assert "fallback_providers: []" in config
+    assert "mcp_servers: {}" in config

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1595,7 +1595,11 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
         path.chmod(0o755)
         binaries[name] = str(path)
     monkeypatch.setattr(acpx_module.shutil, "which", lambda name: binaries.get(name))
-    monkeypatch.setattr(acpx_module, "_probe_participant_cli_version", lambda _path: version)
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_participant_cli_version",
+        lambda _path, _executable: version,
+    )
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
     monkeypatch.delenv("CI", raising=False)
 
@@ -1659,7 +1663,11 @@ def test_new_fleet_discussion_seat_rejects_provider_cli_version_drift(tmp_path, 
         "which",
         lambda name: str({"agy": agy, "node": node}[name]),
     )
-    monkeypatch.setattr(acpx_module, "_probe_participant_cli_version", lambda _path: "9.9.9")
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_participant_cli_version",
+        lambda _path, _executable: "9.9.9",
+    )
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
 
     with acpx_module.active_discussion_scope(), pytest.raises(
@@ -1684,12 +1692,22 @@ def test_new_fleet_discussion_seat_rejects_provider_cli_version_drift(tmp_path, 
 def test_participant_version_probe_accepts_v_prefix_before_build_stamp(tmp_path):
     binary = tmp_path / "hermes"
     binary.write_text(
-        "#!/bin/sh\nprintf '%s\\n' 'Hermes Agent v0.18.2 (2026.7.7.2)'\n",
+        "#!/bin/sh\nprintf '%s\\n' 'Python 3.11.15' "
+        "'Hermes Agent v0.18.2 (2026.7.7.2)'\n",
         encoding="utf-8",
     )
     binary.chmod(0o755)
 
-    assert acpx_module._probe_participant_cli_version(str(binary)) == "0.18.2"
+    assert acpx_module._probe_participant_cli_version(str(binary), "hermes") == "0.18.2"
+
+
+def test_text_agent_digest_mismatch_refuses_before_spawn(tmp_path, monkeypatch):
+    text_agent = tmp_path / "acp_text_agent.mjs"
+    text_agent.write_text("unreviewed confinement change\n", encoding="utf-8")
+    monkeypatch.setattr(acpx_module, "_TEXT_AGENT_PATH", text_agent)
+
+    with pytest.raises(AcpxShadowRefusalError, match="digest mismatch"):
+        acpx_module._require_text_agent(adapter_label="AcpxAgyShadowAdapter")
 
 
 def test_build_grok_agent_command_quotes_absolute_paths_with_spaces(tmp_path):

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -28,8 +28,11 @@ from scripts.agent_runtime.adapters import acpx as acpx_module
 from scripts.agent_runtime.adapters.acpx import (
     ACPX_SUPPORTED_PARTICIPANTS,
     AcpxAdapter,
+    AcpxAgyShadowAdapter,
     AcpxClaudeShadowAdapter,
     AcpxCursorShadowAdapter,
+    AcpxDeepSeekShadowAdapter,
+    AcpxGlmShadowAdapter,
     AcpxGrokShadowAdapter,
     AcpxKimiCcShadowAdapter,
     AcpxKimiShadowAdapter,
@@ -1559,7 +1562,134 @@ def test_supported_participant_registry_has_only_fixed_direct_seats():
         "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},
         "cursor": {"seat": "acpx-cursor-shadow", "agent": "cursor", "model": None},
         "pool": {"seat": "acpx-pool-shadow", "agent": "pool", "model": None},
+        "agy": {
+            "seat": "acpx-agy-shadow",
+            "agent": "agy",
+            "model": "gemini-3.6-flash-high",
+        },
+        "glm": {"seat": "acpx-glm-shadow", "agent": "glm", "model": "glm-5.2"},
+        "deepseek": {
+            "seat": "acpx-deepseek-shadow",
+            "agent": "deepseek",
+            "model": "deepseek-v4-pro",
+        },
     }
+
+
+@pytest.mark.parametrize(
+    ("adapter_class", "participant", "provider_binary", "version", "model"),
+    [
+        (AcpxAgyShadowAdapter, "agy", "agy", "1.1.9", "gemini-3.6-flash-high"),
+        (AcpxGlmShadowAdapter, "glm", "opencode", "1.17.13", "glm-5.2"),
+        (AcpxDeepSeekShadowAdapter, "deepseek", "hermes", "0.18.2", "deepseek-v4-pro"),
+    ],
+)
+def test_new_fleet_discussion_seats_use_fixed_confined_commands(
+    tmp_path, monkeypatch, adapter_class, participant, provider_binary, version, model
+):
+    _stub_binary(monkeypatch, tmp_path)
+    binaries = {}
+    for name in ("node", provider_binary):
+        path = tmp_path / name
+        path.write_text("#!/bin/sh\n", encoding="utf-8")
+        path.chmod(0o755)
+        binaries[name] = str(path)
+    monkeypatch.setattr(acpx_module.shutil, "which", lambda name: binaries.get(name))
+    monkeypatch.setattr(acpx_module, "_probe_participant_cli_version", lambda _path: version)
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+    monkeypatch.delenv("CI", raising=False)
+
+    adapter = adapter_class()
+    with acpx_module.active_discussion_scope():
+        plan = adapter.build_invocation(
+            prompt="ping",
+            mode="read-only",
+            cwd=tmp_path,
+            model=model,
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": participant,
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+    assert adapter.name == f"acpx-{participant}-shadow"
+    assert "--agent" in plan.cmd
+    command = plan.cmd[plan.cmd.index("--agent") + 1]
+    command_tokens = shlex.split(command)
+    assert command_tokens[0] == binaries[provider_binary if participant == "glm" else "node"]
+    assert provider_binary in " ".join(command_tokens)
+    assert plan.cmd[-3:] == ["exec", "-f", "-"]
+    assert plan.metadata["model"] == model
+    assert plan.metadata["provider_cli_pinned_version"] == version
+    assert "--deny-all" in plan.cmd
+    assert "--no-fs" in plan.cmd
+    assert "--no-terminal" in plan.cmd
+    if participant == "glm":
+        assert ("--model", "zai-coding-plan/glm-5.2") in zip(
+            plan.cmd, plan.cmd[1:], strict=False
+        )
+        assert plan.env_overrides == {
+            "ACPX_AUTH_OPENCODE_LOGIN": "1",
+            "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}'
+        }
+        assert build_agent_env(provider=adapter.name, overrides=plan.env_overrides)[
+            "ACPX_AUTH_OPENCODE_LOGIN"
+        ] == "1"
+        assert build_agent_env(provider=adapter.name, overrides=plan.env_overrides)[
+            "OPENCODE_CONFIG_CONTENT"
+        ] == plan.env_overrides["OPENCODE_CONFIG_CONTENT"]
+    else:
+        assert "--model" not in plan.cmd
+        assert plan.env_overrides == {}
+
+
+def test_new_fleet_discussion_seat_rejects_provider_cli_version_drift(tmp_path, monkeypatch):
+    _stub_binary(monkeypatch, tmp_path)
+    agy = tmp_path / "agy"
+    node = tmp_path / "node"
+    for path in (agy, node):
+        path.write_text("#!/bin/sh\n", encoding="utf-8")
+        path.chmod(0o755)
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str({"agy": agy, "node": node}[name]),
+    )
+    monkeypatch.setattr(acpx_module, "_probe_participant_cli_version", lambda _path: "9.9.9")
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+
+    with acpx_module.active_discussion_scope(), pytest.raises(
+        AcpxShadowRefusalError, match="version mismatch"
+    ):
+        AcpxAgyShadowAdapter().build_invocation(
+            prompt="ping",
+            mode="read-only",
+            cwd=tmp_path,
+            model="gemini-3.6-flash-high",
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": "agy",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+
+def test_participant_version_probe_accepts_v_prefix_before_build_stamp(tmp_path):
+    binary = tmp_path / "hermes"
+    binary.write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'Hermes Agent v0.18.2 (2026.7.7.2)'\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+
+    assert acpx_module._probe_participant_cli_version(str(binary)) == "0.18.2"
 
 
 def test_build_grok_agent_command_quotes_absolute_paths_with_spaces(tmp_path):

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1601,7 +1601,8 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
         lambda _path, _executable: version,
     )
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
-    monkeypatch.delenv("CI", raising=False)
+    for name in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "JENKINS_URL"):
+        monkeypatch.delenv(name, raising=False)
 
     adapter = adapter_class()
     with acpx_module.active_discussion_scope():

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -201,7 +201,10 @@ def test_registry_has_known_agents():
         "acpx-claude-shadow",
         "acpx-codex-shadow",
         "acpx-cursor-shadow",
+        "acpx-deepseek-shadow",
+        "acpx-glm-shadow",
         "acpx-grok-shadow",
+        "acpx-agy-shadow",
         "acpx-kimi-shadow",
         "acpx-kimicc-shadow",
         "acpx-pool-shadow",
@@ -289,6 +292,37 @@ def test_acpx_grok_shadow_entry_is_direct_only():
     assert entry["resume_policy"] == "never"
     assert entry["capabilities"] == frozenset()
     assert "acpx-grok-shadow" not in available_agents()
+
+
+@pytest.mark.parametrize(
+    ("seat", "adapter", "model"),
+    [
+        (
+            "acpx-agy-shadow",
+            "scripts.agent_runtime.adapters.acpx:AcpxAgyShadowAdapter",
+            "gemini-3.6-flash-high",
+        ),
+        (
+            "acpx-glm-shadow",
+            "scripts.agent_runtime.adapters.acpx:AcpxGlmShadowAdapter",
+            "glm-5.2",
+        ),
+        (
+            "acpx-deepseek-shadow",
+            "scripts.agent_runtime.adapters.acpx:AcpxDeepSeekShadowAdapter",
+            "deepseek-v4-pro",
+        ),
+    ],
+)
+def test_new_acpx_fleet_entries_are_direct_only(seat, adapter, model):
+    entry = get_agent_entry(seat)
+    assert entry["adapter"] == adapter
+    assert entry["default_model"] == model
+    assert entry["cli_available"] is False
+    assert entry["direct_only"] is True
+    assert entry["resume_policy"] == "never"
+    assert entry["capabilities"] == frozenset()
+    assert seat not in available_agents()
 
 
 def test_cursor_entry_is_well_formed():

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -274,7 +274,18 @@ def test_routine_acp_panel_selection_hierarchy_is_bounded_and_non_authoritative(
     assert "automatically selects" in lower
     assert "read-only" in lower
     assert "exactly two enabled participants" in lower
-    for participant in ("codex", "grok", "claude", "kimi", "kimicc k3", "cursor", "pool"):
+    for participant in (
+        "codex",
+        "grok",
+        "claude",
+        "kimi",
+        "kimicc k3",
+        "cursor",
+        "pool",
+        "agy/gemini",
+        "glm",
+        "deepseek",
+    ):
         assert participant in lower
     assert "acp-discuss" in onboarding
     assert "default two rounds" in lower
@@ -314,7 +325,18 @@ def test_fleet_wide_acp_covers_callers_and_enabled_participants(onboarding: str)
     assert "caller-access parity" in lower
     for caller in ("claude", "codex", "agy/gemini", "grok", "kimi and kimicc", "cursor"):
         assert caller in lower
-    for participant in ("codex", "grok", "claude", "kimi", "kimicc k3", "cursor", "pool"):
+    for participant in (
+        "codex",
+        "grok",
+        "claude",
+        "kimi",
+        "kimicc k3",
+        "cursor",
+        "pool",
+        "agy/gemini",
+        "glm",
+        "deepseek",
+    ):
         assert participant in lower
     assert "do not rotate or silently\nsubstitute" in lower
     assert "ordinary workers and review-only seats" in lower


### PR DESCRIPTION
## Summary

- add fixed direct-only ACP participants for AGY, GLM, and DeepSeek
- confine AGY and DeepSeek through a project ACP text server with temporary source-blind working directories
- use native OpenCode ACP for the fixed Z.AI GLM route with deny-all permissions and disabled tools
- pin ACPX and all provider CLI versions, preserve local/CI egress guards, and document the bridge-to-ACP migration boundary
- provision the pinned ACP SDK only in its pytest shard, under a pinned Node 22 runtime with npm caching

## Live behavior proof

- AGY + DeepSeek: complete conversation `conversation_b8314374c82542b3892097e36ce7d786`
- GLM + DeepSeek: complete conversation `conversation_04da3141faf841bf884c8c6f4a85212e`
- exact replay of the final GLM + DeepSeek conversation completed in 0.16s with `duplicate_suppressed=true` and no provider calls
- live probing exposed and fixed OpenCode ACP auth-method selection and Hermes v-prefixed version parsing

## Verification

- 508 scoped Python tests passed
- the six exact CI failure nodes passed with `GITHUB_ACTIONS=true`
- Ruff, actionlint, workflow YAML parsing, and Prettier passed
- markdownlint, Python compilation, and Node syntax checks passed
- OPSEC, diff, protected-file, artifact, and commit-trailer checks passed

Fixes #6158

Rail-Approval-Receipt: rail-approval-d3426318532d4665b7aae80302355010
