### PR TITLE
feat(runtime): make ACP the inter-agent transport

### DIFF
--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -1,9 +1,9 @@
-"""Bounded, durable ACPX two-seat discussion controller (#6078, #6130).
+"""Bounded, durable ACPX multi-seat discussion controller (#6078, #6130).
 
 This is intentionally a small finite DAG, not a new message-plane router. It
-accepts ``LU_ACPX_TRANSPORT=active`` only here; participants must resolve to
-enabled direct-only ACPX seats, while the final synthesis is a fresh native
-Codex call.
+requires ``LU_ACPX_TRANSPORT=active``; two to six participants resolve through
+the runner-owned normal ACP boundary into enabled direct-only ACPX seats, while
+the final synthesis is a fresh native Codex call.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ import sqlite3
 import sys
 import threading
 import time
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -40,7 +40,12 @@ from scripts.agent_runtime.adapters.acpx import (
 )
 from scripts.agent_runtime.errors import AgentStalledError, AgentTimeoutError, RateLimitedError
 from scripts.agent_runtime.result import Result
-from scripts.agent_runtime.runner import _invoke_direct_only, _invoke_native_once
+from scripts.agent_runtime.runner import (
+    _invoke_direct_only,
+    _invoke_native_once,
+    invoke_inter_agent,
+    resolve_inter_agent_route,
+)
 from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.contracts import new_id
 from scripts.fleet_comms.message_plane import default_plane_root
@@ -48,15 +53,18 @@ from scripts.guardrails.worktree_containment import classify_repo_path
 
 PARTICIPANTS = ("codex", "grok")
 SUPPORTED_PARTICIPANTS = frozenset(ACPX_SUPPORTED_PARTICIPANTS)
+MIN_PARTICIPANTS = 2
+MAX_PARTICIPANTS = 6
 MAX_ROUNDS = 3
 DEFAULT_ROUNDS = 2
 CALL_TIMEOUT_SECONDS = 300
 WHOLE_TIMEOUT_SECONDS = 1200
 TOKEN_BUDGET = 160_000
 CONTENT_BUDGET_BYTES = 512 * 1024
+PARTICIPANT_CONCURRENCY = 3
 
 _TERMINAL = frozenset({"COMPLETE", "PARTIAL_COMPLETE", "FAILED", "CANCELLED"})
-_PARTICIPANT_SLOTS = threading.BoundedSemaphore(2)
+_PARTICIPANT_SLOTS = threading.BoundedSemaphore(PARTICIPANT_CONCURRENCY)
 _LOCAL_ADMISSION = threading.Lock()
 _CONVERSATION_ID = re.compile(r"conversation_[0-9a-f]{32}")
 _NEXT = {
@@ -113,6 +121,8 @@ def _result_outcome(result: Result | None, error: BaseException | None) -> str:
         return "rate_limited"
     if error is not None or result is None:
         return "error"
+    if result.transport_outcome in {"ok", "error", "rate_limited"}:
+        return result.transport_outcome
     if not result.ok:
         return str(result.usage_record.get("outcome") or "error")
     return "ok"
@@ -200,13 +210,16 @@ class AcpxDiscussionController:
         self,
         *,
         root: Path,
-        participant_call: Callable[..., Result] = _invoke_direct_only,
+        participant_call: Callable[..., Result] | None = None,
         synthesis_call: Callable[..., Result] = _invoke_native_once,
         clock: Callable[[], float] = time.monotonic,
         cancelled: Callable[[], bool] | None = None,
     ) -> None:
         self.store = ArtifactStore(root=root)
         self.conn = self.store.connection
+        # The default is the runner-owned normal ACP transport.  Test and
+        # migration callers may inject the previous direct-only callback; that
+        # compatibility seam remains read-only and cannot select a bridge.
         self.participant_call = participant_call
         self.synthesis_call = synthesis_call
         self.clock = clock
@@ -455,7 +468,7 @@ class AcpxDiscussionController:
         idempotency_digest: str,
         rounds: int,
         deadline_at: str,
-        participants: tuple[str, str] = PARTICIPANTS,
+        participants: tuple[str, ...] = PARTICIPANTS,
     ) -> tuple[str, dict[str, Any] | None]:
         """Durably create the conversation before spawning any participant."""
         conversation_id = new_id("conversation")
@@ -588,6 +601,31 @@ class AcpxDiscussionController:
             recovered.append(conversation_id)
         return recovered
 
+    @staticmethod
+    def _normalize_participant_overrides(
+        label: str,
+        overrides: Mapping[str, str] | None,
+        participants: tuple[str, ...],
+    ) -> dict[str, str]:
+        """Accept only exact participant-keyed non-secret model/effort pins."""
+        if overrides is None:
+            return {}
+        if not isinstance(overrides, Mapping):
+            raise AcpxDiscussionError(f"{label} must be a participant-keyed mapping")
+        normalized: dict[str, str] = {}
+        for raw_participant, raw_value in overrides.items():
+            participant = str(raw_participant).strip().lower()
+            if participant not in participants or participant in normalized:
+                raise AcpxDiscussionError(
+                    f"{label} contains an unknown or duplicate participant {raw_participant!r}"
+                )
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                raise AcpxDiscussionError(
+                    f"{label}[{participant!r}] must be a non-empty catalog identifier"
+                )
+            normalized[participant] = raw_value.strip()
+        return normalized
+
     def _call_wave(
         self,
         *,
@@ -598,31 +636,50 @@ class AcpxDiscussionController:
         cwd: Path,
         round_no: int,
         prompts: dict[str, str],
-        deliveries: dict[str, tuple[str, str, str | None]],
+        deliveries: Mapping[str, Sequence[tuple[str, str, str | None]] | tuple[str, str, str | None]],
         state: str,
         deadline: float,
-        initiator: str | None = None,
-        participants: tuple[str, str] = PARTICIPANTS,
+        source: str | None = None,
+        models: Mapping[str, str] | None = None,
+        efforts: Mapping[str, str] | None = None,
+        participants: tuple[str, ...] = PARTICIPANTS,
     ) -> list[ParticipantOutcome]:
         reservations: dict[str, str] = {}
         request_messages: dict[str, str] = {}
+        model_overrides = models or {}
+        effort_overrides = efforts or {}
         for participant in participants:
             leg = _leg_digest(conversation_id, str(round_no), participant, _digest(prompts[participant]))
             reservations[participant] = leg
-            sender, body, reply_to = deliveries[participant]
-            request_messages[participant] = self._message(
-                conversation_id,
-                sender=sender,
-                recipient=participant,
-                body=body,
-                reply_to=reply_to,
-                kind="request" if sender == "root" else "reply",
-            )
+            raw_deliveries = deliveries[participant]
+            if (
+                len(raw_deliveries) == 3
+                and isinstance(raw_deliveries[0], str)
+                and isinstance(raw_deliveries[1], str)
+            ):
+                delivery_items = (raw_deliveries,)
+            else:
+                delivery_items = tuple(raw_deliveries)
+            if not delivery_items:
+                raise AcpxDiscussionError(f"participant {participant!r} has no persisted delivery")
+            message_ids: list[str] = []
+            for sender, body, reply_to in delivery_items:
+                message_ids.append(
+                    self._message(
+                        conversation_id,
+                        sender=sender,
+                        recipient=participant,
+                        body=body,
+                        reply_to=reply_to,
+                        kind="request" if sender == "root" else "reply",
+                    )
+                )
+            request_messages[participant] = message_ids[-1]
             self._append(
                 conversation_id,
                 event_type="CALL_RESERVED",
                 state=state,
-                sender=sender,
+                sender=delivery_items[-1][0],
                 recipient=participant,
                 round_no=round_no,
                 leg_key_digest=leg,
@@ -636,17 +693,43 @@ class AcpxDiscussionController:
             if not _PARTICIPANT_SLOTS.acquire(blocking=False):
                 return ParticipantOutcome(participant, "busy", None, 0, None, None)
             try:
-                with active_discussion_scope():
-                    route = ACPX_SUPPORTED_PARTICIPANTS[participant]
-                    result = self.participant_call(
-                        str(route["seat"]), prompts[participant], cwd=cwd, model=None,
+                timeout = max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock())))
+                if self.participant_call is None:
+                    result = invoke_inter_agent(
+                        participant,
+                        prompts[participant],
+                        cwd=cwd,
                         task_id=task_id,
-                        tool_config={"acpx_discussion": True, "target_agent": route["agent"],
-                                     "correlation_id": correlation_id, "idempotency_key": idempotency_key},
-                        hard_timeout=max(1, min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock()))),
-                        entrypoint="acpx-discuss",
-                        initiator=initiator,
+                        correlation_id=correlation_id,
+                        idempotency_key=idempotency_key,
+                        source=source,
+                        model=model_overrides.get(participant),
+                        effort=effort_overrides.get(participant),
+                        hard_timeout=timeout,
                     )
