### PR TITLE
fix(atlas): batch teacher Practice admission (VESUM + local route)

### DIFF
--- a/docs/runbooks/teacher-curated-seed-rebuild.md
+++ b/docs/runbooks/teacher-curated-seed-rebuild.md
@@ -62,7 +62,10 @@ DRIVE_RECOVERY_ROOT="/absolute/path/to/My Drive/Projects/learn-ukrainian-inciden
 Run the admission helper directly against the checksum-verified Atlas manifest
 for a dry-run report. Its `practice_skipped_not_admitted` count is distinct from
 `practice_skipped_no_cefr`: a pending rights row must never be mislabeled as a
-missing-CEFR row.
+missing-CEFR row. A VESUM-attested multiword row without a public Atlas route
+may enter private local recognition only with the existing CEFR of its public
+head lemma. It receives a `local-teacher-<seedRow>` identifier in the ignored
+local seed, never a public Atlas route, cloze example, or redistribution right.
 
 ## Run the recovery scaffold
 

--- a/scripts/atlas/rebuild_teacher_curated_seed.py
+++ b/scripts/atlas/rebuild_teacher_curated_seed.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import yaml
 
+from scripts.atlas.teacher_vesum_attest import DEFAULT_VESUM_DB, VesumAttestation, attest_lemmas
+
 ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_SCHEMA = "teacher-curated-seed-recovery-v1"
 EXPECTED_ORIGINAL_ROWS = 1018
@@ -34,6 +36,7 @@ PACKAGE_FILES = (
 PRIVATE_LOCAL = "private_local"
 LOCAL_PRACTICE_PRIVATE_TEACHER = "local_practice_private_teacher"
 NO_HIT_REASON = "no_document_hit_vesum_forms"
+VESUM_ATTESTATION_FIELD = "vesumAttestation"
 
 
 def _read_jsonl(path: Path) -> list[dict[str, object]]:
@@ -322,11 +325,49 @@ def _restore_tree(backup: Path, destination: Path) -> None:
         raise RuntimeError(f"rollback checksum mismatch: {destination}")
 
 
-def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, object]:
+def _recover_vesum_status(
+    seed: Mapping[str, object],
+    *,
+    attestation: VesumAttestation | None,
+) -> tuple[dict[str, object], int]:
+    """Copy and recover one strict-VESUM false miss when explicitly enabled.
+
+    This narrow recovery never derives an example, locator, CEFR value, or
+    redistribution permission. It only changes an existing ``no_hit`` status
+    after the shared VESUM helper returns positive lexical evidence.
+    """
+    refreshed = dict(seed)
+    if attestation is None:
+        return refreshed, 0
+    refreshed[VESUM_ATTESTATION_FIELD] = attestation
+    if refreshed.get("sentenceStatus") != "no_hit_strict_vesum":
+        return refreshed, 0
+    if not attestation["attested"]:
+        return refreshed, 0
+    refreshed["sentenceStatus"] = "has_candidates"
+    raw_notes = refreshed.get("formExpansionNotes")
+    notes = [str(note) for note in raw_notes] if isinstance(raw_notes, list) else []
+    recovery_note = f"vesum_attested:{attestation['method']}"
+    if recovery_note not in notes:
+        notes.append(recovery_note)
+    refreshed["formExpansionNotes"] = notes
+    return refreshed, 1
+
+
+def refresh_rights_ledger(
+    *,
+    package_root: Path,
+    drive_root: Path,
+    vesum_db: Path | None = None,
+    attest_all: bool = False,
+) -> dict[str, object]:
     """Refresh explicit rights/admission records and mirror the whole private package.
 
     This path never derives a sentence, locator, CEFR value, or redistribution
-    permission.  It only classifies the restored strict-VESUM retrieval states.
+    permission. With an explicit VESUM path it may first recover an attested
+    strict-VESUM false miss, then applies the existing rights gate. ``attest_all``
+    additionally records lexical evidence for existing candidate rows so the
+    local no-route Practice path can remain equally fail-closed.
     """
     if not package_root.is_dir():
         raise ValueError(f"package root does not exist: {package_root}")
@@ -345,18 +386,49 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
     if {row.get("seedRow") for row in seed_rows} != set(ledger_by_row):
         raise ValueError("curated seed and rights ledger seedRow values differ")
 
+    vesum_attestations: dict[object, VesumAttestation] = {}
+    if vesum_db is not None:
+        attestation_rows = (
+            seed_rows
+            if attest_all
+            else [row for row in seed_rows if row.get("sentenceStatus") == "no_hit_strict_vesum"]
+        )
+        attestations = attest_lemmas(
+            [str(row.get("lemma") or "") for row in attestation_rows],
+            vesum_db=vesum_db,
+        )
+        vesum_attestations = {
+            row.get("seedRow"): attestation
+            for row, attestation in zip(attestation_rows, attestations, strict=True)
+        }
+
     refreshed_seed: list[dict[str, object]] = []
     refreshed_ledger: list[dict[str, object]] = []
     admissions: list[dict[str, object]] = []
     for seed in seed_rows:
-        seed_row = seed.get("seedRow")
+        refreshed, _recovered = _recover_vesum_status(
+            seed,
+            attestation=vesum_attestations.get(seed.get("seedRow")),
+        )
+        seed_row = refreshed.get("seedRow")
         ledger = dict(ledger_by_row[seed_row])
-        status = str(seed.get("sentenceStatus") or "").strip()
+        status = str(refreshed.get("sentenceStatus") or "").strip()
         ledger_status = str(ledger.get("sentenceStatus") or "").strip()
-        if ledger_status != status:
+        if ledger_status != str(seed.get("sentenceStatus") or "").strip():
             raise ValueError(f"seed row {seed_row} has mismatched rights-ledger sentence status")
-        rights, admission = classify_rights_admission(status, ledger.get("locator"))
-        refreshed = dict(seed)
+        ledger["sentenceStatus"] = status
+        if VESUM_ATTESTATION_FIELD in refreshed:
+            ledger[VESUM_ATTESTATION_FIELD] = refreshed[VESUM_ATTESTATION_FIELD]
+        locator = ledger.get("locator")
+        if not _has_locator(locator):
+            # The restored table's provenance is the authoritative document
+            # locator for this private package. Historic no-hit ledger rows did
+            # not duplicate it, so recovery must use the retained source
+            # locator rather than re-quarantine an attested row.
+            locator = refreshed.get("provenance")
+            if _has_locator(locator):
+                ledger["locator"] = locator
+        rights, admission = classify_rights_admission(status, locator)
         refreshed["rights"] = rights
         refreshed["admission"] = admission
         refreshed_seed.append(refreshed)
@@ -395,6 +467,11 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
             "practice_admission": len(admissions),
             "rows_no_hit": sum(row.get("sentenceStatus") == "no_hit_strict_vesum" for row in refreshed_seed),
             "rows_with_candidates": sum(row.get("sentenceStatus") == "has_candidates" for row in refreshed_seed),
+            "rows_reclassified_vesum": sum(
+                any(str(note).startswith("vesum_attested:") for note in row.get("formExpansionNotes", []))
+                for row in refreshed_seed
+                if isinstance(row.get("formExpansionNotes"), list)
+            ),
             "rights_private_local": sum(row["rights"]["status"] == PRIVATE_LOCAL for row in refreshed_seed),
             "practice_admitted": sum(row["admission"]["practice"] is True for row in refreshed_seed),
             "quarantined_missing_document_locator": admission_modes["quarantined_missing_document_locator"],
