### PR TITLE
fix(acp): replay terminal ask failures safely

### DIFF
--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -61,6 +61,22 @@ def _replay_result(raw: bytes) -> object:
     from agent_runtime.result import Result
 
     payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise RuntimeError("terminal ACP result receipt is not an object")
+    if "ok" not in payload:
+        error_type = str(payload.get("error") or "unknown_error")
+        payload = {
+            "ok": False,
+            "agent": payload.get("agent", ""),
+            "model": payload.get("model", ""),
+            "response": "",
+            "stderr_excerpt": f"replayed ACP terminal failure: {error_type}",
+            "duration_s": payload.get("duration_s", 0.0),
+            "returncode": payload.get("returncode", 1),
+            "effort": payload.get("effort", "unknown"),
+            "transport_metadata": payload.get("transport_metadata"),
+            "transport_outcome": payload.get("transport_outcome", "error"),
+        }
     return Result(
         ok=bool(payload["ok"]),
         agent=str(payload["agent"]),
@@ -179,7 +195,20 @@ def run_compat_ask(
                     fence_token=lease.fence_token,
                     state="failed",
                     result=json.dumps(
-                        {"error": type(exc).__name__, "transport": "acp"},
+                        {
+                            "ok": False,
+                            "agent": participant,
+                            "model": model or "",
+                            "response": "",
+                            "stderr_excerpt": (
+                                f"{type(exc).__name__}: terminal ACP invocation failed"
+                            ),
+                            "duration_s": 0.0,
+                            "returncode": 1,
+                            "effort": effort or "unknown",
+                            "transport_metadata": None,
+                            "transport_outcome": "error",
+                        },
                         sort_keys=True,
                     ).encode("utf-8"),
                 )

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -1442,7 +1442,7 @@ def _handle_acp_compat(args, target: str) -> None:
 
     try:
         require_compat_target(target)
-        run_compat_ask(
+        result = run_compat_ask(
             target,
             content,
             task_id=task_id,
@@ -1455,6 +1455,10 @@ def _handle_acp_compat(args, target: str) -> None:
             stdout_only=bool(getattr(args, "stdout_only", False)),
             hard_timeout=86400 if bool(getattr(args, "no_timeout", False)) else 300,
         )
+        if not bool(getattr(result, "ok", False)):
+            raise SystemExit(
+                getattr(result, "stderr_excerpt", None) or "ACP ask failed without a diagnostic"
+            )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -46,6 +48,7 @@ def test_effort_and_to_model_reach_every_enabled_acp_route(
     def fake_compat(*args, **kwargs):
         captured["args"] = args
         captured.update(kwargs)
+        return SimpleNamespace(ok=True)
 
     monkeypatch.setattr(_acp_compat, "run_compat_ask", fake_compat)
     args = _cli._build_parser().parse_args(
@@ -69,6 +72,54 @@ def test_effort_and_to_model_reach_every_enabled_acp_route(
     assert captured["args"][0] == target
     assert "requested-model" in forwarded
     assert captured["effort"] == "xhigh"
+
+
+def test_terminal_failure_replays_without_invoking_provider_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "fleet-comms"))
+    invoke = Mock(side_effect=RuntimeError("protected primary refused"))
+    monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+
+    with pytest.raises(RuntimeError, match="protected primary refused"):
+        _acp_compat.run_compat_ask(
+            "agy",
+            "same prompt",
+            task_id="failure-replay",
+            source="codex",
+            model="gemini-3.6-flash-high",
+            effort="high",
+        )
+
+    replay = _acp_compat.run_compat_ask(
+        "agy",
+        "same prompt",
+        task_id="failure-replay",
+        source="codex",
+        model="gemini-3.6-flash-high",
+        effort="high",
+    )
+
+    assert replay.ok is False
+    assert replay.transport_outcome == "error"
+    assert replay.usage_record == {"replayed": True, "transport": "acp"}
+    assert invoke.call_count == 1
+
+
+def test_cli_returns_nonzero_for_replayed_or_live_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _acp_compat,
+        "run_compat_ask",
+        lambda *args, **kwargs: SimpleNamespace(ok=False, stderr_excerpt="replayed failure"),
+    )
+    args = _cli._build_parser().parse_args(
+        ["ask-agy", "question", "--task-id", "failed-seat", "--from", "codex"]
+    )
+
+    with pytest.raises(SystemExit, match="replayed failure"):
+        _cli._handle_ask_agy(args)
 
 
 @pytest.mark.parametrize(("command", "handler_name", "target"), RETIRED_ASK_SEATS)

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -797,6 +797,7 @@ def test_ask_claude_reads_body_from_stdin_on_dash(monkeypatch):
 
     def _fake_acp(target, content, **_kwargs):
         captured.update(target=target, content=content)
+        return SimpleNamespace(ok=True)
 
     monkeypatch.setattr(_acp_compat, "run_compat_ask", _fake_acp)
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(read=lambda: "the real question body"))
@@ -813,6 +814,7 @@ def test_ask_claude_literal_content_is_not_treated_as_stdin(monkeypatch):
 
     def _fake_acp(target, content, **_kwargs):
         captured.update(target=target, content=content)
+        return SimpleNamespace(ok=True)
 
     monkeypatch.setattr(_acp_compat, "run_compat_ask", _fake_acp)
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(read=lambda: "SHOULD-NOT-BE-USED"))

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -12,6 +12,7 @@ import sys
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -131,10 +132,12 @@ def test_handle_ask_codex_reads_stdin(monkeypatch):
         chain=None,
     )
     captured: dict[str, object] = {}
-    monkeypatch.setattr(
-        "ai_agent_bridge._acp_compat.run_compat_ask",
-        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs),
-    )
+
+    def fake_compat(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return SimpleNamespace(ok=True)
+
+    monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
     with patch("sys.stdin", io.StringIO("stdin prompt")):
         _handle_ask_codex(args)
     assert captured["args"] == ("codex", "stdin prompt")

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -224,7 +225,7 @@ def test_handle_ask_gemini_routes_to_agy(monkeypatch):
     def _fake_ask_agy(*args, **kwargs):
         captured["args"] = args
         captured["kwargs"] = kwargs
-        return 123
+        return SimpleNamespace(ok=True)
 
     monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", _fake_ask_agy)
 


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

Authenticated post-deployment smoke found that a persisted terminal ask failure used the original minimal failure receipt, while the replay decoder assumed a success-result schema and raised `KeyError: ok`. This normalizes new failure receipts, safely reads historical minimal receipts, returns failed asks nonzero, and proves an idempotent terminal failure never invokes the provider twice.

Validation:
- `pytest tests/ai_agent_bridge/test_ask_contract.py tests/test_bridge_inbox_cli.py -q` — 76 passed
- Ruff — passed
- `git diff --check` — passed
- real authority receipt replay — deterministic nonzero `AcpxShadowRefusalError`, no traceback/provider retry

No provider fallback, legacy bridge execution, or receipt mutation was added.