+                else:
+                    # Preserve the injectable legacy callback contract for
+                    # deterministic controller tests and migration consumers.
+                    # It still enters only the read-only active ACP scope.
+                    with active_discussion_scope():
+                        route = ACPX_SUPPORTED_PARTICIPANTS[participant]
+                        result = self.participant_call(
+                            str(route["seat"]),
+                            prompts[participant],
+                            cwd=cwd,
+                            model=model_overrides.get(participant),
+                            task_id=task_id,
+                            tool_config={
+                                "acpx_discussion": True,
+                                "target_agent": route["agent"],
+                                "correlation_id": correlation_id,
+                                "idempotency_key": idempotency_key,
+                            },
+                            hard_timeout=timeout,
+                            effort=effort_overrides.get(participant),
+                            entrypoint="acpx-discuss",
+                            initiator=source,
+                        )
             except BaseException as exc:  # preserve cancellation as typed partial evidence
                 error = exc
             finally:
@@ -684,13 +767,22 @@ class AcpxDiscussionController:
                 leg_key_digest=reservations[outcome.participant],
                 message_id=message_id,
             )
-            outcomes.append(ParticipantOutcome(
-                outcome.participant, outcome.outcome, outcome.response,
-                outcome.duration_ms, outcome.tokens, message_id,
-            ))
+            outcomes.append(
+                ParticipantOutcome(
+                    outcome.participant,
+                    outcome.outcome,
+                    outcome.response,
+                    outcome.duration_ms,
+                    outcome.tokens,
+                    message_id,
+                )
+            )
 
-        pool = ThreadPoolExecutor(max_workers=len(participants), thread_name_prefix="acpx-discuss")
-        futures = {pool.submit(invoke, p): p for p in participants}
+        pool = ThreadPoolExecutor(
+            max_workers=min(PARTICIPANT_CONCURRENCY, len(participants)),
+            thread_name_prefix="acpx-discuss",
+        )
+        futures = {pool.submit(invoke, participant): participant for participant in participants}
         pending = set(futures)
         while pending:
             done, pending = wait(
@@ -719,6 +811,9 @@ class AcpxDiscussionController:
         idempotency_key: str,
         rounds: int = DEFAULT_ROUNDS,
         participants: Sequence[str] = PARTICIPANTS,
+        models: Mapping[str, str] | None = None,
+        efforts: Mapping[str, str] | None = None,
+        source: str | None = None,
         initiator: str | None = None,
     ) -> dict[str, Any]:
         if os.environ.get(TRANSPORT_ENV, "off").strip().lower() != "active":
@@ -727,12 +822,13 @@ class AcpxDiscussionController:
             raise AcpxDiscussionError("prompt must be non-empty")
         normalized_participants = tuple(str(item).strip().lower() for item in participants)
         if (
-            len(normalized_participants) != 2
-            or len(set(normalized_participants)) != 2
+            not MIN_PARTICIPANTS <= len(normalized_participants) <= MAX_PARTICIPANTS
+            or len(set(normalized_participants)) != len(normalized_participants)
             or any(item not in SUPPORTED_PARTICIPANTS for item in normalized_participants)
         ):
             raise AcpxDiscussionError(
-                "participants must name exactly two distinct enabled ACP seats: "
+                f"participants must name {MIN_PARTICIPANTS} to {MAX_PARTICIPANTS} distinct "
+                "enabled ACP seats: "
                 + ", ".join(sorted(SUPPORTED_PARTICIPANTS))
             )
         if len(prompt.encode("utf-8")) * len(normalized_participants) > CONTENT_BUDGET_BYTES:
@@ -745,6 +841,30 @@ class AcpxDiscussionController:
         task_id = _require_local_metadata_field("task_id", task_id, adapter_label="AcpxDiscuss")
         correlation_id = _require_local_metadata_field("correlation_id", correlation_id, adapter_label="AcpxDiscuss")
         idempotency_key = _require_local_metadata_field("idempotency_key", idempotency_key, adapter_label="AcpxDiscuss")
+        if source is not None and initiator is not None and source != initiator:
+            raise AcpxDiscussionError("source and initiator disagree; provenance must be unambiguous")
+        transport_source = source if source is not None else initiator
+        model_overrides = self._normalize_participant_overrides(
+            "models",
+            models,
+            normalized_participants,
+        )
+        effort_overrides = self._normalize_participant_overrides(
+            "efforts",
+            efforts,
+            normalized_participants,
+        )
+        for participant in normalized_participants:
+            try:
+                resolve_inter_agent_route(
+                    participant,
+                    model=model_overrides.get(participant),
+                    effort=effort_overrides.get(participant),
+                )
+            except Exception as exc:
+                raise AcpxDiscussionError(
+                    f"invalid ACP participant selection for {participant!r}: {exc}"
+                ) from exc
         idempotency_digest = _digest(idempotency_key)
         replay = self._terminal_replay(idempotency_digest)
         if replay is not None:
@@ -763,7 +883,9 @@ class AcpxDiscussionController:
                 idempotency_digest=idempotency_digest,
                 rounds=rounds,
                 participants=normalized_participants,
-                initiator=initiator,
+                models=model_overrides,
+                efforts=effort_overrides,
+                source=transport_source,
             )
 
     def _run_admitted(
@@ -776,8 +898,10 @@ class AcpxDiscussionController:
         idempotency_key: str,
         idempotency_digest: str,
         rounds: int,
-        participants: tuple[str, str],
-        initiator: str | None,
+        participants: tuple[str, ...],
+        models: Mapping[str, str],
+        efforts: Mapping[str, str],
+        source: str | None,
     ) -> dict[str, Any]:
         started = self.clock()
         deadline = started + WHOLE_TIMEOUT_SECONDS
@@ -808,9 +932,11 @@ class AcpxDiscussionController:
             idempotency_key=idempotency_key, cwd=cwd, round_no=1,
             participants=participants,
             prompts={p: prompt for p in participants},
-            deliveries={p: ("root", prompt, None) for p in participants},
+            deliveries={p: (("root", prompt, None),) for p in participants},
             state="INITIAL_FANOUT", deadline=deadline,
-            initiator=initiator,
+            source=source,
+            models=models,
+            efforts=efforts,
         )
         all_outcomes = list(outcomes)
         content_used += sum(len(item.response.encode("utf-8")) for item in outcomes if item.response)
@@ -842,19 +968,25 @@ class AcpxDiscussionController:
             self._append(conversation_id, event_type="STATE", state="CROSS_EXCHANGE", transition=True)
             prior = {item.participant: item.response for item in outcomes}
             prompts: dict[str, str] = {}
-            deliveries: dict[str, tuple[str, str, str | None]] = {}
+            deliveries: dict[str, Sequence[tuple[str, str, str | None]]] = {}
             prior_messages = {item.participant: item.message_id for item in outcomes}
             for participant in participants:
-                peer = next(item for item in participants if item != participant)
-                peer_response = prior.get(peer) or "[unavailable]"
-                prompts[participant] = (
-                    f"Original task:\n{prompt}\n\n{peer}'s prior response:\n"
-                    f"{peer_response}\n\nRespond with your critique or refinement."
+                peers = tuple(peer for peer in participants if peer != participant)
+                peer_evidence = "\n\n".join(
+                    f"{peer}'s prior response:\n{prior.get(peer) or '[unavailable]'}"
+                    for peer in peers
                 )
-                deliveries[participant] = (
-                    peer,
-                    peer_response,
-                    prior_messages.get(peer),
+                prompts[participant] = (
+                    f"Original task:\n{prompt}\n\n{peer_evidence}\n\n"
+                    "Respond with your critique or refinement."
+                )
+                deliveries[participant] = tuple(
+                    (
+                        peer,
+                        prior.get(peer) or "[unavailable]",
+                        prior_messages.get(peer),
+                    )
+                    for peer in peers
                 )
             outcomes = self._call_wave(
                 conversation_id=conversation_id, task_id=task_id, correlation_id=correlation_id,
@@ -863,7 +995,9 @@ class AcpxDiscussionController:
                 prompts=prompts,
                 deliveries=deliveries,
                 state="CROSS_EXCHANGE", deadline=deadline,
-                initiator=initiator,
+                source=source,
+                models=models,
+                efforts=efforts,
             )
             all_outcomes.extend(outcomes)
             content_used += sum(len(value.encode("utf-8")) for value in prompts.values())
@@ -929,7 +1063,7 @@ class AcpxDiscussionController:
                         1,
                         min(CALL_TIMEOUT_SECONDS, int(deadline - self.clock())),
                     ),
-                    initiator=initiator,
+                    initiator=source,
                 )
                 if synthesis_result.ok:
                     synthesis = synthesis_result.response