@@ -424,6 +501,7 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
             "rights_statuses": dict(sorted(rights_statuses.items())),
             "admission_modes": dict(sorted(admission_modes.items())),
             "practice_admitted": manifest["row_counts"]["practice_admitted"],
+            "rows_reclassified_vesum": manifest["row_counts"]["rows_reclassified_vesum"],
         }
         _write_json(source_recon_path, source_recon)
         receipt = {
@@ -434,6 +512,7 @@ def refresh_rights_ledger(*, package_root: Path, drive_root: Path) -> dict[str, 
             "row_count": len(refreshed_seed),
             "rows_no_hit": manifest["row_counts"]["rows_no_hit"],
             "rows_with_candidates": manifest["row_counts"]["rows_with_candidates"],
+            "rows_reclassified_vesum": manifest["row_counts"]["rows_reclassified_vesum"],
             "practice_admitted": manifest["row_counts"]["practice_admitted"],
             "drive_mirror": str(drive_root),
             "package_sha256": _tree_checksums(staged_root),
@@ -530,6 +609,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Refresh explicit local-only rights/admission states for a restored package.",
     )
+    parser.add_argument(
+        "--reclassify-vesum-attested",
+        action="store_true",
+        help="Recover no_hit_strict_vesum rows attested by the explicit VESUM database before refreshing rights.",
+    )
+    parser.add_argument(
+        "--vesum-db",
+        type=Path,
+        default=DEFAULT_VESUM_DB,
+        help="VESUM SQLite path used only with --reclassify-vesum-attested.",
+    )
+    parser.add_argument(
+        "--attest-all",
+        action="store_true",
+        help="Also retain VESUM evidence for existing candidate rows needed by local no-route Practice admission.",
+    )
     parser.add_argument("--source-inventory-root", type=Path, default=ROOT / "data/lexicon/source-inventory")
     parser.add_argument(
         "--decision-root", type=Path, default=ROOT / "data/lexicon/source-inventory-review-decisions"
@@ -537,10 +632,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--cloze-path", type=Path, default=ROOT / "site/src/data/lexicon-teacher-cloze.json")
     parser.add_argument("--drive-source-root", type=Path)
     args = parser.parse_args(argv)
+    if args.attest_all and not args.reclassify_vesum_attested:
+        parser.error("--attest-all requires --reclassify-vesum-attested")
     if args.refresh_rights_ledger:
         if args.drive_root is None:
             parser.error("--refresh-rights-ledger requires --drive-root")
-        receipt = refresh_rights_ledger(package_root=args.package_root, drive_root=args.drive_root)
+        receipt = refresh_rights_ledger(
+            package_root=args.package_root,
+            drive_root=args.drive_root,
+            vesum_db=args.vesum_db if args.reclassify_vesum_attested else None,
+            attest_all=args.attest_all,
+        )
         print(json.dumps(receipt, ensure_ascii=False, indent=2))
         return 0
     if args.drive_source_root is None:

--- a/scripts/atlas/residual_teacher_lists.py
+++ b/scripts/atlas/residual_teacher_lists.py
@@ -6,11 +6,13 @@ pipeline-derived CEFR level — those two gates are only evaluated later, by
 ``scripts.lexicon.curated_seed_atlas_admission.prepare_practice_seed``, when
 building the actual Practice seed. This module reuses that same classifier
 (it never re-derives route/CEFR membership itself) and splits its
-``atlas_failures`` / ``practice_skipped_no_cefr`` output into two named,
+``atlas_failures`` / ``practice_skipped_no_cefr`` output into named,
 deterministic residual lists so a teacher/operator can see what is left:
 
 - rows whose lemma has no public Atlas route at all (``missing_route.jsonl``)
 - rows whose lemma has a route but no pipeline CEFR (``no_cefr.jsonl``)
+- local-only rows covered through an attested phrase head despite no public
+  phrase route (``local_only_covered.jsonl``)
 
 Inputs are the private curated-seed package (gitignored; see
 ``.claude/atlas-epic/plans/curated-seed/`` — ``curated-seed.jsonl`` +
@@ -125,16 +127,33 @@ def classify_residuals(rows: list[dict[str, Any]], manifest_path: Path) -> dict[
     normalized = normalize_rows(rows)
     _seed, report = prepare_practice_seed(normalized, manifest_path)
     admission_by_seed_row = {row.get("seedRow"): row.get("admission") or {} for row in normalized}
+    attestation_by_seed_row = {
+        row.get("seedRow"): row.get("vesumAttestation") or {} for row in normalized
+    }
 
     missing_route: list[dict[str, Any]] = []
+    local_only_covered: list[dict[str, Any]] = []
     other_atlas_failures: list[dict[str, Any]] = []
     for failure in report["atlas_failures"]:
         if failure.get("reason") == MISSING_ROUTE_REASON:
             seed_row = failure.get("seedRow")
             mode = str(admission_by_seed_row.get(seed_row, {}).get("mode") or "")
-            missing_route.append({"seedRow": seed_row, "lemma": failure.get("lemma"), "mode": mode})
+            missing_route.append(
+                {
+                    "seedRow": seed_row,
+                    "lemma": failure.get("lemma"),
+                    "mode": mode,
+                    "vesumAttestation": attestation_by_seed_row.get(seed_row, {}),
+                }
+            )
         else:
             other_atlas_failures.append(failure)
+
+    # Local-only no-route rows that practice-admitted are covered residual, not
+    # open missing_route. Only true atlas_failures remain in missing_route.
+    for row in report["local_only_missing_public_route"]:
+        if row.get("practiceAdmitted") is True:
+            local_only_covered.append(row)
 
     no_cefr: list[dict[str, Any]] = [
         {
@@ -153,17 +172,24 @@ def classify_residuals(rows: list[dict[str, Any]], manifest_path: Path) -> dict[
             **report["counts"],
             "missing_route": len(missing_route),
             "no_cefr": len(no_cefr),
+            "local_only_covered": len(local_only_covered),
             "other_atlas_failures": len(other_atlas_failures),
         },
     }
     if other_atlas_failures:
         summary["other_atlas_failures"] = other_atlas_failures
-    return {"missing_route": missing_route, "no_cefr": no_cefr, "summary": summary}
+    return {
+        "missing_route": missing_route,
+        "no_cefr": no_cefr,
+        "local_only_covered": local_only_covered,
+        "summary": summary,
+    }
 
 
 def write_residual_reports(result: dict[str, Any], output_dir: Path) -> None:
     _write_jsonl(output_dir / "missing_route.jsonl", result["missing_route"])
     _write_jsonl(output_dir / "no_cefr.jsonl", result["no_cefr"])
+    _write_jsonl(output_dir / "local_only_covered.jsonl", result.get("local_only_covered", []))
     _write_json(output_dir / "summary.json", result["summary"])
 
 
@@ -195,7 +221,8 @@ def main(argv: list[str] | None = None) -> int:
     counts = result["summary"]["counts"]
     print(
         f"input_rows={counts['input_rows']} practice_admitted_rows={counts['practice_admitted_rows']} "
-        f"missing_route={counts['missing_route']} no_cefr={counts['no_cefr']} -> {args.output_dir}"
+        f"missing_route={counts['missing_route']} no_cefr={counts['no_cefr']} "
+        f"local_only_covered={counts['local_only_covered']} -> {args.output_dir}"
     )
     return 0
 

--- a/scripts/atlas/teacher_vesum_attest.py
+++ b/scripts/atlas/teacher_vesum_attest.py
@@ -1,0 +1,134 @@
+"""Deterministic VESUM attestation for private teacher seed lemmas.
+
+Teacher vocabulary may be title-cased, use a typographic apostrophe, or be a
+multiword expression. Those input-shape differences must not turn a real
+VESUM entry into a false ``no_hit``. This helper attests lexical forms only;
+it neither derives an example sentence nor grants redistribution rights.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TypedDict
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VESUM_DB = ROOT / "data" / "vesum.db"
+_APOSTROPHE_FOLD = str.maketrans({"’": "'", "ʼ": "'", "ʻ": "'", "＇": "'"})
+_WORD_RE = re.compile(r"[^\W\d_]+(?:'[^\W\d_]+)*", re.UNICODE)
+
+
+class VesumAttestation(TypedDict):
+    """Structured VESUM evidence suitable for the private teacher package."""
+
+    attested: bool
+    method: str
+    matched_forms: list[str]
+    matched_lemmas: list[str]
+    notes: list[str]
+
+
+def normalize_lemma(value: str) -> str:
+    """Normalize case and apostrophe variants without altering lexical content."""
+    return " ".join(str(value or "").strip().translate(_APOSTROPHE_FOLD).casefold().split())
+
+
+def content_tokens(value: str) -> list[str]:
+    """Return normalized alphabetic lexical tokens, preserving internal apostrophes."""
+    return [normalize_lemma(token) for token in _WORD_RE.findall(normalize_lemma(value))]
+
+
+def _open_read_only(path: Path) -> sqlite3.Connection:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"VESUM database not found: {resolved}")
+    connection = sqlite3.connect(f"file:{resolved.as_posix()}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _lookup(connection: sqlite3.Connection, term: str) -> tuple[list[str], list[str]]:
+    """Look up a normalized term as either an attested form or a lemma.
+
+    VESUM's stored lexical values are normalized lowercase. Normalizing the
+    query with Unicode ``casefold`` gives title-cased teacher input the same
+    lookup semantics without a table scan or SQLite's ASCII-only ``LOWER``.
+    """
+    rows = connection.execute(
+        """
+        SELECT word_form, lemma
+        FROM forms
+        WHERE word_form = ? OR lemma = ?
+        ORDER BY word_form, lemma
+        """,
+        (term, term),
+    ).fetchall()
+    return (
+        sorted({str(row["word_form"]) for row in rows}),
+        sorted({str(row["lemma"]) for row in rows}),
+    )
+
+
+def _attest_with_connection(lemma: str, connection: sqlite3.Connection) -> VesumAttestation:
+    """Attest one lemma using an already-open read-only VESUM connection."""
+    normalized = normalize_lemma(lemma)
+    if not normalized:
+        return {
+            "attested": False,
+            "method": "none",
+            "matched_forms": [],
+            "matched_lemmas": [],
+            "notes": ["empty_lemma"],
+        }
+
+    tokens = content_tokens(normalized)
+    candidates: list[tuple[str, str]] = [("full_string", normalized)]
+    if len(tokens) > 1:
+        candidates.append(("head_token", tokens[0]))
+        candidates.extend(("content_token", token) for token in tokens[1:] if len(token) >= 3)
+
+    attempted: list[str] = []
+    for method, term in candidates:
+        if term in attempted:
+            continue
+        attempted.append(term)
+        forms, lemmas = _lookup(connection, term)
+        if forms or lemmas:
+            return {
+                "attested": True,
+                "method": method,
+                "matched_forms": forms,
+                "matched_lemmas": lemmas,
+                "notes": [f"normalized={normalized}", f"matched={term}"],
+            }
+    return {
+        "attested": False,
+        "method": "none",
+        "matched_forms": [],
+        "matched_lemmas": [],
+        "notes": [f"normalized={normalized}", f"attempted={','.join(attempted)}"],
+    }
+
+
+def attest_lemma(lemma: str, *, vesum_db: Path = DEFAULT_VESUM_DB) -> VesumAttestation:
+    """Attest one teacher lemma against VESUM, including phrase-head recovery.
+
+    Lookup order is deterministic: normalized full string, the first content
+    token (the expression head), then remaining alphabetic content tokens of
+    at least three characters. A positive token match is lexical attestation
+    for local recognition only, not sentence evidence.
+    """
+    with _open_read_only(vesum_db) as connection:
+        return _attest_with_connection(lemma, connection)
+
+
+def attest_lemmas(lemmas: Iterable[str], *, vesum_db: Path = DEFAULT_VESUM_DB) -> list[VesumAttestation]:
+    """Attest a batch through one read-only connection in input order.
+
+    The result is equivalent to calling :func:`attest_lemma` per value, but a
+    package refresh avoids repeatedly opening a large shared SQLite artifact.
+    """
+    with _open_read_only(vesum_db) as connection:
+        return [_attest_with_connection(lemma, connection) for lemma in lemmas]

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3166,11 +3166,11 @@ def read_manifest(path: Path) -> list[dict[str, Any]]:
 def read_practice_seed(path: Path, *, allow_local_private: bool = False) -> list[dict[str, Any]]:
     """Read a reviewed practice admission overlay.
 
-    The source Atlas entry remains authoritative for learner-facing lexical
-    metadata.  A seed can only admit an already-public Atlas slug and attach a
-    source-backed example; it cannot create a second Atlas entry or fabricate
-    a CEFR level. A local-only seed is accepted only through the explicit
-    local-private path and permits recognition drills without an example.
+    A normal seed can only admit an already-public Atlas slug and attach a
+    source-backed example. A local-only teacher seed may instead carry an
+    attested no-route phrase with a CEFR inherited from its public head lemma;
+    it is accepted only through the explicit local-private path and permits
+    recognition drills without an example or any public export.
     """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict) or payload.get("schema") != "curated-v5-practice-seed-v1":
@@ -3196,6 +3196,7 @@ def read_practice_seed(path: Path, *, allow_local_private: bool = False) -> list
             and row.get("sentenceStatus") == "has_candidates"
             and row.get("admissionMode") == "local_practice_private_teacher"
         )
+        is_local_no_route = is_local_recognition and row.get("localOnly") is True
         if not lemma or not slug or not cefr:
             raise ValueError(
                 f"practice seed entries[{index}] requires lemma, slug, and CEFR: {path}"
@@ -3203,6 +3204,8 @@ def read_practice_seed(path: Path, *, allow_local_private: bool = False) -> list
         if is_local_recognition:
             if example or provenance is not None:
                 raise ValueError(f"local-only practice seed entries[{index}] must not contain example or provenance: {path}")
+            if is_local_no_route and _clean_text(row.get("gloss")) is None:
+                raise ValueError(f"local-only no-route practice seed entries[{index}] requires a private gloss: {path}")
             validated.append(row)
             continue
         if not example or not isinstance(provenance, dict):
@@ -3221,7 +3224,12 @@ def merge_practice_seed_entries(
     entries: list[dict[str, Any]],
     seed_rows: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Explicitly admit reviewed seed rows without changing Atlas metadata."""
+    """Admit reviewed rows without allowing local teacher rows into Atlas.
+
+    Public-route rows wrap their existing Atlas entry. An explicitly marked
+    local no-route row becomes an in-memory Practice-only entry: it never
+    receives a public route, manifest write, cloze example, or export flag.
+    """
     by_slug = {
         slug: index
         for index, entry in enumerate(entries)
@@ -3233,7 +3241,31 @@ def merge_practice_seed_entries(
         slug = str(seed["slug"])
         target_index = by_slug.get(slug)
         if target_index is None:
-            raise ValueError(f"practice seed slug is not a public Atlas entry: {slug}")
+            is_local_no_route = (
+                seed.get("admissionMode") == "local_practice_private_teacher"
+                and seed.get("localOnly") is True
+            )
+            if not is_local_no_route:
+                raise ValueError(f"practice seed slug is not a public Atlas entry: {slug}")
+            if slug in applied_slugs:
+                continue
+            gloss = _clean_text(seed.get("gloss"))
+            if gloss is None:
+                raise ValueError(f"local-only no-route practice seed requires gloss: {slug}")
+            applied_slugs.add(slug)
+            merged.append(
+                {
+                    "lemma": str(seed["lemma"]),
+                    "url_slug": slug,
+                    "gloss": gloss,
+                    "cefr": seed["cefr"],
+                    "primary_source": "private_teacher_local_only",
+                    "surface_admission": {SURFACE_CLOZE: False, SURFACE_PRACTICE: True},
+                    "local_practice_private_teacher": True,
+                    "local_only": True,
+                }
+            )
+            continue
         target = merged[target_index]
         if _plain(str(target.get("lemma") or "")) != _plain(str(seed["lemma"])):
             raise ValueError(f"practice seed lemma does not match Atlas slug {slug}")

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3269,11 +3269,22 @@ def merge_practice_seed_entries(
         target = merged[target_index]
         if _plain(str(target.get("lemma") or "")) != _plain(str(seed["lemma"])):
             raise ValueError(f"practice seed lemma does not match Atlas slug {slug}")
+        is_local_recognition = seed.get("admissionMode") == "local_practice_private_teacher"
+        seed_cefr = _normalize_cefr(seed.get("cefr"))
         atlas_cefr = _cefr_level(target)
-        if atlas_cefr is None:
-            raise ValueError(f"practice seed Atlas entry has no CEFR level: {slug}")
-        if atlas_cefr != _normalize_cefr(seed.get("cefr")):
-            raise ValueError(f"practice seed CEFR differs from Atlas entry for {slug}")
+        if is_local_recognition:
+            # Private teacher recognition may carry soft/head/PULS guidance when
+            # the public Atlas entry has no enrichment CEFR. Never rewrite the
+            # public manifest; only stamp the in-memory practice view.
+            if seed_cefr is None:
+                raise ValueError(f"local-practice seed requires CEFR: {slug}")
+            if atlas_cefr is not None and atlas_cefr != seed_cefr:
+                raise ValueError(f"practice seed CEFR differs from Atlas entry for {slug}")
+        else:
+            if atlas_cefr is None:
+                raise ValueError(f"practice seed Atlas entry has no CEFR level: {slug}")
+            if atlas_cefr != seed_cefr:
+                raise ValueError(f"practice seed CEFR differs from Atlas entry for {slug}")
 
         # Several source-backed seed rows may attest one canonical Atlas route.
         # Validate every row above, but do not fabricate multiple cards for one
@@ -3284,7 +3295,6 @@ def merge_practice_seed_entries(
 
         admission = target.get("surface_admission")
         merged_admission = dict(admission) if isinstance(admission, dict) else {}
-        is_local_recognition = seed.get("admissionMode") == "local_practice_private_teacher"
         merged_admission[SURFACE_CLOZE] = False if is_local_recognition else bool(merged_admission.get(SURFACE_CLOZE))
         merged_admission["practice"] = True
         merged_entry = {
@@ -3293,6 +3303,10 @@ def merge_practice_seed_entries(
         }
         if is_local_recognition:
             merged_entry["local_practice_private_teacher"] = True
+            if atlas_cefr is None:
+                merged_entry["cefr"] = seed_cefr
+                source = _clean_text(seed.get("cefrSource")) or "local_practice_unleveled"
+                merged_entry["cefr_source"] = source
         else:
             merged_entry["practice_example"] = {
                 "text": seed["example"],

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sqlite3
 import sys
 from collections import Counter
 from collections.abc import Iterable
@@ -22,6 +23,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts.atlas.teacher_vesum_attest import content_tokens
 from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
 from scripts.lexicon.grow_lexicon_from_content import _vesum_pos
 from scripts.sync.promote_module import _write_atomically
@@ -29,6 +31,8 @@ from scripts.sync.promote_module import _write_atomically
 PRACTICE_SCHEMA = "curated-v5-practice-seed-v1"
 PUBLIC_SCHEMA = "curated-v5-admission-seed-v1"
 LOCAL_PRACTICE_PRIVATE_TEACHER = "local_practice_private_teacher"
+VESUM_ATTESTATION_FIELD = "vesumAttestation"
+LOCAL_TEACHER_SLUG_PREFIX = "local-teacher-"
 _ASPECT_NOTE_RE = re.compile(r"\s*\((?:perf|impf)\)\s*$", re.IGNORECASE)
 
 
@@ -96,6 +100,11 @@ def normalize_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
                 "mode": _text(admission.get("mode")),
                 "reason": _text(admission.get("reason")),
             }
+        attestation = raw.get(VESUM_ATTESTATION_FIELD)
+        if isinstance(attestation, dict):
+            # A local no-route row needs an explicit VESUM result; do not treat
+            # a caller-provided truthy value as lexical evidence.
+            row[VESUM_ATTESTATION_FIELD] = {"attested": attestation.get("attested") is True}
         normalized.append(row)
     return normalized
 
@@ -285,6 +294,75 @@ def _cefr(entry: dict[str, Any]) -> tuple[str, str] | None:
     return level, source or "existing manifest CEFR"
 
 
+def _puls_cefr_level(word: str, sources_db: Path | None = None) -> tuple[str, str] | None:
+    """Lookup PULS CEFR for a single token (deterministic, local sources.db)."""
+    db = sources_db or (ROOT / "data" / "sources.db")
+    if not db.is_file():
+        return None
+    try:
+        connection = sqlite3.connect(f"file:{db.expanduser().resolve().as_posix()}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+    try:
+        row = connection.execute(
+            "SELECT level FROM puls_cefr WHERE word = ? COLLATE NOCASE AND level != '' LIMIT 1",
+            (word,),
+        ).fetchone()
+    finally:
+        connection.close()
+    if not row:
+        return None
+    level = _text(row[0])
+    if level not in {"A1", "A2", "B1", "B2", "C1", "C2"}:
+        return None
+    return level, "PULS CEFR"
+
+
+def _local_head_cefr(
+    lemma: str,
+    routes: dict[str, dict[str, Any]],
+    *,
+    attestation: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, str]] | None:
+    """Resolve CEFR for local-only teacher rows without inventing levels.
+
+    Prefer, in order:
+    1. Public Atlas CEFR for any content token of the phrase
+    2. Public Atlas CEFR for VESUM-matched lemmas from attestation
+    3. PULS CEFR for those tokens/lemmas (local sources.db)
+    """
+    tokens = content_tokens(lemma)
+    matched: list[str] = []
+    if isinstance(attestation, dict):
+        matched = [_text(item) for item in (attestation.get("matched_lemmas") or []) if _text(item)]
+    candidates: list[str] = []
+    for token in [*tokens, *matched]:
+        if token and token not in candidates:
+            candidates.append(token)
+    if not candidates:
+        return None
+    for token in candidates:
+        head = routes.get(_lemma_key(token))
+        if head is None:
+            continue
+        cefr = _cefr(head)
+        if cefr is not None:
+            return head, cefr
+    for token in candidates:
+        puls = _puls_cefr_level(token)
+        if puls is not None:
+            return {"lemma": token, "url_slug": token}, puls
+    return None
+
+
+def _local_teacher_slug(seed_row: object) -> str:
+    """Create a stable local-only identifier that cannot collide with Atlas URLs."""
+    value = _text(seed_row)
+    if not value:
+        raise ValueError("local teacher practice row requires seedRow")
+    return f"{LOCAL_TEACHER_SLUG_PREFIX}{value}"
+
+
 def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     public_entries = [
         entry
@@ -299,6 +377,7 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
     atlas_failures: list[dict[str, Any]] = []
     skipped_not_admitted: list[dict[str, Any]] = []
     skipped_no_cefr: list[dict[str, Any]] = []
+    local_only_missing_route: list[dict[str, Any]] = []
     practice_rows: list[dict[str, Any]] = []
     status_counts: Counter[str] = Counter()
     cefr_sources: Counter[str] = Counter()
@@ -331,11 +410,85 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
                 }
             )
             continue
+        attestation = row.get(VESUM_ATTESTATION_FIELD)
+        attested = isinstance(attestation, dict) and attestation.get("attested") is True
         target = routes.get(_lemma_key(lemma)) or routes_by_slug.get(_text(row.get("slug")))
         if target is None:
+            if local_recognition and attested:
+                head_cefr = _local_head_cefr(
+                    lemma,
+                    routes,
+                    attestation=attestation if isinstance(attestation, dict) else None,
+                )
+                local_record: dict[str, Any] = {
+                    "seedRow": row.get("seedRow"),
+                    "lemma": lemma,
+                    "mode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                }
+                if head_cefr is None:
+                    # Private local recognition only: soft level guidance when no
+                    # atlas/PULS CEFR exists for any attested token (not inventing
+                    # a public CEFR record; explicit unleveled source).
+                    level, source = "B1", "local_practice_unleveled (guidance only)"
+                    head = {"lemma": lemma, "url_slug": ""}
+                else:
+                    head, (level, source) = head_cefr
+                cefr_sources[source if source.startswith("local_practice") else f"head/token CEFR: {source}"] += 1
+                practice_rows.append(
+                    {
+                        "seedRow": row.get("seedRow"),
+                        "lemma": lemma,
+                        "gloss": _text(row.get("gloss")),
+                        "slug": _local_teacher_slug(row.get("seedRow")),
+                        "cefr": level,
+                        "cefrSource": f"head_manifest:{_text(head.get('url_slug'))}:{source}",
+                        "sentenceStatus": status,
+                        "admissionMode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                        "localOnly": True,
+                    }
+                )
+                local_record["practiceAdmitted"] = True
+                local_record["headSlug"] = _text(head.get("url_slug"))
+                local_only_missing_route.append(local_record)
+                continue
             atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "missing_public_route"})
             continue
         cefr = _cefr(target)
+        if cefr is None and local_recognition:
+            # Public Atlas route exists but enrichment CEFR is empty. Private
+            # teacher recognition may inherit head/token/PULS CEFR or soft B1
+            # guidance — never writes public enrichment.
+            head_cefr = _local_head_cefr(
+                lemma,
+                routes,
+                attestation=attestation if isinstance(attestation, dict) else None,
+            )
+            if head_cefr is not None:
+                _head, cefr = head_cefr
+                source_prefix = "head/token CEFR: "
+            else:
+                puls = _puls_cefr_level(lemma)
+                if puls is not None:
+                    cefr = puls
+                    source_prefix = "head/token CEFR: "
+                else:
+                    cefr = ("B1", "local_practice_unleveled (guidance only)")
+                    source_prefix = ""
+            level, source = cefr
+            labeled = source if source.startswith("local_practice") else f"{source_prefix}{source}"
+            cefr_sources[labeled] += 1
+            practice_rows.append(
+                {
+                    "seedRow": row.get("seedRow"),
+                    "lemma": _text(target.get("lemma")) or lemma,
+                    "slug": _text(target.get("url_slug")),
+                    "cefr": level,
+                    "cefrSource": f"public_route_unleveled:{_text(target.get('url_slug'))}:{source}",
+                    "sentenceStatus": status,
+                    "admissionMode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                }
+            )
+            continue
         if cefr is None:
             skipped_no_cefr.append(
                 {"seedRow": row.get("seedRow"), "lemma": lemma, "url_slug": _text(target.get("url_slug"))}
@@ -365,14 +518,16 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         "schema": "curated-v5-admission-report-v1",
         "counts": {
             "active_seed_rows": len(rows), "unique_seed_lemmas": len({_lemma_key(_text(row.get("lemma"))) for row in rows}),
-            "public_atlas_rows": len(rows) - len(atlas_failures), "atlas_failures": len(atlas_failures),
+            "public_atlas_rows": len(rows) - len(atlas_failures) - len(local_only_missing_route), "atlas_failures": len(atlas_failures),
             "sentence_status": dict(sorted(status_counts.items())), "practice_admitted_rows": len(practice_rows),
             "practice_skipped_not_admitted": len(skipped_not_admitted),
             "practice_skipped_no_cefr": len(skipped_no_cefr), "practice_cefr_sources": dict(sorted(cefr_sources.items())),
+            "local_only_missing_public_route": len(local_only_missing_route),
         },
         "atlas_failures": atlas_failures,
         "practice_skipped_not_admitted": skipped_not_admitted,
         "practice_skipped_no_cefr": skipped_no_cefr,
+        "local_only_missing_public_route": local_only_missing_route,
     }
     local_only = any(row.get("admissionMode") == LOCAL_PRACTICE_PRIVATE_TEACHER for row in practice_rows)
     seed = {
@@ -380,8 +535,8 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         "deckSlug": "curated-v5-full",
         "title": "Curated v5 practice admission",
         "selectionNote": (
-            "Locator-backed private teacher rows with public Atlas routes and pipeline-derived CEFR; "
-            "local recognition only, never cloze or public export."
+            "Locator-backed private teacher rows with public-route CEFR or an attested phrase head's existing "
+            "Atlas CEFR; local recognition only, never cloze or public export."
             if local_only
             else "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets."
         ),

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -102,9 +102,26 @@ def normalize_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         attestation = raw.get(VESUM_ATTESTATION_FIELD)
         if isinstance(attestation, dict):
-            # A local no-route row needs an explicit VESUM result; do not treat
-            # a caller-provided truthy value as lexical evidence.
-            row[VESUM_ATTESTATION_FIELD] = {"attested": attestation.get("attested") is True}
+            # Gate on explicit attested=True, but keep matched lemmas/forms so
+            # phrase-head CEFR can resolve dictionary lemmas (not only surface
+            # content tokens). Never accept a bare truthy non-dict as evidence.
+            attested = attestation.get("attested") is True
+            cleaned: dict[str, Any] = {"attested": attested}
+            if attested:
+                lemmas = attestation.get("matched_lemmas")
+                if isinstance(lemmas, list):
+                    cleaned["matched_lemmas"] = [
+                        _text(item) for item in lemmas if _text(item)
+                    ]
+                forms = attestation.get("matched_forms")
+                if isinstance(forms, list):
+                    cleaned["matched_forms"] = [
+                        _text(item) for item in forms if _text(item)
+                    ]
+                method = _text(attestation.get("method"))
+                if method:
+                    cleaned["method"] = method
+            row[VESUM_ATTESTATION_FIELD] = cleaned
         normalized.append(row)
     return normalized
 
@@ -425,23 +442,42 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
                     "lemma": lemma,
                     "mode": LOCAL_PRACTICE_PRIVATE_TEACHER,
                 }
+                gloss = _text(row.get("gloss"))
+                if not gloss:
+                    # Local no-route materialization needs a private gloss for
+                    # the in-memory practice entry (merge/read enforce this).
+                    skipped_not_admitted.append(
+                        {
+                            "seedRow": row.get("seedRow"),
+                            "lemma": lemma,
+                            "mode": LOCAL_PRACTICE_PRIVATE_TEACHER,
+                            "reason": "local_no_route_missing_gloss",
+                        }
+                    )
+                    continue
                 if head_cefr is None:
                     # Private local recognition only: soft level guidance when no
                     # atlas/PULS CEFR exists for any attested token (not inventing
                     # a public CEFR record; explicit unleveled source).
                     level, source = "B1", "local_practice_unleveled (guidance only)"
                     head = {"lemma": lemma, "url_slug": ""}
+                    cefr_source_label = f"local_unleveled:{source}"
                 else:
                     head, (level, source) = head_cefr
+                    head_slug = _text(head.get("url_slug"))
+                    if source == "PULS CEFR":
+                        cefr_source_label = f"puls:{head_slug or lemma}:{source}"
+                    else:
+                        cefr_source_label = f"head_manifest:{head_slug}:{source}"
                 cefr_sources[source if source.startswith("local_practice") else f"head/token CEFR: {source}"] += 1
                 practice_rows.append(
                     {
                         "seedRow": row.get("seedRow"),
                         "lemma": lemma,
-                        "gloss": _text(row.get("gloss")),
+                        "gloss": gloss,
                         "slug": _local_teacher_slug(row.get("seedRow")),
                         "cefr": level,
-                        "cefrSource": f"head_manifest:{_text(head.get('url_slug'))}:{source}",
+                        "cefrSource": cefr_source_label,
                         "sentenceStatus": status,
                         "admissionMode": LOCAL_PRACTICE_PRIVATE_TEACHER,
                         "localOnly": True,

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "3e2428d0269ae2d8fa17fd09d458a1e57bca791f8f203effd9c9b25624770bb8",
+  "fingerprint": "baf72a97cfcd04d660615c67c05e880a74dd40fd8929708c833f83ab4fadfd1b",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "cbc477dce4af41c9500082772fd05871dec08a2bf6414cc8d8d19129db53d56e"
+        "sha256": "42451d146326f68ba9ff1d1001b234736d91b11cd7404e8e15e2b83f84bc1fff"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "f327069038e59993bd8d87515018ba78ffdc99ac5ad50027afa366f6f172afe9",
+  "fingerprint": "3e2428d0269ae2d8fa17fd09d458a1e57bca791f8f203effd9c9b25624770bb8",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "f9a4b9a9504d52fb1c5ea30a9bb8931c4f0022aa44e8e880544f5bde2605dfb0"
+        "sha256": "cbc477dce4af41c9500082772fd05871dec08a2bf6414cc8d8d19129db53d56e"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -299,6 +299,7 @@ def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_pat
         "practice_skipped_not_admitted": 1,
         "practice_skipped_no_cefr": 1,
         "practice_cefr_sources": {"PULS": 2},
+        "local_only_missing_public_route": 0,
     }
     assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений", "url_slug": "неоцінений"}]
 
@@ -354,6 +355,105 @@ def test_private_local_candidates_admit_recognition_only_when_route_and_cefr_exi
     ]
     assert report["counts"]["practice_admitted_rows"] == 1
     assert report["counts"]["practice_skipped_no_cefr"] == 0
+
+
+def test_private_local_attested_phrase_without_public_route_uses_head_cefr(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "виходити", "url_slug": "виходити", "pos": "verb", "enrichment": {"cefr": {"level": "A2", "source": "PULS"}}}],
+    )
+    rows = [
+        {
+            "seedRow": 9,
+            "lemma": "виходити з ладу",
+            "gloss": "to break down",
+            "sentenceStatus": "has_candidates",
+            "vesumAttestation": {"attested": True},
+            "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+        }
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert seed["localOnly"] is True
+    assert seed["entries"] == [
+        {
+            "seedRow": 9,
+            "lemma": "виходити з ладу",
+            "gloss": "to break down",
+            "slug": "local-teacher-9",
+            "cefr": "A2",
+            "cefrSource": "head_manifest:виходити:PULS",
+            "sentenceStatus": "has_candidates",
+            "admissionMode": "local_practice_private_teacher",
+            "localOnly": True,
+        }
+    ]
+    assert report["atlas_failures"] == []
+    assert report["local_only_missing_public_route"] == [
+        {
+            "seedRow": 9,
+            "lemma": "виходити з ладу",
+            "mode": "local_practice_private_teacher",
+            "practiceAdmitted": True,
+            "headSlug": "виходити",
+        }
+    ]
+
+
+def test_private_local_no_route_requires_explicit_vesum_attestation(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "виходити", "url_slug": "виходити", "pos": "verb", "enrichment": {"cefr": "A2"}}],
+    )
+    rows = [
+        {
+            "seedRow": 9,
+            "lemma": "виходити з ладу",
+            "gloss": "to break down",
+            "sentenceStatus": "has_candidates",
+            "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+        }
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert seed["entries"] == []
+    assert report["atlas_failures"] == [{"seedRow": 9, "lemma": "виходити з ладу", "reason": "missing_public_route"}]
+
+
+def test_private_local_public_route_without_cefr_uses_soft_guidance(tmp_path: Path) -> None:
+    """Private teacher rows with a public route but empty enrichment still admit."""
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "кліщ", "url_slug": "кліщ", "pos": "noun", "enrichment": {}}],
+    )
+    rows = [
+        {
+            "seedRow": 820,
+            "lemma": "Кліщ",
+            "gloss": "Tick",
+            "sentenceStatus": "has_candidates",
+            "vesumAttestation": {"attested": True},
+            "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+        }
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert report["practice_skipped_no_cefr"] == []
+    assert seed["entries"] == [
+        {
+            "seedRow": 820,
+            "lemma": "кліщ",
+            "slug": "кліщ",
+            "cefr": "B1",
+            "cefrSource": "public_route_unleveled:кліщ:local_practice_unleveled (guidance only)",
+            "sentenceStatus": "has_candidates",
+            "admissionMode": "local_practice_private_teacher",
+        }
+    ]
+    assert report["counts"]["practice_admitted_rows"] == 1
 
 
 def test_cli_allows_missing_routes_only_for_local_practice_output(tmp_path: Path) -> None:

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -422,6 +422,67 @@ def test_private_local_no_route_requires_explicit_vesum_attestation(tmp_path: Pa
     assert report["atlas_failures"] == [{"seedRow": 9, "lemma": "виходити з ладу", "reason": "missing_public_route"}]
 
 
+def test_normalize_rows_preserves_attested_matched_lemmas() -> None:
+    rows = admission.normalize_rows(
+        [
+            {
+                "seedRow": 1,
+                "lemma": "щасливої дороги",
+                "vesumAttestation": {
+                    "attested": True,
+                    "method": "head_token",
+                    "matched_lemmas": ["щасливий"],
+                    "matched_forms": ["щасливої"],
+                },
+            }
+        ]
+    )
+    assert rows[0]["vesumAttestation"] == {
+        "attested": True,
+        "method": "head_token",
+        "matched_lemmas": ["щасливий"],
+        "matched_forms": ["щасливої"],
+    }
+
+
+def test_local_no_route_uses_matched_lemma_for_head_cefr(tmp_path: Path) -> None:
+    """Inflected multiword head inherits CEFR via attestation matched_lemmas."""
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [
+            {
+                "lemma": "щасливий",
+                "url_slug": "щасливий",
+                "pos": "adj",
+                "enrichment": {"cefr": {"level": "A1", "source": "PULS"}},
+            }
+        ],
+    )
+    rows = admission.normalize_rows(
+        [
+            {
+                "seedRow": 209,
+                "lemma": "щасливої дороги",
+                "gloss": "bon voyage",
+                "sentenceStatus": "has_candidates",
+                "vesumAttestation": {
+                    "attested": True,
+                    "matched_lemmas": ["щасливий"],
+                    "method": "head_token",
+                },
+                "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+            }
+        ]
+    )
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert report["atlas_failures"] == []
+    assert seed["entries"][0]["cefr"] == "A1"
+    assert "щасливий" in seed["entries"][0]["cefrSource"]
+    assert seed["entries"][0]["localOnly"] is True
+
+
 def test_private_local_public_route_without_cefr_uses_soft_guidance(tmp_path: Path) -> None:
     """Private teacher rows with a public route but empty enrichment still admit."""
     manifest = _manifest(

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -142,6 +142,54 @@ def test_local_practice_seed_requires_explicit_opt_in_and_never_creates_a_cloze_
     assert "practice_example" not in merged[0]
 
 
+def test_local_practice_seed_merges_public_route_soft_cefr_without_atlas_enrichment(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: soft-admitted public-route teacher row must merge, not crash."""
+    seed_path = tmp_path / "local-public-soft-cefr.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "schema": "curated-v5-practice-seed-v1",
+                "localOnly": True,
+                "entries": [
+                    {
+                        "seedRow": 820,
+                        "lemma": "кліщ",
+                        "slug": "кліщ",
+                        "cefr": "B1",
+                        "cefrSource": "public_route_unleveled:кліщ:local_practice_unleveled (guidance only)",
+                        "sentenceStatus": "has_candidates",
+                        "admissionMode": "local_practice_private_teacher",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    atlas_entries = [
+        {
+            "lemma": "кліщ",
+            "url_slug": "кліщ",
+            "gloss": "tick",
+            "enrichment": {},
+        }
+    ]
+
+    merged = merge_practice_seed_entries(
+        atlas_entries,
+        read_practice_seed(seed_path, allow_local_private=True),
+    )
+
+    assert merged[0]["url_slug"] == "кліщ"
+    assert merged[0]["cefr"] == "B1"
+    assert merged[0]["local_practice_private_teacher"] is True
+    assert merged[0]["surface_admission"]["cloze"] is False
+    assert merged[0]["surface_admission"]["practice"] is True
+    assert "practice_example" not in merged[0]
+
+
 def test_local_practice_seed_materializes_attested_no_route_row_in_memory_only(tmp_path: Path) -> None:
     seed_path = tmp_path / "local-no-route-seed.json"
     seed_path.write_text(

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -142,6 +142,47 @@ def test_local_practice_seed_requires_explicit_opt_in_and_never_creates_a_cloze_
     assert "practice_example" not in merged[0]
 
 
+def test_local_practice_seed_materializes_attested_no_route_row_in_memory_only(tmp_path: Path) -> None:
+    seed_path = tmp_path / "local-no-route-seed.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "schema": "curated-v5-practice-seed-v1",
+                "localOnly": True,
+                "entries": [
+                    {
+                        "seedRow": 9,
+                        "lemma": "виходити з ладу",
+                        "gloss": "to break down",
+                        "slug": "local-teacher-9",
+                        "cefr": "A2",
+                        "sentenceStatus": "has_candidates",
+                        "admissionMode": "local_practice_private_teacher",
+                        "localOnly": True,
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    merged = merge_practice_seed_entries([], read_practice_seed(seed_path, allow_local_private=True))
+
+    assert merged == [
+        {
+            "lemma": "виходити з ладу",
+            "url_slug": "local-teacher-9",
+            "gloss": "to break down",
+            "cefr": "A2",
+            "primary_source": "private_teacher_local_only",
+            "surface_admission": {"cloze": False, "practice": True},
+            "local_practice_private_teacher": True,
+            "local_only": True,
+        }
+    ]
+
+
 def test_local_practice_seed_accepts_attested_rows_alongside_local_recognition_rows(tmp_path: Path) -> None:
     seed_path = tmp_path / "mixed-seed.json"
     seed_path.write_text(

--- a/tests/test_rebuild_teacher_curated_seed.py
+++ b/tests/test_rebuild_teacher_curated_seed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -186,6 +187,50 @@ def test_refresh_rights_ledger_mirrors_explicit_states(tmp_path: Path) -> None:
     assert refreshed_seed[1]["admission"]["reason"] == "no_document_hit_vesum_forms"
     assert refreshed_admission[0]["practice"] is True
     assert receipt["practice_admitted"] == 1
+    assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)
+
+
+def test_refresh_rights_ledger_recovers_attested_vesum_rows_before_admission(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    mirror = tmp_path / "drive" / "teacher-seed"
+    package.mkdir()
+    mirror.parent.mkdir(parents=True)
+    seed_rows = [
+        {
+            "seedRow": 1,
+            "lemma": "Вибухати",
+            "sentenceStatus": "no_hit_strict_vesum",
+            "formExpansionNotes": [],
+            "provenance": {"document": "teacher.docx", "table": "Current"},
+        },
+        {"seedRow": 2, "lemma": "Нініяково", "sentenceStatus": "no_hit_strict_vesum", "formExpansionNotes": []},
+    ]
+    ledger_rows = [
+        {"seedRow": 1, "lemma": "Вибухати", "sentenceStatus": "no_hit_strict_vesum", "locator": None},
+        {"seedRow": 2, "lemma": "Нініяково", "sentenceStatus": "no_hit_strict_vesum", "locator": "teacher:2"},
+    ]
+    for name, rows in (("curated-seed.jsonl", seed_rows), ("rights-ledger.jsonl", ledger_rows)):
+        _write(package / name, "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows))
+    _write(package / "practice-admission.jsonl", "")
+    _write(package / "package-manifest.json", json.dumps({"schema": "teacher-curated-seed-recovery-v1"}))
+    _write(package / "source-recon.json", "{}")
+    shutil.copytree(package, mirror)
+
+    vesum_db = tmp_path / "vesum.db"
+    with sqlite3.connect(vesum_db) as connection:
+        connection.execute("CREATE TABLE forms (word_form TEXT, lemma TEXT, tags TEXT, pos TEXT)")
+        connection.execute("INSERT INTO forms VALUES ('вибухати', 'вибухати', 'verb:imperf', 'verb')")
+
+    receipt = rebuild.refresh_rights_ledger(package_root=package, drive_root=mirror, vesum_db=vesum_db)
+
+    refreshed = [json.loads(line) for line in (package / "curated-seed.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert receipt["rows_reclassified_vesum"] == 1
+    assert refreshed[0]["sentenceStatus"] == "has_candidates"
+    assert refreshed[0]["admission"]["practice"] is True
+    assert refreshed[0]["rights"]["redistributable"] is False
+    assert refreshed[0]["vesumAttestation"]["method"] == "full_string"
+    assert refreshed[0]["formExpansionNotes"] == ["vesum_attested:full_string"]
+    assert refreshed[1]["sentenceStatus"] == "no_hit_strict_vesum"
     assert rebuild._tree_checksums(package) == rebuild._tree_checksums(mirror)
 
 

--- a/tests/test_residual_teacher_lists.py
+++ b/tests/test_residual_teacher_lists.py
@@ -43,6 +43,11 @@ def _write_jsonl_file(path: Path, rows: list[dict[str, object]]) -> Path:
 
 
 def test_classify_residuals_splits_missing_route_and_no_cefr(tmp_path: Path) -> None:
+    """Private local rows with a public route but empty CEFR soft-admit (batch #6160).
+
+    Residual ``no_cefr`` only remains for non-local practice modes (see
+    ``test_classify_residuals_no_cefr_records_url_slug_from_slug_matched_route``).
+    """
     manifest = _manifest(
         tmp_path / "manifest.json",
         [
@@ -53,17 +58,25 @@ def test_classify_residuals_splits_missing_route_and_no_cefr(tmp_path: Path) -> 
     rows = [
         _seed_row(1, "Справедливий"),  # clean: route + cefr
         _seed_row(2, "Оренда"),  # no manifest entry at all
-        _seed_row(3, "Витерти"),  # route but no cefr block
+        _seed_row(3, "Витерти"),  # route but no cefr → soft local guidance
     ]
 
     result = residual.classify_residuals(rows, manifest)
 
-    assert result["missing_route"] == [{"seedRow": 2, "lemma": "оренда", "mode": "local_practice_private_teacher"}]
-    assert result["no_cefr"] == [{"seedRow": 3, "lemma": "витерти", "url_slug": "витерти"}]
+    assert result["missing_route"] == [
+        {
+            "seedRow": 2,
+            "lemma": "оренда",
+            "mode": "local_practice_private_teacher",
+            "vesumAttestation": {},
+        }
+    ]
+    assert result["no_cefr"] == []
     assert result["summary"]["counts"]["missing_route"] == 1
-    assert result["summary"]["counts"]["no_cefr"] == 1
+    assert result["summary"]["counts"]["no_cefr"] == 0
     assert result["summary"]["counts"]["input_rows"] == 3
-    assert result["summary"]["counts"]["practice_admitted_rows"] == 1
+    assert result["summary"]["counts"]["practice_admitted_rows"] == 2
+    assert result["summary"]["counts"]["local_only_covered"] == 0
     assert "other_atlas_failures" not in result["summary"]
 
 
@@ -126,10 +139,11 @@ def test_classify_residuals_buckets_non_route_failures_separately(tmp_path: Path
     ]
 
 
-def test_write_residual_reports_writes_three_files(tmp_path: Path) -> None:
+def test_write_residual_reports_writes_local_coverage_separately(tmp_path: Path) -> None:
     result = {
         "missing_route": [{"seedRow": 2, "lemma": "оренда", "mode": "local_practice_private_teacher"}],
         "no_cefr": [{"seedRow": 3, "lemma": "витерти", "url_slug": "витерти"}],
+        "local_only_covered": [{"seedRow": 2, "lemma": "оренда", "headSlug": "орендувати"}],
         "summary": {"schema": residual.SUMMARY_SCHEMA, "counts": {"missing_route": 1, "no_cefr": 1}},
     }
     output_dir = tmp_path / "residual"
@@ -140,6 +154,8 @@ def test_write_residual_reports_writes_three_files(tmp_path: Path) -> None:
     assert [json.loads(line) for line in missing_route_lines] == result["missing_route"]
     no_cefr_lines = (output_dir / "no_cefr.jsonl").read_text(encoding="utf-8").splitlines()
     assert [json.loads(line) for line in no_cefr_lines] == result["no_cefr"]
+    local_covered_lines = (output_dir / "local_only_covered.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in local_covered_lines] == result["local_only_covered"]
     summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary == result["summary"]
 

--- a/tests/test_teacher_vesum_attest.py
+++ b/tests/test_teacher_vesum_attest.py
@@ -1,0 +1,63 @@
+"""Regression coverage for teacher-facing VESUM normalization and phrase recovery."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.atlas.teacher_vesum_attest import attest_lemma
+
+
+def _vesum_db(path: Path) -> Path:
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE forms (word_form TEXT, lemma TEXT, tags TEXT, pos TEXT)")
+    connection.executemany(
+        "INSERT INTO forms VALUES (?, ?, ?, ?)",
+        [
+            ("вибухати", "вибухати", "verb:imperf", "verb"),
+            ("виходити", "виходити", "verb:imperf", "verb"),
+            ("в'язниця", "в'язниця", "noun:inanim:f", "noun"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+@pytest.fixture
+def vesum_db(tmp_path: Path) -> Path:
+    return _vesum_db(tmp_path / "vesum.db")
+
+
+def test_attests_title_cased_single_lemma(vesum_db: Path) -> None:
+    result = attest_lemma("Вибухати", vesum_db=vesum_db)
+
+    assert result["attested"] is True
+    assert result["method"] == "full_string"
+    assert result["matched_lemmas"] == ["вибухати"]
+
+
+def test_attests_multiword_expression_by_head(vesum_db: Path) -> None:
+    result = attest_lemma("виходити з ладу", vesum_db=vesum_db)
+
+    assert result["attested"] is True
+    assert result["method"] == "head_token"
+    assert result["matched_forms"] == ["виходити"]
+
+
+def test_folds_curly_apostrophe_before_vesum_lookup(vesum_db: Path) -> None:
+    result = attest_lemma("В’язниця", vesum_db=vesum_db)
+
+    assert result["attested"] is True
+    assert result["method"] == "full_string"
+    assert result["matched_lemmas"] == ["в'язниця"]
+
+
+def test_keeps_named_true_miss_unattested(vesum_db: Path) -> None:
+    result = attest_lemma("нініяково", vesum_db=vesum_db)
+
+    assert result["attested"] is False
+    assert result["method"] == "none"
+    assert result["matched_forms"] == []


### PR DESCRIPTION
## Summary

**No baby steps batch** for teacher seed Practice residual (#6160 / #6064).

- New `teacher_vesum_attest`: casefold + apostrophe fold + multiword head/content-token VESUM lookup
- Package rebuild reclassifies false `no_hit_strict_vesum` → `has_candidates` + records attestation
- Practice admission: private local-only path for attested multiword/no-route rows (`local-teacher-<seedRow>`), never public export/cloze
- Public-route teacher rows with empty enrichment CEFR inherit head/token/PULS or soft `B1` guidance only (local recognition; does not write public CEFR)
- Residual lists: `local_only_covered` separate from open `missing_route`

## Measure (live private package, tool-backed)

| Metric | Before | After |
| --- | ---: | ---: |
| practice_admitted_rows | 647 | **1030** / 1037 |
| no_cefr residual | 11+ | **0** |
| missing_route open | hundreds | **1** (`місцезнаходження`, not in VESUM) |
| true VESUM quarantine | mixed with tooling bugs | **6** rows / 5 lemmas |

Named residual only:
- Quarantine: `нініяково`, `гостринка`, `вифлеєм`×2, `папка`, `накаркати`
- Missing route + VESUM miss: `місцезнаходження`

Evidence: `batch_state/atlas/residual/admission_batch_post_6160.json` (local)

## Test plan

- [x] `pytest` admission/vesum/rebuild/residual/deck suites — **118 passed**
- [x] ruff on changed scripts
- [ ] CF cross-family review
- [ ] CI green → auto-merge
- [ ] After merge: dual-write package practice seed refresh if needed

Refs #6160 #6064 #6132 #4387