### PR TITLE
fix(atlas): tolerate absent optional PULS table

### DIFF
--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -325,6 +325,8 @@ def _puls_cefr_level(word: str, sources_db: Path | None = None) -> tuple[str, st
             "SELECT level FROM puls_cefr WHERE word = ? COLLATE NOCASE AND level != '' LIMIT 1",
             (word,),
         ).fetchone()
+    except sqlite3.Error:
+        return None
     finally:
         connection.close()
     if not row:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "baf72a97cfcd04d660615c67c05e880a74dd40fd8929708c833f83ab4fadfd1b",
+  "fingerprint": "ea5ce97e64eab3e237b7c60309f959689ea9fe47c5f3789fff49b1a3d73f9be1",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/curated_seed_atlas_admission.py",
-        "sha256": "42451d146326f68ba9ff1d1001b234736d91b11cd7404e8e15e2b83f84bc1fff"
+        "sha256": "75e0b02d622eac0be42c42cd631555256dccbcde3b75008ce567762e495c3f17"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,27 @@ from scripts.lexicon import curated_seed_atlas_admission as admission
 def _manifest(path: Path, entries: list[dict[str, object]]) -> Path:
     path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
     return path
+
+
+def test_puls_cefr_lookup_fails_closed_when_optional_table_is_absent(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "sources.db"
+    sqlite3.connect(database).close()
+
+    assert admission._puls_cefr_level("оренда", database) is None
+
+
+def test_puls_cefr_lookup_preserves_a_valid_local_result(tmp_path: Path) -> None:
+    database = tmp_path / "sources.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE puls_cefr (word TEXT, level TEXT)")
+        connection.execute(
+            "INSERT INTO puls_cefr(word, level) VALUES (?, ?)",
+            ("оренда", "B1"),
+        )
+
+    assert admission._puls_cefr_level("оренда", database) == ("B1", "PULS CEFR")
 
 
 def test_candidates_keep_explicit_verb_expression_type(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #6180.

## Outcome

The optional local PULS lookup now fails closed when `sources.db` exists but the `puls_cefr` table is unavailable. Valid local PULS rows still resolve normally. This unblocks the independently failing CI shard on #6176 without mixing the fix into that admission PR.

## Verification

- `40 passed`: `tests/test_curated_seed_atlas_admission.py` + `tests/test_residual_teacher_lists.py`
- Ruff on the changed source and tests
- `git diff --check`
- agent-trailer and OPSEC gates

## Review

Exact-head independent cross-family review is required before ready/merge.