### PR TITLE
feat(runtime): attribute fleet call initiators

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -376,13 +376,17 @@ function renderRecent(records) {
     return;
   }
   document.getElementById('recent-content').innerHTML = `<table>
-    <thead><tr><th>ts</th><th>agent</th><th>entrypoint</th><th>model</th><th>outcome</th><th>duration</th></tr></thead>
+    <thead><tr><th>Time</th><th>Source</th><th>Agent</th><th>Via</th><th>Model</th><th>Outcome</th><th>Duration</th></tr></thead>
     <tbody>${records.map(record => {
       const cls = record.outcome === 'ok' ? 'ok' : record.outcome === 'rate_limited' ? 'warn' : record.outcome === 'timeout' ? 'gray' : 'err';
       return `<tr>
         <td>${formatTs(record.ts)}</td>
+        <td>
+          <div>${escapeHtml(record.source || 'unknown')}</div>
+          ${record.source_task_id ? `<div class="muted mono">${escapeHtml(record.source_task_id)}</div>` : ''}
+        </td>
         <td>${escapeHtml(record.agent || '—')}</td>
-        <td class="mono">${escapeHtml(record.entrypoint || '—')}</td>
+        <td class="mono">${escapeHtml(record.via || record.entrypoint || '—')}</td>
         <td class="mono">${escapeHtml(record.model || '—')}</td>
         <td><span class="pill ${cls}">${escapeHtml(record.outcome || 'unknown')}</span></td>
         <td>${formatDuration(record.duration_s)}</td>

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1399,12 +1399,16 @@ Quota gate for one `(agent, model)` pair.
 ### `GET /api/runtime/recent?limit=50`
 
 Newest usage records from today's runtime logs, newest first.
+`source` is the initiating orchestrator, while `agent` is the destination and
+`via` is the transport. The runtime persists only bounded identifiers and
+reports legacy or unattributable records as `unknown`; it never guesses the
+caller from the destination agent.
 
 ```json
 {
   "records": [
-    {"ts": "2026-04-11T00:10:00Z", "agent": "codex", "entrypoint": "dispatch", "outcome": "ok"},
-    {"ts": "2026-04-11T00:09:00Z", "agent": "gemini", "entrypoint": "bridge", "outcome": "timeout"}
+    {"ts": "2026-04-11T00:10:00Z", "source": "claude", "agent": "codex", "via": "delegate", "outcome": "ok"},
+    {"ts": "2026-04-11T00:09:00Z", "source": "codex", "agent": "gemini", "via": "bridge", "outcome": "timeout"}
   ]
 }
 ```

--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -601,6 +601,7 @@ class AcpxDiscussionController:
         deliveries: dict[str, tuple[str, str, str | None]],
         state: str,
         deadline: float,
+        initiator: str | None = None,
         participants: tuple[str, str] = PARTICIPANTS,
     ) -> list[ParticipantOutcome]:
         reservations: dict[str, str] = {}
@@ -644,6 +645,7 @@ class AcpxDiscussionController:
                                      "correlation_id": correlation_id, "idempotency_key": idempotency_key},
                         hard_timeout=max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock()))),
                         entrypoint="acpx-discuss",
+                        initiator=initiator,
                     )
             except BaseException as exc:  # preserve cancellation as typed partial evidence
                 error = exc
@@ -717,6 +719,7 @@ class AcpxDiscussionController:
         idempotency_key: str,
         rounds: int = DEFAULT_ROUNDS,
         participants: Sequence[str] = PARTICIPANTS,
+        initiator: str | None = None,
     ) -> dict[str, Any]:
         if os.environ.get(TRANSPORT_ENV, "off").strip().lower() != "active":
             raise AcpxDiscussionError("LU_ACPX_TRANSPORT=active is required by acp-discuss")
@@ -760,6 +763,7 @@ class AcpxDiscussionController:
                 idempotency_digest=idempotency_digest,
                 rounds=rounds,
                 participants=normalized_participants,
+                initiator=initiator,
             )
 
     def _run_admitted(
@@ -773,6 +777,7 @@ class AcpxDiscussionController:
         idempotency_digest: str,
         rounds: int,
         participants: tuple[str, str],
+        initiator: str | None,
     ) -> dict[str, Any]:
         started = self.clock()
         deadline = started + WHOLE_TIMEOUT_SECONDS