@@ -1075,9 +1209,9 @@ def verify_discussion_receipt(
         participants = None
     participants_valid = (
         isinstance(participants, list)
-        and len(participants) == 2
+        and MIN_PARTICIPANTS <= len(participants) <= MAX_PARTICIPANTS
         and all(isinstance(item, str) and item in SUPPORTED_PARTICIPANTS for item in participants)
-        and len(set(participants)) == 2
+        and len(set(participants)) == len(participants)
     )
     participant_names: tuple[str, ...] = tuple(participants) if participants_valid else ()
     rounds_value = row["rounds_requested"]

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -81,6 +81,7 @@ import shutil
 import subprocess
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -175,14 +176,21 @@ _GROK_XAI_API_KEY_ENV_UNSETS: tuple[str, ...] = (
 # "correlation_id"/"idempotency_key" are local runtime metadata only
 # (see _require_local_metadata_field): never forwarded to the ACP wire protocol.
 _ALLOWED_TOOL_CONFIG_KEYS = frozenset(
-    {"acpx_shadow", "acpx_discussion", "target_agent", "correlation_id", "idempotency_key"}
+    {
+        "acpx_shadow",
+        "acpx_discussion",
+        "acpx_transport",
+        "target_agent",
+        "correlation_id",
+        "idempotency_key",
+    }
 )
 
-# Fixed ACPX built-ins that are safe to expose only through the bounded
-# discussion controller.  This is deliberately a small declarative registry,
-# rather than a caller-selectable adapter: consumers can enumerate the proven
-# participants without duplicating seat names, while each adapter below still
-# hard-codes its one target.
+# Fixed ACPX built-ins available only through the runner-owned inter-agent
+# transport boundary (or its bounded discussion controller).  This is
+# deliberately a small declarative registry, rather than a caller-selectable
+# adapter: consumers can enumerate the proven participants without duplicating
+# seat names, while each adapter below still hard-codes its one target.
 ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     "codex": {"seat": "acpx-codex-shadow", "agent": "codex", "model": None},
     "grok": {"seat": "acpx-grok-shadow", "agent": "grok", "model": GROK_SHADOW_MODEL},
@@ -200,11 +208,58 @@ ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     },
 }
 
+# The adapter registry is the only source of ACP provider/model selection.
+# These values describe routes that are already implemented above; they do
+# not advertise an ACP route for a provider merely because it appears in the
+# broader fleet catalog.  A caller may request only the exact pinned model or
+# effort for a participant that has one.  Unpinned ACP built-ins intentionally
+# retain their adapter-owned defaults and reject model/effort overrides.
+ACPX_PARTICIPANT_CATALOG_TRANSPORTS: dict[str, str] = {
+    "codex": "native_codex",
+    "grok": "native_grok",
+    "claude": "native_claude",
+    "kimi": "native_kimi",
+    "kimicc": "native_kimi",
+    "cursor": "cursor",
+    "pool": "opencode",
+    "agy": "agy",
+    "glm": "opencode",
+    "deepseek": "hermes",
+}
+ACPX_PARTICIPANT_EFFORTS: dict[str, str] = {
+    "grok": GROK_SHADOW_EFFORT,
+    "agy": "high",
+    "glm": "high",
+}
+
+@dataclass(frozen=True)
+class AcpxTransportProvenance:
+    """Runner-sealed provenance for one ACP inter-agent invocation.
+
+    It is intentionally held in a process-local context rather than caller
+    supplied ``tool_config``.  The latter is adapter input and therefore must
+    never be able to forge the Source/Agent/Via fields attached to the plan,
+    result, or usage record.
+    """
+
+    source: str
+    agent: str
+    target_agent: str
+    via: str = "acp"
+
+    def metadata(self) -> dict[str, str]:
+        return {"source": self.source, "agent": self.agent, "via": self.via}
+
+
 # Active ACPX is deliberately not a generally selectable adapter mode.  The
-# discussion controller enters this process-local scope immediately around a
-# direct-only invocation; all other callers, including normal runner routing,
-# continue to receive the shadow-only refusal.
+# bounded discussion controller and the normal runner-owned communication
+# boundary enter distinct process-local scopes immediately around a direct-only
+# invocation; all ordinary runner routing continues to receive the refusal.
 _ACTIVE_DISCUSSION_SCOPE: ContextVar[bool] = ContextVar("acpx_active_discussion", default=False)
+_ACTIVE_COMMUNICATION_PROVENANCE: ContextVar[AcpxTransportProvenance | None] = ContextVar(
+    "acpx_active_communication_provenance",
+    default=None,
+)
 
 
 @contextmanager
@@ -215,6 +270,45 @@ def active_discussion_scope():
         yield
     finally:
         _ACTIVE_DISCUSSION_SCOPE.reset(token)
+
+
+@contextmanager
+def active_communication_scope(*, source: str, agent: str, target_agent: str):
+    """Authorize one runner-owned normal ACP communication invocation.
+
+    This scope does not grant filesystem, terminal, session, queue, or
+    execution lifecycle access.  It only proves that the runner selected a
+    fixed ACP participant and seals its provenance for the adapter plan.
+    """
+    validated_source = _require_local_metadata_field(
+        "source", source, adapter_label="AcpxTransport"
+    )
+    if validated_source == "unknown":
+        raise AcpxShadowRefusalError(
+            "AcpxTransport: Source must resolve to a trusted non-unknown initiator"
+        )
+    validated_agent = _require_local_metadata_field(
+        "agent", agent, adapter_label="AcpxTransport"
+    )
+    validated_target_agent = _require_local_metadata_field(
+        "target_agent", target_agent, adapter_label="AcpxTransport"
+    )
+    token = _ACTIVE_COMMUNICATION_PROVENANCE.set(
+        AcpxTransportProvenance(
+            source=validated_source,
+            agent=validated_agent,
+            target_agent=validated_target_agent,
+        )
+    )
+    try:
+        yield
+    finally:
+        _ACTIVE_COMMUNICATION_PROVENANCE.reset(token)
+
+
+def current_communication_provenance() -> AcpxTransportProvenance | None:
+    """Return runner-sealed ACP provenance, never a caller-provided value."""
+    return _ACTIVE_COMMUNICATION_PROVENANCE.get()
 
 # Bounds for task_id/correlation_id/idempotency_key: opaque local identifiers
 # used only for this adapter's own InvocationPlan.metadata (telemetry/dedup
@@ -387,9 +481,16 @@ def _require_shadow_tool_config(
             f"{adapter_label}: unsupported tool_config keys {sorted(unsupported_keys)!r}; "
             f"only {sorted(_ALLOWED_TOOL_CONFIG_KEYS)!r} are recognized"
         )
-    active = tc.get("acpx_discussion") is True
-    if active:
+    discussion = tc.get("acpx_discussion") is True
+    communication = tc.get("acpx_transport") is True
+    if discussion and communication:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: acpx_discussion and acpx_transport are mutually exclusive"
+        )
+    if discussion:
         _require_discussion_transport(adapter_label=adapter_label)
+    elif communication:
+        _require_communication_transport(adapter_label=adapter_label)
     else:
         _require_shadow_transport(adapter_label=adapter_label)
         if tc.get("acpx_shadow") is not True:
@@ -403,6 +504,11 @@ def _require_shadow_tool_config(
             f"{adapter_label}: target_agent={target_agent!r} rejected; this seat supports "
             f"exactly one ACP participant: {required_target}"
         )
+    if communication:
+        _require_communication_target(
+            adapter_label=adapter_label,
+            required_target=required_target,
+        )
     return tc
 
 
@@ -412,7 +518,12 @@ def _require_active_discussion_tool_config(
     adapter_label: str,
     required_target: str,
 ) -> dict[str, Any]:
-    """Require the controller-owned active discussion marker before spawn."""
+    """Require one controller-owned active ACP marker before spawn.
+
+    ``acpx_discussion`` remains accepted for the existing durable discussion
+    controller.  ``acpx_transport`` is the reusable normal communication
+    route and additionally requires runner-sealed provenance.
+    """
     tc = dict(tool_config or {})
     unsupported_keys = set(tc) - _ALLOWED_TOOL_CONFIG_KEYS
     if unsupported_keys:
@@ -420,26 +531,62 @@ def _require_active_discussion_tool_config(
             f"{adapter_label}: unsupported tool_config keys {sorted(unsupported_keys)!r}; "
             f"only {sorted(_ALLOWED_TOOL_CONFIG_KEYS)!r} are recognized"
         )
-    if tc.get("acpx_discussion") is not True:
+    discussion = tc.get("acpx_discussion") is True
+    communication = tc.get("acpx_transport") is True
+    if discussion == communication:
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: this direct-only seat requires acpx_discussion=True "
-            "from the active discussion controller"
+            f"{adapter_label}: this direct-only seat requires exactly one of "
+            "acpx_discussion=True or acpx_transport=True"
         )
-    _require_discussion_transport(adapter_label=adapter_label)
+    if discussion:
+        _require_discussion_transport(adapter_label=adapter_label)
+    else:
+        _require_communication_transport(adapter_label=adapter_label)
     target_agent = tc.get("target_agent", required_target)
     if target_agent != required_target:
         raise AcpxShadowRefusalError(
             f"{adapter_label}: target_agent={target_agent!r} rejected; this seat supports "
             f"exactly one ACP participant: {required_target}"
         )
+    if communication:
+        _require_communication_target(
+            adapter_label=adapter_label,
+            required_target=required_target,
+        )
     return tc
+
+
+def _require_communication_transport(*, adapter_label: str) -> None:
+    """Refuse normal ACP communication unless the runner sealed provenance."""
+    transport = os.environ.get(TRANSPORT_ENV, "off").strip().lower()
+    if transport != "active" or current_communication_provenance() is None:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: active ACPX communication requires the runner-owned "
+            "transport selection boundary"
+        )
+
+
+def _require_communication_target(*, adapter_label: str, required_target: str) -> None:
+    """Bind runner-sealed logical provenance to this adapter's fixed target."""
+    provenance = current_communication_provenance()
+    if provenance is None or provenance.target_agent != required_target:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: runner-sealed ACP target provenance does not match "
+            f"required target {required_target!r}"
+        )
+
+
+def _communication_metadata() -> dict[str, str]:
+    """Return immutable-by-construction provenance for plan metadata."""
+    provenance = current_communication_provenance()
+    return {} if provenance is None else provenance.metadata()
 
 
 def _require_non_primary_worktree(cwd: Path, *, adapter_label: str) -> None:
     if _worktree_containment.classify_repo_path(cwd, cwd=cwd) == "primary_checkout":
         raise AcpxShadowRefusalError(
             f"{adapter_label}: refusing to spawn against the protected primary checkout "
-            f"({cwd}); run ACPX shadow calls from a worktree"
+            f"({cwd}); run ACPX calls from a worktree"
         )
 
 
@@ -492,7 +639,7 @@ def _require_pinned_acpx_binary(*, adapter_label: str, cwd: Path) -> str:
 
 
 def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
