### PR TITLE
feat(fleet): mount observer and declare authority doctrine

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -1,11 +1,11 @@
-# Fleet-comms coordination (binding mid-cutover)
+# Fleet-comms coordination (binding authority cutover)
 
 <critical>
 
-**Product epic:** #5512 · **Stream:** #4707 (infra-harness) · **Sol memo:** `SHIP-THIS-ARCHITECTURE`
+**Cutover issue:** #6159 · **Stream:** #4707 (infra-harness) · **Operator GO:** 2026-08-01
 **Applies to:** every standalone TUI/UI and epic-driver seat (Claude/Sonnet, Grok, AGY/Gemini, Kimi, Cursor, wrappers) — not only agents that load a skill.
 
-This is the **shared-context SSOT** for coordination during the fleet-comms cutover. It is
+This is the **shared-context SSOT** for coordination after the fleet-comms authority cutover. It is
 served in `GET /api/rules`. Launchers inject a short pointer; the **`drive-epic` skill**
 teaches the full method loop. Neither may invent a competing design or silently flip
 cutovers.
@@ -34,29 +34,29 @@ at the **onboarding contract** for ownership and experimental ACPX scope; this r
 | Half | Status | Surfaces |
 | --- | --- | --- |
 | **Session stream / lease** | Live | `claim_session_supervisor_env`, `SESSION_STREAM_*`, stream tail/digest, canary mint (hook-less seats) |
-| **Message plane + CF-comms** | Mid-cutover | `scripts.fleet_comms`, `review-pr`, `publish-review-verdict` |
+| **Message plane + CF-comms** | Authority | `scripts.fleet_comms`, `review-pr`, `publish-review-verdict` |
 
 Launchers already claim leases. Drivers must **also** speak the message-plane + CF half.
 
-## Plane modes (Sol-corrected — #5632 F003)
+## Plane modes
 
 ```bash
 .venv/bin/python -m scripts.fleet_comms plane-status
 ```
 
-Implemented modes are **only** `off` | `shadow` | `dual_write`. Production default is
-**`shadow`** after Gate A parity + operator finish GO (2026-07-23); override with
-`FLEET_COMMS_MESSAGE_PLANE=off|dual_write`.
+Implemented modes are `off` | `shadow` | `dual_write` | `authority`. Production
+default is **`authority`** after the present-tense operator GO in #6159. Override
+only for an explicit rollback or compatibility probe.
 
 | Fact | Binding |
 | --- | --- |
-| File dual-write / diary | **Stays authoritative in every plane mode** today |
-| `dual_write` mode | Shadow/mirror of plane traffic — **not** stream-authority cutover |
-| Post-cutover “plane-only authority” | **Not implemented** — do not claim a one-line yaml flip retires files |
-| Who may flip plane / retention apply / eligibility | **Infra/harness lane** after parity + present-tense operator/advisor GO |
+| `authority` mode | Fleet-comms is the durable source of truth; legacy stores are read-only migration/projection sources |
+| `dual_write` mode | Compatibility soak/rollback mode, not normal operation |
+| ACP | Provider transport only; durable queues, retries, conversations, artifacts, receipts, and formal jobs belong to fleet-comms |
+| Who may roll back authority / retention apply / eligibility | **Infra/harness lane** with present-tense operator/advisor approval |
 
-**Never drop the file handoff on your own.** Retiring file handoffs is a future infra step
-gated on an authority signal the plane does not yet expose.
+Do not create new authoritative bridge, channel, broker, or diary writes. Historical
+stores stay available through bounded read-only projections and idempotent migration.
 
 Forbidden: inventing a third message bus; encoding only file-handoff folklore in new
 cold-prompts; silent plane flips; “for now” cutovers.
@@ -90,9 +90,9 @@ Every epic driver session (any harness) MUST:
 
 1. Obey this rule (via `/api/rules` or offline fallback of this file).
 2. Run `plane-status` before assuming message-plane availability.
-3. Prefer plane/CF **command surfaces** for topology and formal review; **keep** the lane
-   diary dual-write current (`.claude/<epic>-epic/*-DRIVER-HANDOFF.md` and stream notes)
-   in **all** plane modes.
+3. Use fleet-comms for durable coordination, queues, messages, conversations, artifacts,
+   retries, dead letters, receipts, formal jobs, and session continuity. In authority
+   mode, never create a new legacy bridge/channel/broker/file coordination write.
 4. Use `review-pr <PR_NUMBER> …` / `publish-review-verdict` for formal PR CF — discussion
    and same-family chat are not the review gate.
 5. Treat launcher-claimed stream leases as held — do not open/resume the lease yourself.
@@ -135,28 +135,25 @@ Supported fleet seats cold-start through:
    KimiCC (K3 defaults `high`), rollback, and no-auth fresh-agent smoke.
 
 Discussion is never formal CF. Formal CF remains `review-pr` /
-`publish-review-verdict` only. ACPX is structured invocation transport, not a
-coordination authority. File dual-write stays authoritative in every plane mode.
+`publish-review-verdict` only. ACP is structured provider transport; fleet-comms
+owns the durable record and publication state.
 
-## Bounded ACP panel (approved selection)
+## ACP provider transport
 