@@ -805,6 +810,7 @@ class AcpxDiscussionController:
             prompts={p: prompt for p in participants},
             deliveries={p: ("root", prompt, None) for p in participants},
             state="INITIAL_FANOUT", deadline=deadline,
+            initiator=initiator,
         )
         all_outcomes = list(outcomes)
         content_used += sum(len(item.response.encode("utf-8")) for item in outcomes if item.response)
@@ -857,6 +863,7 @@ class AcpxDiscussionController:
                 prompts=prompts,
                 deliveries=deliveries,
                 state="CROSS_EXCHANGE", deadline=deadline,
+                initiator=initiator,
             )
             all_outcomes.extend(outcomes)
             content_used += sum(len(value.encode("utf-8")) for value in prompts.values())
@@ -910,7 +917,20 @@ class AcpxDiscussionController:
                 kind="request",
             )
             try:
-                synthesis_result = self.synthesis_call("codex", synthesis_prompt, mode="read-only", cwd=cwd, task_id=task_id, session_id=None, entrypoint="acpx-discuss-synthesis", hard_timeout=max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock()))))
+                synthesis_result = self.synthesis_call(
+                    "codex",
+                    synthesis_prompt,
+                    mode="read-only",
+                    cwd=cwd,
+                    task_id=task_id,
+                    session_id=None,
+                    entrypoint="acpx-discuss-synthesis",
+                    hard_timeout=max(
+                        1,
+                        min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock())),
+                    ),
+                    initiator=initiator,
+                )
                 if synthesis_result.ok:
                     synthesis = synthesis_result.response
             except BaseException as exc:

--- a/scripts/agent_runtime/attribution.py
+++ b/scripts/agent_runtime/attribution.py
@@ -1,0 +1,73 @@
+"""Privacy-safe attribution for agent-runtime calls.
+
+The target agent and the transport entrypoint cannot identify the caller.  This
+module resolves that caller once, records how it was resolved, and deliberately
+falls back to ``unknown`` instead of guessing from the destination.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,99}$")
+_ATTRIBUTION_SOURCES = frozenset({"explicit", "session_env", "unknown"})
+
+
+@dataclass(frozen=True)
+class InvocationAttribution:
+    """Bounded caller identity suitable for persisted runtime telemetry."""
+
+    initiator: str
+    source: str
+    task_id: str | None
+
+
+def _safe_id(value: object) -> str | None:
+    candidate = str(value or "").strip().lower()
+    return candidate if _SAFE_ID_RE.fullmatch(candidate) else None
+
+
+def _safe_task_id(value: object) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate if _SAFE_ID_RE.fullmatch(candidate) else None
+
+
+def resolve_invocation_attribution(
+    *,
+    explicit: str | None = None,
+    task_id: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> InvocationAttribution:
+    """Resolve caller identity without inferring it from the target agent."""
+    environ = os.environ if env is None else env
+    if explicit is not None:
+        initiator = _safe_id(explicit)
+        if initiator is None:
+            raise ValueError(
+                "initiator must be a 1-100 character identifier containing only "
+                "letters, digits, dot, underscore, colon, slash, or hyphen"
+            )
+        return InvocationAttribution(initiator, "explicit", _safe_task_id(task_id))
+
+    forwarded = _safe_id(environ.get("LU_RUNTIME_INITIATOR"))
+    forwarded_source = str(environ.get("LU_RUNTIME_INITIATOR_SOURCE") or "").strip()
+    if forwarded and forwarded_source in _ATTRIBUTION_SOURCES - {"unknown"}:
+        return InvocationAttribution(forwarded, forwarded_source, _safe_task_id(task_id))
+
+    handoff = _safe_id(environ.get("SESSION_HANDOFF_AGENT"))
+    if handoff:
+        return InvocationAttribution(handoff, "session_env", _safe_task_id(task_id))
+    if environ.get("CODEX_THREAD_ID") or environ.get("CODEX_SESSION"):
+        return InvocationAttribution("codex", "session_env", _safe_task_id(task_id))
+    claude = _safe_id(environ.get("CLAUDE_AGENT_NAME"))
+    if claude:
+        return InvocationAttribution(claude, "session_env", _safe_task_id(task_id))
+    if environ.get("GROK_AGENT") == "1":
+        return InvocationAttribution("grok", "session_env", _safe_task_id(task_id))
+    if environ.get("GEMINI_SESSION"):
+        return InvocationAttribution("gemini", "session_env", _safe_task_id(task_id))
+
+    return InvocationAttribution("unknown", "unknown", _safe_task_id(task_id))

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -28,6 +28,7 @@ Issue: #1184
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import importlib
 import logging
 import os
@@ -53,6 +54,7 @@ from ai_llm.fallback import (
 
 from .adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
 from .adapters.base import AgentAdapter
+from .attribution import InvocationAttribution, resolve_invocation_attribution
 from .env_sanitize import build_agent_env
 from .errors import (
     AgentRuntimeError,
@@ -112,10 +114,18 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
     {"acpx-pilot-native", "acpx-pilot-shadow", "acpx-discuss", "acpx-discuss-synthesis"}
 )
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
+# Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
+# built-in seats. Keep it bounded, but above the production-observed 263,070
+# bytes that otherwise killed a valid concise GLM response before its terminal
+# frame arrived (#6159).
+_ACPX_GLM_OUTPUT_LIMIT_BYTES = 512 * 1024
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
 _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
+_INVOCATION_ATTRIBUTION: contextvars.ContextVar[InvocationAttribution | None] = (
+    contextvars.ContextVar("agent_runtime_invocation_attribution", default=None)
+)
 
 
 class AgentOutputLimitError(AgentRuntimeError):
@@ -138,6 +148,8 @@ def _streamed_output_limit(*, agent_name: str, entrypoint: str) -> int | None:
         agent_name in acpx_seats
         and entrypoint in {"acpx-pilot-shadow", "acpx-discuss"}
     ):
+        if agent_name == "acpx-glm-shadow":
+            return _ACPX_GLM_OUTPUT_LIMIT_BYTES
         return _ACPX_DIRECT_OUTPUT_LIMIT_BYTES
     return None
 
@@ -729,6 +741,9 @@ def _build_usage_record(
         None if privacy_limited else (session_id[:100] if session_id else None)
     )
     telemetry_source = None if privacy_limited else os.environ.get("LU_TELEMETRY_SOURCE")
+    attribution = _INVOCATION_ATTRIBUTION.get() or resolve_invocation_attribution(
+        task_id=task_id
+    )
 
     record = {
         "ts": datetime.now(UTC).isoformat(),
@@ -745,6 +760,9 @@ def _build_usage_record(
         "slug": None if privacy_limited else os.environ.get("LU_TELEMETRY_SLUG"),
         "track": None if privacy_limited else os.environ.get("LU_TELEMETRY_TRACK"),
         "source": telemetry_source[:100] if telemetry_source else None,
+        "initiator": attribution.initiator,
+        "attribution_source": attribution.source,
+        "attribution_task_id": attribution.task_id,
         "duration_s": round(duration_s, 2),
         "input_chars": input_chars,
         "output_chars": output_chars,
@@ -2663,6 +2681,7 @@ def invoke(
     initial_response_timeout: int | None = None,
     event_sink: Callable[..., None] | None = None,
     effort: str | None = None,
+    initiator: str | None = None,
 ) -> Result:
     """Invoke an agent CLI, provisioning trail isolation before any spawn.
 
