### PR TITLE
fix(fleet): report active authority posture

### DIFF
--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -398,9 +398,12 @@ def fleet_overview() -> dict[str, Any]:
             "total": sum(authority_job_states.values()),
             "by_state": authority_job_states,
         }
-        if _table_exists(connection, "dead_letters"):
+        dead_letter_table = (
+            "authority_dead_letters" if status["mode"] == "authority" else "dead_letters"
+        )
+        if _table_exists(connection, dead_letter_table):
             counts["dead_letters"]["total"] = int(
-                connection.execute("SELECT COUNT(*) FROM dead_letters").fetchone()[0]
+                connection.execute(f"SELECT COUNT(*) FROM {dead_letter_table}").fetchone()[0]
             )
         if _table_exists(connection, "acp_conversations"):
             counts["acp_conversations"]["total"] = int(
@@ -1517,7 +1520,7 @@ def fleet_dead_letters(
     limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
-    """Dead-letter metadata tied back to a request when optional tables exist."""
+    """Current authority DLQ metadata, or the legacy read projection during rollback."""
     since_value = _normalize_time(since, "since")
     until_value = _normalize_time(until, "until")
     filters = {
@@ -1531,6 +1534,65 @@ def fleet_dead_letters(
         if connection is None:
             return _empty_collection(
                 "dead_letters", limit=limit, offset=offset, availability=availability, filters=filters
+            )
+        if _safe_plane_status()["mode"] == "authority":
+            if not _table_exists(connection, "authority_dead_letters"):
+                return _empty_collection(
+                    "dead_letters",
+                    limit=limit,
+                    offset=offset,
+                    availability="table_missing",
+                    filters=filters,
+                )
+            clauses: list[str] = []
+            params: list[Any] = []
+            if state is not None:
+                clauses.append("COALESCE(delivery.state, job.state) = ?")
+                params.append(state)
+            if agent is not None:
+                clauses.append("COALESCE(delivery.recipient, 'authority-job') = ?")
+                params.append(agent)
+            if source is not None:
+                clauses.append(
+                    "COALESCE(json_extract(authority_meta.provenance_json, '$.Source'), "
+                    "'authority') = ?"
+                )
+                params.append(source)
+            _time_clauses(
+                "letter.created_at",
+                since=since_value,
+                until=until_value,
+                clauses=clauses,
+                params=params,
+            )
+            return _paged_query(
+                connection,
+                key="dead_letters",
+                select_sql=(
+                    "SELECT letter.dead_letter_id, job.subject_id AS request_id, "
+                    "letter.delivery_id, letter.reason_code AS reason, NULL AS successor, "
+                    "COALESCE(delivery.deadline_at, job.deadline_at) AS original_expires_at, "
+                    "letter.created_at, COALESCE(delivery.state, job.state) AS request_state, "
+                    "delivery.recipient AS resolved_recipient, 'authority' AS conversation_source, "
+                    "authority_meta.provenance_json AS authority_provenance_json"
+                ),
+                from_sql=(
+                    " FROM authority_dead_letters AS letter"
+                    " LEFT JOIN authority_deliveries AS delivery"
+                    " ON delivery.delivery_id = letter.delivery_id"
+                    " LEFT JOIN comms_messages AS message"
+                    " ON message.message_id = delivery.message_id"
+                    " LEFT JOIN authority_message_metadata AS authority_meta"
+                    " ON authority_meta.message_id = message.message_id"
+                    " LEFT JOIN authority_jobs AS job ON job.job_id = letter.job_id"
+                ),
+                clauses=clauses,
+                params=params,
+                order_sql="letter.created_at DESC, letter.dead_letter_id ASC",
+                limit=limit,
+                offset=offset,
+                filters=filters,
+                transform=_dead_letter_item,
             )
         if not _table_exists(connection, "dead_letters"):
             return _empty_collection(

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -306,6 +306,8 @@ def _paged_query(
 def _safe_plane_status() -> dict[str, Any]:
     """Project the existing plane read model without paths or raw telemetry rows."""
     status = read_plane_status(repo_root=Path(PROJECT_ROOT), recent_limit=0)
+    mode = _safe_text(status.get("mode"), fallback="invalid")
+    authority_active = mode == "authority"
     schema = status.get("schema") if isinstance(status.get("schema"), dict) else {}
     telemetry = (
         status.get("parity_telemetry")
@@ -313,11 +315,13 @@ def _safe_plane_status() -> dict[str, Any]:
         else {}
     )
     return {
-        "mode": status.get("mode", "invalid"),
+        "mode": mode,
         "enabled": bool(status.get("enabled")),
         "read_only": True,
-        "authority": "file_handoffs_authoritative",
-        "cutover": "pre_flip_operator_gated",
+        "authority": (
+            "fleet_comms_authoritative" if authority_active else "file_handoffs_authoritative"
+        ),
+        "cutover": "authority_active" if authority_active else "pre_flip_operator_gated",
         "schema": {
             "known_version": schema.get("known_version"),
             "applied_version": schema.get("applied_version"),
@@ -348,7 +352,7 @@ def _count_by_state(connection: sqlite3.Connection, table: str, column: str) -> 
 
 @router.get("/health")
 def fleet_health() -> dict[str, Any]:
-    """Read-only health, mode, schema, and pre-flip authority posture."""
+    """Read-only health, mode, schema, and current authority posture."""
     status = _safe_plane_status()
     return {
         "ok": True,
@@ -365,8 +369,8 @@ def fleet_overview() -> dict[str, Any]:
     status = _safe_plane_status()
     result: dict[str, Any] = {
         "read_only": True,
-        "authority": "file_handoffs_authoritative",
-        "cutover": "pre_flip_operator_gated",
+        "authority": status["authority"],
+        "cutover": status["cutover"],
         "health": status,
         "counts": {
             "requests": {"total": 0, "by_state": {}},

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -1228,8 +1228,24 @@ def fleet_discussion_detail(
     with _read_connection() as (connection, _availability):
         if connection is None or not _table_exists(connection, "conversations"):
             raise HTTPException(status_code=404, detail="Discussion not found")
+        message_summary = (
+            "(SELECT COUNT(*) FROM comms_messages AS summary_message "
+            "WHERE summary_message.conversation_id = conversation.conversation_id) AS message_count, "
+            "(SELECT MAX(summary_message.created_at) FROM comms_messages AS summary_message "
+            "WHERE summary_message.conversation_id = conversation.conversation_id) AS latest_message_at"
+            if _table_exists(connection, "comms_messages")
+            else "0 AS message_count, NULL AS latest_message_at"
+        )
+        rounds_summary = (
+            "(SELECT MAX(summary_acp.rounds_requested) FROM acp_conversations AS summary_acp "
+            "WHERE summary_acp.conversation_id = conversation.conversation_id) AS rounds_requested"
+            if _table_exists(connection, "acp_conversations")
+            else "NULL AS rounds_requested"
+        )
         row = connection.execute(
-            "SELECT conversation_id, source, title, created_at FROM conversations WHERE conversation_id = ?",
+            "SELECT conversation.conversation_id, conversation.source, conversation.title, "
+            f"conversation.created_at, {message_summary}, {rounds_summary} "
+            "FROM conversations AS conversation WHERE conversation.conversation_id = ?",
             (conversation_id,),
         ).fetchone()
         if row is None:

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -307,6 +307,8 @@ def test_discussion_review_and_dead_letter_metadata_stay_read_only(
     assert discussion_detail.status_code == 200
     assert discussion_detail.headers["cache-control"] == "no-store"
     assert discussion_detail.json()["body_policy"].startswith("redacted_inline")
+    assert discussion_detail.json()["discussion"]["message_count"] == 2
+    assert discussion_detail.json()["discussion"]["latest_message_at"] == "2026-08-01T12:02:00Z"
     assert len(discussion_detail.json()["messages"]["messages"]) == 2
 
     reviews = client.get(

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -142,6 +142,23 @@ def _seed_plane(root: Path) -> None:
                 'legacy-bridge', '2026-08-01T12:07:00Z'
             );
 
+            INSERT INTO authority_deliveries(
+                delivery_id, message_id, recipient, state, deadline_at, lease_owner,
+                lease_expires_at, fence_token, attempt_count, acknowledgment_artifact_id,
+                terminal_sha256, created_at, updated_at, completed_at
+            ) VALUES (
+                'authority-delivery-1', 'authority-message', 'codex', 'failed', NULL, NULL,
+                NULL, 3, 3, NULL, 'terminal-sha', '2026-08-01T12:07:00Z',
+                '2026-08-01T12:08:00Z', '2026-08-01T12:08:00Z'
+            );
+
+            INSERT INTO authority_dead_letters(
+                dead_letter_id, delivery_id, job_id, reason_code, created_at
+            ) VALUES (
+                'authority-dead-letter-1', 'authority-delivery-1', NULL,
+                'attempts_exhausted', '2026-08-01T12:08:00Z'
+            );
+
             INSERT INTO authority_jobs(
                 job_id, job_kind, subject_id, payload_artifact_id, state, deadline_at,
                 lease_owner, lease_expires_at, fence_token, attempt_count, result_artifact_id,
@@ -223,6 +240,15 @@ def test_plane_health_and_overview_expose_active_authority_posture(
     assert health["cutover"] == "authority_active"
     assert overview["authority"] == health["authority"]
     assert overview["cutover"] == health["cutover"]
+    assert overview["counts"]["dead_letters"]["total"] == 1
+
+    dead_letters = client.get(
+        "/api/fleet/dead-letters",
+        params={"state": "failed", "agent": "codex", "source": "legacy-bridge"},
+    ).json()
+    assert dead_letters["total"] == 1
+    assert dead_letters["dead_letters"][0]["reason"] == "attempts_exhausted"
+    assert dead_letters["dead_letters"][0]["via"] == "queue"
 
 
 def test_message_and_request_filters_are_stable_and_bodies_are_bounded(

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -209,6 +209,22 @@ def test_plane_health_and_overview_expose_pre_flip_read_only_posture(
     assert overview.json()["counts"]["authority_jobs"]["total"] == 1
 
 
+def test_plane_health_and_overview_expose_active_authority_posture(
+    client: TestClient, fleet_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+    _seed_plane(fleet_root)
+
+    health = client.get("/api/fleet/health").json()
+    overview = client.get("/api/fleet/overview").json()
+
+    assert health["mode"] == "authority"
+    assert health["authority"] == "fleet_comms_authoritative"
+    assert health["cutover"] == "authority_active"
+    assert overview["authority"] == health["authority"]
+    assert overview["cutover"] == health["cutover"]
+
+
 def test_message_and_request_filters_are_stable_and_bodies_are_bounded(
     client: TestClient, fleet_root: Path
 ) -> None:


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

Post-deployment acceptance of #6208 found that durable authority behavior was live but the unified observer still emitted pre-flip static labels. This derives observer authority/cutover labels from the effective plane mode and keeps the shadow rollback posture explicit.

Validation:
- `pytest tests/test_fleet_observer_api.py -q` — 7 passed
- Ruff — passed
- `git diff --check` — passed
- OPSEC lint — passed
- agent trailer lint — passed

Live failure evidence before fix: `/api/fleet/overview` reported `mode=authority` alongside `authority=file_handoffs_authoritative` and `cutover=pre_flip_operator_gated`.