### PR TITLE
docs(foundry): realign for a solo evidence workflow

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -9,7 +9,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Last refreshed** | 2026-08-01 (Ukrainian Data Foundry Phase 2–4 successor #6164 activated) |
+| **Last refreshed** | 2026-08-01 (Foundry #6164 realigned for a solo operator; paid human review removed from the critical path) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Help people and AI produce measurably better, authentically Ukrainian language through decolonized learning products and reusable, evidence-backed open-model infrastructure. Quality non-negotiable. |
@@ -29,12 +29,15 @@ stream must trace to this chain:
 2. **Products**: the LU curriculum site (learners) and Hramatka (teachers).
 3. **Reusable community infrastructure**: audited, provenance-rich source data;
    the Ukrainian Data Foundry's admitted real data, contextual language-contact
-   diagnostics, human-reviewed corrections, model-ready exports, and causal
-   open-weight evidence (#6164; completed foundation #6056); and
-   narrow, contamination-resistant public evaluation (#2156, #6057).
-4. **Kept honest by**: internal QG machinery (#4913), frozen evidence contracts,
-   Ukrainian linguistic review, and strict separation of public evaluation gold,
-   private product evidence, and future training data.
+   diagnostics, evidence-backed silver corrections with optional human-gold
+   upgrades, model-ready exports, and causal open-weight evidence (#6164;
+   completed foundation #6056); and
+   narrow, contamination-resistant public evaluation (closed #2156; frozen
+   future design preserved in closed #6057).
+4. **Kept honest by**: internal QG machinery (#4913), frozen evidence grades and
+   claim boundaries, independent evaluation, optional Ukrainian linguistic
+   review, and strict separation of public evaluation gold, private product
+   evidence, and future training data.
 5. **Which runs on**: the fleet — build pipeline, dispatch, comms, leases, and CI.
 
 **The trace is falsifiable, not vibes:** every queued item names its stream milestone,
@@ -62,8 +65,7 @@ is the single source of truth for membership (auditor:
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
-| benchmark-2156 | #6057 (successor to closed #2156) | Closed #2156 owns the completed public v0.1.1 release; #6057 owns separately frozen v0.2 error analysis, controls, coverage, and future baselines |
-| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: admit useful-scale real data, detect contextual Ukrainian language-contact failures, freeze qualified-human gold, export model-ready views, test one causal open-weight treatment, and ship a reproducible release candidate |
+| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: admit useful-scale real data, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, test one causal open-weight treatment, and ship a reproducible release candidate |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -72,6 +74,11 @@ is the single source of truth for membership (auditor:
 
 Rules for every orchestrator (Claude, Codex UI, agy, cursor): work from your stream epic;
 link new issues to a stream at creation; orphans get flagged at every cold start.
+
+The completed public benchmark v0.1.1 is owned by closed #2156. Closed #6057
+preserves its frozen v0.2 successor design, but reviewer-intensive #6084 is
+parked under the solo-operator model. Because that program has no open epic or
+active issue, it is not an active registry stream.
 
 ---
 
@@ -90,8 +97,7 @@ epic-board state and bind only once that stream's driver (State: the operator) c
 | --- | --- | --- | --- |
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
 | eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
-| benchmark-2156 | ACTIVE | Acquire and adjudicate the coverage-complete v0.2 evaluation inventory (#6084) | Every frozen category minimum and statistical stop condition is met; every item carries licensing, provenance, contamination, and qualified Ukrainian-human evidence under [#6074](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6074); unresolved conflicts remain non-headline, and no model run is required |
-| open-model-data | ACTIVE | Execute Foundry Phase 2 in parallel under #6164: admit useful-scale real corpus families with complete provenance/rights evidence (#6166) and run the contextual Ukrainian language-contact detector across the full 189,150-record corpus (#6167) | Real records—not fixtures—are admitted or explicitly rejected across the complete denominator, and every detected Russian quotation, modern interference, phonetic rendering, mixed/historical/protected span, and uncertainty retains context and source lineage. The stream then continues through qualified-human gold (#6168), real exports and tokenizer evidence (#6169), one preregistered causal open-weight experiment (#6170), and stranger-reproduced release candidacy (#6171); only the named human approval gates may pause it |
+| open-model-data | ACTIVE | Turn completed admission/detector evidence into real silver and model-ready data under #6164: evidence-grade contextual corrections and protections (#6168) plus admitted source-text and silver exports with tokenizer evidence (#6169) | #6168 emits real deterministic/triangulated silver, protected, and unresolved records without claiming human gold; #6169 emits at least the admitted real continued-pretraining view and reports every other view as eligible or explicitly blocked. A text-free feasibility receipt must stop or redirect work before expensive training if inputs, evaluation isolation, protected-variation probes, reproducibility, or the approved budget are inadequate. Hramatka and qualified-human review are optional later evidence upgrades, not pause gates. |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |

--- a/docs/runbooks/ukrainian-data-foundry-correction-factory.md
+++ b/docs/runbooks/ukrainian-data-foundry-correction-factory.md
@@ -4,6 +4,12 @@
 > under [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
 > **Boundary:** review intake and adjudication, not model-ready export
 
+> **Current scope:** the implemented contracts below remain the optional
+> qualified-human-gold branch. [#6168](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6168)
+> owns a separate evidence-backed silver branch for the solo-operator critical
+> path. Silver must use a distinct contract and must not be relabelled as
+> `qualified_correction_intake`, `headline_gold`, or human review.
+
 ## What this component produces
 
 The correction factory takes span-aware, unresolved candidates from a local
@@ -15,9 +21,12 @@ detector or enrichment stage and produces two deterministic artifacts:
 2. an adjudicated correction record that preserves the complete candidate and
    qualified-human decision while remaining ineligible for training or export.
 
-The component does not infer corrections. A detector, VESUM miss, Russian
-morphology result, `r2u` hit, dictionary result, exact mismatch, or model vote
-remains evidence until the qualified-human review contract is satisfied.
+This qualified-gold component does not infer corrections. A detector, VESUM
+miss, Russian morphology result, `r2u` hit, dictionary result, exact mismatch,
+or model vote remains evidence until the qualified-human review contract is
+satisfied.
+The separate silver branch may combine such evidence under its own explicit
+grade and uncertainty rules, but it cannot satisfy this human contract.
 
 ## Contracts
 

--- a/docs/runbooks/ukrainian-data-foundry-language-contact-detector.md
+++ b/docs/runbooks/ukrainian-data-foundry-language-contact-detector.md
@@ -152,19 +152,27 @@ receipt artifacts.
 ## Phase 3 evidence boundary
 
 The full candidate stream is a deterministic sampling frame, not review gold.
-Phase 3 selects a frozen, source-aware calibration sample without loading this
-2.17 GB JSONL into memory. Only selected rows may receive bounded R2U and ULIF
-lookups or an identified underlying dictionary result from `slovnyk.me`.
-Receipts may retain response hashes and headword-match states; bulk crawling
-and raw dictionary redistribution remain prohibited.
+Phase 3 may build evidence-backed silver records from a frozen, source-aware
+selection without loading this 2.17 GB JSONL into memory. Only selected rows may
+receive bounded R2U and ULIF lookups or an identified underlying dictionary
+result from `slovnyk.me`. Receipts may retain response hashes and headword-match
+states; bulk crawling and raw dictionary redistribution remain prohibited.
 
-The blind first pass must hide detector categories, confidence, queue routes,
+Silver output must retain the detector context, independent evidence sources,
+uncertainty, and protected or unresolved route. No single VESUM miss, Russian
+morphology hit, dictionary hit, aggregate score, or model vote is sufficient.
+Cross-family models may propose alternatives and expose disagreement, but every
+result is labelled non-human silver or model-only research evidence. This path
+does not claim native-speaker acceptance, reviewer reliability, or human gold.
+
+The existing blind-human campaign remains available as an optional gold upgrade.
+If activated, its first pass hides detector categories, confidence, queue routes,
 and other model/rule votes while showing the bounded original context and the
 period/source metadata needed to protect historical, dialectal, regional,
 quoted, and multilingual language. Two independent qualified Ukrainian humans
 review separate salted orders; disagreements require a distinct third human.
-The sample capacity and statistical stopping rule are frozen by an approved
-review plan, never invented by this detector.
+Those requirements govern only a qualified-human-gold claim and do not block
+the silver or admitted-source-text lanes.
 
 ## Reproduction
 

--- a/docs/runbooks/ukrainian-data-foundry-model-views.md
+++ b/docs/runbooks/ukrainian-data-foundry-model-views.md
@@ -5,6 +5,14 @@
 > **Boundary:** local view construction and reproducible manifests, not training
 > or publication
 
+> **Phase 2–4 status:** admitted-source continued pretraining is independent of
+> qualified correction review and may proceed as soon as its source/payload,
+> rights, privacy, origin, destination, and contamination gates pass. The
+> implemented correction-family path below accepts qualified-human records;
+> [#6168](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6168)
+> and [#6169](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6169)
+> own a distinct, explicitly non-human silver contract and exporter path.
+
 ## What this component does
 
 The model-view exporter turns already governed Foundry inputs into five
@@ -72,7 +80,7 @@ Each artifact is homogeneous by origin. Machine-generated, translated,
 human-revised-synthetic, and human-authored material must be exported in
 separate invocations.
 
-### Correction, preference, and quality-filter inputs
+### Qualified-gold correction, preference, and quality-filter inputs
 
 These commands consume the canonical `correction_record_v1` handoff plus the
 exact admitted `source_record_v1` join. The #6121 field
@@ -239,10 +247,12 @@ and recipe behavior while forcing every non-evaluation row to
 `model_training_eligible: false`. Fixture and genuinely eligible records cannot
 share a recipe-bound view.
 
-No real source record or qualified human correction has been admitted by this
-implementation. The exporter makes the missing evidence executable and
-auditable; it does not convert the existing zero-admission corpus inventory
-into permission.
+No qualified human correction has been admitted by this implementation. The
+operator has separately admitted 1,029 Ukrainian Wikipedia source records for
+one declared continued-pretraining destination; that admission does not create
+correction labels or grant any other destination. The exporter makes missing
+evidence executable and auditable rather than converting unresolved inventory
+or silver evidence into human gold.
 
 ## Verification
 

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -6,7 +6,10 @@
 > [PR #6060](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6060).
 > Operator approved the Ukrainian Data Foundry architecture, replacement issue
 > chain, and first implementation on 2026-07-31, then issued **GO REALIGN AND
-> EXECUTE PHASE 2–4** on 2026-08-01.
+> EXECUTE PHASE 2–4** on 2026-08-01. On the same date, the operator recorded
+> that this is a solo project with neither budget nor access to a three-person
+> Ukrainian review panel and directed the Foundry to remove that unavailable
+> labour from the critical path.
 > **Recorded:** 2026-07-30; Foundry direction and existing-asset baseline
 > refreshed 2026-08-01
 > **Applies to:** Ukrainian model evaluation, dataset work, training-data
@@ -35,22 +38,60 @@ model weights. Base models can leapfrog a local fine-tune in one release.
 Curated data, provenance, evaluation, and tooling transfer to every new model
 generation.
 
-This direction implements the existing accepted decision to prioritize grammar
-and lexical naturalness while parking model fine-tuning. It also preserves the
-accepted boundary between public evaluation gold, private product data, and
-future training data.
+This direction prioritizes transferable data, grammar, lexical naturalness,
+and evidence over owning model weights. A bounded model treatment is permitted
+only to test whether those artifacts help. The accepted boundary between public
+evaluation gold, private product data, and training data remains intact.
+
+## Solo-operator execution model
+
+The Foundry must be executable by one operator. It cannot make paid or donated
+review labour a prerequisite for useful source preparation, model-ready data,
+or a bounded causal experiment.
+
+The production evidence lanes are therefore distinct:
+
+- **Admitted human-authored text** supports continued pretraining after source,
+  rights, privacy, origin, destination, and contamination gates pass. It does
+  not require new linguistic annotation.
+- **Evidence-backed silver** combines preserved context with deterministic
+  lexical, morphological, corpus, source, and bounded dictionary evidence.
+  Cross-family model proposals may add alternatives and surface disagreement,
+  but model agreement is never linguistic authority. Every record retains its
+  evidence grade, uncertainty, and protected or unresolved disposition.
+- **Hramatka feedback** may add consented teacher observations over time. It is
+  useful product evidence, but its arrival rate, selection effects, and privacy
+  constraints make it an optional upgrade rather than a critical-path gate.
+- **Qualified-human gold** remains a supported optional upgrade. The existing
+  blinded two-reviewer plus distinct-resolver contract applies only when the
+  project later chooses to claim qualified-human gold; no current milestone or
+  release requires that claim.
+
+Evidence-backed silver may be used in an explicitly silver, provenance-complete
+experiment. It must never be reported as human gold, native-speaker acceptance,
+reviewer reliability, or proof that every proposed correction is correct.
+
+The Foundry can credibly promise reusable preparation, diagnostics, evidence,
+and a controlled test of whether those artifacts help. It cannot promise in
+advance that a treatment will make an LLM fluent. The cheapest falsifying check
+always precedes a more expensive run, and a failed prerequisite or null result
+is reported immediately rather than converted into more work.
 
 ## GitHub execution homes
 
 - [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
   owns Foundry Phase 2–4: real corpus admission, production contextual
-  language-contact detection, qualified-human gold, real model-ready exports,
-  one preregistered causal open-weight experiment, and a reproducible release
-  candidate. Closed [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
+  language-contact detection, evidence-backed silver with an optional
+  qualified-human upgrade, real model-ready exports, one preregistered causal
+  open-weight experiment, and a reproducible release candidate. Closed
+  [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
   owns the completed interfaces, profiler, exporters, recipes, and synthetic
   reference build on which this production program depends.
 - [#6057](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6057)
-  owns the separately frozen public benchmark v0.2 design and release.
+  is closed as not planned under the solo-operator model while preserving the
+  completed v0.2 error analysis and frozen design. Its reviewer-intensive
+  acquisition is parked; the existing v0.1.1 and licensed external evaluations
+  remain the current measurement surfaces.
 - [#4913](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4913)
   owns internal Ukrainian validators, quality gates, product adapters, and
   private calibration.
@@ -238,38 +279,46 @@ status.
 
 ### Immediate work
 
-1. Admit or explicitly reject every real corpus family across the measured
-   189,150-record / 50,298,925-word denominator under complete source,
-   edition, acquisition, rights, permitted-use, origin, and contamination
-   evidence (#6166). The result must be useful-scale real data, not another
-   one-record demonstration.
-2. In parallel, run the production contextual language-contact detector across
-   that complete corpus (#6167). It must distinguish Russian quotation,
-   modern interference, phonetic Russian rendering, mixed-language spans,
-   historical usage, protected Ukrainian variation, and uncertainty while
-   retaining context and source lineage. VESUM absence is only one signal.
-3. Freeze sampling and stopping rules, then obtain real independent review by
-   qualified Ukrainian humans and conflict adjudication (#6168). GPT, Gemini,
-   and Claude may prepare evidence but cannot satisfy this human gate.
-4. Emit real, mechanically disjoint training, correction, preference,
-   quality-filter, and evaluation views with contamination and tokenizer/loss-
-   mask diagnostics (#6169). No universal tokenizer threshold is presumed.
-5. After present-tense operator approval of the exact model revision, compute
-   budget, and preregistration, run the smallest causal open-weight treatment
-   and ablation that can test whether the Foundry data changes Ukrainian
-   behavior (#6170). Report null or adverse results as first-class outcomes.
-6. Package a corpus-portable, rights-safe release candidate and have an
-   independent party reproduce it from clean instructions on their own corpus
-   (#6171). Publication remains a separate present-tense operator gate.
-7. Independently acquire and adjudicate the coverage-complete v0.2 evaluation
-   inventory under #6084. Public evaluation gold remains mechanically isolated
-   from every training or tuning view.
+1. Maintain the complete fail-closed disposition of all 189,150 records and
+   extend real destination-specific admission beyond the accepted 1,029-record
+   Ukrainian Wikipedia family whenever primary evidence permits (#6166).
+2. Preserve and use the completed production detector's 739,564 contextual
+   candidates across Russian quotation, modern interference, phonetic Russian,
+   mixed, historical, protected, and uncertain routes (#6167). VESUM absence
+   remains one signal rather than a verdict.
+3. Produce real evidence-graded silver correction, retention, protection, and
+   unresolved records without requiring reviewer labour (#6168). Preserve the
+   existing blind human campaign as an optional gold-upgrade path and add an
+   optional, privacy-safe Hramatka feedback intake.
+4. Start the admitted source-text continued-pretraining view immediately and
+   add separately manifested silver correction, preference, and quality-filter
+   views only when their evidence and destination gates pass (#6169). Report an
+   empty or blocked view honestly; never fill it with benchmark or fixture data.
+5. Before any paid or large model run, freeze a text-free feasibility receipt:
+   nonzero eligible inputs, source diversity, evaluation isolation, protected-
+   variation safety probes, tokenizer/mask diagnostics, expected runtime/cost,
+   and the exact decision the run can change. A failed prerequisite stops or
+   redirects the treatment immediately.
+6. After present-tense operator approval of the exact model revision, compute
+   ceiling, and preregistration, run the smallest decision-useful control and
+   ablation (#6170). Keep admitted-text and silver interventions separable and
+   report null, mixed, unsafe, or negative results as valid terminal outcomes.
+7. Package a corpus-portable, rights-safe release candidate and reproduce it in
+   a clean independent environment (#6171). Publication remains a separate
+   present-tense operator gate; qualified-human review is required only for an
+   artifact or claim explicitly designated human gold.
+8. Use frozen v0.1.1 and compatible licensed external human-authored
+   evaluations for the current experiment. The reviewer-intensive v0.2
+   acquisition may resume only if Hramatka or a future collaboration supplies
+   suitable consented evidence without becoming a project staffing dependency.
+   Public evaluation gold remains mechanically isolated from every training or
+   tuning view.
 
 The accountable orchestrator continues from one completed child issue to the
 next. A merged implementation PR is progress, not a stopping condition. Work
-pauses only at the source-family admission decision, qualified-Ukrainian-human
-review, exact training preregistration/budget approval, or final publication
-approval named on #6164.
+pauses only at a source-family admission decision, an exact training
+preregistration/budget approval, or final publication approval named on #6164.
+Choosing to claim human gold pauses only that optional upgrade lane.
 
 ### Completed Foundry v1 reference build
 
@@ -282,9 +331,10 @@ without a model call or gold leakage.
 The integration fixture is the observed `звучит` → `звучить` failure. It uses
 VESUM, Russian morphology, `r2u`, ULIF, a heritage source, per-dictionary
 `slovnyk.me` provenance, and Ukrainian corpus context. It remains synthetic:
-fixture reviewers are not qualified-human evidence, all four non-evaluation
-rows are training-ineligible, and the real corpus still has zero admitted
-training records.
+fixture reviewers are not qualified-human evidence and all four fixture rows
+remain training-ineligible. Separately, the operator has admitted 1,029 real
+Ukrainian Wikipedia records / 2,865,506 lexical words for the declared
+continued-pretraining destination; the remaining corpus is still unresolved.
 
 The reference build is proof that teams can run the Foundry interfaces and
 obtain reproducible evidence. It is not a released dataset, a trained model,
@@ -302,7 +352,8 @@ After a usable reference build exists, it may be validated with Lapa,
 
 External feedback may prioritize later adapters, acquisition, or release work.
 It is not a prerequisite for building the architecture, full-corpus profiler,
-correction intake, separate exporters, recipes, or reference validation.
+silver correction intake, separate exporters, recipes, experiment, or reference
+validation. Hramatka teacher feedback follows the same optional-evidence rule.
 
 ## Model-running policy
 
@@ -330,13 +381,15 @@ naturalness, or our narrower evaluation.
 
 ## Anti-distraction test
 
-Before beginning work, answer all five questions:
+Before beginning work, answer all six questions:
 
 1. Which documented Ukrainian failure or ecosystem gap does this address?
 2. Who in the open-weight Ukrainian community can use the output?
 3. Why do existing data, tools, or benchmarks not already solve it?
 4. What artifact remains useful after the next base model release?
 5. How will we measure improvement without contaminating the evaluation?
+6. What is the cheapest observation that would make us stop before further
+   spending?
 
 If those answers are missing, the work is not ready.
 

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -28,9 +28,6 @@ streams:
   eval-harness:
     title: "Internal UA quality machinery — QG gates, validators, product adapters"
     epics: [4913]
-  benchmark-2156:
-    title: "Public Ukrainian calque + grammar evaluation — UA-GEC benchmark"
-    epics: [6057]  # compatibility key retained; completed v0.1.1 epic #2156 is historical
   open-model-data:
     title: "Ukrainian open-model data infrastructure"
     epics: [6164]  # production successor; completed Foundry v1 epic #6056 is historical


### PR DESCRIPTION
Refs #6164

## What changed

- records the operator's solo-project constraint in the durable North Star
- separates admitted human-authored text, evidence-backed silver, optional Hramatka feedback, and optional qualified-human gold
- removes mandatory paid reviewer labour from the Foundry critical path
- unblocks admitted-source continued-pretraining and queues a distinct silver contract rather than weakening the existing human-gold contract
- adds explicit PROCEED / REVISE / STOP evidence before any paid or large treatment
- retires the closed #6057 benchmark stream from the active issue registry while preserving v0.1.1 and the frozen v0.2 design

## GitHub control-plane alignment

The operator decision is recorded on #6164. Issues #6168–#6171 were rewritten around the same evidence and economic gates. Reviewer-intensive #6057/#6084 were closed as not planned under current resources and may be reopened only when genuine consented evidence becomes feasible. Hramatka remains optional observational evidence rather than a staffing promise.

## Claim boundaries

Evidence-backed silver is not human gold, native-speaker acceptance, reviewer reliability, or proof that every automated correction is correct. Existing 2+1 human-review machinery remains intact as an optional future gold-upgrade path.

## Verification

- Markdownlint: 0 errors across five changed Markdown files
- YAML parse and registry assertions pass
- issue-stream audit: no closed/missing epic remains; existing unrelated global orphan/multi-home debt remains
- OPSEC: zero leaks
- agent trailer: pass
- `git diff --check`: pass