@@ -2671,12 +2690,18 @@ def invoke(
     profiles receive a private one-server MCP configuration that is removed
     after success, refusal, timeout, or adapter error.
     """
-    launch = prepare_trail_isolation(
-        agent_name=agent_name,
-        mode=mode,
-        tool_config=tool_config,
+    attribution = resolve_invocation_attribution(
+        explicit=initiator,
+        task_id=task_id,
     )
+    attribution_token = _INVOCATION_ATTRIBUTION.set(attribution)
+    launch = None
     try:
+        launch = prepare_trail_isolation(
+            agent_name=agent_name,
+            mode=mode,
+            tool_config=tool_config,
+        )
         return _invoke_impl(
             agent_name,
             prompt,
@@ -2697,6 +2722,7 @@ def invoke(
     finally:
         if launch is not None:
             launch.cleanup()
+        _INVOCATION_ATTRIBUTION.reset(attribution_token)
 
 
 def _invoke_direct_only(
@@ -2710,6 +2736,7 @@ def _invoke_direct_only(
     hard_timeout: int = 300,
     effort: str | None = None,
     entrypoint: str = "acpx-pilot-shadow",
+    initiator: str | None = None,
 ) -> Result:
     """Invoke one explicitly marked direct-only, read-only shadow seat.
 
@@ -2728,21 +2755,27 @@ def _invoke_direct_only(
         )
     if entrypoint not in {"acpx-pilot-shadow", "acpx-discuss"}:
         raise ValueError("ACPX direct-only invocation entrypoint was altered")
-    return _invoke_impl(
-        agent_name,
-        prompt,
-        mode="read-only",
-        cwd=cwd,
-        model=model,
-        task_id=task_id,
-        session_id=None,
-        tool_config=tool_config,
-        entrypoint=entrypoint,
-        hard_timeout=hard_timeout,
-        effort=effort,
-        allow_direct_only=True,
-        allow_runner_failover=False,
+    attribution_token = _INVOCATION_ATTRIBUTION.set(
+        resolve_invocation_attribution(explicit=initiator, task_id=task_id)
     )
+    try:
+        return _invoke_impl(
+            agent_name,
+            prompt,
+            mode="read-only",
+            cwd=cwd,
+            model=model,
+            task_id=task_id,
+            session_id=None,
+            tool_config=tool_config,
+            entrypoint=entrypoint,
+            hard_timeout=hard_timeout,
+            effort=effort,
+            allow_direct_only=True,
+            allow_runner_failover=False,
+        )
+    finally:
+        _INVOCATION_ATTRIBUTION.reset(attribution_token)
 
 
 def _invoke_native_once(
@@ -2757,6 +2790,7 @@ def _invoke_native_once(
     entrypoint: str = "acpx-pilot-native",
     hard_timeout: int = 300,
     effort: str | None = None,
+    initiator: str | None = None,
 ) -> Result:
     """Invoke one native ACPX-pilot authority call without runner failover."""
     if agent_name not in {"codex", "grok"}:
@@ -2771,17 +2805,23 @@ def _invoke_native_once(
         or (entrypoint == "acpx-discuss-synthesis" and agent_name != "codex")
     ):
         raise ValueError("ACPX pilot native invocation contract was altered")
-    return _invoke_impl(
-        agent_name,
-        prompt,
-        mode=mode,
-        cwd=cwd,
-        model=model,
-        task_id=task_id,
-        session_id=None,
-        tool_config=None,
-        entrypoint=entrypoint,
-        hard_timeout=hard_timeout,
-        effort=effort,
-        allow_runner_failover=False,
+    attribution_token = _INVOCATION_ATTRIBUTION.set(
+        resolve_invocation_attribution(explicit=initiator, task_id=task_id)
     )
+    try:
+        return _invoke_impl(
+            agent_name,
+            prompt,
+            mode=mode,
+            cwd=cwd,
+            model=model,
+            task_id=task_id,
+            session_id=None,
+            tool_config=None,
+            entrypoint=entrypoint,
+            hard_timeout=hard_timeout,
+            effort=effort,
+            allow_runner_failover=False,
+        )
+    finally:
+        _INVOCATION_ATTRIBUTION.reset(attribution_token)

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1467,6 +1467,7 @@ def _handle_discuss(args) -> int:
     try:
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
+        from agent_runtime.attribution import resolve_invocation_attribution
         from agent_runtime.errors import (
             AgentStalledError,
             AgentTimeoutError,
@@ -1484,14 +1485,19 @@ def _handle_discuss(args) -> int:
         return 1
 
     # ── validate inputs ────────────────────────────────────────────
-    acp_routine = (
-        os.environ.get("LU_AGENT_COMM_TRANSPORT", "bridge").strip().lower() == "acp"
-    )
-    acp_participant_routes: dict[str, dict[str, str | None]] = {}
-    if acp_routine:
-        from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+    requested_transport = os.environ.get("LU_AGENT_COMM_TRANSPORT", "acp").strip().lower()
+    if requested_transport not in {"acp", "bridge"}:
+        print(
+            "❌ LU_AGENT_COMM_TRANSPORT must be 'acp' or 'bridge'",
+            file=sys.stderr,
+        )
+        return 1
+    acp_routine = requested_transport == "acp"
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
 
-        acp_participant_routes = ACPX_SUPPORTED_PARTICIPANTS
+    acp_participant_routes: dict[str, dict[str, str | None]] = (
+        ACPX_SUPPORTED_PARTICIPANTS if acp_routine else {}
+    )
     with_agents = _parse_csv(args.with_agents)
     if not with_agents:
         print("❌ --with requires at least one agent", file=sys.stderr)
@@ -1558,6 +1564,12 @@ def _handle_discuss(args) -> int:
     if not body.strip():
         print("❌ empty discussion topic", file=sys.stderr)
         return 1
+    caller_attribution = resolve_invocation_attribution()
+    runtime_initiator = (
+        caller_attribution.initiator
+        if caller_attribution.initiator != "unknown"
+        else None
+    )
 
     # ── post the root question ────────────────────────────────────
     # NOTE: do NOT pass to_agents here — discuss handles fanout itself
@@ -1646,6 +1658,7 @@ def _handle_discuss(args) -> int:
                         idempotency_key=f"ab-discuss:{correlation_id}",
                         rounds=acp_rounds,
                         participants=tuple(with_agents),
+                        initiator=runtime_initiator,
                     )
                 finally:
                     if previous_transport is None:
@@ -1725,6 +1738,7 @@ def _handle_discuss(args) -> int:
                 cwd=REPO_ROOT,
                 model=agent_models.get(agent_name),
                 task_id=f"discuss-{correlation_id[:8]}-r{round_idx}-{agent_name}",
+                initiator=runtime_initiator,
                 # TODO(#1701): keep this flag in the sanitized child-env
                 # allowlist when the runner switches to build_agent_env().
                 tool_config=tool_config,

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -284,6 +284,7 @@ def _run_claude_sync_via_runtime(
                 model=target_model,
                 effort=effort_to_invoke,
                 task_id=msg.get('task_id'),
+                initiator=msg.get("from"),
                 session_id=session_id_to_pass,
                 tool_config=tool_config,
                 entrypoint="bridge",

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -383,6 +383,7 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
             cwd=REPO_ROOT,
             model=model,
             task_id=msg.get("task_id"),
+            initiator=msg.get("from"),
             session_id=None,  # Gemini CLI has no --resume; bridge multi-turn
                               # is handled via conversation context injection
                               # in the prompt builder, not CLI-level resume.

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -773,6 +773,7 @@ def _invoke_thread(
                 cwd=REPO_ROOT,
                 model=requested_model,
                 task_id=task_id,
+                initiator=claimed.deliveries[-1].from_agent,
                 session_id=session_id if resumable_agent else None,
                 tool_config=_with_discussion_readonly_tool_config(
                     tool_config,
@@ -820,6 +821,7 @@ def _invoke_gemini_thread_with_fallback(
                 cwd=REPO_ROOT,
                 model=current_model,
                 task_id=task_id,
+                initiator=claimed.deliveries[-1].from_agent,
                 session_id=None,
                 tool_config=tool_config,
                 entrypoint="bridge",

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -8,6 +8,7 @@ import inspect
 import ipaddress
 import json
 import os
+import re
 import sqlite3
 import sys
 from collections import defaultdict
@@ -53,6 +54,8 @@ router = APIRouter(tags=["runtime"])
 ADAPTERS_DIR = Path(__file__).resolve().parent.parent / "agent_runtime" / "adapters"
 USAGE_DIR = BATCH_STATE_DIR / "api_usage"
 _KNOWN_OUTCOMES = ("ok", "error", "timeout", "rate_limited")
+_RUNTIME_ATTRIBUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,99}$")
+_RUNTIME_ATTRIBUTION_SOURCES = frozenset({"explicit", "session_env", "unknown"})
 _ACP_LEGACY_PARTICIPANTS = ("codex", "grok")
 _ACP_ENABLED_PARTICIPANTS = frozenset(ACPX_SUPPORTED_PARTICIPANTS)
 _ACP_STATES = frozenset({
@@ -441,10 +444,23 @@ def recent_runtime_records(*, limit: int = 50) -> dict[str, Any]:
     summaries: list[dict[str, Any]] = []
     for record in _iter_usage_records(_today_usage_files()):
         ts = _parse_iso_datetime(record.get("ts"))
+        initiator = record.get("initiator")
+        if not isinstance(initiator, str) or not _RUNTIME_ATTRIBUTION_ID.fullmatch(initiator):
+            initiator = "unknown"
+        source_provenance = record.get("attribution_source")
+        if source_provenance not in _RUNTIME_ATTRIBUTION_SOURCES or initiator == "unknown":
+            source_provenance = "unknown"
+        source_task_id = record.get("attribution_task_id")
+        if not isinstance(source_task_id, str) or not _RUNTIME_ATTRIBUTION_ID.fullmatch(source_task_id):
+            source_task_id = None
         summaries.append({
             "ts": _isoformat_z(ts) if ts else record.get("ts"),
             "agent": record.get("agent"),
             "entrypoint": record.get("entrypoint"),
+            "via": record.get("entrypoint"),
+            "source": initiator,
+            "source_provenance": source_provenance,
+            "source_task_id": source_task_id,
             "model": record.get("model"),
             "outcome": record.get("outcome"),
             "duration_s": record.get("duration_s"),

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -3585,9 +3585,18 @@ def _run_worker(
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+    from agent_runtime.attribution import resolve_invocation_attribution
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
 
     task_id = args.task_id
+    try:
+        attribution = resolve_invocation_attribution(
+            explicit=getattr(args, "initiator", None),
+            task_id=task_id,
+        )
+    except ValueError as exc:
+        print(f"❌ invalid --initiator: {exc}", file=sys.stderr)
+        return 2
     try:
         requested_harness = _resolve_dispatch_harness(args.agent, getattr(args, "harness", None))
     except ValueError as exc:
@@ -3909,6 +3918,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         )
         dry_run_state = {
             "task_id": task_id,
+            "initiator": attribution.initiator,
+            "attribution_source": attribution.source,
             "agent": dispatch_agent,
             "model": start_telemetry.model,
             "effort": start_telemetry.effort,
@@ -4052,6 +4063,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worktree_layout = worktree_telemetry.get("layout") if worktree_path else None
     initial_state = {
         "task_id": task_id,
+        "initiator": attribution.initiator,
+        "attribution_source": attribution.source,
         "agent": dispatch_agent,
         "model": start_telemetry.model,
         "effort": start_telemetry.effort,
@@ -4191,6 +4204,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # explicit rather than implicit. Callers that want to scrub
     # secrets from the worker's env can override this here.
     worker_env = os.environ.copy()
+    worker_env["LU_RUNTIME_INITIATOR"] = attribution.initiator
+    worker_env["LU_RUNTIME_INITIATOR_SOURCE"] = attribution.source
     _inject_gh_token_for_agent(worker_env, dispatch_agent)
     worker_env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
     worker_env["TMPDIR"] = str(runtime_tmp_root)
@@ -4890,6 +4905,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")
+    d.add_argument(
+        "--initiator",
+        default=None,
+        help=(
+            "Initiating orchestrator identity for runtime attribution. Launcher "
+            "and Codex Desktop identity are detected automatically when omitted."
+        ),
+    )
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")
     d.add_argument("--prompt-file", help="Read the prompt body from this file path.")
     d.add_argument(

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -109,6 +109,7 @@ from agent_runtime.adapters.base import InvocationPlan
 from agent_runtime.adapters.claude import ClaudeAdapter
 from agent_runtime.adapters.codex import CodexAdapter
 from agent_runtime.adapters.gemini import GeminiAdapter, resolve_gemini_auth_mode
+from agent_runtime.attribution import resolve_invocation_attribution
 from agent_runtime.errors import (
     AgentTimeoutError,
     AgentUnavailableError,
@@ -279,6 +280,34 @@ def test_acpx_pilot_usage_records_strip_sensitive_context(
     assert record["outcome"] == "error"
     assert record["duration_s"] == 1.25
     assert record["tokens"] == 3
+
+
+def test_usage_attribution_is_explicit_and_privacy_safe(monkeypatch):
+    monkeypatch.setenv("SESSION_HANDOFF_AGENT", "claude")
+
+    attribution = resolve_invocation_attribution(
+        explicit="Codex",
+        task_id="routing-6159",
+    )
+
+    assert attribution.initiator == "codex"
+    assert attribution.source == "explicit"
+    assert attribution.task_id == "routing-6159"
+
+
+def test_usage_attribution_detects_codex_desktop(monkeypatch):
+    monkeypatch.delenv("SESSION_HANDOFF_AGENT", raising=False)
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-6159")
+
+    attribution = resolve_invocation_attribution(task_id="routing-6159")
+
+    assert attribution.initiator == "codex"
+    assert attribution.source == "session_env"
+
+
+def test_usage_attribution_rejects_unsafe_explicit_identity():
+    with pytest.raises(ValueError, match="initiator must be"):
+        resolve_invocation_attribution(explicit="<script>")
 
 
 def test_acpx_grok_shadow_entry_is_direct_only():
@@ -4339,3 +4368,16 @@ def test_non_acpx_route_has_no_streamed_output_limit(tmp_path, monkeypatch):
     )
     assert execution.kill_reason is None
     assert execution.returncode == 0
+
+
+def test_glm_acp_route_has_a_separate_bounded_protocol_envelope():
+    from agent_runtime import runner as runtime_runner
+
+    assert runtime_runner._streamed_output_limit(
+        agent_name="acpx-glm-shadow",
+        entrypoint="acpx-discuss",
+    ) == 512 * 1024
+    assert runtime_runner._streamed_output_limit(
+        agent_name="acpx-kimi-shadow",
+        entrypoint="acpx-discuss",
+    ) == 256 * 1024

--- a/tests/test_bridge_inbox.py
+++ b/tests/test_bridge_inbox.py
@@ -116,6 +116,7 @@ def test_run_inbox_single_thread_single_delivery(mock_invoke):
     assert summary.replies_posted == 1
     assert mock_invoke.call_count == 1
     assert mock_invoke.call_args.kwargs["mode"] == "read-only"
+    assert mock_invoke.call_args.kwargs["initiator"] == "user"
     assert mock_invoke.call_args.kwargs["tool_config"]["discussion_readonly"] is True
     delivered = _delivery_rows(str(thread[0]["message_id"]))[0]
     assert delivered["status"] == "delivered"

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -62,7 +62,8 @@ def test_post_preflight_skips_non_workspace_write_mode():
 
 
 @pytest.fixture(autouse=True)
-def isolate_db(tmp_path):
+def isolate_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("LU_AGENT_COMM_TRANSPORT", "bridge")
     db_file = tmp_path / "messages.db"
     with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -14,7 +14,8 @@ from ai_agent_bridge import _channels, _channels_cli, _cli, _db
 
 
 @pytest.fixture(autouse=True)
-def isolate_db(tmp_path):
+def isolate_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("LU_AGENT_COMM_TRANSPORT", "bridge")
     db_file = tmp_path / "messages.db"
     with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
         "ai_agent_bridge._db.DB_PATH", db_file

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -3149,6 +3149,8 @@ def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(
             "codex",
             "--task-id",
             "dry/run tmp",
+            "--initiator",
+            "codex",
             "--prompt",
             "test",
             "--dry-run",
@@ -3161,6 +3163,8 @@ def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(
     assert state is not None
     lease_root = tmp_path / "learn-ukrainian" / "dry-run-tmp"
     assert state["status"] == "dry_run"
+    assert state["initiator"] == "codex"
+    assert state["attribution_source"] == "explicit"
     assert state["runtime_tmp_root"] == str(lease_root)
     assert state["tmp_bytes_freed"] == 0
     assert state["tmp_reap_error"] is None

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -189,7 +189,7 @@ def test_acp_discuss_cli_scopes_active_transport_and_restores_environment(
     assert json.loads(capsys.readouterr().out) == {"state": "COMPLETE"}
 
 
-def test_launcher_transport_routes_supported_bridge_command_to_durable_acp(
+def test_supported_bridge_command_defaults_to_durable_acp(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -206,7 +206,8 @@ def test_launcher_transport_routes_supported_bridge_command_to_durable_acp(
         "load_channel_context",
         lambda channel: {"body": "", "revs": {}, "missing": []},
     )
-    monkeypatch.setenv("LU_AGENT_COMM_TRANSPORT", "acp")
+    monkeypatch.delenv("LU_AGENT_COMM_TRANSPORT", raising=False)
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-6159")
     _channels.create_channel("architecture", exist_ok=False)
     observed: dict[str, object] = {}
 
@@ -235,6 +236,7 @@ def test_launcher_transport_routes_supported_bridge_command_to_durable_acp(
 
     assert _channels_cli._handle_discuss(args) == 0
     assert observed["participants"] == ("kimicc", "pool")
+    assert observed["initiator"] == "codex"
     assert "Compare the bounded options." in str(observed["prompt"])
     assert "--- monitor: project state" not in str(observed["prompt"])
     output = capsys.readouterr().out

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -215,6 +215,7 @@ def test_run_gemini_sync_derives_runtime_mode_from_allow_write(
         )
 
     assert mock_invoke.call_args.kwargs["mode"] == expected_mode
+    assert mock_invoke.call_args.kwargs["initiator"] == "claude"
 
 
 def test_handle_ask_gemini_routes_to_agy(monkeypatch):

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -796,6 +796,9 @@ def test_recent_limits_results(tmp_path, monkeypatch):
                 "ts": _iso(now - timedelta(minutes=2)),
                 "agent": "gemini",
                 "entrypoint": "bridge",
+                "initiator": "codex",
+                "attribution_source": "explicit",
+                "attribution_task_id": "review-6159",
                 "model": "gemini-3.1-pro-preview",
                 "outcome": "ok",
                 "duration_s": 5.0,
@@ -809,7 +812,22 @@ def test_recent_limits_results(tmp_path, monkeypatch):
     records = response.json()["records"]
     assert len(records) == 2
     assert records[0]["outcome"] == "timeout"
+    assert records[0]["source"] == "unknown"
+    assert records[0]["via"] == "dispatch"
     assert records[1]["agent"] == "gemini"
+    assert records[1]["source"] == "codex"
+    assert records[1]["source_provenance"] == "explicit"
+    assert records[1]["source_task_id"] == "review-6159"
+
+
+def test_runtime_page_labels_caller_source_separately_from_transport():
+    html = (DASHBOARDS / "runtime.html").read_text(encoding="utf-8")
+
+    assert "<th>Source</th>" in html
+    assert "<th>Agent</th>" in html
+    assert "<th>Via</th>" in html
+    assert "record.source || 'unknown'" in html
+    assert "record.via || record.entrypoint" in html
 
 
 def test_transport_health_returns_sanitized_cached_probe(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- persist a privacy-safe initiating orchestrator and task reference on every runtime call
- expose `Source`, target `Agent`, and transport `Via` separately in the Runtime API and dashboard
- default supported two-participant `ab discuss` calls to durable ACP instead of launcher-dependent bridge fallback
- keep native OpenCode/GLM ACP bounded while allowing its observed protocol envelope to complete

## Root cause

Runtime rows recorded only the destination agent and entrypoint, so operators could not identify which orchestrator made a bad routing decision. Supported ACP discussions also defaulted to the legacy bridge unless a launcher happened to export `LU_AGENT_COMM_TRANSPORT=acp`; a normal Codex Desktop call therefore silently used the obsolete path. The GLM ACP leg additionally exceeded the generic 256 KiB protocol cap by 926 bytes and was killed before its terminal frame.

## Impact

New rows identify the initiator as `explicit`, launcher/session-derived, or `unknown`; historical rows remain honestly `unknown`. The UI is read-only and keeps caller, destination, and transport distinct. Supported two-seat discussions now choose ACP by default and never retry a failed ACP call over the bridge.

## Validation

- 646 scoped tests passed; 1 existing platform skip
- Ruff, compilation, OPSEC, diff, and commit-trailer checks passed
- browser-verified `Time | Source | Agent | Via | Model | Outcome | Duration`
- live Kimi + GLM + Codex synthesis ACP conversation completed: `conversation_c6c59feda7cc46e58357ef41ddf23133`
- live runtime rows persisted `source=codex`, `via=acpx-discuss`, and `outcome=ok` for both Kimi and GLM

Rail-Approval-Receipt: rail-approval-f227257452854d6795f7a34559e3c469

Advances #6159
