### PR TITLE
fix(acp): isolate discussion recovery rows

### DIFF
--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -577,7 +577,11 @@ class AcpxDiscussionController:
             else observed_at.astimezone(UTC)
         )
         rows = self.conn.execute(
-            "SELECT conversation_id, deadline_at FROM acp_conversations"
+            """SELECT acp.conversation_id, acp.deadline_at
+               FROM acp_conversations AS acp
+               JOIN conversations AS conversation
+                 ON conversation.conversation_id = acp.conversation_id
+               WHERE conversation.source = 'acpx-discuss'"""
         ).fetchall()
         recovered: list[str] = []
         for row in rows:

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -1008,6 +1008,44 @@ def test_expired_recovery_is_terminal_without_provider_retry(tmp_path, monkeypat
     assert calls == []
 
 
+def test_recovery_ignores_authority_native_discussion_rows(tmp_path, monkeypatch):
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda agent, _prompt, **_kwargs: _result(agent, f"{agent} evidence"),
+        lambda agent, _prompt, **_kwargs: _result(agent, "synthesis"),
+    )
+    authority_conversation_id = "conversation_" + ("a" * 32)
+    try:
+        controller.conn.execute(
+            "INSERT INTO conversations(conversation_id, created_at, source, title) "
+            "VALUES (?, '2000-01-01T00:00:00Z', 'authority-discussion', 'authority')",
+            (authority_conversation_id,),
+        )
+        controller.conn.execute(
+            """INSERT INTO acp_conversations(
+                   conversation_id, task_digest, correlation_digest, idempotency_digest,
+                   rounds_requested, participants_json, created_at, deadline_at,
+                   token_budget, content_budget_bytes
+               ) VALUES (?, 'task', 'correlation', 'authority-idempotency', 1,
+                         '["codex","grok"]', '2000-01-01T00:00:00Z',
+                         '2000-01-01T00:00:00Z', 100, 100)""",
+            (authority_conversation_id,),
+        )
+        controller.conn.commit()
+
+        payload = _run(controller, key="fresh-acpx-after-authority", rounds=1)
+        authority_events = controller.conn.execute(
+            "SELECT COUNT(*) FROM acp_conversation_events WHERE conversation_id = ?",
+            (authority_conversation_id,),
+        ).fetchone()[0]
+    finally:
+        controller.close()
+
+    assert payload["state"] == "COMPLETE"
+    assert authority_events == 0
+
+
 def test_next_admitted_discussion_recovers_expired_reservation_before_new_calls(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

Authority-native discussions intentionally share `acp_conversations` for durable metadata but do not emit ACP controller lifecycle events. The ACP orphan-recovery scan now selects only conversations owned by the `acpx-discuss` controller, so authority rows cannot block a new authenticated discussion or be terminalized by the wrong state machine.

Validation:
- `pytest -q tests/agent_runtime/test_acpx_discuss.py` — 37 passed
- Ruff — passed
- `git diff --check` — passed
- OPSEC lint — passed
- agent trailer lint — passed

Regression coverage seeds an expired authority-native discussion with zero ACP lifecycle events, runs a fresh ACP discussion, and confirms the authority row remains untouched.