### PR TITLE
fix(acp): pin current Grok CLI

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1290,7 +1290,7 @@ with no records reports `no_evidence`; that is not a provider-health claim.
   },
   "pins": {
     "acpx": "0.13.0",
-    "grok_cli": "0.2.117",
+    "grok_cli": "0.2.118",
     "validation": "before_spawn"
   },
   "comparison_evidence": {

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -92,7 +92,7 @@ Approved boundary (#6027, #6043, #6078, #6130, #6158):
   candidates.
 - Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); every adapter refuses to
   spawn on any other resolved version.
-- Custom seats also pin their provider CLIs: Grok `0.2.117`, AGY `1.1.9`,
+- Custom seats also pin their provider CLIs: Grok `0.2.118`, AGY `1.1.9`,
   OpenCode/GLM `1.17.13`, and Hermes/DeepSeek `0.18.2`. Provider version
   parsing is anchored to each reviewed CLI output format, and the project text
   ACP server is SHA-256 digest-checked before spawn.

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -154,7 +154,7 @@ not permanent routing weights and do not override current CodexBar headroom.
 - Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
   resolved binary version.
 - Custom participant commands additionally preflight their reviewed provider
-  CLI versions: Grok `0.2.117`, AGY `1.1.9`, OpenCode/GLM `1.17.13`, and
+  CLI versions: Grok `0.2.118`, AGY `1.1.9`, OpenCode/GLM `1.17.13`, and
   Hermes/DeepSeek `0.18.2`. Each version is parsed only from its reviewed CLI
   output shape, and the project text ACP server is digest-checked before use.
 - Every invocation requires a non-empty, bounded, local `task_id`,

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -151,9 +151,9 @@ _OPENCODE_DENY_ALL_CONFIG = json.dumps(
 # Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
 # Built-in acpx ``grok-build`` is intentionally unused: it expands to
 # ``grok agent stdio`` without a place for parent flags required by Grok
-# 0.2.117 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
+# 0.2.118 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
 # before ``stdio``).
-PINNED_GROK_VERSION = "0.2.117"
+PINNED_GROK_VERSION = "0.2.118"
 GROK_SHADOW_MODEL = "grok-4.5"
 GROK_SHADOW_EFFORT = "high"
 _GROK_PROFILE_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "profiles" / "acpx-grok-read-only.md"
@@ -676,7 +676,7 @@ _GROK_VERSION_RE = re.compile(r"\Agrok\s+(\d+\.\d+\.\d+)(?:\s|$)")
 def _probe_grok_version(binary: str) -> str:
     """Return exact semver from ``<binary> --version``, or "" on any failure.
 
-    Native Grok 0.2.117 prints ``grok 0.2.117 (<sha>)``. Wrong,
+    Native Grok 0.2.118 prints ``grok 0.2.118 (<sha>)``. Wrong,
     missing, or unparseable output fails closed before prompt.
     """
     try:
@@ -737,7 +737,7 @@ def _require_grok_profile() -> str:
 
 
 def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
-    """Shell-safe single ``--agent`` value with required Grok 0.2.117 argv order.
+    """Shell-safe single ``--agent`` value with required Grok 0.2.118 argv order.
 
     Exact token order (parent flags before ``stdio``)::
 

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1014,7 +1014,7 @@ def test_parse_response_nonzero_exit_with_end_turn_still_fails():
 # ---------------------------------------------------------------------------
 
 
-def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.117") -> Path:
+def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.118") -> Path:
     """Point the Grok seat at a fake absolute grok binary + version probe."""
     grok = tmp_path / "fake-grok-bin"
     grok.write_text("#!/bin/sh\necho stub-grok\n", encoding="utf-8")
@@ -1297,7 +1297,7 @@ def test_grok_build_invocation_accepts_none_or_fixed_model_and_effort(tmp_path, 
         assert plan.metadata["model"] == "grok-4.5"
         assert plan.metadata["effort"] == "high"
         assert plan.metadata["target_agent"] == "grok"
-        assert plan.metadata["grok_pinned_version"] == "0.2.117"
+        assert plan.metadata["grok_pinned_version"] == "0.2.118"
         assert plan.metadata["acpx_pinned_version"] == "0.13.0"
 
 
@@ -1764,10 +1764,10 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
     monkeypatch.setattr(
         acpx_module.subprocess,
         "run",
-        lambda *_a, **_k: _Proc("grok 0.2.117 (f1c06093089f)\n"),
+        lambda *_a, **_k: _Proc("grok 0.2.118 (1e1687c1cf6a)\n"),
     )
     acpx_module._probe_grok_version.cache_clear()
-    assert acpx_module._probe_grok_version(str(binary)) == "0.2.117"
+    assert acpx_module._probe_grok_version(str(binary)) == "0.2.118"
 
     monkeypatch.setattr(
         acpx_module.subprocess,
@@ -1781,7 +1781,7 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         acpx_module.subprocess,
         "run",
         lambda *_a, **_k: _Proc(
-            "wrapper 9.9.9; grok 0.2.117 (f1c06093089f)\n"
+            "wrapper 9.9.9; grok 0.2.118 (1e1687c1cf6a)\n"
         ),
     )
     acpx_module._probe_grok_version.cache_clear()
@@ -1791,7 +1791,7 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         acpx_module.subprocess,
         "run",
         lambda *_a, **_k: _Proc(
-            "grok 0.2.117 (f1c06093089f)\n",
+            "grok 0.2.118 (1e1687c1cf6a)\n",
             "fatal: startup failed\n",
             returncode=1,
         ),

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -373,7 +373,7 @@ def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned
     assert "minutes=120" in onboarding
     assert "not permanent routing weights" in lower
     assert "not a new coordination plane" in lower or "not** a new coordination plane" in lower
-    assert "0.2.117" in onboarding
+    assert "0.2.118" in onboarding
     assert "grok-4.5" in onboarding
     assert "--no-leader" in onboarding
     assert "--agent-profile" in onboarding

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -247,7 +247,7 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
     }
     assert data["pins"] == {
         "acpx": "0.13.0",
-        "grok_cli": "0.2.117",
+        "grok_cli": "0.2.118",
         "validation": "before_spawn",
     }
     assert data["safety"]["max_in_flight"] == 1


### PR DESCRIPTION
Part of #6159 under stream epic #4707.

The authenticated local Grok CLI advanced from `0.2.117` to `0.2.118`. ACP correctly failed closed on the stale exact-version pin. This updates the runtime pin, its contract tests, and operator documentation after confirming the required `agent`, `--model`, `--reasoning-effort`, and `--no-leader` interface remains present.

Validation:
- `pytest -q tests/agent_runtime/test_acpx_adapter.py tests/test_runtime_api.py tests/test_agent_seat_onboarding_docs.py` — 141 passed
- Ruff — passed
- `git diff --check` — passed
- OPSEC lint — passed
- agent trailer lint — passed
- authenticated ACP Grok smoke (`grok-4.5`, high) — `CUTOVER_OK`, no bridge fallback

This is an exact pin update, not a relaxed version check.