### PR TITLE
docs(launchers): bind authority and ACP doctrine

### DIFF
--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# fleet_comms_cold_start.sh — shared dual-aware fleet-comms cold-start helpers for launchers.
+# fleet_comms_cold_start.sh — shared authority-aware fleet-comms cold-start helpers.
 #
 # Binding doctrine: agents_extensions/shared/rules/fleet-comms-coordination.md
 # (also served at GET /api/rules). Method playbook: drive-epic skill (#5632).
-# Aligned with Sol CF on #5632: file handoffs stay authoritative in every plane mode;
-# dual_write is not stream-authority cutover.
+# Authority cutover approved by the operator in #6159 on 2026-08-01.
 #
 # Usage (from a start-*.sh after PROJECT_DIR is set):
 #   # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
@@ -22,7 +21,7 @@ fleet_comms_rule_relpath() {
   printf '%s' "agents_extensions/shared/rules/fleet-comms-coordination.md"
 }
 
-# Resolve plane mode once (fail-open → off). Modes: off|shadow|dual_write only.
+# Resolve plane mode once (fail-open → off).
 fleet_comms_resolve_plane_mode() {
   local mode="off"
   local root="${PROJECT_DIR:-.}"
@@ -34,33 +33,29 @@ fleet_comms_resolve_plane_mode() {
         2>/dev/null || true
     )"
     case "${mode}" in
-      off|shadow|dual_write) ;;
+      off|shadow|dual_write|authority) ;;
       *) mode="off" ;;
     esac
   fi
   printf '%s' "$mode"
 }
 
-# Compact dual-aware clause for injected cold-start prompts (post-#5632 Sol-aligned).
+# Compact authority-aware clause for injected cold-start prompts.
 fleet_comms_cold_clause() {
   local plane_mode="${FLEET_COMMS_PLANE_MODE:-off}"
   local rule
   rule="$(fleet_comms_rule_relpath)"
   printf '%s' \
-    "Fleet-comms (#5512) mid-cutover — obey ${rule} (also in /api/rules). " \
+    "Fleet-comms (#6159) authority cutover — obey ${rule} (also in /api/rules). " \
     "Method playbook: load skill drive-epic (provider drivers inject the binding after lease + canary). " \
-    "Prefer plane + CF surfaces; file dual-write diary stays authoritative in every plane mode " \
-    "(current mode=${plane_mode}; dual_write is shadow/mirror, not authority cutover — " \
-    "do not flip cutovers or invent a competing design). " \
+    "Use fleet-comms as communication authority when current mode=${plane_mode}; " \
+    "legacy bridge/channel stores are read-only migration projections in authority mode. " \
     "Topology: \`.venv/bin/python -m scripts.fleet_comms plane-status\` (+ metrics/backlog/dead-letters). " \
     "Formal CF: \`.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer <cross-family>\` " \
     "then publish-review-verdict (PR number required; never self-seal). " \
-    "Eligible two-seat read-only \`ab discuss\` calls automatically use ACP when every requested participant " \
-    "has an enabled route (Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, or Pool); cold start launches nothing. " \
-    "Bridge transport is an observable exception only for unsupported participants/counts or model overrides, " \
-    "formal review until separately migrated, write/dispatch/inbox semantics, or typed ACP unhealthy/partial failure; name it in durable coordination evidence. " \
-    "ACP is neither coordination authority nor formal review, and \`acp-verify\` verifies a receipt rather than authorizing retry. " \
-    "Continuity: stream lease already claimed; dual-write \`.claude/<epic>-epic/*-DRIVER-HANDOFF.md\`."
+    "All normal inter-agent asks, 2–6 seat discussions, and sealed formal review provider calls use ACP; " \
+    "never fall back to bridge/provider execution. ACP transports; fleet-comms owns durable state. " \
+    "Continuity: stream lease already claimed; write durable receipts to fleet-comms."
 }
 
 # One-line operator banner (stdout).
@@ -74,7 +69,10 @@ fleet_comms_print_banner_line() {
       echo "  fleet-comms: plane=off · diary authoritative · CF via review-pr · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
       ;;
     shadow|dual_write)
-      echo "  fleet-comms: plane=${plane_mode} (shadow/mirror; diary still authoritative) · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
+      echo "  fleet-comms: plane=${plane_mode} (compatibility soak) · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
+      ;;
+    authority)
+      echo "  fleet-comms: plane=authority · ACP transport · legacy read-only · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
       ;;
     *)
       echo "  fleet-comms: plane=${plane_mode} (unknown→treat off) · rule=$(fleet_comms_rule_relpath)"

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -381,7 +381,7 @@ launcher_bind_drive_epic() {
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     fleet_clause="$(fleet_comms_cold_clause)"
   else
-    fleet_clause='Fleet-comms: run plane-status and review-pr; file dual-write remains authoritative in every plane mode.'
+    fleet_clause='Fleet-comms: run plane-status and review-pr; authority mode is durable state and ACP is provider transport.'
   fi
   LC_DRIVER_PROMPT="Load agents_extensions/shared/skills/drive-epic/SKILL.md before acting. The launcher already claimed the ${LC_EPIC} lease and ran its provider canary; do not claim, renew, or reopen the lease. ${fleet_clause} Obtain independent cross-family review."
   LC_FORWARD_ARGS+=("$LC_DRIVER_PROMPT")

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -60,25 +60,17 @@ def test_prompt_injecting_launchers_include_plane_and_cf_surfaces() -> None:
     assert 'source "$LC_ROOT/scripts/lib/fleet_comms_cold_start.sh"' in text
 
 
-def test_shared_launcher_clause_onboards_routine_acp_selection_hierarchy() -> None:
+def test_shared_launcher_clause_onboards_authority_and_acp_layers() -> None:
     helper = HELPER.read_text(encoding="utf-8")
     for required in (
         "LU_AGENT_COMM_TRANSPORT",
-        "Eligible two-seat read-only",
-        "automatically use ACP",
-        "Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, or Pool",
-        "cold start launches nothing",
-        "observable exception only",
-        "unsupported participants/counts or model overrides",
-        "formal review until separately migrated",
-        "write/dispatch/inbox semantics",
-        "typed ACP unhealthy/partial failure",
-        "durable coordination evidence",
-        "discuss",
-        "neither coordination authority",
-        "nor formal review",
-        "acp-verify",
-        "rather than authorizing retry",
+        "All normal inter-agent asks",
+        "2–6 seat discussions",
+        "sealed formal review provider calls use ACP",
+        "never fall back to bridge/provider execution",
+        "fleet-comms owns durable state",
+        "legacy bridge/channel stores are read-only",
+        "Continuity: stream lease already claimed",
     ):
         assert required in helper
 


### PR DESCRIPTION
Linked to #6159.\n\nUpdates shared cold-start and launcher guidance so operator seats use fleet-comms as the durable source of truth and ACP as the provider transport, with legacy stores read-only. Aligns the launcher-awareness contract with the protected authority doctrine merged in #6200.\n\nVerification:\n- bash -n on both changed shell libraries\n- 8 focused launcher-awareness tests passed\n- git diff --check\n- agent trailer audit\n- OPSEC leak audit