### PR TITLE
fix(kimi): discover canonical project skills

### DIFF
--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -5,11 +5,11 @@ newline-delimited events in ``--output-format stream-json`` mode. OAuth
 credentials stay in Kimi's own home directory; this adapter never reads or
 injects them.
 
-Kimi Code 0.27.0 evidence (2026-07-17): ``kimi --yolo -p \"…\"`` exits with
-``error: Cannot combine --prompt with --yolo.`` Bare ``kimi -p`` also writes
-without an approval prompt. Consequently, headless workspace-write and danger
-must be flagless (delegate.py already verifies their worktrees), while
-read-only is refused because the CLI cannot guarantee it.
+Kimi Code prompt mode runs with automatic tool approval and cannot be combined
+with its interactive permission or plan flags. Consequently, headless
+workspace-write and danger must be flagless (delegate.py already verifies
+their worktrees), while read-only is refused because the CLI cannot guarantee
+it.
 """
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ _logger = logging.getLogger(__name__)
 KIMI_DEFAULT_MODEL = "k2.7-coding"
 KIMI_BRIDGE_DEFAULT_MODEL = "k3"
 KIMI_DEFAULT_EFFORT = "max"
+KIMI_PROJECT_SKILLS_RELATIVE = Path("agents_extensions") / "shared" / "skills"
 # Catalog-backed aliases keep dispatch, the native launcher, and KimiCC in
 # lockstep. The managed seat's usage window depletes fast (operator,
 # 2026-07-16), so dispatch defaults to the coding model; K3 (always-max
@@ -65,7 +66,7 @@ _MODE_FLAGS: dict[str, tuple[str, ...]] = {
 
 _READ_ONLY_REFUSAL = (
     "kimi headless auto-approves mutations; read-only cannot be guaranteed "
-    "on CLI 0.27 — use another agent"
+    "in native prompt mode — use another agent"
 )
 
 
@@ -139,7 +140,7 @@ class KimiAdapter:
         if session_id:
             cmd.extend(["--session", session_id])
 
-        for skills_dir in _as_string_list(config.get("kimi_skills_dirs")):
+        for skills_dir in _resolve_kimi_skills_dirs(cwd=cwd, config=config):
             cmd.extend(["--skills-dir", skills_dir])
         for add_dir in _as_string_list(config.get("kimi_add_dirs")):
             cmd.extend(["--add-dir", add_dir])
@@ -254,6 +255,49 @@ def _as_string_list(value: Any) -> list[str]:
         return []
     values = value if isinstance(value, list | tuple) else [value]
     return [str(item) for item in values if str(item).strip()]
+
+
+def _resolve_kimi_skills_dirs(*, cwd: Path, config: dict[str, Any]) -> list[str]:
+    """Resolve native Kimi skill roots without relying on ignored mirrors.
+
+    Layout-A worktrees contain the canonical shared skill sources but not the
+    gitignored ``.claude``/``.codex``/``.agents`` deployment mirrors. Native
+    Kimi's ``--skills-dir`` is therefore pointed at the canonical project
+    directory by default. Because that flag replaces Kimi's automatic user
+    and project scan, its Kimi-specific and generic user roots are carried
+    forward explicitly. Callers may override or disable the default by
+    supplying ``kimi_skills_dirs`` (including an empty list).
+    """
+
+    if "kimi_skills_dirs" in config:
+        candidates = _as_string_list(config.get("kimi_skills_dirs"))
+    else:
+        project_skills = cwd / KIMI_PROJECT_SKILLS_RELATIVE
+        if not project_skills.is_dir():
+            return []
+        kimi_home_value = os.environ.get("KIMI_CODE_HOME")
+        kimi_home = (
+            Path(kimi_home_value).expanduser()
+            if kimi_home_value
+            else Path.home() / ".kimi-code"
+        )
+        candidates = [
+            str(cwd / ".kimi-code" / "skills"),
+            str(cwd / ".kimi" / "skills"),
+            str(project_skills.resolve()),
+            str(kimi_home / "skills"),
+            str(Path.home() / ".agents" / "skills"),
+        ]
+        candidates = [candidate for candidate in candidates if Path(candidate).is_dir()]
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = str(Path(candidate).expanduser())
+        if normalized not in seen:
+            resolved.append(normalized)
+            seen.add(normalized)
+    return resolved
 
 
 def _assistant_text(value: Any) -> str:

--- a/tests/agent_runtime/adapters/test_kimi_adapter.py
+++ b/tests/agent_runtime/adapters/test_kimi_adapter.py
@@ -16,6 +16,7 @@ from scripts.agent_runtime.adapters.kimi import (
     KIMI_DEFAULT_EFFORT,
     KIMI_DEFAULT_MODEL,
     KIMI_MODEL_ALIASES,
+    KIMI_PROJECT_SKILLS_RELATIVE,
     KimiAdapter,
 )
 from scripts.agent_runtime.adapters.kimicc import KimiccHarness
@@ -32,6 +33,7 @@ def _build(
     mode: str = "workspace-write",
     model: str | None = None,
     effort: str | None = None,
+    tool_config: dict | None = None,
 ):
     binary = tmp_path / "kimi"
     binary.write_text("#!/bin/sh\n", encoding="utf-8")
@@ -44,7 +46,7 @@ def _build(
         model=model,
         task_id="kimi-test",
         session_id=None,
-        tool_config=None,
+        tool_config=tool_config,
         effort=effort,
     )
 
@@ -58,6 +60,75 @@ def test_build_invocation_uses_flagless_write_modes(tmp_path, monkeypatch, mode)
     assert plan.cmd[plan.cmd.index("--output-format") + 1] == "stream-json"
     assert not ({"--auto", "--yolo", "--plan"} & set(plan.cmd))
     assert plan.metadata == {}
+
+
+def test_native_kimi_loads_canonical_project_skills_in_fresh_worktree(tmp_path, monkeypatch):
+    from scripts.agent_runtime.adapters import kimi as kimi_adapter
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    monkeypatch.setattr(kimi_adapter.Path, "home", lambda: fake_home)
+    skills_dir = tmp_path / KIMI_PROJECT_SKILLS_RELATIVE
+    skill = skills_dir / "entire-context" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("---\nname: entire-context\ndescription: recall\n---\n", encoding="utf-8")
+
+    plan = _build(tmp_path, monkeypatch)
+
+    assert plan.cmd.count("--skills-dir") == 1
+    assert plan.cmd[plan.cmd.index("--skills-dir") + 1] == str(skills_dir.resolve())
+
+
+def test_native_kimi_preserves_existing_project_and_user_skill_roots(tmp_path, monkeypatch):
+    from scripts.agent_runtime.adapters import kimi as kimi_adapter
+
+    project_kimi = tmp_path / ".kimi-code" / "skills"
+    project_shared = tmp_path / KIMI_PROJECT_SKILLS_RELATIVE
+    fake_home = tmp_path / "home"
+    user_kimi = fake_home / ".kimi-code" / "skills"
+    user_generic = fake_home / ".agents" / "skills"
+    for directory in (project_kimi, project_shared, user_kimi, user_generic):
+        directory.mkdir(parents=True)
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    monkeypatch.setattr(kimi_adapter.Path, "home", lambda: fake_home)
+
+    plan = _build(tmp_path, monkeypatch)
+    configured_roots = [
+        plan.cmd[index + 1]
+        for index, value in enumerate(plan.cmd)
+        if value == "--skills-dir"
+    ]
+
+    assert configured_roots == [
+        str(project_kimi),
+        str(project_shared.resolve()),
+        str(user_kimi),
+        str(user_generic),
+    ]
+
+
+def test_native_kimi_omits_default_skills_flag_when_canonical_directory_is_missing(tmp_path, monkeypatch):
+    plan = _build(tmp_path, monkeypatch)
+
+    assert "--skills-dir" not in plan.cmd
+
+
+def test_native_kimi_skills_override_is_explicit_deduplicated_and_can_disable_default(tmp_path, monkeypatch):
+    (tmp_path / KIMI_PROJECT_SKILLS_RELATIVE).mkdir(parents=True)
+    override = tmp_path / "custom-skills"
+    override.mkdir()
+
+    configured = _build(
+        tmp_path,
+        monkeypatch,
+        tool_config={"kimi_skills_dirs": [str(override), str(override)]},
+    )
+    disabled = _build(tmp_path, monkeypatch, tool_config={"kimi_skills_dirs": []})
+
+    assert configured.cmd.count("--skills-dir") == 1
+    assert configured.cmd[configured.cmd.index("--skills-dir") + 1] == str(override)
+    assert "--skills-dir" not in disabled.cmd
 
 
 def test_kimicc_harness_is_opt_in_and_native_kimi_remains_default(tmp_path, monkeypatch):

--- a/tests/test_kimi_integration.py
+++ b/tests/test_kimi_integration.py
@@ -152,7 +152,7 @@ def test_fetch_kimi_message_returns_none_for_an_unaddressed_row(monkeypatch, cap
 def test_check_model_refuses_read_only_native_kimi_probe():
     with pytest.raises(
         ValueError,
-        match=r"kimi headless auto-approves mutations; read-only cannot be guaranteed on CLI 0.27",
+        match=r"kimi headless auto-approves mutations; read-only cannot be guaranteed in native prompt mode",
     ):
         _build_kimi_probe_plan("k3")
 


### PR DESCRIPTION
## Summary

- make native Kimi load the canonical `agents_extensions/shared/skills` source in layout-A worktrees, where ignored provider mirrors do not exist
- preserve existing Kimi-specific project skills plus Kimi/generic user skill roots when `--skills-dir` replaces automatic discovery
- retain explicit override, explicit disable, missing-directory, and duplicate-path behavior
- remove the stale Kimi 0.27 version claim from the read-only refusal while preserving the fail-closed behavior

Refs #6183 and #4707.

## Authorization and design

The operator explicitly directed the GUI infra root to complete the already-identified Kimi discovery gap. Fable advisory routing was attempted but the available Fable seat returned `out of usage credits`; no lower-quality architectural substitution was silently treated as approval. The implementation stays within the operator-approved outcome and the existing adapter's `kimi_skills_dirs`/`--skills-dir` seam.

Official Kimi 0.31.1 documentation states that `--skills-dir` replaces automatic project/user discovery. The implementation therefore carries forward existing `.kimi-code/skills`, `.kimi/skills`, `$KIMI_CODE_HOME/skills`, and `~/.agents/skills` roots instead of hiding them.

## Verification

- `.venv/bin/python -m pytest tests/agent_runtime/adapters/test_kimi_adapter.py tests/test_kimi_integration.py tests/test_agent_runtime.py -q` → `216 passed`
- `.venv/bin/python -m ruff check scripts/agent_runtime/adapters/kimi.py tests/agent_runtime/adapters/test_kimi_adapter.py tests/test_kimi_integration.py` → clean
- `git diff --check` → clean
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main...HEAD` → zero leaks
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → commit trailer passes

## Source-blind behavior proof

Native Kimi K3 (`kimi-code/k3`, CLI 0.31.1) ran as task `6183-kimi-entire-native-discovery-canary-v2` from the layout-A worktree without a prompt-injected skill path. Its native `Skill` tool invoked `entire-context` and reported the exact canonical path:

`agents_extensions/shared/skills/entire-context/SKILL.md`

No source file was modified by the canary.

## Scope

Three files only. No Kimi home/config mutation, provider-mirror deployment, Entire CLI/network behavior change, resolver expansion, protected rail mutation, or generated artifact.
