### PR TITLE
feat(entire-context): public body-free context-link index (#6174)

### DIFF
--- a/scripts/entire_context/__init__.py
+++ b/scripts/entire_context/__init__.py
@@ -1,0 +1,37 @@
+"""Public, provider-neutral, body-free Entire context-link index (#6174 / ADR-018).
+
+This package implements the local-only slice of the Entire context layer:
+
+- a versioned, strict, body-free context-link schema (:mod:`.model`);
+- a deterministic locator-ID derivation over canonical metadata;
+- a caller-owned, rebuildable SQLite projection with an append-only lifecycle
+  (pending / promoted / tombstoned) and idempotent admission (:mod:`.store`);
+- a provider-neutral CLI for body-free ``status``, known-ID ``lookup`` /
+  ``explain``, and deterministic ``rebuild`` (``python -m scripts.entire_context``).
+
+Nothing in this package calls Entire, GitHub, Fleet, ACP, Monitor, or the
+network, and nothing here mutates any canonical authority system. The
+projection is disposable and disabled/non-load-bearing by default.
+"""
+
+from .model import (
+    SCHEMA_VERSION,
+    ContextLink,
+    LinkKind,
+    SchemaError,
+    VerificationEvidence,
+    VerificationStatus,
+)
+from .store import AdmitOutcome, AdmitResult, ContextLinkStore
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AdmitOutcome",
+    "AdmitResult",
+    "ContextLink",
+    "ContextLinkStore",
+    "LinkKind",
+    "SchemaError",
+    "VerificationEvidence",
+    "VerificationStatus",
+]