-    """Shared structural confinement flags for every ACPX shadow seat."""
+    """Shared structural confinement flags for every ACPX seat."""
     return [
         binary,
         "--cwd",
@@ -725,13 +872,14 @@ def _build_text_agent_command(
 
 
 class AcpxAdapter:
-    """Adapter for ``acpx codex exec`` — read-only, stateless, shadow-only.
+    """Adapter for one read-only, stateless ``acpx codex exec`` request.
 
-    Not a general-purpose ACPX adapter: it only ever builds one invocation
-    shape (``codex exec``, one Codex ACP participant, no tools, no fs/
-    terminal capability, no session, no queue). Every other ACPX capability
-    (persistent sessions, other agents, flows, compare) is out of scope for
-    this seat and structurally unreachable through this class.
+    Normal communication reaches this seat only through the runner-owned ACP
+    boundary. It is not a general-purpose ACPX adapter: it only ever builds
+    one invocation shape (``codex exec``, one Codex ACP participant, no tools,
+    no fs/terminal capability, no session, no queue). Every other ACPX
+    capability (persistent sessions, other agents, flows, compare) is out of
+    scope for this seat and structurally unreachable through this class.
     """
 
     name: str = "acpx-codex-shadow"
@@ -759,10 +907,10 @@ class AcpxAdapter:
         ``ValueError`` subclass), matching the approved Stage 0/1 contract's
         "reject before spawn" list:
 
-        - ``LU_ACPX_TRANSPORT`` is not exactly ``"shadow"`` (unset, "off", or
-          unrecognized all refuse — the flag-off rollback path).
-        - ``tool_config`` is missing the explicit ``acpx_shadow=True`` marker
-          (the env var alone is not sufficient per-call proof of intent).
+        - the legacy shadow marker lacks ``LU_ACPX_TRANSPORT=shadow``, or the
+          normal marker lacks active runner-sealed ACP provenance.
+        - ``tool_config`` is missing an explicit ``acpx_shadow=True`` legacy
+          marker or ``acpx_transport=True`` normal marker.
         - ``tool_config["target_agent"]`` names anything other than
           ``"codex"``.
         - ``tool_config`` carries any key outside ``_ALLOWED_TOOL_CONFIG_KEYS``.
@@ -817,6 +965,17 @@ class AcpxAdapter:
             _logger.debug("AcpxAdapter: effort=%r has no ACPX flag equivalent; ignoring", effort)
         cmd.extend(["codex", "exec", "-f", "-"])
 
+        metadata: dict[str, Any] = {
+            "acpx_shadow": tc.get("acpx_transport") is not True,
+            "acpx_pinned_version": PINNED_VERSION,
+            "task_id": validated_task_id,
+            "correlation_id": correlation_id,
+            "idempotency_key": idempotency_key,
+        }
+        if tc.get("acpx_transport") is True:
+            metadata["acpx_transport"] = True
+            metadata.update(_communication_metadata())
+
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
@@ -827,13 +986,7 @@ class AcpxAdapter:
             # read, stored, or forwarded by the controller.
             env_overrides={"ACPX_AUTH_CHAT_GPT": "1"},
             liveness_paths=(),
-            metadata={
-                "acpx_shadow": True,
-                "acpx_pinned_version": PINNED_VERSION,
-                "task_id": validated_task_id,
-                "correlation_id": correlation_id,
-                "idempotency_key": idempotency_key,
-            },
+            metadata=metadata,
         )
 
     @classmethod
@@ -1113,13 +1266,21 @@ class _AcpxDiscussionAdapter:
             "correlation_id": correlation_id,
             "idempotency_key": idempotency_key,
         }
+        if tc.get("acpx_transport") is True:
+            metadata["acpx_discussion"] = False
+            metadata["acpx_transport"] = True
         if self.fixed_model is not None:
             metadata["model"] = self.fixed_model
         if self.fixed_effort is not None:
             metadata["effort"] = self.fixed_effort
         metadata.update(self._extra_metadata())
+        if tc.get("acpx_transport") is True:
+            # Keep the runner-sealed transport fields authoritative even if a
+            # future adapter adds diagnostic metadata with a colliding key.
+            metadata.update(_communication_metadata())
         if effort is not None and self.fixed_effort is None:
             _logger.debug("%s: effort=%r has no ACPX flag equivalent; ignoring", type(self).__name__, effort)
+
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
@@ -1207,6 +1368,7 @@ class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
     fixed_model = GLM_ACP_MODEL
     acpx_model = GLM_ACP_INVOCATION_MODEL
     default_model = fixed_model
+    fixed_effort = "high"
 
     def _custom_agent_command(self, cwd: Path) -> str:
         _ = cwd
@@ -1315,8 +1477,10 @@ class AcpxGrokShadowAdapter:
         noted), matching the approved #6043 contract:
 
         - ``mode`` is not ``"read-only"`` (plain ``ValueError``)
-        - ``LU_ACPX_TRANSPORT`` is not exactly ``"shadow"``
-        - missing ``acpx_shadow=True`` or unsupported ``tool_config`` keys
+        - the legacy shadow marker lacks ``LU_ACPX_TRANSPORT=shadow``, or the
+          normal marker lacks active runner-sealed ACP provenance
+        - missing ``acpx_shadow=True`` legacy marker or ``acpx_transport=True``
+          normal marker, or unsupported ``tool_config`` keys
         - ``target_agent`` is not ``"grok"``
         - ``session_id`` is not None
         - ``cwd`` is the protected primary checkout
@@ -1390,6 +1554,24 @@ class AcpxGrokShadowAdapter:
         # "grok-build".
         cmd.extend(["--agent", agent_command, "exec", "-f", "-"])
 
+        metadata: dict[str, Any] = {
+            "acpx_shadow": tc.get("acpx_transport") is not True,
+            "acpx_pinned_version": PINNED_VERSION,
+            "grok_pinned_version": PINNED_GROK_VERSION,
+            "grok_profile_sha256": _GROK_PROFILE_SHA256,
+            "target_agent": "grok",
+            # Effective values are fixed; never fabricate caller-supplied
+            # alternatives in telemetry.
+            "model": GROK_SHADOW_MODEL,
+            "effort": GROK_SHADOW_EFFORT,
+            "task_id": validated_task_id,
+            "correlation_id": correlation_id,
+            "idempotency_key": idempotency_key,
+        }
+        if tc.get("acpx_transport") is True:
+            metadata["acpx_transport"] = True
+            metadata.update(_communication_metadata())
+
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
@@ -1398,20 +1580,7 @@ class AcpxGrokShadowAdapter:
             env_overrides={GROK_AUTH_CACHED_TOKEN_ENV: "1"},
             env_unsets=_GROK_XAI_API_KEY_ENV_UNSETS,
             liveness_paths=(),
-            metadata={
-                "acpx_shadow": True,
-                "acpx_pinned_version": PINNED_VERSION,
-                "grok_pinned_version": PINNED_GROK_VERSION,
-                "grok_profile_sha256": _GROK_PROFILE_SHA256,
-                "target_agent": "grok",
-                # Effective values are fixed; never fabricate caller-supplied
-                # alternatives in telemetry.
-                "model": GROK_SHADOW_MODEL,
-                "effort": GROK_SHADOW_EFFORT,
-                "task_id": validated_task_id,
-                "correlation_id": correlation_id,
-                "idempotency_key": idempotency_key,
-            },
+            metadata=metadata,
         )
 
     def parse_response(

--- a/scripts/agent_runtime/result.py
+++ b/scripts/agent_runtime/result.py
@@ -130,3 +130,7 @@ class Result:
     isolation_prompt_digest: str | None = None
     isolation_prompt_transport: str | None = None
     response_envelope: ResponseEnvelope | None = None
+    # Present only for runner-selected inter-agent ACP calls.  Source, Agent,
+    # and Via are sealed by the runner, not accepted from caller metadata.
+    transport_metadata: dict[str, str] | None = None
+    transport_outcome: str | None = None

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -135,10 +135,11 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
 )
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
 # Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
-# built-in seats. Keep it bounded, but above the production-observed 263,070
+# built-in seats. Keep it bounded, but above the production-observed 1,067,146
 # bytes that otherwise killed a valid concise GLM response before its terminal
-# frame arrived (#6159).
-_ACPX_GLM_OUTPUT_LIMIT_BYTES = 512 * 1024
+# frame arrived (#6159). The parsed response and formal verdict retain their
+# separate, tighter content/evidence bounds.
+_ACPX_GLM_OUTPUT_LIMIT_BYTES = 2 * 1024 * 1024
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -135,11 +135,11 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
 )
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
 # Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
-# built-in seats. Keep it bounded, but above the production-observed 2,100,434
+# built-in seats. Keep it bounded, but above the production-observed 4,204,632
 # bytes that otherwise killed a valid concise GLM response before its terminal
 # frame arrived (#6159). The parsed response and formal verdict retain their
 # separate, tighter content/evidence bounds.
-_ACPX_GLM_OUTPUT_LIMIT_BYTES = 4 * 1024 * 1024
+_ACPX_GLM_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -135,11 +135,11 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
 )
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
 # Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
-# built-in seats. Keep it bounded, but above the production-observed 1,067,146
+# built-in seats. Keep it bounded, but above the production-observed 2,100,434
 # bytes that otherwise killed a valid concise GLM response before its terminal
 # frame arrived (#6159). The parsed response and formal verdict retain their
 # separate, tighter content/evidence bounds.
-_ACPX_GLM_OUTPUT_LIMIT_BYTES = 2 * 1024 * 1024
+_ACPX_GLM_OUTPUT_LIMIT_BYTES = 4 * 1024 * 1024
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -52,7 +52,12 @@ from ai_llm.fallback import (
     run_gemini_fallback_ladder,
 )
 
-from .adapters.acpx import (
+# Registry adapter paths are canonicalized under ``scripts.agent_runtime``.
+# Import the ACP scope from that same module identity even when this runner is
+# reached through the historical top-level ``agent_runtime`` package alias;
+# otherwise ContextVar provenance is set on one module object and checked on
+# another.
+from scripts.agent_runtime.adapters.acpx import (
     ACPX_PARTICIPANT_CATALOG_TRANSPORTS,
     ACPX_PARTICIPANT_EFFORTS,
     ACPX_SUPPORTED_PARTICIPANTS,
@@ -60,7 +65,8 @@ from .adapters.acpx import (
     _require_local_metadata_field,
     active_communication_scope,
 )
-from .adapters.acpx import TRANSPORT_ENV as ACPX_TRANSPORT_ENV
+from scripts.agent_runtime.adapters.acpx import TRANSPORT_ENV as ACPX_TRANSPORT_ENV
+
 from .adapters.base import AgentAdapter
 from .attribution import InvocationAttribution, resolve_invocation_attribution
 from .env_sanitize import build_agent_env

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -39,7 +39,7 @@ import subprocess
 import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -52,7 +52,15 @@ from ai_llm.fallback import (
     run_gemini_fallback_ladder,
 )
 
-from .adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+from .adapters.acpx import (
+    ACPX_PARTICIPANT_CATALOG_TRANSPORTS,
+    ACPX_PARTICIPANT_EFFORTS,
+    ACPX_SUPPORTED_PARTICIPANTS,
+    AcpxTransportProvenance,
+    _require_local_metadata_field,
+    active_communication_scope,
+)
+from .adapters.acpx import TRANSPORT_ENV as ACPX_TRANSPORT_ENV
 from .adapters.base import AgentAdapter
 from .attribution import InvocationAttribution, resolve_invocation_attribution
 from .env_sanitize import build_agent_env
@@ -111,7 +119,13 @@ _MCP_TOOL_EVENT_RE = re.compile(
 _MCP_TRANSPORT_FAILURE_RE = re.compile(r"ERROR\s+rmcp::transport::worker:")
 _MCP_FAILURE_URL_RE = re.compile(r"url \((?P<url>https?://[^)\s]+)\)")
 _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
-    {"acpx-pilot-native", "acpx-pilot-shadow", "acpx-discuss", "acpx-discuss-synthesis"}
+    {
+        "acpx-pilot-native",
+        "acpx-pilot-shadow",
+        "acpx-discuss",
+        "acpx-discuss-synthesis",
+        "acpx-transport",
+    }
 )
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
 # Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
@@ -126,6 +140,11 @@ _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
 _INVOCATION_ATTRIBUTION: contextvars.ContextVar[InvocationAttribution | None] = (
     contextvars.ContextVar("agent_runtime_invocation_attribution", default=None)
 )
+_INTER_AGENT_TRANSPORT: contextvars.ContextVar[AcpxTransportProvenance | None] = (
+    contextvars.ContextVar("agent_runtime_inter_agent_transport", default=None)
+)
+_INTER_AGENT_TRANSPORT_NAME = "acp"
+_RESERVED_TRANSPORT_PROVENANCE = frozenset({"source", "agent", "via"})
 
 
 class AgentOutputLimitError(AgentRuntimeError):
@@ -141,12 +160,22 @@ class AgentOutputLimitError(AgentRuntimeError):
         )
 
 
+class InterAgentTransportError(AgentRuntimeError):
+    """Refusal at the ACP-only inter-agent transport boundary.
+
+    This is deliberately distinct from an adapter/process failure: callers
+    must not translate it into a legacy bridge retry.  The requested route was
+    unavailable, unsupported, malformed, or lacked trusted provenance before
+    any provider process could be spawned.
+    """
+
+
 def _streamed_output_limit(*, agent_name: str, entrypoint: str) -> int | None:
     """Return the opt-in cap for isolated ACP direct-only seats only."""
     acpx_seats = {str(route["seat"]) for route in ACPX_SUPPORTED_PARTICIPANTS.values()}
     if (
         agent_name in acpx_seats
-        and entrypoint in {"acpx-pilot-shadow", "acpx-discuss"}
+        and entrypoint in {"acpx-pilot-shadow", "acpx-discuss", "acpx-transport"}
     ):
         if agent_name == "acpx-glm-shadow":
             return _ACPX_GLM_OUTPUT_LIMIT_BYTES
@@ -744,6 +773,7 @@ def _build_usage_record(
     attribution = _INVOCATION_ATTRIBUTION.get() or resolve_invocation_attribution(
         task_id=task_id
     )
+    transport = _INTER_AGENT_TRANSPORT.get()
 
     record = {
         "ts": datetime.now(UTC).isoformat(),
@@ -780,6 +810,10 @@ def _build_usage_record(
     safe_substitution = _safe_substitution_record(substitution)
     if safe_substitution is not None:
         record["substitution"] = safe_substitution
+    if transport is not None:
+        # The context is installed only by invoke_inter_agent(); no caller
+        # metadata is permitted to supply or overwrite these fields.
+        record["transport"] = transport.metadata()
     return record
 
 
@@ -2661,6 +2695,12 @@ def _invoke_impl(
         isolation_capability_digest=execution.isolation_capability_digest,
         isolation_prompt_digest=execution.isolation_prompt_digest,
         isolation_prompt_transport=execution.isolation_prompt_transport,
+        transport_metadata=(
+            _INTER_AGENT_TRANSPORT.get().metadata()
+            if _INTER_AGENT_TRANSPORT.get() is not None
+            else None
+        ),
+        transport_outcome=outcome if _INTER_AGENT_TRANSPORT.get() is not None else None,
     )
 
 
@@ -2725,6 +2765,262 @@ def invoke(
         _INVOCATION_ATTRIBUTION.reset(attribution_token)
 
 
+@dataclass(frozen=True)
+class InterAgentRoute:
+    """One enabled, fixed ACP participant selected by the runner."""
+
+    participant: str
+    seat: str
+    target_agent: str
+    model: str | None
+    effort: str | None
+
+
+def _require_acp_transport(transport: str | None) -> None:
+    """Select ACP only; bridge fallback belongs outside this boundary."""
+    selected = _INTER_AGENT_TRANSPORT_NAME if transport is None else str(transport).strip().lower()
+    if selected != _INTER_AGENT_TRANSPORT_NAME:
+        raise InterAgentTransportError(
+            "inter-agent transport supports only 'acp'; it never retries the legacy bridge"
+        )
+    active = os.environ.get(ACPX_TRANSPORT_ENV, "off").strip().lower()
+    if active != "active":
+        raise InterAgentTransportError(
+            f"ACP transport is unavailable ({ACPX_TRANSPORT_ENV}={active!r}); refusing before spawn"
+        )
+
+
+def _validate_transport_metadata(metadata: Mapping[str, object] | None) -> None:
+    """Reject arbitrary metadata so credentials and provenance cannot cross this seam."""
+    if metadata is None:
+        return
+    if not isinstance(metadata, Mapping):
+        raise InterAgentTransportError("inter-agent metadata must be a mapping when provided")
+    reserved = sorted(
+        str(key)
+        for key in metadata
+        if str(key).strip().casefold() in _RESERVED_TRANSPORT_PROVENANCE
+    )
+    if reserved:
+        raise InterAgentTransportError(
+            "Source, Agent, and Via are runner-sealed ACP provenance; "
+            f"caller metadata may not override {reserved!r}"
+        )
+    if metadata:
+        raise InterAgentTransportError(
+            "inter-agent transport accepts no arbitrary metadata; use its explicit bounded arguments"
+        )
+
+
+def _validate_catalog_model(
+    *,
+    participant: str,
+    model: str,
+) -> None:
+    """Require a current active catalog model on the adapter's real route."""
+    try:
+        from scripts.review.model_catalog import load_model_catalog
+
+        catalog = load_model_catalog()
+    except (ImportError, OSError, ValueError) as exc:
+        raise InterAgentTransportError(
+            "ACP model selection is unavailable because the canonical model catalog could not load"
+        ) from exc
+
+    try:
+        model_entry = catalog["models"][model]
+        catalog_transport = ACPX_PARTICIPANT_CATALOG_TRANSPORTS[participant]
+    except (KeyError, TypeError) as exc:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} has no enabled catalog route for model {model!r}"
+        ) from exc
+    if model_entry.get("lifecycle") != "active":
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} refuses non-active model {model!r}"
+        )
+    if catalog_transport not in model_entry.get("transports", []):
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} does not implement catalog transport "
+            f"{catalog_transport!r} for model {model!r}"
+        )
+
+
+def resolve_inter_agent_route(
+    agent: str,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
+) -> InterAgentRoute:
+    """Validate one ACP participant/model/effort selection without spawning.
+
+    The selection is deliberately narrower than ordinary runtime routing:
+    only the pinned ACP adapter registry is considered, and an override may
+    only repeat that adapter's current exact pin.  This prevents model catalog
+    presence from inventing a new ACP provider route.
+    """
+    participant = str(agent).strip().lower()
+    try:
+        raw_route = ACPX_SUPPORTED_PARTICIPANTS[participant]
+        seat = raw_route["seat"]
+        target_agent = raw_route["agent"]
+        pinned_model = raw_route["model"]
+    except (KeyError, TypeError) as exc:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} is unsupported; refusing without bridge fallback"
+        ) from exc
+    if not all(isinstance(value, str) and value for value in (seat, target_agent)):
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} has an invalid enabled adapter route"
+        )
+    try:
+        entry = get_agent_entry(seat)
+    except KeyError as exc:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} has no registered direct-only seat"
+        ) from exc
+    if entry.get("direct_only") is not True or entry.get("cli_available") is not False:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} is not an enabled confined direct-only route"
+        )
+
+    if model is not None and model != pinned_model:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} only supports its registered model pin "
+            f"{pinned_model!r}; got {model!r}"
+        )
+    if pinned_model is not None:
+        _validate_catalog_model(participant=participant, model=pinned_model)
+
+    pinned_effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
+    if effort is not None and effort != pinned_effort:
+        raise InterAgentTransportError(
+            f"ACP participant {participant!r} only supports its registered effort pin "
+            f"{pinned_effort!r}; got {effort!r}"
+        )
+    return InterAgentRoute(
+        participant=participant,
+        seat=seat,
+        target_agent=target_agent,
+        model=pinned_model,
+        effort=pinned_effort,
+    )
+
+
+def _resolve_trusted_transport_source(
+    *,
+    source: str | None,
+    task_id: str,
+) -> str:
+    """Resolve Source once and refuse unknown/missing provenance before spawn."""
+    try:
+        attribution = resolve_invocation_attribution(
+            explicit=source,
+            task_id=task_id,
+        )
+    except ValueError as exc:
+        raise InterAgentTransportError("inter-agent Source is invalid") from exc
+    if attribution.initiator == "unknown":
+        raise InterAgentTransportError(
+            "inter-agent ACP requires a trusted initiating Source; unknown or missing is refused"
+        )
+    return attribution.initiator
+
+
+def _normalized_transport_outcome(result: Result) -> str:
+    """Expose one bounded terminal vocabulary to communication callers."""
+    if result.rate_limited:
+        return "rate_limited"
+    if result.ok:
+        return "ok"
+    reported = result.usage_record.get("outcome")
+    return reported if reported in {"error", "rate_limited"} else "error"
+
+
+def invoke_inter_agent(
+    agent: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    task_id: str,
+    correlation_id: str,
+    idempotency_key: str,
+    source: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    transport: str | None = None,
+    metadata: Mapping[str, object] | None = None,
+    hard_timeout: int = 300,
+) -> Result:
+    """Invoke one confined ACP participant through the normal communication seam.
+
+    ACP is the default and only transport exposed here.  It performs one
+    direct-only one-shot call, never creates a worktree or provider session,
+    and never retries a failed ACP request through the legacy bridge.  The
+    returned :class:`Result` carries runner-sealed ``transport_metadata``
+    (Source, Agent, Via) and a normalized ``transport_outcome``.
+    """
+    _require_acp_transport(transport)
+    _validate_transport_metadata(metadata)
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise InterAgentTransportError("inter-agent prompt must be a non-empty string")
+    if isinstance(hard_timeout, bool) or not isinstance(hard_timeout, int) or hard_timeout < 1:
+        raise InterAgentTransportError("inter-agent hard_timeout must be a positive integer")
+
+    validated_task_id = _require_local_metadata_field(
+        "task_id", task_id, adapter_label="InterAgentTransport"
+    )
+    validated_correlation_id = _require_local_metadata_field(
+        "correlation_id", correlation_id, adapter_label="InterAgentTransport"
+    )
+    validated_idempotency_key = _require_local_metadata_field(
+        "idempotency_key", idempotency_key, adapter_label="InterAgentTransport"
+    )
+    route = resolve_inter_agent_route(agent, model=model, effort=effort)
+    trusted_source = _resolve_trusted_transport_source(
+        source=source,
+        task_id=validated_task_id,
+    )
+    provenance = AcpxTransportProvenance(
+        source=trusted_source,
+        agent=route.participant,
+        target_agent=route.target_agent,
+    )
+    transport_token = _INTER_AGENT_TRANSPORT.set(provenance)
+    try:
+        with active_communication_scope(
+            source=trusted_source,
+            agent=route.participant,
+            target_agent=route.target_agent,
+        ):
+            result = _invoke_direct_only(
+                route.seat,
+                prompt,
+                cwd=Path(cwd),
+                model=route.model,
+                task_id=validated_task_id,
+                tool_config={
+                    "acpx_transport": True,
+                    "target_agent": route.target_agent,
+                    "correlation_id": validated_correlation_id,
+                    "idempotency_key": validated_idempotency_key,
+                },
+                hard_timeout=hard_timeout,
+                effort=route.effort,
+                entrypoint="acpx-transport",
+                initiator=trusted_source,
+            )
+            usage_record = dict(result.usage_record)
+            usage_record.setdefault("transport", provenance.metadata())
+            return replace(
+                result,
+                usage_record=usage_record,
+                transport_metadata=provenance.metadata(),
+                transport_outcome=_normalized_transport_outcome(result),
+            )
+    finally:
+        _INTER_AGENT_TRANSPORT.reset(transport_token)
+
+
 def _invoke_direct_only(
     agent_name: str,
     prompt: str,
@@ -2753,7 +3049,7 @@ def _invoke_direct_only(
         raise AgentUnavailableError(
             f"Agent {agent_name!r} is not an unavailable direct-only seat"
         )
-    if entrypoint not in {"acpx-pilot-shadow", "acpx-discuss"}:
+    if entrypoint not in {"acpx-pilot-shadow", "acpx-discuss", "acpx-transport"}:
         raise ValueError("ACPX direct-only invocation entrypoint was altered")
     attribution_token = _INVOCATION_ATTRIBUTION.set(
         resolve_invocation_attribution(explicit=initiator, task_id=task_id)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4376,7 +4376,7 @@ def test_glm_acp_route_has_a_separate_bounded_protocol_envelope():
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-glm-shadow",
         entrypoint="acpx-discuss",
-    ) == 512 * 1024
+    ) == 2 * 1024 * 1024
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-kimi-shadow",
         entrypoint="acpx-discuss",

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4376,7 +4376,7 @@ def test_glm_acp_route_has_a_separate_bounded_protocol_envelope():
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-glm-shadow",
         entrypoint="acpx-discuss",
-    ) == 4 * 1024 * 1024
+    ) == 16 * 1024 * 1024
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-kimi-shadow",
         entrypoint="acpx-discuss",

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4376,7 +4376,7 @@ def test_glm_acp_route_has_a_separate_bounded_protocol_envelope():
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-glm-shadow",
         entrypoint="acpx-discuss",
