### PR TITLE
fix(review): align Claude formal ACP pin

### DIFF
--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -122,6 +122,7 @@ PINNED_AGY_VERSION = "1.1.9"
 PINNED_OPENCODE_VERSION = "1.17.13"
 PINNED_HERMES_VERSION = "0.18.2"
 AGY_ACP_MODEL = "gemini-3.6-flash-high"
+CLAUDE_ACP_MODEL = "claude-sonnet-5"
 GLM_ACP_MODEL = "glm-5.2"
 GLM_ACP_INVOCATION_MODEL = "zai-coding-plan/glm-5.2"
 DEEPSEEK_ACP_MODEL = "deepseek-v4-pro"
@@ -194,7 +195,11 @@ _ALLOWED_TOOL_CONFIG_KEYS = frozenset(
 ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     "codex": {"seat": "acpx-codex-shadow", "agent": "codex", "model": None},
     "grok": {"seat": "acpx-grok-shadow", "agent": "grok", "model": GROK_SHADOW_MODEL},
-    "claude": {"seat": "acpx-claude-shadow", "agent": "claude", "model": None},
+    "claude": {
+        "seat": "acpx-claude-shadow",
+        "agent": "claude",
+        "model": CLAUDE_ACP_MODEL,
+    },
     "kimi": {"seat": "acpx-kimi-shadow", "agent": "kimi", "model": None},
     "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},
     "cursor": {"seat": "acpx-cursor-shadow", "agent": "cursor", "model": None},
@@ -227,6 +232,7 @@ ACPX_PARTICIPANT_CATALOG_TRANSPORTS: dict[str, str] = {
     "deepseek": "hermes",
 }
 ACPX_PARTICIPANT_EFFORTS: dict[str, str] = {
+    "claude": "high",
     "grok": GROK_SHADOW_EFFORT,
     "agy": "high",
     "glm": "high",
@@ -1304,6 +1310,9 @@ class _AcpxDiscussionAdapter:
 class AcpxClaudeShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-claude-shadow"
     target_agent = "claude"
+    fixed_model = CLAUDE_ACP_MODEL
+    default_model = fixed_model
+    fixed_effort = "high"
 
 
 class AcpxKimiShadowAdapter(_AcpxDiscussionAdapter):

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1447,7 +1447,7 @@ def test_codex_adapter_unchanged_still_targets_codex_only(tmp_path, monkeypatch)
 @pytest.mark.parametrize(
     ("adapter_class", "participant", "acpx_agent", "fixed_model", "auth_env"),
     [
-        (AcpxClaudeShadowAdapter, "claude", "claude", None, None),
+        (AcpxClaudeShadowAdapter, "claude", "claude", "claude-sonnet-5", None),
         (AcpxKimiShadowAdapter, "kimi", "kimi", None, "ACPX_AUTH_LOGIN"),
         (AcpxKimiCcShadowAdapter, "kimicc", "kimi", "kimi-code/k3", "ACPX_AUTH_LOGIN"),
         (AcpxCursorShadowAdapter, "cursor", "cursor", None, "ACPX_AUTH_CURSOR_LOGIN"),
@@ -1507,6 +1507,8 @@ def test_builtin_discussion_seats_are_fixed_active_only_and_confined(
     else:
         assert ("--model", fixed_model) in zip(plan.cmd, plan.cmd[1:], strict=False)
         assert plan.metadata["model"] == fixed_model
+    if participant == "claude":
+        assert plan.metadata["effort"] == "high"
 
 
 def test_builtin_discussion_seat_rejects_shadow_marker_wrong_target_and_session(tmp_path, monkeypatch):
@@ -1557,7 +1559,11 @@ def test_supported_participant_registry_has_only_fixed_direct_seats():
     assert ACPX_SUPPORTED_PARTICIPANTS == {
         "codex": {"seat": "acpx-codex-shadow", "agent": "codex", "model": None},
         "grok": {"seat": "acpx-grok-shadow", "agent": "grok", "model": "grok-4.5"},
-        "claude": {"seat": "acpx-claude-shadow", "agent": "claude", "model": None},
+        "claude": {
+            "seat": "acpx-claude-shadow",
+            "agent": "claude",
+            "model": "claude-sonnet-5",
+        },
         "kimi": {"seat": "acpx-kimi-shadow", "agent": "kimi", "model": None},
         "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},
         "cursor": {"seat": "acpx-cursor-shadow", "agent": "cursor", "model": None},

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from scripts.agent_runtime.adapters.acpx import (
+    ACPX_PARTICIPANT_EFFORTS,
+    ACPX_SUPPORTED_PARTICIPANTS,
+)
 from scripts.ai_agent_bridge._review_pr import (
     FORMAL_CF_EFFORT,
     FORMAL_CF_MODEL,
@@ -23,6 +27,13 @@ def test_formal_cf_pins_are_practical_seats_at_high():
     assert formal_cf_pin("glm") == ("glm-5.2", "high")
     assert FORMAL_CF_MODEL["codex"] == "gpt-5.6-terra"
     assert FORMAL_CF_EFFORT["claude"] == "high"
+
+
+def test_formal_cross_family_pins_match_enabled_acp_routes():
+    for reviewer in ("claude", "glm"):
+        model, effort = formal_cf_pin(reviewer)
+        assert ACPX_SUPPORTED_PARTICIPANTS[reviewer]["model"] == model
+        assert ACPX_PARTICIPANT_EFFORTS[reviewer] == effort
 
 
 def test_review_pr_dry_run_emits_model_and_effort(capsys):


### PR DESCRIPTION
Summary:\n- pin the enabled Claude ACP participant to the documented formal-review model and effort\n- make the adapter command and provenance carry claude-sonnet-5 @ high\n- enforce that formal cross-family pins match the enabled ACP registry\n\nRoot cause:\nreview-pr requested the documented Claude formal pin, but the ACP registry advertised Claude as unpinned and correctly rejected the caller override.\n\nVerification:\n- 113 focused tests passed\n- runtime route resolves Claude to claude-sonnet-5 @ high\n- Ruff, OPSEC, trailer audit, and git diff --check passed\n\nIssue: #6159\nStream epic: #4707