--- a/scripts/entire_context/__main__.py
+++ b/scripts/entire_context/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m scripts.entire_context``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -139,7 +139,7 @@ def _load_json_file(path: str, label: str) -> dict[str, Any]:
     try:
         raw = Path(path).read_text(encoding="utf-8")
         payload = json.loads(raw)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise SchemaError(f"{label} is not readable JSON") from exc
     if not isinstance(payload, dict):
         raise SchemaError(f"{label} must be a JSON object")

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -123,9 +123,9 @@ def cmd_rebuild(args: argparse.Namespace) -> int:
         result = ContextLinkStore(db_path).rebuild()
     except (sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
-        return EXIT_OK
+        return EXIT_REFUSED
     _emit({"available": True, "projection_path": str(db_path), **result})
-    return EXIT_OK if result["parity"] else EXIT_REFUSED
+    return EXIT_OK
 
 
 def _load_json_file(path: str, label: str) -> dict[str, Any]:

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -115,6 +115,13 @@ def cmd_explain(args: argparse.Namespace) -> int:
 
 
 def cmd_rebuild(args: argparse.Namespace) -> int:
+    """Replay projection state, refusing corrupt input because this command mutates state.
+
+    Observational commands report an unreadable optional projection with a
+    successful body-free status payload. Rebuild is a recovery mutation: if
+    the event log cannot be read, no repair was applied and callers receive
+    ``EXIT_REFUSED``.
+    """
     db_path, early = _guard(args)
     if early is not None:
         _emit(early)
@@ -204,7 +211,10 @@ def build_parser() -> argparse.ArgumentParser:
     add_db_flag(explain)
     explain.set_defaults(func=cmd_explain)
 
-    rebuild = sub.add_parser("rebuild", help="Replay the append-only event log into the projection")
+    rebuild = sub.add_parser(
+        "rebuild",
+        help="Replay the event log; refuse unreadable input because rebuild mutates projection state",
+    )
     add_db_flag(rebuild)
     rebuild.set_defaults(func=cmd_rebuild)
 

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -1,0 +1,220 @@
+"""Provider-neutral CLI for the body-free context-link projection.
+
+Commands: ``status``, ``lookup``, ``explain``, ``rebuild``, ``admit``.
+Every command is local-only: none of them calls Entire, GitHub, Fleet, ACP,
+Monitor, or the network. A missing or disabled projection is reported as a
+body-free status payload, never as a traceback, and read commands never create
+local state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from .model import ContextLink, SchemaError, VerificationEvidence
+from .store import AdmitOutcome, ContextLinkStore
+
+EXIT_OK = 0
+EXIT_NOT_FOUND = 1
+EXIT_REFUSED = 2
+
+DEFAULT_DB_RELATIVE = Path("batch_state") / "entire-context" / "v1" / "context-links.sqlite3"
+ENV_DB = "ENTIRE_CONTEXT_DB"
+ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n")
+
+
+def _resolve_db(args: argparse.Namespace) -> Path:
+    if getattr(args, "db", None):
+        return Path(args.db)
+    env = os.environ.get(ENV_DB)
+    if env:
+        return Path(env)
+    return Path.cwd() / DEFAULT_DB_RELATIVE
+
+
+def _disabled() -> bool:
+    return os.environ.get(ENV_DISABLED, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _unavailable_payload(db_path: Path, reason: str) -> dict[str, Any]:
+    return {
+        "enabled": True,
+        "available": False,
+        "reason": reason,
+        "projection_path": str(db_path),
+    }
+
+
+def _guard(args: argparse.Namespace) -> tuple[Path, dict[str, Any] | None]:
+    """Resolve the projection; return (path, early-payload) for disabled/missing."""
+    db_path = _resolve_db(args)
+    if _disabled():
+        return db_path, {"enabled": False, "reason": "projection_disabled", "projection_path": str(db_path)}
+    if not db_path.is_file():
+        return db_path, _unavailable_payload(db_path, "projection_missing")
+    return db_path, None
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    try:
+        payload = ContextLinkStore(db_path).status()
+    except sqlite3.Error:
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    payload.update({"enabled": True, "available": True, "projection_path": str(db_path)})
+    _emit(payload)
+    return EXIT_OK
+
+
+def cmd_lookup(args: argparse.Namespace) -> int:
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    try:
+        link = ContextLinkStore(db_path).lookup(args.locator_id)
+    except sqlite3.Error:
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    if link is None:
+        _emit({"found": False, "locator_id": args.locator_id})
+        return EXIT_NOT_FOUND
+    _emit({"found": True, "link": link})
+    return EXIT_OK
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    try:
+        detail = ContextLinkStore(db_path).explain(args.locator_id)
+    except sqlite3.Error:
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    if detail is None:
+        _emit({"found": False, "locator_id": args.locator_id})
+        return EXIT_NOT_FOUND
+    _emit({"found": True, **detail})
+    return EXIT_OK
+
+
+def cmd_rebuild(args: argparse.Namespace) -> int:
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    try:
+        result = ContextLinkStore(db_path).rebuild()
+    except sqlite3.Error:
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    _emit({"available": True, "projection_path": str(db_path), **result})
+    return EXIT_OK if result["parity"] else EXIT_REFUSED
+
+
+def _load_json_file(path: str, label: str) -> dict[str, Any]:
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SchemaError(f"{label} is not readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise SchemaError(f"{label} must be a JSON object")
+    return payload
+
+
+def cmd_admit(args: argparse.Namespace) -> int:
+    db_path = _resolve_db(args)
+    if _disabled():
+        _emit(
+            {
+                "enabled": False,
+                "outcome": AdmitOutcome.REFUSED.value,
+                "reason": "projection_disabled",
+                "state": "unavailable",
+            }
+        )
+        return EXIT_REFUSED
+    try:
+        link = ContextLink.from_dict(_load_json_file(args.link, "link file"))
+        verification = (
+            VerificationEvidence.from_dict(_load_json_file(args.verification, "verification file"))
+            if args.verification
+            else None
+        )
+    except SchemaError as exc:
+        _emit({"outcome": AdmitOutcome.REFUSED.value, "reason": "schema_invalid", "detail": str(exc)})
+        return EXIT_REFUSED
+    result = ContextLinkStore(db_path).admit(link, verification, actor=args.actor)
+    _emit(result.to_dict())
+    return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.entire_context",
+        description=(
+            "Body-free, provider-neutral context-link index (ADR-018 / #6174). "
+            "Local-only: no Entire, GitHub, Fleet, ACP, Monitor, or network calls."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_db_flag(command: argparse.ArgumentParser) -> None:
+        command.add_argument(
+            "--db",
+            default=None,
+            help=f"Projection SQLite path (default: {ENV_DB} or {DEFAULT_DB_RELATIVE})",
+        )
+
+    status = sub.add_parser("status", help="Body-free aggregate projection status")
+    add_db_flag(status)
+    status.set_defaults(func=cmd_status)
+
+    lookup = sub.add_parser("lookup", help="Known-ID lookup of a promoted context link")
+    lookup.add_argument("locator_id", help="Deterministic clink_<sha256> locator ID")
+    add_db_flag(lookup)
+    lookup.set_defaults(func=cmd_lookup)
+
+    explain = sub.add_parser("explain", help="Body-free lifecycle audit trail for a known locator ID")
+    explain.add_argument("locator_id", help="Deterministic clink_<sha256> locator ID")
+    add_db_flag(explain)
+    explain.set_defaults(func=cmd_explain)
+
+    rebuild = sub.add_parser("rebuild", help="Replay the append-only event log into the projection")
+    add_db_flag(rebuild)
+    rebuild.set_defaults(func=cmd_rebuild)
+
+    admit = sub.add_parser("admit", help="Admit one claim from body-free JSON fixtures")
+    admit.add_argument("--link", required=True, help="JSON file with one context-link payload")
+    admit.add_argument(
+        "--verification",
+        default=None,
+        help="JSON file with the caller-recorded canonical verification result",
+    )
+    admit.add_argument("--actor", default="cli", help="Body-free actor identity (default: cli)")
+    add_db_flag(admit)
+    admit.set_defaults(func=cmd_admit)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -72,7 +72,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         return EXIT_OK
     try:
         payload = ContextLinkStore(db_path).status()
-    except sqlite3.Error:
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_OK
     payload.update({"enabled": True, "available": True, "projection_path": str(db_path)})
@@ -87,7 +87,7 @@ def cmd_lookup(args: argparse.Namespace) -> int:
         return EXIT_OK
     try:
         link = ContextLinkStore(db_path).lookup(args.locator_id)
-    except sqlite3.Error:
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_OK
     if link is None:
@@ -104,7 +104,7 @@ def cmd_explain(args: argparse.Namespace) -> int:
         return EXIT_OK
     try:
         detail = ContextLinkStore(db_path).explain(args.locator_id)
-    except sqlite3.Error:
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_OK
     if detail is None:
@@ -121,7 +121,7 @@ def cmd_rebuild(args: argparse.Namespace) -> int:
         return EXIT_OK
     try:
         result = ContextLinkStore(db_path).rebuild()
-    except sqlite3.Error:
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_OK
     _emit({"available": True, "projection_path": str(db_path), **result})
@@ -161,7 +161,14 @@ def cmd_admit(args: argparse.Namespace) -> int:
     except SchemaError as exc:
         _emit({"outcome": AdmitOutcome.REFUSED.value, "reason": "schema_invalid", "detail": str(exc)})
         return EXIT_REFUSED
-    result = ContextLinkStore(db_path).admit(link, verification, actor=args.actor)
+    try:
+        result = ContextLinkStore(db_path).admit(link, verification, actor=args.actor)
+    except SchemaError as exc:
+        _emit({"outcome": AdmitOutcome.REFUSED.value, "reason": "schema_invalid", "detail": str(exc)})
+        return EXIT_REFUSED
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_REFUSED
     _emit(result.to_dict())
     return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
 

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -74,12 +74,21 @@ FORBIDDEN_KEY_RE = re.compile(
 FORBIDDEN_VALUE_PATTERNS = (
     ("private-key", re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |PGP )?PRIVATE KEY-----")),
     ("credential-token", re.compile(r"(?:sk-|gh[pousr]_|AIza)[A-Za-z0-9_-]{16,}")),
+    ("aws-access-key", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+    (
+        "jwt-token",
+        re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    ),
+    ("bearer-token", re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]{16,}={0,2}\b")),
     (
         "credential-assignment",
         re.compile(r"(?i)(?:api[_-]?key|access[_-]?token|secret|password)\s*[:=]\s*\S{8,}"),
     ),
     ("public-entire-ref", re.compile(r"refs/entire(?:/|$)")),
 )
+
+LONG_OPAQUE_FACET_RE = re.compile(r"^[A-Za-z0-9_+/-]{48,}={0,2}$")
 
 MAX_STRING_BYTES = 1024
 MAX_LIST_ITEMS = 64
@@ -141,7 +150,7 @@ def _reject_forbidden_key(path: str) -> None:
         raise SchemaError(f"field rejected by body-free rule: {path!r} names a forbidden concept")
 
 
-def _validate_scalar(path: str, value: Any) -> None:
+def _validate_scalar(path: str, value: Any, *, reject_long_opaque: bool = False) -> None:
     if isinstance(value, bool) or value is None or isinstance(value, int | float):
         return
     if not isinstance(value, str):
@@ -153,6 +162,8 @@ def _validate_scalar(path: str, value: Any) -> None:
     for rule, pattern in FORBIDDEN_VALUE_PATTERNS:
         if pattern.search(value):
             raise SchemaError(f"field {path!r} rejected by {rule} rule")
+    if reject_long_opaque and LONG_OPAQUE_FACET_RE.fullmatch(value):
+        raise SchemaError(f"field {path!r} rejected by long-opaque-token rule")
 
 
 def validate_identity(value: str, *, field_name: str) -> None:
@@ -174,9 +185,9 @@ def validate_facets(facets: dict[str, Any]) -> None:
             if len(value) > MAX_LIST_ITEMS:
                 raise SchemaError(f"facet {key!r} rejected by list-size rule")
             for item in value:
-                _validate_scalar(key, item)
+                _validate_scalar(key, item, reject_long_opaque=True)
         else:
-            _validate_scalar(key, value)
+            _validate_scalar(key, value, reject_long_opaque=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -2,10 +2,10 @@
 
 A context link joins an opaque Entire checkpoint/commit locator to canonical
 GitHub, ACP, Fleet, Monitor, rollover, or formal-review evidence. The schema is
-deliberately body-free: unknown fields are rejected, and any field name or
-value that could carry prompts, responses, transcripts, summaries, raw
-captures, message/artifact bodies, transcript paths, secret/token material, or
-public Entire refs is refused before anything is persisted.
+deliberately body-free: unknown fields are rejected, and fields or values that
+name body-bearing concepts, match known secret/token signatures, look like
+long opaque tokens, or contain public Entire refs are refused before anything
+is persisted.
 """
 
 from __future__ import annotations
@@ -88,7 +88,10 @@ FORBIDDEN_VALUE_PATTERNS = (
     ("public-entire-ref", re.compile(r"refs/entire(?:/|$)")),
 )
 
-LONG_OPAQUE_COMPONENT_RE = re.compile(r"(?:^|[.:/])([A-Za-z0-9_+-]{48,})(?=$|[.:/])")
+LONG_OPAQUE_COMPONENT_RE = re.compile(r"(?:^|[.:/])([A-Za-z0-9_+-]{48,}={0,2})(?=$|[.:/])")
+OPAQUE_DELIMITED_VALUE_RE = re.compile(r"^[A-Za-z0-9_+./:=-]+$")
+OPAQUE_DELIMITER_RE = re.compile(r"[.:/=]")
+GIT_EVIDENCE_LOCATOR_RE = re.compile(r"^git:commit/[0-9a-f]{40}$")
 
 MAX_STRING_BYTES = 1024
 MAX_LIST_ITEMS = 64
@@ -150,7 +153,13 @@ def _reject_forbidden_key(path: str) -> None:
         raise SchemaError(f"field rejected by body-free rule: {path!r} names a forbidden concept")
 
 
-def _validate_scalar(path: str, value: Any, *, reject_long_opaque: bool = False) -> None:
+def _validate_scalar(
+    path: str,
+    value: Any,
+    *,
+    reject_long_opaque: bool = False,
+    long_opaque_exemption: re.Pattern[str] | None = None,
+) -> None:
     if isinstance(value, bool) or value is None or isinstance(value, int | float):
         return
     if not isinstance(value, str):
@@ -162,15 +171,32 @@ def _validate_scalar(path: str, value: Any, *, reject_long_opaque: bool = False)
     for rule, pattern in FORBIDDEN_VALUE_PATTERNS:
         if pattern.search(value):
             raise SchemaError(f"field {path!r} rejected by {rule} rule")
-    if reject_long_opaque and LONG_OPAQUE_COMPONENT_RE.search(value):
-        raise SchemaError(f"field {path!r} rejected by long-opaque-token rule")
+    if reject_long_opaque:
+        collapsed = OPAQUE_DELIMITER_RE.sub("", value)
+        looks_long_opaque = bool(LONG_OPAQUE_COMPONENT_RE.search(value)) or (
+            len(collapsed) >= 48 and OPAQUE_DELIMITED_VALUE_RE.fullmatch(value) is not None
+        )
+        exempt = long_opaque_exemption is not None and long_opaque_exemption.fullmatch(value) is not None
+        if looks_long_opaque and not exempt:
+            raise SchemaError(f"field {path!r} rejected by long-opaque-token rule")
 
 
-def validate_identity(value: str, *, field_name: str, reject_long_opaque: bool = True) -> None:
+def validate_identity(
+    value: str,
+    *,
+    field_name: str,
+    reject_long_opaque: bool = True,
+    long_opaque_exemption: re.Pattern[str] | None = None,
+) -> None:
     """Validate one body-free, path-safe externally supplied identity."""
     if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
         raise SchemaError(f"{field_name} must be a path-safe identity")
-    _validate_scalar(field_name, value, reject_long_opaque=reject_long_opaque)
+    _validate_scalar(
+        field_name,
+        value,
+        reject_long_opaque=reject_long_opaque,
+        long_opaque_exemption=long_opaque_exemption,
+    )
 
 
 def validate_facets(facets: dict[str, Any]) -> None:
@@ -310,7 +336,11 @@ class VerificationEvidence:
             raise SchemaError("status must be an allowlisted VerificationStatus")
         if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
             raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
-        validate_identity(self.evidence_locator, field_name="evidence_locator")
+        validate_identity(
+            self.evidence_locator,
+            field_name="evidence_locator",
+            long_opaque_exemption=GIT_EVIDENCE_LOCATOR_RE,
+        )
         try:
             parse_timestamp(self.checked_at)
         except (ValueError, TypeError) as exc:

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -88,9 +88,7 @@ FORBIDDEN_VALUE_PATTERNS = (
     ("public-entire-ref", re.compile(r"refs/entire(?:/|$)")),
 )
 
-LONG_OPAQUE_COMPONENT_RE = re.compile(r"(?:^|[.:/])([A-Za-z0-9_+-]{48,}={0,2})(?=$|[.:/])")
-OPAQUE_DELIMITED_VALUE_RE = re.compile(r"^[A-Za-z0-9_+./:=-]+$")
-OPAQUE_DELIMITER_RE = re.compile(r"[.:/=]")
+OPAQUE_RUN_RE = re.compile(r"[A-Za-z0-9_+-]+")
 GIT_EVIDENCE_LOCATOR_RE = re.compile(r"^git:commit/[0-9a-f]{40}$")
 
 MAX_STRING_BYTES = 1024
@@ -172,9 +170,10 @@ def _validate_scalar(
         if pattern.search(value):
             raise SchemaError(f"field {path!r} rejected by {rule} rule")
     if reject_long_opaque:
-        collapsed = OPAQUE_DELIMITER_RE.sub("", value)
-        looks_long_opaque = bool(LONG_OPAQUE_COMPONENT_RE.search(value)) or (
-            len(collapsed) >= 48 and OPAQUE_DELIMITED_VALUE_RE.fullmatch(value) is not None
+        opaque_runs = [match.group(0) for match in OPAQUE_RUN_RE.finditer(value)]
+        split_runs = [run for run in opaque_runs if len(run) >= 16]
+        looks_long_opaque = any(len(run) >= 48 for run in opaque_runs) or (
+            len(split_runs) >= 2 and sum(map(len, split_runs)) >= 48
         )
         exempt = long_opaque_exemption is not None and long_opaque_exemption.fullmatch(value) is not None
         if looks_long_opaque and not exempt:

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -1,0 +1,332 @@
+"""Versioned, strict, body-free context-link schema (ADR-018 / #6174).
+
+A context link joins an opaque Entire checkpoint/commit locator to canonical
+GitHub, ACP, Fleet, Monitor, rollover, or formal-review evidence. The schema is
+deliberately body-free: unknown fields are rejected, and any field name or
+value that could carry prompts, responses, transcripts, summaries, raw
+captures, message/artifact bodies, transcript paths, secret/token material, or
+public Entire refs is refused before anything is persisted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+LOCATOR_ID_RE = re.compile(r"^clink_[0-9a-f]{64}$")
+SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}:[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$")
+CANONICAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
+OPAQUE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
+
+ALLOWED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "locator_id",
+        "kind",
+        "canonical_namespace",
+        "canonical_id",
+        "canonical_digest",
+        "entire_checkpoint_id",
+        "git_sha",
+        "facets",
+        "ingested_at",
+    }
+)
+
+# Tier-0 headers-only corpus (ADR-018 / rollout plan): mechanically copied,
+# allowlisted fields only. No composed intent/outcome/rationale/summary.
+ALLOWED_FACET_KEYS = frozenset(
+    {
+        "repository",
+        "source_kind",
+        "stream_epic",
+        "track",
+        "state",
+        "labels",
+        "touched_paths",
+        "actor",
+        "model",
+        "harness",
+        "participants",
+        "token_bucket",
+        "title",
+        "document_path",
+        "document_heading",
+        "event_ts",
+    }
+)
+
+FORBIDDEN_KEY_RE = re.compile(
+    r"(?i)(prompt|response|transcript|summar|raw_?capture|\bbody\b|bodies|message|artifact|"
+    r"secret|password|credential|api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key)"
+)
+
+FORBIDDEN_VALUE_PATTERNS = (
+    ("private-key", re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |PGP )?PRIVATE KEY-----")),
+    ("credential-token", re.compile(r"(?:sk-|gh[pousr]_|AIza)[A-Za-z0-9_-]{16,}")),
+    (
+        "credential-assignment",
+        re.compile(r"(?i)(?:api[_-]?key|access[_-]?token|secret|password)\s*[:=]\s*\S{8,}"),
+    ),
+    ("public-entire-ref", re.compile(r"refs/entire(?:/|$)")),
+)
+
+MAX_STRING_BYTES = 1024
+MAX_LIST_ITEMS = 64
+
+
+class SchemaError(ValueError):
+    """Raised when a context-link payload violates the body-free schema."""
+
+
+class LinkKind(StrEnum):
+    """Allowlisted canonical receipt kinds a locator may join to."""
+
+    GIT_COMMIT = "git_commit"
+    GITHUB_ISSUE = "github_issue"
+    GITHUB_PR = "github_pr"
+    ACP_CONVERSATION = "acp_conversation"
+    FORMAL_REVIEW = "formal_review"
+    ROLLOVER = "rollover"
+    MONITOR_RUN = "monitor_run"
+    FLEET_RECEIPT = "fleet_receipt"
+
+
+class VerificationStatus(StrEnum):
+    """Caller-recorded outcome of resolving evidence against its canonical system."""
+
+    VERIFIED = "verified"
+    STALE = "stale"
+    PARTIAL_TERMINAL = "partial_terminal"
+    DIGEST_MISMATCH = "digest_mismatch"
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamps must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _reject_forbidden_key(path: str) -> None:
+    if FORBIDDEN_KEY_RE.search(path):
+        raise SchemaError(f"field rejected by body-free rule: {path!r} names a forbidden concept")
+
+
+def _validate_scalar(path: str, value: Any) -> None:
+    if isinstance(value, bool) or value is None or isinstance(value, int | float):
+        return
+    if not isinstance(value, str):
+        raise SchemaError(f"facet {path!r} must be a string, number, or boolean")
+    if "\x00" in value:
+        raise SchemaError(f"facet {path!r} rejected by control-character rule")
+    if len(value.encode("utf-8")) > MAX_STRING_BYTES:
+        raise SchemaError(f"facet {path!r} rejected by size rule")
+    for rule, pattern in FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(value):
+            raise SchemaError(f"facet {path!r} rejected by {rule} rule")
+
+
+def validate_facets(facets: dict[str, Any]) -> None:
+    """Enforce the allowlisted, body-free facet contract."""
+    if not isinstance(facets, dict):
+        raise SchemaError("facets must be an object")
+    for key, value in facets.items():
+        _reject_forbidden_key(key)
+        if key not in ALLOWED_FACET_KEYS:
+            raise SchemaError(f"unknown facet field: {key!r}")
+        if isinstance(value, list):
+            if len(value) > MAX_LIST_ITEMS:
+                raise SchemaError(f"facet {key!r} rejected by list-size rule")
+            for item in value:
+                _validate_scalar(key, item)
+        else:
+            _validate_scalar(key, value)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextLink:
+    """One body-free typed locator join. ``locator_id`` is always derived."""
+
+    kind: LinkKind
+    canonical_namespace: str
+    canonical_id: str
+    canonical_digest: str
+    entire_checkpoint_id: str | None = None
+    git_sha: str | None = None
+    facets: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not isinstance(self.kind, LinkKind):
+            raise SchemaError("kind must be an allowlisted LinkKind")
+        if not NAMESPACE_RE.fullmatch(self.canonical_namespace):
+            raise SchemaError("canonical_namespace must be a typed '<system>:<owner/path>' identity")
+        if not CANONICAL_ID_RE.fullmatch(self.canonical_id):
+            raise SchemaError("canonical_id must be an exact, path-safe identity")
+        if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
+            raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
+        if self.entire_checkpoint_id is not None and not OPAQUE_ID_RE.fullmatch(self.entire_checkpoint_id):
+            raise SchemaError("entire_checkpoint_id must be an opaque path-safe identifier")
+        if self.git_sha is not None and not GIT_SHA_RE.fullmatch(self.git_sha):
+            raise SchemaError("git_sha must be a full 40-hex commit SHA")
+        validate_facets(self.facets)
+
+    @property
+    def locator_id(self) -> str:
+        """Deterministic ID over kind, namespace, canonical ID, and digest."""
+        payload = {
+            "schema": "clink.v1",
+            "kind": self.kind.value,
+            "canonical_namespace": self.canonical_namespace,
+            "canonical_id": self.canonical_id,
+            "canonical_digest": self.canonical_digest,
+        }
+        return "clink_" + sha256_text(canonical_json(payload))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "locator_id": self.locator_id,
+            "kind": self.kind.value,
+            "canonical_namespace": self.canonical_namespace,
+            "canonical_id": self.canonical_id,
+            "canonical_digest": self.canonical_digest,
+            "entire_checkpoint_id": self.entire_checkpoint_id,
+            "git_sha": self.git_sha,
+            "facets": dict(self.facets),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ContextLink:
+        """Strictly parse a caller payload; reject unknown/forbidden fields."""
+        if not isinstance(payload, dict):
+            raise SchemaError("context link must be a JSON object")
+        for key in payload:
+            _reject_forbidden_key(key)
+            if key not in ALLOWED_TOP_LEVEL_KEYS:
+                raise SchemaError(f"unknown field: {key!r}")
+        version = payload.get("schema_version", SCHEMA_VERSION)
+        if version != SCHEMA_VERSION:
+            raise SchemaError(f"unsupported schema_version: {version!r}")
+        facets = payload.get("facets") or {}
+        validate_facets(facets)
+        try:
+            kind = LinkKind(payload["kind"])
+        except (KeyError, ValueError) as exc:
+            raise SchemaError("kind must be an allowlisted LinkKind") from exc
+        missing = [
+            key
+            for key in ("canonical_namespace", "canonical_id", "canonical_digest")
+            if not isinstance(payload.get(key), str)
+        ]
+        if missing:
+            raise SchemaError(f"missing required field(s): {', '.join(sorted(missing))}")
+        link = cls(
+            kind=kind,
+            canonical_namespace=payload["canonical_namespace"],
+            canonical_id=payload["canonical_id"],
+            canonical_digest=payload["canonical_digest"],
+            entire_checkpoint_id=payload.get("entire_checkpoint_id"),
+            git_sha=payload.get("git_sha"),
+            facets=dict(facets),
+        )
+        link.validate()
+        declared = payload.get("locator_id")
+        if declared is not None and declared != link.locator_id:
+            raise SchemaError("locator_id does not match the derived deterministic ID")
+        if "ingested_at" in payload:
+            raise SchemaError("ingested_at is projection-assigned and must not be supplied")
+        return link
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationEvidence:
+    """Caller-provided canonical verification result required for admission.
+
+    The context layer never resolves canonical evidence itself; the caller
+    records what its canonical verifier observed. Anything missing, stale,
+    partial-terminal, or digest-mismatched is refused/tombstoned by the store.
+    """
+
+    verifier: str
+    canonical_digest: str
+    status: VerificationStatus
+    evidence_locator: str
+    checked_at: str
+
+    def validate(self) -> None:
+        if not IDENTITY_RE.fullmatch(self.verifier):
+            raise SchemaError("verifier must be a path-safe identity")
+        if not isinstance(self.status, VerificationStatus):
+            raise SchemaError("status must be an allowlisted VerificationStatus")
+        if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
+            raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
+        if not IDENTITY_RE.fullmatch(self.evidence_locator):
+            raise SchemaError("evidence_locator must be a body-free path-safe identity")
+        try:
+            parse_timestamp(self.checked_at)
+        except (ValueError, TypeError) as exc:
+            raise SchemaError("checked_at must be an ISO-8601 timezone-aware timestamp") from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verifier": self.verifier,
+            "canonical_digest": self.canonical_digest,
+            "status": self.status.value,
+            "evidence_locator": self.evidence_locator,
+            "checked_at": self.checked_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> VerificationEvidence:
+        if not isinstance(payload, dict):
+            raise SchemaError("verification evidence must be a JSON object")
+        allowed = {"verifier", "canonical_digest", "status", "evidence_locator", "checked_at"}
+        for key in payload:
+            _reject_forbidden_key(key)
+            if key not in allowed:
+                raise SchemaError(f"unknown verification field: {key!r}")
+        try:
+            status = VerificationStatus(payload["status"])
+        except (KeyError, ValueError) as exc:
+            raise SchemaError("status must be an allowlisted VerificationStatus") from exc
+        missing = [key for key in allowed - {"status"} if not isinstance(payload.get(key), str)]
+        if missing:
+            raise SchemaError(f"missing verification field(s): {', '.join(sorted(missing))}")
+        evidence = cls(
+            verifier=payload["verifier"],
+            canonical_digest=payload["canonical_digest"],
+            status=status,
+            evidence_locator=payload["evidence_locator"],
+            checked_at=payload["checked_at"],
+        )
+        evidence.validate()
+        return evidence

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -88,7 +88,7 @@ FORBIDDEN_VALUE_PATTERNS = (
     ("public-entire-ref", re.compile(r"refs/entire(?:/|$)")),
 )
 
-LONG_OPAQUE_FACET_RE = re.compile(r"^[A-Za-z0-9_+/-]{48,}={0,2}$")
+LONG_OPAQUE_COMPONENT_RE = re.compile(r"(?:^|[.:/])([A-Za-z0-9_+-]{48,})(?=$|[.:/])")
 
 MAX_STRING_BYTES = 1024
 MAX_LIST_ITEMS = 64
@@ -162,15 +162,15 @@ def _validate_scalar(path: str, value: Any, *, reject_long_opaque: bool = False)
     for rule, pattern in FORBIDDEN_VALUE_PATTERNS:
         if pattern.search(value):
             raise SchemaError(f"field {path!r} rejected by {rule} rule")
-    if reject_long_opaque and LONG_OPAQUE_FACET_RE.fullmatch(value):
+    if reject_long_opaque and LONG_OPAQUE_COMPONENT_RE.search(value):
         raise SchemaError(f"field {path!r} rejected by long-opaque-token rule")
 
 
-def validate_identity(value: str, *, field_name: str) -> None:
+def validate_identity(value: str, *, field_name: str, reject_long_opaque: bool = True) -> None:
     """Validate one body-free, path-safe externally supplied identity."""
     if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
         raise SchemaError(f"{field_name} must be a path-safe identity")
-    _validate_scalar(field_name, value)
+    _validate_scalar(field_name, value, reject_long_opaque=reject_long_opaque)
 
 
 def validate_facets(facets: dict[str, Any]) -> None:
@@ -207,16 +207,16 @@ class ContextLink:
             raise SchemaError("kind must be an allowlisted LinkKind")
         if not NAMESPACE_RE.fullmatch(self.canonical_namespace):
             raise SchemaError("canonical_namespace must be a typed '<system>:<owner/path>' identity")
-        _validate_scalar("canonical_namespace", self.canonical_namespace)
+        _validate_scalar("canonical_namespace", self.canonical_namespace, reject_long_opaque=True)
         if not CANONICAL_ID_RE.fullmatch(self.canonical_id):
             raise SchemaError("canonical_id must be an exact, path-safe identity")
-        _validate_scalar("canonical_id", self.canonical_id)
+        _validate_scalar("canonical_id", self.canonical_id, reject_long_opaque=True)
         if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
             raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
         if self.entire_checkpoint_id is not None and not OPAQUE_ID_RE.fullmatch(self.entire_checkpoint_id):
             raise SchemaError("entire_checkpoint_id must be an opaque path-safe identifier")
         if self.entire_checkpoint_id is not None:
-            _validate_scalar("entire_checkpoint_id", self.entire_checkpoint_id)
+            _validate_scalar("entire_checkpoint_id", self.entire_checkpoint_id, reject_long_opaque=True)
         if self.git_sha is not None and not GIT_SHA_RE.fullmatch(self.git_sha):
             raise SchemaError("git_sha must be a full 40-hex commit SHA")
         validate_facets(self.facets)

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -238,11 +238,15 @@ class ContextLink:
         _validate_scalar("canonical_id", self.canonical_id, reject_long_opaque=True)
         if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
             raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
-        if self.entire_checkpoint_id is not None and not OPAQUE_ID_RE.fullmatch(self.entire_checkpoint_id):
-            raise SchemaError("entire_checkpoint_id must be an opaque path-safe identifier")
         if self.entire_checkpoint_id is not None:
+            if not isinstance(self.entire_checkpoint_id, str) or not OPAQUE_ID_RE.fullmatch(
+                self.entire_checkpoint_id
+            ):
+                raise SchemaError("entire_checkpoint_id must be an opaque path-safe identifier")
             _validate_scalar("entire_checkpoint_id", self.entire_checkpoint_id, reject_long_opaque=True)
-        if self.git_sha is not None and not GIT_SHA_RE.fullmatch(self.git_sha):
+        if self.git_sha is not None and (
+            not isinstance(self.git_sha, str) or not GIT_SHA_RE.fullmatch(self.git_sha)
+        ):
             raise SchemaError("git_sha must be a full 40-hex commit SHA")
         validate_facets(self.facets)
 

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -145,14 +145,21 @@ def _validate_scalar(path: str, value: Any) -> None:
     if isinstance(value, bool) or value is None or isinstance(value, int | float):
         return
     if not isinstance(value, str):
-        raise SchemaError(f"facet {path!r} must be a string, number, or boolean")
+        raise SchemaError(f"field {path!r} must be a string, number, or boolean")
     if "\x00" in value:
-        raise SchemaError(f"facet {path!r} rejected by control-character rule")
+        raise SchemaError(f"field {path!r} rejected by control-character rule")
     if len(value.encode("utf-8")) > MAX_STRING_BYTES:
-        raise SchemaError(f"facet {path!r} rejected by size rule")
+        raise SchemaError(f"field {path!r} rejected by size rule")
     for rule, pattern in FORBIDDEN_VALUE_PATTERNS:
         if pattern.search(value):
-            raise SchemaError(f"facet {path!r} rejected by {rule} rule")
+            raise SchemaError(f"field {path!r} rejected by {rule} rule")
+
+
+def validate_identity(value: str, *, field_name: str) -> None:
+    """Validate one body-free, path-safe externally supplied identity."""
+    if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
+        raise SchemaError(f"{field_name} must be a path-safe identity")
+    _validate_scalar(field_name, value)
 
 
 def validate_facets(facets: dict[str, Any]) -> None:
@@ -189,12 +196,16 @@ class ContextLink:
             raise SchemaError("kind must be an allowlisted LinkKind")
         if not NAMESPACE_RE.fullmatch(self.canonical_namespace):
             raise SchemaError("canonical_namespace must be a typed '<system>:<owner/path>' identity")
+        _validate_scalar("canonical_namespace", self.canonical_namespace)
         if not CANONICAL_ID_RE.fullmatch(self.canonical_id):
             raise SchemaError("canonical_id must be an exact, path-safe identity")
+        _validate_scalar("canonical_id", self.canonical_id)
         if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
             raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
         if self.entire_checkpoint_id is not None and not OPAQUE_ID_RE.fullmatch(self.entire_checkpoint_id):
             raise SchemaError("entire_checkpoint_id must be an opaque path-safe identifier")
+        if self.entire_checkpoint_id is not None:
+            _validate_scalar("entire_checkpoint_id", self.entire_checkpoint_id)
         if self.git_sha is not None and not GIT_SHA_RE.fullmatch(self.git_sha):
             raise SchemaError("git_sha must be a full 40-hex commit SHA")
         validate_facets(self.facets)
@@ -283,14 +294,12 @@ class VerificationEvidence:
     checked_at: str
 
     def validate(self) -> None:
-        if not IDENTITY_RE.fullmatch(self.verifier):
-            raise SchemaError("verifier must be a path-safe identity")
+        validate_identity(self.verifier, field_name="verifier")
         if not isinstance(self.status, VerificationStatus):
             raise SchemaError("status must be an allowlisted VerificationStatus")
         if not SHA256_DIGEST_RE.fullmatch(self.canonical_digest):
             raise SchemaError("canonical_digest must be 'sha256:<64 hex>'")
-        if not IDENTITY_RE.fullmatch(self.evidence_locator):
-            raise SchemaError("evidence_locator must be a body-free path-safe identity")
+        validate_identity(self.evidence_locator, field_name="evidence_locator")
         try:
             parse_timestamp(self.checked_at)
         except (ValueError, TypeError) as exc:

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from .model import (
     LOCATOR_ID_RE,
+    SCHEMA_VERSION,
     ContextLink,
     SchemaError,
     VerificationEvidence,
@@ -387,7 +388,7 @@ class ContextLinkStore:
                 "SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM link_events"
             ).fetchone()
         return {
-            "schema_version": 1,
+            "schema_version": SCHEMA_VERSION,
             "counts": {str(row["state"]): int(row["n"]) for row in counts},
             "events": int(events["n"]) if events else 0,
             "last_event_at": events["last_at"] if events else None,

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -470,8 +470,11 @@ class ContextLinkStore:
                     ),
                 )
             after = self._projection_snapshot(connection)
+        input_parity = before == after
         return {
             "events_replayed": len(events),
             "links": len(projection),
-            "parity": before == after,
+            "parity": input_parity,
+            "applied": True,
+            "drift_repaired": not input_parity,
         }

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -24,12 +24,14 @@ from typing import Any
 from .model import (
     LOCATOR_ID_RE,
     ContextLink,
+    SchemaError,
     VerificationEvidence,
     VerificationStatus,
     canonical_json,
     isoformat_z,
     parse_timestamp,
     utc_now,
+    validate_identity,
 )
 
 DEFAULT_VERIFICATION_MAX_AGE_SECONDS = 3600
@@ -137,12 +139,15 @@ class ContextLinkStore:
     ) -> str:
         """Record one pending claim. Idempotent for the same locator ID."""
         link.validate()
+        validate_identity(actor, field_name="actor")
         timestamp = isoformat_z(now or utc_now())
         locator_id = link.locator_id
         with self._transaction() as connection:
             state = self._current_state(connection, locator_id)
             if state is None:
                 self._insert_claim(connection, link, actor=actor, timestamp=timestamp)
+            elif not self._payload_matches(connection, link):
+                raise SchemaError("locator_id is already bound to a different claim payload")
         return locator_id
 
     @staticmethod
@@ -151,6 +156,29 @@ class ContextLinkStore:
             "SELECT state FROM context_links WHERE locator_id = ?", (locator_id,)
         ).fetchone()
         return None if row is None else str(row["state"])
+
+    @staticmethod
+    def _payload_matches(connection: sqlite3.Connection, link: ContextLink) -> bool:
+        row = connection.execute(
+            "SELECT schema_version, locator_id, kind, canonical_namespace, canonical_id,"
+            " canonical_digest, entire_checkpoint_id, git_sha, facets_json"
+            " FROM context_links WHERE locator_id = ?",
+            (link.locator_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        stored = {
+            "schema_version": int(row["schema_version"]),
+            "locator_id": str(row["locator_id"]),
+            "kind": str(row["kind"]),
+            "canonical_namespace": str(row["canonical_namespace"]),
+            "canonical_id": str(row["canonical_id"]),
+            "canonical_digest": str(row["canonical_digest"]),
+            "entire_checkpoint_id": row["entire_checkpoint_id"],
+            "git_sha": row["git_sha"],
+            "facets": json.loads(row["facets_json"]),
+        }
+        return canonical_json(stored) == canonical_json(link.to_dict())
 
     @staticmethod
     def _insert_claim(
@@ -196,6 +224,7 @@ class ContextLinkStore:
     ) -> AdmitResult:
         """Admit one claim. Idempotent; unverifiable claims are tombstoned."""
         link.validate()
+        validate_identity(actor, field_name="actor")
         if verification is not None:
             verification.validate()
         moment = now or utc_now()
@@ -204,12 +233,36 @@ class ContextLinkStore:
 
         with self._transaction() as connection:
             state = self._current_state(connection, locator_id)
-            if state == "promoted":
-                return AdmitResult(locator_id, AdmitOutcome.ALREADY_PROMOTED, "duplicate", state)
             if state == "tombstoned":
                 return AdmitResult(
                     locator_id, AdmitOutcome.ALREADY_TOMBSTONED, "tombstone_terminal", state
                 )
+            if state is not None and not self._payload_matches(connection, link):
+                if state == "pending":
+                    connection.execute(
+                        "INSERT INTO link_events(locator_id, event_type, payload_json, reason, actor, recorded_at)"
+                        " VALUES (?, 'tombstoned', '{}', 'claim_payload_conflict', ?, ?)",
+                        (locator_id, actor, timestamp),
+                    )
+                    connection.execute(
+                        "UPDATE context_links SET state = 'tombstoned',"
+                        " tombstone_reason = 'claim_payload_conflict' WHERE locator_id = ?",
+                        (locator_id,),
+                    )
+                    return AdmitResult(
+                        locator_id,
+                        AdmitOutcome.REFUSED,
+                        "claim_payload_conflict",
+                        "tombstoned",
+                    )
+                return AdmitResult(
+                    locator_id,
+                    AdmitOutcome.REFUSED,
+                    "claim_payload_conflict",
+                    state,
+                )
+            if state == "promoted":
+                return AdmitResult(locator_id, AdmitOutcome.ALREADY_PROMOTED, "duplicate", state)
             if state is None:
                 self._insert_claim(connection, link, actor=actor, timestamp=timestamp)
             # state == "pending": replayed admission of an unresolved claim;

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -1,0 +1,424 @@
+"""Caller-owned, rebuildable SQLite projection for body-free context links.
+
+The projection keeps an append-only ``link_events`` log (claimed / promoted /
+tombstoned) plus a derived ``context_links`` table that search and hydration
+may read. Duplicate admission is a no-op, tombstones are terminal, and a full
+rebuild replays the event log into an identical logical projection.
+
+This store is non-load-bearing by design: it never calls Entire, GitHub,
+Fleet, ACP, Monitor, or the network, and it never writes outside its own
+caller-supplied database file.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from .model import (
+    LOCATOR_ID_RE,
+    ContextLink,
+    VerificationEvidence,
+    VerificationStatus,
+    canonical_json,
+    isoformat_z,
+    parse_timestamp,
+    utc_now,
+)
+
+DEFAULT_VERIFICATION_MAX_AGE_SECONDS = 3600
+MAX_CLOCK_SKEW_SECONDS = 300
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS link_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    locator_id TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('claimed', 'promoted', 'tombstoned')),
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    reason TEXT NOT NULL DEFAULT '',
+    actor TEXT NOT NULL,
+    recorded_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_link_events_locator ON link_events(locator_id, event_id);
+CREATE TABLE IF NOT EXISTS context_links (
+    locator_id TEXT PRIMARY KEY,
+    state TEXT NOT NULL CHECK (state IN ('pending', 'promoted', 'tombstoned')),
+    schema_version INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    canonical_namespace TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    canonical_digest TEXT NOT NULL,
+    entire_checkpoint_id TEXT,
+    git_sha TEXT,
+    facets_json TEXT NOT NULL DEFAULT '{}',
+    ingested_at TEXT NOT NULL,
+    promoted_at TEXT,
+    tombstone_reason TEXT
+);
+"""
+
+
+class AdmitOutcome(StrEnum):
+    PROMOTED = "promoted"
+    ALREADY_PROMOTED = "already_promoted"
+    REFUSED = "refused"
+    ALREADY_TOMBSTONED = "already_tombstoned"
+
+
+@dataclass(frozen=True, slots=True)
+class AdmitResult:
+    locator_id: str
+    outcome: AdmitOutcome
+    reason: str
+    state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "locator_id": self.locator_id,
+            "outcome": self.outcome.value,
+            "reason": self.reason,
+            "state": self.state,
+        }
+
+
+class ContextLinkStore:
+    """High-level admission / lookup / rebuild API over one SQLite file."""
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        verification_max_age_seconds: int = DEFAULT_VERIFICATION_MAX_AGE_SECONDS,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.verification_max_age_seconds = verification_max_age_seconds
+
+    @contextmanager
+    def _connect(self, *, write: bool):
+        if write:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(self.db_path)
+        else:
+            connection = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        try:
+            if write:
+                connection.executescript(_DDL)
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _transaction(self):
+        with self._connect(write=True) as connection:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                yield connection
+                connection.execute("COMMIT")
+            except Exception:
+                with suppress(sqlite3.Error):
+                    connection.execute("ROLLBACK")
+                raise
+
+    # ── admission ────────────────────────────────────────────────────────────
+
+    def submit_claim(
+        self,
+        link: ContextLink,
+        *,
+        actor: str = "unknown",
+        now: datetime | None = None,
+    ) -> str:
+        """Record one pending claim. Idempotent for the same locator ID."""
+        link.validate()
+        timestamp = isoformat_z(now or utc_now())
+        locator_id = link.locator_id
+        with self._transaction() as connection:
+            state = self._current_state(connection, locator_id)
+            if state is None:
+                self._insert_claim(connection, link, actor=actor, timestamp=timestamp)
+        return locator_id
+
+    @staticmethod
+    def _current_state(connection: sqlite3.Connection, locator_id: str) -> str | None:
+        row = connection.execute(
+            "SELECT state FROM context_links WHERE locator_id = ?", (locator_id,)
+        ).fetchone()
+        return None if row is None else str(row["state"])
+
+    @staticmethod
+    def _insert_claim(
+        connection: sqlite3.Connection,
+        link: ContextLink,
+        *,
+        actor: str,
+        timestamp: str,
+    ) -> None:
+        payload = link.to_dict()
+        connection.execute(
+            "INSERT INTO link_events(locator_id, event_type, payload_json, reason, actor, recorded_at)"
+            " VALUES (?, 'claimed', ?, '', ?, ?)",
+            (link.locator_id, canonical_json(payload), actor, timestamp),
+        )
+        connection.execute(
+            "INSERT INTO context_links("
+            "locator_id, state, schema_version, kind, canonical_namespace, canonical_id,"
+            " canonical_digest, entire_checkpoint_id, git_sha, facets_json, ingested_at,"
+            " promoted_at, tombstone_reason"
+            ") VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
+            (
+                link.locator_id,
+                payload["schema_version"],
+                payload["kind"],
+                payload["canonical_namespace"],
+                payload["canonical_id"],
+                payload["canonical_digest"],
+                payload["entire_checkpoint_id"],
+                payload["git_sha"],
+                canonical_json(payload["facets"]),
+                timestamp,
+            ),
+        )
+
+    def admit(
+        self,
+        link: ContextLink,
+        verification: VerificationEvidence | None,
+        *,
+        actor: str = "unknown",
+        now: datetime | None = None,
+    ) -> AdmitResult:
+        """Admit one claim. Idempotent; unverifiable claims are tombstoned."""
+        link.validate()
+        if verification is not None:
+            verification.validate()
+        moment = now or utc_now()
+        timestamp = isoformat_z(moment)
+        locator_id = link.locator_id
+
+        with self._transaction() as connection:
+            state = self._current_state(connection, locator_id)
+            if state == "promoted":
+                return AdmitResult(locator_id, AdmitOutcome.ALREADY_PROMOTED, "duplicate", state)
+            if state == "tombstoned":
+                return AdmitResult(
+                    locator_id, AdmitOutcome.ALREADY_TOMBSTONED, "tombstone_terminal", state
+                )
+            if state is None:
+                self._insert_claim(connection, link, actor=actor, timestamp=timestamp)
+            # state == "pending": replayed admission of an unresolved claim;
+            # fall through and evaluate the (new) verification evidence.
+
+            refusal = self._refusal_reason(link, verification, moment)
+            if refusal is None:
+                connection.execute(
+                    "INSERT INTO link_events(locator_id, event_type, payload_json, reason, actor, recorded_at)"
+                    " VALUES (?, 'promoted', '{}', '', ?, ?)",
+                    (locator_id, actor, timestamp),
+                )
+                connection.execute(
+                    "UPDATE context_links SET state = 'promoted', promoted_at = ? WHERE locator_id = ?",
+                    (timestamp, locator_id),
+                )
+                return AdmitResult(locator_id, AdmitOutcome.PROMOTED, "", "promoted")
+
+            connection.execute(
+                "INSERT INTO link_events(locator_id, event_type, payload_json, reason, actor, recorded_at)"
+                " VALUES (?, 'tombstoned', '{}', ?, ?, ?)",
+                (locator_id, refusal, actor, timestamp),
+            )
+            connection.execute(
+                "UPDATE context_links SET state = 'tombstoned', tombstone_reason = ? WHERE locator_id = ?",
+                (refusal, locator_id),
+            )
+            return AdmitResult(locator_id, AdmitOutcome.REFUSED, refusal, "tombstoned")
+
+    def _refusal_reason(
+        self,
+        link: ContextLink,
+        verification: VerificationEvidence | None,
+        moment: datetime,
+    ) -> str | None:
+        """Return a body-free machine reason, or None when admission is safe."""
+        if verification is None:
+            return "verification_missing"
+        if verification.status is not VerificationStatus.VERIFIED:
+            return f"verification_{verification.status.value}"
+        if verification.canonical_digest != link.canonical_digest:
+            return "digest_mismatch"
+        checked_at = parse_timestamp(verification.checked_at)
+        age = (moment - checked_at).total_seconds()
+        if age > self.verification_max_age_seconds or age < -MAX_CLOCK_SKEW_SECONDS:
+            return "verification_stale"
+        return None
+
+    # ── reads ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _row_to_link_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "schema_version": int(row["schema_version"]),
+            "locator_id": str(row["locator_id"]),
+            "kind": str(row["kind"]),
+            "canonical_namespace": str(row["canonical_namespace"]),
+            "canonical_id": str(row["canonical_id"]),
+            "canonical_digest": str(row["canonical_digest"]),
+            "entire_checkpoint_id": row["entire_checkpoint_id"],
+            "git_sha": row["git_sha"],
+            "facets": json.loads(row["facets_json"]),
+            "ingested_at": str(row["ingested_at"]),
+            "promoted_at": row["promoted_at"],
+        }
+
+    def lookup(self, locator_id: str) -> dict[str, Any] | None:
+        """Return a promoted link for a known locator ID, else None.
+
+        Pending and tombstoned claims are never searchable/hydratable.
+        """
+        if not LOCATOR_ID_RE.fullmatch(locator_id):
+            return None
+        with self._connect(write=False) as connection:
+            row = connection.execute(
+                "SELECT * FROM context_links WHERE locator_id = ? AND state = 'promoted'",
+                (locator_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_link_dict(row)
+
+    def explain(self, locator_id: str) -> dict[str, Any] | None:
+        """Return the body-free lifecycle audit trail for a known locator ID."""
+        if not LOCATOR_ID_RE.fullmatch(locator_id):
+            return None
+        with self._connect(write=False) as connection:
+            link_row = connection.execute(
+                "SELECT * FROM context_links WHERE locator_id = ?", (locator_id,)
+            ).fetchone()
+            if link_row is None:
+                return None
+            events = connection.execute(
+                "SELECT event_id, event_type, reason, actor, recorded_at FROM link_events"
+                " WHERE locator_id = ? ORDER BY event_id",
+                (locator_id,),
+            ).fetchall()
+        return {
+            "locator_id": locator_id,
+            "state": str(link_row["state"]),
+            "tombstone_reason": link_row["tombstone_reason"],
+            "link": self._row_to_link_dict(link_row),
+            "events": [
+                {
+                    "event_id": int(event["event_id"]),
+                    "event_type": str(event["event_type"]),
+                    "reason": str(event["reason"]),
+                    "actor": str(event["actor"]),
+                    "recorded_at": str(event["recorded_at"]),
+                }
+                for event in events
+            ],
+        }
+
+    def status(self) -> dict[str, Any]:
+        """Body-free aggregate status of the projection."""
+        with self._connect(write=False) as connection:
+            counts = connection.execute(
+                "SELECT state, COUNT(*) AS n FROM context_links GROUP BY state ORDER BY state"
+            ).fetchall()
+            events = connection.execute(
+                "SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM link_events"
+            ).fetchone()
+        return {
+            "schema_version": 1,
+            "counts": {str(row["state"]): int(row["n"]) for row in counts},
+            "events": int(events["n"]) if events else 0,
+            "last_event_at": events["last_at"] if events else None,
+        }
+
+    # ── rebuild ──────────────────────────────────────────────────────────────
+
+    def _projection_snapshot(self, connection: sqlite3.Connection) -> str:
+        rows = connection.execute(
+            "SELECT locator_id, state, schema_version, kind, canonical_namespace, canonical_id,"
+            " canonical_digest, entire_checkpoint_id, git_sha, facets_json, ingested_at,"
+            " promoted_at, tombstone_reason FROM context_links ORDER BY locator_id"
+        ).fetchall()
+        return canonical_json([dict(row) for row in rows])
+
+    def rebuild(self, *, actor: str = "rebuild", now: datetime | None = None) -> dict[str, Any]:
+        """Replay the append-only event log into the projection deterministically."""
+        del actor, now  # replay is fully derived from the event log
+        with self._transaction() as connection:
+            before = self._projection_snapshot(connection)
+            events = connection.execute(
+                "SELECT event_id, locator_id, event_type, payload_json, reason, recorded_at"
+                " FROM link_events ORDER BY event_id"
+            ).fetchall()
+            projection: dict[str, dict[str, Any]] = {}
+
+            for event in events:
+                locator_id = str(event["locator_id"])
+                event_type = str(event["event_type"])
+                if event_type == "claimed":
+                    if locator_id in projection:
+                        continue  # duplicate claim replay is a no-op
+                    payload = json.loads(event["payload_json"])
+                    projection[locator_id] = {
+                        "locator_id": locator_id,
+                        "state": "pending",
+                        "schema_version": payload["schema_version"],
+                        "kind": payload["kind"],
+                        "canonical_namespace": payload["canonical_namespace"],
+                        "canonical_id": payload["canonical_id"],
+                        "canonical_digest": payload["canonical_digest"],
+                        "entire_checkpoint_id": payload["entire_checkpoint_id"],
+                        "git_sha": payload["git_sha"],
+                        "facets_json": canonical_json(payload["facets"]),
+                        "ingested_at": str(event["recorded_at"]),
+                        "promoted_at": None,
+                        "tombstone_reason": None,
+                    }
+                elif event_type == "promoted":
+                    if locator_id in projection and projection[locator_id]["state"] != "promoted":
+                        projection[locator_id]["state"] = "promoted"
+                        projection[locator_id]["promoted_at"] = str(event["recorded_at"])
+                elif event_type == "tombstoned":
+                    if locator_id in projection and projection[locator_id]["state"] != "tombstoned":
+                        projection[locator_id]["state"] = "tombstoned"
+                        projection[locator_id]["tombstone_reason"] = str(event["reason"])
+
+            connection.execute("DELETE FROM context_links")
+            for row in projection.values():
+                connection.execute(
+                    "INSERT INTO context_links("
+                    "locator_id, state, schema_version, kind, canonical_namespace, canonical_id,"
+                    " canonical_digest, entire_checkpoint_id, git_sha, facets_json, ingested_at,"
+                    " promoted_at, tombstone_reason"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        row["locator_id"],
+                        row["state"],
+                        row["schema_version"],
+                        row["kind"],
+                        row["canonical_namespace"],
+                        row["canonical_id"],
+                        row["canonical_digest"],
+                        row["entire_checkpoint_id"],
+                        row["git_sha"],
+                        row["facets_json"],
+                        row["ingested_at"],
+                        row["promoted_at"],
+                        row["tombstone_reason"],
+                    ),
+                )
+            after = self._projection_snapshot(connection)
+        return {
+            "events_replayed": len(events),
+            "links": len(projection),
+            "parity": before == after,
+        }

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -179,10 +179,27 @@ def test_non_facet_identity_fields_reject_long_opaque_values(field: str) -> None
         ContextLink.from_dict(payload)
 
 
+@pytest.mark.parametrize("field", ["canonical_id", "entire_checkpoint_id"])
+def test_non_facet_identity_fields_reject_delimiter_split_opaque_values(field: str) -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload[field] = "A" * 47 + "." + "A" * 47
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        ContextLink.from_dict(payload)
+
+
 def test_canonical_namespace_rejects_long_opaque_path_component() -> None:
     payload = make_link().to_dict()
     payload.pop("locator_id")
     payload["canonical_namespace"] = "github:" + "A" * 64
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        ContextLink.from_dict(payload)
+
+
+def test_canonical_namespace_rejects_delimiter_split_opaque_value() -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload["canonical_namespace"] = "github:" + "A" * 30 + "." + "A" * 30
     with pytest.raises(SchemaError, match="long-opaque-token"):
         ContextLink.from_dict(payload)
 
@@ -202,11 +219,25 @@ def test_verification_identity_fields_reject_long_opaque_values(field: str) -> N
         VerificationEvidence.from_dict(payload)
 
 
+@pytest.mark.parametrize("field", ["verifier", "evidence_locator"])
+def test_verification_identity_fields_reject_delimiter_split_opaque_values(field: str) -> None:
+    payload = make_verification().to_dict()
+    payload[field] = "A" * 47 + "." + "A" * 47
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        VerificationEvidence.from_dict(payload)
+
+
 def test_typed_verification_locator_rejects_long_opaque_path_component() -> None:
     payload = make_verification().to_dict()
     payload["evidence_locator"] = "github:" + "A" * 64
     with pytest.raises(SchemaError, match="long-opaque-token"):
         VerificationEvidence.from_dict(payload)
+
+
+def test_git_commit_evidence_locator_remains_allowed() -> None:
+    payload = make_verification().to_dict()
+    payload["evidence_locator"] = "git:commit/" + GIT_SHA
+    assert VerificationEvidence.from_dict(payload).evidence_locator == payload["evidence_locator"]
 
 
 def test_from_dict_rejects_unsupported_schema_version() -> None:
@@ -672,6 +703,20 @@ def test_cli_admit_rejects_schema_violations(tmp_path: Path) -> None:
     code, out = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
     assert code == cli.EXIT_REFUSED
     assert out["reason"] == "schema_invalid"
+    assert not db.exists()
+
+
+def test_cli_admit_rejects_non_utf8_json_without_traceback(tmp_path: Path) -> None:
+    db = tmp_path / "non-utf8.sqlite3"
+    link_file = tmp_path / "link.json"
+    link_file.write_bytes(b"\xff\xfe\x00\x01")
+
+    code, payload = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+
+    assert code == cli.EXIT_REFUSED
+    assert payload["outcome"] == "refused"
+    assert payload["reason"] == "schema_invalid"
+    assert "not readable JSON" in payload["detail"]
     assert not db.exists()
 
 

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -204,6 +204,23 @@ def test_non_facet_identity_fields_reject_delimiter_split_opaque_values(field: s
         ContextLink.from_dict(payload)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("entire_checkpoint_id", 123),
+        ("entire_checkpoint_id", True),
+        ("git_sha", 123),
+        ("git_sha", True),
+    ],
+)
+def test_optional_identity_fields_reject_non_strings(field: str, value: object) -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload[field] = value
+    with pytest.raises(SchemaError, match=field):
+        ContextLink.from_dict(payload)
+
+
 def test_canonical_namespace_rejects_long_opaque_path_component() -> None:
     payload = make_link().to_dict()
     payload.pop("locator_id")
@@ -719,6 +736,33 @@ def test_cli_admit_rejects_schema_violations(tmp_path: Path) -> None:
     code, out = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
     assert code == cli.EXIT_REFUSED
     assert out["reason"] == "schema_invalid"
+    assert not db.exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("entire_checkpoint_id", 123),
+        ("entire_checkpoint_id", True),
+        ("git_sha", 123),
+        ("git_sha", True),
+    ],
+)
+def test_cli_admit_rejects_non_string_optional_identifiers(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    db = tmp_path / "schema.sqlite3"
+    link_file = tmp_path / "link.json"
+    payload = make_link().to_dict()
+    payload[field] = value
+    link_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    code, out = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+
+    assert code == cli.EXIT_REFUSED
+    assert out["outcome"] == "refused"
+    assert out["reason"] == "schema_invalid"
+    assert field in out["detail"]
     assert not db.exists()
 
 

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -1,0 +1,536 @@
+"""Acceptance coverage for the public body-free context-link index (#6174).
+
+Proves: schema allowlist and forbidden-field rejection, deterministic locator
+IDs, duplicate/replay idempotency, pending/tombstoned invisibility, stale /
+partial-terminal / digest-mismatched evidence refusal, rebuild parity,
+missing/disabled projection behavior, and body-free CLI output.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.entire_context import cli
+from scripts.entire_context.model import (
+    ContextLink,
+    LinkKind,
+    SchemaError,
+    VerificationEvidence,
+    VerificationStatus,
+    isoformat_z,
+)
+from scripts.entire_context.store import AdmitOutcome, ContextLinkStore
+
+NOW = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+GIT_SHA = "0" * 40
+
+# Tokens that must never appear in any CLI output (body-free contract).
+FORBIDDEN_OUTPUT_TOKENS = (
+    "prompt",
+    "response",
+    "transcript",
+    "summar",
+    "raw_capture",
+    "message",
+    "artifact",
+    "secret",
+    "password",
+    "credential",
+    "api_key",
+    "refs/entire",
+    "-----BEGIN",
+    "ghp_",
+    "sk-",
+)
+
+
+def make_link(**overrides) -> ContextLink:
+    fields = {
+        "kind": LinkKind.GIT_COMMIT,
+        "canonical_namespace": "git:learn-ukrainian/learn-ukrainian.github.io",
+        "canonical_id": GIT_SHA,
+        "canonical_digest": DIGEST_A,
+        "git_sha": GIT_SHA,
+        "facets": {
+            "repository": "learn-ukrainian/learn-ukrainian.github.io",
+            "stream_epic": "4707",
+            "track": "infra-harness",
+            "title": "Public context-link index",
+            "labels": ["infra", "entire"],
+            "token_bucket": "small",
+        },
+    }
+    fields.update(overrides)
+    return ContextLink(**fields)
+
+
+def make_verification(**overrides) -> VerificationEvidence:
+    fields = {
+        "verifier": "git",
+        "canonical_digest": DIGEST_A,
+        "status": VerificationStatus.VERIFIED,
+        "evidence_locator": "git:commit/" + GIT_SHA,
+        "checked_at": isoformat_z(NOW),
+    }
+    fields.update(overrides)
+    return VerificationEvidence(**fields)
+
+
+def make_store(tmp_path: Path) -> ContextLinkStore:
+    return ContextLinkStore(tmp_path / "context-links.sqlite3")
+
+
+def event_count(store: ContextLinkStore) -> int:
+    with sqlite3.connect(store.db_path) as connection:
+        return int(connection.execute("SELECT COUNT(*) FROM link_events").fetchone()[0])
+
+
+# ── schema: allowlist and forbidden-field rejection ──────────────────────────
+
+
+def test_valid_link_roundtrips_and_validates() -> None:
+    link = make_link()
+    link.validate()
+    parsed = ContextLink.from_dict(link.to_dict())
+    assert parsed.locator_id == link.locator_id
+
+
+def test_locator_id_format() -> None:
+    assert make_link().locator_id.startswith("clink_")
+    assert len(make_link().locator_id) == len("clink_") + 64
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "prompt",
+        "response",
+        "transcript",
+        "summary",
+        "raw_capture",
+        "message_body",
+        "artifact_body",
+        "transcript_path",
+        "secret_token",
+        "session_notes",
+        "entire_ref",
+    ],
+)
+def test_from_dict_rejects_unknown_and_body_bearing_fields(field: str) -> None:
+    payload = make_link().to_dict()
+    payload[field] = "x"
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+@pytest.mark.parametrize("facet_key", ["prompt", "body", "transcript_path", "unknown_field"])
+def test_facets_reject_forbidden_and_unknown_keys(facet_key: str) -> None:
+    payload = make_link().to_dict()
+    payload["facets"] = {facet_key: "x"}
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ghp_" + "x" * 32,
+        "sk-" + "y" * 32,
+        "-----BEGIN " + "OPENSSH PRIVATE KEY-----",
+        "password: supersecret1",
+        "api_key=abcdefgh123",
+        "refs/entire/checkpoints/abc",
+    ],
+)
+def test_facet_values_reject_secrets_and_public_entire_refs(value: str) -> None:
+    payload = make_link().to_dict()
+    payload["facets"] = {"title": value}
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+def test_from_dict_rejects_unsupported_schema_version() -> None:
+    payload = make_link().to_dict()
+    payload["schema_version"] = 99
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+def test_from_dict_rejects_tampered_locator_id() -> None:
+    payload = make_link().to_dict()
+    payload["locator_id"] = "clink_" + "f" * 64
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+def test_from_dict_rejects_caller_supplied_ingested_at() -> None:
+    payload = make_link().to_dict()
+    payload["ingested_at"] = isoformat_z(NOW)
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+def test_from_dict_rejects_bad_digest_and_kind() -> None:
+    payload = make_link().to_dict()
+    payload["canonical_digest"] = "not-a-digest"
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+    payload = make_link().to_dict()
+    payload["kind"] = "entire_session"
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
+# ── deterministic locator IDs ────────────────────────────────────────────────
+
+
+def test_locator_id_is_deterministic() -> None:
+    first = make_link().locator_id
+    second = make_link(facets={"title": "different facets do not matter"}).locator_id
+    assert first == second
+
+
+def test_changed_digest_produces_new_locator_id() -> None:
+    assert make_link().locator_id != make_link(canonical_digest=DIGEST_B).locator_id
+
+
+def test_changed_kind_namespace_or_id_produce_new_locator_id() -> None:
+    base = make_link()
+    assert base.locator_id != make_link(kind=LinkKind.GITHUB_ISSUE).locator_id
+    assert base.locator_id != make_link(canonical_namespace="github:learn-ukrainian/learn-ukrainian.github.io").locator_id
+    assert base.locator_id != make_link(canonical_id="6174").locator_id
+
+
+# ── admission lifecycle ──────────────────────────────────────────────────────
+
+
+def test_admit_promotes_with_valid_verification(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    result = store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.PROMOTED
+    assert store.lookup(result.locator_id) is not None
+
+
+def test_duplicate_admission_is_idempotent(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    first = store.admit(link, make_verification(), actor="test", now=NOW)
+    events_after_first = event_count(store)
+    second = store.admit(link, make_verification(), actor="test", now=NOW)
+    assert second.outcome is AdmitOutcome.ALREADY_PROMOTED
+    assert event_count(store) == events_after_first
+    assert store.lookup(first.locator_id) is not None
+
+
+def test_pending_claims_are_invisible(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    locator_id = store.submit_claim(link, actor="test", now=NOW)
+    assert store.lookup(locator_id) is None
+    detail = store.explain(locator_id)
+    assert detail is not None
+    assert detail["state"] == "pending"
+    assert [event["event_type"] for event in detail["events"]] == ["claimed"]
+    # Re-submitting the same claim is a no-op.
+    store.submit_claim(link, actor="test", now=NOW)
+    assert event_count(store) == 1
+
+
+def test_pending_claim_promotes_on_replayed_admission(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    store.submit_claim(link, actor="test", now=NOW)
+    result = store.admit(link, make_verification(), actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.PROMOTED
+    assert store.lookup(result.locator_id) is not None
+    detail = store.explain(result.locator_id)
+    assert detail is not None
+    assert [event["event_type"] for event in detail["events"]] == ["claimed", "promoted"]
+
+
+def test_missing_verification_is_tombstoned_and_invisible(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    locator_id = link.locator_id
+    store.admit(link, None, actor="test", now=NOW)
+    assert store.lookup(locator_id) is None
+    detail = store.explain(locator_id)
+    assert detail is not None
+    assert detail["state"] == "tombstoned"
+    assert detail["tombstone_reason"] == "verification_missing"
+
+
+def test_tombstoned_claims_are_invisible_and_terminal(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    refused = store.admit(link, None, actor="test", now=NOW)
+    assert refused.outcome is AdmitOutcome.REFUSED
+    events_after_refusal = event_count(store)
+    retry = store.admit(link, make_verification(), actor="test", now=NOW)
+    assert retry.outcome is AdmitOutcome.ALREADY_TOMBSTONED
+    assert event_count(store) == events_after_refusal
+    assert store.lookup(refused.locator_id) is None
+
+
+def test_stale_evidence_cannot_promote(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    stale = make_verification(status=VerificationStatus.STALE)
+    result = store.admit(make_link(), stale, actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "verification_stale"
+    assert store.lookup(result.locator_id) is None
+
+
+def test_old_checked_at_evidence_cannot_promote(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    old = make_verification(checked_at=isoformat_z(NOW - timedelta(hours=2)))
+    result = store.admit(make_link(), old, actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "verification_stale"
+
+
+def test_partial_terminal_evidence_cannot_promote(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    partial = make_verification(status=VerificationStatus.PARTIAL_TERMINAL)
+    result = store.admit(make_link(), partial, actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "verification_partial_terminal"
+    assert store.lookup(result.locator_id) is None
+
+
+def test_digest_mismatched_evidence_cannot_promote(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    mismatch = make_verification(
+        status=VerificationStatus.DIGEST_MISMATCH, canonical_digest=DIGEST_B
+    )
+    result = store.admit(make_link(), mismatch, actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "verification_digest_mismatch"
+    assert store.lookup(result.locator_id) is None
+
+
+def test_verified_status_with_wrong_digest_cannot_promote(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    wrong_digest = make_verification(canonical_digest=DIGEST_B)
+    result = store.admit(make_link(), wrong_digest, actor="test", now=NOW)
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "digest_mismatch"
+
+
+def test_explain_returns_body_free_audit_trail(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = make_link()
+    result = store.admit(link, make_verification(), actor="test", now=NOW)
+    detail = store.explain(result.locator_id)
+    assert detail is not None
+    assert [event["event_type"] for event in detail["events"]] == ["claimed", "promoted"]
+    rendered = json.dumps(detail, ensure_ascii=False).lower()
+    for token in FORBIDDEN_OUTPUT_TOKENS:
+        assert token not in rendered
+
+
+def test_multiple_links_stay_distinct(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    first = store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    second = store.admit(
+        make_link(canonical_digest=DIGEST_B),
+        make_verification(canonical_digest=DIGEST_B),
+        actor="test",
+        now=NOW,
+    )
+    assert first.locator_id != second.locator_id
+    assert store.lookup(first.locator_id)["canonical_digest"] == DIGEST_A
+    assert store.lookup(second.locator_id)["canonical_digest"] == DIGEST_B
+
+
+# ── rebuild parity ───────────────────────────────────────────────────────────
+
+
+def test_rebuild_reproduces_identical_projection(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    store.admit(
+        make_link(canonical_digest=DIGEST_B),
+        make_verification(canonical_digest=DIGEST_B),
+        actor="test",
+        now=NOW,
+    )
+    store.admit(make_link(canonical_id="6174"), None, actor="test", now=NOW)
+    result = store.rebuild()
+    assert result["parity"] is True
+    assert result["links"] == 3
+    again = store.rebuild()
+    assert again["parity"] is True
+    status = store.status()
+    assert status["counts"] == {"promoted": 2, "tombstoned": 1}
+    assert status["events"] == 6
+
+
+# ── cross-harness equivalence ────────────────────────────────────────────────
+
+
+def test_same_fixture_yields_same_body_free_result_across_projections(tmp_path: Path) -> None:
+    link_payload = make_link().to_dict()
+    verification = make_verification()
+    results = []
+    for seat in ("codex", "kimi", "glm"):
+        store = ContextLinkStore(tmp_path / f"{seat}.sqlite3")
+        link = ContextLink.from_dict(link_payload)
+        admitted = store.admit(link, verification, actor=seat, now=NOW)
+        results.append(store.lookup(admitted.locator_id))
+    assert results[0] is not None
+    assert results[0] == results[1] == results[2]
+
+
+# ── CLI: status / lookup / explain / rebuild / admit ─────────────────────────
+
+
+def run_cli(argv: list[str]) -> tuple[int, dict]:
+    from io import StringIO
+    from unittest.mock import patch
+
+    buffer = StringIO()
+    with patch("sys.stdout", buffer):
+        code = cli.main(argv)
+    return code, json.loads(buffer.getvalue())
+
+
+def test_cli_status_missing_projection_does_not_create_state(tmp_path: Path) -> None:
+    db = tmp_path / "missing.sqlite3"
+    code, payload = run_cli(["status", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_missing"
+    assert not db.exists()
+
+
+def test_cli_lookup_missing_projection_is_clean(tmp_path: Path) -> None:
+    code, payload = run_cli(["lookup", "clink_" + "0" * 64, "--db", str(tmp_path / "m.sqlite3")])
+    assert code == cli.EXIT_OK
+    assert payload["available"] is False
+
+
+def test_cli_rebuild_missing_projection_is_clean(tmp_path: Path) -> None:
+    db = tmp_path / "missing.sqlite3"
+    code, payload = run_cli(["rebuild", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["available"] is False
+    assert not db.exists()
+
+
+def test_cli_disabled_projection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(cli.ENV_DISABLED, "1")
+    db = tmp_path / "disabled.sqlite3"
+    code, payload = run_cli(["status", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["enabled"] is False
+    assert payload["reason"] == "projection_disabled"
+    link_file = tmp_path / "link.json"
+    link_file.write_text(json.dumps(make_link().to_dict()), encoding="utf-8")
+    code, payload = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+    assert code == cli.EXIT_REFUSED
+    assert payload["reason"] == "projection_disabled"
+    assert not db.exists()
+
+
+def test_cli_corrupt_projection_fails_open(tmp_path: Path) -> None:
+    db = tmp_path / "corrupt.sqlite3"
+    db.write_bytes(b"not a sqlite database at all")
+    code, payload = run_cli(["status", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_unreadable"
+
+
+def test_cli_admit_lookup_explain_roundtrip(tmp_path: Path) -> None:
+    db = tmp_path / "roundtrip.sqlite3"
+    link_file = tmp_path / "link.json"
+    verification_file = tmp_path / "verification.json"
+    link = make_link()
+    link_file.write_text(json.dumps(link.to_dict()), encoding="utf-8")
+    verification_file.write_text(
+        json.dumps(make_verification(checked_at=isoformat_z(datetime.now(UTC))).to_dict()),
+        encoding="utf-8",
+    )
+
+    code, payload = run_cli(
+        ["admit", "--link", str(link_file), "--verification", str(verification_file), "--db", str(db)]
+    )
+    assert code == cli.EXIT_OK
+    assert payload["outcome"] == "promoted"
+    locator_id = payload["locator_id"]
+    assert locator_id == link.locator_id
+
+    code, payload = run_cli(["lookup", locator_id, "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["found"] is True
+    assert payload["link"]["canonical_id"] == GIT_SHA
+
+    code, payload = run_cli(["explain", locator_id, "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["found"] is True
+    assert payload["state"] == "promoted"
+
+    code, payload = run_cli(["status", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["counts"] == {"promoted": 1}
+
+    code, payload = run_cli(["rebuild", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["parity"] is True
+
+    code, payload = run_cli(["lookup", "clink_" + "f" * 64, "--db", str(db)])
+    assert code == cli.EXIT_NOT_FOUND
+    assert payload["found"] is False
+
+
+def test_cli_admit_without_verification_refuses(tmp_path: Path) -> None:
+    db = tmp_path / "noverif.sqlite3"
+    link_file = tmp_path / "link.json"
+    link_file.write_text(json.dumps(make_link().to_dict()), encoding="utf-8")
+    code, payload = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+    assert code == cli.EXIT_REFUSED
+    assert payload["reason"] == "verification_missing"
+    lookup_code, lookup_payload = run_cli(["lookup", make_link().locator_id, "--db", str(db)])
+    assert lookup_code == cli.EXIT_NOT_FOUND
+    assert lookup_payload["found"] is False
+
+
+def test_cli_admit_rejects_schema_violations(tmp_path: Path) -> None:
+    db = tmp_path / "schema.sqlite3"
+    link_file = tmp_path / "link.json"
+    payload = make_link().to_dict()
+    payload["prompt"] = "ignored"
+    link_file.write_text(json.dumps(payload), encoding="utf-8")
+    code, out = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+    assert code == cli.EXIT_REFUSED
+    assert out["reason"] == "schema_invalid"
+    assert not db.exists()
+
+
+def test_cli_output_is_body_free(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    db = tmp_path / "bodyfree.sqlite3"
+    store = ContextLinkStore(db)
+    promoted = store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    store.admit(make_link(canonical_id="6174"), None, actor="test", now=NOW)
+
+    outputs: list[str] = []
+    for argv in (
+        ["status", "--db", str(db)],
+        ["lookup", promoted.locator_id, "--db", str(db)],
+        ["explain", promoted.locator_id, "--db", str(db)],
+        ["rebuild", "--db", str(db)],
+        ["status", "--db", str(tmp_path / "missing.sqlite3")],
+    ):
+        code = cli.main(argv)
+        outputs.append(capsys.readouterr().out)
+    rendered = "\n".join(outputs).lower()
+    for token in FORBIDDEN_OUTPUT_TOKENS:
+        assert token not in rendered

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -156,6 +156,22 @@ def test_facet_values_reject_secrets_and_public_entire_refs(value: str) -> None:
         ContextLink.from_dict(payload)
 
 
+@pytest.mark.parametrize("field", ["canonical_id", "entire_checkpoint_id"])
+def test_non_facet_identity_fields_reject_token_like_values(field: str) -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload[field] = "ghp_" + "x" * 32
+    with pytest.raises(SchemaError, match="credential-token"):
+        ContextLink.from_dict(payload)
+
+
+def test_verification_locator_rejects_token_like_values() -> None:
+    payload = make_verification().to_dict()
+    payload["evidence_locator"] = "ghp_" + "x" * 32
+    with pytest.raises(SchemaError, match="credential-token"):
+        VerificationEvidence.from_dict(payload)
+
+
 def test_from_dict_rejects_unsupported_schema_version() -> None:
     payload = make_link().to_dict()
     payload["schema_version"] = 99
@@ -229,6 +245,18 @@ def test_duplicate_admission_is_idempotent(tmp_path: Path) -> None:
     assert store.lookup(first.locator_id) is not None
 
 
+def test_actor_must_be_a_body_free_identity(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    with pytest.raises(SchemaError, match="credential-token"):
+        store.admit(
+            make_link(),
+            make_verification(),
+            actor="ghp_" + "x" * 32,
+            now=NOW,
+        )
+    assert not store.db_path.exists()
+
+
 def test_pending_claims_are_invisible(tmp_path: Path) -> None:
     store = make_store(tmp_path)
     link = make_link()
@@ -253,6 +281,39 @@ def test_pending_claim_promotes_on_replayed_admission(tmp_path: Path) -> None:
     detail = store.explain(result.locator_id)
     assert detail is not None
     assert [event["event_type"] for event in detail["events"]] == ["claimed", "promoted"]
+
+
+def test_pending_claim_payload_conflict_tombstones_instead_of_promoting(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    pending = make_link(entire_checkpoint_id="unverified-checkpoint", facets={"title": "unverified"})
+    admitted = make_link(entire_checkpoint_id="verified-checkpoint", facets={"title": "verified"})
+    store.submit_claim(pending, actor="test", now=NOW)
+
+    result = store.admit(admitted, make_verification(), actor="test", now=NOW)
+
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "claim_payload_conflict"
+    assert result.state == "tombstoned"
+    assert store.lookup(result.locator_id) is None
+    detail = store.explain(result.locator_id)
+    assert detail is not None
+    assert detail["tombstone_reason"] == "claim_payload_conflict"
+
+
+def test_promoted_claim_payload_conflict_is_refused_without_replacement(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    original = make_link(entire_checkpoint_id="verified-checkpoint", facets={"title": "verified"})
+    first = store.admit(original, make_verification(), actor="test", now=NOW)
+    conflicting = make_link(entire_checkpoint_id="other-checkpoint", facets={"title": "other"})
+
+    result = store.admit(conflicting, make_verification(), actor="test", now=NOW)
+
+    assert result.outcome is AdmitOutcome.REFUSED
+    assert result.reason == "claim_payload_conflict"
+    stored = store.lookup(first.locator_id)
+    assert stored is not None
+    assert stored["entire_checkpoint_id"] == "verified-checkpoint"
+    assert stored["facets"] == {"title": "verified"}
 
 
 def test_missing_verification_is_tombstoned_and_invisible(tmp_path: Path) -> None:
@@ -444,6 +505,36 @@ def test_cli_corrupt_projection_fails_open(tmp_path: Path) -> None:
     db = tmp_path / "corrupt.sqlite3"
     db.write_bytes(b"not a sqlite database at all")
     code, payload = run_cli(["status", "--db", str(db)])
+    assert code == cli.EXIT_OK
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_unreadable"
+
+
+def test_cli_admit_corrupt_projection_fails_closed_without_traceback(tmp_path: Path) -> None:
+    db = tmp_path / "corrupt.sqlite3"
+    db.write_bytes(b"not a sqlite database at all")
+    link_file = tmp_path / "link.json"
+    link_file.write_text(json.dumps(make_link().to_dict()), encoding="utf-8")
+
+    code, payload = run_cli(["admit", "--link", str(link_file), "--db", str(db)])
+
+    assert code == cli.EXIT_REFUSED
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_unreadable"
+
+
+def test_cli_malformed_projection_row_fails_open_without_traceback(tmp_path: Path) -> None:
+    db = tmp_path / "malformed.sqlite3"
+    store = ContextLinkStore(db)
+    result = store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    with sqlite3.connect(db) as connection:
+        connection.execute(
+            "UPDATE context_links SET facets_json = ? WHERE locator_id = ?",
+            ("not-json", result.locator_id),
+        )
+
+    code, payload = run_cli(["lookup", result.locator_id, "--db", str(db)])
+
     assert code == cli.EXIT_OK
     assert payload["available"] is False
     assert payload["reason"] == "projection_unreadable"

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -161,6 +161,22 @@ def test_facet_values_reject_secrets_and_public_entire_refs(value: str) -> None:
         ContextLink.from_dict(payload)
 
 
+@pytest.mark.parametrize("separator", [" ", ",", "\u2022"])
+def test_facet_values_reject_separator_split_opaque_tokens(separator: str) -> None:
+    payload = make_link().to_dict()
+    payload["facets"] = {"title": "A" * 47 + separator + "A" * 47}
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        ContextLink.from_dict(payload)
+
+
+def test_long_natural_language_facet_remains_allowed() -> None:
+    payload = make_link().to_dict()
+    payload["facets"] = {
+        "title": "Public context links keep canonical systems authoritative across every agent harness"
+    }
+    assert ContextLink.from_dict(payload).facets == payload["facets"]
+
+
 @pytest.mark.parametrize("field", ["canonical_id", "entire_checkpoint_id"])
 def test_non_facet_identity_fields_reject_token_like_values(field: str) -> None:
     payload = make_link().to_dict()

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -147,6 +147,11 @@ def test_facets_reject_forbidden_and_unknown_keys(facet_key: str) -> None:
         "password: supersecret1",
         "api_key=abcdefgh123",
         "refs/entire/checkpoints/abc",
+        "AKIA" + "A" * 16,
+        "xoxb-" + "A" * 24,
+        "eyJ" + "A" * 12 + "." + "B" * 12 + "." + "C" * 12,
+        "Bearer " + "A" * 32,
+        "A" * 64,
     ],
 )
 def test_facet_values_reject_secrets_and_public_entire_refs(value: str) -> None:
@@ -426,12 +431,31 @@ def test_rebuild_reproduces_identical_projection(tmp_path: Path) -> None:
     store.admit(make_link(canonical_id="6174"), None, actor="test", now=NOW)
     result = store.rebuild()
     assert result["parity"] is True
+    assert result["applied"] is True
+    assert result["drift_repaired"] is False
     assert result["links"] == 3
     again = store.rebuild()
     assert again["parity"] is True
     status = store.status()
     assert status["counts"] == {"promoted": 2, "tombstoned": 1}
     assert status["events"] == 6
+
+
+def test_rebuild_repairs_projection_drift_and_reports_applied_state(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    admitted = store.admit(make_link(), make_verification(), actor="test", now=NOW)
+    with sqlite3.connect(store.db_path) as connection:
+        connection.execute(
+            "UPDATE context_links SET state = 'pending', promoted_at = NULL WHERE locator_id = ?",
+            (admitted.locator_id,),
+        )
+
+    result = store.rebuild()
+
+    assert result["parity"] is False
+    assert result["applied"] is True
+    assert result["drift_repaired"] is True
+    assert store.lookup(admitted.locator_id) is not None
 
 
 # ── cross-harness equivalence ────────────────────────────────────────────────
@@ -576,6 +600,8 @@ def test_cli_admit_lookup_explain_roundtrip(tmp_path: Path) -> None:
     code, payload = run_cli(["rebuild", "--db", str(db)])
     assert code == cli.EXIT_OK
     assert payload["parity"] is True
+    assert payload["applied"] is True
+    assert payload["drift_repaired"] is False
 
     code, payload = run_cli(["lookup", "clink_" + "f" * 64, "--db", str(db)])
     assert code == cli.EXIT_NOT_FOUND

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -170,10 +170,42 @@ def test_non_facet_identity_fields_reject_token_like_values(field: str) -> None:
         ContextLink.from_dict(payload)
 
 
+@pytest.mark.parametrize("field", ["canonical_id", "entire_checkpoint_id"])
+def test_non_facet_identity_fields_reject_long_opaque_values(field: str) -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload[field] = "A" * 64
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        ContextLink.from_dict(payload)
+
+
+def test_canonical_namespace_rejects_long_opaque_path_component() -> None:
+    payload = make_link().to_dict()
+    payload.pop("locator_id")
+    payload["canonical_namespace"] = "github:" + "A" * 64
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        ContextLink.from_dict(payload)
+
+
 def test_verification_locator_rejects_token_like_values() -> None:
     payload = make_verification().to_dict()
     payload["evidence_locator"] = "ghp_" + "x" * 32
     with pytest.raises(SchemaError, match="credential-token"):
+        VerificationEvidence.from_dict(payload)
+
+
+@pytest.mark.parametrize("field", ["verifier", "evidence_locator"])
+def test_verification_identity_fields_reject_long_opaque_values(field: str) -> None:
+    payload = make_verification().to_dict()
+    payload[field] = "A" * 64
+    with pytest.raises(SchemaError, match="long-opaque-token"):
+        VerificationEvidence.from_dict(payload)
+
+
+def test_typed_verification_locator_rejects_long_opaque_path_component() -> None:
+    payload = make_verification().to_dict()
+    payload["evidence_locator"] = "github:" + "A" * 64
+    with pytest.raises(SchemaError, match="long-opaque-token"):
         VerificationEvidence.from_dict(payload)
 
 
@@ -530,6 +562,17 @@ def test_cli_corrupt_projection_fails_open(tmp_path: Path) -> None:
     db.write_bytes(b"not a sqlite database at all")
     code, payload = run_cli(["status", "--db", str(db)])
     assert code == cli.EXIT_OK
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_unreadable"
+
+
+def test_cli_rebuild_corrupt_projection_refuses_without_traceback(tmp_path: Path) -> None:
+    db = tmp_path / "corrupt.sqlite3"
+    db.write_bytes(b"not a sqlite database at all")
+
+    code, payload = run_cli(["rebuild", "--db", str(db)])
+
+    assert code == cli.EXIT_REFUSED
     assert payload["available"] is False
     assert payload["reason"] == "projection_unreadable"
 


### PR DESCRIPTION
Closes #6174.

## What

Implements the public, provider-neutral, body-free context-link layer from ADR-018 and the present-tense #6174 Sol architecture approval:

- `scripts/entire_context/model.py` defines a strict v1 schema and deterministic `clink_<sha256>` locator IDs. Unknown/body-bearing fields, public Entire refs, credential assignments, and known or opaque token shapes are rejected.
- `scripts/entire_context/store.py` provides a caller-owned SQLite projection backed by append-only claimed/promoted/tombstoned events. Admission is fenced by fresh caller-recorded verification, exact payload binding, and terminal tombstones. `rebuild()` replays the event log and explicitly reports whether drift was repaired.
- `scripts/entire_context/cli.py` and `__main__.py` expose `status`, known-ID `lookup`/`explain`, `rebuild`, and fixture `admit`. They make no calls to Entire, GitHub, Fleet, ACP, Monitor, or the network. Missing/disabled/corrupt projections fail body-free and do not silently create state on reads.

This is public integration code, not a public checkpoint store. It creates no Entire checkpoints, transcript bodies, generated summaries, or public `refs/entire/*` refs. Monitor API wiring remains a separate protected-rail change. The private capture pilot is parked while this public layer ships.

## Verification

- `.venv/bin/pytest -q tests/test_entire_context.py` — **86 passed**
- `.venv/bin/ruff check scripts/entire_context tests/test_entire_context.py` — passed
- `.venv/bin/python -m compileall -q scripts/entire_context` — passed
- `git diff --check` — passed
- `\.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main...HEAD` — zero leaks
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — all six commits passed
- Exact-head source-blind CLI proof at `61e999c084716bea21075a98345b5d9b03e102f0`: missing projection remained non-creating; verified issue locator promoted; lookup/explain were body-free; rebuild returned `applied=true`, `parity=true`, `drift_repaired=false`; final state was one promoted link and two events.

## Review

- Initial source-aware Codex review found three admission/body-free gaps; all were fixed and regression-tested.
- Independent Claude Sonnet 5 review found two additional issues: incomplete secret-pattern coverage and ambiguous rebuild success semantics. Both were fixed and regression-tested.
- A second sealed Claude pass found an identity-field opaque-token bypass and an undocumented corrupt-rebuild exit rule. Both were fixed and regression-tested.
- A third sealed Claude pass found delimiter-splitting around the opaque-token fence and an unhandled non-UTF-8 JSON path. Both were fixed and regression-tested.
- A fourth sealed Claude pass found arbitrary-separator bypass in free-text facets. The proposed regex-only change did not cover the reproduced split case, so the fix detects both embedded long runs and multiple long opaque chunks across any separator; normal prose remains accepted.
- Final sealed Claude Sonnet 5 formal review of exact head `61e999c084716bea21075a98345b5d9b03e102f0` returned no findings (`correct`, confidence 0.78). The cross-family verdict is published and approved.
- The unrelated base-CI defect was repaired and merged by #6181; this edit refreshes CI against that repaired base without changing the reviewed head.

## Residual scope

- Verification freshness defaults to 3600 seconds and is constructor-tunable.
- Tombstones are terminal by design; clearing one requires an explicit follow-up policy.
- Entire remains optional and non-authoritative. GitHub, Fleet Comms, Monitor, rollover, and formal review remain the control plane.