-    ) == 2 * 1024 * 1024
+    ) == 4 * 1024 * 1024
     assert runtime_runner._streamed_output_limit(
         agent_name="acpx-kimi-shadow",
         entrypoint="acpx-discuss",

--- a/tests/test_agent_runtime_acp_transport_cutover.py
+++ b/tests/test_agent_runtime_acp_transport_cutover.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import threading
 import time
 
@@ -33,6 +34,23 @@ def _result(agent: str, response: str = "bounded response") -> Result:
 
 def _active_acp(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LU_ACPX_TRANSPORT", "active")
+
+
+def test_top_level_runner_uses_canonical_adapter_scope() -> None:
+    top_level_runner = importlib.import_module("agent_runtime.runner")
+    canonical_acpx = importlib.import_module("scripts.agent_runtime.adapters.acpx")
+    with top_level_runner.active_communication_scope(
+        source="codex",
+        agent="glm",
+        target_agent="glm",
+    ):
+        provenance = canonical_acpx.current_communication_provenance()
+        assert provenance is not None
+        assert provenance.metadata() == {
+            "source": "codex",
+            "agent": "glm",
+            "via": "acp",
+        }
 
 
 def test_inter_agent_defaults_to_acp_and_seals_provenance(tmp_path, monkeypatch) -> None:

--- a/tests/test_agent_runtime_acp_transport_cutover.py
+++ b/tests/test_agent_runtime_acp_transport_cutover.py
@@ -1,0 +1,314 @@
+"""Focused contract tests for the normal ACP inter-agent transport cutover."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from scripts.agent_runtime import acpx_discuss, runner
+from scripts.agent_runtime.adapters import acpx as acpx_module
+from scripts.agent_runtime.adapters.acpx import AcpxKimiShadowAdapter
+from scripts.agent_runtime.env_sanitize import build_agent_env
+from scripts.agent_runtime.result import Result
+
+
+def _result(agent: str, response: str = "bounded response") -> Result:
+    return Result(
+        ok=True,
+        agent=agent,
+        model="fixture",
+        mode="read-only",
+        response=response,
+        stderr_excerpt=None,
+        duration_s=0.01,
+        session_id=None,
+        rate_limited=False,
+        stalled=False,
+        returncode=0,
+        usage_record={"outcome": "ok", "tokens": 5},
+    )
+
+
+def _active_acp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "active")
+
+
+def test_inter_agent_defaults_to_acp_and_seals_provenance(tmp_path, monkeypatch) -> None:
+    _active_acp(monkeypatch)
+    observed: dict[str, object] = {}
+
+    def fake_direct(agent: str, _prompt: str, **kwargs) -> Result:
+        observed["agent"] = agent
+        observed["kwargs"] = kwargs
+        observed["runner_provenance"] = runner._INTER_AGENT_TRANSPORT.get()
+        observed["adapter_provenance"] = acpx_module.current_communication_provenance()
+        return _result(agent)
+
+    monkeypatch.setattr(runner, "_invoke_direct_only", fake_direct)
+
+    result = runner.invoke_inter_agent(
+        "GROK",
+        "Compare the two bounded choices.",
+        cwd=tmp_path,
+        task_id="task-6159",
+        correlation_id="corr-6159",
+        idempotency_key="idem-6159",
+        source="Codex",
+    )
+
+    assert observed["agent"] == "acpx-grok-shadow"
+    kwargs = observed["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["entrypoint"] == "acpx-transport"
+    assert kwargs["tool_config"] == {
+        "acpx_transport": True,
+        "target_agent": "grok",
+        "correlation_id": "corr-6159",
+        "idempotency_key": "idem-6159",
+    }
+    assert observed["runner_provenance"].metadata() == {
+        "source": "codex",
+        "agent": "grok",
+        "via": "acp",
+    }
+    assert observed["adapter_provenance"].metadata() == result.transport_metadata
+    assert result.transport_metadata == {
+        "source": "codex",
+        "agent": "grok",
+        "via": "acp",
+    }
+    assert result.transport_outcome == "ok"
+    assert result.usage_record["transport"] == result.transport_metadata
+
+
+def test_inter_agent_refuses_unsupported_or_bridge_without_legacy_fallback(tmp_path, monkeypatch) -> None:
+    _active_acp(monkeypatch)
+    calls: list[str] = []
+    monkeypatch.setattr(runner, "_invoke_direct_only", lambda *_a, **_k: calls.append("acp"))
+    monkeypatch.setattr(runner, "invoke", lambda *_a, **_k: calls.append("legacy"))
+
+    kwargs = {
+        "cwd": tmp_path,
+        "task_id": "task-6159",
+        "correlation_id": "corr-6159",
+        "idempotency_key": "idem-6159",
+        "source": "codex",
+    }
+    with pytest.raises(runner.InterAgentTransportError, match="unsupported"):
+        runner.invoke_inter_agent("not-a-seat", "prompt", **kwargs)
+    with pytest.raises(runner.InterAgentTransportError, match="only 'acp'"):
+        runner.invoke_inter_agent("grok", "prompt", transport="bridge", **kwargs)
+
+    monkeypatch.setenv("LU_ACPX_TRANSPORT", "off")
+    with pytest.raises(runner.InterAgentTransportError, match="unavailable"):
+        runner.invoke_inter_agent("grok", "prompt", **kwargs)
+
+    assert calls == []
+
+
+def test_inter_agent_rejects_spoofed_provenance_and_unknown_source_before_spawn(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _active_acp(monkeypatch)
+    spawned: list[bool] = []
+    monkeypatch.setattr(runner, "_invoke_direct_only", lambda *_a, **_k: spawned.append(True))
+    for variable in (
+        "SESSION_HANDOFF_AGENT",
+        "CODEX_THREAD_ID",
+        "CODEX_SESSION",
+        "CLAUDE_AGENT_NAME",
+        "GROK_AGENT",
+        "GEMINI_SESSION",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+    kwargs = {
+        "cwd": tmp_path,
+        "task_id": "task-6159",
+        "correlation_id": "corr-6159",
+        "idempotency_key": "idem-6159",
+    }
+    with pytest.raises(runner.InterAgentTransportError, match="runner-sealed"):
+        runner.invoke_inter_agent(
+            "grok",
+            "prompt",
+            source="codex",
+            metadata={"Source": "forged"},
+            **kwargs,
+        )
+    with pytest.raises(runner.InterAgentTransportError, match="trusted initiating Source"):
+        runner.invoke_inter_agent("grok", "prompt", **kwargs)
+
+    assert spawned == []
+
+
+def test_inter_agent_does_not_forward_or_return_raw_credentials(tmp_path, monkeypatch) -> None:
+    _active_acp(monkeypatch)
+    secret = "secret-value-never-for-acp-result"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    captured: dict[str, object] = {}
+
+    def fake_direct(agent: str, _prompt: str, **kwargs) -> Result:
+        captured["agent"] = agent
+        captured["kwargs"] = kwargs
+        return _result(agent)
+
+    monkeypatch.setattr(runner, "_invoke_direct_only", fake_direct)
+    result = runner.invoke_inter_agent(
+        "grok",
+        "Prompt text has no credential.",
+        cwd=tmp_path,
+        task_id="task-6159",
+        correlation_id="corr-6159",
+        idempotency_key="idem-credential-boundary",
+        source="codex",
+    )
+
+    assert secret not in repr(captured)
+    assert secret not in repr(result)
+    assert secret not in repr(result.usage_record)
+
+
+def test_adapter_transport_metadata_and_auth_selector_are_non_secret(tmp_path, monkeypatch) -> None:
+    _active_acp(monkeypatch)
+    secret = "moonshot-secret-must-not-leak"
+    monkeypatch.setenv("KIMI_API_KEY", secret)
+    monkeypatch.setattr(acpx_module, "_require_non_primary_worktree", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        acpx_module,
+        "_require_pinned_acpx_binary",
+        lambda **_kwargs: str(tmp_path / "acpx"),
+    )
+
+    with acpx_module.active_communication_scope(
+        source="codex",
+        agent="kimi",
+        target_agent="kimi",
+    ):
+        plan = AcpxKimiShadowAdapter().build_invocation(
+            prompt="bounded prompt",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id="task-6159",
+            session_id=None,
+            tool_config={
+                "acpx_transport": True,
+                "target_agent": "kimi",
+                "correlation_id": "corr-6159",
+                "idempotency_key": "idem-6159",
+            },
+        )
+
+    env = build_agent_env(provider="acpx-kimi-shadow", overrides=plan.env_overrides)
+    assert plan.metadata["source"] == "codex"
+    assert plan.metadata["agent"] == "kimi"
+    assert plan.metadata["via"] == "acp"
+    assert plan.metadata["acpx_discussion"] is False
+    assert plan.metadata["acpx_transport"] is True
+    assert plan.env_overrides == {"ACPX_AUTH_LOGIN": "1"}
+    assert env["ACPX_AUTH_LOGIN"] == "1"
+    assert "KIMI_API_KEY" not in env
+    assert secret not in repr(plan)
+    assert secret not in repr(env)
+
+
+def test_adapter_extra_metadata_cannot_override_runner_sealed_provenance(tmp_path, monkeypatch) -> None:
+    _active_acp(monkeypatch)
+    monkeypatch.setattr(acpx_module, "_require_non_primary_worktree", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        acpx_module,
+        "_require_pinned_acpx_binary",
+        lambda **_kwargs: str(tmp_path / "acpx"),
+    )
+
+    class SpoofingAdapter(AcpxKimiShadowAdapter):
+        def _extra_metadata(self):
+            return {"source": "forged", "agent": "forged", "via": "bridge"}
+
+    with acpx_module.active_communication_scope(
+        source="codex",
+        agent="kimi",
+        target_agent="kimi",
+    ):
+        plan = SpoofingAdapter().build_invocation(
+            prompt="bounded prompt",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id="task-6159",
+            session_id=None,
+            tool_config={
+                "acpx_transport": True,
+                "target_agent": "kimi",
+                "correlation_id": "corr-6159",
+                "idempotency_key": "idem-6159",
+            },
+        )
+
+    assert {field: plan.metadata[field] for field in ("source", "agent", "via")} == {
+        "source": "codex",
+        "agent": "kimi",
+        "via": "acp",
+    }
+
+
+def test_discussion_uses_normal_transport_for_three_participants_with_pins(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _active_acp(monkeypatch)
+    monkeypatch.setattr(acpx_discuss, "classify_repo_path", lambda *_a, **_k: "dispatch_worktree")
+    calls: list[tuple[str, dict[str, object]]] = []
+    active = 0
+    active_max = 0
+    lock = threading.Lock()
+
+    def participant(agent: str, _prompt: str, **kwargs) -> Result:
+        nonlocal active, active_max
+        with lock:
+            active += 1
+            active_max = max(active_max, active)
+        try:
+            time.sleep(0.02)
+            calls.append((agent, kwargs))
+            return _result(agent, f"{agent} response")
+        finally:
+            with lock:
+                active -= 1
+
+    controller = acpx_discuss.AcpxDiscussionController(
+        root=tmp_path / "plane",
+        participant_call=None,
+        synthesis_call=lambda agent, _prompt, **_kwargs: _result(agent, "synthesis"),
+    )
+    monkeypatch.setattr(acpx_discuss, "invoke_inter_agent", participant)
+    try:
+        payload = controller.run(
+            prompt="Compare the bounded options.",
+            cwd=tmp_path,
+            task_id="task-6159",
+            correlation_id="corr-6159",
+            idempotency_key="idem-three-seat",
+            rounds=2,
+            participants=("claude", "kimicc", "glm"),
+            models={"kimicc": "kimi-code/k3", "glm": "glm-5.2"},
+            efforts={"glm": "high"},
+            source="codex",
+        )
+    finally:
+        controller.close()
+
+    assert payload["state"] == "COMPLETE"
+    assert len(payload["participant_outcomes"]) == 6
+    assert {agent for agent, _kwargs in calls} == {"claude", "kimicc", "glm"}
+    assert len(calls) == 6
+    assert active_max <= acpx_discuss.PARTICIPANT_CONCURRENCY
+    kimicc_calls = [kwargs for agent, kwargs in calls if agent == "kimicc"]
+    glm_calls = [kwargs for agent, kwargs in calls if agent == "glm"]
+    assert all(kwargs["model"] == "kimi-code/k3" for kwargs in kimicc_calls)
+    assert all(kwargs["model"] == "glm-5.2" for kwargs in glm_calls)
+    assert all(kwargs["effort"] == "high" for kwargs in glm_calls)


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

Makes ACP the only normal inter-agent provider transport, seals Source/Agent/Via at the runner-owned boundary, removes legacy fallback from communication calls, and keeps delegation confined to execution/isolation concerns. Includes bounded GLM protocol-envelope handling observed during exact-head review.

Validation:
- 326 focused runtime/ACP tests passed
- Ruff passed
- git diff --check passed

Depends on merged authority core PR #6191.