### PR TITLE
fix(fleet-comms): preserve imported reply links

### DIFF
--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -1948,6 +1948,7 @@ class AuthorityService:
         delivery_map: Mapping[str, tuple[str, ...]],
     ) -> dict[str, Any]:
         message_id = str(row["message_id"])
+        parent_id = row["parent_id"]
         return {
             "external_id": f"channel:{message_id}",
             "body": str(row["body"] or ""),
@@ -1956,7 +1957,10 @@ class AuthorityService:
             "recipients": delivery_map.get(message_id, ()),
             "kind": str(row["kind"] or "post"),
             "conversation_id": str(row["thread_id"]),
-            "in_reply_to": row["parent_id"],
+            # Channel records use a namespaced external identity. Apply the
+            # same namespace to their parent link so normalization resolves
+            # both sides to the same immutable authority message ID.
+            "in_reply_to": f"channel:{parent_id}" if parent_id else None,
             "correlation_id": row["correlation_id"],
             "context_revisions": {
                 "shared": str(row["context_rev_shared"] or ""),

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -619,6 +619,22 @@ def test_legacy_sqlite_import_preserves_bridge_and_channel_metadata(tmp_path: Pa
                 "2037-01-01T00:01:00Z",
             ),
         )
+        conn.execute(
+            """INSERT INTO channel_messages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "channel-2",
+                "coordination",
+                "thread-1",
+                "channel-1",
+                "corr-1",
+                "claude",
+                "reply",
+                "channel reply",
+                "",
+                "",
+                "2037-01-01T00:02:00Z",
+            ),
+        )
         conn.execute("INSERT INTO deliveries VALUES (?, ?)", ("channel-1", "claude"))
         conn.commit()
     finally:
@@ -626,13 +642,17 @@ def test_legacy_sqlite_import_preserves_bridge_and_channel_metadata(tmp_path: Pa
 
     with AuthorityService(root=_root(tmp_path)) as service:
         result = service.import_legacy_sqlite(legacy, source="legacy-broker-v1")
-        assert result.imported == 2
+        assert result.imported == 3
         channel = service.get_channel("coordination")
         assert channel.subscribers == ("claude", "codex")
         imported_channel = service.get_message(result.message_ids[1])
         assert imported_channel.correlation_id == "corr-1"
         assert imported_channel.provenance["Via"] == "legacy-channel"
         assert service.read_message_body(imported_channel.message_id) == "channel body"
+        imported_reply = service.get_message(result.message_ids[2])
+        assert imported_reply.in_reply_to == imported_channel.message_id
+        assert imported_reply.conversation_id == imported_channel.conversation_id
+        assert service.read_message_body(imported_reply.message_id) == "channel reply"
 
 
 def test_formal_review_refuses_head_mismatch_before_verdict_publication(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve the `channel:` external-ID namespace when translating legacy reply parents
- add a threaded legacy SQLite import regression test

## Evidence
- 16 authority cutover tests passed
- real 753-record legacy database imported into a clean canary store
- second pass replayed all 753 records without duplication
- foreign-key check returned zero violations

Part of #6159
Parent stream: #4707
Follow-up to #6191