### PR TITLE
feat(entire-context): public LLM recall and ACP provenance (#6183)

### DIFF
--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: entire-context
+description: Provider-neutral recall over the public body-free context-link index (ADR-018, Phase 2). Invoke when a task needs to find prior public work, explain why a commit or ACP discussion exists, or prepare a bounded handoff capsule for another seat. Works identically for Codex, Kimi, GLM, Claude, and other harnesses — no model-specific semantics, no Entire plugin, no Entire CLI call. Local-only; GitHub, Fleet Comms, Monitor, session streams, rollover, and formal review remain authoritative.
+effort: low
+---
+
+# Entire context recall (public, body-free)
+
+This skill is the canonical agent-facing contract for the public context layer.
+It runs one provider-neutral CLI — `python -m scripts.entire_context` — over the
+local context-link projection. It is **supplemental**: it never replaces GitHub,
+Fleet Comms, Monitor, session streams, rollover receipts, or formal review, and
+it never mutates them.
+
+## Hard privacy and scope rules
+
+- **Body-free only.** Results are locator cards and verified canonical excerpts
+  (commit parents/touched paths/timestamps; ACP terminal metadata with
+  `content_included: false`). Never request, emit, or persist transcripts,
+  prompts, responses, subjects, artifacts, raw captures, secrets, or
+  AI-generated summaries.
+- **No Entire dependency.** Entire CLI 0.8.42 stays pinned, optional, and
+  non-load-bearing. This workflow makes **zero** Entire CLI invocations and
+  zero network calls. Do not run `entire` login, search, checkpoint, attach,
+  resume, push, or create `refs/entire/*`.
+- **Fail closed.** Missing, stale, tombstoned, partial-terminal, unsupported,
+  or digest-mismatched evidence is omitted with a machine reason. Never inject
+  an omitted item into your context, and never fabricate coverage for a kind
+  the resolver reports as `unsupported_kind`.
+- **Query hygiene.** Query text is a ranking needle only: at most 256 UTF-8
+  bytes, never persisted, never echoed into results.
+
+## Commands
+
+All commands are local and read-only except the two explicit `bootstrap-*`
+index commands, which write only to the projection SQLite file.
+
+```bash
+# Projection state (body-free aggregate)
+.venv/bin/python -m scripts.entire_context status
+
+# Explicit bootstrap/index of real public evidence (idempotent)
+.venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha> [--repo PATH] [--namespace NS]
+.venv/bin/python -m scripts.entire_context bootstrap-acp conversation_<32hex> [--git-sha SHA] [--acp-root PATH]
+
+# search-past-work: ranked verified locator cards (<= 10 results, <= 500 scanned)
+.venv/bin/python -m scripts.entire_context search --query "<needle>" [--repo PATH] [--acp-root PATH]
+
+# explain-change: typed provenance traversal from an exact seed
+.venv/bin/python -m scripts.entire_context explain-change --sha <40-hex>
+.venv/bin/python -m scripts.entire_context explain-change --locator-id clink_<64hex>
+.venv/bin/python -m scripts.entire_context explain-change --canonical-id <id>
+
+# prepare-handoff: bounded capsule of verified locators/excerpts (<= 5 items, <= 8 KiB)
+.venv/bin/python -m scripts.entire_context handoff --locator-id clink_<64hex> [--locator-id ...]
+.venv/bin/python -m scripts.entire_context handoff --query "<needle>"
+```
+
+Resolution flags: `--repo` (default: cwd) supplies the local git repository;
+`--acp-root` or `ENTIRE_CONTEXT_ACP_ROOT` supplies the ACP receipt plane root.
+Without an ACP root, ACP links fail closed as `source_missing`. `--db` or
+`ENTIRE_CONTEXT_DB` overrides the projection path. `--consumer <label>` may be
+passed by any harness; it is validated, never persisted, and never echoed, so
+all harnesses receive byte-identical results for identical invocations.
+
+## Typed resolvers in this slice
+
+| Kind | Resolver | Verification |
+| --- | --- | --- |
+| `git_commit` | Real | Read-only local git plumbing: parents, touched paths, committer timestamp, author. No commit subject/body. |
+| `acp_conversation` | Real | Existing terminal receipt verifier (`verify_discussion_receipt`), metadata-only, `content_included: false`. |
+| `github_issue` / `github_pr` | Unsupported | No local canonical store verifiable without network; fails closed. |
+| `fleet_receipt` / `rollover` / `formal_review` / `monitor_run` | Unsupported | No local canonical store verifiable without protected-rail access; fails closed. |
+
+## How to consume results
+
+1. Prefer exact identifiers when you have them (commit SHA, conversation ID,
+   locator ID) — exact canonical ID or SHA matches rank first.
+2. Treat every card as a **locator**: read the canonical source itself
+   (`git show`, the ACP receipt, the GitHub issue) before relying on details.
+   The card's `canonical_digest` proves the locator matches the canonical
+   evidence at recall time.
+3. Check `omitted` before concluding absence: an omitted card names the
+   locator and a machine reason (`source_missing`, `digest_mismatch`,
+   `partial_terminal`, `tombstoned`, `unsupported_kind`, `capsule_budget`).
+4. A handoff capsule with `"complete": false` intentionally dropped items to
+   stay within the item/byte caps; it is still valid JSON and safe to pass on.
+5. Ranking is deterministic and Unicode-casefold based with `locator_id` as
+   the final tie-break, so identical fixtures give identical results to every
+   harness.
+
+## Failure posture
+
+A missing, disabled, or unreadable projection yields a body-free status
+payload (`"available": false`) with exit code 0 for read commands — recall is
+optional and must never block or mutate your canonical workflow. If recall is
+unavailable, continue with the authoritative systems directly.

--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -62,6 +62,9 @@ Without an ACP root, ACP links fail closed as `source_missing`. `--db` or
 `ENTIRE_CONTEXT_DB` overrides the projection path. `--consumer <label>` may be
 passed by any harness; it is validated, never persisted, and never echoed, so
 all harnesses receive byte-identical results for identical invocations.
+An ACP `--git-sha` join is admitted only when hashing that exact SHA matches
+the conversation's canonical correlation digest. Caller-asserted joins fail
+closed as `digest_mismatch`.
 
 ## Typed resolvers in this slice
 

--- a/scripts/entire_context/__init__.py
+++ b/scripts/entire_context/__init__.py
@@ -6,11 +6,17 @@ This package implements the local-only slice of the Entire context layer:
 - a deterministic locator-ID derivation over canonical metadata;
 - a caller-owned, rebuildable SQLite projection with an append-only lifecycle
   (pending / promoted / tombstoned) and idempotent admission (:mod:`.store`);
-- a provider-neutral CLI for body-free ``status``, known-ID ``lookup`` /
-  ``explain``, and deterministic ``rebuild`` (``python -m scripts.entire_context``).
+- explicit, local-only typed resolvers that map an exact Git commit SHA or an
+  exact ACP conversation ID to a verified body-free canonical projection
+  (:mod:`.resolvers`), failing closed for every unsupported kind;
+- deterministic promoted-only recall workflows — ``search_past_work``,
+  ``explain_change``, and ``prepare_handoff`` — that re-resolve every
+  candidate and recompute its canonical digest before it may enter an
+  LLM-facing result or handoff capsule (:mod:`.recall`);
+- a provider-neutral CLI (``python -m scripts.entire_context``).
 
-Nothing in this package calls Entire, GitHub, Fleet, ACP, Monitor, or the
-network, and nothing here mutates any canonical authority system. The
+Nothing in this package calls Entire, GitHub, Fleet, ACP providers, Monitor,
+or the network, and nothing here mutates any canonical authority system. The
 projection is disposable and disabled/non-load-bearing by default.
 """
 
@@ -22,16 +28,52 @@ from .model import (
     VerificationEvidence,
     VerificationStatus,
 )
+from .recall import (
+    MAX_CAPSULE_BYTES,
+    MAX_HANDOFF_ITEMS,
+    MAX_QUERY_BYTES,
+    MAX_RESULTS,
+    MAX_SCAN_ROWS,
+    RecallInputError,
+    explain_change,
+    prepare_handoff,
+    search_past_work,
+)
+from .resolvers import (
+    SUPPORTED_RESOLVER_KINDS,
+    Resolution,
+    ResolutionError,
+    resolve_acp_conversation,
+    resolve_bootstrap,
+    resolve_git_commit,
+    reverify_link,
+)
 from .store import AdmitOutcome, AdmitResult, ContextLinkStore
 
 __all__ = [
+    "MAX_CAPSULE_BYTES",
+    "MAX_HANDOFF_ITEMS",
+    "MAX_QUERY_BYTES",
+    "MAX_RESULTS",
+    "MAX_SCAN_ROWS",
     "SCHEMA_VERSION",
+    "SUPPORTED_RESOLVER_KINDS",
     "AdmitOutcome",
     "AdmitResult",
     "ContextLink",
     "ContextLinkStore",
     "LinkKind",
+    "RecallInputError",
+    "Resolution",
+    "ResolutionError",
     "SchemaError",
     "VerificationEvidence",
     "VerificationStatus",
+    "explain_change",
+    "prepare_handoff",
+    "resolve_acp_conversation",
+    "resolve_bootstrap",
+    "resolve_git_commit",
+    "reverify_link",
+    "search_past_work",
 ]

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -245,15 +245,11 @@ def cmd_bootstrap_git(args: argparse.Namespace) -> int:
     if _disabled():
         return _refused("projection_disabled")
     try:
-        resolution = resolve_git_commit(
-            args.sha, repo=_resolve_repo(args), namespace=args.namespace
-        )
+        resolution = resolve_git_commit(args.sha, repo=_resolve_repo(args), namespace=args.namespace)
     except ResolutionError as exc:
         return _refused(exc.reason)
     try:
-        result = ContextLinkStore(db_path).admit(
-            resolution.link, resolution.verification, actor=args.actor
-        )
+        result = ContextLinkStore(db_path).admit(resolution.link, resolution.verification, actor=args.actor)
     except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_REFUSED
@@ -261,11 +257,7 @@ def cmd_bootstrap_git(args: argparse.Namespace) -> int:
     if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED):
         payload["excerpt"] = resolution.excerpt
     _emit(payload)
-    return (
-        EXIT_OK
-        if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED)
-        else EXIT_REFUSED
-    )
+    return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
 
 
 def cmd_bootstrap_acp(args: argparse.Namespace) -> int:
@@ -277,15 +269,11 @@ def cmd_bootstrap_acp(args: argparse.Namespace) -> int:
     if acp_root is None:
         return _refused("source_missing")
     try:
-        resolution = resolve_acp_conversation(
-            args.conversation_id, acp_root=acp_root, git_sha=args.git_sha
-        )
+        resolution = resolve_acp_conversation(args.conversation_id, acp_root=acp_root, git_sha=args.git_sha)
     except ResolutionError as exc:
         return _refused(exc.reason)
     try:
-        result = ContextLinkStore(db_path).admit(
-            resolution.link, resolution.verification, actor=args.actor
-        )
+        result = ContextLinkStore(db_path).admit(resolution.link, resolution.verification, actor=args.actor)
     except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
         _emit(_unavailable_payload(db_path, "projection_unreadable"))
         return EXIT_REFUSED
@@ -293,11 +281,7 @@ def cmd_bootstrap_acp(args: argparse.Namespace) -> int:
     if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED):
         payload["excerpt"] = resolution.excerpt
     _emit(payload)
-    return (
-        EXIT_OK
-        if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED)
-        else EXIT_REFUSED
-    )
+    return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
 
 
 def cmd_search(args: argparse.Namespace) -> int:

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -494,7 +494,10 @@ def build_parser() -> argparse.ArgumentParser:
     bootstrap_acp.add_argument(
         "--git-sha",
         default=None,
-        help="Optional exact commit SHA this conversation is provenance for",
+        help=(
+            "Optional exact commit SHA; admitted only when it matches the ACP "
+            "conversation's canonical correlation digest"
+        ),
     )
     bootstrap_acp.add_argument("--actor", default="cli", help="Body-free actor identity")
     add_db_flag(bootstrap_acp)

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -1,10 +1,17 @@
 """Provider-neutral CLI for the body-free context-link projection.
 
-Commands: ``status``, ``lookup``, ``explain``, ``rebuild``, ``admit``.
-Every command is local-only: none of them calls Entire, GitHub, Fleet, ACP,
-Monitor, or the network. A missing or disabled projection is reported as a
-body-free status payload, never as a traceback, and read commands never create
-local state.
+Phase-1 commands: ``status``, ``lookup``, ``explain``, ``rebuild``, ``admit``.
+Phase-2 commands: ``bootstrap-git``, ``bootstrap-acp``, ``search``,
+``explain-change``, ``handoff``.
+
+Every command is local-only: none of them calls Entire, GitHub, Fleet, ACP
+providers, Monitor, or the network. Resolution uses read-only local ``git``
+plumbing and the body-free ACP terminal receipt verifier. A missing or
+disabled projection is reported as a body-free status payload, never as a
+traceback, and read commands never create local state. Query text and
+consumer labels are accepted but never persisted or echoed, so Codex, Kimi,
+GLM, and other harnesses receive byte-identical results for identical
+invocations.
 """
 
 from __future__ import annotations
@@ -17,7 +24,26 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .model import ContextLink, SchemaError, VerificationEvidence
+from .model import (
+    ContextLink,
+    SchemaError,
+    VerificationEvidence,
+    canonical_json,
+    validate_identity,
+)
+from .recall import (
+    MAX_RESULTS,
+    MAX_SCAN_ROWS,
+    RecallInputError,
+    explain_change,
+    prepare_handoff,
+    search_past_work,
+)
+from .resolvers import (
+    ResolutionError,
+    resolve_acp_conversation,
+    resolve_git_commit,
+)
 from .store import AdmitOutcome, ContextLinkStore
 
 EXIT_OK = 0
@@ -27,6 +53,7 @@ EXIT_REFUSED = 2
 DEFAULT_DB_RELATIVE = Path("batch_state") / "entire-context" / "v1" / "context-links.sqlite3"
 ENV_DB = "ENTIRE_CONTEXT_DB"
 ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
+ENV_ACP_ROOT = "ENTIRE_CONTEXT_ACP_ROOT"
 
 
 def _emit(payload: dict[str, Any]) -> None:
@@ -180,6 +207,204 @@ def cmd_admit(args: argparse.Namespace) -> int:
     return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
 
 
+# ── Phase-2: explicit bootstrap, recall, explain, handoff ────────────────────
+
+
+def _resolve_repo(args: argparse.Namespace) -> Path:
+    return Path(getattr(args, "repo", None) or Path.cwd())
+
+
+def _resolve_acp_root(args: argparse.Namespace) -> Path | None:
+    explicit = getattr(args, "acp_root", None)
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get(ENV_ACP_ROOT)
+    return Path(env) if env else None
+
+
+def _consumer_error(args: argparse.Namespace) -> dict[str, Any] | None:
+    """Validate the optional consumer label; it is never persisted or echoed."""
+    consumer = getattr(args, "consumer", None)
+    if consumer is None:
+        return None
+    try:
+        validate_identity(consumer, field_name="consumer")
+    except SchemaError:
+        return {"error": "consumer_invalid"}
+    return None
+
+
+def _refused(reason: str) -> int:
+    _emit({"outcome": AdmitOutcome.REFUSED.value, "reason": reason})
+    return EXIT_REFUSED
+
+
+def cmd_bootstrap_git(args: argparse.Namespace) -> int:
+    """Resolve an exact commit SHA locally and admit its body-free projection."""
+    db_path = _resolve_db(args)
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_git_commit(
+            args.sha, repo=_resolve_repo(args), namespace=args.namespace
+        )
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    try:
+        result = ContextLinkStore(db_path).admit(
+            resolution.link, resolution.verification, actor=args.actor
+        )
+    except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_REFUSED
+    payload = result.to_dict()
+    if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED):
+        payload["excerpt"] = resolution.excerpt
+    _emit(payload)
+    return (
+        EXIT_OK
+        if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED)
+        else EXIT_REFUSED
+    )
+
+
+def cmd_bootstrap_acp(args: argparse.Namespace) -> int:
+    """Resolve an exact ACP conversation ID via the terminal receipt verifier."""
+    db_path = _resolve_db(args)
+    if _disabled():
+        return _refused("projection_disabled")
+    acp_root = _resolve_acp_root(args)
+    if acp_root is None:
+        return _refused("source_missing")
+    try:
+        resolution = resolve_acp_conversation(
+            args.conversation_id, acp_root=acp_root, git_sha=args.git_sha
+        )
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    try:
+        result = ContextLinkStore(db_path).admit(
+            resolution.link, resolution.verification, actor=args.actor
+        )
+    except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_REFUSED
+    payload = result.to_dict()
+    if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED):
+        payload["excerpt"] = resolution.excerpt
+    _emit(payload)
+    return (
+        EXIT_OK
+        if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED)
+        else EXIT_REFUSED
+    )
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    """search-past-work: ranked, re-verified, body-free locator cards."""
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    consumer_error = _consumer_error(args)
+    if consumer_error is not None:
+        _emit(consumer_error)
+        return EXIT_REFUSED
+    try:
+        payload = search_past_work(
+            ContextLinkStore(db_path),
+            args.query,
+            repo=_resolve_repo(args),
+            acp_root=_resolve_acp_root(args),
+            limit=args.limit,
+            scan_limit=args.scan_limit,
+        )
+    except RecallInputError as exc:
+        _emit({"error": str(exc)})
+        return EXIT_REFUSED
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    payload.update({"enabled": True, "available": True})
+    _emit(payload)
+    return EXIT_OK
+
+
+def cmd_explain_change(args: argparse.Namespace) -> int:
+    """explain-change: typed provenance traversal from an exact seed ID."""
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    consumer_error = _consumer_error(args)
+    if consumer_error is not None:
+        _emit(consumer_error)
+        return EXIT_REFUSED
+    try:
+        payload = explain_change(
+            ContextLinkStore(db_path),
+            locator_id=args.locator_id,
+            canonical_id=args.canonical_id,
+            git_sha=args.sha,
+            repo=_resolve_repo(args),
+            acp_root=_resolve_acp_root(args),
+        )
+    except RecallInputError as exc:
+        _emit({"error": str(exc)})
+        return EXIT_REFUSED
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    if not payload["found"]:
+        _emit({"found": False})
+        return EXIT_NOT_FOUND
+    payload.update({"enabled": True, "available": True})
+    _emit(payload)
+    return EXIT_OK
+
+
+def cmd_handoff(args: argparse.Namespace) -> int:
+    """prepare-handoff: a bounded capsule of verified locators and excerpts."""
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_OK
+    consumer_error = _consumer_error(args)
+    if consumer_error is not None:
+        _emit(consumer_error)
+        return EXIT_REFUSED
+    store = ContextLinkStore(db_path)
+    locator_ids = list(args.locator_id or [])
+    try:
+        if args.query is not None:
+            search = search_past_work(
+                store,
+                args.query,
+                repo=_resolve_repo(args),
+                acp_root=_resolve_acp_root(args),
+                limit=MAX_RESULTS,
+            )
+            locator_ids.extend(card["locator_id"] for card in search["results"])
+        if not locator_ids:
+            raise RecallInputError("seed_invalid")
+        capsule = prepare_handoff(
+            store,
+            locator_ids,
+            repo=_resolve_repo(args),
+            acp_root=_resolve_acp_root(args),
+        )
+    except RecallInputError as exc:
+        _emit({"error": str(exc)})
+        return EXIT_REFUSED
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(db_path, "projection_unreadable"))
+        return EXIT_OK
+    # The capsule is emitted as canonical JSON so the emitted serialization is
+    # exactly the byte-capped one (<= 8 KiB) and always valid JSON.
+    sys.stdout.write(canonical_json(capsule) + "\n")
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m scripts.entire_context",
@@ -228,6 +453,104 @@ def build_parser() -> argparse.ArgumentParser:
     admit.add_argument("--actor", default="cli", help="Body-free actor identity (default: cli)")
     add_db_flag(admit)
     admit.set_defaults(func=cmd_admit)
+
+    def add_resolution_flags(command: argparse.ArgumentParser) -> None:
+        command.add_argument(
+            "--repo",
+            default=None,
+            help="Local git repository used for commit re-resolution (default: cwd)",
+        )
+        command.add_argument(
+            "--acp-root",
+            default=None,
+            help=f"ACP receipt plane root (default: {ENV_ACP_ROOT}); required to verify ACP links",
+        )
+        command.add_argument(
+            "--consumer",
+            default=None,
+            help="Optional harness label (codex, kimi, glm, ...); validated, never persisted or echoed",
+        )
+
+    bootstrap_git = sub.add_parser(
+        "bootstrap-git",
+        help="Resolve an exact commit SHA locally and admit its body-free projection",
+    )
+    bootstrap_git.add_argument("sha", help="Full 40-hex commit SHA")
+    bootstrap_git.add_argument(
+        "--namespace",
+        default=None,
+        help="Canonical namespace override (default: derived from remote.origin.url)",
+    )
+    bootstrap_git.add_argument("--repo", default=None, help="Local git repository (default: cwd)")
+    bootstrap_git.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_git)
+    bootstrap_git.set_defaults(func=cmd_bootstrap_git)
+
+    bootstrap_acp = sub.add_parser(
+        "bootstrap-acp",
+        help="Resolve an exact ACP conversation ID through the terminal receipt verifier",
+    )
+    bootstrap_acp.add_argument("conversation_id", help="Canonical conversation_<32 hex> ID")
+    bootstrap_acp.add_argument(
+        "--git-sha",
+        default=None,
+        help="Optional exact commit SHA this conversation is provenance for",
+    )
+    bootstrap_acp.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_acp)
+    bootstrap_acp.add_argument(
+        "--acp-root",
+        default=None,
+        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT})",
+    )
+    bootstrap_acp.set_defaults(func=cmd_bootstrap_acp)
+
+    search = sub.add_parser(
+        "search",
+        help="search-past-work: ranked, re-verified, body-free locator cards (query never echoed)",
+    )
+    search.add_argument("--query", required=True, help="Bounded ranking needle (<= 256 UTF-8 bytes)")
+    search.add_argument("--limit", type=int, default=MAX_RESULTS, help="Max results (cap 10)")
+    search.add_argument(
+        "--scan-limit",
+        type=int,
+        default=MAX_SCAN_ROWS,
+        help="Max promoted rows scanned (cap 500)",
+    )
+    add_resolution_flags(search)
+    add_db_flag(search)
+    search.set_defaults(func=cmd_search)
+
+    explain_cmd = sub.add_parser(
+        "explain-change",
+        help="explain-change: typed provenance traversal from an exact seed identifier",
+    )
+    seed = explain_cmd.add_mutually_exclusive_group(required=True)
+    seed.add_argument("--locator-id", default=None, help="Deterministic clink_<sha256> locator ID")
+    seed.add_argument("--canonical-id", default=None, help="Exact canonical identifier")
+    seed.add_argument("--sha", default=None, help="Exact full 40-hex commit SHA")
+    add_resolution_flags(explain_cmd)
+    add_db_flag(explain_cmd)
+    explain_cmd.set_defaults(func=cmd_explain_change)
+
+    handoff = sub.add_parser(
+        "handoff",
+        help="prepare-handoff: bounded capsule of verified locators/excerpts (<= 5 items, <= 8 KiB)",
+    )
+    handoff.add_argument(
+        "--locator-id",
+        action="append",
+        default=None,
+        help="Promoted locator ID to include (repeatable, max 5 used)",
+    )
+    handoff.add_argument(
+        "--query",
+        default=None,
+        help="Optional bounded ranking needle; top verified results seed the capsule",
+    )
+    add_resolution_flags(handoff)
+    add_db_flag(handoff)
+    handoff.set_defaults(func=cmd_handoff)
 
     return parser
 

--- a/scripts/entire_context/recall.py
+++ b/scripts/entire_context/recall.py
@@ -33,6 +33,7 @@ MAX_CAPSULE_BYTES = 8192
 MAX_EXPLAIN_DEPTH = 2
 MAX_EXPLAIN_NODES = 50
 MAX_HANDOFF_SEEDS = 500
+MAX_SEARCH_OMISSIONS = 50
 
 REASON_TOMBSTONED = "tombstoned"
 REASON_HANDOFF_ITEM_CAP = "handoff_item_cap"
@@ -195,6 +196,7 @@ def search_past_work(
     )
     results: list[dict[str, Any]] = []
     omitted: list[dict[str, str]] = []
+    omissions_truncated = False
     for entry in ranked:
         if entry.score <= 0 or len(results) >= capped_limit:
             break
@@ -202,7 +204,10 @@ def search_past_work(
         try:
             card = _verified_card(store, entry.link, repo=repo, acp_root=acp_root, now=now)
         except GateReject as exc:
-            omitted.append(_omitted(locator_id, exc.reason))
+            if len(omitted) < MAX_SEARCH_OMISSIONS:
+                omitted.append(_omitted(locator_id, exc.reason))
+            else:
+                omissions_truncated = True
             continue
         card["score"] = entry.score
         card["matched_fields"] = list(entry.matched_fields)
@@ -211,6 +216,7 @@ def search_past_work(
         "schema": "ec-search.v1",
         "results": results,
         "omitted": omitted,
+        "omissions_truncated": omissions_truncated,
         "scanned": len(candidates),
         "limit": capped_limit,
     }

--- a/scripts/entire_context/recall.py
+++ b/scripts/entire_context/recall.py
@@ -1,0 +1,362 @@
+"""Deterministic, promoted-only recall workflows over the context-link store.
+
+Implements the Phase-2 workflows of ADR-018 / the rollout plan:
+
+- ``search_past_work`` — bounded, Unicode-casefold ranked locator cards;
+- ``explain_change`` — typed provenance traversal (commit ↔ receipt joins);
+- ``prepare_handoff`` — a bounded capsule of verified locators/excerpts.
+
+Every candidate is re-resolved against its canonical local system and its
+canonical digest is recomputed before it may enter an LLM-facing result or
+handoff capsule. Missing, stale, tombstoned, partial-terminal, unsupported,
+or digest-mismatched evidence is omitted with a body-free machine reason.
+Query text is never persisted and never echoed into any result payload.
+Nothing here calls Entire, the network, GitHub, or any protected rail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .model import LOCATOR_ID_RE, canonical_json
+from .resolvers import REASON_SOURCE_MISSING, ResolutionError, reverify_link
+from .store import ContextLinkStore
+
+MAX_QUERY_BYTES = 256
+MAX_SCAN_ROWS = 500
+MAX_RESULTS = 10
+MAX_HANDOFF_ITEMS = 5
+MAX_CAPSULE_BYTES = 8192
+MAX_EXPLAIN_DEPTH = 2
+MAX_EXPLAIN_NODES = 50
+
+REASON_TOMBSTONED = "tombstoned"
+REASON_HANDOFF_ITEM_CAP = "handoff_item_cap"
+REASON_CAPSULE_BUDGET = "capsule_budget"
+
+#: Weighted ranking facets, evaluated in this fixed declaration order.
+_FACET_WEIGHTS: tuple[tuple[str, int], ...] = (
+    ("title", 30),
+    ("labels", 20),
+    ("touched_paths", 15),
+    ("repository", 12),
+    ("document_path", 12),
+    ("document_heading", 12),
+    ("track", 10),
+    ("stream_epic", 10),
+    ("state", 8),
+    ("source_kind", 8),
+    ("actor", 8),
+    ("model", 8),
+    ("harness", 8),
+    ("participants", 8),
+    ("token_bucket", 4),
+)
+
+_EXACT_ID_SCORE = 1000
+_CANONICAL_ID_SUBSTR_SCORE = 25
+_NAMESPACE_SUBSTR_SCORE = 40
+_GIT_SHA_SUBSTR_SCORE = 10
+_KIND_SUBSTR_SCORE = 5
+
+
+class RecallInputError(ValueError):
+    """Caller input violated a bounded-workflow rule (never echoes the input)."""
+
+
+class GateReject(Exception):
+    """A candidate failed the re-resolve/digest gate with a machine reason."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class RankedCandidate:
+    link: dict[str, Any]
+    score: int
+    matched_fields: tuple[str, ...]
+
+
+def validate_query(query: Any) -> str:
+    """Validate the bounded query and return its Unicode casefold needle."""
+    if not isinstance(query, str) or not query.strip():
+        raise RecallInputError("query_invalid")
+    if "\x00" in query or len(query.encode("utf-8")) > MAX_QUERY_BYTES:
+        raise RecallInputError("query_invalid")
+    return query.casefold()
+
+
+def _facet_values(facets: dict[str, Any], key: str) -> list[str]:
+    value = facets.get(key)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def rank_candidate(link: dict[str, Any], needle: str) -> RankedCandidate:
+    """Score one candidate deterministically against the casefold needle."""
+    needle = needle.casefold()  # idempotent; callers pass an already-folded needle
+    score = 0
+    matched: list[str] = []
+    canonical_id = str(link["canonical_id"]).casefold()
+    git_sha = str(link.get("git_sha") or "").casefold()
+    locator_id = str(link["locator_id"])
+    if needle in (canonical_id, locator_id) or (git_sha and needle == git_sha):
+        score += _EXACT_ID_SCORE
+        matched.append("exact_id")
+    else:
+        if needle in canonical_id:
+            score += _CANONICAL_ID_SUBSTR_SCORE
+            matched.append("canonical_id")
+        if git_sha and needle in git_sha:
+            score += _GIT_SHA_SUBSTR_SCORE
+            matched.append("git_sha")
+    namespace = str(link["canonical_namespace"]).casefold()
+    if needle in namespace:
+        score += _NAMESPACE_SUBSTR_SCORE
+        matched.append("canonical_namespace")
+    if needle in str(link["kind"]).casefold():
+        score += _KIND_SUBSTR_SCORE
+        matched.append("kind")
+    facets = link.get("facets") or {}
+    for facet_key, weight in _FACET_WEIGHTS:
+        if any(needle in value.casefold() for value in _facet_values(facets, facet_key)):
+            score += weight
+            matched.append(facet_key)
+    return RankedCandidate(link=link, score=score, matched_fields=tuple(matched))
+
+
+def _verified_card(
+    store: ContextLinkStore,
+    link: dict[str, Any],
+    *,
+    repo: Path,
+    acp_root: Path | None,
+    now: datetime | None,
+) -> dict[str, Any]:
+    """Re-check promotion state and re-resolve/recompute the canonical digest."""
+    fresh = store.lookup(str(link["locator_id"]))
+    if fresh is None:
+        raise GateReject(REASON_TOMBSTONED)
+    try:
+        excerpt = reverify_link(fresh, repo=repo, acp_root=acp_root, now=now)
+    except ResolutionError as exc:
+        raise GateReject(exc.reason) from exc
+    return {
+        "locator_id": fresh["locator_id"],
+        "kind": fresh["kind"],
+        "canonical_namespace": fresh["canonical_namespace"],
+        "canonical_id": fresh["canonical_id"],
+        "canonical_digest": fresh["canonical_digest"],
+        "entire_checkpoint_id": fresh["entire_checkpoint_id"],
+        "git_sha": fresh["git_sha"],
+        "facets": fresh["facets"],
+        "excerpt": excerpt,
+    }
+
+
+def _omitted(locator_id: str, reason: str) -> dict[str, str]:
+    return {"locator_id": locator_id, "reason": reason}
+
+
+# ── search-past-work ─────────────────────────────────────────────────────────
+
+
+def search_past_work(
+    store: ContextLinkStore,
+    query: str,
+    *,
+    repo: Path,
+    acp_root: Path | None,
+    limit: int = MAX_RESULTS,
+    scan_limit: int = MAX_SCAN_ROWS,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Rank promoted candidates and return verified locator cards only.
+
+    The query is used only as an in-memory ranking needle: it is never
+    persisted and never echoed into the result payload.
+    """
+    needle = validate_query(query)
+    capped_scan = max(0, min(int(scan_limit), MAX_SCAN_ROWS))
+    capped_limit = max(0, min(int(limit), MAX_RESULTS))
+    candidates = store.candidates(limit=capped_scan)
+    ranked = sorted(
+        (rank_candidate(link, needle) for link in candidates),
+        key=lambda entry: (-entry.score, entry.link["locator_id"]),
+    )
+    results: list[dict[str, Any]] = []
+    omitted: list[dict[str, str]] = []
+    for entry in ranked:
+        if entry.score <= 0 or len(results) >= capped_limit:
+            break
+        locator_id = entry.link["locator_id"]
+        try:
+            card = _verified_card(store, entry.link, repo=repo, acp_root=acp_root, now=now)
+        except GateReject as exc:
+            omitted.append(_omitted(locator_id, exc.reason))
+            continue
+        card["score"] = entry.score
+        card["matched_fields"] = list(entry.matched_fields)
+        results.append(card)
+    return {
+        "schema": "ec-search.v1",
+        "results": results,
+        "omitted": omitted,
+        "scanned": len(candidates),
+        "limit": capped_limit,
+    }
+
+
+# ── explain-change ───────────────────────────────────────────────────────────
+
+
+def _resolve_seeds(
+    store: ContextLinkStore,
+    *,
+    locator_id: str | None,
+    canonical_id: str | None,
+    git_sha: str | None,
+) -> list[dict[str, Any]]:
+    if locator_id is not None:
+        found = store.lookup(locator_id)
+        return [found] if found is not None else []
+    candidates = store.candidates(limit=MAX_SCAN_ROWS)
+    if canonical_id is not None:
+        return [link for link in candidates if link["canonical_id"] == canonical_id]
+    if git_sha is not None:
+        needle = git_sha.lower()
+        return [
+            link
+            for link in candidates
+            if link.get("git_sha") == needle or link["canonical_id"] == needle
+        ]
+    raise RecallInputError("seed_invalid")
+
+
+def explain_change(
+    store: ContextLinkStore,
+    *,
+    locator_id: str | None = None,
+    canonical_id: str | None = None,
+    git_sha: str | None = None,
+    repo: Path,
+    acp_root: Path | None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Traverse typed provenance joins from an exact seed identifier.
+
+    The traversal is a bounded breadth-first walk over promoted links using
+    the explicit typed joins (shared commit SHA, commit cross-reference,
+    shared canonical ID). Every visited node is re-verified before it enters
+    the result; unverifiable nodes are omitted and their edges dropped.
+    """
+    seeds = _resolve_seeds(
+        store, locator_id=locator_id, canonical_id=canonical_id, git_sha=git_sha
+    )
+    if not seeds:
+        return {"schema": "ec-explain.v1", "found": False}
+    seed_ids = {str(seed["locator_id"]) for seed in seeds}
+    nodes: dict[str, dict[str, Any]] = {str(seed["locator_id"]): seed for seed in seeds}
+    edges: set[tuple[str, str, str]] = set()
+    frontier = list(seed_ids)
+    depth = 0
+    while frontier and depth < MAX_EXPLAIN_DEPTH and len(nodes) < MAX_EXPLAIN_NODES:
+        next_frontier: list[str] = []
+        for current_id in frontier:
+            for related, join in store.find_related(nodes[current_id]):
+                related_id = str(related["locator_id"])
+                edges.add((current_id, related_id, join))
+                if related_id not in nodes and len(nodes) < MAX_EXPLAIN_NODES:
+                    nodes[related_id] = related
+                    next_frontier.append(related_id)
+        frontier = next_frontier
+        depth += 1
+
+    verified: dict[str, dict[str, Any]] = {}
+    omitted: list[dict[str, str]] = []
+    for node_id in sorted(nodes):
+        try:
+            verified[node_id] = _verified_card(
+                store, nodes[node_id], repo=repo, acp_root=acp_root, now=now
+            )
+        except GateReject as exc:
+            omitted.append(_omitted(node_id, exc.reason))
+    kept_edges = [
+        {"from": source, "to": target, "join": join}
+        for source, target, join in sorted(edges)
+        if source in verified and target in verified
+    ]
+    return {
+        "schema": "ec-explain.v1",
+        "found": True,
+        "seeds": [verified[node_id] for node_id in sorted(seed_ids) if node_id in verified],
+        "nodes": [verified[node_id] for node_id in sorted(verified)],
+        "edges": kept_edges,
+        "omitted": omitted,
+        "depth": depth,
+    }
+
+
+# ── prepare-handoff ──────────────────────────────────────────────────────────
+
+
+def prepare_handoff(
+    store: ContextLinkStore,
+    locator_ids: list[str],
+    *,
+    repo: Path,
+    acp_root: Path | None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a bounded capsule of verified locator cards and excerpts.
+
+    The capsule holds at most ``MAX_HANDOFF_ITEMS`` items and at most
+    ``MAX_CAPSULE_BYTES`` of canonical JSON. Items are processed in
+    deterministic locator-ID order; an item that would exceed the byte
+    budget is omitted whole, so the serialized capsule is always valid
+    JSON and never a truncated stream. A handoff is never a summary.
+    """
+    for locator_id in locator_ids:
+        if not isinstance(locator_id, str) or not LOCATOR_ID_RE.fullmatch(locator_id):
+            raise RecallInputError("locator_id_invalid")
+    capsule: dict[str, Any] = {
+        "schema": "ec-handoff.v1",
+        "items": [],
+        "omitted": [],
+        "complete": True,
+    }
+    items: list[dict[str, Any]] = capsule["items"]
+    omitted: list[dict[str, str]] = capsule["omitted"]
+    for locator_id in sorted(set(locator_ids)):
+        if len(items) >= MAX_HANDOFF_ITEMS:
+            omitted.append(_omitted(locator_id, REASON_HANDOFF_ITEM_CAP))
+            capsule["complete"] = False
+            continue
+        link = store.lookup(locator_id)
+        if link is None:
+            omitted.append(_omitted(locator_id, REASON_SOURCE_MISSING))
+            continue
+        try:
+            card = _verified_card(store, link, repo=repo, acp_root=acp_root, now=now)
+        except GateReject as exc:
+            omitted.append(_omitted(locator_id, exc.reason))
+            continue
+        items.append(card)
+        if len(canonical_json(capsule).encode("utf-8")) > MAX_CAPSULE_BYTES:
+            items.pop()
+            omitted.append(_omitted(locator_id, REASON_CAPSULE_BUDGET))
+            capsule["complete"] = False
+    return capsule
+
+
+def serialize_capsule(capsule: dict[str, Any]) -> str:
+    """Deterministic canonical-JSON serialization of a handoff capsule."""
+    return canonical_json(capsule)

--- a/scripts/entire_context/recall.py
+++ b/scripts/entire_context/recall.py
@@ -32,6 +32,7 @@ MAX_HANDOFF_ITEMS = 5
 MAX_CAPSULE_BYTES = 8192
 MAX_EXPLAIN_DEPTH = 2
 MAX_EXPLAIN_NODES = 50
+MAX_HANDOFF_SEEDS = 500
 
 REASON_TOMBSTONED = "tombstoned"
 REASON_HANDOFF_ITEM_CAP = "handoff_item_cap"
@@ -226,18 +227,30 @@ def _resolve_seeds(
     git_sha: str | None,
 ) -> list[dict[str, Any]]:
     if locator_id is not None:
+        if not LOCATOR_ID_RE.fullmatch(locator_id):
+            raise RecallInputError("seed_invalid")
         found = store.lookup(locator_id)
         return [found] if found is not None else []
     candidates = store.candidates(limit=MAX_SCAN_ROWS)
     if canonical_id is not None:
-        return [link for link in candidates if link["canonical_id"] == canonical_id]
+        if not isinstance(canonical_id, str) or not canonical_id:
+            raise RecallInputError("seed_invalid")
+        return sorted(
+            (link for link in candidates if link["canonical_id"] == canonical_id),
+            key=lambda link: link["locator_id"],
+        )[:MAX_EXPLAIN_NODES]
     if git_sha is not None:
+        if (
+            not isinstance(git_sha, str)
+            or len(git_sha) != 40
+            or any(character not in "0123456789abcdef" for character in git_sha)
+        ):
+            raise RecallInputError("seed_invalid")
         needle = git_sha.lower()
-        return [
-            link
-            for link in candidates
-            if link.get("git_sha") == needle or link["canonical_id"] == needle
-        ]
+        return sorted(
+            (link for link in candidates if link.get("git_sha") == needle or link["canonical_id"] == needle),
+            key=lambda link: link["locator_id"],
+        )[:MAX_EXPLAIN_NODES]
     raise RecallInputError("seed_invalid")
 
 
@@ -258,15 +271,13 @@ def explain_change(
     shared canonical ID). Every visited node is re-verified before it enters
     the result; unverifiable nodes are omitted and their edges dropped.
     """
-    seeds = _resolve_seeds(
-        store, locator_id=locator_id, canonical_id=canonical_id, git_sha=git_sha
-    )
+    seeds = _resolve_seeds(store, locator_id=locator_id, canonical_id=canonical_id, git_sha=git_sha)
     if not seeds:
         return {"schema": "ec-explain.v1", "found": False}
     seed_ids = {str(seed["locator_id"]) for seed in seeds}
     nodes: dict[str, dict[str, Any]] = {str(seed["locator_id"]): seed for seed in seeds}
     edges: set[tuple[str, str, str]] = set()
-    frontier = list(seed_ids)
+    frontier = sorted(seed_ids)
     depth = 0
     while frontier and depth < MAX_EXPLAIN_DEPTH and len(nodes) < MAX_EXPLAIN_NODES:
         next_frontier: list[str] = []
@@ -284,9 +295,7 @@ def explain_change(
     omitted: list[dict[str, str]] = []
     for node_id in sorted(nodes):
         try:
-            verified[node_id] = _verified_card(
-                store, nodes[node_id], repo=repo, acp_root=acp_root, now=now
-            )
+            verified[node_id] = _verified_card(store, nodes[node_id], repo=repo, acp_root=acp_root, now=now)
         except GateReject as exc:
             omitted.append(_omitted(node_id, exc.reason))
     kept_edges = [
@@ -327,33 +336,48 @@ def prepare_handoff(
     for locator_id in locator_ids:
         if not isinstance(locator_id, str) or not LOCATOR_ID_RE.fullmatch(locator_id):
             raise RecallInputError("locator_id_invalid")
+    unique_locator_ids = sorted(set(locator_ids))
+    if len(unique_locator_ids) > MAX_HANDOFF_SEEDS:
+        raise RecallInputError("handoff_seed_limit")
     capsule: dict[str, Any] = {
         "schema": "ec-handoff.v1",
         "items": [],
         "omitted": [],
         "complete": True,
+        "omissions_truncated": False,
     }
     items: list[dict[str, Any]] = capsule["items"]
     omitted: list[dict[str, str]] = capsule["omitted"]
-    for locator_id in sorted(set(locator_ids)):
+
+    def append_omission(locator_id: str, reason: str) -> None:
+        capsule["complete"] = False
+        omitted.append(_omitted(locator_id, reason))
+        if len(canonical_json(capsule).encode("utf-8")) <= MAX_CAPSULE_BYTES:
+            return
+        omitted.pop()
+        capsule["omissions_truncated"] = True
+        while omitted and len(canonical_json(capsule).encode("utf-8")) > MAX_CAPSULE_BYTES:
+            omitted.pop()
+
+    for locator_id in unique_locator_ids:
         if len(items) >= MAX_HANDOFF_ITEMS:
-            omitted.append(_omitted(locator_id, REASON_HANDOFF_ITEM_CAP))
-            capsule["complete"] = False
+            append_omission(locator_id, REASON_HANDOFF_ITEM_CAP)
             continue
         link = store.lookup(locator_id)
         if link is None:
-            omitted.append(_omitted(locator_id, REASON_SOURCE_MISSING))
+            append_omission(locator_id, REASON_SOURCE_MISSING)
             continue
         try:
             card = _verified_card(store, link, repo=repo, acp_root=acp_root, now=now)
         except GateReject as exc:
-            omitted.append(_omitted(locator_id, exc.reason))
+            append_omission(locator_id, exc.reason)
             continue
         items.append(card)
         if len(canonical_json(capsule).encode("utf-8")) > MAX_CAPSULE_BYTES:
             items.pop()
-            omitted.append(_omitted(locator_id, REASON_CAPSULE_BUDGET))
-            capsule["complete"] = False
+            append_omission(locator_id, REASON_CAPSULE_BUDGET)
+    if len(canonical_json(capsule).encode("utf-8")) > MAX_CAPSULE_BYTES:
+        raise AssertionError("handoff capsule exceeded its hard byte cap")
     return capsule
 
 

--- a/scripts/entire_context/recall.py
+++ b/scripts/entire_context/recall.py
@@ -283,19 +283,29 @@ def explain_change(
     seed_ids = {str(seed["locator_id"]) for seed in seeds}
     nodes: dict[str, dict[str, Any]] = {str(seed["locator_id"]): seed for seed in seeds}
     edges: set[tuple[str, str, str]] = set()
+    relation_rows_examined = 0
+    truncation_reasons: set[str] = set()
     frontier = sorted(seed_ids)
     depth = 0
     while frontier and depth < MAX_EXPLAIN_DEPTH and len(nodes) < MAX_EXPLAIN_NODES:
         next_frontier: list[str] = []
         for current_id in frontier:
-            for related, join in store.find_related(nodes[current_id]):
+            related_scan = store.find_related(nodes[current_id])
+            relation_rows_examined += related_scan.examined
+            if related_scan.truncated:
+                truncation_reasons.add("relation_scan_cap")
+            for related, join in related_scan.items:
                 related_id = str(related["locator_id"])
                 edges.add((current_id, related_id, join))
                 if related_id not in nodes and len(nodes) < MAX_EXPLAIN_NODES:
                     nodes[related_id] = related
                     next_frontier.append(related_id)
+                elif related_id not in nodes:
+                    truncation_reasons.add("node_cap")
         frontier = next_frontier
         depth += 1
+    if frontier:
+        truncation_reasons.add("depth_cap")
 
     verified: dict[str, dict[str, Any]] = {}
     omitted: list[dict[str, str]] = []
@@ -317,6 +327,12 @@ def explain_change(
         "edges": kept_edges,
         "omitted": omitted,
         "depth": depth,
+        "relation_scan": {
+            "examined": relation_rows_examined,
+            "truncated": "relation_scan_cap" in truncation_reasons,
+        },
+        "complete": not truncation_reasons,
+        "truncation_reasons": sorted(truncation_reasons),
     }
 
 

--- a/scripts/entire_context/resolvers.py
+++ b/scripts/entire_context/resolvers.py
@@ -26,6 +26,7 @@ network access or protected-rail mutation, so they fail closed with
 from __future__ import annotations
 
 import re
+import sqlite3
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
@@ -178,6 +179,7 @@ def git_projection_digest(projection: dict[str, Any]) -> str:
                 "parents": projection["parents"],
                 "touched_paths": projection["touched_paths"],
                 "commit_ts": projection["commit_ts"],
+                "author": projection["author"],
             }
         )
     )
@@ -235,9 +237,9 @@ def resolve_git_commit(
 # ── acp_conversation ─────────────────────────────────────────────────────────
 
 
-def acp_receipt_projection(receipt: dict[str, Any]) -> dict[str, Any]:
+def acp_receipt_projection(receipt: dict[str, Any], *, git_sha: str | None = None) -> dict[str, Any]:
     """Extract the body-free terminal metadata covered by the digest."""
-    return {
+    projection = {
         "schema": "acp-receipt-projection.v1",
         "conversation_id": receipt["conversation_id"],
         "state": receipt["state"],
@@ -253,6 +255,9 @@ def acp_receipt_projection(receipt: dict[str, Any]) -> dict[str, Any]:
         "duration_ms": receipt["duration_ms"],
         "token_count": receipt["token_count"],
     }
+    if git_sha is not None:
+        projection["git_sha_correlation"] = git_sha
+    return projection
 
 
 def acp_projection_digest(projection: dict[str, Any]) -> str:
@@ -275,6 +280,29 @@ def _verified_acp_receipt(acp_root: Path, conversation_id: str) -> dict[str, Any
     return receipt
 
 
+def _verify_acp_git_correlation(acp_root: Path, conversation_id: str, git_sha: str | None) -> None:
+    """Prove an optional ACP-to-commit join from canonical correlation metadata."""
+    if git_sha is None:
+        return
+    if not GIT_SHA_RE.fullmatch(git_sha):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "git_sha must be a full 40-hex commit SHA")
+    db_path = Path(acp_root).expanduser().resolve() / "comms.sqlite3"
+    if not db_path.is_file():
+        raise ResolutionError(REASON_SOURCE_MISSING)
+    try:
+        with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:
+            row = connection.execute(
+                "SELECT correlation_digest FROM acp_conversations WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+    except sqlite3.Error as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "ACP correlation metadata unreadable") from exc
+    if row is None:
+        raise ResolutionError(REASON_SOURCE_MISSING)
+    if not isinstance(row[0], str) or row[0] != sha256_text(git_sha):
+        raise ResolutionError(REASON_DIGEST_MISMATCH, "ACP correlation does not bind this commit")
+
+
 def resolve_acp_conversation(
     conversation_id: str,
     *,
@@ -284,10 +312,9 @@ def resolve_acp_conversation(
 ) -> Resolution:
     """Resolve an exact ACP conversation ID through the terminal receipt verifier."""
     receipt = _verified_acp_receipt(Path(acp_root), conversation_id)
-    projection = acp_receipt_projection(receipt)
+    _verify_acp_git_correlation(Path(acp_root), conversation_id, git_sha)
+    projection = acp_receipt_projection(receipt, git_sha=git_sha)
     digest = acp_projection_digest(projection)
-    if git_sha is not None and not GIT_SHA_RE.fullmatch(git_sha):
-        raise ResolutionError(REASON_RESOLUTION_ERROR, "git_sha must be a full 40-hex commit SHA")
     facets = {
         "source_kind": "acp_conversation",
         "state": str(receipt["state"]),
@@ -327,6 +354,8 @@ def resolve_acp_conversation(
         "token_bucket": _token_bucket(receipt["token_count"]),
         "content_included": False,
     }
+    if git_sha is not None:
+        excerpt["git_sha_correlation"] = git_sha
     return Resolution(link=link, verification=verification, excerpt=excerpt)
 
 
@@ -380,9 +409,6 @@ def reverify_link(
         now=now,
     )
     fresh = resolution.link
-    if (
-        fresh.canonical_digest != link["canonical_digest"]
-        or fresh.canonical_namespace != link["canonical_namespace"]
-    ):
+    if fresh.canonical_digest != link["canonical_digest"] or fresh.canonical_namespace != link["canonical_namespace"]:
         raise ResolutionError(REASON_DIGEST_MISMATCH)
     return resolution.excerpt

--- a/scripts/entire_context/resolvers.py
+++ b/scripts/entire_context/resolvers.py
@@ -151,14 +151,29 @@ def git_commit_projection(repo: Path, sha: str) -> dict[str, Any]:
     lines = header.split("\n")
     if len(lines) < 3:
         raise ResolutionError(REASON_RESOLUTION_ERROR, "unexpected git show output shape")
-    parents = sorted(parent for parent in lines[0].split() if parent)
+    parent_order = [parent for parent in lines[0].split() if parent]
+    parents = sorted(parent_order)
     try:
         commit_ts = int(lines[1].strip())
     except ValueError as exc:
         raise ResolutionError(REASON_RESOLUTION_ERROR, "unparseable commit timestamp") from exc
     author = lines[2].strip()
-    touched = _run_git(repo, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha)
-    touched_paths = sorted(path for path in touched.split("\n") if path.strip())
+    if parents:
+        # A commit's public touched-path projection is its change relative to
+        # the first parent. This is explicit for merges; plain `diff-tree SHA`
+        # suppresses merge diffs and would silently emit an empty path set.
+        touched = _run_git(
+            repo,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            parent_order[0],
+            sha,
+        )
+    else:
+        touched = _run_git(repo, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha)
+    touched_paths = sorted({path for path in touched.split("\n") if path.strip()})
     return {
         "schema": "git-commit-projection.v1",
         "sha": sha,

--- a/scripts/entire_context/resolvers.py
+++ b/scripts/entire_context/resolvers.py
@@ -409,6 +409,10 @@ def reverify_link(
         now=now,
     )
     fresh = resolution.link
-    if fresh.canonical_digest != link["canonical_digest"] or fresh.canonical_namespace != link["canonical_namespace"]:
+    # Git namespaces may be explicit organizational labels, so re-resolution
+    # deliberately preserves them instead of pretending to derive them anew.
+    # ACP namespaces are canonical resolver output and can be compared.
+    namespace_mismatch = kind is not LinkKind.GIT_COMMIT and fresh.canonical_namespace != link["canonical_namespace"]
+    if fresh.canonical_digest != link["canonical_digest"] or namespace_mismatch:
         raise ResolutionError(REASON_DIGEST_MISMATCH)
     return resolution.excerpt

--- a/scripts/entire_context/resolvers.py
+++ b/scripts/entire_context/resolvers.py
@@ -1,0 +1,388 @@
+"""Explicit, local-only typed resolvers for context-link bootstrap and re-verify.
+
+Every resolver maps one exact, caller-supplied identifier to a body-free
+canonical projection: a deterministic digest over public metadata, never over
+subjects, prompts, transcripts, or any composed text. Resolution is fully
+local — read-only ``git`` plumbing and the existing body-free ACP terminal
+receipt verifier — and fails closed: a source that cannot be verified raises
+:class:`ResolutionError` with a machine reason and nothing is fabricated.
+
+Real resolvers in this slice:
+
+- ``git_commit`` — an exact full commit SHA in a local repository resolves to
+  parents, touched paths, committer timestamp, and author (public metadata,
+  no commit subject/body).
+- ``acp_conversation`` — an exact ACP conversation ID resolves through
+  :func:`scripts.agent_runtime.acpx_discuss.verify_discussion_receipt` to
+  body-free terminal metadata with ``content_included: false``.
+
+``github_issue``, ``github_pr``, ``fleet_receipt``, ``rollover``,
+``formal_review``, and ``monitor_run`` remain explicitly unsupported here:
+this slice has no local canonical store for them that is verifiable without
+network access or protected-rail mutation, so they fail closed with
+``unsupported_kind`` instead of fabricating coverage.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.agent_runtime.acpx_discuss import (
+    AcpxDiscussionError,
+    AcpxDiscussionNotFoundError,
+    verify_discussion_receipt,
+)
+
+from .model import (
+    GIT_SHA_RE,
+    ContextLink,
+    LinkKind,
+    SchemaError,
+    VerificationEvidence,
+    VerificationStatus,
+    canonical_json,
+    isoformat_z,
+    sha256_text,
+    utc_now,
+    validate_facets,
+)
+
+GIT_TIMEOUT_SECONDS = 30
+
+ACP_CONVERSATION_ID_RE = re.compile(r"^conversation_[0-9a-f]{32}$")
+
+#: Kinds with a real local resolver in this slice. Everything else fails closed.
+SUPPORTED_RESOLVER_KINDS = frozenset({LinkKind.GIT_COMMIT, LinkKind.ACP_CONVERSATION})
+
+#: Body-free machine reasons a resolution or re-verification can end with.
+REASON_SOURCE_MISSING = "source_missing"
+REASON_DIGEST_MISMATCH = "digest_mismatch"
+REASON_PARTIAL_TERMINAL = "partial_terminal"
+REASON_UNSUPPORTED_KIND = "unsupported_kind"
+REASON_RESOLUTION_ERROR = "resolution_error"
+
+
+class ResolutionError(ValueError):
+    """Fail-closed resolver outcome with a body-free machine reason."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        super().__init__(reason if not detail else f"{reason}: {detail}")
+        self.reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class Resolution:
+    """One verified body-free canonical projection plus admission evidence."""
+
+    link: ContextLink
+    verification: VerificationEvidence
+    excerpt: dict[str, Any]
+
+
+def _token_bucket(token_count: int | None) -> str:
+    if token_count is None or token_count <= 0:
+        return "none"
+    if token_count < 10_000:
+        return "small"
+    if token_count < 100_000:
+        return "medium"
+    return "large"
+
+
+# ── git_commit ───────────────────────────────────────────────────────────────
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    """Run one read-only git plumbing command; fail closed on any error."""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"git unavailable: {type(exc).__name__}") from exc
+    if completed.returncode != 0:
+        raise ResolutionError(REASON_SOURCE_MISSING, "git object or repository not resolvable")
+    return completed.stdout
+
+
+def _origin_namespace(repo: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    url = completed.stdout.strip()
+    match = re.search(r"[:/]([A-Za-z0-9._-]+/[A-Za-z0-9._-]+?)(?:\.git)?$", url)
+    if match is None:
+        return None
+    return f"git:{match.group(1)}"
+
+
+def git_commit_projection(repo: Path, sha: str) -> dict[str, Any]:
+    """Resolve one exact commit SHA to its body-free canonical projection.
+
+    The projection covers the SHA, parent SHAs, touched paths, and committer
+    timestamp — never the commit subject or body.
+    """
+    if not GIT_SHA_RE.fullmatch(sha):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "identifier is not a full 40-hex commit SHA")
+    repo = Path(repo)
+    object_type = _run_git(repo, "cat-file", "-t", sha).strip()
+    if object_type != "commit":
+        raise ResolutionError(REASON_SOURCE_MISSING, "git object is not a commit")
+    header = _run_git(repo, "show", "-s", "--format=%P%n%ct%n%an", sha)
+    lines = header.split("\n")
+    if len(lines) < 3:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "unexpected git show output shape")
+    parents = sorted(parent for parent in lines[0].split() if parent)
+    try:
+        commit_ts = int(lines[1].strip())
+    except ValueError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "unparseable commit timestamp") from exc
+    author = lines[2].strip()
+    touched = _run_git(repo, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha)
+    touched_paths = sorted(path for path in touched.split("\n") if path.strip())
+    return {
+        "schema": "git-commit-projection.v1",
+        "sha": sha,
+        "parents": parents,
+        "touched_paths": touched_paths,
+        "commit_ts": commit_ts,
+        "author": author,
+    }
+
+
+def git_projection_digest(projection: dict[str, Any]) -> str:
+    """Deterministic digest over the body-free commit projection only."""
+    return "sha256:" + sha256_text(
+        canonical_json(
+            {
+                "schema": projection["schema"],
+                "sha": projection["sha"],
+                "parents": projection["parents"],
+                "touched_paths": projection["touched_paths"],
+                "commit_ts": projection["commit_ts"],
+            }
+        )
+    )
+
+
+def resolve_git_commit(
+    sha: str,
+    *,
+    repo: Path,
+    namespace: str | None = None,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve an exact commit SHA into a verified body-free context link."""
+    projection = git_commit_projection(Path(repo), sha)
+    resolved_namespace = namespace or _origin_namespace(Path(repo)) or f"git:local/{Path(repo).resolve().name}"
+    digest = git_projection_digest(projection)
+    facets = {
+        "source_kind": "git_commit",
+        "touched_paths": projection["touched_paths"],
+        "actor": projection["author"],
+        "event_ts": str(projection["commit_ts"]),
+    }
+    if resolved_namespace.startswith("git:") and not resolved_namespace.startswith("git:local/"):
+        facets["repository"] = resolved_namespace.removeprefix("git:")
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.GIT_COMMIT,
+            canonical_namespace=resolved_namespace,
+            canonical_id=sha,
+            canonical_digest=digest,
+            git_sha=sha,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="git",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"git:commit/{sha}",
+        checked_at=isoformat_z(now or utc_now()),
+    )
+    excerpt = {
+        "source": f"git:commit/{sha}",
+        "parents": projection["parents"],
+        "touched_paths": projection["touched_paths"],
+        "commit_ts": projection["commit_ts"],
+        "author": projection["author"],
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── acp_conversation ─────────────────────────────────────────────────────────
+
+
+def acp_receipt_projection(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Extract the body-free terminal metadata covered by the digest."""
+    return {
+        "schema": "acp-receipt-projection.v1",
+        "conversation_id": receipt["conversation_id"],
+        "state": receipt["state"],
+        "participants": sorted(receipt["participants"]),
+        "rounds_requested": receipt["rounds_requested"],
+        "rounds_observed": receipt["rounds_observed"],
+        "successful_rounds": receipt["successful_rounds"],
+        "participant_outcomes": receipt["participant_outcomes"],
+        "synthesis_outcome": receipt["synthesis_outcome"],
+        "duplicate_suppressed_count": receipt["duplicate_suppressed_count"],
+        "created_at": receipt["created_at"],
+        "updated_at": receipt["updated_at"],
+        "duration_ms": receipt["duration_ms"],
+        "token_count": receipt["token_count"],
+    }
+
+
+def acp_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def _verified_acp_receipt(acp_root: Path, conversation_id: str) -> dict[str, Any]:
+    if not ACP_CONVERSATION_ID_RE.fullmatch(conversation_id):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "identifier is not a canonical ACP conversation ID")
+    try:
+        receipt = verify_discussion_receipt(root=Path(acp_root), conversation_id=conversation_id)
+    except AcpxDiscussionNotFoundError as exc:
+        raise ResolutionError(REASON_SOURCE_MISSING) from exc
+    except AcpxDiscussionError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, type(exc).__name__) from exc
+    if receipt.get("content_included") is not False:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "receipt violates the body-free contract")
+    if receipt.get("verified") is not True:
+        raise ResolutionError(REASON_PARTIAL_TERMINAL, ",".join(receipt.get("reasons") or []))
+    return receipt
+
+
+def resolve_acp_conversation(
+    conversation_id: str,
+    *,
+    acp_root: Path,
+    git_sha: str | None = None,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve an exact ACP conversation ID through the terminal receipt verifier."""
+    receipt = _verified_acp_receipt(Path(acp_root), conversation_id)
+    projection = acp_receipt_projection(receipt)
+    digest = acp_projection_digest(projection)
+    if git_sha is not None and not GIT_SHA_RE.fullmatch(git_sha):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "git_sha must be a full 40-hex commit SHA")
+    facets = {
+        "source_kind": "acp_conversation",
+        "state": str(receipt["state"]),
+        "participants": sorted(receipt["participants"]),
+        "token_bucket": _token_bucket(receipt["token_count"]),
+        "event_ts": str(receipt["updated_at"]),
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.ACP_CONVERSATION,
+            canonical_namespace="acp:conversations",
+            canonical_id=conversation_id,
+            canonical_digest=digest,
+            git_sha=git_sha,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="acp-receipt",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"acp:conversation/{conversation_id}",
+        checked_at=isoformat_z(now or utc_now()),
+    )
+    excerpt = {
+        "source": f"acp:conversation/{conversation_id}",
+        "state": receipt["state"],
+        "participants": sorted(receipt["participants"]),
+        "rounds_requested": receipt["rounds_requested"],
+        "successful_rounds": receipt["successful_rounds"],
+        "synthesis_outcome": receipt["synthesis_outcome"],
+        "created_at": receipt["created_at"],
+        "updated_at": receipt["updated_at"],
+        "token_bucket": _token_bucket(receipt["token_count"]),
+        "content_included": False,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── typed dispatch and re-verification gate ──────────────────────────────────
+
+
+def resolve_bootstrap(
+    kind: LinkKind,
+    identifier: str,
+    *,
+    repo: Path,
+    acp_root: Path | None,
+    namespace: str | None = None,
+    git_sha: str | None = None,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve one explicit typed identifier for bootstrap/index admission."""
+    if kind is LinkKind.GIT_COMMIT:
+        return resolve_git_commit(identifier, repo=repo, namespace=namespace, now=now)
+    if kind is LinkKind.ACP_CONVERSATION:
+        if acp_root is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "no ACP receipt root available")
+        return resolve_acp_conversation(identifier, acp_root=acp_root, git_sha=git_sha, now=now)
+    raise ResolutionError(REASON_UNSUPPORTED_KIND, kind.value)
+
+
+def reverify_link(
+    link: dict[str, Any],
+    *,
+    repo: Path,
+    acp_root: Path | None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Re-resolve one stored link and recompute its canonical digest.
+
+    Returns the fresh body-free excerpt, or raises :class:`ResolutionError`
+    with a machine reason. Missing sources, partial-terminal receipts,
+    unsupported kinds, and digest mismatches all fail closed.
+    """
+    try:
+        kind = LinkKind(str(link["kind"]))
+    except ValueError as exc:
+        raise ResolutionError(REASON_UNSUPPORTED_KIND, str(link.get("kind"))) from exc
+    resolution = resolve_bootstrap(
+        kind,
+        str(link["canonical_id"]),
+        repo=repo,
+        acp_root=acp_root,
+        namespace=str(link["canonical_namespace"]),
+        git_sha=link.get("git_sha") if kind is LinkKind.ACP_CONVERSATION else None,
+        now=now,
+    )
+    fresh = resolution.link
+    if (
+        fresh.canonical_digest != link["canonical_digest"]
+        or fresh.canonical_namespace != link["canonical_namespace"]
+    ):
+        raise ResolutionError(REASON_DIGEST_MISMATCH)
+    return resolution.excerpt

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -394,6 +394,68 @@ class ContextLinkStore:
             "last_event_at": events["last_at"] if events else None,
         }
 
+    # ── recall candidate scan and provenance joins ─────────────────────────────
+
+    def candidates(self, *, limit: int = 500) -> list[dict[str, Any]]:
+        """Body-free promoted candidate scan for ranking (deterministic order).
+
+        Pending and tombstoned claims are never candidates. The order is fully
+        derived from the stored locator IDs so recall ranking is reproducible.
+        """
+        capped = max(0, int(limit))
+        with self._connect(write=False) as connection:
+            rows = connection.execute(
+                "SELECT * FROM context_links WHERE state = 'promoted'"
+                " ORDER BY locator_id LIMIT ?",
+                (capped,),
+            ).fetchall()
+        return [self._row_to_link_dict(row) for row in rows]
+
+    def find_related(
+        self,
+        link: dict[str, Any],
+        *,
+        limit: int = 50,
+    ) -> list[tuple[dict[str, Any], str]]:
+        """Body-free promoted provenance joins for explain-change traversal.
+
+        Returns ``(candidate, join)`` pairs using explicit typed joins only:
+        ``same_git_sha`` (commit-backed provenance), ``references_commit`` /
+        ``referenced_by_commit`` (commit ↔ receipt cross-reference), and
+        ``same_canonical_id`` (the same exact identifier in another kind).
+        Namespace equality is deliberately not a join: it would connect every
+        same-repository commit. The seed itself and any non-promoted claim are
+        excluded. Order is deterministic and bounded by ``limit``.
+        """
+        capped = max(0, int(limit))
+        locator_id = str(link["locator_id"])
+        with self._connect(write=False) as connection:
+            rows = connection.execute(
+                "SELECT * FROM context_links WHERE state = 'promoted'"
+                " AND locator_id != ? ORDER BY locator_id",
+                (locator_id,),
+            ).fetchall()
+        related: list[tuple[dict[str, Any], str]] = []
+        seed_sha = link.get("git_sha")
+        seed_id = link.get("canonical_id")
+        for row in rows:
+            candidate = self._row_to_link_dict(row)
+            candidate_sha = candidate.get("git_sha")
+            join: str | None = None
+            if seed_sha and candidate.get("canonical_id") == seed_sha:
+                join = "references_commit"
+            elif candidate_sha and candidate_sha == seed_id:
+                join = "referenced_by_commit"
+            elif seed_sha and candidate_sha == seed_sha:
+                join = "same_git_sha"
+            elif seed_id and candidate.get("canonical_id") == seed_id:
+                join = "same_canonical_id"
+            if join is not None:
+                related.append((candidate, join))
+                if len(related) >= capped:
+                    break
+        return related
+
     # ── rebuild ──────────────────────────────────────────────────────────────
 
     def _projection_snapshot(self, connection: sqlite3.Connection) -> str:

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -37,6 +37,7 @@ from .model import (
 
 DEFAULT_VERIFICATION_MAX_AGE_SECONDS = 3600
 MAX_CLOCK_SKEW_SECONDS = 300
+MAX_RELATED_SCAN_ROWS = 500
 
 _DDL = """
 CREATE TABLE IF NOT EXISTS link_events (
@@ -402,7 +403,7 @@ class ContextLinkStore:
         Pending and tombstoned claims are never candidates. The order is fully
         derived from the stored locator IDs so recall ranking is reproducible.
         """
-        capped = max(0, int(limit))
+        capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
         with self._connect(write=False) as connection:
             rows = connection.execute(
                 "SELECT * FROM context_links WHERE state = 'promoted'"
@@ -427,13 +428,13 @@ class ContextLinkStore:
         same-repository commit. The seed itself and any non-promoted claim are
         excluded. Order is deterministic and bounded by ``limit``.
         """
-        capped = max(0, int(limit))
+        capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
         locator_id = str(link["locator_id"])
         with self._connect(write=False) as connection:
             rows = connection.execute(
                 "SELECT * FROM context_links WHERE state = 'promoted'"
-                " AND locator_id != ? ORDER BY locator_id",
-                (locator_id,),
+                " AND locator_id != ? ORDER BY locator_id LIMIT ?",
+                (locator_id, MAX_RELATED_SCAN_ROWS),
             ).fetchall()
         related: list[tuple[dict[str, Any], str]] = []
         seed_sha = link.get("git_sha")

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -91,6 +91,15 @@ class AdmitResult:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RelatedScan:
+    """Bounded typed-join scan with explicit completeness metadata."""
+
+    items: tuple[tuple[dict[str, Any], str], ...]
+    examined: int
+    truncated: bool
+
+
 class ContextLinkStore:
     """High-level admission / lookup / rebuild API over one SQLite file."""
 
@@ -154,9 +163,7 @@ class ContextLinkStore:
 
     @staticmethod
     def _current_state(connection: sqlite3.Connection, locator_id: str) -> str | None:
-        row = connection.execute(
-            "SELECT state FROM context_links WHERE locator_id = ?", (locator_id,)
-        ).fetchone()
+        row = connection.execute("SELECT state FROM context_links WHERE locator_id = ?", (locator_id,)).fetchone()
         return None if row is None else str(row["state"])
 
     @staticmethod
@@ -236,9 +243,7 @@ class ContextLinkStore:
         with self._transaction() as connection:
             state = self._current_state(connection, locator_id)
             if state == "tombstoned":
-                return AdmitResult(
-                    locator_id, AdmitOutcome.ALREADY_TOMBSTONED, "tombstone_terminal", state
-                )
+                return AdmitResult(locator_id, AdmitOutcome.ALREADY_TOMBSTONED, "tombstone_terminal", state)
             if state is not None and not self._payload_matches(connection, link):
                 if state == "pending":
                     connection.execute(
@@ -352,9 +357,7 @@ class ContextLinkStore:
         if not LOCATOR_ID_RE.fullmatch(locator_id):
             return None
         with self._connect(write=False) as connection:
-            link_row = connection.execute(
-                "SELECT * FROM context_links WHERE locator_id = ?", (locator_id,)
-            ).fetchone()
+            link_row = connection.execute("SELECT * FROM context_links WHERE locator_id = ?", (locator_id,)).fetchone()
             if link_row is None:
                 return None
             events = connection.execute(
@@ -385,9 +388,7 @@ class ContextLinkStore:
             counts = connection.execute(
                 "SELECT state, COUNT(*) AS n FROM context_links GROUP BY state ORDER BY state"
             ).fetchall()
-            events = connection.execute(
-                "SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM link_events"
-            ).fetchone()
+            events = connection.execute("SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM link_events").fetchone()
         return {
             "schema_version": SCHEMA_VERSION,
             "counts": {str(row["state"]): int(row["n"]) for row in counts},
@@ -406,8 +407,7 @@ class ContextLinkStore:
         capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
         with self._connect(write=False) as connection:
             rows = connection.execute(
-                "SELECT * FROM context_links WHERE state = 'promoted'"
-                " ORDER BY locator_id LIMIT ?",
+                "SELECT * FROM context_links WHERE state = 'promoted' ORDER BY locator_id LIMIT ?",
                 (capped,),
             ).fetchall()
         return [self._row_to_link_dict(row) for row in rows]
@@ -417,7 +417,7 @@ class ContextLinkStore:
         link: dict[str, Any],
         *,
         limit: int = 50,
-    ) -> list[tuple[dict[str, Any], str]]:
+    ) -> RelatedScan:
         """Body-free promoted provenance joins for explain-change traversal.
 
         Returns ``(candidate, join)`` pairs using explicit typed joins only:
@@ -426,21 +426,36 @@ class ContextLinkStore:
         ``same_canonical_id`` (the same exact identifier in another kind).
         Namespace equality is deliberately not a join: it would connect every
         same-repository commit. The seed itself and any non-promoted claim are
-        excluded. Order is deterministic and bounded by ``limit``.
+        excluded. SQL prefilters for typed joins before applying ``limit``, so
+        unrelated locator rows cannot hide a valid join. Order is deterministic
+        and truncation is explicit.
         """
         capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
-        if capped == 0:
-            return []
         locator_id = str(link["locator_id"])
+        seed_sha = link.get("git_sha")
+        seed_id = link.get("canonical_id")
+        predicates: list[str] = []
+        predicate_values: list[str] = []
+        if seed_sha:
+            predicates.extend(("canonical_id = ?", "git_sha = ?"))
+            predicate_values.extend((str(seed_sha), str(seed_sha)))
+        if seed_id:
+            predicates.extend(("git_sha = ?", "canonical_id = ?"))
+            predicate_values.extend((str(seed_id), str(seed_id)))
+        if not predicates:
+            return RelatedScan(items=(), examined=0, truncated=False)
+        # Fetch one sentinel beyond the caller-visible cap so truncation is
+        # observable even when the requested limit is zero.
         with self._connect(write=False) as connection:
             rows = connection.execute(
                 "SELECT * FROM context_links WHERE state = 'promoted'"
-                " AND locator_id != ? ORDER BY locator_id LIMIT ?",
-                (locator_id, capped),
+                f" AND locator_id != ? AND ({' OR '.join(predicates)})"
+                " ORDER BY locator_id LIMIT ?",
+                (locator_id, *predicate_values, capped + 1),
             ).fetchall()
+        truncated = len(rows) > capped
+        rows = rows[:capped]
         related: list[tuple[dict[str, Any], str]] = []
-        seed_sha = link.get("git_sha")
-        seed_id = link.get("canonical_id")
         for row in rows:
             candidate = self._row_to_link_dict(row)
             candidate_sha = candidate.get("git_sha")
@@ -455,7 +470,7 @@ class ContextLinkStore:
                 join = "same_canonical_id"
             if join is not None:
                 related.append((candidate, join))
-        return related
+        return RelatedScan(items=tuple(related), examined=len(rows), truncated=truncated)
 
     # ── rebuild ──────────────────────────────────────────────────────────────
 

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -429,12 +429,14 @@ class ContextLinkStore:
         excluded. Order is deterministic and bounded by ``limit``.
         """
         capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
+        if capped == 0:
+            return []
         locator_id = str(link["locator_id"])
         with self._connect(write=False) as connection:
             rows = connection.execute(
                 "SELECT * FROM context_links WHERE state = 'promoted'"
                 " AND locator_id != ? ORDER BY locator_id LIMIT ?",
-                (locator_id, MAX_RELATED_SCAN_ROWS),
+                (locator_id, capped),
             ).fetchall()
         related: list[tuple[dict[str, Any], str]] = []
         seed_sha = link.get("git_sha")
@@ -453,8 +455,6 @@ class ContextLinkStore:
                 join = "same_canonical_id"
             if join is not None:
                 related.append((candidate, join))
-                if len(related) >= capped:
-                    break
         return related
 
     # ── rebuild ──────────────────────────────────────────────────────────────

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -11,6 +11,7 @@ without invalid JSON.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -196,6 +197,7 @@ def make_acp_plane(
     conversation_id: str = CONV_ID,
     terminal: bool = True,
     name: str = "plane",
+    correlation_id: str | None = None,
 ) -> Path:
     root = tmp_path / name
     root.mkdir()
@@ -207,7 +209,9 @@ def make_acp_plane(
             (
                 conversation_id,
                 "task-digest",
-                "correlation-digest",
+                hashlib.sha256(correlation_id.encode("utf-8")).hexdigest()
+                if correlation_id is not None
+                else "correlation-digest",
                 f"idem-{conversation_id[-4:]}",
                 1,
                 json.dumps(["claude", "kimi"]),
@@ -298,12 +302,8 @@ def bootstrap_git(store: ContextLinkStore, repo: Path, sha: str) -> str:
     return admit(store, resolve_git_commit(sha, repo=repo))
 
 
-def bootstrap_acp(
-    store: ContextLinkStore, acp_root: Path, conversation_id: str = CONV_ID, **kwargs
-) -> str:
-    return admit(
-        store, resolve_acp_conversation(conversation_id, acp_root=acp_root, **kwargs)
-    )
+def bootstrap_acp(store: ContextLinkStore, acp_root: Path, conversation_id: str = CONV_ID, **kwargs) -> str:
+    return admit(store, resolve_acp_conversation(conversation_id, acp_root=acp_root, **kwargs))
 
 
 def run_cli(capsys: pytest.CaptureFixture, *args: str) -> tuple[int, str]:
@@ -343,9 +343,7 @@ def test_git_bootstrap_then_search_recall(
     assert card["excerpt"]["parents"] == [git_repo["sha1"]]
 
     # Facet needle finds the same verified card.
-    code, out = run_cli(
-        capsys, "search", "--query", "gamma.md", "--repo", repo, "--db", str(db)
-    )
+    code, out = run_cli(capsys, "search", "--query", "gamma.md", "--repo", repo, "--db", str(db))
     assert code == 0
     result = json.loads(out)
     assert [entry["locator_id"] for entry in result["results"]] == [card["locator_id"]]
@@ -353,9 +351,7 @@ def test_git_bootstrap_then_search_recall(
     assert_body_free(out)
 
 
-def test_acp_bootstrap_then_recall(
-    tmp_path: Path, capsys: pytest.CaptureFixture
-) -> None:
+def test_acp_bootstrap_then_recall(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     acp_root = make_acp_plane(tmp_path)
     db = tmp_path / "db.sqlite3"
     code, out = run_cli(
@@ -439,8 +435,16 @@ def test_provider_consumer_labels_yield_identical_bytes(
     handoff_outputs = []
     for consumer in ("codex", "kimi", "glm"):
         code, out = run_cli(
-            capsys, "handoff", "--query", "alpha", "--repo", repo, "--db", db,
-            "--consumer", consumer,
+            capsys,
+            "handoff",
+            "--query",
+            "alpha",
+            "--repo",
+            repo,
+            "--db",
+            db,
+            "--consumer",
+            consumer,
         )
         assert code == 0
         handoff_outputs.append(out)
@@ -488,9 +492,7 @@ def _link_dict(locator_suffix: str, **overrides) -> dict[str, object]:
 
 def test_ranking_exact_id_first_casefold_and_tiebreak() -> None:
     exact = rank_candidate(_link_dict("b"), "ab" * 20)
-    facet = rank_candidate(
-        _link_dict("a", facets={"title": "Matching Alpha Work"}), "matching alpha work"
-    )
+    facet = rank_candidate(_link_dict("a", facets={"title": "Matching Alpha Work"}), "matching alpha work")
     assert exact.score == 0  # no match against zero-sha candidate
     exact = rank_candidate(_link_dict("b", canonical_id="cd" * 20, git_sha="cd" * 20), "CD" * 20)
     assert exact.score >= 1000
@@ -522,8 +524,16 @@ def test_search_deterministic_limit_and_scan(
 
     # Result cap: limit=1 keeps the deterministic top entry.
     code, out = run_cli(
-        capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db,
-        "--limit", "1",
+        capsys,
+        "search",
+        "--query",
+        "learn-ukrainian",
+        "--repo",
+        repo,
+        "--db",
+        db,
+        "--limit",
+        "1",
     )
     top = json.loads(out)
     assert len(top["results"]) == 1
@@ -531,8 +541,16 @@ def test_search_deterministic_limit_and_scan(
 
     # Scan cap: only the first promoted row (locator_id order) is a candidate.
     code, out = run_cli(
-        capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db,
-        "--scan-limit", "1",
+        capsys,
+        "search",
+        "--query",
+        "learn-ukrainian",
+        "--repo",
+        repo,
+        "--db",
+        db,
+        "--scan-limit",
+        "1",
     )
     scanned = json.loads(out)
     assert scanned["scanned"] == 1
@@ -540,9 +558,7 @@ def test_search_deterministic_limit_and_scan(
     assert [card["locator_id"] for card in scanned["results"]] == [expected_first]
 
     # Exact SHA outranks facet matches regardless of locator order.
-    code, out = run_cli(
-        capsys, "search", "--query", str(git_repo["sha2"]), "--repo", repo, "--db", db
-    )
+    code, out = run_cli(capsys, "search", "--query", str(git_repo["sha2"]), "--repo", repo, "--db", db)
     exact = json.loads(out)
     assert exact["results"][0]["canonical_id"] == git_repo["sha2"]
 
@@ -550,13 +566,9 @@ def test_search_deterministic_limit_and_scan(
 def test_result_cap_of_ten(tmp_path: Path, git_repo: dict[str, object]) -> None:
     store = make_store(tmp_path)
     for index in range(12):
-        sha = commit_files(
-            git_repo["repo"], {f"series/file-{index:02d}.txt": f"{index}\n"}, "series"
-        )
+        sha = commit_files(git_repo["repo"], {f"series/file-{index:02d}.txt": f"{index}\n"}, "series")
         bootstrap_git(store, git_repo["repo"], sha)
-    result = recall.search_past_work(
-        store, "series", repo=git_repo["repo"], acp_root=None, limit=50
-    )
+    result = recall.search_past_work(store, "series", repo=git_repo["repo"], acp_root=None, limit=50)
     assert result["scanned"] == 12
     assert len(result["results"]) == 10  # hard cap, not the requested 50
     assert result["limit"] == 10
@@ -588,18 +600,12 @@ def test_stale_digest_is_omitted(tmp_path: Path) -> None:
     locator_id = bootstrap_acp(store, acp_root)
     append_acp_state_event(acp_root)  # receipt moves on; stored digest is stale
 
-    result = recall.search_past_work(
-        store, CONV_ID, repo=tmp_path, acp_root=acp_root
-    )
+    result = recall.search_past_work(store, CONV_ID, repo=tmp_path, acp_root=acp_root)
     assert result["results"] == []
-    assert result["omitted"] == [
-        {"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}
-    ]
+    assert result["omitted"] == [{"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}]
     capsule = recall.prepare_handoff(store, [locator_id], repo=tmp_path, acp_root=acp_root)
     assert capsule["items"] == []
-    assert capsule["omitted"] == [
-        {"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}
-    ]
+    assert capsule["omitted"] == [{"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}]
 
 
 def test_missing_source_is_omitted_and_bootstrap_refused(
@@ -609,16 +615,17 @@ def test_missing_source_is_omitted_and_bootstrap_refused(
     locator_id = bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
     other = make_git_repo(tmp_path, name="other")  # no such commit here
 
-    result = recall.search_past_work(
-        store, str(git_repo["sha1"]), repo=other, acp_root=None
-    )
+    result = recall.search_past_work(store, str(git_repo["sha1"]), repo=other, acp_root=None)
     assert result["results"] == []
-    assert result["omitted"] == [
-        {"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}
-    ]
+    assert result["omitted"] == [{"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}]
 
     code, out = run_cli(
-        capsys, "bootstrap-git", "f" * 40, "--repo", str(other), "--db",
+        capsys,
+        "bootstrap-git",
+        "f" * 40,
+        "--repo",
+        str(other),
+        "--db",
         str(tmp_path / "other-db.sqlite3"),
     )
     assert code == 2
@@ -633,9 +640,7 @@ def test_acp_link_fails_closed_without_receipt_root(
     locator_id = bootstrap_acp(store, acp_root)
     result = recall.search_past_work(store, CONV_ID, repo=tmp_path, acp_root=None)
     assert result["results"] == []
-    assert result["omitted"] == [
-        {"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}
-    ]
+    assert result["omitted"] == [{"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}]
 
 
 def test_tombstoned_claim_never_recalled(tmp_path: Path) -> None:
@@ -657,9 +662,7 @@ def test_tombstoned_claim_never_recalled(tmp_path: Path) -> None:
 def test_partial_acp_receipt_fails_closed(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     acp_root = make_acp_plane(tmp_path, terminal=False)
     db = tmp_path / "db.sqlite3"
-    code, out = run_cli(
-        capsys, "bootstrap-acp", CONV_ID, "--acp-root", str(acp_root), "--db", str(db)
-    )
+    code, out = run_cli(capsys, "bootstrap-acp", CONV_ID, "--acp-root", str(acp_root), "--db", str(db))
     assert code == 2
     assert json.loads(out)["reason"] == "partial_terminal"
     assert not db.exists()  # nothing was admitted
@@ -670,6 +673,17 @@ def test_unknown_acp_conversation_fails_closed(tmp_path: Path) -> None:
     with pytest.raises(ResolutionError) as excinfo:
         resolve_acp_conversation("conversation_" + "9" * 32, acp_root=acp_root)
     assert excinfo.value.reason == REASON_SOURCE_MISSING
+
+
+def test_acp_commit_join_requires_canonical_correlation(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_acp_conversation(
+            CONV_ID,
+            acp_root=acp_root,
+            git_sha=str(git_repo["sha1"]),
+        )
+    assert excinfo.value.reason == REASON_DIGEST_MISMATCH
 
 
 def test_unsupported_kind_fails_closed(tmp_path: Path, git_repo: dict[str, object]) -> None:
@@ -701,9 +715,7 @@ def test_unsupported_kind_fails_closed(tmp_path: Path, git_repo: dict[str, objec
     assert admitted.outcome is AdmitOutcome.PROMOTED
     result = recall.search_past_work(store, "6183", repo=tmp_path, acp_root=None)
     assert result["results"] == []
-    assert result["omitted"] == [
-        {"locator_id": admitted.locator_id, "reason": REASON_UNSUPPORTED_KIND}
-    ]
+    assert result["omitted"] == [{"locator_id": admitted.locator_id, "reason": REASON_UNSUPPORTED_KIND}]
 
 
 def test_entire_cli_is_never_invoked(
@@ -717,9 +729,7 @@ def test_entire_cli_is_never_invoked(
     bin_dir.mkdir()
     marker = tmp_path / "entire-was-called"
     stub = bin_dir / "entire"
-    stub.write_text(
-        '#!/bin/sh\n/bin/touch "$ENTIRE_STUB_MARKER"\nexit 1\n', encoding="utf-8"
-    )
+    stub.write_text('#!/bin/sh\n/bin/touch "$ENTIRE_STUB_MARKER"\nexit 1\n', encoding="utf-8")
     stub.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
     monkeypatch.setenv("ENTIRE_STUB_MARKER", str(marker))
@@ -727,8 +737,14 @@ def test_entire_cli_is_never_invoked(
     store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
     code, out = run_cli(
-        capsys, "search", "--query", "alpha", "--repo", str(git_repo["repo"]),
-        "--db", str(store.db_path),
+        capsys,
+        "search",
+        "--query",
+        "alpha",
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 0
     assert not marker.exists()
@@ -745,14 +761,26 @@ def test_query_over_256_bytes_refused_without_echo(
     bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
     needle = "q" * 257
     code, out = run_cli(
-        capsys, "search", "--query", needle, "--repo", str(git_repo["repo"]),
-        "--db", str(store.db_path),
+        capsys,
+        "search",
+        "--query",
+        needle,
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 2
     assert needle not in out
     code, out = run_cli(
-        capsys, "search", "--query", "   ", "--repo", str(git_repo["repo"]),
-        "--db", str(store.db_path),
+        capsys,
+        "search",
+        "--query",
+        "   ",
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 2
 
@@ -766,8 +794,14 @@ def test_query_is_never_echoed_or_persisted(
     # Uppercase needle matches the casefolded facet but never appears raw.
     needle = "ALPHA.TXT"
     code, out = run_cli(
-        capsys, "search", "--query", needle, "--repo", str(git_repo["repo"]),
-        "--db", str(store.db_path),
+        capsys,
+        "search",
+        "--query",
+        needle,
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 0
     assert needle not in out
@@ -782,16 +816,23 @@ def test_query_is_never_echoed_or_persisted(
 def test_explain_change_traverses_typed_joins(
     tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
 ) -> None:
-    acp_root = make_acp_plane(tmp_path)
-    store = make_store(tmp_path)
     sha = str(git_repo["sha2"])
+    acp_root = make_acp_plane(tmp_path, correlation_id=sha)
+    store = make_store(tmp_path)
     git_locator = bootstrap_git(store, git_repo["repo"], sha)
     acp_locator = bootstrap_acp(store, acp_root, git_sha=sha)
 
     code, out = run_cli(
-        capsys, "explain-change", "--sha", sha,
-        "--repo", str(git_repo["repo"]), "--acp-root", str(acp_root),
-        "--db", str(store.db_path),
+        capsys,
+        "explain-change",
+        "--sha",
+        sha,
+        "--repo",
+        str(git_repo["repo"]),
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(store.db_path),
     )
     assert code == 0
     payload = json.loads(out)
@@ -809,25 +850,19 @@ def test_explain_change_traverses_typed_joins(
     assert_body_free(out)
 
 
-def test_explain_change_omits_unverifiable_nodes(
-    tmp_path: Path, git_repo: dict[str, object]
-) -> None:
-    acp_root = make_acp_plane(tmp_path)
-    store = make_store(tmp_path)
+def test_explain_change_omits_unverifiable_nodes(tmp_path: Path, git_repo: dict[str, object]) -> None:
     sha = str(git_repo["sha2"])
+    acp_root = make_acp_plane(tmp_path, correlation_id=sha)
+    store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], sha)
     acp_locator = bootstrap_acp(store, acp_root, git_sha=sha)
     append_acp_state_event(acp_root)  # ACP node goes stale
 
-    result = recall.explain_change(
-        store, git_sha=sha, repo=git_repo["repo"], acp_root=acp_root
-    )
+    result = recall.explain_change(store, git_sha=sha, repo=git_repo["repo"], acp_root=acp_root)
     assert result["found"] is True
     assert {node["kind"] for node in result["nodes"]} == {"git_commit"}
     assert result["edges"] == []  # edges to omitted nodes are dropped
-    assert result["omitted"] == [
-        {"locator_id": acp_locator, "reason": REASON_DIGEST_MISMATCH}
-    ]
+    assert result["omitted"] == [{"locator_id": acp_locator, "reason": REASON_DIGEST_MISMATCH}]
 
 
 def test_explain_change_unknown_seed_not_found(
@@ -836,8 +871,14 @@ def test_explain_change_unknown_seed_not_found(
     store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
     code, out = run_cli(
-        capsys, "explain-change", "--locator-id", "clink_" + "f" * 64,
-        "--repo", str(git_repo["repo"]), "--db", str(store.db_path),
+        capsys,
+        "explain-change",
+        "--locator-id",
+        "clink_" + "f" * 64,
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 1
     assert json.loads(out)["found"] is False
@@ -846,26 +887,18 @@ def test_explain_change_unknown_seed_not_found(
 # ── prepare-handoff capsule ──────────────────────────────────────────────────
 
 
-def test_handoff_item_cap_and_deterministic_order(
-    tmp_path: Path, git_repo: dict[str, object]
-) -> None:
+def test_handoff_item_cap_and_deterministic_order(tmp_path: Path, git_repo: dict[str, object]) -> None:
     store = make_store(tmp_path)
     locators = []
     for index in range(MAX_HANDOFF_ITEMS + 1):
-        sha = commit_files(
-            git_repo["repo"], {f"cap/item-{index:02d}.txt": f"{index}\n"}, "cap"
-        )
+        sha = commit_files(git_repo["repo"], {f"cap/item-{index:02d}.txt": f"{index}\n"}, "cap")
         locators.append(bootstrap_git(store, git_repo["repo"], sha))
-    capsule = recall.prepare_handoff(
-        store, list(reversed(locators)), repo=git_repo["repo"], acp_root=None
-    )
+    capsule = recall.prepare_handoff(store, list(reversed(locators)), repo=git_repo["repo"], acp_root=None)
     assert len(capsule["items"]) == MAX_HANDOFF_ITEMS
     assert capsule["complete"] is False
     ordered = sorted(locators)
     assert [item["locator_id"] for item in capsule["items"]] == ordered[:MAX_HANDOFF_ITEMS]
-    assert capsule["omitted"] == [
-        {"locator_id": ordered[MAX_HANDOFF_ITEMS], "reason": "handoff_item_cap"}
-    ]
+    assert capsule["omitted"] == [{"locator_id": ordered[MAX_HANDOFF_ITEMS], "reason": "handoff_item_cap"}]
 
 
 def test_handoff_byte_cap_never_emits_invalid_json(
@@ -876,8 +909,7 @@ def test_handoff_byte_cap_never_emits_invalid_json(
     for commit_index in range(3):
         files = {
             (
-                f"dir.{commit_index}/mod.{file_index:02d}.controller.component."
-                "extension.service.adapter.registry.txt"
+                f"dir.{commit_index}/mod.{file_index:02d}.controller.component.extension.service.adapter.registry.txt"
             ): "x\n"
             for file_index in range(30)
         }
@@ -899,20 +931,56 @@ def test_handoff_byte_cap_never_emits_invalid_json(
     assert_body_free(out)
 
 
+def test_handoff_many_omissions_stays_under_byte_cap(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    store.submit_claim(
+        ContextLink(
+            kind=LinkKind.GIT_COMMIT,
+            canonical_namespace=NAMESPACE,
+            canonical_id="f" * 40,
+            canonical_digest="sha256:" + "f" * 64,
+            git_sha="f" * 40,
+        ),
+        actor="test",
+    )
+    locator_ids = [f"clink_{index:064x}" for index in range(100)]
+    capsule = recall.prepare_handoff(store, locator_ids, repo=tmp_path, acp_root=None)
+    assert capsule["items"] == []
+    assert capsule["complete"] is False
+    assert capsule["omissions_truncated"] is True
+    assert len(canonical_json(capsule).encode("utf-8")) <= MAX_CAPSULE_BYTES
+
+
+def test_handoff_rejects_unbounded_seed_set(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    locator_ids = [f"clink_{index:064x}" for index in range(501)]
+    with pytest.raises(recall.RecallInputError, match="handoff_seed_limit"):
+        recall.prepare_handoff(store, locator_ids, repo=tmp_path, acp_root=None)
+
+
 def test_handoff_from_query_uses_only_verified_results(
     tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
 ) -> None:
-    acp_root = make_acp_plane(tmp_path)
-    store = make_store(tmp_path)
     sha = str(git_repo["sha2"])
+    acp_root = make_acp_plane(tmp_path, correlation_id=sha)
+    store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], sha)
     stale_locator = bootstrap_acp(store, acp_root, git_sha=sha)
     append_acp_state_event(acp_root)
 
     code, out = run_cli(
-        capsys, "handoff", "--locator-id", stale_locator, "--query", sha,
-        "--repo", str(git_repo["repo"]), "--acp-root", str(acp_root),
-        "--db", str(store.db_path),
+        capsys,
+        "handoff",
+        "--locator-id",
+        stale_locator,
+        "--query",
+        sha,
+        "--repo",
+        str(git_repo["repo"]),
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(store.db_path),
     )
     assert code == 0
     capsule = json.loads(out)
@@ -923,14 +991,10 @@ def test_handoff_from_query_uses_only_verified_results(
     assert [item["canonical_id"] for item in capsule["items"]] == [sha]
 
 
-def test_handoff_requires_a_seed(
-    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
-) -> None:
+def test_handoff_requires_a_seed(tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture) -> None:
     store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
-    code, out = run_cli(
-        capsys, "handoff", "--repo", str(git_repo["repo"]), "--db", str(store.db_path)
-    )
+    code, out = run_cli(capsys, "handoff", "--repo", str(git_repo["repo"]), "--db", str(store.db_path))
     assert code == 2
     assert "seed_invalid" in out
 
@@ -941,8 +1005,14 @@ def test_handoff_rejects_malformed_locator_without_echo(
     store = make_store(tmp_path)
     bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
     code, out = run_cli(
-        capsys, "handoff", "--locator-id", "not-a-locator",
-        "--repo", str(git_repo["repo"]), "--db", str(store.db_path),
+        capsys,
+        "handoff",
+        "--locator-id",
+        "not-a-locator",
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
     )
     assert code == 2
     assert "not-a-locator" not in out
@@ -952,9 +1022,7 @@ def test_handoff_rejects_malformed_locator_without_echo(
 
 
 def test_search_missing_projection_is_clean(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-    code, out = run_cli(
-        capsys, "search", "--query", "alpha", "--db", str(tmp_path / "missing.sqlite3")
-    )
+    code, out = run_cli(capsys, "search", "--query", "alpha", "--db", str(tmp_path / "missing.sqlite3"))
     assert code == 0
     payload = json.loads(out)
     assert payload["available"] is False
@@ -964,8 +1032,12 @@ def test_search_missing_projection_is_clean(tmp_path: Path, capsys: pytest.Captu
 
 def test_handoff_missing_projection_is_clean(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     code, out = run_cli(
-        capsys, "handoff", "--locator-id", "clink_" + "a" * 64,
-        "--db", str(tmp_path / "missing.sqlite3"),
+        capsys,
+        "handoff",
+        "--locator-id",
+        "clink_" + "a" * 64,
+        "--db",
+        str(tmp_path / "missing.sqlite3"),
     )
     assert code == 0
     assert json.loads(out)["available"] is False

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -299,6 +299,19 @@ def admit(store: ContextLinkStore, resolution) -> str:
     return result.locator_id
 
 
+def promote_link(store: ContextLinkStore, link: ContextLink) -> str:
+    verification = VerificationEvidence(
+        verifier="test",
+        canonical_digest=link.canonical_digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator="test:synthetic-link",
+        checked_at=isoformat_z(utc_now()),
+    )
+    result = store.admit(link, verification, actor="test")
+    assert result.outcome is AdmitOutcome.PROMOTED
+    return result.locator_id
+
+
 def bootstrap_git(store: ContextLinkStore, repo: Path, sha: str) -> str:
     return admit(store, resolve_git_commit(sha, repo=repo))
 
@@ -364,6 +377,7 @@ def test_git_projection_supports_merge_parents_and_rejects_tree(tmp_path: Path) 
 
     resolution = resolve_git_commit(merge_sha, repo=repo)
     assert resolution.excerpt["parents"] == sorted([left, right])
+    assert resolution.excerpt["touched_paths"] == ["left.txt"]
 
     tree_sha = git(repo, "rev-parse", "HEAD^{tree}")
     with pytest.raises(ResolutionError) as excinfo:
@@ -890,6 +904,9 @@ def test_explain_change_traverses_typed_joins(
         assert "excerpt" in node
         assert node["canonical_digest"].startswith("sha256:")
     assert payload["omitted"] == []
+    assert payload["relation_scan"]["truncated"] is False
+    assert payload["complete"] is True
+    assert payload["truncation_reasons"] == []
     assert_body_free(out)
 
     code, out = run_cli(
@@ -916,7 +933,36 @@ def test_find_related_limit_zero_is_empty(tmp_path: Path, git_repo: dict[str, ob
     bootstrap_acp(store, acp_root, git_sha=sha)
     seed = store.lookup(git_locator)
     assert seed is not None
-    assert store.find_related(seed, limit=0) == []
+    related = store.find_related(seed, limit=0)
+    assert related.items == ()
+    assert related.examined == 0
+    assert related.truncated is True
+
+
+def test_explain_change_reports_typed_join_truncation(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    sha = str(git_repo["sha2"])
+    store = make_store(tmp_path)
+    seed_locator = bootstrap_git(store, git_repo["repo"], sha)
+    for index in range(51):
+        promote_link(
+            store,
+            ContextLink(
+                kind=LinkKind.GITHUB_ISSUE,
+                canonical_namespace="github:test/repo",
+                canonical_id=sha,
+                canonical_digest="sha256:" + hashlib.sha256(f"related-{index}".encode()).hexdigest(),
+            ),
+        )
+
+    result = recall.explain_change(
+        store,
+        locator_id=seed_locator,
+        repo=git_repo["repo"],
+        acp_root=None,
+    )
+    assert result["relation_scan"] == {"examined": 50, "truncated": True}
+    assert result["complete"] is False
+    assert "relation_scan_cap" in result["truncation_reasons"]
 
 
 def test_explain_change_omits_unverifiable_nodes(tmp_path: Path, git_repo: dict[str, object]) -> None:

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -1,0 +1,1000 @@
+"""Acceptance coverage for the Phase-2 public recall workflows (#6183).
+
+Proves: real Git and ACP explicit-ID bootstrap/admission then recall,
+provider-neutral byte equivalence (Codex/Kimi/GLM), deterministic ranking and
+caps, scan/pagination behavior, idempotent retry, stale digest / missing
+source / tombstone / partial ACP receipt / unsupported kind failure closure,
+zero Entire CLI invocation, forbidden-field leakage sweeps over every public
+result and capsule, typed provenance traversal, and the 8 KiB handoff cap
+without invalid JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.entire_context import cli, recall
+from scripts.entire_context.model import (
+    ContextLink,
+    LinkKind,
+    VerificationEvidence,
+    VerificationStatus,
+    canonical_json,
+    isoformat_z,
+    utc_now,
+)
+from scripts.entire_context.recall import (
+    MAX_CAPSULE_BYTES,
+    MAX_HANDOFF_ITEMS,
+    rank_candidate,
+)
+from scripts.entire_context.resolvers import (
+    REASON_DIGEST_MISMATCH,
+    REASON_SOURCE_MISSING,
+    REASON_UNSUPPORTED_KIND,
+    ResolutionError,
+    resolve_acp_conversation,
+    resolve_bootstrap,
+    resolve_git_commit,
+)
+from scripts.entire_context.store import AdmitOutcome, ContextLinkStore
+
+ORIGIN_URL = "https://github.com/learn-ukrainian/learn-ukrainian.github.io.git"
+NAMESPACE = "git:learn-ukrainian/learn-ukrainian.github.io"
+COMMIT_SUBJECT_CANARY = "zyxsubjcanary"
+CONV_ID = "conversation_" + "1" * 32
+
+FORBIDDEN_OUTPUT_TOKENS = (
+    "prompt",
+    "response",
+    "transcript",
+    "summar",
+    "raw_capture",
+    "message",
+    "artifact",
+    "secret",
+    "password",
+    "credential",
+    "api_key",
+    "refs/entire",
+    "-----BEGIN",
+    "ghp_",
+    "sk-",
+    COMMIT_SUBJECT_CANARY,
+)
+
+
+# ── fixtures: real local git repository ──────────────────────────────────────
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def make_git_repo(tmp_path: Path, *, name: str = "repo") -> Path:
+    repo = tmp_path / name
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.email", "test@example.invalid")
+    git(repo, "config", "user.name", "tester")
+    git(repo, "remote", "add", "origin", ORIGIN_URL)
+    return repo
+
+
+def commit_files(repo: Path, files: dict[str, str], subject: str) -> str:
+    for relative, content in files.items():
+        path = repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", subject)
+    return git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> dict[str, object]:
+    repo = make_git_repo(tmp_path)
+    sha1 = commit_files(
+        repo,
+        {"alpha.txt": "one\n", "src/beta.py": "two\n"},
+        f"add alpha and beta {COMMIT_SUBJECT_CANARY}",
+    )
+    sha2 = commit_files(
+        repo,
+        {"alpha.txt": "one\ntwo\n", "gamma.md": "three\n"},
+        f"extend alpha {COMMIT_SUBJECT_CANARY}",
+    )
+    return {"repo": repo, "sha1": sha1, "sha2": sha2}
+
+
+# ── fixtures: synthetic ACP receipt plane ────────────────────────────────────
+
+_ACP_DDL = """
+CREATE TABLE acp_conversations (
+    conversation_id TEXT PRIMARY KEY,
+    task_digest TEXT NOT NULL,
+    correlation_digest TEXT NOT NULL,
+    idempotency_digest TEXT NOT NULL UNIQUE,
+    rounds_requested INTEGER NOT NULL CHECK (rounds_requested BETWEEN 1 AND 3),
+    participants_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    deadline_at TEXT NOT NULL,
+    token_budget INTEGER NOT NULL CHECK (token_budget >= 0),
+    content_budget_bytes INTEGER NOT NULL CHECK (content_budget_bytes >= 0)
+);
+CREATE TABLE acp_conversation_events (
+    event_id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    state TEXT NOT NULL,
+    sender TEXT,
+    recipient TEXT,
+    round INTEGER,
+    outcome TEXT,
+    duration_ms INTEGER,
+    token_count INTEGER,
+    leg_key_digest TEXT,
+    message_id TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    UNIQUE (conversation_id, sequence)
+);
+"""
+
+
+def _insert_acp_event(
+    connection: sqlite3.Connection,
+    conversation_id: str,
+    sequence: int,
+    event_type: str,
+    *,
+    state: str = "IN_PROGRESS",
+    sender: str | None = None,
+    round_no: int | None = None,
+    outcome: str | None = None,
+    duration_ms: int | None = None,
+    token_count: int | None = None,
+    created_at: str,
+) -> None:
+    connection.execute(
+        "INSERT INTO acp_conversation_events("
+        "event_id, conversation_id, sequence, event_type, state, sender, recipient,"
+        ' "round", outcome, duration_ms, token_count, leg_key_digest, message_id,'
+        " metadata_json, created_at) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, NULL, NULL, '{}', ?)",
+        (
+            f"evt-{conversation_id[-4:]}-{sequence}",
+            conversation_id,
+            sequence,
+            event_type,
+            state,
+            sender,
+            round_no,
+            outcome,
+            duration_ms,
+            token_count,
+            created_at,
+        ),
+    )
+
+
+def make_acp_plane(
+    tmp_path: Path,
+    *,
+    conversation_id: str = CONV_ID,
+    terminal: bool = True,
+    name: str = "plane",
+) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    connection = sqlite3.connect(root / "comms.sqlite3")
+    try:
+        connection.executescript(_ACP_DDL)
+        connection.execute(
+            "INSERT INTO acp_conversations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                conversation_id,
+                "task-digest",
+                "correlation-digest",
+                f"idem-{conversation_id[-4:]}",
+                1,
+                json.dumps(["claude", "kimi"]),
+                "2026-08-01T10:00:00Z",
+                "2026-08-01T11:00:00Z",
+                10_000,
+                1_024,
+            ),
+        )
+        _insert_acp_event(
+            connection,
+            conversation_id,
+            1,
+            "CALL_TERMINAL",
+            sender="claude",
+            round_no=1,
+            outcome="ok",
+            created_at="2026-08-01T10:00:01Z",
+        )
+        _insert_acp_event(
+            connection,
+            conversation_id,
+            2,
+            "CALL_TERMINAL",
+            sender="kimi",
+            round_no=1,
+            outcome="ok",
+            created_at="2026-08-01T10:00:02Z",
+        )
+        if terminal:
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                3,
+                "SYNTHESIS_TERMINAL",
+                outcome="ok",
+                created_at="2026-08-01T10:00:03Z",
+            )
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                4,
+                "STATE",
+                state="COMPLETE",
+                duration_ms=25,
+                token_count=150,
+                created_at="2026-08-01T10:00:04Z",
+            )
+        connection.commit()
+    finally:
+        connection.close()
+    return root
+
+
+def append_acp_state_event(root: Path, conversation_id: str = CONV_ID) -> None:
+    """Advance the terminal receipt so its canonical digest changes."""
+    connection = sqlite3.connect(root / "comms.sqlite3")
+    try:
+        _insert_acp_event(
+            connection,
+            conversation_id,
+            5,
+            "STATE",
+            state="COMPLETE",
+            duration_ms=30,
+            token_count=160,
+            created_at="2026-08-01T10:05:00Z",
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_store(tmp_path: Path) -> ContextLinkStore:
+    return ContextLinkStore(tmp_path / "context-links.sqlite3")
+
+
+def admit(store: ContextLinkStore, resolution) -> str:
+    result = store.admit(resolution.link, resolution.verification, actor="test")
+    assert result.outcome is AdmitOutcome.PROMOTED
+    return result.locator_id
+
+
+def bootstrap_git(store: ContextLinkStore, repo: Path, sha: str) -> str:
+    return admit(store, resolve_git_commit(sha, repo=repo))
+
+
+def bootstrap_acp(
+    store: ContextLinkStore, acp_root: Path, conversation_id: str = CONV_ID, **kwargs
+) -> str:
+    return admit(
+        store, resolve_acp_conversation(conversation_id, acp_root=acp_root, **kwargs)
+    )
+
+
+def run_cli(capsys: pytest.CaptureFixture, *args: str) -> tuple[int, str]:
+    code = cli.main(list(args))
+    return code, capsys.readouterr().out
+
+
+def assert_body_free(output: str) -> None:
+    lowered = output.lower()
+    for token in FORBIDDEN_OUTPUT_TOKENS:
+        assert token.lower() not in lowered, f"forbidden token leaked: {token!r}"
+
+
+# ── real Git and ACP bootstrap/admission, then recall ────────────────────────
+
+
+def test_git_bootstrap_then_search_recall(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    db = tmp_path / "db.sqlite3"
+    repo = str(git_repo["repo"])
+    sha2 = str(git_repo["sha2"])
+    code, out = run_cli(capsys, "bootstrap-git", sha2, "--repo", repo, "--db", str(db))
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["outcome"] == "promoted"
+    assert_body_free(out)
+
+    # Exact SHA ranks first.
+    code, out = run_cli(capsys, "search", "--query", sha2, "--repo", repo, "--db", str(db))
+    assert code == 0
+    result = json.loads(out)
+    assert [card["canonical_id"] for card in result["results"]] == [sha2]
+    card = result["results"][0]
+    assert card["matched_fields"][0] == "exact_id"
+    assert card["excerpt"]["touched_paths"] == ["alpha.txt", "gamma.md"]
+    assert card["excerpt"]["parents"] == [git_repo["sha1"]]
+
+    # Facet needle finds the same verified card.
+    code, out = run_cli(
+        capsys, "search", "--query", "gamma.md", "--repo", repo, "--db", str(db)
+    )
+    assert code == 0
+    result = json.loads(out)
+    assert [entry["locator_id"] for entry in result["results"]] == [card["locator_id"]]
+    assert result["omitted"] == []
+    assert_body_free(out)
+
+
+def test_acp_bootstrap_then_recall(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    db = tmp_path / "db.sqlite3"
+    code, out = run_cli(
+        capsys,
+        "bootstrap-acp",
+        CONV_ID,
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(db),
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["outcome"] == "promoted"
+    assert payload["excerpt"]["content_included"] is False
+    assert_body_free(out)
+
+    code, out = run_cli(
+        capsys,
+        "search",
+        "--query",
+        CONV_ID,
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(db),
+    )
+    assert code == 0
+    result = json.loads(out)
+    assert len(result["results"]) == 1
+    card = result["results"][0]
+    assert card["kind"] == "acp_conversation"
+    assert card["excerpt"]["state"] == "COMPLETE"
+    assert card["excerpt"]["content_included"] is False
+
+    # Participant facet needle finds the conversation.
+    code, out = run_cli(
+        capsys,
+        "search",
+        "--query",
+        "kimi",
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(db),
+    )
+    assert code == 0
+    assert [c["canonical_id"] for c in json.loads(out)["results"]] == [CONV_ID]
+    assert_body_free(out)
+
+
+# ── provider neutrality ──────────────────────────────────────────────────────
+
+
+def test_provider_consumer_labels_yield_identical_bytes(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha2"]))
+    db = str(store.db_path)
+    repo = str(git_repo["repo"])
+    outputs = []
+    for consumer in ("codex", "kimi", "glm"):
+        code, out = run_cli(
+            capsys,
+            "search",
+            "--query",
+            "alpha",
+            "--repo",
+            repo,
+            "--db",
+            db,
+            "--consumer",
+            consumer,
+        )
+        assert code == 0
+        outputs.append(out)
+    assert outputs[0] == outputs[1] == outputs[2]
+
+    handoff_outputs = []
+    for consumer in ("codex", "kimi", "glm"):
+        code, out = run_cli(
+            capsys, "handoff", "--query", "alpha", "--repo", repo, "--db", db,
+            "--consumer", consumer,
+        )
+        assert code == 0
+        handoff_outputs.append(out)
+    assert handoff_outputs[0] == handoff_outputs[1] == handoff_outputs[2]
+
+
+def test_invalid_consumer_label_is_refused_without_echo(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    code, out = run_cli(
+        capsys,
+        "search",
+        "--query",
+        "alpha",
+        "--repo",
+        str(git_repo["repo"]),
+        "--db",
+        str(store.db_path),
+        "--consumer",
+        "not a valid consumer!",
+    )
+    assert code == 2
+    assert "not a valid consumer!" not in out
+
+
+# ── ranking, caps, scan behavior ─────────────────────────────────────────────
+
+
+def _link_dict(locator_suffix: str, **overrides) -> dict[str, object]:
+    link: dict[str, object] = {
+        "locator_id": "clink_" + locator_suffix * 64,
+        "kind": "git_commit",
+        "canonical_namespace": NAMESPACE,
+        "canonical_id": "0" * 40,
+        "canonical_digest": "sha256:" + "a" * 64,
+        "git_sha": "0" * 40,
+        "entire_checkpoint_id": None,
+        "facets": {},
+    }
+    link.update(overrides)
+    return link
+
+
+def test_ranking_exact_id_first_casefold_and_tiebreak() -> None:
+    exact = rank_candidate(_link_dict("b"), "ab" * 20)
+    facet = rank_candidate(
+        _link_dict("a", facets={"title": "Matching Alpha Work"}), "matching alpha work"
+    )
+    assert exact.score == 0  # no match against zero-sha candidate
+    exact = rank_candidate(_link_dict("b", canonical_id="cd" * 20, git_sha="cd" * 20), "CD" * 20)
+    assert exact.score >= 1000
+    assert exact.matched_fields[0] == "exact_id"
+    assert facet.score < 1000  # weighted facets cannot outrank an exact ID
+    # Unicode casefold: uppercase needle matches lowercase title.
+    folded = rank_candidate(_link_dict("c", facets={"title": "alpha work"}), "ALPHA")
+    assert "title" in folded.matched_fields
+
+
+def test_search_deterministic_limit_and_scan(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    ids = {
+        bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"])),
+        bootstrap_git(store, git_repo["repo"], str(git_repo["sha2"])),
+    }
+    db = str(store.db_path)
+    repo = str(git_repo["repo"])
+
+    code, out = run_cli(capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db)
+    assert code == 0
+    first = json.loads(out)
+    code, out = run_cli(capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db)
+    assert json.loads(out) == first  # deterministic across calls
+    assert first["scanned"] == 2
+    assert {card["locator_id"] for card in first["results"]} == ids
+
+    # Result cap: limit=1 keeps the deterministic top entry.
+    code, out = run_cli(
+        capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db,
+        "--limit", "1",
+    )
+    top = json.loads(out)
+    assert len(top["results"]) == 1
+    assert top["results"][0] == first["results"][0]
+
+    # Scan cap: only the first promoted row (locator_id order) is a candidate.
+    code, out = run_cli(
+        capsys, "search", "--query", "learn-ukrainian", "--repo", repo, "--db", db,
+        "--scan-limit", "1",
+    )
+    scanned = json.loads(out)
+    assert scanned["scanned"] == 1
+    expected_first = min(ids)
+    assert [card["locator_id"] for card in scanned["results"]] == [expected_first]
+
+    # Exact SHA outranks facet matches regardless of locator order.
+    code, out = run_cli(
+        capsys, "search", "--query", str(git_repo["sha2"]), "--repo", repo, "--db", db
+    )
+    exact = json.loads(out)
+    assert exact["results"][0]["canonical_id"] == git_repo["sha2"]
+
+
+def test_result_cap_of_ten(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    store = make_store(tmp_path)
+    for index in range(12):
+        sha = commit_files(
+            git_repo["repo"], {f"series/file-{index:02d}.txt": f"{index}\n"}, "series"
+        )
+        bootstrap_git(store, git_repo["repo"], sha)
+    result = recall.search_past_work(
+        store, "series", repo=git_repo["repo"], acp_root=None, limit=50
+    )
+    assert result["scanned"] == 12
+    assert len(result["results"]) == 10  # hard cap, not the requested 50
+    assert result["limit"] == 10
+
+
+# ── idempotent retry ─────────────────────────────────────────────────────────
+
+
+def test_bootstrap_retry_is_idempotent(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    db = tmp_path / "db.sqlite3"
+    repo = str(git_repo["repo"])
+    sha = str(git_repo["sha1"])
+    code, out = run_cli(capsys, "bootstrap-git", sha, "--repo", repo, "--db", str(db))
+    assert code == 0 and json.loads(out)["outcome"] == "promoted"
+    code, out = run_cli(capsys, "bootstrap-git", sha, "--repo", repo, "--db", str(db))
+    assert code == 0 and json.loads(out)["outcome"] == "already_promoted"
+    status = ContextLinkStore(db).status()
+    assert status["counts"] == {"promoted": 1}
+
+
+# ── failure closure ──────────────────────────────────────────────────────────
+
+
+def test_stale_digest_is_omitted(tmp_path: Path) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    store = make_store(tmp_path)
+    locator_id = bootstrap_acp(store, acp_root)
+    append_acp_state_event(acp_root)  # receipt moves on; stored digest is stale
+
+    result = recall.search_past_work(
+        store, CONV_ID, repo=tmp_path, acp_root=acp_root
+    )
+    assert result["results"] == []
+    assert result["omitted"] == [
+        {"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}
+    ]
+    capsule = recall.prepare_handoff(store, [locator_id], repo=tmp_path, acp_root=acp_root)
+    assert capsule["items"] == []
+    assert capsule["omitted"] == [
+        {"locator_id": locator_id, "reason": REASON_DIGEST_MISMATCH}
+    ]
+
+
+def test_missing_source_is_omitted_and_bootstrap_refused(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    locator_id = bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    other = make_git_repo(tmp_path, name="other")  # no such commit here
+
+    result = recall.search_past_work(
+        store, str(git_repo["sha1"]), repo=other, acp_root=None
+    )
+    assert result["results"] == []
+    assert result["omitted"] == [
+        {"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}
+    ]
+
+    code, out = run_cli(
+        capsys, "bootstrap-git", "f" * 40, "--repo", str(other), "--db",
+        str(tmp_path / "other-db.sqlite3"),
+    )
+    assert code == 2
+    assert json.loads(out)["reason"] == REASON_SOURCE_MISSING
+
+
+def test_acp_link_fails_closed_without_receipt_root(
+    tmp_path: Path,
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    store = make_store(tmp_path)
+    locator_id = bootstrap_acp(store, acp_root)
+    result = recall.search_past_work(store, CONV_ID, repo=tmp_path, acp_root=None)
+    assert result["results"] == []
+    assert result["omitted"] == [
+        {"locator_id": locator_id, "reason": REASON_SOURCE_MISSING}
+    ]
+
+
+def test_tombstoned_claim_never_recalled(tmp_path: Path) -> None:
+    store = make_store(tmp_path)
+    link = ContextLink(
+        kind=LinkKind.GIT_COMMIT,
+        canonical_namespace=NAMESPACE,
+        canonical_id="0" * 40,
+        canonical_digest="sha256:" + "a" * 64,
+        git_sha="0" * 40,
+    )
+    result = store.admit(link, None, actor="test")
+    assert result.outcome is AdmitOutcome.REFUSED
+    found = recall.search_past_work(store, "0" * 40, repo=tmp_path, acp_root=None)
+    assert found["results"] == []
+    assert found["scanned"] == 0  # tombstoned rows are not even candidates
+
+
+def test_partial_acp_receipt_fails_closed(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    acp_root = make_acp_plane(tmp_path, terminal=False)
+    db = tmp_path / "db.sqlite3"
+    code, out = run_cli(
+        capsys, "bootstrap-acp", CONV_ID, "--acp-root", str(acp_root), "--db", str(db)
+    )
+    assert code == 2
+    assert json.loads(out)["reason"] == "partial_terminal"
+    assert not db.exists()  # nothing was admitted
+
+
+def test_unknown_acp_conversation_fails_closed(tmp_path: Path) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_acp_conversation("conversation_" + "9" * 32, acp_root=acp_root)
+    assert excinfo.value.reason == REASON_SOURCE_MISSING
+
+
+def test_unsupported_kind_fails_closed(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_bootstrap(
+            LinkKind.GITHUB_ISSUE,
+            "6183",
+            repo=git_repo["repo"],
+            acp_root=None,
+        )
+    assert excinfo.value.reason == REASON_UNSUPPORTED_KIND
+
+    # A promoted link of an unsupported kind is omitted from recall, never emitted.
+    store = make_store(tmp_path)
+    link = ContextLink(
+        kind=LinkKind.GITHUB_ISSUE,
+        canonical_namespace="github:learn-ukrainian/learn-ukrainian.github.io",
+        canonical_id="issue/6183",
+        canonical_digest="sha256:" + "c" * 64,
+    )
+    verification = VerificationEvidence(
+        verifier="test",
+        canonical_digest=link.canonical_digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator="github:issue/6183",
+        checked_at=isoformat_z(utc_now()),
+    )
+    admitted = store.admit(link, verification, actor="test")
+    assert admitted.outcome is AdmitOutcome.PROMOTED
+    result = recall.search_past_work(store, "6183", repo=tmp_path, acp_root=None)
+    assert result["results"] == []
+    assert result["omitted"] == [
+        {"locator_id": admitted.locator_id, "reason": REASON_UNSUPPORTED_KIND}
+    ]
+
+
+def test_entire_cli_is_never_invoked(
+    tmp_path: Path,
+    git_repo: dict[str, object],
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing stub `entire` on PATH changes nothing and is never executed."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    marker = tmp_path / "entire-was-called"
+    stub = bin_dir / "entire"
+    stub.write_text(
+        '#!/bin/sh\n/bin/touch "$ENTIRE_STUB_MARKER"\nexit 1\n', encoding="utf-8"
+    )
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("ENTIRE_STUB_MARKER", str(marker))
+
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    code, out = run_cli(
+        capsys, "search", "--query", "alpha", "--repo", str(git_repo["repo"]),
+        "--db", str(store.db_path),
+    )
+    assert code == 0
+    assert not marker.exists()
+    assert len(json.loads(out)["results"]) == 1
+
+
+# ── query bounds, echo, and persistence hygiene ──────────────────────────────
+
+
+def test_query_over_256_bytes_refused_without_echo(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    needle = "q" * 257
+    code, out = run_cli(
+        capsys, "search", "--query", needle, "--repo", str(git_repo["repo"]),
+        "--db", str(store.db_path),
+    )
+    assert code == 2
+    assert needle not in out
+    code, out = run_cli(
+        capsys, "search", "--query", "   ", "--repo", str(git_repo["repo"]),
+        "--db", str(store.db_path),
+    )
+    assert code == 2
+
+
+def test_query_is_never_echoed_or_persisted(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    before = store.status()["events"]
+    # Uppercase needle matches the casefolded facet but never appears raw.
+    needle = "ALPHA.TXT"
+    code, out = run_cli(
+        capsys, "search", "--query", needle, "--repo", str(git_repo["repo"]),
+        "--db", str(store.db_path),
+    )
+    assert code == 0
+    assert needle not in out
+    assert json.loads(out)["results"]  # it did match via casefold
+    assert store.status()["events"] == before  # no writes
+    assert needle.encode() not in store.db_path.read_bytes()
+
+
+# ── explain-change provenance traversal ──────────────────────────────────────
+
+
+def test_explain_change_traverses_typed_joins(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    store = make_store(tmp_path)
+    sha = str(git_repo["sha2"])
+    git_locator = bootstrap_git(store, git_repo["repo"], sha)
+    acp_locator = bootstrap_acp(store, acp_root, git_sha=sha)
+
+    code, out = run_cli(
+        capsys, "explain-change", "--sha", sha,
+        "--repo", str(git_repo["repo"]), "--acp-root", str(acp_root),
+        "--db", str(store.db_path),
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["found"] is True
+    node_ids = {node["locator_id"] for node in payload["nodes"]}
+    assert node_ids == {git_locator, acp_locator}
+    joins = {(edge["from"], edge["to"], edge["join"]) for edge in payload["edges"]}
+    assert (git_locator, acp_locator, "referenced_by_commit") in joins
+    assert (acp_locator, git_locator, "references_commit") in joins
+    # Every node was re-verified and carries a body-free excerpt.
+    for node in payload["nodes"]:
+        assert "excerpt" in node
+        assert node["canonical_digest"].startswith("sha256:")
+    assert payload["omitted"] == []
+    assert_body_free(out)
+
+
+def test_explain_change_omits_unverifiable_nodes(
+    tmp_path: Path, git_repo: dict[str, object]
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    store = make_store(tmp_path)
+    sha = str(git_repo["sha2"])
+    bootstrap_git(store, git_repo["repo"], sha)
+    acp_locator = bootstrap_acp(store, acp_root, git_sha=sha)
+    append_acp_state_event(acp_root)  # ACP node goes stale
+
+    result = recall.explain_change(
+        store, git_sha=sha, repo=git_repo["repo"], acp_root=acp_root
+    )
+    assert result["found"] is True
+    assert {node["kind"] for node in result["nodes"]} == {"git_commit"}
+    assert result["edges"] == []  # edges to omitted nodes are dropped
+    assert result["omitted"] == [
+        {"locator_id": acp_locator, "reason": REASON_DIGEST_MISMATCH}
+    ]
+
+
+def test_explain_change_unknown_seed_not_found(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    code, out = run_cli(
+        capsys, "explain-change", "--locator-id", "clink_" + "f" * 64,
+        "--repo", str(git_repo["repo"]), "--db", str(store.db_path),
+    )
+    assert code == 1
+    assert json.loads(out)["found"] is False
+
+
+# ── prepare-handoff capsule ──────────────────────────────────────────────────
+
+
+def test_handoff_item_cap_and_deterministic_order(
+    tmp_path: Path, git_repo: dict[str, object]
+) -> None:
+    store = make_store(tmp_path)
+    locators = []
+    for index in range(MAX_HANDOFF_ITEMS + 1):
+        sha = commit_files(
+            git_repo["repo"], {f"cap/item-{index:02d}.txt": f"{index}\n"}, "cap"
+        )
+        locators.append(bootstrap_git(store, git_repo["repo"], sha))
+    capsule = recall.prepare_handoff(
+        store, list(reversed(locators)), repo=git_repo["repo"], acp_root=None
+    )
+    assert len(capsule["items"]) == MAX_HANDOFF_ITEMS
+    assert capsule["complete"] is False
+    ordered = sorted(locators)
+    assert [item["locator_id"] for item in capsule["items"]] == ordered[:MAX_HANDOFF_ITEMS]
+    assert capsule["omitted"] == [
+        {"locator_id": ordered[MAX_HANDOFF_ITEMS], "reason": "handoff_item_cap"}
+    ]
+
+
+def test_handoff_byte_cap_never_emits_invalid_json(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    locators = []
+    for commit_index in range(3):
+        files = {
+            (
+                f"dir.{commit_index}/mod.{file_index:02d}.controller.component."
+                "extension.service.adapter.registry.txt"
+            ): "x\n"
+            for file_index in range(30)
+        }
+        sha = commit_files(git_repo["repo"], files, "bulk")
+        locators.append(bootstrap_git(store, git_repo["repo"], sha))
+
+    args = ["handoff", "--repo", str(git_repo["repo"]), "--db", str(store.db_path)]
+    for locator_id in locators:
+        args.extend(["--locator-id", locator_id])
+    code, out = run_cli(capsys, *args)
+    assert code == 0
+    capsule = json.loads(out)  # always valid JSON, never a truncated stream
+    assert len(out.encode("utf-8")) <= MAX_CAPSULE_BYTES + 1  # + newline
+    assert len(canonical_json(capsule).encode("utf-8")) <= MAX_CAPSULE_BYTES
+    assert capsule["complete"] is False
+    assert 1 <= len(capsule["items"]) < 3
+    reasons = [entry["reason"] for entry in capsule["omitted"]]
+    assert "capsule_budget" in reasons
+    assert_body_free(out)
+
+
+def test_handoff_from_query_uses_only_verified_results(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    store = make_store(tmp_path)
+    sha = str(git_repo["sha2"])
+    bootstrap_git(store, git_repo["repo"], sha)
+    stale_locator = bootstrap_acp(store, acp_root, git_sha=sha)
+    append_acp_state_event(acp_root)
+
+    code, out = run_cli(
+        capsys, "handoff", "--locator-id", stale_locator, "--query", sha,
+        "--repo", str(git_repo["repo"]), "--acp-root", str(acp_root),
+        "--db", str(store.db_path),
+    )
+    assert code == 0
+    capsule = json.loads(out)
+    assert [item["kind"] for item in capsule["items"]] == ["git_commit"]
+    assert {entry["reason"] for entry in capsule["omitted"]} == {REASON_DIGEST_MISMATCH}
+    # The handoff is a capsule of verified locators/excerpts, never a summary.
+    assert "summary" not in capsule
+    assert [item["canonical_id"] for item in capsule["items"]] == [sha]
+
+
+def test_handoff_requires_a_seed(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    code, out = run_cli(
+        capsys, "handoff", "--repo", str(git_repo["repo"]), "--db", str(store.db_path)
+    )
+    assert code == 2
+    assert "seed_invalid" in out
+
+
+def test_handoff_rejects_malformed_locator_without_echo(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    store = make_store(tmp_path)
+    bootstrap_git(store, git_repo["repo"], str(git_repo["sha1"]))
+    code, out = run_cli(
+        capsys, "handoff", "--locator-id", "not-a-locator",
+        "--repo", str(git_repo["repo"]), "--db", str(store.db_path),
+    )
+    assert code == 2
+    assert "not-a-locator" not in out
+
+
+# ── projection availability posture ──────────────────────────────────────────
+
+
+def test_search_missing_projection_is_clean(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    code, out = run_cli(
+        capsys, "search", "--query", "alpha", "--db", str(tmp_path / "missing.sqlite3")
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["available"] is False
+    assert payload["reason"] == "projection_missing"
+    assert not (tmp_path / "missing.sqlite3").exists()  # reads never create state
+
+
+def test_handoff_missing_projection_is_clean(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    code, out = run_cli(
+        capsys, "handoff", "--locator-id", "clink_" + "a" * 64,
+        "--db", str(tmp_path / "missing.sqlite3"),
+    )
+    assert code == 0
+    assert json.loads(out)["available"] is False
+
+
+# ── forbidden-field leakage sweep over every public command ──────────────────
+
+
+def test_all_public_outputs_are_body_free(
+    tmp_path: Path, git_repo: dict[str, object], capsys: pytest.CaptureFixture
+) -> None:
+    acp_root = make_acp_plane(tmp_path)
+    db = str(tmp_path / "db.sqlite3")
+    repo = str(git_repo["repo"])
+    sha = str(git_repo["sha2"])
+    outputs = []
+    for args in (
+        ("bootstrap-git", sha, "--repo", repo, "--db", db),
+        ("bootstrap-acp", CONV_ID, "--acp-root", str(acp_root), "--db", db),
+        ("status", "--db", db),
+        ("search", "--query", "alpha", "--repo", repo, "--acp-root", str(acp_root), "--db", db),
+        ("search", "--query", "no-such-needle", "--repo", repo, "--db", db),
+        ("explain-change", "--sha", sha, "--repo", repo, "--acp-root", str(acp_root), "--db", db),
+        ("handoff", "--query", "alpha", "--repo", repo, "--acp-root", str(acp_root), "--db", db),
+    ):
+        code, out = run_cli(capsys, *args)
+        assert code == 0, args
+        outputs.append(out)
+    combined = "".join(outputs)
+    assert_body_free(combined)
+    # The commit subject canary never reaches any public output.
+    assert COMMIT_SUBJECT_CANARY not in combined

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -33,6 +33,7 @@ from scripts.entire_context.model import (
 from scripts.entire_context.recall import (
     MAX_CAPSULE_BYTES,
     MAX_HANDOFF_ITEMS,
+    MAX_SEARCH_OMISSIONS,
     rank_candidate,
 )
 from scripts.entire_context.resolvers import (
@@ -351,6 +352,25 @@ def test_git_bootstrap_then_search_recall(
     assert_body_free(out)
 
 
+def test_git_projection_supports_merge_parents_and_rejects_tree(tmp_path: Path) -> None:
+    repo = make_git_repo(tmp_path)
+    base = commit_files(repo, {"base.txt": "base\n"}, "base")
+    git(repo, "checkout", "-qb", "left")
+    left = commit_files(repo, {"left.txt": "left\n"}, "left")
+    git(repo, "checkout", "-qb", "right", base)
+    right = commit_files(repo, {"right.txt": "right\n"}, "right")
+    git(repo, "merge", "--no-ff", "-qm", "merge", "left")
+    merge_sha = git(repo, "rev-parse", "HEAD")
+
+    resolution = resolve_git_commit(merge_sha, repo=repo)
+    assert resolution.excerpt["parents"] == sorted([left, right])
+
+    tree_sha = git(repo, "rev-parse", "HEAD^{tree}")
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_git_commit(tree_sha, repo=repo)
+    assert excinfo.value.reason == REASON_SOURCE_MISSING
+
+
 def test_acp_bootstrap_then_recall(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     acp_root = make_acp_plane(tmp_path)
     db = tmp_path / "db.sqlite3"
@@ -572,6 +592,29 @@ def test_result_cap_of_ten(tmp_path: Path, git_repo: dict[str, object]) -> None:
     assert result["scanned"] == 12
     assert len(result["results"]) == 10  # hard cap, not the requested 50
     assert result["limit"] == 10
+
+
+def test_search_omission_metadata_is_capped(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    store = make_store(tmp_path)
+    for index in range(MAX_SEARCH_OMISSIONS + 1):
+        sha = commit_files(
+            git_repo["repo"],
+            {f"stale-series/file-{index:02d}.txt": f"{index}\n"},
+            "stale-series",
+        )
+        bootstrap_git(store, git_repo["repo"], sha)
+
+    missing_repo = make_git_repo(tmp_path, name="missing")
+    result = recall.search_past_work(
+        store,
+        "stale-series",
+        repo=missing_repo,
+        acp_root=None,
+        limit=10,
+    )
+    assert result["results"] == []
+    assert len(result["omitted"]) == MAX_SEARCH_OMISSIONS
+    assert result["omissions_truncated"] is True
 
 
 # ── idempotent retry ─────────────────────────────────────────────────────────
@@ -848,6 +891,32 @@ def test_explain_change_traverses_typed_joins(
         assert node["canonical_digest"].startswith("sha256:")
     assert payload["omitted"] == []
     assert_body_free(out)
+
+    code, out = run_cli(
+        capsys,
+        "explain-change",
+        "--canonical-id",
+        sha,
+        "--repo",
+        str(git_repo["repo"]),
+        "--acp-root",
+        str(acp_root),
+        "--db",
+        str(store.db_path),
+    )
+    assert code == 0
+    assert json.loads(out)["found"] is True
+
+
+def test_find_related_limit_zero_is_empty(tmp_path: Path, git_repo: dict[str, object]) -> None:
+    sha = str(git_repo["sha2"])
+    acp_root = make_acp_plane(tmp_path, correlation_id=sha)
+    store = make_store(tmp_path)
+    git_locator = bootstrap_git(store, git_repo["repo"], sha)
+    bootstrap_acp(store, acp_root, git_sha=sha)
+    seed = store.lookup(git_locator)
+    assert seed is not None
+    assert store.find_related(seed, limit=0) == []
 
 
 def test_explain_change_omits_unverifiable_nodes(tmp_path: Path, git_repo: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary

- add real, local-only Git commit and ACP terminal-receipt bootstrap resolvers
- add deterministic search-past-work, explain-change, and bounded prepare-handoff workflows
- expose one provider-neutral CLI and canonical entire-context skill source for Codex, Kimi, GLM, and other harnesses
- require canonical digest revalidation before any locator or excerpt reaches an LLM-facing result
- prove optional ACP-to-commit joins against the stored ACP correlation digest rather than trusting a caller assertion

## Safety

- Entire CLI remains pinned to 0.8.42, optional, and is never invoked
- zero cloud search, checkpoint capture, public refs/entire refs, transcript/prompt/response bodies, raw captures, AI summaries, or canonical-system mutations
- missing, stale, tombstoned, partial-terminal, unsupported, or digest-mismatched evidence fails closed
- query text and consumer labels are never persisted or echoed
- handoff is hard-capped at five items and 8 KiB, including omission metadata

## Verification

- 126 focused Phase-1 + Phase-2 tests passed
- Ruff check and format check passed
- Python compileall passed
- markdownlint passed for the canonical skill
- git diff check passed
- OPSEC scan passed with zero leaks
- X-Agent trailer audit passed for both commits

## Deliberate residual

This PR implements the approved public local-projection slice with real Git and ACP resolvers. GitHub issue/PR, Fleet receipt, rollover, formal-review, and Monitor kinds remain explicit unsupported_kind until a canonical local projection can verify them without fabricating coverage. The generated .codex/.claude/.gemini skill mirrors are protected rail paths and are not changed here; deployment requires a separately human-issued machine-verifiable rail receipt. Therefore this PR references but does not close #6183.

Refs #6183
Refs #4707