### PR TITLE
feat(routing): promote Luna max for bounded workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,8 +376,15 @@ Prefer `explorer` subagents for read-only investigation and validation. Use `wor
 
 Routine subagent model routing:
 
-- Use `gpt-5.4-mini` for general repo search, small summaries, docs/index checks, simple validation, and straightforward documentation edits.
-- Use `gpt-5.3-codex-spark` for narrow code-heavy routine tasks where code fluency matters: mechanical Python/TypeScript edits, focused test-failure triage, small refactors with clear ownership, diff review, and targeted validation. This model has a separate usage/limit counter, so prefer it over the main model for bounded coding chores when it can run independently.
+- Use `gpt-5.6-luna` at `max` for clearly bounded repo search, summaries,
+  docs/index checks, focused implementation, test/log triage, small refactors,
+  and targeted validation. Every Luna task must name its owned paths and an
+  objective scope ceiling; Luna does not make consequential decisions or the
+  final disposition.
+- Use `gpt-5.3-codex-spark` only as a separate-quota fallback for the same
+  bounded work when Luna is unavailable or the Codex lane is hot. Use
+  `gpt-5.6-terra` at `high` when the scope ceiling is missing, integration is
+  broader, or consequential ambiguity remains.
 
 Use routine subagents for:
 
@@ -394,7 +401,10 @@ Do not use routine subagents for architecture decisions, security-sensitive judg
 Cost controls:
 
 - Use local deterministic tools before model calls: `rg`, `git diff --check`, `bash -n`, `.venv/bin/ruff`, targeted tests, JSON/YAML parsers, and local API endpoints.
-- Escalate routine model work in this order when quality allows: `gpt-5.4-mini` for general routine work, `gpt-5.3-codex-spark` for bounded code-heavy routine work, then the main model for judgment/integration.
+- Route bounded Codex work to `gpt-5.6-luna` at `max`; use
+  `gpt-5.3-codex-spark` only as the separate-quota fallback, and move to
+  `gpt-5.6-terra` at `high` for broader autonomous integration. The accountable
+  root retains judgment and final disposition.
 - Do not spawn a subagent for work the main agent can finish faster than delegation overhead.
 - Keep routine delegation to one to three subagents at a time unless the user explicitly asks for a larger sweep.
 - Do not let subagents read secrets, source `.envrc`, call `gh`, request reviews, or merge PRs.

--- a/agents_extensions/codex/config.toml
+++ b/agents_extensions/codex/config.toml
@@ -20,6 +20,6 @@ tool_namespace = "agents"
 [agents]
 enabled = true
 max_concurrent_threads_per_session = 3
-default_subagent_model = "gpt-5.6-terra"
-default_subagent_reasoning_effort = "medium"
+default_subagent_model = "gpt-5.6-luna"
+default_subagent_reasoning_effort = "max"
 interrupt_message = true

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -426,13 +426,13 @@ All three tiers expose **272K context (~258.4K effectively usable before the con
 
 Policy: **prefer 5.6 for NEW work**; retain 5.5/5.4 only for pinned workflows (qg_bakeoff arms, the V7 pipeline reviewer seat until spot-checked post-reset), proven compatibility, or quota pressure. Codex dispatch + `ask-codex` defaults = `gpt-5.6-terra`.
 
-**Luna economics refresh (operator directive 2026-08-01):** OpenAI cut Luna API
-pricing by 80% on 2026-07-30; current standard short-context token rates and
-Codex plan limits place it at roughly one tenth of Terra for equivalent usage
-units. Promote Luna @ `max` for bounded worker tasks; this cost/throughput
-change does not grant advisor, orchestrator, release, or formal-review
-authority. Terra remains the autonomous-integration fallback, and independent
-cross-family review still binds.
+**Luna economics refresh (operator directive 2026-08-01):** OpenAI currently
+positions Luna for cost-sensitive, high-volume workloads, and its published
+standard short-context token prices are below Terra's. Promote Luna @ `max` for
+bounded worker tasks; this cost/throughput advantage does not grant advisor,
+orchestrator, release, or formal-review authority. Terra remains the
+autonomous-integration fallback, and independent cross-family review still
+binds.
 
 Probe evidence (2026-07-09): `luna@medium` QG 69-item triage PASS (69/69 processed, 5/5 spot-verified verdicts, 160s); `sol@xhigh` (Layer B design) + `terra@high` (#4824 fix) probes ran same day; Sonnet-5-vs-Terra and Haiku-4.5-vs-Luna matched pairs queued for the 07-13 claude reset.
 

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -80,7 +80,7 @@ or count as a formal review.
 | --- | --- |
 | Inline code edit ≤5 LOC, fixing a CI failure I just caused | Me, current model |
 | Claude-side ROUTINE work — formulaic reviews, config/fixture edits, monitoring-only sessions, wiki fixes, mechanical PR babysitting | **Sonnet 5** (user 2026-07-07: "use Sonnet more often for routine work") — dispatch `--model sonnet` / Sonnet session. Reserve the frontier Claude tier (Opus 5 / whatever frontier model is active) for judgment work: architecture, adversarial review, pedagogy, hard bugs. **Route by TIER-FIT, not model name — the Claude lane rotates** (Fable 5 was temporary). **Motive = SAVE THE FRONTIER WINDOW** (user-confirmed 2026-07-07): if Sonnet is busy, QUEUE routine work or reroute to agy/codex — do not burn the frontier window on it. |
-| Code change >5 LOC, mechanical / pattern-applying / fixtures | `delegate.py dispatch --agent codex --mode danger --worktree --base origin/main` (no `--model`) |
+| Code change >5 LOC, mechanical / pattern-applying / fixtures | Clearly bounded with exact owned paths + an objective scope ceiling → `delegate.py dispatch --agent codex --model gpt-5.6-luna --effort max --mode danger --worktree --base origin/main`. Missing ceiling, broader integration, or consequential ambiguity → omit `--model` and retain the Terra @ `high` default. |
 | Code Review (PR diff) | Resolve with `.venv/bin/python -m scripts.review.closeout_cli ... resolve-reviewer --author-model <exact-model> --review-profile code --risk <low\|medium\|high\|critical>`. The resolver applies hard filters first, then the #5293 quality prior above for every formal review; risk remains recorded in the receipt but does not allow a lower tier to leapfrog an eligible higher one. Execute the returned `invocation`; preserve its concrete model, family, `route`, `transport`, health trace, and `requires_silence_timeout` receipt. Do not hand-pick Flash while an eligible higher-tier reviewer remains usable. |
 | Content Review with VESUM verification (load-bearing) | **LANGUAGE-LANES RULE binds (user 2026-07-17): agy / codex / claude / grok-4.5 only** — dispatch the reviewer on one of the four with the `sources` MCP (`verify_words`, `query_cefr_level`, `check_russian_shadow`). ~~deepseek-v4-pro default (#4358)~~ RETIRED for language seats by the same order; the #2112/# 4358 validation history stands as evidence only |
 | Wiki / content writing · content / pedagogy / factual **review** | agy — `delegate.py dispatch --agent agy` (write) or `ab ask-agy --to-model gemini-3.1-pro-high` (review). **Use agy actively here** (user 2026-06-24): the §7/factual-fabrication fence is LIFTED (cleared 2026-06-13 — it grounds in the `sources` MCP and abstains "NO SOURCE"), and its pedagogy/CEFR review is strong — it LED the 2026-06-24 practice-hub panel. **Metered** → be cost-aware, but do NOT under-use it where it's strong. NOT for cross-file architecture / security-concurrency / auth-heavy git / mass-mechanical (→ codex/claude). Caveat: agy `--data` truncates large/binary attachments → paste trimmed content or use codex `--data`. |
@@ -88,7 +88,7 @@ or count as a formal review.
 | Adversarial review of design / ADR / architecture / code — the **Claude reviewer seat** | **Prefer IN-SESSION INLINE for cost** — the interactive orchestrator reads the artifact, verifies claims, writes the verdict + fix notes on the main quota (cheapest path; economics below). When the requested model is Fable, route `claude-fable-5` through native Claude first and use pinned Cursor Fable only if native Claude does not expose it. Dispatching Claude (`claude -p` / `--agent claude` / `review-deep` / an `Agent` review subagent) **is permitted when it adds value or inline isn't feasible** — the `-p` sunset was cancelled (user 2026-06-22). For routine reviews still prefer inline or a non-Claude lane; reserve dispatched Claude for catches that need it. Context heavy → DEFER to the next interactive session, or dispatch if it must clear now. |
 | Q&A or single-shot review without commit | `ab ask-codex` / `ab ask-agy --to-model gemini-3.6-flash-high` for routine/agentic (top AGY default), `--to-model gemini-3.1-pro-high` only for deep single-shot (gemini-cli retired → agy) |
 | Live web fact-check (current version / pricing / URL & citation currency, "is this API still live") | **opencode + lightpanda-MCP HARNESS capability — any opencode-hosted model browses** (kubedojo-verified incl. deepseek); it is NOT model-specific. Route by fit: `ab ask-pool` (poolside.ai, **free**) · `ab ask-glm` (⚠️ LOCAL-ONLY, China-egress) · or an opencode-hosted deepseek. |
-| Search / grep / "find me X" across files | `Agent` tool with `subagent_type: Explore`, `model: "haiku"` |
+| Search / grep / "find me X" across files | Native Codex subagent, default `gpt-5.6-luna` @ `max`, with explicit owned paths and an objective scope ceiling |
 | Status check on running dispatches | Monitor API curl, never inline file scans |
 
 If I'm about to write code inline and it doesn't match row 1, STOP and dispatch instead. Tooling enforces (worktree + commits) — memory does not.
@@ -223,13 +223,17 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
   and escalation triggers. Do not use Sol for routine work; explicit escalation
   may raise effort to `xhigh`/`max`.
 * **Sol-advised bounded execution:** when that envelope is complete, prefer
-  `gpt-5.6-luna` @ `xhigh` for bounded implementation or investigation. Luna must
+  `gpt-5.6-luna` @ `max` for bounded implementation or investigation. Luna must
   follow the envelope rather than re-decide its contract, and must escalate
   any owned-path or scope-ceiling overrun, consequential architecture, security,
   release, high-risk go/no-go, unresolved consequential ambiguity, broader
-  integration, or final disposition. Keep direct Luna @ `medium` for simple
-  evidence/mechanical work only. If no stable envelope exists or broader
-  autonomous integration is needed, use Terra.
+  integration, or final disposition.
+* **Direct bounded execution:** use Luna @ `max` without a Sol envelope only
+  when the accountable root supplies exact owned paths, an objective scope
+  ceiling, and a non-consequential task contract. This covers bounded
+  implementation/investigation, recon, checks, and test/log triage. A missing
+  ceiling, broader autonomous integration, or unresolved consequential
+  ambiguity routes to Terra @ `high`.
 * **Review boundary:** Sol and Luna are both OpenAI-family seats. Sol's advisory
   output never satisfies the independent cross-family review gate.
 * **Workers = every other lane** — `gpt-5.6-terra` / `gpt-5.6-luna` (codex coding, not driver),
@@ -266,11 +270,11 @@ lane's current strengths/caveats live in the catalog, the per-task table, and th
 
 | Work type | 1st pick | 2nd | 3rd | gate / never |
 | --- | --- | --- | --- | --- |
-| **Coding / impl / fixtures** | **Luna @ `xhigh`** after a complete Sol envelope; otherwise **codex** — `terra` default · Luna @ `medium` = simple evidence/mechanical | **agy** — default `gemini-3.6-flash-high` (agentic workhorse ≈ Terra/Sonnet class); Pro only for deep | cursor · grok | claude seat = only ≤5-LOC CI-fix-I-caused; Luna never sole authority |
+| **Coding / impl / fixtures** | **Luna @ `max`** for bounded work with exact owned paths + an objective scope ceiling; use a complete Sol envelope when consequential boundaries need definition. **Terra @ `high`** for broader autonomous integration or unresolved ambiguity | **agy** — default `gemini-3.6-flash-high` (agentic workhorse ≈ Terra/Sonnet class); Pro only for deep | cursor · grok | claude seat = only ≤5-LOC CI-fix-I-caused; Luna never sole authority |
 | **Code review** (cross-family = outside author's family) | **critical only:** Opus/Fable ↔ Sol (authority) | **high/medium/low formal CF defaults:** `gpt-5.6-terra` · `claude-sonnet-5` · `gemini-3.6-flash-high` · native `grok-4.5` (Cursor **`grok-4.5` explicit** if native dark) · Kimi K3 · GLM-5.2 · DeepSeek V4 Pro · pool **`laguna-s-2.1`** | **second dissent / volume:** Pool S 2.1 · DeepSeek Flash · Gemini 3.5 Flash | `review-pr` pins Terra/Sonnet5/GLM @ **high**; resolve-reviewer walks `model_catalog.yaml` ladders; cost never lowers quality floor within a risk rung |
 | **UK content authoring** (author immersion-first, never translate) | **agy** (A1–A2 voice) ≈ **codex** | **claude** (B1–C2, sparingly — save the window) | **grok-4.5** | **LANGUAGE-LANES RULE below binds**: only these four; cursor/deepseek/kimi/pool/glm/gemma excluded |
 | **Content / factual / CEFR review** (VESUM-gated) | **agy** (pedagogy/CEFR, + `sources` MCP) | **codex** · **grok-4.5** | **claude** (judgment tier) | **LANGUAGE-LANES RULE below binds**; NO grok as a QG judge seat (separate standing ban); FOLK stays cross-family GPT↔Claude per the folk rubric |
-| **Research / recon / triage** | **Luna @ `xhigh`** inside a complete Sol envelope; direct Luna @ `medium` for simple evidence | Explore-haiku (grep/find) | terra (deeper or no envelope) | Luna never sole authority on consequential calls |
+| **Research / recon / triage** | **Luna @ `max`** with exact owned paths + an objective scope ceiling; add a Sol envelope when the boundaries themselves need judgment | Terra @ `high` for broader or ambiguous work | agy | Luna never sole authority on consequential calls |
 | **Live web fact-check** (pricing/URL/citation currency) | any opencode model — pool (FREE) · glm (LOCAL) · deepseek | — | — | browsing = harness property, not a model trait |
 
 **LANGUAGE-LANES RULE (HARD, user order 2026-07-17): ALL language-related work — Ukrainian authoring, linguistic/content review, CEFR/russicism analysis, anything that judges Ukrainian text — routes ONLY to claude, codex, gemini (agy), or grok-4.5.** deepseek, glm, kimi, cursor, pool, and gemma are excluded from every language seat (deepseek's former VESUM-gated content-review default is retired; gemma's surface-review slice applies to non-language work only). Standing carve-outs still bind on top: NO deepseek for folk (moot under this rule, kept for history), grok is never a QG judge seat, folk review pairing stays GPT↔Claude. Code/infra/tooling work is unaffected.
@@ -418,9 +422,17 @@ All three tiers expose **272K context (~258.4K effectively usable before the con
 | --- | --- | --- | --- |
 | Sol | `gpt-5.6-sol` | Frontier lead: hard architecture, high-stakes advisory/review, bounded advisory envelopes, difficult debugging, final synthesis | **START = `high`** (never below high); `xhigh`/`max` only for explicit escalation |
 | Terra | `gpt-5.6-terra` | Balanced default: normal implementation, scoped planning, investigations, standard reviews (≈5.5-level quality, cheaper) | default `high`; `xhigh` for the hardest cells |
-| Luna | `gpt-5.6-luna` | Fast bounded worker: Sol-enveloped implementation/investigation at `xhigh`; simple recon, test/log triage, mechanical checks, draft summaries at `medium`. **NEVER sole authority** on consequential decisions or release approval | `xhigh` inside a stable Sol envelope; `medium` for simple evidence/mechanical work |
+| Luna | `gpt-5.6-luna` | Default high-volume bounded worker: focused implementation/investigation, recon, test/log triage, mechanical checks, and draft summaries with exact owned paths + an objective scope ceiling. **NEVER sole authority** on consequential decisions or release approval | `max` for bounded work; add a Sol envelope when task boundaries need authority judgment |
 
 Policy: **prefer 5.6 for NEW work**; retain 5.5/5.4 only for pinned workflows (qg_bakeoff arms, the V7 pipeline reviewer seat until spot-checked post-reset), proven compatibility, or quota pressure. Codex dispatch + `ask-codex` defaults = `gpt-5.6-terra`.
+
+**Luna economics refresh (operator directive 2026-08-01):** OpenAI cut Luna API
+pricing by 80% on 2026-07-30; current standard short-context token rates and
+Codex plan limits place it at roughly one tenth of Terra for equivalent usage
+units. Promote Luna @ `max` for bounded worker tasks; this cost/throughput
+change does not grant advisor, orchestrator, release, or formal-review
+authority. Terra remains the autonomous-integration fallback, and independent
+cross-family review still binds.
 
 Probe evidence (2026-07-09): `luna@medium` QG 69-item triage PASS (69/69 processed, 5/5 spot-verified verdicts, 160s); `sol@xhigh` (Layer B design) + `terra@high` (#4824 fix) probes ran same day; Sonnet-5-vs-Terra and Haiku-4.5-vs-Luna matched pairs queued for the 07-13 claude reset.
 

--- a/docs/best-practices/fleet-role-scorecard.md
+++ b/docs/best-practices/fleet-role-scorecard.md
@@ -31,7 +31,7 @@
 | Code/security CF review | **Author-family-conditional** (see §3) | — | `high`+ | provisional |
 | Critical CF review | Sol ↔ Fable/Opus **cross-family** | — | `xhigh` | provisional |
 | Ukrainian language | Gemini 3.1 Pro (AGY) | LANGUAGE-LANES: codex/claude/grok-4.5 + sources | `high` | provisional (UA primacy AGY; morphology still VESUM-gated) |
-| Recon / triage | Luna, Claude Haiku, Gemini 3.5 Flash | — | `medium`–`high`; never sole release | provisional |
+| Recon / triage | Luna, Claude Haiku, Gemini 3.5 Flash | — | Luna `max` with exact owned paths + objective scope ceiling; others `medium`–`high`; never sole release | provisional |
 
 **One orchestrator per stream.** Advisors recommend; orchestrator owns terminal disposition.
 
@@ -45,7 +45,7 @@
 | **Sol** | Frontier coding/agent claims; synthesis; hard debug; design judgment; multi-agent `ultra` class capabilities in family docs | Expensive; OpenAI-family CF limits if author is OpenAI | OpenAI / Codex | Ceiling advisor; floor `high` |
 | **Opus 4.8** | Durable long agentic sessions; orchestration; architecture | Costly as bulk worker | Anthropic | Prefer orchestrator |
 | **Terra** | Balanced implementer/orchestrator; strong everyday agentic | Not Sol/Fable ceiling | OpenAI / Codex | Orchestrator + worker |
-| **Luna** | Fast recon, cheap mechanical checks | Never sole architecture/security/language/release authority | OpenAI / Codex | Recon |
+| **Luna** | Fast bounded implementation, recon, and mechanical checks | Never sole architecture/security/language/release authority | OpenAI / Codex | Bounded worker / recon |
 | **Claude Haiku** | Fast cheap recon/triage on Anthropic lane; good for log/search skim | Never sole architecture/security/language/release authority | Anthropic | Recon (with Luna / 3.5 Flash) |
 | **Sonnet 5** | Near-flagship coding at better cost; daily driver agentic | Escalate systemic ambiguity | Anthropic | Default worker |
 | **Grok 4.5** | Strong coding agent; token-efficient; good CF review value | Prefer worker/reviewer not sole orchestrator | xAI; SuperGrok Heavy = capacity entitlement (re-verify) | Worker + CF review |

--- a/docs/best-practices/fleet-shared-doctrine.md
+++ b/docs/best-practices/fleet-shared-doctrine.md
@@ -87,7 +87,8 @@ Assign by **role × task family × harness × route/egress**, not marketing rank
 | Terra (orchestrating hard stream) | **`xhigh`** |
 | Terra (routine implement) | **`medium`–`high`**, escalate with risk |
 | Opus orchestrating | **`high`+** |
-| Luna / Claude Haiku recon | **`medium`** default; never sole authority |
+| Luna bounded work / recon | **`max`** with exact owned paths + objective scope ceiling; never sole authority |
+| Claude Haiku recon | **`medium`** default; never sole authority |
 
 ---
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -83,7 +83,7 @@ Same-family helper output, design panels, and channel chat never seal a PR.
 Workers implement inside `.worktrees/dispatch/<agent>/<task>/`. They do not
 become a second coordination plane.
 
-### Sol-advised bounded execution
+### Luna bounded execution
 
 For bounded implementation or investigation, read the machine-readable
 `execution_routing.sol_advised_bounded` route in
@@ -94,11 +94,13 @@ before dispatching:
    contract, exact owned paths, maximum changed-file and non-test-LOC ceilings,
    constraints, risk boundaries, acceptance evidence, and escalation triggers.
 2. If the envelope is complete and the work is bounded, hand it to
-   `gpt-5.6-luna` at `xhigh`. Luna executes within that contract; it does not
+   `gpt-5.6-luna` at `max`. Luna executes within that contract; it does not
    re-decide the task.
-3. Use direct Luna at `medium` only for simple evidence or mechanical checks.
-   Use Terra when the envelope is missing or broader autonomous integration is
-   required.
+3. Direct Luna at `max` is also the default for a clearly bounded,
+   non-consequential task when the accountable root supplies exact owned paths
+   and an objective scope ceiling. Use Terra at `high` when the ceiling is
+   missing, broader autonomous integration is required, or consequential
+   ambiguity remains.
 4. The accountable orchestrator checks the owned paths and ceilings before
    dispatch and again against Luna's returned diff. Luna escalates any ceiling
    overrun, consequential architecture, security, release, high-risk go/no-go,

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -119,9 +119,8 @@ models:
     weaknesses: [not_sole_consequential_authority]
     sources:
       - https://developers.openai.com/api/docs/guides/latest-model
-      - https://developers.openai.com/api/docs/changelog
-      - https://developers.openai.com/api/docs/pricing
-      - https://learn.chatgpt.com/docs/pricing
+      - https://developers.openai.com/api/docs/models/gpt-5.6-luna
+      - https://developers.openai.com/api/docs/models/gpt-5.6-terra
   claude-fable-5:
     family: anthropic
     tier: frontier_authority

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -1,5 +1,5 @@
 schema_version: model-catalog.v1
-reviewed_on: 2026-07-21
+reviewed_on: 2026-08-01
 refresh_after_days: 30
 
 # This is the preferred/current fleet, not every legacy model exposed by a
@@ -60,7 +60,7 @@ execution_routing:
         - escalation_triggers
     preferred_worker:
       model_id: gpt-5.6-luna
-      effort: xhigh
+      effort: max
       requires: [complete_advisory_envelope, objective_scope_ceiling]
       task_types: [bounded_implementation, bounded_investigation]
       escalate_to: gpt-5.6-sol
@@ -76,13 +76,13 @@ execution_routing:
         - final_disposition
     direct_worker:
       model_id: gpt-5.6-luna
-      effort: medium
-      task_types: [simple_evidence, mechanical_checks]
-      constraints: [no_consequential_decisions]
+      effort: max
+      task_types: [bounded_implementation, bounded_investigation, recon, bounded_checks, log_triage]
+      constraints: [objective_scope_ceiling, no_consequential_decisions, no_final_disposition]
     autonomous_fallback:
       model_id: gpt-5.6-terra
       effort: high
-      when: [missing_advisory_envelope, broader_autonomous_integration]
+      when: [missing_objective_scope_ceiling, broader_autonomous_integration, unresolved_consequential_ambiguity]
     review_boundary:
       advisory_family: openai
       advisory_satisfies_cross_family_review: false
@@ -115,10 +115,13 @@ models:
     lifecycle: active
     roles: [recon, bounded_checks, log_triage, bounded_implementation, bounded_investigation]
     transports: [native_codex, cursor]
-    strengths: [speed, high_volume]
+    strengths: [speed, high_volume, max_effort_bounded_execution, quality_cost_frontier]
     weaknesses: [not_sole_consequential_authority]
     sources:
       - https://developers.openai.com/api/docs/guides/latest-model
+      - https://developers.openai.com/api/docs/changelog
+      - https://developers.openai.com/api/docs/pricing
+      - https://learn.chatgpt.com/docs/pricing
   claude-fable-5:
     family: anthropic
     tier: frontier_authority

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -114,8 +114,8 @@ def test_codex_project_config_leaves_root_model_user_selectable() -> None:
     assert config["agents"] == {
         "enabled": True,
         "max_concurrent_threads_per_session": 3,
-        "default_subagent_model": "gpt-5.6-terra",
-        "default_subagent_reasoning_effort": "medium",
+        "default_subagent_model": "gpt-5.6-luna",
+        "default_subagent_reasoning_effort": "max",
         "interrupt_message": True,
     }
 

--- a/tests/test_luna_max_routing_contract.py
+++ b/tests/test_luna_max_routing_contract.py
@@ -1,0 +1,71 @@
+"""Contract for the Luna @ max bounded-worker routing policy.
+
+Focused on the machine-readable invariants of the 2026-08-01 routing change:
+Luna @ max is the default bounded worker, Terra @ high is the autonomous
+fallback, and neither promotion weakens the independent cross-family review
+gate. Large structural assertions stay in ``test_model_catalog.py`` and
+``test_codex_hooks_contract.py``; this file guards only the routing contract.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from scripts.review.model_catalog import load_model_catalog
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODEX_PROJECT_CONFIG = REPO_ROOT / "agents_extensions" / "codex" / "config.toml"
+
+
+def test_codex_source_config_defaults_subagents_to_luna_max() -> None:
+    config = tomllib.loads(CODEX_PROJECT_CONFIG.read_text(encoding="utf-8"))
+
+    agents = config["agents"]
+    assert agents["default_subagent_model"] == "gpt-5.6-luna"
+    assert agents["default_subagent_reasoning_effort"] == "max"
+
+
+def test_catalog_routes_bounded_workers_to_luna_max_terra_high_fallback() -> None:
+    route = load_model_catalog()["execution_routing"]["sol_advised_bounded"]
+
+    preferred = route["preferred_worker"]
+    assert preferred["model_id"] == "gpt-5.6-luna"
+    assert preferred["effort"] == "max"
+
+    direct = route["direct_worker"]
+    assert direct["model_id"] == "gpt-5.6-luna"
+    assert direct["effort"] == "max"
+    assert "objective_scope_ceiling" in direct["constraints"]
+    assert "no_final_disposition" in direct["constraints"]
+
+    fallback = route["autonomous_fallback"]
+    assert fallback["model_id"] == "gpt-5.6-terra"
+    assert fallback["effort"] == "high"
+    assert "missing_objective_scope_ceiling" in fallback["when"]
+
+
+def test_luna_is_absent_from_formal_review_candidates_and_ladders() -> None:
+    catalog = load_model_catalog()
+
+    assert "gpt-5.6-luna" not in catalog["review_candidates"]
+    for ladder in catalog["review_ladders"].values():
+        rung_candidates = {candidate for rung in ladder for candidate in rung}
+        assert "gpt-5.6-luna" not in rung_candidates
+
+
+def test_kimi_k3_and_glm_5_2_remain_on_every_code_review_ladder() -> None:
+    ladders = load_model_catalog()["review_ladders"]
+    assert set(ladders) == {"critical", "high", "medium", "low"}
+
+    for ladder in ladders.values():
+        rung_candidates = {candidate for rung in ladder for candidate in rung}
+        assert {"kimi-k3", "glm-5.2"} <= rung_candidates
+
+
+def test_review_boundary_rejects_same_family_advisory_output() -> None:
+    boundary = load_model_catalog()["execution_routing"]["sol_advised_bounded"]["review_boundary"]
+
+    assert boundary["advisory_family"] == "openai"
+    assert boundary["advisory_satisfies_cross_family_review"] is False
+    assert boundary["independent_cross_family_review_required"] is True

--- a/tests/test_luna_max_routing_contract.py
+++ b/tests/test_luna_max_routing_contract.py
@@ -16,6 +16,8 @@ from scripts.review.model_catalog import load_model_catalog
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEX_PROJECT_CONFIG = REPO_ROOT / "agents_extensions" / "codex" / "config.toml"
+SHARED_DOCTRINE = REPO_ROOT / "docs" / "best-practices" / "fleet-shared-doctrine.md"
+ROLE_SCORECARD = REPO_ROOT / "docs" / "best-practices" / "fleet-role-scorecard.md"
 
 
 def test_codex_source_config_defaults_subagents_to_luna_max() -> None:
@@ -69,3 +71,12 @@ def test_review_boundary_rejects_same_family_advisory_output() -> None:
     assert boundary["advisory_family"] == "openai"
     assert boundary["advisory_satisfies_cross_family_review"] is False
     assert boundary["independent_cross_family_review_required"] is True
+
+
+def test_served_doctrine_uses_luna_max_without_overriding_other_recon_seats() -> None:
+    doctrine = SHARED_DOCTRINE.read_text(encoding="utf-8")
+    scorecard = ROLE_SCORECARD.read_text(encoding="utf-8")
+
+    assert "| Luna bounded work / recon | **`max`**" in doctrine
+    assert "| Claude Haiku recon | **`medium`** default" in doctrine
+    assert "Luna `max` with exact owned paths + objective scope ceiling" in scorecard

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -72,6 +72,14 @@ def test_luna_worker_does_not_enter_formal_review_ladders() -> None:
         assert "gpt-5.6-luna" not in {candidate for rung in ladder for candidate in rung}
 
 
+def test_luna_economics_use_model_specific_openai_sources() -> None:
+    sources = set(load_model_catalog()["models"]["gpt-5.6-luna"]["sources"])
+    assert {
+        "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+        "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+    } <= sources
+
+
 def test_kimi_k3_and_glm_5_2_remain_on_every_code_review_ladder() -> None:
     """The two operator-requested cross-family seats must not silently disappear."""
     for ladder in load_model_catalog()["review_ladders"].values():

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -30,7 +30,7 @@ def test_committed_catalog_is_structurally_valid_and_current():
     assert catalog["schema_version"] == "model-catalog.v1"
     assert catalog["reviewed_on"] == "2026-08-01"
     assert catalog_age_days(catalog, as_of=date(2026, 8, 1)) == 0
-    assert not catalog_is_stale(catalog, as_of=date(2026, 8, 30))
+    assert not catalog_is_stale(catalog, as_of=date(2026, 8, 31))
     assert catalog_is_stale(catalog, as_of=date(2026, 9, 1))
 
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -28,10 +28,10 @@ from scripts.review.model_catalog import (
 def test_committed_catalog_is_structurally_valid_and_current():
     catalog = load_model_catalog()
     assert catalog["schema_version"] == "model-catalog.v1"
-    assert catalog["reviewed_on"] == "2026-07-21"
-    assert catalog_age_days(catalog, as_of=date(2026, 7, 21)) == 0
-    assert not catalog_is_stale(catalog, as_of=date(2026, 8, 20))
-    assert catalog_is_stale(catalog, as_of=date(2026, 8, 21))
+    assert catalog["reviewed_on"] == "2026-08-01"
+    assert catalog_age_days(catalog, as_of=date(2026, 8, 1)) == 0
+    assert not catalog_is_stale(catalog, as_of=date(2026, 8, 30))
+    assert catalog_is_stale(catalog, as_of=date(2026, 9, 1))
 
 
 def test_catalog_covers_current_preferred_frontier_and_efficient_models():
@@ -62,6 +62,21 @@ def test_catalog_covers_current_preferred_frontier_and_efficient_models():
     assert models["poolside/laguna-xs-2.1"]["lifecycle"] == "active"
     assert models["poolside/laguna-m.1"]["lifecycle"] == "fallback"
     assert "pool" in models["poolside/laguna-s-2.1"].get("aliases", [])
+
+
+def test_luna_worker_does_not_enter_formal_review_ladders() -> None:
+    """Same-family bounded execution must never become its own formal gate."""
+    catalog = load_model_catalog()
+    assert "gpt-5.6-luna" not in catalog["review_candidates"]
+    for ladder in catalog["review_ladders"].values():
+        assert "gpt-5.6-luna" not in {candidate for rung in ladder for candidate in rung}
+
+
+def test_kimi_k3_and_glm_5_2_remain_on_every_code_review_ladder() -> None:
+    """The two operator-requested cross-family seats must not silently disappear."""
+    for ladder in load_model_catalog()["review_ladders"].values():
+        candidates = {candidate for rung in ladder for candidate in rung}
+        assert {"kimi-k3", "glm-5.2"} <= candidates
 
 
 def test_kimi_aliases_and_routes_are_catalog_backed() -> None:
@@ -408,7 +423,7 @@ def test_sol_advised_luna_execution_route_is_bounded_and_machine_readable():
 
     preferred = route["preferred_worker"]
     assert preferred["model_id"] == "gpt-5.6-luna"
-    assert preferred["effort"] == "xhigh"
+    assert preferred["effort"] == "max"
     assert {
         "bounded_implementation",
         "bounded_investigation",
@@ -432,14 +447,28 @@ def test_sol_advised_luna_execution_route_is_bounded_and_machine_readable():
     direct = route["direct_worker"]
     assert direct == {
         "model_id": "gpt-5.6-luna",
-        "effort": "medium",
-        "task_types": ["simple_evidence", "mechanical_checks"],
-        "constraints": ["no_consequential_decisions"],
+        "effort": "max",
+        "task_types": [
+            "bounded_implementation",
+            "bounded_investigation",
+            "recon",
+            "bounded_checks",
+            "log_triage",
+        ],
+        "constraints": [
+            "objective_scope_ceiling",
+            "no_consequential_decisions",
+            "no_final_disposition",
+        ],
     }
     assert route["autonomous_fallback"] == {
         "model_id": "gpt-5.6-terra",
         "effort": "high",
-        "when": ["missing_advisory_envelope", "broader_autonomous_integration"],
+        "when": [
+            "missing_objective_scope_ceiling",
+            "broader_autonomous_integration",
+            "unresolved_consequential_ambiguity",
+        ],
     }
 
     models = catalog["models"]

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -185,7 +185,7 @@ def test_low_risk_pool_author_gets_terra_before_economical_routes():
 def test_policy_receipt_exposes_catalog_version_date_and_risk():
     resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk="high"))
     assert resolution.policy_version == "model-catalog.v1"
-    assert resolution.catalog_reviewed_on == "2026-07-21"
+    assert resolution.catalog_reviewed_on == "2026-08-01"
     assert resolution.resolved_risk == "high"
 
 


### PR DESCRIPTION
## Summary

- promote `gpt-5.6-luna` at `max` to the default for clearly bounded Codex worker tasks with exact owned paths and an objective scope ceiling
- retain `gpt-5.6-terra` at `high` for broader autonomous integration or consequential ambiguity, without changing Sol/Fable authority or the independent cross-family review gate
- keep GLM-5.2 and Kimi K3 on every code-review ladder and add focused contract coverage, including a Kimi K3-authored verification file

## Validation

- `pytest tests/test_review_reviewer_resolver.py tests/test_model_catalog.py tests/test_codex_hooks_contract.py tests/test_luna_max_routing_contract.py -q` — 117 passed
- deploy behavior proof — 3 passed (fresh sync, second-run no-op, managed source contract)
- model catalog linter — passed
- Ruff — passed
- deploy dry-run — passed
- `git diff --check` — passed
- OPSEC leak lint — passed
- commit trailer lint — passed

## Review evidence

- GLM-5.2 advisory pass used to preserve review-ladder and authority boundaries
- Kimi K3 max bounded worker authored `tests/test_luna_max_routing_contract.py`
- independent cross-family closeout reviewer: Claude Sonnet 5; the initial doctrine-drift finding was fixed and regression-tested; the sealed review's P3 sourcing concern was also fixed with model-specific OpenAI pages; final sealed verdict `review_b2d4589939064081b8f6eb82c0adab23` is approved with zero findings
- refreshed exact-head GLM 5.2 review `review-pr-6178-cutover-prereq` approved the updated head; archived sidecar SHA-256 `b388b87d78b8b4ea2ac7aaa271a080eff5d205054e376908847b21e313192859`

## Lifecycle

Refs #6159. This is the requested bounded-worker routing prerequisite for the full fleet-communications cutover.

Rail-Approval-Receipt: rail-approval-a4ee79649dde41d78cc7148b7bef85d3
