### PR TITLE
docs(foundry): activate Phase 2–4 production chain

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -9,7 +9,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Last refreshed** | 2026-08-01 (Ukrainian Data Foundry reference chain #6119–#6123 implemented end to end) |
+| **Last refreshed** | 2026-08-01 (Ukrainian Data Foundry Phase 2–4 successor #6164 activated) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Help people and AI produce measurably better, authentically Ukrainian language through decolonized learning products and reusable, evidence-backed open-model infrastructure. Quality non-negotiable. |
@@ -28,8 +28,9 @@ stream must trace to this chain:
    or register variation.
 2. **Products**: the LU curriculum site (learners) and Hramatka (teachers).
 3. **Reusable community infrastructure**: audited, provenance-rich source data;
-   the Ukrainian Data Foundry's morphology diagnostics, review-candidate
-   extraction, and model-ready export contracts (#6056); and
+   the Ukrainian Data Foundry's admitted real data, contextual language-contact
+   diagnostics, human-reviewed corrections, model-ready exports, and causal
+   open-weight evidence (#6164; completed foundation #6056); and
    narrow, contamination-resistant public evaluation (#2156, #6057).
 4. **Kept honest by**: internal QG machinery (#4913), frozen evidence contracts,
    Ukrainian linguistic review, and strict separation of public evaluation gold,
@@ -62,7 +63,7 @@ is the single source of truth for membership (auditor:
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
 | benchmark-2156 | #6057 (successor to closed #2156) | Closed #2156 owns the completed public v0.1.1 release; #6057 owns separately frozen v0.2 error analysis, controls, coverage, and future baselines |
-| open-model-data | #6056 | Ukrainian Data Foundry: audited sources, streaming profiling, morphology evidence, qualified correction review, disjoint exports, recipes, and reference validation |
+| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: admit useful-scale real data, detect contextual Ukrainian language-contact failures, freeze qualified-human gold, export model-ready views, test one causal open-weight treatment, and ship a reproducible release candidate |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -90,7 +91,7 @@ epic-board state and bind only once that stream's driver (State: the operator) c
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
 | eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
 | benchmark-2156 | ACTIVE | Acquire and adjudicate the coverage-complete v0.2 evaluation inventory (#6084) | Every frozen category minimum and statistical stop condition is met; every item carries licensing, provenance, contamination, and qualified Ukrainian-human evidence under [#6074](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6074); unresolved conflicts remain non-headline, and no model run is required |
-| open-model-data | ACTIVE | Deliver the Ukrainian Data Foundry reference build under #6056: architecture (#6119) → full-corpus profiling (#6120) → qualified correction review (#6121) → disjoint exporters and recipes (#6122) → end-to-end validation (#6123) | Versioned fail-closed interfaces and deterministic receipts cover provenance through adjudication; full-corpus coverage and unknowns are measured; training, correction, preference, quality-filter, and evaluation views are mechanically disjoint; recipes and the frozen baseline harness validate end to end; #6082 remains superseded history, and no release, upload, training, OCR, or external outreach is performed |
+| open-model-data | ACTIVE | Execute Foundry Phase 2 in parallel under #6164: admit useful-scale real corpus families with complete provenance/rights evidence (#6166) and run the contextual Ukrainian language-contact detector across the full 189,150-record corpus (#6167) | Real records—not fixtures—are admitted or explicitly rejected across the complete denominator, and every detected Russian quotation, modern interference, phonetic rendering, mixed/historical/protected span, and uncertainty retains context and source lineage. The stream then continues through qualified-human gold (#6168), real exports and tokenizer evidence (#6169), one preregistered causal open-weight experiment (#6170), and stranger-reproduced release candidacy (#6171); only the named human approval gates may pause it |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |

--- a/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
@@ -1,9 +1,11 @@
 # Ukrainian Data Foundry Architecture
 
 > **Status:** Operator-approved architecture; implementation contract
-> **Owner:** [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
+> **Owner:** [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
+> (production successor to completed foundation
+> [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056))
 > **Architecture issue:** [#6119](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6119)
-> **Recorded:** 2026-07-31
+> **Recorded:** 2026-07-31; production execution chain refreshed 2026-08-01
 > **Does not authorize:** model training, fine-tuning, weight publication,
 > dataset upload or release, redistribution, researcher outreach, private-data
 > disclosure, or OCR
@@ -351,7 +353,7 @@ Tokenizer diagnostics are optional in this first component unless an existing
 approved interface can be included without compromising the full-corpus
 morphology deliverable.
 
-## Execution chain
+## Completed v1 execution chain
 
 1. [#6119](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6119)
    merges this architecture and aligns the control plane.
@@ -369,3 +371,43 @@ External validation may follow a built artifact. It is not a prerequisite for
 any step above. Dataset release, upload, redistribution, model training, weight
 publication, private-data disclosure, researcher contact, and OCR each require
 separate present-tense authorization.
+
+## Phase 2–4 production execution chain
+
+The v1 interfaces are foundations, not delivery of the Foundry's ultimate
+outcome. At the start of Phase 2, the corpus profiler covers 189,150 records and
+50,298,925 lexical words, but no real record is training-admitted and the only
+end-to-end correction is a synthetic fixture. Production therefore proceeds
+through the following hard-gated chain under #6164:
+
+1. [#6166](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6166)
+   resolves source, edition, acquisition, rights, permitted-use, origin, and
+   contamination evidence for every real corpus family and admits useful-scale
+   real data where the evidence permits it.
+2. [#6167](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6167)
+   runs a contextual detector across the complete corpus and preserves the
+   difference between Russian quotation, modern interference, phonetic
+   rendering, mixed or historical language, protected Ukrainian variation,
+   and uncertainty.
+3. [#6168](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6168)
+   freezes sampling and stopping rules before labeling, then obtains two
+   independent qualified-Ukrainian-human judgments plus distinct conflict
+   adjudication. Model judgments never substitute for this gate.
+4. [#6169](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6169)
+   emits real disjoint consumer views with lineage, benchmark isolation,
+   tokenizer diagnostics, and loss-mask evidence.
+5. [#6170](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6170)
+   runs one operator-approved, preregistered open-weight treatment and causal
+   ablation only after real data, frozen gold, an exact model revision, and a
+   compute budget exist.
+6. [#6171](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6171)
+   packages the corpus-portable, rights-safe release candidate and requires a
+   clean independent reproduction before publication is considered.
+
+Admission and full-corpus detection begin in parallel. Later stages consume
+their frozen evidence in order. The orchestrator does not stop at intermediate
+PR merges; only the source-family admission, qualified-human review, exact
+training preregistration/budget, and final publication approvals are deliberate
+human gates. No arbitrary row count, agreement score, tokenizer ratio,
+significance threshold, or effect size may be invented to replace evidence-led
+criteria frozen in the owning issue.

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -5,9 +5,10 @@
 > realignment on 2026-07-30; recorded in
 > [PR #6060](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6060).
 > Operator approved the Ukrainian Data Foundry architecture, replacement issue
-> chain, and first implementation on 2026-07-31.
+> chain, and first implementation on 2026-07-31, then issued **GO REALIGN AND
+> EXECUTE PHASE 2–4** on 2026-08-01.
 > **Recorded:** 2026-07-30; Foundry direction and existing-asset baseline
-> refreshed 2026-07-31
+> refreshed 2026-08-01
 > **Applies to:** Ukrainian model evaluation, dataset work, training-data
 > preparation, and UNLP ecosystem monitoring
 > **Does not authorize:** model training, dataset publication, or mixing
@@ -41,10 +42,13 @@ future training data.
 
 ## GitHub execution homes
 
-- [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
-  owns the Ukrainian Data Foundry: provenance and rights contracts,
-  full-corpus diagnostics, candidate review and adjudication, mechanically
-  disjoint consumer exports, recipes, and reference validation.
+- [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
+  owns Foundry Phase 2–4: real corpus admission, production contextual
+  language-contact detection, qualified-human gold, real model-ready exports,
+  one preregistered causal open-weight experiment, and a reproducible release
+  candidate. Closed [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
+  owns the completed interfaces, profiler, exporters, recipes, and synthetic
+  reference build on which this production program depends.
 - [#6057](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6057)
   owns the separately frozen public benchmark v0.2 design and release.
 - [#4913](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4913)
@@ -234,27 +238,40 @@ status.
 
 ### Immediate work
 
-1. Define and implement the versioned Foundry interfaces from source and
-   provenance evidence through streaming normalization, language-span
-   handling, classification, morphology evidence, candidate generation,
-   qualified Ukrainian-human adjudication, and separate consumer views.
-2. Profile the complete locally accessible public/external human-authored
-   corpus before any admission decision. Report measured coverage and explicit
-   unknowns; do not convert inventory rows or VESUM forms into rights-cleared
-   contextual training text.
-3. Emit evidence-backed grammar, calque, collocation, and
-   Russian-interference review candidates. Keep every candidate unresolved
-   until contextual evidence and qualified Ukrainian-human adjudication exist.
-4. Build mechanically separate training, correction, preference,
-   quality-filter, and evaluation exporters with end-to-end lineage,
-   exact/near-duplicate controls, and frozen benchmark exclusions.
-5. Add reproducible preparation and training recipes, then validate an
-   end-to-end reference build against the frozen baseline harness. Recipes do
-   not authorize a training run.
-6. Independently acquire and adjudicate the coverage-complete v0.2 evaluation
-   inventory under its frozen evidence plan and qualified-review protocol.
+1. Admit or explicitly reject every real corpus family across the measured
+   189,150-record / 50,298,925-word denominator under complete source,
+   edition, acquisition, rights, permitted-use, origin, and contamination
+   evidence (#6166). The result must be useful-scale real data, not another
+   one-record demonstration.
+2. In parallel, run the production contextual language-contact detector across
+   that complete corpus (#6167). It must distinguish Russian quotation,
+   modern interference, phonetic Russian rendering, mixed-language spans,
+   historical usage, protected Ukrainian variation, and uncertainty while
+   retaining context and source lineage. VESUM absence is only one signal.
+3. Freeze sampling and stopping rules, then obtain real independent review by
+   qualified Ukrainian humans and conflict adjudication (#6168). GPT, Gemini,
+   and Claude may prepare evidence but cannot satisfy this human gate.
+4. Emit real, mechanically disjoint training, correction, preference,
+   quality-filter, and evaluation views with contamination and tokenizer/loss-
+   mask diagnostics (#6169). No universal tokenizer threshold is presumed.
+5. After present-tense operator approval of the exact model revision, compute
+   budget, and preregistration, run the smallest causal open-weight treatment
+   and ablation that can test whether the Foundry data changes Ukrainian
+   behavior (#6170). Report null or adverse results as first-class outcomes.
+6. Package a corpus-portable, rights-safe release candidate and have an
+   independent party reproduce it from clean instructions on their own corpus
+   (#6171). Publication remains a separate present-tense operator gate.
+7. Independently acquire and adjudicate the coverage-complete v0.2 evaluation
+   inventory under #6084. Public evaluation gold remains mechanically isolated
+   from every training or tuning view.
 
-### First Foundry reference build
+The accountable orchestrator continues from one completed child issue to the
+next. A merged implementation PR is progress, not a stopping condition. Work
+pauses only at the source-family admission decision, qualified-Ukrainian-human
+review, exact training preregistration/budget approval, or final publication
+approval named on #6164.
+
+### Completed Foundry v1 reference build
 
 The #6119–#6123 implementation chain now has an executable reference build. It
 reproduces the complete 189,150-record / 50,298,925-word morphology profile,

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -33,7 +33,7 @@ streams:
     epics: [6057]  # compatibility key retained; completed v0.1.1 epic #2156 is historical
   open-model-data:
     title: "Ukrainian open-model data infrastructure"
-    epics: [6056]
+    epics: [6164]  # production successor; completed Foundry v1 epic #6056 is historical
   core-quality:
     title: "Core-track deterministic quality"
     epics: [4274]


### PR DESCRIPTION
## What changed

- makes #6164 the active `open-model-data` stream epic, replacing completed foundation epic #6056
- records the operator's **GO REALIGN AND EXECUTE PHASE 2–4**
- aligns the North Star, architecture contract, and current Workstreams milestone with #6166–#6171
- makes real corpus admission and full-corpus contextual detection the parallel Phase 2 entry point
- names the only deliberate human gates and keeps public benchmark gold isolated

## Why

The v1 reference chain #6119–#6123 is complete, but the repository still pointed the active stream at closed #6056 and described the synthetic reference build as the current milestone. That could stop execution after infrastructure while the corpus still has zero real training-admitted records.

This PR restores continuity from the measured 189,150-record corpus through qualified-Ukrainian-human gold, real model views, one preregistered causal open-weight experiment, and independently reproduced release candidacy.

## Scope boundaries

No corpus mutation, admission decision, detector implementation, human labeling, model training, publication, upload, OCR, outreach, or benchmark-gold reuse occurs here.

## Verification

- 69 focused issue-stream/research-registry tests
- Markdownlint on all three changed documents
- YAML schema/load assertion
- live issue-stream audit: #6166–#6171 uniquely map to #6164 / `open-model-data`
- staged OPSEC scan
- `git diff --check`
- exact-head Claude Sonnet 5 cross-family review: **PASS — no findings**
- structured review receipt: `clean`, reviewer-output SHA-256 `5e3158427ee3975dcaaf82e53f3acbb2d08dc91dc3a8fe5a11c7c952c0bf46d0`

Program epic: #6164