### PR TITLE
feat(atlas): scale sentence inventory for practice cloze (#6141)

### DIFF
--- a/docs/practice/daily-sentence-inventory.md
+++ b/docs/practice/daily-sentence-inventory.md
@@ -12,15 +12,18 @@ Regenerate it from the current daily pool with:
 .venv/bin/python -m scripts.audit.generate_sentence_inventory \
   --daily-pool site/src/data/lexicon-daily-pool.json \
   --sources-db data/sources.db \
-  --vesum-db data/vesum.db
+  --vesum-db data/vesum.db \
+  --max-per-lemma 3
 ```
 
 The extractor searches textbook FTS for an exact daily-lemma surface, accepts
-only short sentence-shaped matches with a VESUM-attested verb, and records the
-source label, locator, and licence status for every row. The default inventory
-uses textbook matches. `--include-ulp` may add ULP fallback rows, but its
-provenance is intentionally only the safe source-family label — never a local
-file, transcript id, URL, or private locator.
+only short sentence-shaped matches with a VESUM-attested verb, keeps up to three
+distinct blankable sentences per lemma, and records the source label, locator,
+and licence status for every row. The default inventory uses textbook matches.
+`--include-ulp` may add ULP fallback rows, but its provenance is intentionally
+only the safe source-family label — never a local file, transcript id, URL, or
+private locator. `targetForm` preserves the exact source capitalization so the
+deck can replace one and only one attested token with `___`.
 
 The daily generator overlays this inventory after its existing entry-enrichment
 example lookup and preserves `exampleProvenance` and `exampleLicense` in the

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3552,7 +3552,9 @@ def read_sentence_inventory(path: Path | None) -> list[dict[str, Any]]:
             continue
         if not isinstance(source_provenance, dict) or not isinstance(license_info, dict):
             continue
-        pattern = re.compile(rf"(?<!\w){re.escape(target_form)}(?!\w)")
+        # Treat hyphenated and apostrophe-bearing words as one source token;
+        # ``сумка`` in ``сумка-пакет`` is not an independently blankable form.
+        pattern = re.compile(rf"(?<![\wʼ'’\u2010\u2011\u2012-]){re.escape(target_form)}(?![\wʼ'’\u2010\u2011\u2012-])")
         blanked_sentence, replacements = pattern.subn("___", sentence)
         if replacements != 1:
             continue

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3554,7 +3554,12 @@ def read_sentence_inventory(path: Path | None) -> list[dict[str, Any]]:
             continue
         # Treat hyphenated and apostrophe-bearing words as one source token;
         # ``сумка`` in ``сумка-пакет`` is not an independently blankable form.
-        pattern = re.compile(rf"(?<![\wʼ'’\u2010\u2011\u2012-]){re.escape(target_form)}(?![\wʼ'’\u2010\u2011\u2012-])")
+        # Include ASCII hyphen and Unicode Pd-ish dashes U+2010–U+2015 so en/em
+        # dash compounds are not split (CF #6186 F1).
+        _dash = r"\-\u2010\u2011\u2012\u2013\u2014\u2015"
+        pattern = re.compile(
+            rf"(?<![\wʼ'’{_dash}]){re.escape(target_form)}(?![\wʼ'’{_dash}])"
+        )
         blanked_sentence, replacements = pattern.subn("___", sentence)
         if replacements != 1:
             continue

--- a/scripts/audit/generate_sentence_inventory.py
+++ b/scripts/audit/generate_sentence_inventory.py
@@ -209,18 +209,6 @@ def _source_sentences(
     return results
 
 
-def _first_source_sentence(
-    conn: sqlite3.Connection,
-    *,
-    target: dict[str, str],
-    source_kind: str,
-    vesum: VesumSentenceVerifier | None = None,
-) -> dict[str, Any] | None:
-    """Return the first source sentence for callers that need one example."""
-    rows = _source_sentences(conn, target=target, source_kind=source_kind, limit=1, vesum=vesum)
-    return rows[0] if rows else None
-
-
 def load_daily_lemmas(path: Path) -> list[str]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, list):

--- a/scripts/audit/generate_sentence_inventory.py
+++ b/scripts/audit/generate_sentence_inventory.py
@@ -53,6 +53,13 @@ def _exact_target_present(sentence: str, lemma: str) -> bool:
     return any(token.casefold() == target for token in _tokens(sentence))
 
 
+def _single_target_surface(sentence: str, lemma: str) -> str | None:
+    """Return the one exact target token when a sentence can be safely blanked."""
+    target = lemma.casefold()
+    matches = [token for token in _tokens(sentence) if token.casefold() == target]
+    return matches[0] if len(matches) == 1 else None
+
+
 class VesumSentenceVerifier:
     """Small cached VESUM lookup used only for sentence-shape screening."""
 
@@ -126,13 +133,16 @@ def _fts_rows(
     yield from conn.execute(sql, (query,))
 
 
-def _first_source_sentence(
+def _source_sentences(
     conn: sqlite3.Connection,
     *,
     target: dict[str, str],
     source_kind: str,
+    limit: int,
     vesum: VesumSentenceVerifier | None = None,
-) -> dict[str, Any] | None:
+) -> list[dict[str, Any]]:
+    if limit < 1:
+        raise ValueError("source sentence limit must be positive")
     lemma = target["lemma"]
     if source_kind == "textbook":
         rows = _fts_rows(
@@ -155,11 +165,24 @@ def _first_source_sentence(
         source_label = "Ukrainian Lessons Podcast"
         license_info = ULP_LICENSE
 
+    results: list[dict[str, Any]] = []
+    seen_sentences: set[str] = set()
     for row in rows:
         text = _text(row["text"])
         if text is None:
             continue
         for sentence in _candidate_sentences(text, lemma, vesum=vesum):
+            target_form = _single_target_surface(sentence, lemma)
+            if target_form is None:
+                # ``read_sentence_inventory`` replaces exactly one literal
+                # target token.  Reject repeated targets here so every emitted
+                # row is independently blankable and retain the source's
+                # capitalization in ``targetForm``.
+                continue
+            sentence_key = sentence.casefold()
+            if sentence_key in seen_sentences:
+                continue
+            seen_sentences.add(sentence_key)
             provenance: dict[str, Any] = {
                 "source": source_kind,
                 "label": source_label,
@@ -169,17 +192,33 @@ def _first_source_sentence(
                 # attribution while keeping the inventory independent of DB ids.
                 provenance["locator"] = _text(row["chunk_id"])
                 provenance["title"] = _text(row["title"])
-            return {
-                "lemma": lemma,
-                "lemmaId": target["lemmaId"],
-                "sentence": sentence,
-                "targetForm": lemma,
-                "cefr": target.get("cefr"),
-                "uses": ["example"],
-                "provenance": provenance,
-                "license": dict(license_info),
-            }
-    return None
+            results.append(
+                {
+                    "lemma": lemma,
+                    "lemmaId": target["lemmaId"],
+                    "sentence": sentence,
+                    "targetForm": target_form,
+                    "cefr": target.get("cefr"),
+                    "uses": ["example"],
+                    "provenance": provenance,
+                    "license": dict(license_info),
+                }
+            )
+            if len(results) >= limit:
+                return results
+    return results
+
+
+def _first_source_sentence(
+    conn: sqlite3.Connection,
+    *,
+    target: dict[str, str],
+    source_kind: str,
+    vesum: VesumSentenceVerifier | None = None,
+) -> dict[str, Any] | None:
+    """Return the first source sentence for callers that need one example."""
+    rows = _source_sentences(conn, target=target, source_kind=source_kind, limit=1, vesum=vesum)
+    return rows[0] if rows else None
 
 
 def load_daily_lemmas(path: Path) -> list[str]:
@@ -217,18 +256,32 @@ def build_inventory(
     *,
     include_ulp: bool = False,
     vesum_db: Path | None = None,
+    max_per_lemma: int = 3,
 ) -> list[dict[str, Any]]:
+    if max_per_lemma < 1:
+        raise ValueError("max_per_lemma must be positive")
     conn = sqlite3.connect(sources_db)
     conn.row_factory = sqlite3.Row
     vesum = VesumSentenceVerifier(vesum_db) if vesum_db is not None and vesum_db.exists() else None
     try:
         rows: list[dict[str, Any]] = []
         for target in sorted(targets, key=lambda row: row["lemma"]):
-            row = _first_source_sentence(conn, target=target, source_kind="textbook", vesum=vesum)
-            if row is None and include_ulp:
-                row = _first_source_sentence(conn, target=target, source_kind="ulp", vesum=vesum)
-            if row is not None:
-                rows.append(row)
+            source_rows = _source_sentences(
+                conn,
+                target=target,
+                source_kind="textbook",
+                limit=max_per_lemma,
+                vesum=vesum,
+            )
+            if not source_rows and include_ulp:
+                source_rows = _source_sentences(
+                    conn,
+                    target=target,
+                    source_kind="ulp",
+                    limit=max_per_lemma,
+                    vesum=vesum,
+                )
+            rows.extend(source_rows)
         return rows
     finally:
         conn.close()
@@ -253,9 +306,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
     parser.add_argument("--include-ulp", action="store_true")
+    parser.add_argument(
+        "--max-per-lemma",
+        type=int,
+        default=3,
+        help="Maximum distinct source sentences to retain for each daily lemma.",
+    )
     args = parser.parse_args(argv)
     rows = build_inventory(
-        load_daily_targets(args.daily_pool), args.sources_db, include_ulp=args.include_ulp, vesum_db=args.vesum_db
+        load_daily_targets(args.daily_pool),
+        args.sources_db,
+        include_ulp=args.include_ulp,
+        vesum_db=args.vesum_db,
+        max_per_lemma=args.max_per_lemma,
     )
     write_inventory(rows, args.out)
     print(f"sentence inventory: {len(rows)} rows")

--- a/site/src/data/lexicon-sentence-inventory.json
+++ b/site/src/data/lexicon-sentence-inventory.json
@@ -5,6 +5,46 @@
     {
       "lemma": "Покрова",
       "lemmaId": "покрова",
+      "sentence": "Покрова з портретом гетьмана Богдана Хмельницького.",
+      "targetForm": "Покрова",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-mishhenko-2017_s0129",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "Покрова",
+      "lemmaId": "покрова",
+      "sentence": "Ікона «Покрова Богородиці» з портретом Б.",
+      "targetForm": "Покрова",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0366",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "Покрова",
+      "lemmaId": "покрова",
       "sentence": "Хмельницький був обраний для сюжету ікони «Покрова Богородиці»?",
       "targetForm": "Покрова",
       "cefr": "B1",
@@ -43,6 +83,46 @@
       }
     },
     {
+      "lemma": "США",
+      "lemmaId": "сша",
+      "sentence": "Які види діяльності, що належать до третинного сектору економіки, визначають міжнародну спеціалізацію США?",
+      "targetForm": "США",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-geografija-bojko-2018_s0367",
+        "title": "Сторінка 200"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "США",
+      "lemmaId": "сша",
+      "sentence": "Покажіть на карті найбільші фінансові центри США.",
+      "targetForm": "США",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-geografija-bojko-2018_s0367",
+        "title": "Сторінка 200"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "Хрещатик",
       "lemmaId": "хрещатик",
       "sentence": "Боно та Едж з U-2 виступають у київському метро на станції «Хрещатик».",
@@ -63,10 +143,10 @@
       }
     },
     {
-      "lemma": "адміністратор",
-      "lemmaId": "адміністратор",
-      "sentence": "Адміністратор: Сало́н краси́ «Верса́ль».",
-      "targetForm": "адміністратор",
+      "lemma": "Хрещатик",
+      "lemmaId": "хрещатик",
+      "sentence": "Центральна вулиця Києва — Хрещатик.",
+      "targetForm": "Хрещатик",
       "cefr": "A2",
       "uses": [
         "example"
@@ -74,8 +154,88 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "ulp-2-00-lesson-notes_l0068_w003",
-        "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 3/11)"
+        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0033",
+        "title": "Сторінка 32"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "Хрещатик",
+      "lemmaId": "хрещатик",
+      "sentence": "Є в Києві дві найвідоміші вулиці — Хрещатик і Андріївський узвіз.",
+      "targetForm": "Хрещатик",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-ponomarova-2020-1_s0140",
+        "title": "Сторінка 141"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "адміністратор",
+      "lemmaId": "адміністратор",
+      "sentence": "Адміністратор: Тоді́ в понеді́лок, п’я́того Administrator: Then on Monday, the fifth of March at бе́резня о дев’я́тій годи́ні.",
+      "targetForm": "Адміністратор",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0068_w005",
+        "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 5/11)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "адміністратор",
+      "lemmaId": "адміністратор",
+      "sentence": "Адміністратор: Так, об одина́дцятій годи́ні Administrator: Yes, Maryna works at eleven.",
+      "targetForm": "Адміністратор",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0068_w005",
+        "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 5/11)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "адміністратор",
+      "lemmaId": "адміністратор",
+      "sentence": "Адміністратор: Звича́йно.",
+      "targetForm": "Адміністратор",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0068_w005",
+        "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 5/11)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -103,6 +263,46 @@
       }
     },
     {
+      "lemma": "аналогічно",
+      "lemmaId": "аналогічно",
+      "sentence": "Аналогічно можна задавати внутрішні відступи: padding-top, padding-left, padding-right, padding-bottom.",
+      "targetForm": "Аналогічно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0285",
+        "title": "Сторінка 190"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "аналогічно",
+      "lemmaId": "аналогічно",
+      "sentence": "1 2 3 4 5 6 Завдання для самостійного виконання Створіть сторінки, на яких відображатимуться графічні об’єкти, аналогічно рис.",
+      "targetForm": "аналогічно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0285",
+        "title": "Сторінка 190"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "апостроф",
       "lemmaId": "апостроф",
       "sentence": "Перепишіть слова, поставивши, де потрібно, апостроф.",
@@ -123,10 +323,90 @@
       }
     },
     {
+      "lemma": "апостроф",
+      "lemmaId": "апостроф",
+      "sentence": "Випишіть слова, у яких треба писати апостроф.",
+      "targetForm": "апостроф",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0141",
+        "title": "Сторінка 91"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "апостроф",
+      "lemmaId": "апостроф",
+      "sentence": "Перей йо апостроф не пишемо: зйомка, Воробйов, серйозний.",
+      "targetForm": "апостроф",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0135",
+        "title": "Сторінка 131"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "аудиторія",
       "lemmaId": "аудиторія",
-      "sentence": "Витлумачте пряме й переносне значення слова аудиторія.",
+      "sentence": "Елементи мовленнєвої ситуації (мовець (адресант), слухач ( аудиторія), предмет мовлення, умови успішного спілкування) .",
       "targetForm": "аудиторія",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0317",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "аудиторія",
+      "lemmaId": "аудиторія",
+      "sentence": ".45 Аудиторія (слухач, слухачі).",
+      "targetForm": "Аудиторія",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0317",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "аудиторія",
+      "lemmaId": "аудиторія",
+      "sentence": "Практична риторика Аудиторія (слухач, слухачі).",
+      "targetForm": "Аудиторія",
       "cefr": "A2",
       "uses": [
         "example"
@@ -163,9 +443,89 @@
       }
     },
     {
+      "lemma": "багаж",
+      "lemmaId": "багаж",
+      "sentence": "Чим поповнився ваш багаж сьогодні?",
+      "targetForm": "багаж",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-golub-2022_s0038",
+        "title": "Сторінка 39"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "багаж",
+      "lemmaId": "багаж",
+      "sentence": "Хата, форма, багаж.",
+      "targetForm": "багаж",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-zabolotnyi-2023_s0083",
+        "title": "Сторінка 85"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "бажання",
       "lemmaId": "бажання",
       "sentence": "25 потреби та бажання Подумайте про те, чого ви дуже хочете.",
+      "targetForm": "бажання",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0024",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бажання",
+      "lemmaId": "бажання",
+      "sentence": "Нерідко наші потреби й бажання збігаються.",
+      "targetForm": "бажання",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0024",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бажання",
+      "lemmaId": "бажання",
+      "sentence": "Подивіться мультфільм «Потреби, бажання, товари та послуги».",
       "targetForm": "бажання",
       "cefr": "A2",
       "uses": [
@@ -203,6 +563,46 @@
       }
     },
     {
+      "lemma": "батьків",
+      "lemmaId": "батьків",
+      "sentence": "Співочий грім батьків моїх, «Співочий» — це той, який вміє гарно співати.",
+      "targetForm": "батьків",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0224_w010",
+        "title": "Lesson 224: Українська поезія. Олександр Олесь «О слово рідне! Орле скутий!..» (part 10/30)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "батьків",
+      "lemmaId": "батьків",
+      "sentence": "Обов’язок з утримання є взаємним — після досягнення дітьми повноліття цей обов’язок щодо батьків покладається саме на них.",
+      "targetForm": "батьків",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0456",
+        "title": "Сторінка 237"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "бачення",
       "lemmaId": "бачення",
       "sentence": "Спробуйте за допомоги ШІ створити образ майбутнього людства на основі вашого бачення.",
@@ -223,9 +623,89 @@
       }
     },
     {
+      "lemma": "бачення",
+      "lemmaId": "бачення",
+      "sentence": "Стрільцю залишається або добиватися чіткого бачення «рівної мушки», або точки прицілювання за чіткої видимості мішені, або точки прицілювання.",
+      "targetForm": "бачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0292",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бачення",
+      "lemmaId": "бачення",
+      "sentence": "В умовах обмеженої видимості спостереження ведуть із застосуванням приладів нічного бачення (іл.",
+      "targetForm": "бачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0301",
+        "title": "Сторінка 162"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "безкоштовний",
       "lemmaId": "безкоштовний",
       "sentence": "Зазвичай компанія, що надає безкоштовний хостинг, заробляє шляхом показу реклами на сторінках, розміщених на ньому.",
+      "targetForm": "безкоштовний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0311",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "безкоштовний",
+      "lemmaId": "безкоштовний",
+      "sentence": "Безкоштовний хостинг використовують приватні особи для своїх домашніх сторінок на початковому етапі їх розвитку.",
+      "targetForm": "Безкоштовний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0311",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "безкоштовний",
+      "lemmaId": "безкоштовний",
+      "sentence": "Громадські організації можуть використовувати як платний хостинг, так і безкоштовний.",
       "targetForm": "безкоштовний",
       "cefr": "A2",
       "uses": [
@@ -263,6 +743,86 @@
       }
     },
     {
+      "lemma": "бланк",
+      "lemmaId": "бланк",
+      "sentence": "• Перейдіть за QR-кодом і завантажте бланк для виконання завдання про вартість куріння.",
+      "targetForm": "бланк",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0098",
+        "title": "Сторінка 101"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бланк",
+      "lemmaId": "бланк",
+      "sentence": "• Завантажте бланк «Замість куріння» і заповніть його своїми ідеями, що можна зробити замість куріння.",
+      "targetForm": "бланк",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0098",
+        "title": "Сторінка 101"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ближчий",
+      "lemmaId": "ближчий",
+      "sentence": "Другий шлях, тухольський, хоч вужчий і не так рівний, але зате ближчий і рівно безпечний.",
+      "targetForm": "ближчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0054",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ближчий",
+      "lemmaId": "ближчий",
+      "sentence": "в.) зоні клімату, за винятком Криму, де клімат ближчий до 2.",
+      "targetForm": "ближчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0217_w019",
+        "title": "Lesson 217: Про Крим. Частина 1: Географія та корінні народи (part 19/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "ближчий",
       "lemmaId": "ближчий",
       "sentence": "Рум’янець на українських іконах додавав образам теплішого, більш людяного вигляду, що відбивало ближчий зв’язок між святими й вірянами.",
@@ -285,7 +845,7 @@
     {
       "lemma": "варта",
       "lemmaId": "варта",
-      "sentence": "Прийшло до мене втомлене поліття і роздуми достиглі принесло хвилина щастя варта півстоліття хвилина горя варта півстоліття (І.",
+      "sentence": "Тепер я бачу, що ти варта бути дочкою Захара Беркута!",
       "targetForm": "варта",
       "cefr": "A2",
       "uses": [
@@ -294,8 +854,68 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0209",
-        "title": "Сторінка 150"
+        "locator": "7-klas-ukrlit-avramenko-2024_s0047",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "варта",
+      "lemmaId": "варта",
+      "sentence": "Нічого вона не варта, твоя гнила вода.",
+      "targetForm": "варта",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zarubizhna-literatura-voloshchuk-2022_s0197",
+        "title": "Сторінка 189"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "варта",
+      "lemmaId": "варта",
+      "sentence": "Нічого не варта?!",
+      "targetForm": "варта",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zarubizhna-literatura-voloshchuk-2022_s0197",
+        "title": "Сторінка 189"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вартість",
+      "lemmaId": "вартість",
+      "sentence": "Це номінальна вартість.",
+      "targetForm": "вартість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0021",
+        "title": "Сторінка 22"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -306,6 +926,26 @@
       "lemma": "вартість",
       "lemmaId": "вартість",
       "sentence": "вартість виготовлення одного пенні розǸовна назва Ȃента сягала приǭлизно \u0014,\u001a Ȃента.",
+      "targetForm": "вартість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0021",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вартість",
+      "lemmaId": "вартість",
+      "sentence": "А якщо їхня власна вартість нижча від номіналу, то гроші називають неповноцінними (наприклад, банкноти).",
       "targetForm": "вартість",
       "cefr": "A2",
       "uses": [
@@ -343,9 +983,89 @@
       }
     },
     {
+      "lemma": "ведення",
+      "lemmaId": "ведення",
+      "sentence": "Засоби ведення війни — це зброя й інші засоби, які застосовують збройні сили у війні для перемоги над супротивником.",
+      "targetForm": "ведення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0045",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ведення",
+      "lemmaId": "ведення",
+      "sentence": "Методи ведення війни — способи застосування засобів: положення Додаткового протоколу І (ст.",
+      "targetForm": "ведення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0045",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "великий",
+      "lemmaId": "великий",
+      "sentence": "Блискучий, життєрадісний фільм «Великий вальс» (1938 р.) присвячений творчості Йоганна Штрауса-сина, автора чарівних, неперевершених вальсів.",
+      "targetForm": "Великий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0182",
+        "title": "Сторінка 182"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "великий",
       "lemmaId": "великий",
       "sentence": "Іван Франко — Великий Каменяр Іван Якович Франко народився 27 серпня 1856 року на Галичині, в селі Нагуєвичі.",
+      "targetForm": "Великий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0158_w002",
+        "title": "Lesson 158: Іван Франко — Великий Каменяр (part 2/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "великий",
+      "lemmaId": "великий",
+      "sentence": "Галичина — це досить великий регіон на заході України і сході Польщі.",
       "targetForm": "великий",
       "cefr": "A1",
       "uses": [
@@ -383,6 +1103,46 @@
       }
     },
     {
+      "lemma": "виглядати",
+      "lemmaId": "виглядати",
+      "sentence": "Але іноді люди в Україні, ви почуєте, кажуть і to look виглядати.",
+      "targetForm": "виглядати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w010",
+        "title": "Lesson 128: Рослини — символи України (part 10/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "виглядати",
+      "lemmaId": "виглядати",
+      "sentence": "Дуже хочу знати, Звідки нареченого маю виглядати?",
+      "targetForm": "виглядати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0139_w010",
+        "title": "Lesson 139: Андріївські вечорниці (part 10/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вийняти",
       "lemmaId": "вийняти",
       "sentence": "Відвести ручку затворної рами і, утримуючи її у задньому положенні, від’єднати магазин і вийняти патрон, що уткнувся.",
@@ -396,6 +1156,86 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-zakhyst-fuka-2023_s0320",
         "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вийняти",
+      "lemmaId": "вийняти",
+      "sentence": "Вийняти затвором чи шомполом гільзу із патронника.",
+      "targetForm": "Вийняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0320",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вийняти",
+      "lemmaId": "вийняти",
+      "sentence": "1) Яблуко якого кольору ймовірніше всього вийняти навмання із сумки?",
+      "targetForm": "вийняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-matematyka-nelin-2019_s0146",
+        "title": "Сторінка 133"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "викладач",
+      "lemmaId": "викладач",
+      "sentence": "Викладач курсу Світлана Шабаранська, Web UI-девелопер у компанії N-iX.",
+      "targetForm": "Викладач",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0246",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "викладач",
+      "lemmaId": "викладач",
+      "sentence": "Моя подруга — викладач англійської мови, вона мене до IELTS.",
+      "targetForm": "викладач",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0112_w013",
+        "title": "Lesson 112: Майстер-клас з приготування вареників How to cook varenyky Imperative mood (Part 2) (part 13/18)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -423,6 +1263,46 @@
       }
     },
     {
+      "lemma": "використовувати",
+      "lemmaId": "використовувати",
+      "sentence": "  Я вмію використовувати середовище для створення, редагування та запуску проєктів на виконання з використанням вікна введення-виведення.",
+      "targetForm": "використовувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0141",
+        "title": "Сторінка 120"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "використовувати",
+      "lemmaId": "використовувати",
+      "sentence": "  Я знаю, у яких випадках в алгоритмах потрібно використовувати розгалуження, які є види розгалужень.",
+      "targetForm": "використовувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0141",
+        "title": "Сторінка 120"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вилетіти",
       "lemmaId": "вилетіти",
       "sentence": "Серед молекул поверхневого шару рідини завжди є такі, що «намагаються» вилетіти з рідини.",
@@ -436,6 +1316,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-fizyka-bariakhtar-2025_s0143",
         "title": "Сторінка 130"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вилетіти",
+      "lemmaId": "вилетіти",
+      "sentence": "випрати винести виговоритися вийти вистояти вирости виспатися вилетіти вигадати випросити вилікуватися 0.",
+      "targetForm": "вилетіти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0229_w028",
+        "title": "Lesson 229: Українська поезія. Василь Стус «Господи, гніву пречистого…» (part 28/30)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вилетіти",
+      "lemmaId": "вилетіти",
+      "sentence": "Присудки: вилетіти з голови, ловити ґав.",
+      "targetForm": "вилетіти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0098",
+        "title": "Сторінка 93"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -463,6 +1383,46 @@
       }
     },
     {
+      "lemma": "вимикати",
+      "lemmaId": "вимикати",
+      "sentence": "Вимикати з розетки електроприлади, що потребують періодичної зарядки (ноутбук, мобільний телефон тощо) після того, як вони зарядилися.",
+      "targetForm": "Вимикати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0243",
+        "title": "Сторінка 245"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вимикати",
+      "lemmaId": "вимикати",
+      "sentence": "• Які електроприлади не треба вимикати, йдучи з дому?",
+      "targetForm": "вимикати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0132",
+        "title": "Сторінка 137"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "виникати",
       "lemmaId": "виникати",
       "sentence": "Які проблеми можуть виникати під час проведення штучного запліднення?",
@@ -476,6 +1436,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-biologija-i-ekologija-zadorozhnij-2018-stand_s0214",
         "title": "Сторінка 187"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "виникати",
+      "lemmaId": "виникати",
+      "sentence": "Захворювання органів дихання (респіраторні захворювання) можуть виникати внаслідок впливу інфекційних агентів або різноманітних зовнішніх чинників.",
+      "targetForm": "виникати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0172",
+        "title": "Сторінка 141"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "виникати",
+      "lemmaId": "виникати",
+      "sentence": "Він може виникати як самостійне захворювання або як компонент інших респіраторних захворювань.",
+      "targetForm": "виникати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0172",
+        "title": "Сторінка 141"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -503,6 +1503,46 @@
       }
     },
     {
+      "lemma": "вирости",
+      "lemmaId": "вирости",
+      "sentence": "А Знайомлячи (знайомити) Б Зустрічаючи (зустрічати) А Спілкуючись (спілкуватись) В Бачачи (бачити) Б Вирісши (вирости) В Вивчивши (вивчити) 2.",
+      "targetForm": "вирости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0107_w012",
+        "title": "Lesson 107: У барі At the bar Adverbal participle in Ukrainian (part 12/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вирости",
+      "lemmaId": "вирости",
+      "sentence": "І з кожною хвилиною знань, сили набирайся, щоб вирости Людиною.",
+      "targetForm": "вирости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-2_s0008",
+        "title": "Сторінка 10"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "витратити",
       "lemmaId": "витратити",
       "sentence": "А чи однакову кількість теплоти не­ обхідно витратити на плавлення різних речовин однакової маси?",
@@ -516,6 +1556,66 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-fizyka-bariakhtar-2025_s0135",
         "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "витратити",
+      "lemmaId": "витратити",
+      "sentence": "Яку суму коштів із Вашого бюджету, Ви готові витратити протягом місяця на шкільні аксесуари?",
+      "targetForm": "витратити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ekonomika-homiak-2019_s0198",
+        "title": "Сторінка 128"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "витратити",
+      "lemmaId": "витратити",
+      "sentence": "А витратити зароблені кошти можна (на) подарунки друзям, аквагрим або караоке.",
+      "targetForm": "витратити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-ponomarova-2020-1_s0142",
+        "title": "Сторінка 143"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вишитий",
+      "lemmaId": "вишитий",
+      "sentence": "Ö²ÊÀÂÎ ÇÍÀÒÈ Вишитий рушник – це не просто предмет побуту, а й важливий елемент в українській культурі.",
+      "targetForm": "Вишитий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0135",
+        "title": "Сторінка 92"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -543,6 +1643,26 @@
       }
     },
     {
+      "lemma": "вишитий",
+      "lemmaId": "вишитий",
+      "sentence": "Вишитий в колі хрест символізує вогонь, блискавку або Сонце.",
+      "targetForm": "Вишитий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0131",
+        "title": "Сторінка 133"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вище",
       "lemmaId": "вище",
       "sentence": "Третє речення: День стає довший, сонце починає підніматися вище.",
@@ -556,6 +1676,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-5-00-lesson-notes_l0173_w014",
         "title": "Lesson 173: Зимовий цикл свят (part 14/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вище",
+      "lemmaId": "вище",
+      "sentence": "А зараз повторіть речення: День стає довший, сонце починає підніматися вище.",
+      "targetForm": "вище",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w014",
+        "title": "Lesson 173: Зимовий цикл свят (part 14/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вище",
+      "lemmaId": "вище",
+      "sentence": "Якщо перелом у нижній частині ноги, то шина має виступати вище за коліно й нижче за гомілку.",
+      "targetForm": "вище",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0267",
+        "title": "Сторінка 146"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -583,6 +1743,46 @@
       }
     },
     {
+      "lemma": "всередині",
+      "lemmaId": "всередині",
+      "sentence": "Виникає питання: що знижує температуру всередині плями?",
+      "targetForm": "всередині",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-astronomiya-pryshliak-2019_s0106",
+        "title": "Сторінка 71"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "всередині",
+      "lemmaId": "всередині",
+      "sentence": "За дуже малий інтервал часу напруженість E E E = + ′ 0 результуючого поля всередині провідника дорівнюватиме нулю.",
+      "targetForm": "всередині",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-fizyka-barjakhtar-2018_s0445",
+        "title": "Сторінка 252"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вчити",
       "lemmaId": "вчити",
       "sentence": "вивча́ти = вчи́ти = учи́ти, to learn, to study something ви́вчити (imperfective, perfective) Я вивча́ю (вчу) чудо́ву I am learning the wonderful Ukrainian украї́нську мо́ву.",
@@ -596,6 +1796,46 @@
         "label": "Ukrainian school textbook",
         "locator": "anna-ohoiko-1000-words-2nd-ed_e0090",
         "title": "вивча́ти = вчи́ти = учи́ти,"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вчити",
+      "lemmaId": "вчити",
+      "sentence": "До речі, зверніть увагу на дієслово «вчити», воно може означати вчи́ти — 1) to learn, to study; 2) to teach «вивчати».",
+      "targetForm": "вчити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0171_w015",
+        "title": "Lesson 171: Інтерв’ю з Міленою про навчання в музичному коледжі (part 15/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вчити",
+      "lemmaId": "вчити",
+      "sentence": "Наприклад, вчити українську мову, вивчати вивча́ти — to learn, to study українську мову — це те саме.",
+      "targetForm": "вчити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0171_w015",
+        "title": "Lesson 171: Інтерв’ю з Міленою про навчання в музичному коледжі (part 15/24)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -623,6 +1863,46 @@
       }
     },
     {
+      "lemma": "відділ",
+      "lemmaId": "відділ",
+      "sentence": "Відділ, позначений цифрою 2, учень назвав довгастим мозком.",
+      "targetForm": "Відділ",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0292",
+        "title": "Сторінка 240"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відділ",
+      "lemmaId": "відділ",
+      "sentence": "2 Південно-Західний відділ імператорського Російського географічного товариства.",
+      "targetForm": "відділ",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0269",
+        "title": "Сторінка 149"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "відкривати",
       "lemmaId": "відкривати",
       "sentence": "Ми любимо подорожувати і відкривати відкрива́ти — 1) to discover; 2) to open нові культури.",
@@ -643,9 +1923,89 @@
       }
     },
     {
+      "lemma": "відкривати",
+      "lemmaId": "відкривати",
+      "sentence": "записати Пояснювати → відкривати 3.",
+      "targetForm": "відкривати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0092_w011",
+        "title": "Lesson 92: На блошиному ринку At the flea market Forming perfective verb aspect in Ukrainian (part 11/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відкривати",
+      "lemmaId": "відкривати",
+      "sentence": "Художник щоразу все мусить відкривати заново, все з самого початку.",
+      "targetForm": "відкривати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0283",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "відлік",
       "lemmaId": "відлік",
       "sentence": "Як ведуть відлік відстаней за паралелями і меридіанами.",
+      "targetForm": "відлік",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0020",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відлік",
+      "lemmaId": "відлік",
+      "sentence": "Його називають нульовою паралеллю і від нього ведуть відлік інших паралелей.",
+      "targetForm": "відлік",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0020",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відлік",
+      "lemmaId": "відлік",
+      "sentence": "Тому домовилися вести відлік від нульового меридіана.",
       "targetForm": "відлік",
       "cefr": "B1",
       "uses": [
@@ -683,6 +2043,46 @@
       }
     },
     {
+      "lemma": "відстань",
+      "lemmaId": "відстань",
+      "sentence": "Тоді за першу годину відстань між об’єктами скоротиться на 8 км.",
+      "targetForm": "відстань",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-matematyka-ister-2022_s0076",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відстань",
+      "lemmaId": "відстань",
+      "sentence": "Відстань, на яку зближаються об’єкти за одиницю часу, називають швидкістю зближення vзбл.",
+      "targetForm": "Відстань",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-matematyka-ister-2022_s0076",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "відчинити",
       "lemmaId": "відчинити",
       "sentence": "Тому вирішив відчинити двері та перевірити, що сталося.",
@@ -696,6 +2096,66 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-zdorovia-vorontsova-2022_s0208",
         "title": "Сторінка 209"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчинити",
+      "lemmaId": "відчинити",
+      "sentence": "Відчини вікно і щосили кричи «Пожежа, допоможіть!» Якщо не можеш відчинити вікно, розбий скло твердим предметом.",
+      "targetForm": "відчинити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0033",
+        "title": "Сторінка 31"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчинити",
+      "lemmaId": "відчинити",
+      "sentence": "відкрити / відчинити / розплющити / розгорнути 1.",
+      "targetForm": "відчинити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-zabolotnyi-2023_s0040",
+        "title": "Сторінка 42"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчуження",
+      "lemmaId": "відчуження",
+      "sentence": "Коні Пржевальського в зоні відчуження біля ЧАЕС.",
+      "targetForm": "відчуження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0241",
+        "title": "Сторінка 144"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -723,6 +2183,26 @@
       }
     },
     {
+      "lemma": "відчуження",
+      "lemmaId": "відчуження",
+      "sentence": "Повторюйте за мною: У Чорнобильській зоні відчуження сталась масштабна лісова пожежа.",
+      "targetForm": "відчуження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0174_w017",
+        "title": "Lesson 174: Україна в 2020 році: головні новини (part 17/25)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "відчуття",
       "lemmaId": "відчуття",
       "sentence": "Через це серотонін і дофамін накопичуються в синаптичній щілині, викликаючи відчуття насолоди.",
@@ -736,6 +2216,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0394",
         "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчуття",
+      "lemmaId": "відчуття",
+      "sentence": "Якщо комусь дано слово то обов’язково дається і його відчуття (Г.",
+      "targetForm": "відчуття",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0110",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчуття",
+      "lemmaId": "відчуття",
+      "sentence": "Опишіть свої відчуття.",
+      "targetForm": "відчуття",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0068",
+        "title": "Сторінка 65"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -763,6 +2283,46 @@
       }
     },
     {
+      "lemma": "відійти",
+      "lemmaId": "відійти",
+      "sentence": "Відійти, відходити від теми.",
+      "targetForm": "Відійти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0150_w011",
+        "title": "Lesson 150: Коронавірус в Україні (part 11/18)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відійти",
+      "lemmaId": "відійти",
+      "sentence": "Мені хотілося розсунути рамки екрана, відійти від шаблонної розповіді й заговорити, так би мовити, мовою великих узагальнень (О.",
+      "targetForm": "відійти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0158",
+        "title": "Сторінка 115"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вінок",
       "lemmaId": "вінок",
       "sentence": "Знаєте вінок, вінки?",
@@ -776,6 +2336,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-4-00-lesson-notes_l0128_w007",
         "title": "Lesson 128: Рослини — символи України (part 7/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вінок",
+      "lemmaId": "вінок",
+      "sentence": "У вінок вплітають колосочки жита, щоб могли багато і в достатку жити.",
+      "targetForm": "вінок",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-2_s0026",
+        "title": "Сторінка 28"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вінок",
+      "lemmaId": "вінок",
+      "sentence": "Є ще різні квіти в нашім ріднім краї, їх веселе літо у вінок вплітає.",
+      "targetForm": "вінок",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-2_s0026",
+        "title": "Сторінка 28"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -803,6 +2403,66 @@
       }
     },
     {
+      "lemma": "вісім",
+      "lemmaId": "вісім",
+      "sentence": "І якщо ви з’їли порівну, то на кожну людину припадає по вісім часток.",
+      "targetForm": "вісім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0022",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вісім",
+      "lemmaId": "вісім",
+      "sentence": "Вісім з’їв ти сам, і залишається лише одна.",
+      "targetForm": "Вісім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0022",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вісімнадцять",
+      "lemmaId": "вісімнадцять",
+      "sentence": "Продавець: Вісімнадцять гривень.",
+      "targetForm": "Вісімнадцять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-1-00-lesson-notes_l0010_w004",
+        "title": "Lesson 10: Review 1-09 (part 4/4)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "вісімнадцять",
       "lemmaId": "вісімнадцять",
       "sentence": "Потреба кохання гостро спалахнула в ньому, як тільки минуло йому вісімнадцять років.",
@@ -823,10 +2483,30 @@
       }
     },
     {
+      "lemma": "вісімнадцять",
+      "lemmaId": "вісімнадцять",
+      "sentence": "Ворона вертілася всюдибіч: витягла високоякісну вермішель, відкрила вишневе варення, відщипнула вісімнадцять виноградин, відламала восьмушку ванілі.",
+      "targetForm": "вісімнадцять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0018",
+        "title": "Сторінка 11"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "геть",
       "lemmaId": "геть",
-      "sentence": "Леся Українка «Contra spem spero!» «Геть думи сумні», — у першій строфі Леся звертається до строфа́ ― strophe своїх думок, дум.",
-      "targetForm": "геть",
+      "sentence": "Геть думи сумні!",
+      "targetForm": "Геть",
       "cefr": "A2",
       "uses": [
         "example"
@@ -836,6 +2516,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-6-00-lesson-notes_l0223_w008",
         "title": "Lesson 223: Українська поезія. Леся Українка «Contra spem spero!» (part 8/36)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "геть",
+      "lemmaId": "геть",
+      "sentence": "Леся Українка «Contra spem spero!» «Геть думи сумні», — у першій строфі Леся звертається до строфа́ ― strophe своїх думок, дум.",
+      "targetForm": "Геть",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0223_w008",
+        "title": "Lesson 223: Українська поезія. Леся Українка «Contra spem spero!» (part 8/36)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "геть",
+      "lemmaId": "геть",
+      "sentence": "Геть, думи сумні!",
+      "targetForm": "Геть",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0223_w010",
+        "title": "Lesson 223: Українська поезія. Леся Українка «Contra spem spero!» (part 10/36)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -863,9 +2583,29 @@
       }
     },
     {
+      "lemma": "голитися",
+      "lemmaId": "голитися",
+      "sentence": "Проте якщо ріст волосся дуже активний (це зумовлено генетично), голитися можна з 14–15 років.",
+      "targetForm": "голитися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+        "title": "Сторінка 112"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "голосування",
       "lemmaId": "голосування",
-      "sentence": "Голосування проводиться в день вибо­ рів або в день повторного голосування.",
+      "sentence": "Проведення процедури голосування.",
       "targetForm": "голосування",
       "cefr": "A1",
       "uses": [
@@ -883,9 +2623,49 @@
       }
     },
     {
+      "lemma": "голосування",
+      "lemmaId": "голосування",
+      "sentence": "Він розпочинається одразу після закінчення часу голосування.",
+      "targetForm": "голосування",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0136",
+        "title": "Сторінка 71"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "голосування",
+      "lemmaId": "голосування",
+      "sentence": "Бюлетені для голо­ сування заповнюються в кабіні або кімнаті для таємного голосування.",
+      "targetForm": "голосування",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0393",
+        "title": "Сторінка 178"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "грамів",
       "lemmaId": "грамів",
-      "sentence": " ПРИКЛАД 4 Скільки грамів 3 %-го та скільки грамів 8 %-го розчинів солі треба взяти, щоб отримати 500 г 4 %-го розчину?",
+      "sentence": "Скільки грамів кожного з 2-відсоткового і 6-відсоткового розчинів солі потрібно взяти, щоб отримати 200 г 5-відсоткового розчину?",
       "targetForm": "грамів",
       "cefr": "A2",
       "uses": [
@@ -894,8 +2674,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "7-klas-algebra-merzliak-2024_s0299",
-        "title": "Сторінка 301"
+        "locator": "7-klas-matematyka-ister-2024-2_s0210",
+        "title": "Сторінка 207"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грамів",
+      "lemmaId": "грамів",
+      "sentence": "По скільки грамів кожного сплаву потрібно взяти, щоб одержати зливок масою 260 г, що містить 15 % цинку?",
+      "targetForm": "грамів",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-matematyka-ister-2024-2_s0210",
+        "title": "Сторінка 207"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грамів",
+      "lemmaId": "грамів",
+      "sentence": "Скільки грамів цукерок купить син?",
+      "targetForm": "грамів",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-informatyka-ryvkind-2017_s0227",
+        "title": "Сторінка 142"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -923,6 +2743,66 @@
       }
     },
     {
+      "lemma": "гривня",
+      "lemmaId": "гривня",
+      "sentence": "Але повноцінно гривня ввійшла до обігу лише в 1996 р.",
+      "targetForm": "гривня",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0037",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "гривня",
+      "lemmaId": "гривня",
+      "sentence": "Ключові терміни: гіперінфляція, гривня, елементи захисту банкнот.",
+      "targetForm": "гривня",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0037",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "громадський",
+      "lemmaId": "громадський",
+      "sentence": "Карусель 1 Мурашко Олександр (1875–1919) — український живописець і громадський діяч.",
+      "targetForm": "громадський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0189",
+        "title": "Сторінка 123"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "громадський",
       "lemmaId": "громадський",
       "sentence": "Публіцистика формує … думку (громадський, громадянський).",
@@ -943,9 +2823,69 @@
       }
     },
     {
+      "lemma": "громадський",
+      "lemmaId": "громадський",
+      "sentence": "І в Україні ми працювали в трьох секторах: зале́жати від — to depend on громадський розвиток, освіта і молодіжний розвиток.",
+      "targetForm": "громадський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0179_w004",
+        "title": "Lesson 179: Інтерв’ю з Кортні про вивчення української мови (part 4/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "грубий",
       "lemmaId": "грубий",
       "sentence": "Те саме можна сказати й про слова грубий – товстий.",
+      "targetForm": "грубий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p138",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грубий",
+      "lemmaId": "грубий",
+      "sentence": "Пилинським виходить, що слова грубий у такому значенні нема в народній мові.",
+      "targetForm": "грубий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p138",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грубий",
+      "lemmaId": "грубий",
+      "sentence": "Коцюбинський); \"Юрба розбила ногами грубий морський пісок\" (Леся Українка).",
       "targetForm": "грубий",
       "cefr": "B1",
       "uses": [
@@ -983,6 +2923,46 @@
       }
     },
     {
+      "lemma": "дальший",
+      "lemmaId": "дальший",
+      "sentence": "Кримського наводить тільки слово дальший: \"Дальші чотири століття\".",
+      "targetForm": "дальший",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p053",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дальший",
+      "lemmaId": "дальший",
+      "sentence": "Він безпосередньо йде за тими трьома кращими нашими повістярами і знаменує собою дальший ступінь в обробці нашої повісті.",
+      "targetForm": "дальший",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0038",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дані",
       "lemmaId": "дані",
       "sentence": "Складний запит для таблиць МАГАЗИНИ і КАДРИ, за яким формуються дані, наведено в табл.",
@@ -1003,9 +2983,49 @@
       }
     },
     {
+      "lemma": "дані",
+      "lemmaId": "дані",
+      "sentence": "Як вам відомо, запити не містять даних, лише формують потрібні дані з таблиць.",
+      "targetForm": "дані",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0046",
+        "title": "Сторінка 31"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дані",
+      "lemmaId": "дані",
+      "sentence": "Наприклад, дані, наведені в табл.",
+      "targetForm": "дані",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0046",
+        "title": "Сторінка 31"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дарувати",
       "lemmaId": "дарувати",
-      "sentence": "дарувати буду дарувати, подарую подарувати даруватиму 2.",
+      "sentence": "Заповніть пропуски формами дієслова «дарувати»: 5.",
       "targetForm": "дарувати",
       "cefr": "A1",
       "uses": [
@@ -1014,8 +3034,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "ulp-3-00-lesson-notes_l0099_w019",
-        "title": "Lesson 99: План подорожі (Голосове повідомлення №4) Travel plan (Voice message №4) (part 19/21)"
+        "locator": "ulp-3-00-lesson-notes_l0111_w013",
+        "title": "Lesson 111: Подарунки на день народження Birthday presents Imperative mood (Part 1) (part 13/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дарувати",
+      "lemmaId": "дарувати",
+      "sentence": "Не обов’язково дарувати дитині дорогі – Який сюрприз!",
+      "targetForm": "дарувати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0111_w014",
+        "title": "Lesson 111: Подарунки на день народження Birthday presents Imperative mood (Part 1) (part 14/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дарувати",
+      "lemmaId": "дарувати",
+      "sentence": "Липа, собака, кошеня, дарувати, дякувати.",
+      "targetForm": "дарувати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-1_s0017",
+        "title": "Сторінка 18"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1026,7 +3086,47 @@
       "lemma": "дата",
       "lemmaId": "дата",
       "sentence": "Моволюбка Дата: Четвер, 25.10.2018, 14:48 | Повідомлення # 16 Група: Користувачі Повідомлень: 30 Статус: Offline Не бачу проблем.",
-      "targetForm": "дата",
+      "targetForm": "Дата",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0038",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дата",
+      "lemmaId": "дата",
+      "sentence": "Грамотій Дата: Четвер, 25.10.2018, 15:10 | Повідомлення # 17 Група: Користувачі Повідомлень: 16 Статус: Offline Може, так: 1.",
+      "targetForm": "Дата",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0038",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дата",
+      "lemmaId": "дата",
+      "sentence": "Моволюбка Дата: Четвер, 25.10.2018, 15:30 | Повідомлення # 18 Група: Користувачі Повідомлень: 31 Статус: Offline Цілком пристойно.",
+      "targetForm": "Дата",
       "cefr": "A1",
       "uses": [
         "example"
@@ -1045,7 +3145,27 @@
     {
       "lemma": "два",
       "lemmaId": "два",
-      "sentence": "два two Два моро́зива, будь ла́ска.",
+      "sentence": "Дмитро Павличко «Два кольори» Українська поезія.",
+      "targetForm": "Два",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0228_w008",
+        "title": "Lesson 228: Українська поезія. Дмитро Павличко «Два кольори» (part 8/35)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "два",
+      "lemmaId": "два",
+      "sentence": "Антоніна каже: злама́тися — to break Я плакала тут, напевно, місяців зо два, зо три.",
       "targetForm": "два",
       "cefr": "A1",
       "uses": [
@@ -1054,8 +3174,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "anna-ohoiko-1000-words-2nd-ed_e0192",
-        "title": "два"
+        "locator": "ulp-5-00-lesson-notes_l0192_w023",
+        "title": "Lesson 192: Українці в Аргентині: розмова з Антоніною Чембарович (part 23/29)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "два",
+      "lemmaId": "два",
+      "sentence": "Антоніна плакала через те, що бандура зламалася, напевно або мабуть, місяців зо два, зо три.",
+      "targetForm": "два",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0192_w023",
+        "title": "Lesson 192: Українці в Аргентині: розмова з Антоніною Чембарович (part 23/29)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дедалі",
+      "lemmaId": "дедалі",
+      "sentence": "людей», але все-таки «дедалі більше» — це кращий варіант.",
+      "targetForm": "дедалі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0136_w014",
+        "title": "Lesson 136: Екологічні тренди та екологічні традиції в Україні (part 14/19)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1083,6 +3243,26 @@
       }
     },
     {
+      "lemma": "дедалі",
+      "lemmaId": "дедалі",
+      "sentence": "Оце слово «дедалі» — що воно означає?",
+      "targetForm": "дедалі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0136_w013",
+        "title": "Lesson 136: Екологічні тренди та екологічні традиції в Україні (part 13/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дешевий",
       "lemmaId": "дешевий",
       "sentence": "Знання про хімічну рівновагу допомагає організувати більш дешевий і зручний технологічний процес одержання речовин.",
@@ -1096,6 +3276,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-himia-grygorovych-2019_s0084",
         "title": "Сторінка 61"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дешевий",
+      "lemmaId": "дешевий",
+      "sentence": "____ чинний Д дешевий 7.",
+      "targetForm": "дешевий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0209_w024",
+        "title": "Lesson 209: Питання-відповіді: частина перша (part 24/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дешевий",
+      "lemmaId": "дешевий",
+      "sentence": "дорогий → боліли боліла болів боліло дешевий → буде боліти (болітиме) чистий → Зверніть увагу на прислівники (виділені у 2.",
+      "targetForm": "дешевий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0101_w012",
+        "title": "Lesson 101: Мені погано I don’t feel good Forming and using adverbs in Ukrainian (part 12/19)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1123,9 +3343,89 @@
       }
     },
     {
+      "lemma": "деякий",
+      "lemmaId": "деякий",
+      "sentence": "1.6) — деякий плоский многокутник.",
+      "targetForm": "деякий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-matematyka-nelin-2019_s0179",
+        "title": "Сторінка 164"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "деякий",
+      "lemmaId": "деякий",
+      "sentence": "Через деякий час у ліс прийшли мисливці.",
+      "targetForm": "деякий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0052",
+        "title": "Сторінка 54"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "джерело",
       "lemmaId": "джерело",
       "sentence": "Вибрати джерело відеозапису.",
+      "targetForm": "джерело",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0172",
+        "title": "Сторінка 149"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "джерело",
+      "lemmaId": "джерело",
+      "sentence": "4.15) потрібне джерело відеозапису, наприклад Захоплення екрана.",
+      "targetForm": "джерело",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0172",
+        "title": "Сторінка 149"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "джерело",
+      "lemmaId": "джерело",
+      "sentence": "Установити перемикач Створити нове у вікні Створити/ вибрати джерело (мал.",
       "targetForm": "джерело",
       "cefr": "B1",
       "uses": [
@@ -1163,9 +3463,89 @@
       }
     },
     {
+      "lemma": "дивувати",
+      "lemmaId": "дивувати",
+      "sentence": "Але вона може дивувати звуками, які нагадують крик котів, що б’ються.",
+      "targetForm": "дивувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-kravtsova-2021-1_s0036",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дивувати",
+      "lemmaId": "дивувати",
+      "sentence": "Людина, яка не перестає мене дивувати.",
+      "targetForm": "дивувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0255",
+        "title": "Сторінка 179"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "довкілля",
       "lemmaId": "довкілля",
       "sentence": "38 Що я знаю про еколог³ю Поміркуєте про вплив діяльності людини на стан довкілля, про Європейський зелений курс.",
+      "targetForm": "довкілля",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0042",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "довкілля",
+      "lemmaId": "довкілля",
+      "sentence": "Як дбають про довкілля у вашому місті, селищі, селі?",
+      "targetForm": "довкілля",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0042",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "довкілля",
+      "lemmaId": "довкілля",
+      "sentence": "Чи достатньо висвітлю­ ють заходи контролю за станом довкілля в місцевій пресі?",
       "targetForm": "довкілля",
       "cefr": "A1",
       "uses": [
@@ -1203,6 +3583,46 @@
       }
     },
     {
+      "lemma": "дозволяти",
+      "lemmaId": "дозволяти",
+      "sentence": "«Дозволити собі», або «собі дозволити», «дозволяти собі» (недоконаний вид).",
+      "targetForm": "дозволяти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0137_w011",
+        "title": "Lesson 137: 5 порад для покращення української мови (part 11/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дозволяти",
+      "lemmaId": "дозволяти",
+      "sentence": "А головне — не можна дозволяти, щоб багатший знущався з біднішого, сильніша держава тиснула на слабшу.",
+      "targetForm": "дозволяти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0016",
+        "title": "Сторінка 16"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дозвілля",
       "lemmaId": "дозвілля",
       "sentence": "Як проводили дозвілля робітники й селяни?",
@@ -1223,9 +3643,89 @@
       }
     },
     {
+      "lemma": "дозвілля",
+      "lemmaId": "дозвілля",
+      "sentence": "Світ захоплень безмежний: спорт, танці, моделювання, музикування, хендмейд, малювання — складно порахувати все, що урізноманітнює дозвілля, розвиває художні здібності.",
+      "targetForm": "дозвілля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-mystetstvo-rublia-2023_s0057",
+        "title": "Сторінка 58"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дозвілля",
+      "lemmaId": "дозвілля",
+      "sentence": "допустимих витрат на корисне дозвілля?",
+      "targetForm": "дозвілля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0142",
+        "title": "Сторінка 98"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "доїхати",
       "lemmaId": "доїхати",
       "sentence": "А ви не підкажете, як ми можемо доїхати до Чигирина?",
+      "targetForm": "доїхати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w016",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 16/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "доїхати",
+      "lemmaId": "доїхати",
+      "sentence": "Софі́йський собо́р — Saint Sophia Cathedral А ви не підкажете, як ми можемо доїхати до Чигирина?",
+      "targetForm": "доїхати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w016",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 16/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "доїхати",
+      "lemmaId": "доїхати",
+      "sentence": "Тобто як ми можемо дістатися, доїхати до міста Чигирин.",
       "targetForm": "доїхати",
       "cefr": "B1",
       "uses": [
@@ -1263,6 +3763,46 @@
       }
     },
     {
+      "lemma": "думати",
+      "lemmaId": "думати",
+      "sentence": "Шоу, що функція театру – змушувати людей думати?",
+      "targetForm": "думати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0403",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "думати",
+      "lemmaId": "думати",
+      "sentence": "Що для вас більш важливе у виставі: захопливий сюжет, цікаві персонажі, комедійність, можливість думати?",
+      "targetForm": "думати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0403",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "діаспора",
       "lemmaId": "діаспора",
       "sentence": "Історично українська діаспора формувалася під впливом чотирьох основних міграційних хвиль (див.",
@@ -1283,10 +3823,90 @@
       }
     },
     {
+      "lemma": "діаспора",
+      "lemmaId": "діаспора",
+      "sentence": "Діаспора (в перекладі з грецької – розсіяння) – перебування частини того чи того народу (етносу) поза межами країни свого походження.",
+      "targetForm": "Діаспора",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-geografiia-boiko-2026_s0061",
+        "title": "Сторінка 33"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "діаспора",
+      "lemmaId": "діаспора",
+      "sentence": "Із розгортанням процесів «перебудови» в СРСР українська діаспора надавала значну інформаційну підтримку визвольній боротьбі.",
+      "targetForm": "діаспора",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-galimov-2024_s0275",
+        "title": "Сторінка 153"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дівчина",
+      "lemmaId": "дівчина",
+      "sentence": "Домонтовича «Дівчина з ведмедиком»?",
+      "targetForm": "Дівчина",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0146",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дівчина",
       "lemmaId": "дівчина",
       "sentence": "\u0003  Чому роман має назву «Дівчина з ведмедиком»?",
-      "targetForm": "дівчина",
+      "targetForm": "Дівчина",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0146",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дівчина",
+      "lemmaId": "дівчина",
+      "sentence": "Домонтовича «Дівчина з ведмедиком» — це роман .",
+      "targetForm": "Дівчина",
       "cefr": "A1",
       "uses": [
         "example"
@@ -1323,10 +3943,90 @@
       }
     },
     {
+      "lemma": "дідусь",
+      "lemmaId": "дідусь",
+      "sentence": "Проте дідусь відповів дуже скоро.",
+      "targetForm": "дідусь",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0060",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дідусь",
+      "lemmaId": "дідусь",
+      "sentence": "І ось що писав Івасеві дідусь: «Мій дорогий онучку!",
+      "targetForm": "дідусь",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0060",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дім",
+      "lemmaId": "дім",
+      "sentence": "Мій дім в Поло́нному — це трикімна́тна My home in Polonne is a three-room apartment.",
+      "targetForm": "дім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0045_w003",
+        "title": "Lesson 45: Повторення 41-44: Мій дім Review 41-44: My home (part 3/7)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "дім",
       "lemmaId": "дім",
       "sentence": "Шевчука «Дім на горі» якраз і представляє життя людей у такому незвичайному поєднанні.",
-      "targetForm": "дім",
+      "targetForm": "Дім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0401",
+        "title": "Сторінка 211"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дім",
+      "lemmaId": "дім",
+      "sentence": "Роман «Дім на горі» вийшов 1983 року.",
+      "targetForm": "Дім",
       "cefr": "A1",
       "uses": [
         "example"
@@ -1383,6 +4083,46 @@
       }
     },
     {
+      "lemma": "забирати",
+      "lemmaId": "забирати",
+      "sentence": "Іду в садочок забирати малу.",
+      "targetForm": "забирати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0135_w004",
+        "title": "Lesson 135: Суржик в українській мові (part 4/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "забирати",
+      "lemmaId": "забирати",
+      "sentence": "Можете забирати до дідька все, що є в цьому домі.",
+      "targetForm": "забирати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0438",
+        "title": "Сторінка 243"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "завгодно",
       "lemmaId": "завгодно",
       "sentence": "При необмеженому збільшенні кількості сторін правильного многокутника його периметр буде як завгодно мало відрізнятися від довжини кола.",
@@ -1396,6 +4136,46 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-heometriya-merzliak-2017_s0063",
         "title": "Сторінка 62"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "завгодно",
+      "lemmaId": "завгодно",
+      "sentence": "При необмеженому збільшенні значення n периметри Pn и Pn′ відповідно будуть як завгодно мало відрізнятися від довжин C і C′ описаних кіл.",
+      "targetForm": "завгодно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-heometriya-merzliak-2017_s0063",
+        "title": "Сторінка 62"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "завгодно",
+      "lemmaId": "завгодно",
+      "sentence": "Хлопець уже ладен був зустрітися з ким завгодно, навіть індіанець Джо вже не лякав його.",
+      "targetForm": "завгодно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zarubizhna-literatura-voloshchuk-2022_s0216",
+        "title": "Сторінка 205"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1423,9 +4203,89 @@
       }
     },
     {
+      "lemma": "загадковий",
+      "lemmaId": "загадковий",
+      "sentence": "\u0007Який танець виконували сніжинки — ніжний, загадковий чи урочистий, енергійний?",
+      "targetForm": "загадковий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0068",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "загадковий",
+      "lemmaId": "загадковий",
+      "sentence": "Довідка: мальовничий, справжнісінький, страшний, загадковий, величний.",
+      "targetForm": "загадковий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0029",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "заздрість",
       "lemmaId": "заздрість",
       "sentence": "45 НАРОДНІ КАЗКИ Прийнято розрізняти заздрість злобну (чорну) і незлобну (білу).",
+      "targetForm": "заздрість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заздрість",
+      "lemmaId": "заздрість",
+      "sentence": "Людина, яка відчуває незлобну заздрість, прагне мати те, що має інший, досягти такого самого успіху.",
+      "targetForm": "заздрість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заздрість",
+      "lemmaId": "заздрість",
+      "sentence": "Біла заздрість спонукає йти вперед, самовдосконалюватися.",
       "targetForm": "заздрість",
       "cefr": "A2",
       "uses": [
@@ -1463,9 +4323,49 @@
       }
     },
     {
+      "lemma": "запис",
+      "lemmaId": "запис",
+      "sentence": "Після завершення пошуку на знайдений запис встановлюється курсор, і поле цього рядка висвітлюється іншим кольором.",
+      "targetForm": "запис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0038",
+        "title": "Сторінка 26"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "запис",
+      "lemmaId": "запис",
+      "sentence": "Виділити потрібний запис і натиснути кнопку Видалити на вкладці Основне.",
+      "targetForm": "запис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0038",
+        "title": "Сторінка 26"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "затримка",
       "lemmaId": "затримка",
-      "sentence": "Якщо затримка не усунулася, то необхідно з’ясувати причину її виникнення й усунути затримку.",
+      "sentence": "start delay – затримка на старті), у середині (англ.",
       "targetForm": "затримка",
       "cefr": "A2",
       "uses": [
@@ -1474,8 +4374,88 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "10-klas-zakhyst-fuka-2023_s0319",
-        "title": "Сторінка 173"
+        "locator": "7-klas-informatyka-ryvkind-2024_s0247",
+        "title": "Сторінка 217"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "затримка",
+      "lemmaId": "затримка",
+      "sentence": "middle delay – затримка в середині) чи в кінці (англ.",
+      "targetForm": "затримка",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0247",
+        "title": "Сторінка 217"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "затримка",
+      "lemmaId": "затримка",
+      "sentence": "end delay – затримка в кінці) анімації, використовуючи відповідні повзунки.",
+      "targetForm": "затримка",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0247",
+        "title": "Сторінка 217"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "захист",
+      "lemmaId": "захист",
+      "sentence": "захист права власності на землю § 57.",
+      "targetForm": "захист",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0518",
+        "title": "Сторінка 271"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "захист",
+      "lemmaId": "захист",
+      "sentence": "Захист права власності на землю .....................................................",
+      "targetForm": "Захист",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0518",
+        "title": "Сторінка 271"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1506,6 +4486,26 @@
       "lemma": "заява",
       "lemmaId": "заява",
       "sentence": "Заява може містити перелік документів, що додають до неї.",
+      "targetForm": "Заява",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0101",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заява",
+      "lemmaId": "заява",
+      "sentence": "Назву документа (заява) треба записувати посередині рядка з великої літери.",
       "targetForm": "заява",
       "cefr": "A1",
       "uses": [
@@ -1516,6 +4516,26 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0101",
         "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заява",
+      "lemmaId": "заява",
+      "sentence": "Лесі Українки, 94 ЗАЯВА Прошу зарахувати мене студентом І курсу училища.",
+      "targetForm": "ЗАЯВА",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0350",
+        "title": "Сторінка 238"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1543,9 +4563,49 @@
       }
     },
     {
+      "lemma": "зберігається",
+      "lemmaId": "зберігається",
+      "sentence": "У власних назвах Подвоєння зберігається: Гаррі Поттер, Інна, Голландія, Мекка.",
+      "targetForm": "зберігається",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0072",
+        "title": "Сторінка 67"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "зберігається",
+      "lemmaId": "зберігається",
+      "sentence": "Субекваторіальний Висока температура (вище +25 С) зберігається впродовж року й майже не зазнає сезонних коливань.",
+      "targetForm": "зберігається",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0211",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "звичайно",
       "lemmaId": "звичайно",
-      "sentence": "навести́ при́клад ― to provide an example Олеся: Звичайно, звичайно.",
+      "sentence": "Найбільший наш захід ― це, звичайно, фестиваль.",
       "targetForm": "звичайно",
       "cefr": "A1",
       "uses": [
@@ -1556,6 +4616,66 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-5-00-lesson-notes_l0195_w007",
         "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 7/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "звичайно",
+      "lemmaId": "звичайно",
+      "sentence": "Звичайно, це соняшник!",
+      "targetForm": "Звичайно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w009",
+        "title": "Lesson 128: Рослини — символи України (part 9/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "звичайно",
+      "lemmaId": "звичайно",
+      "sentence": "насі́ння — seeds виробни́к — producer Звичайно, соняшник — це символ сонця і символ достатку.",
+      "targetForm": "Звичайно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w009",
+        "title": "Lesson 128: Рослини — символи України (part 9/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "звідки",
+      "lemmaId": "звідки",
+      "sentence": "(на + місцевий відмінок) на Полтавщині Звідки?",
+      "targetForm": "Звідки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0126_w020",
+        "title": "Lesson 126: Державні символи України: гімн (part 20/21)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1583,6 +4703,26 @@
       }
     },
     {
+      "lemma": "звідки",
+      "lemmaId": "звідки",
+      "sentence": "Маємо рівняння: Звідки Отже, Олена отримала 57 повідомлень, (повід.) – отримала Наталя.",
+      "targetForm": "Звідки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-matematyka-ister-2024-1_s0032",
+        "title": "Сторінка 32"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "здебільшого",
       "lemmaId": "здебільшого",
       "sentence": "Тому великі міста країни мають, здебільшого, погану якість повітря.",
@@ -1596,6 +4736,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0253",
         "title": "Сторінка 150"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здебільшого",
+      "lemmaId": "здебільшого",
+      "sentence": "Україна не отримала ПДЧ здебільшого через протидію Німеччини (канцлерка А.",
+      "targetForm": "здебільшого",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-galimov-2024_s0362",
+        "title": "Сторінка 200"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здебільшого",
+      "lemmaId": "здебільшого",
+      "sentence": "Велике князівство Литовське та Королівство Польське здебільшого були під владою спільного монарха, тож у 1568 р.",
+      "targetForm": "здебільшого",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-schupak-2025_s0032",
+        "title": "Сторінка 24"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1623,6 +4803,46 @@
       }
     },
     {
+      "lemma": "здоровий",
+      "lemmaId": "здоровий",
+      "sentence": "Руханка «Молодь за здоровий спосіб життя!» (на пісню С.",
+      "targetForm": "здоровий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0198",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здоровий",
+      "lemmaId": "здоровий",
+      "sentence": "Здоровий спосіб життя 78 Навіщо піклуватися про здоров’я?",
+      "targetForm": "Здоровий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0085",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "здійснено",
       "lemmaId": "здійснено",
       "sentence": "Петлюри було здійснено низку заходів, покликаних викорінити в Армії УНР отаманщину та перетворити її на регулярне військо.",
@@ -1636,6 +4856,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-istorija-ukrajiny-gisem-2018_s0125",
         "title": "Сторінка 68"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здійснено",
+      "lemmaId": "здійснено",
+      "sentence": "Під його керівництвом було здійснено кілька морських походів і походи на Молдавське князівство.",
+      "targetForm": "здійснено",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0074",
+        "title": "Сторінка 49"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здійснено",
+      "lemmaId": "здійснено",
+      "sentence": "Як було здійснено аграрну реформу на західноукраїнських землях?",
+      "targetForm": "здійснено",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0203",
+        "title": "Сторінка 113"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1663,10 +4923,50 @@
       }
     },
     {
+      "lemma": "здійснювати",
+      "lemmaId": "здійснювати",
+      "sentence": "● Я вмію здійснювати редагування тексту (операції виділення, пошук і замінювання, перевірка правопису, операції з фрагментами тексту).",
+      "targetForm": "здійснювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0179",
+        "title": "Сторінка 178"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здійснювати",
+      "lemmaId": "здійснювати",
+      "sentence": "● Я вмію здійснювати форматування текстового документа (символів, абзаців, сторінок).",
+      "targetForm": "здійснювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0179",
+        "title": "Сторінка 178"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "змінити",
       "lemmaId": "змінити",
       "sentence": "Створення закладки на відкриту сторінку: 1 – Панель закладок; 2 – Вікно 2 Закладку додано; 3 – Кнопка 3 Змінити закладку для цієї вкладки 1.",
-      "targetForm": "змінити",
+      "targetForm": "Змінити",
       "cefr": "A2",
       "uses": [
         "example"
@@ -1676,6 +4976,46 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-informatyka-ryvkind-2024_s0012",
         "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "змінити",
+      "lemmaId": "змінити",
+      "sentence": "Поясни, що означає змінити форму слова.",
+      "targetForm": "змінити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-ponomarova-2020-1_s0048",
+        "title": "Сторінка 49"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "змінити",
+      "lemmaId": "змінити",
+      "sentence": "Новими в усіх редакторах є такі команди в меню Файл: Перейменувати — змінити ім’я файла безпосередньо в середовищі редактора.",
+      "targetForm": "змінити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-informatyka-ryvkind-2017_s0394",
+        "title": "Сторінка 248"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1703,10 +5043,50 @@
       }
     },
     {
+      "lemma": "знищити",
+      "lemmaId": "знищити",
+      "sentence": "Тож мушу якнайскоріше знищити і Сварога, і Берегиню, і творіння їхнє...».",
+      "targetForm": "знищити",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0012",
+        "title": "Сторінка 11"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "знищити",
+      "lemmaId": "знищити",
+      "sentence": "На їхню вимогу вітраж довелося знищити.",
+      "targetForm": "знищити",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-gisem-2024_s0161",
+        "title": "Сторінка 88"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кадр",
       "lemmaId": "кадр",
-      "sentence": "75 Кадр із фільму «Захар Беркут» Кадр із фільму-серіалу «Роксолана» З історичним жанром кіно часто поєднується пригодницький.",
-      "targetForm": "кадр",
+      "sentence": "Кадр із фільму «Життя Пі» Постер фільму «Сторожова застава» (реж.",
+      "targetForm": "Кадр",
       "cefr": "A2",
       "uses": [
         "example"
@@ -1716,6 +5096,46 @@
         "label": "Ukrainian school textbook",
         "locator": "6-klas-mystetstvo-rublia-2023_s0076",
         "title": "Сторінка 77"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кадр",
+      "lemmaId": "кадр",
+      "sentence": "Кадр із кінофільму «Пані оварі» режисер С.",
+      "targetForm": "Кадр",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0229",
+        "title": "Сторінка 134"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кадр",
+      "lemmaId": "кадр",
+      "sentence": "Кадр із кінофільму «Мадам оварі» режисер К.",
+      "targetForm": "Кадр",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0229",
+        "title": "Сторінка 134"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1743,6 +5163,46 @@
       }
     },
     {
+      "lemma": "календарний",
+      "lemmaId": "календарний",
+      "sentence": "ВІДМІННЕ ВІДМІННЕ Історичний час (характерні ознаки) Календарний час (характерні ознаки) СПІЛЬНЕ 2.",
+      "targetForm": "Календарний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0052",
+        "title": "Сторінка 54"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "календарний",
+      "lemmaId": "календарний",
+      "sentence": "< \" — _ ______ ______ _ ______ — — — ч Дата — календарний час будь-якої події (день, місяць, рік).",
+      "targetForm": "календарний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-1_s0090",
+        "title": "Сторінка 92"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "камін",
       "lemmaId": "камін",
       "sentence": "Коефіцієнт корисної дії нагрівника Багато людей вважають, що в приватному будинку обов’язково має бути камін.",
@@ -1756,6 +5216,66 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-fizyka-bariakhtar-2025_s0160",
         "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "камін",
+      "lemmaId": "камін",
+      "sentence": "• Камін у будинку створює особливу атмосферу.",
+      "targetForm": "Камін",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0160",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "камін",
+      "lemmaId": "камін",
+      "sentence": "• \u0007Камін швидко нагріває приміщення й довго тримає тепло.",
+      "targetForm": "Камін",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0160",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "квасоля",
+      "lemmaId": "квасоля",
+      "sentence": "Риба, м’ясо, яйця, молочні продукти, квасоля — джерело білків.",
+      "targetForm": "квасоля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0199",
+        "title": "Сторінка 200"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1783,6 +5303,26 @@
       }
     },
     {
+      "lemma": "квасоля",
+      "lemmaId": "квасоля",
+      "sentence": "Місткі образи поетеси насправді дуже прозорі і земні – що може бути більш простим і звичним, ніж квасоля?",
+      "targetForm": "квасоля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0264",
+        "title": "Сторінка 165"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "керівний",
       "lemmaId": "керівний",
       "sentence": "Квіти щасливі, — сказав керівний робот корабля.",
@@ -1796,6 +5336,66 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-avramenko-2024_s0317",
         "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "керівний",
+      "lemmaId": "керівний",
+      "sentence": "Назвіть головний керівний орган Ліги Націй.",
+      "targetForm": "керівний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-vsesvitnia-istoriia-gisem-2018-stand_s0051",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "керівний",
+      "lemmaId": "керівний",
+      "sentence": "Керівництво підприємства, фірми; керівний орган.",
+      "targetForm": "керівний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0235",
+        "title": "Сторінка 153"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кислий",
+      "lemmaId": "кислий",
+      "sentence": "Якщо папірець забарвлений у червоний колір – ґрунт кислий, рожевий – середньокислий, зелений – близький до нейтраль­ ного, жовтий – слабокислий.",
+      "targetForm": "кислий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0193",
+        "title": "Сторінка 139"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1823,9 +5423,69 @@
       }
     },
     {
+      "lemma": "кислий",
+      "lemmaId": "кислий",
+      "sentence": "Кислий ґрунт люблять щавель, хвощ, осока, мох.",
+      "targetForm": "Кислий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0193",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "клавіатура",
+      "lemmaId": "клавіатура",
+      "sentence": "Проєкційна клавіатура Мал.",
+      "targetForm": "клавіатура",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0087",
+        "title": "Сторінка 65"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "клавіатура",
       "lemmaId": "клавіатура",
       "sentence": "КЛАВІАТУРА Поміркуйте ● Значення яких властивостей користувач враховує під час вибору клавіатури для комп’ютера?",
+      "targetForm": "КЛАВІАТУРА",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0085",
+        "title": "Сторінка 64"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "клавіатура",
+      "lemmaId": "клавіатура",
+      "sentence": "● Чим відрізняється клавіатура стаціонарного комп’ютера від кла­ віатури ноутбука?",
       "targetForm": "клавіатура",
       "cefr": "B1",
       "uses": [
@@ -1836,6 +5496,26 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-informatyka-ryvkind-2025_s0085",
         "title": "Сторінка 64"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "колего",
+      "lemmaId": "колего",
+      "sentence": "Наприклад: шановний пане, наш дорогий колего.",
+      "targetForm": "колего",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0148",
+        "title": "Сторінка 141"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1863,10 +5543,30 @@
       }
     },
     {
+      "lemma": "колего",
+      "lemmaId": "колего",
+      "sentence": "Наприклад: колего Степане, пані Катерино, брате Петре.",
+      "targetForm": "колего",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0222",
+        "title": "Сторінка 164"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кольоровий",
       "lemmaId": "кольоровий",
       "sentence": "Виберіть стиль SmartArt — Плоска сцена, кольорову гаму — Кольоровий діапазон — кольори акценту 5–6.",
-      "targetForm": "кольоровий",
+      "targetForm": "Кольоровий",
       "cefr": "A2",
       "uses": [
         "example"
@@ -1883,10 +5583,50 @@
       }
     },
     {
+      "lemma": "кольоровий",
+      "lemmaId": "кольоровий",
+      "sentence": "Чому біле світло, проходячи крізь призму, розкладається в кольоровий спектр?",
+      "targetForm": "кольоровий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0296",
+        "title": "Сторінка 184"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кольоровий",
+      "lemmaId": "кольоровий",
+      "sentence": "Створи власну декоративну композицію за мотивами квітки, дерева тощо (кольоровий папір).",
+      "targetForm": "кольоровий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0235",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кома",
       "lemmaId": "кома",
-      "sentence": "На місці крапок має стояти А кома Б тире В кома й тире Г крапка й тире 7.",
-      "targetForm": "кома",
+      "sentence": "223 Кома між однорідними членами речення .",
+      "targetForm": "Кома",
       "cefr": "B1",
       "uses": [
         "example"
@@ -1894,8 +5634,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0206",
-        "title": "Сторінка 147"
+        "locator": "5-klas-ukrmova-litvinova-2022_s0009",
+        "title": "Сторінка 5"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кома",
+      "lemmaId": "кома",
+      "sentence": "227 Кома між однорідними членами речення .",
+      "targetForm": "Кома",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0009",
+        "title": "Сторінка 5"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кома",
+      "lemmaId": "кома",
+      "sentence": "233 Кома між частинами складного речення, з’єднаними безсполучниковим і сполучниковим зв’язком .",
+      "targetForm": "Кома",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0009",
+        "title": "Сторінка 5"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1923,9 +5703,49 @@
       }
     },
     {
+      "lemma": "коментар",
+      "lemmaId": "коментар",
+      "sentence": "КОМЕНТАР § 89 Громадянська активність Слово дня: волàти, бентåжити, переймàтися.",
+      "targetForm": "КОМЕНТАР",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0227",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "коментар",
+      "lemmaId": "коментар",
+      "sentence": "4 Як правильно написати коментар?",
+      "targetForm": "коментар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0227",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "контекст",
       "lemmaId": "контекст",
-      "sentence": "Контекст Основним способом точної передачі значення слова є контекст.",
+      "sentence": "Дискурс — складне комунікативне явище, що включає соціальний контекст, інформацію про учасників комунікації, осмислення процесу створення й сприйняття текстів.",
       "targetForm": "контекст",
       "cefr": "A2",
       "uses": [
@@ -1934,8 +5754,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0023",
-        "title": "Сторінка 18"
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0368",
+        "title": "Сторінка 239"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "контекст",
+      "lemmaId": "контекст",
+      "sentence": "Висловлювання об’єднує як саме речення, так і соціальний контекст його використання.",
+      "targetForm": "контекст",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0368",
+        "title": "Сторінка 239"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "контекст",
+      "lemmaId": "контекст",
+      "sentence": ".24 § 5 Слово і контекст.",
+      "targetForm": "контекст",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0309",
+        "title": "Сторінка 221"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -1963,6 +5823,66 @@
       }
     },
     {
+      "lemma": "контролювати",
+      "lemmaId": "контролювати",
+      "sentence": "Контролювати появу блювання.",
+      "targetForm": "Контролювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0251",
+        "title": "Сторінка 136"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "контролювати",
+      "lemmaId": "контролювати",
+      "sentence": "Використання кухонного термометра дає змогу контролювати температуру в середині страви.",
+      "targetForm": "контролювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0374",
+        "title": "Сторінка 222"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кориця",
+      "lemmaId": "кориця",
+      "sentence": "грип, застуда, нежить, кашель, кориця 4.",
+      "targetForm": "кориця",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0138_w019",
+        "title": "Lesson 138: Як пережити зиму в Україні? (part 19/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кориця",
       "lemmaId": "кориця",
       "sentence": "щеплення, гвоздика, кориця, імбир, перець Поєднайте числівники та іменники: 1.",
@@ -1983,9 +5903,69 @@
       }
     },
     {
+      "lemma": "кориця",
+      "lemmaId": "кориця",
+      "sentence": "ведмедИця Мед\u000f горіхи та кориця ± Ɍорт пектиме ведмедɂця.",
+      "targetForm": "кориця",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0167",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "космос",
       "lemmaId": "космос",
       "sentence": "Космічні апарати для польоту людей у космос називають кос­ мічними кораблями.",
+      "targetForm": "космос",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0138",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "космос",
+      "lemmaId": "космос",
+      "sentence": "Вже через чотири роки космонавт Олексій Леонов здійснив 12-хвилинний вихід у відкритий космос.",
+      "targetForm": "космос",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0138",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "космос",
+      "lemmaId": "космос",
+      "sentence": "У 1997 році здійснив політ у космос перший український космонавт Леонід Каденюк.",
       "targetForm": "космос",
       "cefr": "B1",
       "uses": [
@@ -2023,6 +6003,46 @@
       }
     },
     {
+      "lemma": "кошик",
+      "lemmaId": "кошик",
+      "sentence": "А крім їжі, у кошик ставлять свічку ― це буде потрібно для ритуалу сві́чка ― candle освячення в церкві.",
+      "targetForm": "кошик",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0190_w008",
+        "title": "Lesson 190: Великодній кошик (part 8/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кошик",
+      "lemmaId": "кошик",
+      "sentence": "Інколи кладуть також квіти, прикрашають ритуа́л ― ritual гарненько кошик.",
+      "targetForm": "кошик",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0190_w008",
+        "title": "Lesson 190: Великодній кошик (part 8/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "крайній",
       "lemmaId": "крайній",
       "sentence": "Пересуватися на скутері, мопеді дозволено тільки по крайній правій смузі, не дозволено на автомагістралях !",
@@ -2036,6 +6056,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-zdorovia-vasylenko-2025_s0040",
         "title": "Сторінка 36"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "крайній",
+      "lemmaId": "крайній",
+      "sentence": "extremum - крайній), а значення функції у цих точках - екстремумами функції.",
+      "targetForm": "крайній",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-algebra-ister-2018_s0411",
+        "title": "Сторінка 383"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "крайній",
+      "lemmaId": "крайній",
+      "sentence": "Основною ідеологією фашизму став крайній шовінізм, який переходив в ідею расової винятковості, мілітаризм і вождизм.",
+      "targetForm": "крайній",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-vsesvitnia-istoriia-gisem-2018-stand_s0007",
+        "title": "Сторінка 6"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2063,9 +6123,69 @@
       }
     },
     {
+      "lemma": "культура",
+      "lemmaId": "культура",
+      "sentence": "В Україні її називають Трипільська архео́лог — archaeologist культура, а цих людей називають трипільці.",
+      "targetForm": "культура",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0149_w002",
+        "title": "Lesson 149: Трипільська культура (part 2/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "культура",
+      "lemmaId": "культура",
+      "sentence": "А назва «Трипільська культура» пішла від села писе́мна па́м’ятка — written «Трипілля», що знаходиться на Київщині.",
+      "targetForm": "культура",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0149_w002",
+        "title": "Lesson 149: Трипільська культура (part 2/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "культурний",
       "lemmaId": "культурний",
       "sentence": "Чинники ЧИННИКИ, ЩО ВПЛИВАЛИ НА КУЛЬТУРНИЙ ПРОЦЕС НА УКРАЇНСЬКИХ ЗЕМЛЯХ у XIV—XV ст.",
+      "targetForm": "КУЛЬТУРНИЙ",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-galimov-2024_s0285",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "культурний",
+      "lemmaId": "культурний",
+      "sentence": "Обговоріть і поясніть кожен із чинників, що впливали на культурний процес на українських землях у XIV—XV ст.",
       "targetForm": "культурний",
       "cefr": "A2",
       "uses": [
@@ -2083,10 +6203,30 @@
       }
     },
     {
+      "lemma": "культурний",
+      "lemmaId": "культурний",
+      "sentence": "Поміркуємо разом Чому саме ці країни об’єднали в далекосхідний культурний регіон?",
+      "targetForm": "культурний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-11-klas-mystectvo-nazarenko-2018_s0108",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "купатися",
       "lemmaId": "купатися",
       "sentence": "Купатися можна у вбиральні, на кухні, в кабінеті чи в конторі – за вибором.",
-      "targetForm": "купатися",
+      "targetForm": "Купатися",
       "cefr": "A2",
       "uses": [
         "example"
@@ -2103,9 +6243,49 @@
       }
     },
     {
+      "lemma": "купатися",
+      "lemmaId": "купатися",
+      "sentence": "Він мені віддає «своє право» купатися в калюжах крові?",
+      "targetForm": "купатися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0085",
+        "title": "Сторінка 55"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "купатися",
+      "lemmaId": "купатися",
+      "sentence": "Назвіть чо­ти­ри правила «надто не­без­печ­но» для тих, хто збирається купатися.",
+      "targetForm": "купатися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0234",
+        "title": "Сторінка 235"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кілька",
       "lemmaId": "кілька",
-      "sentence": "кі́лька = де́кілька some У ме́не є кі́лька (де́кілька) I have some questions.",
+      "sentence": "Наступне, шосте речення: Ціни залежать від університету, переважно це кілька десятків тисяч гривень на рік.",
       "targetForm": "кілька",
       "cefr": "B1",
       "uses": [
@@ -2114,8 +6294,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "anna-ohoiko-1000-words-2nd-ed_e0391",
-        "title": "кі́лька = де́кілька"
+        "locator": "ulp-5-00-lesson-notes_l0189_w018",
+        "title": "Lesson 189: Вища освіта в Україні та США (part 18/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кілька",
+      "lemmaId": "кілька",
+      "sentence": "Це може бути двадцять, тридцять чи сорок ― це кілька десятків.",
+      "targetForm": "кілька",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0189_w018",
+        "title": "Lesson 189: Вища освіта в Україні та США (part 18/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кілька",
+      "lemmaId": "кілька",
+      "sentence": "Повторіть: Ціни залежать від університету, переважно це кілька десятків тисяч гривень на рік.",
+      "targetForm": "кілька",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0189_w018",
+        "title": "Lesson 189: Вища освіта в Україні та США (part 18/26)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2143,10 +6363,50 @@
       }
     },
     {
+      "lemma": "лавка",
+      "lemmaId": "лавка",
+      "sentence": "Ольга підійшла до того повороту, на якому стояла лавка, з якої вона любила дивитися на море.",
+      "targetForm": "лавка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0294",
+        "title": "Сторінка 203"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лавка",
+      "lemmaId": "лавка",
+      "sentence": "Чому лавка перевернулася (рис.",
+      "targetForm": "лавка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-fizyka-barjakhtar-2018_s0147",
+        "title": "Сторінка 91"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "лагідний",
       "lemmaId": "лагідний",
-      "sentence": "Кетчуп «Лагідний» доповнює будь-який гарнір і м’ясо.",
-      "targetForm": "лагідний",
+      "sentence": "Кетчуп «Лагідний» — найпопулярніший кетчуп серед українців.",
+      "targetForm": "Лагідний",
       "cefr": "B1",
       "uses": [
         "example"
@@ -2156,6 +6416,66 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0112",
         "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лагідний",
+      "lemmaId": "лагідний",
+      "sentence": "Кетчуп «Лагідний» доповнює будь-який гарнір і м’ясо.",
+      "targetForm": "Лагідний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0112",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лагідний",
+      "lemmaId": "лагідний",
+      "sentence": "І далі: Шовковий спів степів широких, «Спів» — від «співати»; «спів шовковий» — тобто «ніжний», ні́жний = ла́гідний ― tender «лагідний».",
+      "targetForm": "лагідний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0224_w012",
+        "title": "Lesson 224: Українська поезія. Олександр Олесь «О слово рідне! Орле скутий!..» (part 12/30)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лекція",
+      "lemmaId": "лекція",
+      "sentence": "Лекція — основний жанр академічного красномовства.",
+      "targetForm": "Лекція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0119",
+        "title": "Сторінка 82"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2183,6 +6503,26 @@
       }
     },
     {
+      "lemma": "лекція",
+      "lemmaId": "лекція",
+      "sentence": "Лекція про втрати врожаю в сільгоспартілі.",
+      "targetForm": "Лекція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0044",
+        "title": "Сторінка 28"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "листок",
       "lemmaId": "листок",
       "sentence": "Маргарита вирвала з блокнота листок, написала: «ЩО ВСЕ?» – склала його і кинула Флоріанові.",
@@ -2196,6 +6536,46 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0136",
         "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "листок",
+      "lemmaId": "листок",
+      "sentence": "Флоріан прочитав Маргаритине пи­ тання, люто видер із середини свого словничка листок і щось на ньому нашкрябав.",
+      "targetForm": "листок",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0136",
+        "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "листок",
+      "lemmaId": "листок",
+      "sentence": "Маю п'ять пелюсток і напівкруглий зелений листок, а серединка в мене жовтенька, личко не кругле, а трохи довгеньке.",
+      "targetForm": "листок",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-1_s0069",
+        "title": "Сторінка 71"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2223,9 +6603,89 @@
       }
     },
     {
+      "lemma": "листя",
+      "lemmaId": "листя",
+      "sentence": "Для цього потрібно помістити опале листя в ящик, присипати його ´рунтом і полити водою.",
+      "targetForm": "листя",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0192",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "листя",
+      "lemmaId": "листя",
+      "sentence": "Чому не можна спалювати листя?",
+      "targetForm": "листя",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0192",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лице",
+      "lemmaId": "лице",
+      "sentence": "обли́ччя = лице́ face Це мій улю́блений крем для This is my favorite face cream.",
+      "targetForm": "лице",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0532",
+        "title": "обли́ччя = лице́"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "лице",
       "lemmaId": "лице",
       "sentence": "Запалене лице було гарне, але дуже молоде.",
+      "targetForm": "лице",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-avramenko-2025_s0239",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лице",
+      "lemmaId": "лице",
+      "sentence": "Гаряче сонце заглянуло під грушу, обсипало вогнем білу сорочку, чорняве лице.",
       "targetForm": "лице",
       "cefr": "A2",
       "uses": [
@@ -2263,9 +6723,49 @@
       }
     },
     {
+      "lemma": "ложка",
+      "lemmaId": "ложка",
+      "sentence": "Тримаючи її в руці, з’ясуй, теплішою чи холоднішою стала ложка.",
+      "targetForm": "ложка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0077",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ложка",
+      "lemmaId": "ложка",
+      "sentence": "Приготуй у склянці суміш із води об’ємом 50 мл і кухонної солі масою 10 г (це приблизно неповна чайна ложка).",
+      "targetForm": "ложка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0241",
+        "title": "Сторінка 243"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "люблять",
       "lemmaId": "люблять",
-      "sentence": "І це сва́рка — quarrel прислів’я говорить про те, що українці не люблять суперечки, не люблять конфлікти.",
+      "sentence": "Українці досить-таки миролюбні — вони люблять мир.",
       "targetForm": "люблять",
       "cefr": "A1",
       "uses": [
@@ -2276,6 +6776,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-4-00-lesson-notes_l0133_w008",
         "title": "Lesson 133: Прислів’я та приказки Частина 2 (part 8/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "люблять",
+      "lemmaId": "люблять",
+      "sentence": "Чим люблять займатися українці в повсякденному житті?",
+      "targetForm": "люблять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0204_w023",
+        "title": "Lesson 204: Як змінилася мовна ситуація в Україні (part 23/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "люблять",
+      "lemmaId": "люблять",
+      "sentence": "І люблять дині пахнути там, де їх немає.",
+      "targetForm": "люблять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-avramenko-2025_s0017",
+        "title": "Сторінка 16"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2303,10 +6843,50 @@
       }
     },
     {
+      "lemma": "літр",
+      "lemmaId": "літр",
+      "sentence": "Повідомити: «1 літр рідини міститься в 3-літровій посудині».",
+      "targetForm": "літр",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0186",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "літр",
+      "lemmaId": "літр",
+      "sentence": "to express the quantity літр кефі́ру — a liter of kefir скля́нка води́ — a glass of water кілогра́м моро́зива — a kilo of ice cream 2.",
+      "targetForm": "літр",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0049_w003",
+        "title": "Lesson 49: Рецепт сирників Родовий відмінок Syrnyky recipe Genitive case (part 3/7)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "лічильник",
       "lemmaId": "лічильник",
       "sentence": "Найчастіше первинний ключ складається з одного поля, а в ролі первинного ключа використовується поле типу Лічильник.",
-      "targetForm": "лічильник",
+      "targetForm": "Лічильник",
       "cefr": "B1",
       "uses": [
         "example"
@@ -2316,6 +6896,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-informatika-rudenko-2018-stand_s0104",
         "title": "Сторінка 99"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лічильник",
+      "lemmaId": "лічильник",
+      "sentence": "1), тобто типу Лічильник, то воно за замовчуванням стає ключовим.",
+      "targetForm": "Лічильник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-informatika-rudenko-2018-stand_s0104",
+        "title": "Сторінка 99"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лічильник",
+      "lemmaId": "лічильник",
+      "sentence": "Найчастіше первинний ключ складається з одного поля, а як первинний ключ використовується поле типу Лічильник.",
+      "targetForm": "Лічильник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0028",
+        "title": "Сторінка 20"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2343,6 +6963,66 @@
       }
     },
     {
+      "lemma": "малі",
+      "lemmaId": "малі",
+      "sentence": "Купались тільки ми, малі.",
+      "targetForm": "малі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0271",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "малі",
+      "lemmaId": "малі",
+      "sentence": "Малі інтерферуючі РНК беруть участь в РНК-інтрференції, що при­ глушує утворення продуктів тих чи інших генів.",
+      "targetForm": "Малі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-biolohiya-zadorozhnyi-2026_s0053",
+        "title": "Сторінка 49"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мандрівник",
+      "lemmaId": "мандрівник",
+      "sentence": "1 Лі­вінг­сто­н Девід — англійський мандрівник, дослідник Африки.",
+      "targetForm": "мандрівник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0162",
+        "title": "Сторінка 130"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "мандрівник",
       "lemmaId": "мандрівник",
       "sentence": "Знайдіть інформацію, на що витрачає кошти мандрівник, готуючись до підйому на найвищу вершину світу.",
@@ -2356,6 +7036,26 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-heohrafiya-hilberh-2024_s0048",
         "title": "Сторінка 50"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мандрівник",
+      "lemmaId": "мандрівник",
+      "sentence": "Мандрівник Метью Фліндерс (1774–1814) першим досліджував австралійський берег і створив його карту, використавши у своїй роботі назву «Австралія».",
+      "targetForm": "Мандрівник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0126",
+        "title": "Сторінка 115"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2383,9 +7083,89 @@
       }
     },
     {
+      "lemma": "маршрут",
+      "lemmaId": "маршрут",
+      "sentence": "Позначте цей маршрут на контурній карті: 1.",
+      "targetForm": "маршрут",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0081",
+        "title": "Сторінка 83"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "маршрут",
+      "lemmaId": "маршрут",
+      "sentence": "Прокладіть маршрут подорожі, з’єднавши міста, які ви плануєте відвідати.",
+      "targetForm": "маршрут",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0081",
+        "title": "Сторінка 83"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "мед",
       "lemmaId": "мед",
-      "sentence": "ДЛЯ ДОПИТЛИВИХ Виявлення глюкози в мед\u0003 Глюкозу виявляють у мед\u0003 так.",
+      "sentence": "мед honey Я хо́чу чай з ме́дом і лимо́ном.",
+      "targetForm": "мед",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0438",
+        "title": "мед"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мед",
+      "lemmaId": "мед",
+      "sentence": "Український мед з українським of grocery stores трав’яним чаєм — це справжній український досвід!",
+      "targetForm": "мед",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0130_w008",
+        "title": "Lesson 130: Які сувеніри привезти з України? (part 8/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мед",
+      "lemmaId": "мед",
+      "sentence": "Поява жовтого осаду, який поступо\u0002 во перетворюється на червоний, свідчить про наявність у мед\u0003 глюкози.",
       "targetForm": "мед",
       "cefr": "A1",
       "uses": [
@@ -2406,7 +7186,7 @@
       "lemma": "методологія",
       "lemmaId": "методологія",
       "sentence": "Методологія — принципи, сукупність ідей, методів і засобів, які визначають підхід до розробки програмного забезпечення.",
-      "targetForm": "методологія",
+      "targetForm": "Методологія",
       "cefr": "B1",
       "uses": [
         "example"
@@ -2423,9 +7203,89 @@
       }
     },
     {
+      "lemma": "методологія",
+      "lemmaId": "методологія",
+      "sentence": "Загальна методологія визначення економічної ефективності полягає у відношенні результату виробництва до затрачених ресурсів (витрат).",
+      "targetForm": "методологія",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ekonomika-homiak-2019_s0134",
+        "title": "Сторінка 89"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "методологія",
+      "lemmaId": "методологія",
+      "sentence": "Основними з них є ступінь автоматизації проектування алгоритмів і програм та методологія проектування програмних продуктів (рис.",
+      "targetForm": "методологія",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0082",
+        "title": "Сторінка 56"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "мешканець",
       "lemmaId": "мешканець",
       "sentence": "Плекаймо слово і ЖИТЕЛЬ ЧИ МЕШКАНЕЦЬ?",
+      "targetForm": "МЕШКАНЕЦЬ",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0272",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мешканець",
+      "lemmaId": "мешканець",
+      "sentence": "Мешканець — це особа, що займає якесь приміщення як житло; жилець.",
+      "targetForm": "Мешканець",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0272",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мешканець",
+      "lemmaId": "мешканець",
+      "sentence": "Наприклад: Тарпан, або дикий кінь, — мешканець степів.",
       "targetForm": "мешканець",
       "cefr": "B1",
       "uses": [
@@ -2463,6 +7323,46 @@
       }
     },
     {
+      "lemma": "мило",
+      "lemmaId": "мило",
+      "sentence": "Звичайне мило варять із жирів та соди.",
+      "targetForm": "мило",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0049",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мило",
+      "lemmaId": "мило",
+      "sentence": "Проте в природі можна знайти й «готове» мило.",
+      "targetForm": "мило",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0049",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "миритися",
       "lemmaId": "миритися",
       "sentence": "Прийшов битися чи миритися?",
@@ -2476,6 +7376,46 @@
         "label": "Ukrainian school textbook",
         "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0043",
         "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "миритися",
+      "lemmaId": "миритися",
+      "sentence": "Де вже миритися?",
+      "targetForm": "миритися",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0043",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "миритися",
+      "lemmaId": "миритися",
+      "sentence": "Мирилка (від слова «миритися») — невеликий вірш, який допомагає помиритися із друзями.",
+      "targetForm": "миритися",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0041",
+        "title": "Сторінка 43"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2503,6 +7443,46 @@
       }
     },
     {
+      "lemma": "мислити",
+      "lemmaId": "мислити",
+      "sentence": "Даний метод спонукає критично мислити і творчо виконувати завдання, знаходити правильні рішення і не лише у навчальній діяльності.",
+      "targetForm": "мислити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ekonomika-homiak-2019_s0017",
+        "title": "Сторінка 12"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мислити",
+      "lemmaId": "мислити",
+      "sentence": "Вона може не так одягатися, не так поводитися, а головне – мислити не так, як усі.",
+      "targetForm": "мислити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0091",
+        "title": "Сторінка 65"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "мох",
       "lemmaId": "мох",
       "sentence": "Вербинка обережно підважила мох.",
@@ -2516,6 +7496,86 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-ukrlit-avramenko-2022_s0094",
         "title": "Сторінка 90"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мох",
+      "lemmaId": "мох",
+      "sentence": "Вона була така прозора, що на дні виднівся зелений мох.",
+      "targetForm": "мох",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0152",
+        "title": "Сторінка 154"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мох",
+      "lemmaId": "мох",
+      "sentence": "Від тертя паличка й дощечка нагрівалися, і від них загорався легкозаймистий матеріал (сухий мох або сіно).",
+      "targetForm": "мох",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0082",
+        "title": "Сторінка 83"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "музей",
+      "lemmaId": "музей",
+      "sentence": "Національний археологічний музей Афін (Греція).",
+      "targetForm": "музей",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-istoriya-gisem-2023_s0262",
+        "title": "Сторінка 192"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "музей",
+      "lemmaId": "музей",
+      "sentence": "Британський музей у Лондоні.",
+      "targetForm": "музей",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-istoriya-gisem-2023_s0262",
+        "title": "Сторінка 192"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2545,6 +7605,26 @@
     {
       "lemma": "міроприємство",
       "lemmaId": "міроприємство",
+      "sentence": "___ міроприємство Ґ відпустка 6.",
+      "targetForm": "міроприємство",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0192_w026",
+        "title": "Lesson 192: Українці в Аргентині: розмова з Антоніною Чембарович (part 26/29)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "міроприємство",
+      "lemmaId": "міроприємство",
       "sentence": "Помилку допущено в рядку А ухвалити рішення Б запобігти помилці В здійснити контроль Г відвідати міроприємство 5.",
       "targetForm": "міроприємство",
       "cefr": null,
@@ -2556,6 +7636,66 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0028",
         "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "міроприємство",
+      "lemmaId": "міроприємство",
+      "sentence": "£ановний проôесор äвашкевич, маю честь запросити Вас на святкове міроприємство.",
+      "targetForm": "міроприємство",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0140",
+        "title": "Сторінка 100"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "місяць",
+      "lemmaId": "місяць",
+      "sentence": "Новий Місяць (новак).",
+      "targetForm": "Місяць",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-astronomiya-pryshliak-2019_s0032",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "місяць",
+      "lemmaId": "місяць",
+      "sentence": "Повний Місяць (повня).",
+      "targetForm": "Місяць",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-astronomiya-pryshliak-2019_s0032",
+        "title": "Сторінка 22"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2603,6 +7743,66 @@
       }
     },
     {
+      "lemma": "мішати",
+      "lemmaId": "мішати",
+      "sentence": "Заважати гратися – мішати слухати на уроці.",
+      "targetForm": "мішати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0015",
+        "title": "Сторінка 17"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мішати",
+      "lemmaId": "мішати",
+      "sentence": "Проте він оже може а мішати ка у ложкою.",
+      "targetForm": "мішати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0027",
+        "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наближення",
+      "lemmaId": "наближення",
+      "sentence": "Світ у просторі й часі Глобалізація – це процес скорочення світу, наближення речей.",
+      "targetForm": "наближення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-geografiia-boiko-2026_s0163",
+        "title": "Сторінка 87"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "наближення",
       "lemmaId": "наближення",
       "sentence": "Чому глобалізацію розглядають як «скорочення світу» і «наближення речей»?",
@@ -2623,10 +7823,30 @@
       }
     },
     {
+      "lemma": "наближення",
+      "lemmaId": "наближення",
+      "sentence": "Чому в міру наближення до сучасності періоди історії України охоплюють менший проміжок часу?",
+      "targetForm": "наближення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-galimov-2024_s0008",
+        "title": "Сторінка 7"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "набрати",
       "lemmaId": "набрати",
       "sentence": "Набрати з колодязя повне відро води.",
-      "targetForm": "набрати",
+      "targetForm": "Набрати",
       "cefr": "A2",
       "uses": [
         "example"
@@ -2636,6 +7856,46 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-informatyka-ryvkind-2022_s0214",
         "title": "Сторінка 213"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "набрати",
+      "lemmaId": "набрати",
+      "sentence": "набирати чи набрати?",
+      "targetForm": "набрати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0202_w018",
+        "title": "Lesson 202: Наша подорож в Україну влітку 2023 року (part 18/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "набрати",
+      "lemmaId": "набрати",
+      "sentence": "Наприклад: набрати в рот води — мовчати; як сніг на голову — зненацька.",
+      "targetForm": "набрати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-golub-2022_s0058",
+        "title": "Сторінка 59"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2663,9 +7923,89 @@
       }
     },
     {
+      "lemma": "наведено",
+      "lemmaId": "наведено",
+      "sentence": "Перший варіант програми обчислення чисел Фібоначчі Ще один варіант програми обчислення чисел Фібоначчі наведено на рис.",
+      "targetForm": "наведено",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0172",
+        "title": "Сторінка 115"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наведено",
+      "lemmaId": "наведено",
+      "sentence": "На сторінці науково-популярної книги наведено опис зображеної на рисунку частини кровоносної системи: «Цифрою 1 на рисунку позначено артерію.",
+      "targetForm": "наведено",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0299",
+        "title": "Сторінка 247"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "нагода",
       "lemmaId": "нагода",
       "sentence": "І одного разу йому випала нагода поїхати до Петербурга і працювати там при царському дворі.",
+      "targetForm": "нагода",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0155_w008",
+        "title": "Lesson 155: Григорій Сковорода — мандрівний філософ (part 8/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "нагода",
+      "lemmaId": "нагода",
+      "sentence": "Йому випала нагода.",
+      "targetForm": "нагода",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0155_w008",
+        "title": "Lesson 155: Григорій Сковорода — мандрівний філософ (part 8/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "нагода",
+      "lemmaId": "нагода",
+      "sentence": "Слово «нагода» ми вже згадували в попередніх епізодах.",
       "targetForm": "нагода",
       "cefr": "A2",
       "uses": [
@@ -2703,10 +8043,90 @@
       }
     },
     {
+      "lemma": "надіслано",
+      "lemmaId": "надіслано",
+      "sentence": "Тому й у наведеній фразі треба було написати: \"надіслано післяплатою\".",
+      "targetForm": "надіслано",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p032",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 32"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "надіслано",
+      "lemmaId": "надіслано",
+      "sentence": "Ваш лист буде надіслано до електронних поштових скриньок адресатів, яких ви зазначили.",
+      "targetForm": "надіслано",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0031",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "називний",
+      "lemmaId": "називний",
+      "sentence": "кінь, річка Відмінок Однина Множина Називний — хто?",
+      "targetForm": "Називний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-avramenko-2023_s0241",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "називний",
       "lemmaId": "називний",
       "sentence": "три, третій Відмінок Кількісні числівники Порядкові числівники Однина Множина Називний скільки?",
-      "targetForm": "називний",
+      "targetForm": "Називний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-avramenko-2023_s0241",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "називний",
+      "lemmaId": "називний",
+      "sentence": "чистий, сестрин Відмінок Однина Множина чоловічий і середній рід жіночий рід Називний який?",
+      "targetForm": "Називний",
       "cefr": "A2",
       "uses": [
         "example"
@@ -2726,6 +8146,26 @@
       "lemma": "найвищий",
       "lemmaId": "найвищий",
       "sentence": "137 Прикметник Н Найвищий ступінь порівняння вказує, що певний предмет переважає всі інші за якою-небудь ознакою.",
+      "targetForm": "Найвищий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0139",
+        "title": "Сторінка 137"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "найвищий",
+      "lemmaId": "найвищий",
+      "sentence": "Інколи найвищий ступінь виражають додаванням до вищого ступеня сполучень від усіх, над усе, за всіх.",
       "targetForm": "найвищий",
       "cefr": "A2",
       "uses": [
@@ -2736,6 +8176,26 @@
         "label": "Ukrainian school textbook",
         "locator": "6-klas-ukrmova-zabolotnyi-2020_s0139",
         "title": "Сторінка 137"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "найвищий",
+      "lemmaId": "найвищий",
+      "sentence": "Який із виділених прислівників указує на вищий ступінь порівняння, а який – на найвищий?",
+      "targetForm": "найвищий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0154",
+        "title": "Сторінка 155"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2763,6 +8223,46 @@
       }
     },
     {
+      "lemma": "найняти",
+      "lemmaId": "найняти",
+      "sentence": "Ціною на ринку праці є рівень ­заробітної плати, за який найманий робітник погоджується працювати, а підприємець — його найняти.",
+      "targetForm": "найняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0292",
+        "title": "Сторінка 149"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "найняти",
+      "lemmaId": "найняти",
+      "sentence": "Це правило фірма використовує при при­ йнятті рішення: скільки робітників необхід­ но найняти?",
+      "targetForm": "найняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0145",
+        "title": "Сторінка 77"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "наліво",
       "lemmaId": "наліво",
       "sentence": "Поверніть ліворуч (наліво), ідіть прямо по вулиці Зеленій.",
@@ -2776,6 +8276,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-1-00-lesson-notes_l0019_w005",
         "title": "Lesson 19: Asking for a phone number in Ukrainian (part 5/7)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наліво",
+      "lemmaId": "наліво",
+      "sentence": "Ідіть прямо, поверніть наліво, ідіть прямо, 3.",
+      "targetForm": "наліво",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-1-00-lesson-notes_l0018_w005",
+        "title": "Lesson 18: Directions in Ukrainian (part 5/8)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наліво",
+      "lemmaId": "наліво",
+      "sentence": "знову поверніть наліво, ідіть прямо, поверніть направо.",
+      "targetForm": "наліво",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-1-00-lesson-notes_l0018_w005",
+        "title": "Lesson 18: Directions in Ukrainian (part 5/8)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2803,6 +8343,46 @@
       }
     },
     {
+      "lemma": "намалювати",
+      "lemmaId": "намалювати",
+      "sentence": "Щоб намалювати квадрат, потрібно використати метод create_rectangle і вказати координати вершин прямокутника такі, щоб х2 – х1 = у2 – у1.",
+      "targetForm": "намалювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0135",
+        "title": "Сторінка 114"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "намалювати",
+      "lemmaId": "намалювати",
+      "sentence": "Щоб намалювати ламану, потрібно використати метод create_line() і ввести послідовно координати всіх її вершин.",
+      "targetForm": "намалювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0135",
+        "title": "Сторінка 114"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "напруження",
       "lemmaId": "напруження",
       "sentence": "Саме із цієї миті відбувається перелом у сюжеті та спадає напруження, яке збільшувалося постійно впродовж усього твору.",
@@ -2816,6 +8396,46 @@
         "label": "Ukrainian school textbook",
         "locator": "6-klas-ukrlit-avramenko-2023_s0248",
         "title": "Сторінка 188"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "напруження",
+      "lemmaId": "напруження",
+      "sentence": "Розв’язка — це сюжетний елемент, у якому напруження спадає і конфлікт розв’язується.",
+      "targetForm": "напруження",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0248",
+        "title": "Сторінка 188"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "напруження",
+      "lemmaId": "напруження",
+      "sentence": "67 Статичні напруження людини пов’язані з підтриманням у нерухомому стані предметів, а також із підтриманням постави тіла.",
+      "targetForm": "напруження",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0077",
+        "title": "Сторінка 67"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2843,10 +8463,50 @@
       }
     },
     {
+      "lemma": "народити",
+      "lemmaId": "народити",
+      "sentence": "_____ сподіватися З народити Українська поезія.",
+      "targetForm": "народити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0229_w027",
+        "title": "Lesson 229: Українська поезія. Василь Стус «Господи, гніву пречистого…» (part 27/30)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "народити",
+      "lemmaId": "народити",
+      "sentence": "запрошувати) 9 народити Ж ялинку 5.",
+      "targetForm": "народити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0095_w012",
+        "title": "Lesson 95: Моє життя в Києві (Голосове повідомлення №3) My life in Kyiv (Voice message №3) (part 12/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "наскільки",
       "lemmaId": "наскільки",
       "sentence": "взаємовідно́шення — relationship Наскільки часто ви будете слухати подкаст, настільки добре будете розуміти українську мову.",
-      "targetForm": "наскільки",
+      "targetForm": "Наскільки",
       "cefr": "A1",
       "uses": [
         "example"
@@ -2863,10 +8523,90 @@
       }
     },
     {
+      "lemma": "наскільки",
+      "lemmaId": "наскільки",
+      "sentence": "Наскільки добре або як добре в мене це виходить.",
+      "targetForm": "Наскільки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0145_w012",
+        "title": "Lesson 145: Українські народні музичні інструменти (part 12/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наскільки",
+      "lemmaId": "наскільки",
+      "sentence": "grade Інший приклад: «Наскільки мені відомо, кобзи були поширені на східній, південній і центральній Україні».",
+      "targetForm": "Наскільки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0145_w012",
+        "title": "Lesson 145: Українські народні музичні інструменти (part 12/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наступний",
+      "lemmaId": "наступний",
+      "sentence": "Дмитра, нього, хом’яка (наступний тиждень)?",
+      "targetForm": "наступний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0047_w007",
+        "title": "Lesson 47: Гастрономічні фестивалі Родовий відмінок Food festivals Genitive case (part 7/9)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "наступний",
       "lemmaId": "наступний",
       "sentence": "Максим: _________________________ (Наступний п’ятниця) ми поїдемо на фестиваль ____________________ (борщ) в Тернопільській області.",
-      "targetForm": "наступний",
+      "targetForm": "Наступний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0047_w007",
+        "title": "Lesson 47: Гастрономічні фестивалі Родовий відмінок Food festivals Genitive case (part 7/9)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наступний",
+      "lemmaId": "наступний",
+      "sentence": "Максим: _________________________ (Наступний день) з _____________ (фестиваль) ми плануємо поїхати в Чернівці.",
+      "targetForm": "Наступний",
       "cefr": "A1",
       "uses": [
         "example"
@@ -2886,6 +8626,26 @@
       "lemma": "натуральний",
       "lemmaId": "натуральний",
       "sentence": "Натуральний каучук був уперше описаний французьким астрономом та мандрівником Шарлем Марі де ла Кондоміном 1751 року.",
+      "targetForm": "Натуральний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-himija-grygorovych-2018_s0231",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "натуральний",
+      "lemmaId": "натуральний",
+      "sentence": "Під час нагрівання або іншої обробки цей полімер вивільнюється й утворює натуральний каучук.",
       "targetForm": "натуральний",
       "cefr": "A2",
       "uses": [
@@ -2896,6 +8656,26 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-himija-grygorovych-2018_s0231",
         "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "натуральний",
+      "lemmaId": "натуральний",
+      "sentence": "шту́чний ― artificial яскра́вий ― bright Ми зазвичай робимо вдома натуральний червоний барвник, пофарбо́ваний ― painted як робила моя бабуся.",
+      "targetForm": "натуральний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0190_w005",
+        "title": "Lesson 190: Великодній кошик (part 5/22)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -2923,6 +8703,66 @@
       }
     },
     {
+      "lemma": "недостатньо",
+      "lemmaId": "недостатньо",
+      "sentence": "Тому ми запере́чення — negation кажемо не це не достатньо, ні, ми кажемо — цього недостатньо.",
+      "targetForm": "недостатньо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0178_w020",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 20/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "недостатньо",
+      "lemmaId": "недостатньо",
+      "sentence": "ча́стка — particle Повторіть: Цього недостатньо.",
+      "targetForm": "недостатньо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0178_w020",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 20/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "неістота",
+      "lemmaId": "неістота",
+      "sentence": "назва, неістота, ч.",
+      "targetForm": "неістота",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0287",
+        "title": "Сторінка 222"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "неістота",
       "lemmaId": "неістота",
       "sentence": "Визначте групу за значенням істота/неістота.",
@@ -2935,6 +8775,46 @@
         "source": "textbook",
         "label": "Ukrainian school textbook",
         "locator": "6-klas-ukrmova-litvinova-2023_s0129",
+        "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "неістота",
+      "lemmaId": "неістота",
+      "sentence": "Надпишіть над іменниками групу — істота/неістота.",
+      "targetForm": "неістота",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0129",
+        "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "нижчий",
+      "lemmaId": "нижчий",
+      "sentence": "За рівнем місячних доходів: низький; нижчий від середнього; середній; вищий від середнього; високий.",
+      "targetForm": "нижчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ekonomika-homiak-2019_s0188",
         "title": "Сторінка 122"
       },
       "license": {
@@ -2963,6 +8843,26 @@
       }
     },
     {
+      "lemma": "нижчий",
+      "lemmaId": "нижчий",
+      "sentence": "А нижчий ступінь окиснення визначається тим, скільки електронів бракує атому, щоб на зовнішньому рівні їх було вісім (табл.",
+      "targetForm": "нижчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-khimiya-hryhorovych-2025_s0299",
+        "title": "Сторінка 297"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "низько",
       "lemmaId": "низько",
       "sentence": "Карпо ненавидів тих, хто панові дуже низько кланявся, до землі нагинався.",
@@ -2983,9 +8883,49 @@
       }
     },
     {
+      "lemma": "низько",
+      "lemmaId": "низько",
+      "sentence": "Хлопець збентежився й заплакав, а митрополит ще раз низько вклонився йому: «Дякую тобі, сину, за все!..».",
+      "targetForm": "низько",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-mishhenko-2017_s0157",
+        "title": "Сторінка 95"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "низько",
+      "lemmaId": "низько",
+      "sentence": "Гостро, глибоко, низько.",
+      "targetForm": "низько",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0155",
+        "title": "Сторінка 156"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "ніби",
       "lemmaId": "ніби",
-      "sentence": "Працюй так, ніби тобі не потрібні не можна повернути: час, слово і гроші… Танцюй так, ніби можливість.",
+      "sentence": "Немає хорошого і ніби поганого.",
       "targetForm": "ніби",
       "cefr": "B1",
       "uses": [
@@ -3003,9 +8943,49 @@
       }
     },
     {
+      "lemma": "ніби",
+      "lemmaId": "ніби",
+      "sentence": "Все залежить не чує, живи так, ніби на Землі рай...",
+      "targetForm": "ніби",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0106_w012",
+        "title": "Lesson 106: Події на вихідних Weekend events Negative adverbs and pronouns in Ukrainian (part 12/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ніби",
+      "lemmaId": "ніби",
+      "sentence": "Вся Кайдашева садиба ніби дихала холодком.",
+      "targetForm": "ніби",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0053",
+        "title": "Сторінка 30"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "ніхто",
       "lemmaId": "ніхто",
-      "sentence": "ніхто́ nobody, no one Ніхто́ мене́ не зупи́нить.",
+      "sentence": "Я для неї зірву Оріон золотий, я — поет робітничої рані… Так ніхто не кохав.",
       "targetForm": "ніхто",
       "cefr": "A2",
       "uses": [
@@ -3014,8 +8994,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "anna-ohoiko-1000-words-2nd-ed_e0518",
-        "title": "ніхто́"
+        "locator": "ulp-6-00-lesson-notes_l0226_w008",
+        "title": "Lesson 226: Українська поезія. Володимир Сосюра «Так ніхто не кохав» (part 8/31)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ніхто",
+      "lemmaId": "ніхто",
+      "sentence": "Володимир Сосюра «Так ніхто не кохав» Українська поезія.",
+      "targetForm": "ніхто",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0226_w008",
+        "title": "Lesson 226: Українська поезія. Володимир Сосюра «Так ніхто не кохав» (part 8/31)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ніхто",
+      "lemmaId": "ніхто",
+      "sentence": "Так, це ще вияв певної міри: «так си́льно ― strongly сильно», «так ніхто не кохав» («no one has loved like this»).",
+      "targetForm": "ніхто",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0226_w009",
+        "title": "Lesson 226: Українська поезія. Володимир Сосюра «Так ніхто не кохав» (part 9/31)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3043,9 +9063,89 @@
       }
     },
     {
+      "lemma": "обманювати",
+      "lemmaId": "обманювати",
+      "sentence": "Підводити або підвести — це підво́дити — to put one in a difficult обманювати, не бути таким, як ми думаємо.",
+      "targetForm": "обманювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0187_w016",
+        "title": "Lesson 187: Дитинство 90-их (part 16/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "обманювати",
+      "lemmaId": "обманювати",
+      "sentence": "Водити один одного за ніс – дурити, обманювати один одного.",
+      "targetForm": "обманювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zarubizhna-literatura-voloshchuk-2022_s0083",
+        "title": "Сторінка 84"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "оболонка",
+      "lemmaId": "оболонка",
+      "sentence": "Межі географічної оболонки 51 ГЕОГРАФІЧНА ОБОЛОНКА — НАЙБІЛЬША ЕКОСИСТЕМА ЗЕМЛІ Природні комплекси Тема 5.",
+      "targetForm": "ОБОЛОНКА",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-heohrafiya-zapotockyi-2023_s0246",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "оболонка",
       "lemmaId": "оболонка",
       "sentence": "Під склерою розташована судинна оболонка, де проходять кровоносні судини.",
+      "targetForm": "оболонка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0208",
+        "title": "Сторінка 168"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "оболонка",
+      "lemmaId": "оболонка",
+      "sentence": "Спереду судинна оболонка переходить у війкове тіло (містить війковий м’яз) і райдужну оболонку.",
       "targetForm": "оболонка",
       "cefr": "B1",
       "uses": [
@@ -3083,6 +9183,46 @@
       }
     },
     {
+      "lemma": "овес",
+      "lemmaId": "овес",
+      "sentence": "р.), пшеницю, ячмінь, просо, овес, гречку.",
+      "targetForm": "овес",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0038",
+        "title": "Сторінка 40"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "овес",
+      "lemmaId": "овес",
+      "sentence": "Зеленеє жито ще й овес, тут зібрався рід наш увесь.",
+      "targetForm": "овес",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0130",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "одягатися",
       "lemmaId": "одягатися",
       "sentence": "Завоювавши Персію, Александр почав одягатися як перський шахиншах та одружився із двома персіянками.",
@@ -3103,10 +9243,90 @@
       }
     },
     {
+      "lemma": "одягатися",
+      "lemmaId": "одягатися",
+      "sentence": "Вставте дієслово у теперішньому часі: одягати / одягатися 1.",
+      "targetForm": "одягатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0189_w023",
+        "title": "Lesson 189: Вища освіта в Україні та США (part 23/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "одягатися",
+      "lemmaId": "одягатися",
+      "sentence": "су́кня ― dress смо́кінг ― tuxedo Порівняно з «одягатися» — це про звичайний одяг.",
+      "targetForm": "одягатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0226_w010",
+        "title": "Lesson 226: Українська поезія. Володимир Сосюра «Так ніхто не кохав» (part 10/31)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ой",
+      "lemmaId": "ой",
+      "sentence": "Ой, я надісла́ла повідо́млення не Oops, I sent (female) a message to тій люди́ні.",
+      "targetForm": "Ой",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0549",
+        "title": "ой!"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "ой",
       "lemmaId": "ой",
       "sentence": "Ой радуйся, земле, Син Божий народився.",
-      "targetForm": "ой",
+      "targetForm": "Ой",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0014",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ой",
+      "lemmaId": "ой",
+      "sentence": "Ой перший же празник — то Різдво Христове, Радуйся!",
+      "targetForm": "Ой",
       "cefr": "A1",
       "uses": [
         "example"
@@ -3143,6 +9363,46 @@
       }
     },
     {
+      "lemma": "опонент",
+      "lemmaId": "опонент",
+      "sentence": "Пилинський обстоює престиж своєї установи, то другий мій опонент, Н.",
+      "targetForm": "опонент",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p142",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 142"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "опонент",
+      "lemmaId": "опонент",
+      "sentence": "Якщо мій опонент не вірить, хай загляне в Словник мови Шевченка видання нашого Інституту мовознавства.",
+      "targetForm": "опонент",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p142",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 142"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "орендар",
       "lemmaId": "орендар",
       "sentence": "Отже, слова орендар, дипломант, касир мають чоловічий рід, але так можна називати й чоловіків, і жінок.",
@@ -3156,6 +9416,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0256",
         "title": "Сторінка 181"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "орендар",
+      "lemmaId": "орендар",
+      "sentence": "Володарем об’єкта може бути як влас­ ник, так і не власник (наприклад орендар).",
+      "targetForm": "орендар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0156",
+        "title": "Сторінка 83"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "орендар",
+      "lemmaId": "орендар",
+      "sentence": "Початок «перебудови» в СРСР і УРСР 137 орендар самостійно розпоряджатиметься всією виробленою продукцією.",
+      "targetForm": "орендар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-galimov-2024_s0250",
+        "title": "Сторінка 139"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3183,6 +9483,46 @@
       }
     },
     {
+      "lemma": "основа",
+      "lemmaId": "основа",
+      "sentence": "На який звук закінчується його основа?",
+      "targetForm": "основа",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0051",
+        "title": "Сторінка 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "основа",
+      "lemmaId": "основа",
+      "sentence": "У якому слові основа закінчується на [й]?",
+      "targetForm": "основа",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0054",
+        "title": "Сторінка 56"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "основний",
       "lemmaId": "основний",
       "sentence": "Це визначає основний метод правового регулювання, який використовує фінансове право, — імперативний метод, або метод субординації, владних приписів.",
@@ -3203,9 +9543,49 @@
       }
     },
     {
+      "lemma": "основний",
+      "lemmaId": "основний",
+      "sentence": "Користуючись таблицею 16.2, назвіть основний чинник формування рельєфу місцевості, де ви проживаєте.",
+      "targetForm": "основний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0100",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "основний",
+      "lemmaId": "основний",
+      "sentence": "Який основний мотив вірша?",
+      "targetForm": "основний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-kovalenko-2023_s0257",
+        "title": "Сторінка 252"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "офіс",
       "lemmaId": "офіс",
-      "sentence": "Ми маєм офіс в Києві і офіс в Торонто.",
+      "sentence": "Зокрема, там міститься європейський офіс консорціуму W3C, що розробляє технічні стандарти World Wide Web (WWW) – «всесвітньої павутини».",
       "targetForm": "офіс",
       "cefr": "A1",
       "uses": [
@@ -3214,8 +9594,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "ulp-5-00-lesson-notes_l0199_w013",
-        "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 13/33)"
+        "locator": "10-klas-geografija-bojko-2018_s0120",
+        "title": "Сторінка 65"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "офіс",
+      "lemmaId": "офіс",
+      "sentence": "В ), офіс 404, м.",
+      "targetForm": "офіс",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0432",
+        "title": "Сторінка 307"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "офіс",
+      "lemmaId": "офіс",
+      "sentence": "Головний офіс компанії знаходиться в Женеві (Швейцарія).",
+      "targetForm": "офіс",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ekonomika-homiak-2019_s0431",
+        "title": "Сторінка 266"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3243,6 +9663,46 @@
       }
     },
     {
+      "lemma": "палати",
+      "lemmaId": "палати",
+      "sentence": "Довжини відрізків прямого коридору між входами у будь-які дві сусідні лікарняні палати однакові.",
+      "targetForm": "палати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heometriya-merzliak-2024_s0163",
+        "title": "Сторінка 165"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "палати",
+      "lemmaId": "палати",
+      "sentence": "У кожному касаційному суді утворюються судові палати з розгляду окремих категорій справ з урахуванням спеціалізації суддів.",
+      "targetForm": "палати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0509",
+        "title": "Сторінка 227"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "перевантаження",
       "lemmaId": "перевантаження",
       "sentence": "12.11 і зробіть висновки: куди напрямлене прискорення руху тіла, коли тіло зазнає перевантаження?",
@@ -3256,6 +9716,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-fizyka-barjakhtar-2018_s0120",
         "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "перевантаження",
+      "lemmaId": "перевантаження",
+      "sentence": "За яких умов тіло зазнає перевантаження?",
+      "targetForm": "перевантаження",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-fizyka-barjakhtar-2018_s0125",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "перевантаження",
+      "lemmaId": "перевантаження",
+      "sentence": "Але особливо стрімко розвиваються контейнерні порти, оснащені для розвантаження, сортування і перевантаження контейнерів на залізниці й вантажні автомобілі.",
+      "targetForm": "перевантаження",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-geografija-bojko-2018_s0088",
+        "title": "Сторінка 49"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3283,10 +9783,90 @@
       }
     },
     {
+      "lemma": "переглянути",
+      "lemmaId": "переглянути",
+      "sentence": "Переглянути відео, використовуючи кнопки керування переглядом .",
+      "targetForm": "Переглянути",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0253",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "переглянути",
+      "lemmaId": "переглянути",
+      "sentence": "Переглянути відео та встановити значення властивостей майбутньої анімації.",
+      "targetForm": "Переглянути",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0253",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "повідомлення",
+      "lemmaId": "повідомлення",
+      "sentence": "Що таке повідомлення?",
+      "targetForm": "повідомлення",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0012",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "повідомлення",
       "lemmaId": "повідомлення",
       "sentence": "Як людина сприймає повідомлення?",
       "targetForm": "повідомлення",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0012",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "повідомлення",
+      "lemmaId": "повідомлення",
+      "sentence": "ПОВІДОМЛЕННЯ Поміркуйте ● ● ● Мал.",
+      "targetForm": "ПОВІДОМЛЕННЯ",
       "cefr": "A2",
       "uses": [
         "example"
@@ -3323,6 +9903,46 @@
       }
     },
     {
+      "lemma": "покращення",
+      "lemmaId": "покращення",
+      "sentence": "5 порад для покращення української мови Саме від ваших цілей, вашої мети, залежить, як саме вам працювати над мовою.",
+      "targetForm": "покращення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0137_w002",
+        "title": "Lesson 137: 5 порад для покращення української мови (part 2/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "покращення",
+      "lemmaId": "покращення",
+      "sentence": "До кожної з причин запропонуйте шлях покращення природоохоронного впливу Червоної книги.",
+      "targetForm": "покращення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0330",
+        "title": "Сторінка 197"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "полуничний",
       "lemmaId": "полуничний",
       "sentence": "Беатріс купила в сільському магазині морозиво і зробила полуничний полуни́чний — strawberry (adjective) коктейль.",
@@ -3336,6 +9956,26 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-5-00-lesson-notes_l0185_w011",
         "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 11/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "полуничний",
+      "lemmaId": "полуничний",
+      "sentence": "Я люблю ще замовити (полуничний) желе або ж (невагомий) суфле.",
+      "targetForm": "полуничний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0178",
+        "title": "Сторінка 171"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3363,6 +10003,46 @@
       }
     },
     {
+      "lemma": "поліція",
+      "lemmaId": "поліція",
+      "sentence": "Національна поліція України.",
+      "targetForm": "поліція",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0529",
+        "title": "Сторінка 235"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поліція",
+      "lemmaId": "поліція",
+      "sentence": "8 Поліція — уособлення імперської влади в Наддніпрянській Україні*.",
+      "targetForm": "Поліція",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0249",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "порівнювати",
       "lemmaId": "порівнювати",
       "sentence": "Чи потрібно постійно порівнювати себе з іншими?",
@@ -3383,6 +10063,46 @@
       }
     },
     {
+      "lemma": "порівнювати",
+      "lemmaId": "порівнювати",
+      "sentence": "Чи не краще порівнювати себе, свої успіхи з попереднім періодом свого життя?",
+      "targetForm": "порівнювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "порівнювати",
+      "lemmaId": "порівнювати",
+      "sentence": "Наприклад, учнів 11 класів можна порівнювати за зростом, розміром одягу, успішністю і т.",
+      "targetForm": "порівнювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-matematyka-nelin-2019_s0151",
+        "title": "Сторінка 137"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "постійно",
       "lemmaId": "постійно",
       "sentence": "Після евакуації пораненого в укриття потрібно постійно дбати про власну безпеку і безпеку пораненого.",
@@ -3396,6 +10116,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0197",
         "title": "Сторінка 105"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "постійно",
+      "lemmaId": "постійно",
+      "sentence": "Постійно здійснюють контроль тактичної ситуації.",
+      "targetForm": "Постійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0197",
+        "title": "Сторінка 105"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "постійно",
+      "lemmaId": "постійно",
+      "sentence": "Ми постійно зв’язуємося, зідзвонюємося, бачимося.",
+      "targetForm": "постійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0192_w022",
+        "title": "Lesson 192: Українці в Аргентині: розмова з Антоніною Чембарович (part 22/29)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3443,6 +10203,46 @@
       }
     },
     {
+      "lemma": "починати",
+      "lemmaId": "починати",
+      "sentence": "Чітких обмежень щодо віку не існує, проте експерти рекомендують починати фарбувати волосся не раніше 16-річного віку.",
+      "targetForm": "починати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+        "title": "Сторінка 112"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "починати",
+      "lemmaId": "починати",
+      "sentence": "Коли потрібно починати голитися?",
+      "targetForm": "починати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+        "title": "Сторінка 112"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "поширити",
       "lemmaId": "поширити",
       "sentence": "Із метою відволікти населення від боротьби проти самодержавства царський уряд намагався поширити на українські землі антисемітські настрої.",
@@ -3456,6 +10256,46 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-istorija-ukrajini-gisem-2017_s0421",
         "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поширити",
+      "lemmaId": "поширити",
+      "sentence": "і зробив спробу поширити повстання на територію Литви, Білорусії та Правобережної України.",
+      "targetForm": "поширити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0074",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поширити",
+      "lemmaId": "поширити",
+      "sentence": "Зрозуміло, що це правило можна поширити на три і більше елементів.",
+      "targetForm": "поширити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-algebra-ister-2019-prof_s0222",
+        "title": "Сторінка 218"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3483,6 +10323,46 @@
       }
     },
     {
+      "lemma": "поїду",
+      "lemmaId": "поїду",
+      "sentence": "Запряжу я півня в сани Та й поїду до Оксани.",
+      "targetForm": "поїду",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-mystetstvo-rublia-2023_s0056",
+        "title": "Сторінка 57"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поїду",
+      "lemmaId": "поїду",
+      "sentence": "Один хлопець хотів поїхати на кризі, та злякався, а я завтра поїду.",
+      "targetForm": "поїду",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0191",
+        "title": "Сторінка 148"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "правопис",
       "lemmaId": "правопис",
       "sentence": "Перевірити правопис слова можна в орфографічному словнику .",
@@ -3503,10 +10383,90 @@
       }
     },
     {
+      "lemma": "правопис",
+      "lemmaId": "правопис",
+      "sentence": "Існує кілька орфографічних правил, аби перевірити правопис літер на позначення ненаголошених [е] та [и]: 1.",
+      "targetForm": "правопис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0122",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "правопис",
+      "lemmaId": "правопис",
+      "sentence": "У слові ш_ро кий правопис ненаголошеного звука перевіряємо, дібравши спільнокореневе ши роко .",
+      "targetForm": "правопис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0122",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "працюємо",
       "lemmaId": "працюємо",
       "sentence": "Працюємо в малих групах.",
-      "targetForm": "працюємо",
+      "targetForm": "Працюємо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0408",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "працюємо",
+      "lemmaId": "працюємо",
+      "sentence": "Працюємо в парах.",
+      "targetForm": "Працюємо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0408",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "працюємо",
+      "lemmaId": "працюємо",
+      "sentence": "Працюємо з хронологією 1764— 1786 рр.",
+      "targetForm": "Працюємо",
       "cefr": "A1",
       "uses": [
         "example"
@@ -3543,6 +10503,46 @@
       }
     },
     {
+      "lemma": "препарат",
+      "lemmaId": "препарат",
+      "sentence": "Жиророзчинний лікувальний препарат.",
+      "targetForm": "препарат",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0507",
+        "title": "Сторінка 298"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "препарат",
+      "lemmaId": "препарат",
+      "sentence": "Водорозчинний лікувальний препарат.",
+      "targetForm": "препарат",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0507",
+        "title": "Сторінка 298"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "привезти",
       "lemmaId": "привезти",
       "sentence": "Які сувеніри привезти з України?",
@@ -3563,9 +10563,89 @@
       }
     },
     {
+      "lemma": "привезти",
+      "lemmaId": "привезти",
+      "sentence": "Привезти — доконаний, тобто один раз.",
+      "targetForm": "Привезти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0130_w016",
+        "title": "Lesson 130: Які сувеніри привезти з України? (part 16/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "привезти",
+      "lemmaId": "привезти",
+      "sentence": "заплу́тано — confusing Привóзити (недок.) — привезти́ (док.) — to bring, to deliver, to import (something) using transportation: Привези́ мені́, будь ла́ска, сувені́ри з Украї́ни.",
+      "targetForm": "привезти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0130_w017",
+        "title": "Lesson 130: Які сувеніри привезти з України? (part 17/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "привітання",
       "lemmaId": "привітання",
-      "sentence": "Прочитайте фрагмент привітання Президента України з нагоди Дня Соборності.",
+      "sentence": "Сенс будь-якого привітання – щире ви­ словлення почуттів.",
+      "targetForm": "привітання",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-zabolotnyi-2025_s0341",
+        "title": "Сторінка 275"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "привітання",
+      "lemmaId": "привітання",
+      "sentence": "Типова структура офіційного привітання 1.",
+      "targetForm": "привітання",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-zabolotnyi-2025_s0341",
+        "title": "Сторінка 275"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "привітання",
+      "lemmaId": "привітання",
+      "sentence": "Власне текст привітання.",
       "targetForm": "привітання",
       "cefr": "B1",
       "uses": [
@@ -3603,6 +10683,46 @@
       }
     },
     {
+      "lemma": "прийняти",
+      "lemmaId": "прийняти",
+      "sentence": "Бойове хрещення усуси (від абревіатури УСС) прийняти 25 вересня, захищаючи Ужоцький перевал Карпат.",
+      "targetForm": "прийняти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0142",
+        "title": "Сторінка 74"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "прийняти",
+      "lemmaId": "прийняти",
+      "sentence": "зупинися З’ясуйте, чи маєте змогу негайно прийняти рішення.",
+      "targetForm": "прийняти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0087",
+        "title": "Сторінка 90"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "прикраса",
       "lemmaId": "прикраса",
       "sentence": "Д Різдвяна прикраса на палиці, сповіщає про народження Ісуса Христа.",
@@ -3623,10 +10743,90 @@
       }
     },
     {
+      "lemma": "прикраса",
+      "lemmaId": "прикраса",
+      "sentence": "З Солом’яна прикраса, яку підвішують на стелю.",
+      "targetForm": "прикраса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0214_w021",
+        "title": "Lesson 214: Символи Різдва в Україні (part 21/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "прикраса",
+      "lemmaId": "прикраса",
+      "sentence": "Дідух — це прикраса, зроблена з колосків жита чи пшениці.",
+      "targetForm": "прикраса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0214_w008",
+        "title": "Lesson 214: Символи Різдва в Україні (part 8/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "приспів",
       "lemmaId": "приспів",
       "sentence": "(Приспів) Та кладіть калачі з ярої пшениці.",
-      "targetForm": "приспів",
+      "targetForm": "Приспів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-zabolotnyi-2023_s0026",
+        "title": "Сторінка 27"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приспів",
+      "lemmaId": "приспів",
+      "sentence": "(Приспів) Бо прийдуть до тебе три празники в гості.",
+      "targetForm": "Приспів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-zabolotnyi-2023_s0026",
+        "title": "Сторінка 27"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приспів",
+      "lemmaId": "приспів",
+      "sentence": "(Приспів) Ой перший же празник – то Різдво Христове.",
+      "targetForm": "Приспів",
       "cefr": "B1",
       "uses": [
         "example"
@@ -3645,7 +10845,7 @@
     {
       "lemma": "приховати",
       "lemmaId": "приховати",
-      "sentence": "Коли потрібно приховати деякі поля, їх слід виділити й у групі Записи виконати команду Додатково → Приховати поля.",
+      "sentence": "ФАХ (Скорочено) Джордж Плейтен не міг приховати суму в голосі: – Завтра перше травня.",
       "targetForm": "приховати",
       "cefr": "A1",
       "uses": [
@@ -3654,8 +10854,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "11-klas-informatyka-rudenko-2019_s0039",
-        "title": "Сторінка 26"
+        "locator": "8-klas-zarlit-voloschuk-2025_s0387",
+        "title": "Сторінка 226"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приховати",
+      "lemmaId": "приховати",
+      "sentence": "Мені було ніяково, і, щоб приховати свою ніяковість, я стала поправляти ковдру.",
+      "targetForm": "приховати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0398",
+        "title": "Сторінка 222"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приховати",
+      "lemmaId": "приховати",
+      "sentence": "У певних випадках виникає потреба скоротити показ презентації, приховати несуттєві для слухацької аудиторії деталі.",
+      "targetForm": "приховати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-informatyka-ryvkind-2017_s0158",
+        "title": "Сторінка 102"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3666,7 +10906,47 @@
       "lemma": "приєднати",
       "lemmaId": "приєднати",
       "sentence": "Приєднати газову трубку.",
-      "targetForm": "приєднати",
+      "targetForm": "Приєднати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0326",
+        "title": "Сторінка 177"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приєднати",
+      "lemmaId": "приєднати",
+      "sentence": "Приєднати затвор до затворної рами.",
+      "targetForm": "Приєднати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0326",
+        "title": "Сторінка 177"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приєднати",
+      "lemmaId": "приєднати",
+      "sentence": "Приєднати затворну раму із затвором до ствольної коробки.",
+      "targetForm": "Приєднати",
       "cefr": "B1",
       "uses": [
         "example"
@@ -3686,7 +10966,7 @@
       "lemma": "приєднатися",
       "lemmaId": "приєднатися",
       "sentence": "Приєднатися до такого народу — це гірше, ніж скочити живим у вогонь.",
-      "targetForm": "приєднатися",
+      "targetForm": "Приєднатися",
       "cefr": "A1",
       "uses": [
         "example"
@@ -3703,10 +10983,50 @@
       }
     },
     {
+      "lemma": "приєднатися",
+      "lemmaId": "приєднатися",
+      "sentence": "Join with Computer Audio — приєднатися з використанням звуку комп’ютера).",
+      "targetForm": "приєднатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0085",
+        "title": "Сторінка 84"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приєднатися",
+      "lemmaId": "приєднатися",
+      "sentence": "Польський сейм звернувся до населення Правобережжя, ­закликаючи приєднатися до повстання.",
+      "targetForm": "приєднатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0074",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "про",
       "lemmaId": "про",
       "sentence": "Нузет Умеров ПРО КНИЖКУ Дбайливо тонесеньку книжку гортаю, рядок за рядочком уважно читаю.",
-      "targetForm": "про",
+      "targetForm": "ПРО",
       "cefr": "A1",
       "uses": [
         "example"
@@ -3723,9 +11043,89 @@
       }
     },
     {
+      "lemma": "про",
+      "lemmaId": "про",
+      "sentence": "\u0007Про що ти любиш читати?",
+      "targetForm": "Про",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0018",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "про",
+      "lemmaId": "про",
+      "sentence": "Поміркуй, про що може розповісти твір.",
+      "targetForm": "про",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0015",
+        "title": "Сторінка 17"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "провідник",
       "lemmaId": "провідник",
       "sentence": "сила аМпЕра Із матеріалу § 1 ви дізналися, що магнітне поле діє на провідник зі струмом із де­ якою силою.",
+      "targetForm": "провідник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-fizyka-bariakhtar-2022_s0029",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "провідник",
+      "lemmaId": "провідник",
+      "sentence": "Якщо в провіднику пропустити струм, провідник відхилиться від положення рівноваги (рис.",
+      "targetForm": "провідник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-fizyka-bariakhtar-2022_s0029",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "провідник",
+      "lemmaId": "провідник",
+      "sentence": "Причиною такого відхилення є сила, що діє на провідник зі струмом з боку магнітного поля.",
       "targetForm": "провідник",
       "cefr": "B1",
       "uses": [
@@ -3763,6 +11163,46 @@
       }
     },
     {
+      "lemma": "програвати",
+      "lemmaId": "програвати",
+      "sentence": "Завозити — вивозити, вдихати — видихати, забігати — вибігати, взуватися — роззуватися, вигравати — програвати, вмикати — вимикати.",
+      "targetForm": "програвати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0093",
+        "title": "Сторінка 95"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "програвати",
+      "lemmaId": "програвати",
+      "sentence": "Думаю, ти в якийсь момент почав програвати, і дядя Костя, директор цього залу, почав тобі позичати.",
+      "targetForm": "програвати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0430",
+        "title": "Сторінка 283"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "продавати",
       "lemmaId": "продавати",
       "sentence": "Її не можна було передавати в спадок, продавати тощо.",
@@ -3776,6 +11216,46 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-istoria-ukr-galimov-2024_s0106",
         "title": "Сторінка 73"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "продавати",
+      "lemmaId": "продавати",
+      "sentence": "Через цю платформу можна купувати (купити) і продавати (продати) одяг.",
+      "targetForm": "продавати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0196_w023",
+        "title": "Lesson 196: Українці в США: розмова з Андрієм Бойчуком (part 23/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "продавати",
+      "lemmaId": "продавати",
+      "sentence": "Через цю платформу ви можете (ти можеш) купувати (купити) і продавати (продати) одяг.",
+      "targetForm": "продавати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0196_w023",
+        "title": "Lesson 196: Українці в США: розмова з Андрієм Бойчуком (part 23/24)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3803,10 +11283,50 @@
       }
     },
     {
+      "lemma": "продовжувати",
+      "lemmaId": "продовжувати",
+      "sentence": "Адже навряд чи, перебуваючи в місцях позбавлення волі, злочинець зможе продовжувати свою злочинну діяльність.",
+      "targetForm": "продовжувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0135",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "продовжувати",
+      "lemmaId": "продовжувати",
+      "sentence": "За роботою він міг несподівано розсміятися і, сміючись, продовжувати писати.",
+      "targetForm": "продовжувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zarlit-voloschuk-2025_s0232",
+        "title": "Сторінка 133"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "проза",
       "lemmaId": "проза",
-      "sentence": "­Ораторсько-проповідницька проза включала твори з тлумаченням євангельських текстів і моралістичними повчаннями.",
-      "targetForm": "проза",
+      "sentence": "РЕАЛІСТИЧНА УКРАЇНСЬКА ПРОЗА УКРАЇНСЬКА ЛІТЕРАТУРА ДРУГОЇ ПОЛОВИНИ ХІХ ст.",
+      "targetForm": "ПРОЗА",
       "cefr": "B1",
       "uses": [
         "example"
@@ -3814,8 +11334,68 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "8-klas-istoriya-ukr-gisem-2021_s0077",
-        "title": "Сторінка 41"
+        "locator": "10-klas-ukrajinska-literatura-avramenko-2018_s0002",
+        "title": "Сторінка 3"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "проза",
+      "lemmaId": "проза",
+      "sentence": "ПРОЗА ХІХ ст.: ВІД РОМАНТИЗМУ ДО РЕАЛІЗМУ Обкладинка до повісті М.",
+      "targetForm": "ПРОЗА",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-avramenko-2025_s0209",
+        "title": "Сторінка 123"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "проза",
+      "lemmaId": "проза",
+      "sentence": "43 Проза 20–30-х років ХХ ст.",
+      "targetForm": "Проза",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0416",
+        "title": "Сторінка 253"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "простір",
+      "lemmaId": "простір",
+      "sentence": "Що таке простір?",
+      "targetForm": "простір",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0042",
+        "title": "Сторінка 43"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3826,6 +11406,26 @@
       "lemma": "простір",
       "lemmaId": "простір",
       "sentence": "Що таке особистий простір та якими є його складники.",
+      "targetForm": "простір",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0042",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "простір",
+      "lemmaId": "простір",
+      "sentence": "Цю територію вони визначають як свій особистий простір.",
       "targetForm": "простір",
       "cefr": "B1",
       "uses": [
@@ -3863,6 +11463,46 @@
       }
     },
     {
+      "lemma": "професія",
+      "lemmaId": "професія",
+      "sentence": "Складіть і запишіть текст (0,5–1 сторінка) у публіцистичному стилі на одну з тем: «Професійний вибір», «Професія і характер».",
+      "targetForm": "Професія",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0272",
+        "title": "Сторінка 190"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "професія",
+      "lemmaId": "професія",
+      "sentence": "Зауважте, що ваша професія дотична до зони ризику.",
+      "targetForm": "професія",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0167",
+        "title": "Сторінка 118"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "психологічний",
       "lemmaId": "психологічний",
       "sentence": "Думаю скласти психологічний портрет людини можна за кількістю і якістю прочитаних і зібраних нею книжок.",
@@ -3876,6 +11516,66 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-ukrajinska-mova-glazova-2019_s0221",
         "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "психологічний",
+      "lemmaId": "психологічний",
+      "sentence": "Як ви розумієте значення терміна психологічний портрет?",
+      "targetForm": "психологічний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0221",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "психологічний",
+      "lemmaId": "психологічний",
+      "sentence": "Складіть жартівливий психологічний портрет сучасного молодого українця (усно), узявши за основу його ставлення до книжки.",
+      "targetForm": "психологічний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0221",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "птаха",
+      "lemmaId": "птаха",
+      "sentence": "У краї синього птаха.",
+      "targetForm": "птаха",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0334",
+        "title": "Сторінка 193"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -3903,6 +11603,46 @@
       }
     },
     {
+      "lemma": "птаха",
+      "lemmaId": "птаха",
+      "sentence": "Оберіть одну зі сцен «Синього птаха» і за системою Станіславського підготуйте виставу.",
+      "targetForm": "птаха",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0342",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "півострів",
+      "lemmaId": "півострів",
+      "sentence": "Речення-підказки yy Балканський півострів розташований на _____________ Європи.",
+      "targetForm": "півострів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-istoriia-shchupak-2023_s0128",
+        "title": "Сторінка 126"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "півострів",
       "lemmaId": "півострів",
       "sentence": "yy Балканський півострів омивається ________________ морями.",
@@ -3923,10 +11663,70 @@
       }
     },
     {
+      "lemma": "півострів",
+      "lemmaId": "півострів",
+      "sentence": "Речення номер вісім — коротеньке: короте́нький = коро́ткий — short (diminutive) Крим — це півострів.",
+      "targetForm": "півострів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0169_w015",
+        "title": "Lesson 169: Етнографічні регіони України. Частина 2: Південь і Схід України (part 15/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "підліток",
       "lemmaId": "підліток",
       "sentence": "В Підліток може висловити свої скарги вчителю, шкільному адміністратору чи батькам.",
-      "targetForm": "підліток",
+      "targetForm": "Підліток",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0077",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підліток",
+      "lemmaId": "підліток",
+      "sentence": "Г Підліток може звернутися до батьків, учителів або шкільного психолога та вимагати відновлення конфіденційності.",
+      "targetForm": "Підліток",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0077",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підліток",
+      "lemmaId": "підліток",
+      "sentence": "Д Підліток може спробувати відверто розмовляти з батьками, опікунами або шкільними представниками і висловити свої побажання та думки.",
+      "targetForm": "Підліток",
       "cefr": "B1",
       "uses": [
         "example"
@@ -3963,6 +11763,46 @@
       }
     },
     {
+      "lemma": "підряд",
+      "lemmaId": "підряд",
+      "sentence": "Колективно складіть невеликий усний роздум «Кожному мила рідна сто­ рона», використовуючи складнопідрядні речення з кількома підряд­ ними.",
+      "targetForm": "підряд",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0122",
+        "title": "Сторінка 95"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підряд",
+      "lemmaId": "підряд",
+      "sentence": "Назви́ приголосні звуки, які стоять у слові підряд, тобто є збіг приголосних.",
+      "targetForm": "підряд",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-1_s0015",
+        "title": "Сторінка 16"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "підсилити",
       "lemmaId": "підсилити",
       "sentence": "Його потужність, колір, напрям допомагають зробити декорації виразнішими, виділити головне, підсилити враження глядачів/глядачок.",
@@ -3983,6 +11823,46 @@
       }
     },
     {
+      "lemma": "підсилити",
+      "lemmaId": "підсилити",
+      "sentence": "Як повтори звуків допомагають поетесі підсилити думку й точніше передати настрій?",
+      "targetForm": "підсилити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-kovalenko-2023_s0027",
+        "title": "Сторінка 28"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підсилити",
+      "lemmaId": "підсилити",
+      "sentence": "Основне її завдання — підсилити й зміцнити стилістичні якості мовлення.",
+      "targetForm": "підсилити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0121",
+        "title": "Сторінка 68"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "підтвердження",
       "lemmaId": "підтвердження",
       "sentence": "Доберіть історичні факти на підтвердження тези «Самвидав» — зброя в руках дисидентів».",
@@ -3996,6 +11876,86 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0320",
         "title": "Сторінка 175"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підтвердження",
+      "lemmaId": "підтвердження",
+      "sentence": "Віднайдіть у тексті уривки на підтвердження цих слів, виразно прочитайте і прокоментуйте їх.",
+      "targetForm": "підтвердження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-mishhenko-2017_s0234",
+        "title": "Сторінка 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підтвердження",
+      "lemmaId": "підтвердження",
+      "sentence": "Універсальний ключ Двофакторна автентифікація (ДФА, 2FA) — це метод додаткового захисту облікового запису, який використовує два різні типи підтвердження особи.",
+      "targetForm": "підтвердження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-hromadianska-osvita-pometun-2026_s0132",
+        "title": "Сторінка 108"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "пізно",
+      "lemmaId": "пізно",
+      "sentence": "Краще пізно ніж ніколи.",
+      "targetForm": "пізно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0104_w012",
+        "title": "Lesson 104: Здоровий спосіб життя Healthy lifestyle Degrees of comparison in Ukrainian (part 12/18)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "пізно",
+      "lemmaId": "пізно",
+      "sentence": "Краще пізно ніж ніколи!",
+      "targetForm": "пізно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0104_w012",
+        "title": "Lesson 104: Здоровий спосіб життя Healthy lifestyle Degrees of comparison in Ukrainian (part 12/18)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4043,9 +12003,89 @@
       }
     },
     {
+      "lemma": "разом",
+      "lemmaId": "разом",
+      "sentence": "Вони вирішили, що далі будуть рухатися по життю разом.",
+      "targetForm": "разом",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0195_w017",
+        "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 17/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "разом",
+      "lemmaId": "разом",
+      "sentence": "Можна ще сказати: рухатися життям разом (без прийменника в орудному відмінку).",
+      "targetForm": "разом",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0195_w017",
+        "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 17/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "рекорд",
       "lemmaId": "рекорд",
       "sentence": "Номер 5 ― побити світовий рекорд.",
+      "targetForm": "рекорд",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0141_w012",
+        "title": "Lesson 141: Україна в 2019: головні новини (part 12/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рекорд",
+      "lemmaId": "рекорд",
+      "sentence": "Президент України Володимир Зеленський побив світовий рекорд, провівши найдовшу пресконференцію в історії.",
+      "targetForm": "рекорд",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0141_w012",
+        "title": "Lesson 141: Україна в 2019: головні новини (part 12/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рекорд",
+      "lemmaId": "рекорд",
+      "sentence": "А ви зможете побити свій рекорд з кількості прослуханих епізодів Ukrainian Lessons за день?",
       "targetForm": "рекорд",
       "cefr": "B1",
       "uses": [
@@ -4083,9 +12123,29 @@
       }
     },
     {
+      "lemma": "реєструється",
+      "lemmaId": "реєструється",
+      "sentence": "Відповідно реєструється і значна кількість отруєнь та передозувань ними.",
+      "targetForm": "реєструється",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0121",
+        "title": "Сторінка 63"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "риса",
       "lemmaId": "риса",
-      "sentence": "(imperfective, perfective) торту́ри ― torture Очевидно, ця риса — риса стоїцизму — не може бути здава́тися, зда́тися ― to give up притаманною усім людям.",
+      "sentence": "Відповідальність як моральна риса.",
       "targetForm": "риса",
       "cefr": "B1",
       "uses": [
@@ -4094,8 +12154,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "ulp-6-00-lesson-notes_l0229_w002",
-        "title": "Lesson 229: Українська поезія. Василь Стус «Господи, гніву пречистого…» (part 2/30)"
+        "locator": "6-klas-etyka-martyniuk-2023_s0026",
+        "title": "Сторінка 27"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "риса",
+      "lemmaId": "риса",
+      "sentence": "\u0007Відповідальність як моральна риса.",
+      "targetForm": "риса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0026",
+        "title": "Сторінка 27"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "риса",
+      "lemmaId": "риса",
+      "sentence": "Впевненість у собі — це досить корисна риса характеру.",
+      "targetForm": "риса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0122_w015",
+        "title": "Lesson 122: Як я вивчала і вивчила англійську мову (part 15/23)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4116,6 +12216,86 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-5-00-lesson-notes_l0189_w026",
         "title": "Lesson 189: Вища освіта в Україні та США (part 26/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "родич",
+      "lemmaId": "родич",
+      "sentence": "Однак сталося непоправне: родич помер і кредитор стає спадкоємцем майна боржника.",
+      "targetForm": "родич",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0298",
+        "title": "Сторінка 155"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "родич",
+      "lemmaId": "родич",
+      "sentence": "Іменник у формі однини позначає одну особу, істоту, предмет: свято, родич, пампушка.",
+      "targetForm": "родич",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0140",
+        "title": "Сторінка 133"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розмова",
+      "lemmaId": "розмова",
+      "sentence": "Lesson 198: Українці в Австралії: розмова з Богуславом Когутом Вступ Привіт-привіт!",
+      "targetForm": "розмова",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0198_w001",
+        "title": "Lesson 198: Українці в Австралії: розмова з Богуславом Когутом (part 1/28)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розмова",
+      "lemmaId": "розмова",
+      "sentence": "Lesson 194: Українці в Шотландії: розмова з Олексою Курилюком Вступ Привіт!",
+      "targetForm": "розмова",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0194_w001",
+        "title": "Lesson 194: Українці в Шотландії: розмова з Олексою Курилюком (part 1/21)"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4163,9 +12343,89 @@
       }
     },
     {
+      "lemma": "розповісти",
+      "lemmaId": "розповісти",
+      "sentence": "☆☆☆ Я можу розповісти про види небезпечних підприємств і ознаки аварії на підприємстві.",
+      "targetForm": "розповісти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0163",
+        "title": "Сторінка 168"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розповісти",
+      "lemmaId": "розповісти",
+      "sentence": "Бо пора вже розповісти про дивну дружбу двох хлопців – Данила Ланового та Богдана Майстренка.",
+      "targetForm": "розповісти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0350",
+        "title": "Сторінка 234"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розпорядження",
+      "lemmaId": "розпорядження",
+      "sentence": "Власність, користування, володіння, розпорядження, сервітут, суперфіцій, емфітевзис.",
+      "targetForm": "розпорядження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0240",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "розпорядження",
       "lemmaId": "розпорядження",
       "sentence": "\u0007Поясніть поняття «власність», «користування», «володіння», «розпорядження», «сервітут», «суперфіцій», «емфітевзис».",
+      "targetForm": "розпорядження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0240",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розпорядження",
+      "lemmaId": "розпорядження",
+      "sentence": "Порівняйте А первинні та похідні способи набуття власності Б користування, володіння та розпорядження В сервітут, суперфіцій та емфітевзис !",
       "targetForm": "розпорядження",
       "cefr": "A1",
       "uses": [
@@ -4203,10 +12463,90 @@
       }
     },
     {
+      "lemma": "розум",
+      "lemmaId": "розум",
+      "sentence": "божеві́льний — mad, insane Людина, яка втратила розум, збожеволіла.",
+      "targetForm": "розум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0153_w011",
+        "title": "Lesson 153: Маруся Чурай — дівчина з легенди (part 11/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розум",
+      "lemmaId": "розум",
+      "sentence": "Хто має розум та багато знає, — той буде завше сильним і міцним.",
+      "targetForm": "розум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0009",
+        "title": "Сторінка 10"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "розширювати",
       "lemmaId": "розширювати",
       "sentence": "для тих, хто вже добре розуміє українську мову, але хоче розширювати словниковий запас».",
       "targetForm": "розширювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w010",
+        "title": "Lesson 128: Рослини — символи України (part 10/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розширювати",
+      "lemmaId": "розширювати",
+      "sentence": "Розширювати словниковий запас означає vocabulary (stock) збільшувати кількість слів, вивчати нові слова.",
+      "targetForm": "Розширювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w010",
+        "title": "Lesson 128: Рослини — символи України (part 10/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розширювати",
+      "lemmaId": "розширювати",
+      "sentence": "Розширювати словниковий запас.",
+      "targetForm": "Розширювати",
       "cefr": "A2",
       "uses": [
         "example"
@@ -4243,10 +12583,50 @@
       }
     },
     {
+      "lemma": "роль",
+      "lemmaId": "роль",
+      "sentence": "Часто ми кажемо це про важливих історичних осіб, наприклад: Тарас Шевченко відіграв важливу роль у розвитку української мови.",
+      "targetForm": "роль",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0151_w010",
+        "title": "Lesson 151: Ярослав Мудрий — «тесть Європи» (part 10/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "роль",
+      "lemmaId": "роль",
+      "sentence": "Або: На початку революції на Майдані важливу роль відігравали студенти.",
+      "targetForm": "роль",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0151_w010",
+        "title": "Lesson 151: Ярослав Мудрий — «тесть Європи» (part 10/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "рости",
       "lemmaId": "рости",
-      "sentence": "і заспівала: «Плавай, плавай, леб;едонько, По синьому морю – Рости, рости, топ;оленько, Все вгору та вгору!",
-      "targetForm": "рости",
+      "sentence": "Рости гнучка та висока, До самої хмари, Спитай Бога, чи діжду я, Чи не діжду пари.",
+      "targetForm": "Рости",
       "cefr": "A2",
       "uses": [
         "example"
@@ -4256,6 +12636,46 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-zabolotnyi-2024_s0211",
         "title": "Сторінка 144"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рости",
+      "lemmaId": "рости",
+      "sentence": "Рости ж, серце-тополенько, Все вгору та вгору; Плавай, плавай, лебедонько, По синьому морю!» Отак тая чорнобрива Плакала, співала...",
+      "targetForm": "Рости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0211",
+        "title": "Сторінка 144"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рости",
+      "lemmaId": "рости",
+      "sentence": "Рости тонка та висока До самої хмари, Спитай Бога, чи діжду я, Чи не діжду пари?",
+      "targetForm": "Рости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0092",
+        "title": "Сторінка 66"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4283,9 +12703,49 @@
       }
     },
     {
+      "lemma": "рушник",
+      "lemmaId": "рушник",
+      "sentence": "Я візьму той рушник, простелю, наче долю, В тихім шелесті трав, в щебетанні дібров.",
+      "targetForm": "рушник",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0407",
+        "title": "Сторінка 246"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рушник",
+      "lemmaId": "рушник",
+      "sentence": "далеку ти мене на зорі And into the distant journey you sent me at dawn, проводжала, І рушник 1.",
+      "targetForm": "рушник",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0228_w030",
+        "title": "Lesson 228: Українська поезія. Дмитро Павличко «Два кольори» (part 30/35)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "рідко",
       "lemmaId": "рідко",
-      "sentence": "У формі називного відмінка іменник, яким виражено звертання, уживають рідко — зазвичай у поетичних творах.",
+      "sentence": "Вогкий, кігті, солодкий, просьба, смужка, ходьба, рідко.",
       "targetForm": "рідко",
       "cefr": "A2",
       "uses": [
@@ -4294,8 +12754,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0149",
-        "title": "Сторінка 104"
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0113",
+        "title": "Сторінка 79"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рідко",
+      "lemmaId": "рідко",
+      "sentence": "260 Додатки в’юнкий, в’юнистий, хвилястий, кривулястий розм., кривулькуватий розм., покривулений розм., звивчастий рідко; заломистий (з різкими вигинами).",
+      "targetForm": "рідко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0384",
+        "title": "Сторінка 260"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рідко",
+      "lemmaId": "рідко",
+      "sentence": "ЗГОДА, злагода, лад, мир, спокій, порозуміння, лагода розм., злада діал., покій заст., ряд заст., рідко.",
+      "targetForm": "рідко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0384",
+        "title": "Сторінка 260"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4323,9 +12823,89 @@
       }
     },
     {
+      "lemma": "різдвяний",
+      "lemmaId": "різдвяний",
+      "sentence": "Знайдіть місця, коли різдвяний ангел з’являється, а коли — зникає?",
+      "targetForm": "різдвяний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0073",
+        "title": "Сторінка 74"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "різдвяний",
+      "lemmaId": "різдвяний",
+      "sentence": "І коли це сталося, чудовий різдвяний ангел із тоненькими білими крильцями та лагідними оченятами весело закружляв над ними...",
+      "targetForm": "різдвяний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0073",
+        "title": "Сторінка 74"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "сад",
       "lemmaId": "сад",
       "sentence": "Пагутяк «Потрапити в сад» за родовою ознакою — епічний.",
+      "targetForm": "сад",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0403",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сад",
+      "lemmaId": "сад",
+      "sentence": "Визначте ідею оповідання «Потрапити в сад».",
+      "targetForm": "сад",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0403",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сад",
+      "lemmaId": "сад",
+      "sentence": "Пагутяк «Потрапити в сад».",
       "targetForm": "сад",
       "cefr": "A1",
       "uses": [
@@ -4363,9 +12943,89 @@
       }
     },
     {
+      "lemma": "садівництво",
+      "lemmaId": "садівництво",
+      "sentence": "На Заêарпатті розвивалися виноãрадарство, садівництво, ó ãірсьêих районах поширювалися тваринництво (вівчарство), лісозаãотівлі.",
+      "targetForm": "садівництво",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-burnejko-2017_s0085",
+        "title": "Сторінка 58"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "садівництво",
+      "lemmaId": "садівництво",
+      "sentence": "Тут вирощували злакові й городні культури, поширювалися виноградарство й садівництво.",
+      "targetForm": "садівництво",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-galimov-2024_s0302",
+        "title": "Сторінка 204"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "салат",
       "lemmaId": "салат",
-      "sentence": "Ще був салат мімоза — з вареними мімо́за — mimosa salad яйцями і рибними консервами.",
+      "sentence": "оливкова олія… Ну це в мене зараз таке уявлення про салат.",
+      "targetForm": "салат",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0181_w008",
+        "title": "Lesson 181: Українська кухня в радянські часи (part 8/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "салат",
+      "lemmaId": "салат",
+      "sentence": "Наприклад, салат з крабовими паличками.",
+      "targetForm": "салат",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0181_w010",
+        "title": "Lesson 181: Українська кухня в радянські часи (part 10/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "салат",
+      "lemmaId": "салат",
+      "sentence": "Також салат з куркою і ананасами — мені таке анана́с — pineapple поєднання не до смаку.",
       "targetForm": "салат",
       "cefr": "A1",
       "uses": [
@@ -4403,6 +13063,46 @@
       }
     },
     {
+      "lemma": "самостійно",
+      "lemmaId": "самостійно",
+      "sentence": "Початкові значення властивостей вікна і напису виберіть самостійно.",
+      "targetForm": "самостійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0167",
+        "title": "Сторінка 120"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "самостійно",
+      "lemmaId": "самостійно",
+      "sentence": "Самі, тобто самостійно.",
+      "targetForm": "самостійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0165_w012",
+        "title": "Lesson 165: Як використовувати смартфон для вивчення мов (part 12/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "свята",
       "lemmaId": "свята",
       "sentence": "Речення номер один: Деякі свята потрохи відходять в історію.",
@@ -4423,9 +13123,69 @@
       }
     },
     {
+      "lemma": "свята",
+      "lemmaId": "свята",
+      "sentence": "Повторіть повне речення: Деякі свята потрохи відходять в історію.",
+      "targetForm": "свята",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w013",
+        "title": "Lesson 173: Зимовий цикл свят (part 13/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свята",
+      "lemmaId": "свята",
+      "sentence": "У нас на подкасті вже був сезо́н — season не один епізод про зимові свята.",
+      "targetForm": "свята",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w001",
+        "title": "Lesson 173: Зимовий цикл свят (part 1/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "свідомість",
       "lemmaId": "свідомість",
       "sentence": "Свідомість Прагнення пізнання себе є одним з головних рушіїв розвитку людства.",
+      "targetForm": "Свідомість",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0250",
+        "title": "Сторінка 202"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свідомість",
+      "lemmaId": "свідомість",
+      "sentence": "Найскладнішим і найменш вивченим феноменом людської психіки є свідомість.",
       "targetForm": "свідомість",
       "cefr": "A1",
       "uses": [
@@ -4436,6 +13196,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-biolohiya-anderson-2025_s0250",
         "title": "Сторінка 202"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свідомість",
+      "lemmaId": "свідомість",
+      "sentence": "Свідомість і мислення.",
+      "targetForm": "Свідомість",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0250",
+        "title": "Сторінка 202"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свіжий",
+      "lemmaId": "свіжий",
+      "sentence": "Поцілунок мами, свіжий у віконце.",
+      "targetForm": "свіжий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-mystetstvo-masol-2024_s0263",
+        "title": "Сторінка 264"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4463,6 +13263,26 @@
       }
     },
     {
+      "lemma": "свіжий",
+      "lemmaId": "свіжий",
+      "sentence": "202 Тумас Транстремер: чи можливий «свіжий погляд на реальність» .....................................................",
+      "targetForm": "свіжий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0004",
+        "title": "Сторінка 4"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "середній",
       "lemmaId": "середній",
       "sentence": "Це така відстань, з якої середній радіус земної орбіти видно під кутом 1″ (секунда дуги).",
@@ -4476,6 +13296,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0387",
         "title": "Сторінка 240"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "середній",
+      "lemmaId": "середній",
+      "sentence": "80 ВІДМІНЮВАННЯ ПРИКМЕТНИКІВ Відмінок Питання Відмінкові форми однини чоловічий рід жіночий рід середній рід Н.",
+      "targetForm": "середній",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-varzatska-2021-1_s0078",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "середній",
+      "lemmaId": "середній",
+      "sentence": "од., то найбагатші та середній клас: 7800 – 1170 = = 6630 млрд грош.",
+      "targetForm": "середній",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0414",
+        "title": "Сторінка 211"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4503,10 +13363,50 @@
       }
     },
     {
+      "lemma": "символічно",
+      "lemmaId": "символічно",
+      "sentence": "До них Так художник символічно зобразив укладення Великої хартії вольностей.",
+      "targetForm": "символічно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0044",
+        "title": "Сторінка 26"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "символічно",
+      "lemmaId": "символічно",
+      "sentence": "Механізми подібності ільшість народних чарівних казок символічно описує обряд ініціації, що побутував у родовому суспільстві.",
+      "targetForm": "символічно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0371",
+        "title": "Сторінка 215"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "скарб",
       "lemmaId": "скарб",
-      "sentence": "Люди – дуже цікаві створіння!» – думає персонаж твору А «Скарб» В «Мишка» Б «Кольорові миші» Г «Чайка на крижині» 6.",
-      "targetForm": "скарб",
+      "sentence": "Лежень – це герой твору А «Мишка» В «Гер переможений» Б «Скарб» Г «Кольорові миші» 2.",
+      "targetForm": "Скарб",
       "cefr": "B1",
       "uses": [
         "example"
@@ -4516,6 +13416,46 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-mishhenko-2015_s0345",
         "title": "Сторінка 209"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "скарб",
+      "lemmaId": "скарб",
+      "sentence": "Люди – дуже цікаві створіння!» – думає персонаж твору А «Скарб» В «Мишка» Б «Кольорові миші» Г «Чайка на крижині» 6.",
+      "targetForm": "Скарб",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0345",
+        "title": "Сторінка 209"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "скарб",
+      "lemmaId": "скарб",
+      "sentence": "У гру «Зачарований скарб» діти грають на майданчику.",
+      "targetForm": "скарб",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0122",
+        "title": "Сторінка 124"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4543,6 +13483,46 @@
       }
     },
     {
+      "lemma": "слюсар",
+      "lemmaId": "слюсар",
+      "sentence": "Слюсар — робітник, який обробляє метали, ремонтує машини, механізми.",
+      "targetForm": "Слюсар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0003",
+        "title": "Сторінка 5"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "слюсар",
+      "lemmaId": "слюсар",
+      "sentence": "(23 роки, слюсар, раніше засуджений за крадіжку), Р.",
+      "targetForm": "слюсар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0176",
+        "title": "Сторінка 93"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "слідуючий",
       "lemmaId": "слідуючий",
       "sentence": "Студенти сіли в потяг, слідуючий до Рівного.",
@@ -4563,9 +13543,89 @@
       }
     },
     {
+      "lemma": "слідуючий",
+      "lemmaId": "слідуючий",
+      "sentence": "Слідуючий оратор уже жде свого часу!",
+      "targetForm": "Слідуючий",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0071",
+        "title": "Сторінка 52"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "слідуючий",
+      "lemmaId": "слідуючий",
+      "sentence": "Хто там слідуючий?",
+      "targetForm": "слідуючий",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0379",
+        "title": "Сторінка 216"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "сніг",
       "lemmaId": "сніг",
       "sentence": "\u0007Якими фарбами зображено на картині сніг, небо, дерева?",
+      "targetForm": "сніг",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0067",
+        "title": "Сторінка 69"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сніг",
+      "lemmaId": "сніг",
+      "sentence": "\u0007Як зображено сніг, осяяний сонцем?",
+      "targetForm": "сніг",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0067",
+        "title": "Сторінка 69"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сніг",
+      "lemmaId": "сніг",
+      "sentence": "Сипле, сипле, сипле сніг...",
       "targetForm": "сніг",
       "cefr": "A1",
       "uses": [
@@ -4623,6 +13683,46 @@
       }
     },
     {
+      "lemma": "сорок",
+      "lemmaId": "сорок",
+      "sentence": "Про походження числівника сорок відомо кілька гіпотез.",
+      "targetForm": "сорок",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0164",
+        "title": "Сторінка 161"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сорок",
+      "lemmaId": "сорок",
+      "sentence": "404 Провідміняйте словосполучення сорок сторінок, дев’яносто будинків, сто учасників.",
+      "targetForm": "сорок",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0164",
+        "title": "Сторінка 161"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "спитати",
       "lemmaId": "спитати",
       "sentence": "Міжбанківський валютний ринок (міжбанк) Можете спитати в батьків чи в дорослих, яким довіряєте, як вам купити 100 доларів.",
@@ -4643,9 +13743,69 @@
       }
     },
     {
+      "lemma": "спитати",
+      "lemmaId": "спитати",
+      "sentence": "Передній ангел дивився прямо на Галю, ніби хотів спитати, чого вона прийшла.",
+      "targetForm": "спитати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0254",
+        "title": "Сторінка 192"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спитати",
+      "lemmaId": "спитати",
+      "sentence": "сказати сфотографувати спитати стемніти схитрити Знайди ці букви у словесній формулі кафе «Птах».",
+      "targetForm": "спитати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-1_s0086",
+        "title": "Сторінка 88"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "споживач",
       "lemmaId": "споживач",
       "sentence": "Споживач в економіці 51 кожного додаткового літра значно зменшу­ ється, а кожний додатковий карат алмаза збільшує корисність коштовностей.",
+      "targetForm": "Споживач",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0098",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "споживач",
+      "lemmaId": "споживач",
+      "sentence": "Ми уже визначали, що в умовах ринко­ вої економіки споживач робить вибір із по­ зиції обмеженості свого доходу.",
       "targetForm": "споживач",
       "cefr": "A2",
       "uses": [
@@ -4656,6 +13816,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ekonomika-krupska-2018_s0098",
         "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "споживач",
+      "lemmaId": "споживач",
+      "sentence": "Набір товарів, який ку­ пує споживач, називається ринковим спо­ живчим кошиком.",
+      "targetForm": "споживач",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0098",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спортивний",
+      "lemmaId": "спортивний",
+      "sentence": "Стилі одягу: класичний, спортивний, романтичний, діловий, кежуал, вінтаж, готичний… 3.",
+      "targetForm": "спортивний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0231",
+        "title": "Сторінка 226"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4683,6 +13883,26 @@
       }
     },
     {
+      "lemma": "спортивний",
+      "lemmaId": "спортивний",
+      "sentence": "Ти такий спортивний!",
+      "targetForm": "спортивний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-1-00-lesson-notes_l0028_w006",
+        "title": "Lesson 28: Making plans + Future tense in Ukrainian (part 6/8)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "спостереження",
       "lemmaId": "спостереження",
       "sentence": "Пост радіаційного та хімічного спостереження встановлюють на території об’єкта недалеко від пункту управління.",
@@ -4696,6 +13916,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0326",
         "title": "Сторінка 176"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спостереження",
+      "lemmaId": "спостереження",
+      "sentence": "29 НУМО ДОСЛІДЖУВАТИ ЯК СПЛАНУВАТИ І ВИКОНАТИ СПОСТЕРЕЖЕННЯ Завдання.",
+      "targetForm": "СПОСТЕРЕЖЕННЯ",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0028",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спостереження",
+      "lemmaId": "спостереження",
+      "sentence": "Ознайомитись, як за наданим планом виконати спостереження за забарвленням листків рослин восени.",
+      "targetForm": "спостереження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0028",
+        "title": "Сторінка 29"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4723,6 +13983,46 @@
       }
     },
     {
+      "lemma": "стадіон",
+      "lemmaId": "стадіон",
+      "sentence": "Стадіон ревів як несамовитий.",
+      "targetForm": "Стадіон",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0388",
+        "title": "Сторінка 236"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стадіон",
+      "lemmaId": "стадіон",
+      "sentence": "Стадіон заворожено принишк.",
+      "targetForm": "Стадіон",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0388",
+        "title": "Сторінка 236"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "стажування",
       "lemmaId": "стажування",
       "sentence": "Учасники наукового стажування отримали престижну премію.",
@@ -4736,6 +14036,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-6-00-lesson-notes_l0210_w027",
         "title": "Lesson 210: Питання-відповіді: частина друга (part 27/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стажування",
+      "lemmaId": "стажування",
+      "sentence": "Ще дитиною він вступив у знамениту Паризьку консерваторію, після закінчення якої був удостоєний премії для стажування в Італії.",
+      "targetForm": "стажування",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-mystetstvo-masol-2024_s0041",
+        "title": "Сторінка 42"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стажування",
+      "lemmaId": "стажування",
+      "sentence": "Після стажування в Італії С.",
+      "targetForm": "стажування",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0225",
+        "title": "Сторінка 201"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4763,6 +14103,46 @@
       }
     },
     {
+      "lemma": "стілець",
+      "lemmaId": "стілець",
+      "sentence": "Вона вже геть знесилилася й сіла на стілець, що невідомо звідки взявся в коридорі.",
+      "targetForm": "стілець",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-avramenko-2022_s0249",
+        "title": "Сторінка 230"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стілець",
+      "lemmaId": "стілець",
+      "sentence": "Вона швиденько встала — і стілець зник!",
+      "targetForm": "стілець",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-avramenko-2022_s0249",
+        "title": "Сторінка 230"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "сума",
       "lemmaId": "сума",
       "sentence": "Знайдіть ймовірність того, що: 1) його куб менший за 8000; 2) сума квадратів його цифр менша за 20.",
@@ -4776,6 +14156,46 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-algebra-ister-2019-prof_s0251",
         "title": "Сторінка 243"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сума",
+      "lemmaId": "сума",
+      "sentence": "17.32.•• Чи може сума яких-небудь п’яти послідовних членів арифметичної прогресії 3, 7, 11, ...",
+      "targetForm": "сума",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-algebra-merzliak-2017_s0170",
+        "title": "Сторінка 171"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сума",
+      "lemmaId": "сума",
+      "sentence": "17.33.•• Чи може сума яких-небудь чотирьох послідовних членів арифметичної прогресії 2, 8, 14, ...",
+      "targetForm": "сума",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-algebra-merzliak-2017_s0170",
+        "title": "Сторінка 171"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4803,6 +14223,46 @@
       }
     },
     {
+      "lemma": "сумка",
+      "lemmaId": "сумка",
+      "sentence": "Омріяна сумка не з’явилася в її руках, Бондаренко зі своїми служками не вибігла з крамниці зі словами прокляття.",
+      "targetForm": "сумка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0298",
+        "title": "Сторінка 194"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сумка",
+      "lemmaId": "сумка",
+      "sentence": "А сумка...» Чи кожній людині допоможе магічний набір «Успіх»?",
+      "targetForm": "сумка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0296",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "сумніватися",
       "lemmaId": "сумніватися",
       "sentence": "(сумніватися) в тому, що я кажу правду?",
@@ -4823,9 +14283,89 @@
       }
     },
     {
+      "lemma": "сумніватися",
+      "lemmaId": "сумніватися",
+      "sentence": "(пишатися) мною, я в цьому не (сумніватися).",
+      "targetForm": "сумніватися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0109_w015",
+        "title": "Lesson 109: На побаченні On a date Reflexive verbs (part 15/18)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сумніватися",
+      "lemmaId": "сумніватися",
+      "sentence": "Стояти на розпутті — вагатися, сумніватися.",
+      "targetForm": "сумніватися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0308",
+        "title": "Сторінка 220"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "суспільство",
       "lemmaId": "суспільство",
       "sentence": "Сутність громадянського суспільства та його інститути Чим відрізняється громадянське суспільство від суспільства?",
+      "targetForm": "суспільство",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0071",
+        "title": "Сторінка 34"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "суспільство",
+      "lemmaId": "суспільство",
+      "sentence": "Звісно, вони не тотожні, адже громадянське суспільство різниться від загалом людського суспільства певними якісними ознаками.",
+      "targetForm": "суспільство",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0071",
+        "title": "Сторінка 34"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "суспільство",
+      "lemmaId": "суспільство",
+      "sentence": "Тобто громадянське суспільство означає стан упорядкування суспільства в інтересах кожної людини.",
       "targetForm": "суспільство",
       "cefr": "A1",
       "uses": [
@@ -4863,6 +14403,46 @@
       }
     },
     {
+      "lemma": "сусід",
+      "lemmaId": "сусід",
+      "sentence": "І той сусід сказав тоді у тиші: – Панове судді!",
+      "targetForm": "сусід",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0262",
+        "title": "Сторінка 164"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сусід",
+      "lemmaId": "сусід",
+      "sentence": "І сірий був сусід.",
+      "targetForm": "сусід",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-avramenko-2024_s0125",
+        "title": "Сторінка 99"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "схвалено",
       "lemmaId": "схвалено",
       "sentence": "Верховною Радою схвалено «Основні напрями зовнішньої політики України»; – 5 грудня 1994 р.",
@@ -4883,10 +14463,50 @@
       }
     },
     {
+      "lemma": "схвалено",
+      "lemmaId": "схвалено",
+      "sentence": "Водночас схвалено угоду про створення Співдружності Незалежних Держав (СНД).",
+      "targetForm": "схвалено",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0386",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "схвалено",
+      "lemmaId": "схвалено",
+      "sentence": "Однак не було схвалено Державний бюджет й основи економічної політики.",
+      "targetForm": "схвалено",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-istorija-ukrajiny-gisem-2018_s0069",
+        "title": "Сторінка 40"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "схильний",
       "lemmaId": "схильний",
       "sentence": "Схильний, охочий що-небудь робити; готовий до певних учинків; згоден на певну дію, стан.",
-      "targetForm": "схильний",
+      "targetForm": "Схильний",
       "cefr": "A2",
       "uses": [
         "example"
@@ -4903,10 +14523,10 @@
       }
     },
     {
-      "lemma": "сцена",
-      "lemmaId": "сцена",
-      "sentence": "(Лиховісно сміється.) СЦЕНА 3 Покої в королівському палаці.",
-      "targetForm": "сцена",
+      "lemma": "схильний",
+      "lemmaId": "схильний",
+      "sentence": "1 Суєсл.ов – пустобрех; той, що схильний до довгих, беззмістовних розмов.",
+      "targetForm": "схильний",
       "cefr": "A2",
       "uses": [
         "example"
@@ -4914,8 +14534,88 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0060",
-        "title": "Сторінка 62"
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0321",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "схильний",
+      "lemmaId": "схильний",
+      "sentence": "157 НОВА УКРАЇНСЬКА ЛІТЕРАТУРА Романтичний герой схильний до бурхливих почувань, пристрастей, емоцій.",
+      "targetForm": "схильний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-mishhenko-2017_s0267",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сцена",
+      "lemmaId": "сцена",
+      "sentence": "Сцена з вистави «Лускунчик».",
+      "targetForm": "Сцена",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0122",
+        "title": "Сторінка 75"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сцена",
+      "lemmaId": "сцена",
+      "sentence": "150 Сцена з балету К.",
+      "targetForm": "Сцена",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0150",
+        "title": "Сторінка 150"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сцена",
+      "lemmaId": "сцена",
+      "sentence": "Данькевича «Лілея» Сцена з балету М.",
+      "targetForm": "Сцена",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0150",
+        "title": "Сторінка 150"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -4943,9 +14643,89 @@
       }
     },
     {
+      "lemma": "сценарій",
+      "lemmaId": "сценарій",
+      "sentence": "Використовуючи матеріали Інтернету, розробіть сценарій відео фільму про оперного співака Василя Сліпака.",
+      "targetForm": "сценарій",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0206",
+        "title": "Сторінка 181"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сценарій",
+      "lemmaId": "сценарій",
+      "sentence": "Сценарій збережіть у вашій папці у файлі з іменем завдання 4.3.1.docx.",
+      "targetForm": "Сценарій",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0206",
+        "title": "Сторінка 181"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "телебачення",
+      "lemmaId": "телебачення",
+      "sentence": "Жанрова система сучасного телебачення достатньо різноманітна.",
+      "targetForm": "телебачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0184",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "телебачення",
       "lemmaId": "телебачення",
       "sentence": "До яких жанрів телебачення вони належать?",
+      "targetForm": "телебачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0184",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "телебачення",
+      "lemmaId": "телебачення",
+      "sentence": "Невід’ємною складовою сучасного телебачення є телевізійне кіно: анімаційні, неігрові та ігрові короткометражні фільми, телевізійні фільми, серіали.",
       "targetForm": "телебачення",
       "cefr": "B1",
       "uses": [
@@ -4983,10 +14763,10 @@
       }
     },
     {
-      "lemma": "тема",
-      "lemmaId": "тема",
-      "sentence": "ПОВЕРНЕННЯ ДО ІДЕАЛІВ КРАСИ МИНУЛОГО Тема 1 5 -1 6 .",
-      "targetForm": "тема",
+      "lemma": "телефонувати",
+      "lemmaId": "телефонувати",
+      "sentence": "(ви) можна телефонувати варто (я) зателефонувати.",
+      "targetForm": "телефонувати",
       "cefr": "A1",
       "uses": [
         "example"
@@ -4994,8 +14774,88 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "9-klas-mystetstvo-masol-2017_s0002",
-        "title": "Сторінка 4"
+        "locator": "ulp-2-00-lesson-notes_l0053_w007",
+        "title": "Lesson 53: Соціальні мережі Давальний відмінок Social media Dative case (part 7/9)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "телефонувати",
+      "lemmaId": "телефонувати",
+      "sentence": "Так, знаю я, що мамі й тату Теж можуть телефонувати.",
+      "targetForm": "телефонувати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "1-klas-bukvar-bolshakova-2018-2_s0063",
+        "title": "Сторінка 64"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "240 УРОКИ РОЗВИТКУ МОВЛЕННЯ Тема 1.",
+      "targetForm": "Тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-zabolotnyi-2023_s0244",
+        "title": "Сторінка 243"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "221 УРОКИ РОЗВИТКУ МОВЛЕННЯ Тема 1.",
+      "targetForm": "Тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0262",
+        "title": "Сторінка 254"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "239 Тема 10 Будова опису приміщення .............................................",
+      "targetForm": "Тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0262",
+        "title": "Сторінка 254"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5006,6 +14866,26 @@
       "lemma": "тест",
       "lemmaId": "тест",
       "sentence": "Тест — це слово, яке часто має негативну конотацію.",
+      "targetForm": "Тест",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0178_w007",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 7/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тест",
+      "lemmaId": "тест",
+      "sentence": "Насправді українською мовою, коли ми говоримо слово «тест», то зазвичай уявляємо собі питання і варіанти відповідей.",
       "targetForm": "тест",
       "cefr": "A1",
       "uses": [
@@ -5023,9 +14903,29 @@
       }
     },
     {
+      "lemma": "тест",
+      "lemmaId": "тест",
+      "sentence": "І останнє речення також було про ЗНО: Це чесний і справедливий тест, результати якого неможливо підробити.",
+      "targetForm": "тест",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0188_w020",
+        "title": "Lesson 188: Шкільна система в Україні (part 20/28)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "тестувати",
       "lemmaId": "тестувати",
-      "sentence": "У процесі здійснення тест-дизайну тест-аналітик визначає, ЩО тестувати, а тест-дизайнер — ЯК тестувати.",
+      "sentence": "Також хочу нагадати, що ви можете використовувати наші преміум-матеріали для того, щоб відтворювати, тестувати себе і практикуватися.",
       "targetForm": "тестувати",
       "cefr": "B1",
       "uses": [
@@ -5034,8 +14934,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "11-klas-informatyka-rudenko-2019_s0388",
-        "title": "Сторінка 249"
+        "locator": "ulp-5-00-lesson-notes_l0178_w022",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 22/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тестувати",
+      "lemmaId": "тестувати",
+      "sentence": "На яких тестових наборах вхідних даних доцільно тестувати проєкт із циклом з лічильником?",
+      "targetForm": "тестувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0223",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тестувати",
+      "lemmaId": "тестувати",
+      "sentence": "Таке моделювання умов досліджуваної планети допомагає вченим і конструкторам тестувати обладнання.",
+      "targetForm": "тестувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0135",
+        "title": "Сторінка 137"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5045,7 +14985,47 @@
     {
       "lemma": "тисяча",
       "lemmaId": "тисяча",
-      "sentence": "(на) тисяча дев’ятсот сьомому Кожен компонент складеного числівника відмінюється за своїм правилом.",
+      "sentence": "тисяча дев’ятсот сьомий Р.",
+      "targetForm": "тисяча",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0054",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тисяча",
+      "lemmaId": "тисяча",
+      "sentence": "тисяча дев’ятсот сьомого Д.",
+      "targetForm": "тисяча",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0054",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тисяча",
+      "lemmaId": "тисяча",
+      "sentence": "тисяча дев’ятсот сьомому Зн.",
       "targetForm": "тисяча",
       "cefr": "A1",
       "uses": [
@@ -5083,6 +15063,46 @@
       }
     },
     {
+      "lemma": "тихо",
+      "lemmaId": "тихо",
+      "sentence": "Відповідно, тут земля «дихає тихо і легко у синяву».",
+      "targetForm": "тихо",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0226_w011",
+        "title": "Lesson 226: Українська поезія. Володимир Сосюра «Так ніхто не кохав» (part 11/31)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тихо",
+      "lemmaId": "тихо",
+      "sentence": "Біля озера стало тихо: відлетіли останні качки.",
+      "targetForm": "тихо",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0239",
+        "title": "Сторінка 160"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "тканина",
       "lemmaId": "тканина",
       "sentence": "Скелетна м’язова тканина утворює скелетні м’язи, язик тощо.",
@@ -5096,6 +15116,86 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-biolohiya-anderson-2025_s0014",
         "title": "Сторінка 13"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тканина",
+      "lemmaId": "тканина",
+      "sentence": "Посмугована серцева тканина утворена поодинокими клітинами — кардіоміоцитами, внутрішній уміст яких організовано подібно до скелетних м’язових волокон.",
+      "targetForm": "тканина",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0014",
+        "title": "Сторінка 13"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тканина",
+      "lemmaId": "тканина",
+      "sentence": "Гладенька м’язова тканина складена з веретеноподібних клітин — міоцитів.",
+      "targetForm": "тканина",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0014",
+        "title": "Сторінка 13"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "товариський",
+      "lemmaId": "товариський",
+      "sentence": "Життєрадісний і товариський, але водночас надзвичайно скромний.",
+      "targetForm": "товариський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-zabolotnyi-2023_s0167",
+        "title": "Сторінка 167"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "товариський",
+      "lemmaId": "товариський",
+      "sentence": "Наприклад: товариський, празький, донецький.",
+      "targetForm": "товариський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0072",
+        "title": "Сторінка 74"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5143,6 +15243,46 @@
       }
     },
     {
+      "lemma": "точний",
+      "lemmaId": "точний",
+      "sentence": "Однак хронологія дає змогу встановити точний час подій відповідно до сучасних уявлень про вимірювання часу.",
+      "targetForm": "точний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0053",
+        "title": "Сторінка 55"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "точний",
+      "lemmaId": "точний",
+      "sentence": "Уболівальник 2 скоротити Б текст точний рахунок матчу і виграв майже 50 (недок.",
+      "targetForm": "точний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0095_w011",
+        "title": "Lesson 95: Моє життя в Києві (Голосове повідомлення №3) My life in Kyiv (Voice message №3) (part 11/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "трава",
       "lemmaId": "трава",
       "sentence": "трава́ grass Ми лежимо́ на траві́ в па́рку.",
@@ -5163,9 +15303,89 @@
       }
     },
     {
+      "lemma": "трава",
+      "lemmaId": "трава",
+      "sentence": "Речення номер два: Ліворуч було поле, праворуч – лише трава та квіти.",
+      "targetForm": "трава",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w014",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 14/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "трава",
+      "lemmaId": "трава",
+      "sentence": "Ліворуч було поле (field), праворуч ― розмо́вний — colloquial, conversational лише трава та квіти (grass and flowers).",
+      "targetForm": "трава",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w014",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 14/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "традиція",
+      "lemmaId": "традиція",
+      "sentence": "І останнє речення про традицію купання взимку на Водохреще: Ця традиція не для боягузів.",
+      "targetForm": "традиція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w017",
+        "title": "Lesson 173: Зимовий цикл свят (part 17/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "традиція",
       "lemmaId": "традиція",
       "sentence": "А от традиція купання в боягу́з — coward холодній воді не для боягузів, не для тих, хто боїться, так?",
+      "targetForm": "традиція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w017",
+        "title": "Lesson 173: Зимовий цикл свят (part 17/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "традиція",
+      "lemmaId": "традиція",
+      "sentence": "Повторіть: Ця традиція не для боягузів.",
       "targetForm": "традиція",
       "cefr": "A1",
       "uses": [
@@ -5203,6 +15423,46 @@
       }
     },
     {
+      "lemma": "тричі",
+      "lemmaId": "тричі",
+      "sentence": "Таким чином, ви зможете завантажувати нові уроки щосереди́ — every Wednesday тричі на тиждень ― через день.",
+      "targetForm": "тричі",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0161_w012",
+        "title": "Lesson 161: Як у мене справи і що нового в Ukrainian Lessons (part 12/28)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тричі",
+      "lemmaId": "тричі",
+      "sentence": "Прочитай скоромовку тричі: повільно, швидко, дуже швидко.",
+      "targetForm": "тричі",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "1-klas-bukvar-zaharijchuk-2025-2_s0011",
+        "title": "Сторінка 12"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "тротуар",
       "lemmaId": "тротуар",
       "sentence": "УÑÅ заметено снігом: тротуар, дорога, стадіон.",
@@ -5216,6 +15476,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-ukrmova-zabolotnyi-2025_s0192",
         "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тротуар",
+      "lemmaId": "тротуар",
+      "sentence": "Тротуар, дорога, стадіон – УÑÅ заметено снігом.",
+      "targetForm": "Тротуар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-zabolotnyi-2025_s0192",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тротуар",
+      "lemmaId": "тротуар",
+      "sentence": "Не знаю, – сказала вона, тоді озирну­ лась на тротуар, що вів до їхніх будинків.",
+      "targetForm": "тротуар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0455",
+        "title": "Сторінка 253"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5243,10 +15543,70 @@
       }
     },
     {
+      "lemma": "трохи",
+      "lemmaId": "трохи",
+      "sentence": "За командою «Ліворуч — РІВНЯЙСЬ» усі, крім лівофлангового, повертають голову ліворуч (ліве вухо вище від правого, підборіддя трохи підняте).",
+      "targetForm": "трохи",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0215",
+        "title": "Сторінка 113"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "трохи",
+      "lemmaId": "трохи",
+      "sentence": "Під час рівняння військовослужбовці можуть трохи пересуватися вперед, назад або в той чи інший бік.",
+      "targetForm": "трохи",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0215",
+        "title": "Сторінка 113"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "туалет",
+      "lemmaId": "туалет",
+      "sentence": "На фото зображений римський туалет посеред пральні.",
+      "targetForm": "туалет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-pryrodnychi-nauky-mandrenko-2025_s0051",
+        "title": "Сторінка 46"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "туалет",
       "lemmaId": "туалет",
       "sentence": "Туалет • Не куріть, не шуміть, не запалюйте свічки без дозволу відповідальної особи.",
-      "targetForm": "туалет",
+      "targetForm": "Туалет",
       "cefr": "A1",
       "uses": [
         "example"
@@ -5256,6 +15616,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-zdorovia-vasylenko-2025_s0024",
         "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "туалет",
+      "lemmaId": "туалет",
+      "sentence": "Туалет ротової порожнини Іл.",
+      "targetForm": "Туалет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0228",
+        "title": "Сторінка 124"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тістечко",
+      "lemmaId": "тістечко",
+      "sentence": "Тістечко, цукерки, морозиво, шоколад — це ласощі.",
+      "targetForm": "Тістечко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-1_s0051",
+        "title": "Сторінка 52"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5283,6 +15683,26 @@
       }
     },
     {
+      "lemma": "тістечко",
+      "lemmaId": "тістечко",
+      "sentence": "вершки тістечко полуничка збивати вершки набір тістечок три полунички А.",
+      "targetForm": "тістечко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0147",
+        "title": "Сторінка 143"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "удома",
       "lemmaId": "удома",
       "sentence": "Бояри та представники знаті винаймали для своїх дітей приватних учителів, які навчали їх удома.",
@@ -5303,10 +15723,90 @@
       }
     },
     {
+      "lemma": "удома",
+      "lemmaId": "удома",
+      "sentence": "сЛова — назви ДІЙ Що ти робиш у школі, удома, на вулиці?",
+      "targetForm": "удома",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0054",
+        "title": "Сторінка 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "удома",
+      "lemmaId": "удома",
+      "sentence": "У школі Удома на вулиці Редагуємо • Постав наголос у кожному слові.",
+      "targetForm": "Удома",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0054",
+        "title": "Сторінка 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "узимку",
       "lemmaId": "узимку",
       "sentence": "Узимку – пом’якшує морози, приносить снігопади, відлиги.",
-      "targetForm": "узимку",
+      "targetForm": "Узимку",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0114",
+        "title": "Сторінка 82"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "узимку",
+      "lemmaId": "узимку",
+      "sentence": "Улітку – зменшує спеку, підвищує вологість, приносить опади Узимку – ясна і морозна погода.",
+      "targetForm": "Узимку",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0114",
+        "title": "Сторінка 82"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "узимку",
+      "lemmaId": "узимку",
+      "sentence": "Улітку – суха, ясна та спекотна погода Узимку – різке потепління.",
+      "targetForm": "Узимку",
       "cefr": "B1",
       "uses": [
         "example"
@@ -5325,7 +15825,47 @@
     {
       "lemma": "фінал",
       "lemmaId": "фінал",
+      "sentence": "Нескінченний простір, холод і темрява — ось неминучий фінал такого Всесвіту.",
+      "targetForm": "фінал",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0416",
+        "title": "Сторінка 258"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "фінал",
+      "lemmaId": "фінал",
       "sentence": "У першому виданні твір мав відкритий фінал: груша розросталася, а сварки не припинялись.",
+      "targetForm": "фінал",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0051",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "фінал",
+      "lemmaId": "фінал",
+      "sentence": "Який фінал, на вашу думку, є більш реалістичним?",
       "targetForm": "фінал",
       "cefr": "A1",
       "uses": [
@@ -5363,10 +15903,50 @@
       }
     },
     {
+      "lemma": "фінальний",
+      "lemmaId": "фінальний",
+      "sentence": "Фінальний прототип містить опис елементів у зонах з їхнім призначеннням і зв’язками з іншими елементами.",
+      "targetForm": "Фінальний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0379",
+        "title": "Сторінка 244"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "фінальний",
+      "lemmaId": "фінальний",
+      "sentence": "postgraduate studies (by old system in Ukraine) А захист дисертації — це фінальний етап навчання на докторантурі, коли людина здобуває науковий ступінь.",
+      "targetForm": "фінальний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0158_w009",
+        "title": "Lesson 158: Іван Франко — Великий Каменяр (part 9/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "ходить",
       "lemmaId": "ходить",
       "sentence": "Ходить сон стежками лісовими.",
-      "targetForm": "ходить",
+      "targetForm": "Ходить",
       "cefr": "A1",
       "uses": [
         "example"
@@ -5383,9 +15963,49 @@
       }
     },
     {
+      "lemma": "ходить",
+      "lemmaId": "ходить",
+      "sentence": "Ходить сонце у крисані, спить слов’янськеє Дитя.",
+      "targetForm": "Ходить",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0092",
+        "title": "Сторінка 49"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ходить",
+      "lemmaId": "ходить",
+      "sentence": "Хлопчик ходить понад річку, поглядає на смерічку.",
+      "targetForm": "ходить",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchuk-2020-2_s0028",
+        "title": "Сторінка 30"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "цвісти",
       "lemmaId": "цвісти",
-      "sentence": "Цвісти або процвітати можуть квіти, коли вони розкриваються, цвісти́ — to bloom, to blossom квіти стають такі гарні квіти.",
+      "sentence": "І квіткою й калиною цвісти над ними буду щоб не пекло чуже сонце не топтали люди (Т.",
       "targetForm": "цвісти",
       "cefr": "B1",
       "uses": [
@@ -5394,8 +16014,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "ulp-5-00-lesson-notes_l0199_w023",
-        "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 23/33)"
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0296",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "цвісти",
+      "lemmaId": "цвісти",
+      "sentence": "Отак цвісти, отак рости, Так одружитися і йти, Не сварячись в тяжкій дорозі...",
+      "targetForm": "цвісти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-avramenko-2017_s0432",
+        "title": "Сторінка 328"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "цвісти",
+      "lemmaId": "цвісти",
+      "sentence": "дія відбувається в момент мовлення (під час повідом­ лення, зараз) теперішній зацвіте (цвістиме, буде цвісти) що зробить?",
+      "targetForm": "цвісти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrmova-zaharijchuk_s0143",
+        "title": "Сторінка 144"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5423,6 +16083,46 @@
       }
     },
     {
+      "lemma": "часовий",
+      "lemmaId": "часовий",
+      "sentence": "Період нарахування — часовий інтервал для відсоткової ставки (може бути день, місяць або рік).",
+      "targetForm": "часовий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-informatika-rudenko-2018-stand_s0075",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "часовий",
+      "lemmaId": "часовий",
+      "sentence": "Під простим відсотком мають на увазі прибуток, який нараховується лише на початкову суму за кожен певний часовий проміжок.",
+      "targetForm": "часовий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-informatika-rudenko-2018-stand_s0074",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "червень",
       "lemmaId": "червень",
       "sentence": "Послухайте ще один уривочок про червень в Україні.",
@@ -5436,6 +16136,46 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-5-00-lesson-notes_l0185_w010",
         "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 10/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "червень",
+      "lemmaId": "червень",
+      "sentence": "сіє́ста — siesta Цей червень був дуже спекотний.",
+      "targetForm": "червень",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w010",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 10/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "червень",
+      "lemmaId": "червень",
+      "sentence": "операція «Вісла» червень 1956 р.",
+      "targetForm": "червень",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-vsesvit-schupak-2024_s0205",
+        "title": "Сторінка 112"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5463,10 +16203,90 @@
       }
     },
     {
+      "lemma": "чомусь",
+      "lemmaId": "чомусь",
+      "sentence": "Чомусь одвернувшись, Ів стиха почав: Ми побачили те, що станеться в дуже далекому майбутньому...",
+      "targetForm": "Чомусь",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0346",
+        "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чомусь",
+      "lemmaId": "чомусь",
+      "sentence": "Так, дехто українською мовою поділи́тися — to share чомусь називає подкаст словом підкаст.",
+      "targetForm": "чомусь",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0172_w005",
+        "title": "Lesson 172: Українськомовні подкасти (part 5/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "чорна",
       "lemmaId": "чорна",
       "sentence": "ПІДНЯТИСЯ НАД БУДЕННІСТЮ здивувати», – повідомляли губи світу, доки Чорна Пані мовчки роздивлялася Софійку.",
-      "targetForm": "чорна",
+      "targetForm": "Чорна",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0372",
+        "title": "Сторінка 250"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чорна",
+      "lemmaId": "чорна",
+      "sentence": "Чорна Пані гойднулася на підборах уперед-назад і різко розвернулася.",
+      "targetForm": "Чорна",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0372",
+        "title": "Сторінка 250"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чорна",
+      "lemmaId": "чорна",
+      "sentence": "запитала Чорна Пані, нахилившись до хлопчика.",
+      "targetForm": "Чорна",
       "cefr": "A1",
       "uses": [
         "example"
@@ -5486,7 +16306,7 @@
       "lemma": "чорні",
       "lemmaId": "чорні",
       "sentence": "Чорні клобуки часом повставали або відходили в степ, відмовляючись нести службу.",
-      "targetForm": "чорні",
+      "targetForm": "Чорні",
       "cefr": "A1",
       "uses": [
         "example"
@@ -5503,10 +16323,50 @@
       }
     },
     {
+      "lemma": "чорні",
+      "lemmaId": "чорні",
+      "sentence": "Дві верхні чорні цятки – ніби 1 «Усѕ помил ѕ яються» – ко медія англійського драматурга Артура Мерфі (1727–1805).",
+      "targetForm": "чорні",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zarlit-voloschuk-2024_s0280",
+        "title": "Сторінка 196"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чорні",
+      "lemmaId": "чорні",
+      "sentence": "Чорне волосся на голові, чорні рівні брови дуже виразно блищали на білій свиті.",
+      "targetForm": "чорні",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-avramenko-2025_s0239",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "чіпати",
       "lemmaId": "чіпати",
       "sentence": "Чіпати і їсти їх не (дозволятися).",
-      "targetForm": "чіпати",
+      "targetForm": "Чіпати",
       "cefr": "A2",
       "uses": [
         "example"
@@ -5523,9 +16383,49 @@
       }
     },
     {
+      "lemma": "чіпати",
+      "lemmaId": "чіпати",
+      "sentence": "Якщо її довго не чіпати, сміттячком зверху добре вкутати, то й народжується хлопчик-нехайко.",
+      "targetForm": "чіпати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0048",
+        "title": "Сторінка 50"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чіпати",
+      "lemmaId": "чіпати",
+      "sentence": "Не треба було чіпати моркви.",
+      "targetForm": "чіпати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0282",
+        "title": "Сторінка 171"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "швидкий",
       "lemmaId": "швидкий",
-      "sentence": "Згодом розпочався «промисловий» бум – швидкий розвиток вторинного сектору економіки: металургії, машинобудування, хімічної промисловості.",
+      "sentence": "Гомінка, швидкий, голосна, стрімка.",
       "targetForm": "швидкий",
       "cefr": "A1",
       "uses": [
@@ -5534,8 +16434,48 @@
       "provenance": {
         "source": "textbook",
         "label": "Ukrainian school textbook",
-        "locator": "9-klas-geografiia-boiko-2026_s0548",
-        "title": "Сторінка 289"
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-1_s0055",
+        "title": "Сторінка 57"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "швидкий",
+      "lemmaId": "швидкий",
+      "sentence": "Довідка синоніми антоніми Слова швидкий — стрімкий ?",
+      "targetForm": "швидкий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-1_s0055",
+        "title": "Сторінка 57"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "швидкий",
+      "lemmaId": "швидкий",
+      "sentence": "Хмельницького, наділяючи його такими характеристиками: «Козак розторопний у ділах козацьких воєнних і в письмі швидкий».",
+      "targetForm": "швидкий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-avramenko-2017_s0070",
+        "title": "Сторінка 59"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5563,10 +16503,50 @@
       }
     },
     {
+      "lemma": "швидко",
+      "lemmaId": "швидко",
+      "sentence": "Коли сходить сонце, то роса швидко зникає.",
+      "targetForm": "швидко",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0126_w009",
+        "title": "Lesson 126: Державні символи України: гімн (part 9/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "швидко",
+      "lemmaId": "швидко",
+      "sentence": "Роса на сонці зникає моментально, схо́дити — to rise дуже швидко.",
+      "targetForm": "швидко",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0126_w009",
+        "title": "Lesson 126: Державні символи України: гімн (part 9/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "шум",
       "lemmaId": "шум",
       "sentence": "Вони в захваті від ритмів пісні «Шум», яку український гурт «Go A» прославив на співочому конкурсі «Євробачення» у 2021 р.",
-      "targetForm": "шум",
+      "targetForm": "Шум",
       "cefr": "B1",
       "uses": [
         "example"
@@ -5576,6 +16556,66 @@
         "label": "Ukrainian school textbook",
         "locator": "6-klas-ukrlit-avramenko-2023_s0008",
         "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "шум",
+      "lemmaId": "шум",
+      "sentence": "• Підготуйте розповідь про веснянку «Шум», скориставшись відомостями рубрики «До речі» та переглянувши виступ гурту «Go A» на Євробаченні.",
+      "targetForm": "Шум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0008",
+        "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "шум",
+      "lemmaId": "шум",
+      "sentence": "Павленко за основу пісні для конкурсу «Євро­ бачення» взяла старовинну українську пісню «Шум», а композитори І.",
+      "targetForm": "Шум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0008",
+        "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "щодо",
+      "lemmaId": "щодо",
+      "sentence": "Документ Із Конвенції ООН про ліквідацію всіх форм дискримінації щодо жінок (1979 р.) …Стаття 2.",
+      "targetForm": "щодо",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0126",
+        "title": "Сторінка 66"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5603,10 +16643,30 @@
       }
     },
     {
+      "lemma": "щодо",
+      "lemmaId": "щодо",
+      "sentence": "Мати, батько можуть бути позбавлені батьківських прав щодо всіх своїх дітей або когось із них (…).",
+      "targetForm": "щодо",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0457",
+        "title": "Сторінка 238"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "якось",
       "lemmaId": "якось",
       "sentence": "Якось враз знялася курява й завертівся перед­ грозовий вихор.",
-      "targetForm": "якось",
+      "targetForm": "Якось",
       "cefr": "B1",
       "uses": [
         "example"
@@ -5616,6 +16676,46 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-ukrajinska-mova-voron-2017_s0047",
         "title": "Сторінка 40"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "якось",
+      "lemmaId": "якось",
+      "sentence": "Потім знову сідали й сиділи якось надзвичайно недвижно, ніби пильно вдивлялися в мене.",
+      "targetForm": "якось",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-literatura-avramenko-2018_s0363",
+        "title": "Сторінка 192"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "якось",
+      "lemmaId": "якось",
+      "sentence": "Пам’ятаю, село виринуло якось несподівано для мене.",
+      "targetForm": "якось",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-literatura-avramenko-2018_s0363",
+        "title": "Сторінка 192"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5643,6 +16743,46 @@
       }
     },
     {
+      "lemma": "інвалідність",
+      "lemmaId": "інвалідність",
+      "sentence": "Однак вживання допінгів негативно впливає на здоров’я, може спричинити інвалідність чи навіть смерть спортсменів.",
+      "targetForm": "інвалідність",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0099",
+        "title": "Сторінка 100"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інвалідність",
+      "lemmaId": "інвалідність",
+      "sentence": "Художник мав інвалідність, перебував у підпіллі, переховуючись від радянських каральних органів.",
+      "targetForm": "інвалідність",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-gisem-2024_s0085",
+        "title": "Сторінка 47"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "індивідуально",
       "lemmaId": "індивідуально",
       "sentence": "Узагалі одяг добирають індивідуально, охопити всі нюанси і тонкощі тих чи інших видів одягу неможливо.",
@@ -5656,6 +16796,46 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-zakhyst-fuka-2023_s0482",
         "title": "Сторінка 264"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "індивідуально",
+      "lemmaId": "індивідуально",
+      "sentence": "І, бажано, окремо, упаковувати кожну річ індивідуально, у свій мішечок, а не запихати все в один великий пакет.",
+      "targetForm": "індивідуально",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0484",
+        "title": "Сторінка 265"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "індивідуально",
+      "lemmaId": "індивідуально",
+      "sentence": "У цій рубриці ви отримаєте проєктні завдання, щоб виконати їх у групах або індивідуально.",
+      "targetForm": "індивідуально",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0014",
+        "title": "Сторінка 7"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5683,10 +16863,50 @@
       }
     },
     {
+      "lemma": "інтенсивний",
+      "lemmaId": "інтенсивний",
+      "sentence": "Поясніть значення понять: еêстенсивний та інтенсивний методи ãосподарювання, війсьêові поселення, чóмацьêий промисел, промисловий переворот.",
+      "targetForm": "інтенсивний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-burnejko-2017_s0041",
+        "title": "Сторінка 28"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інтенсивний",
+      "lemmaId": "інтенсивний",
+      "sentence": "А зараз просто у мене досить інтенсивний період роботи до́сить ― quite, enough над книгою.",
+      "targetForm": "інтенсивний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0221_w002",
+        "title": "Lesson 221: Українська поезія. Григорій Сковорода «De libertate» (part 2/28)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "інтернет",
       "lemmaId": "інтернет",
       "sentence": "Використавши мережу Skype, організуйте та проведіть інтернет-дискусію на тему «Інтернет у житті сучасного школяра».",
-      "targetForm": "інтернет",
+      "targetForm": "Інтернет",
       "cefr": "A1",
       "uses": [
         "example"
@@ -5696,6 +16916,86 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ukrmova-glazova-2018_s0058",
         "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інтернет",
+      "lemmaId": "інтернет",
+      "sentence": "Обговоріть питання: «Інтернет зближує людей чи поглиблює самотність?» Уживайте лексичні й фразеологічні синоніми та антоніми.",
+      "targetForm": "Інтернет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0058",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інтернет",
+      "lemmaId": "інтернет",
+      "sentence": "Що таке інтернет речей?",
+      "targetForm": "інтернет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0352",
+        "title": "Сторінка 253"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформація",
+      "lemmaId": "інформація",
+      "sentence": "Графічна та числова інформація .........................................",
+      "targetForm": "інформація",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-golub-2022_s0255",
+        "title": "Сторінка 254"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформація",
+      "lemmaId": "інформація",
+      "sentence": "Звукова та мультимедійна інформація ................................",
+      "targetForm": "інформація",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-golub-2022_s0255",
+        "title": "Сторінка 254"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -5736,6 +17036,46 @@
         "label": "Ukrainian school textbook",
         "locator": "8-klas-zdorovia-vasylenko-2025_s0023",
         "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформувати",
+      "lemmaId": "інформувати",
+      "sentence": "Швидко інформувати Вітати зі святами Завтра не буде останнього уроку.",
+      "targetForm": "інформувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-golub-2022_s0211",
+        "title": "Сторінка 212"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформувати",
+      "lemmaId": "інформувати",
+      "sentence": "Інформувати першокласників про важливу подію.",
+      "targetForm": "Інформувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0236",
+        "title": "Сторінка 232"
       },
       "license": {
         "status": "not_openly_licensed",

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1665,6 +1665,36 @@ def test_sentence_inventory_rejects_ambiguous_or_repeated_target_forms(tmp_path:
     assert read_sentence_inventory(inventory_path) == []
 
 
+def test_sentence_inventory_blanks_standalone_form_not_hyphenated_compound(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "sentence-inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema": "atlas-sentence-inventory",
+                "schemaVersion": 1,
+                "rows": [
+                    {
+                        "lemma": "сумка",
+                        "lemmaId": "sumka",
+                        "sentence": "Це сумка, а сумка-пакет лежить поруч.",
+                        "targetForm": "сумка",
+                        "uses": ["example"],
+                        "provenance": {"source": "textbook", "label": "Fixture textbook"},
+                        "license": {"status": "fixture"},
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    candidates = read_sentence_inventory(inventory_path)
+
+    assert len(candidates) == 1
+    assert candidates[0]["sentence"] == "Це ___, а сумка-пакет лежить поруч."
+
+
 def test_cloze_output_preserves_sentence_cefr() -> None:
     cloze = _build()["A1"]["cloze"]["cloze"][0]
 

--- a/tests/test_generate_sentence_inventory.py
+++ b/tests/test_generate_sentence_inventory.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sqlite3
 
+import pytest
+
 from scripts.audit.generate_sentence_inventory import (
     build_inventory,
     load_daily_lemmas,
@@ -64,6 +66,64 @@ def test_ulp_provenance_never_exposes_private_locator(tmp_path) -> None:
     assert rows[0]["provenance"] == {"source": "ulp", "label": "Ukrainian Lessons Podcast"}
     assert "private-local-id" not in json.dumps(rows, ensure_ascii=False)
     assert "Private title" not in json.dumps(rows, ensure_ascii=False)
+
+
+def test_inventory_can_keep_multiple_unique_sentences_per_lemma(tmp_path) -> None:
+    db = _sources_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        INSERT INTO textbooks VALUES (
+            2,
+            'grade-1-p-5',
+            'Grade 1',
+            'Ми часто говоримо про Україну, але живемо в Україні.'
+        );
+        INSERT INTO textbooks_fts(rowid, title, text) VALUES (
+            2,
+            'Grade 1',
+            'Ми часто говоримо про Україну, але живемо в Україні.'
+        );
+        INSERT INTO textbooks VALUES (
+            3,
+            'grade-1-p-6',
+            'Grade 1',
+            'Україні добре, коли діти читають українською.'
+        );
+        INSERT INTO textbooks_fts(rowid, title, text) VALUES (
+            3,
+            'Grade 1',
+            'Україні добре, коли діти читають українською.'
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    rows = build_inventory(
+        [{"lemma": "Україні", "lemmaId": "ukraini", "cefr": "A1"}],
+        db,
+        max_per_lemma=2,
+    )
+
+    assert len(rows) == 2
+    assert len({row["sentence"] for row in rows}) == 2
+    assert {row["sentence"] for row in rows} <= {
+        "Ми живемо в Україні.",
+        "Ми часто говоримо про Україну, але живемо в Україні.",
+        "Україні добре, коли діти читають українською.",
+    }
+    assert all(row["targetForm"] == "Україні" for row in rows)
+    assert {row["provenance"]["locator"] for row in rows} <= {
+        "grade-1-p-4",
+        "grade-1-p-5",
+        "grade-1-p-6",
+    }
+
+
+def test_inventory_rejects_non_positive_sentence_cap(tmp_path) -> None:
+    with pytest.raises(ValueError, match="max_per_lemma"):
+        build_inventory([], _sources_db(tmp_path), max_per_lemma=0)
 
 
 def test_daily_lemmas_and_written_schema(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Scale public sentence inventory so practice cloze can grow beyond post-#6179 levels.

### Tool-backed counts (worker worktree)

| Metric | Before | After |
| --- | ---: | ---: |
| Inventory raw rows | **287** | **854** |
| A1 cloze (regen) | **121** | **261** |
| A2 cloze | **74** | **219** |
| B1 cloze | **75** | **223** |
| Cloze total (A1–B1) | **270** | **703** |

All inventory rows source-backed with blanks. Dry-run publish version `atlas-practice-v1-52e8343fac622b09`.

Still not full A1 practice-lexeme coverage (~1467); residual is more public sentences / sources.

## Changes
- `scripts/audit/generate_sentence_inventory.py` expansion
- `site/src/data/lexicon-sentence-inventory.json`
- Tests + small practice-deck glue

## Test plan
- [x] Worker: 102 tests, ruff, OPSEC, trailer
- [ ] CI
- [ ] CF
- [ ] After merge: practice-deck + publish for live hydrate

Refs #6141 #6132 #4387 #6134