-For eligible two-seat **read-only agent communication**, ACP is the routine
-transport. Fleet launchers make the project `discuss` command select the durable ACP controller
-automatically when both requested participants have enabled routes: Codex,
-Grok, Claude, Kimi, KimiCC K3, Cursor, or Pool. The direct
+For normal **read-only inter-agent communication**, ACP is the only provider
+transport. Fleet launchers make ordinary `ask-*`, 2–6 participant `discuss`, and
+sealed formal-review calls use the durable ACP controller for enabled routes:
+Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool, AGY, GLM, and DeepSeek. The direct
 `.venv/bin/python -m scripts.fleet_comms acp-discuss` surface remains available
 to operators. Selection starts no process at cold start and does not change
 `delegate.py`. The default is two rounds and the hard maximum is three.
 
-Bridge transport is an observable exception only: use it for an unsupported
-participant/count, a per-participant model override, formal review until
-separately migrated, write / dispatch / inbox semantics, or a typed ACP
-unhealthy or partial failure. Name
-the exception in the task handoff or other durable coordination evidence;
-never silently fall back. Admission is one conversation repository-wide:
-return `busy` when occupied, with zero queue and zero automatic retry. ACP
-output is deliberation evidence: a typed partial outcome is valid evidence but
-never a successful discussion, formal review, or coordination authority. The
+There is no bridge/provider-execution fallback. Unknown routes, invalid model or
+effort overrides, unavailable ACP, cancellation, timeout, and partial results are
+typed durable outcomes and never trigger a second provider call. Fleet-comms owns
+bounded queueing, leases, deadlines, retries, dead letters, idempotency, transcripts,
+and wake receipts. ACP output is deliberation evidence: a typed partial outcome is
+valid evidence but never a successful discussion or formal review. The
 exact command, primary-install and body-free `acp-verify` E2E/replay procedure
 are in the onboarding contract.
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -68,6 +68,7 @@ from .decisions_router import router as decisions_router
 from .delegate_router import router as delegate_router
 from .discussions_router import router as discussions_router
 from .docs_router import router as docs_router
+from .fleet_router import router as fleet_router
 from .git_hygiene_router import router as git_hygiene_router
 from .gold_router import router as gold_router
 from .governance_router import collect_governance_summary
@@ -158,6 +159,7 @@ app.include_router(agent_monitor_router, prefix="/api/agent-monitor")
 app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
 app.include_router(blue_router, prefix="/api/blue")
 app.include_router(comms_router, prefix="/api/comms")
+app.include_router(fleet_router, prefix="/api/fleet", tags=["fleet"])
 app.include_router(session_streams_router, prefix="/api/session-streams", tags=["session-streams"])
 app.include_router(coordination_router, prefix="/api/coordination")
 app.include_router(consultation_router, prefix="/api/consultation")

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -1,4 +1,4 @@
-"""Standalone TUI launchers must point at shared fleet-comms mid-cutover doctrine."""
+"""Standalone TUI launchers must point at shared fleet-comms authority doctrine."""
 
 from __future__ import annotations
 
@@ -29,7 +29,9 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     assert "drive-epic" in body
     assert "-driver.sh" in body
     assert "authoritative" in body.lower()
-    assert "not implemented" in body.lower() or "shadow/mirror" in body.lower()
+    assert "fleet-comms is the durable source of truth" in body.lower()
+    assert "legacy stores are read-only" in body.lower()
+    assert "acp" in body.lower() and "provider transport" in body.lower()
     assert "PR_NUMBER" in body or "PR number" in body.lower()
     assert HELPER.is_file(), "missing shared launcher helper"
     helper = HELPER.read_text(encoding="utf-8")

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -76,7 +76,7 @@ def test_rules_live_assembly_includes_fleet_scorecard():
 
 
 def test_rules_live_assembly_includes_fleet_comms_coordination():
-    """Standalone TUI/UI drivers must receive dual-aware fleet-comms mid-cutover SSOT."""
+    """Standalone TUI/UI drivers receive the fleet-comms authority SSOT."""
     resp = client.get("/api/rules?format=json")
     assert resp.status_code == 200
     body = resp.json()
@@ -87,8 +87,9 @@ def test_rules_live_assembly_includes_fleet_comms_coordination():
     assert "review-pr" in md
     assert "dual_write" in md or "dual-write" in md
     assert "do not invent a competing design" in md.lower() or "competing design" in md
-    # Sol #5632 F003: no false "post-cutover drop file handoffs" doctrine.
-    assert "authoritative in every" in md.lower() or "stays authoritative" in md.lower()
+    assert "fleet-comms is the durable source of truth" in md.lower()
+    assert "legacy stores are read-only" in md.lower()
+    assert "acp" in md.lower() and "provider transport" in md.lower()
     assert "drive-epic" in md
 
 


### PR DESCRIPTION
Summary:\n- mount the already-merged read-only fleet observer at /api/fleet\n- replace mid-cutover doctrine with the operator-approved fleet-comms authority contract\n- update doctrine consumers to reject legacy write authority\n\nVerification:\n- 64 focused tests passed\n- Ruff, Markdownlint, OPSEC, git diff --check, and X-Agent trailer audit passed\n\nIssue: #6159\nStream epic: #4707\n\nRail approval is intentionally pending issuance against this exact PR number and head.

Rail-Approval-Receipt: rail-approval-bd616370adce46e4b73e0578d863b1ef