### PR TITLE
fix(fleet): persist request initiator provenance

### DIFF
--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -536,7 +536,7 @@ class AuthorityService:
                 channel=channel,
                 recipients=(recipient_name,),
                 kind="request",
-                provenance={"Source": "authority", "Agent": sender, "Via": "queue"},
+                provenance={"Source": sender, "Agent": recipient_name, "Via": "queue"},
                 deadline_at=deadline_at,
                 idempotency_key=f"request-message:{key}",
             )

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -127,6 +127,21 @@ def test_queue_claim_is_concurrent_and_exactly_once(tmp_path: Path) -> None:
         assert loaded.fence_token == 1
 
 
+def test_request_message_persists_initiating_source_and_target_agent(tmp_path: Path) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job = service.enqueue_request(
+            recipient="agy",
+            sender="codex",
+            body="bounded provenance request",
+            idempotency_key="request-provenance",
+        )
+        message = service.get_message(job.subject_id)
+
+    assert message.sender == "codex"
+    assert message.recipient == "agy"
+    assert message.provenance == {"Source": "codex", "Agent": "agy", "Via": "queue"}
+
+
 def test_exact_claim_and_terminal_result_replay_do_not_take_unrelated_work(tmp_path: Path) -> None:
     root = _root(tmp_path)
     with AuthorityService(root=root) as service:


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

Authenticated authority-mode smoke proved runtime telemetry had the trusted initiator (`Source=codex`) and target (`Agent=agy`), while the durable request message incorrectly persisted `Source=authority` and `Agent=codex`. This makes new request-message provenance represent the initiating sender and target recipient; historical rows remain unchanged and readable.

Validation:
- `pytest tests/test_fleet_comms_authority_cutover.py -q` — 17 passed
- Ruff — passed
- `git diff --check` — passed
- OPSEC lint — passed
- agent trailer lint — passed

The durable queue remains `Via=queue`; provider execution still records the ACP harness/transport in runtime telemetry.