### PR TITLE
fix(practice): recover residual cloze coverage under measured cloze budget (#6188)

### DIFF
--- a/docs/plans/2026-07-27-atlas-practice-gradual-ramp.md
+++ b/docs/plans/2026-07-27-atlas-practice-gradual-ramp.md
@@ -119,6 +119,7 @@ SOURCES → LEXICAL CORE (lemmas / senses / attestations / rights)
 | Practice pool (union A1–C1 lemmaIds) | ~4.9k |
 | Curated private teacher-lesson v5 active seed | ~1.0k (not-in-VESUM skipped) |
 | Practice lexemes gzip budget / level | 180 KB gzip / 1.6 MB raw (headroom today) |
+| Practice cloze emit budget / level | 210 KB gzip / 2.0 MB raw after diagnostic-field compaction |
 
 Banner **“Not in the practice pool yet”** = not in `practice-index.*`, **not** “empty atlas page.”
 Example: `інвалідність` is a rich A2 atlas entry with morphology; it is simply out of the practice pool.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -50,6 +50,12 @@ DEFAULT_SYNONYM_VERDICTS = Path("data/lexicon/synonym_pair_verdicts.yaml")
 DEFAULT_TARGET = 6000
 DEFAULT_RAW_LIMIT = 1_600_000
 DEFAULT_GZIP_LIMIT = 180_000
+# Cloze cards are the intentionally denser mode: their production emit drops
+# builder-only diagnostics before budgeting, while preserving every field used
+# by the client and static validators.  These limits are sized from the full
+# current canonical 6000-lemma build: B1 measures 1,949,044 raw / 209,612 gzip bytes.
+DEFAULT_CLOZE_RAW_LIMIT = 2_000_000
+DEFAULT_CLOZE_GZIP_LIMIT = 210_000
 SCHEMA_VERSION = 1
 CEFR_ORDER = ("A1", "A2", "B1", "B2", "C1", "C2")
 CEFR_RANK = {level: index for index, level in enumerate(CEFR_ORDER)}
@@ -167,6 +173,8 @@ class BuildConfig:
     target: int = DEFAULT_TARGET
     raw_limit: int = DEFAULT_RAW_LIMIT
     gzip_limit: int = DEFAULT_GZIP_LIMIT
+    cloze_raw_limit: int = DEFAULT_CLOZE_RAW_LIMIT
+    cloze_gzip_limit: int = DEFAULT_CLOZE_GZIP_LIMIT
     fixture_note: str | None = None
     source_label: str = "manifest"
     seed_selection: str = "priority"
@@ -3928,6 +3936,36 @@ def _json_bytes(payload: dict[str, Any]) -> bytes:
     return text.encode("utf-8")
 
 
+def compact_cloze_emit_fields(
+    shards: dict[str, dict[str, dict[str, Any]]],
+) -> None:
+    """Remove builder-only cloze fields before measuring production shards.
+
+    The in-memory builder output deliberately retains diagnostic fields for
+    tests, audits, and downstream quality decisions.  The browser only needs
+    the sentence, answer, rules, attribution, and validated option metadata;
+    omitting the unused diagnostics from the static emit keeps the cloze
+    budget focused on distinct eligible lemmas.  Non-empty ``acceptedAlt``
+    remains part of the runtime answer contract.
+    """
+    for level_shards in shards.values():
+        payload = level_shards.get("cloze")
+        if not isinstance(payload, dict) or not isinstance(payload.get("cloze"), list):
+            continue
+        for item in payload["cloze"]:
+            if not isinstance(item, dict):
+                continue
+            if not item.get("acceptedAlt"):
+                item.pop("acceptedAlt", None)
+            for field in ("number", "cefr", "lemma"):
+                item.pop(field, None)
+            options = item.get("options")
+            if isinstance(options, list):
+                for option in options:
+                    if isinstance(option, dict):
+                        option.pop("strategy", None)
+
+
 def _size_budget(payload: dict[str, Any], raw_limit: int, gzip_limit: int) -> dict[str, int | bool]:
     raw = _json_bytes(payload)
     gzipped = gzip.compress(raw, mtime=0)
@@ -3944,6 +3982,9 @@ def apply_size_budgets(
     shards: dict[str, dict[str, dict[str, Any]]],
     raw_limit: int,
     gzip_limit: int,
+    *,
+    cloze_raw_limit: int | None = None,
+    cloze_gzip_limit: int | None = None,
 ) -> None:
     """Measure shards and trim only the payload that exceeds its own budget.
 
@@ -3965,8 +4006,14 @@ def apply_size_budgets(
             return None
         return payload[key]
 
-    def set_budget(payload: dict[str, Any]) -> dict[str, int | bool]:
-        budget = _size_budget(payload, raw_limit, gzip_limit)
+    def set_budget(payload: dict[str, Any], kind: str) -> dict[str, int | bool]:
+        effective_raw_limit = (
+            cloze_raw_limit if kind == "cloze" and cloze_raw_limit is not None else raw_limit
+        )
+        effective_gzip_limit = (
+            cloze_gzip_limit if kind == "cloze" and cloze_gzip_limit is not None else gzip_limit
+        )
+        budget = _size_budget(payload, effective_raw_limit, effective_gzip_limit)
         payload["sizeBudget"] = budget
         return budget
 
@@ -4164,7 +4211,7 @@ def apply_size_budgets(
         def surface_fits(selected: list[Any]) -> bool:
             apply_selection(selected)
             return all(
-                set_budget(level_shards[kind])["ok"]
+                set_budget(level_shards[kind], kind)["ok"]
                 for kind in oversized_surface
                 if kind in level_shards
             )
@@ -4194,7 +4241,7 @@ def apply_size_budgets(
 
         def mode_fits(candidate: list[Any]) -> bool:
             items[:] = candidate
-            return bool(set_budget(payload)["ok"])
+            return bool(set_budget(payload, kind)["ok"])
 
         selected: list[Any] = []
         for _index, candidate in coverage_first_rows(original):
@@ -4205,7 +4252,7 @@ def apply_size_budgets(
         # order so deterministic deck sequencing and source ranking are stable.
         selected_ids = {id(item) for item in selected}
         items[:] = [item for item in original if id(item) in selected_ids]
-        set_budget(payload)
+        set_budget(payload, kind)
         kept = len(selected)
         if kept == len(original):
             return False
@@ -4221,7 +4268,7 @@ def apply_size_budgets(
         for kind, payload in level_shards.items():
             if not isinstance(payload, dict):
                 continue
-            if not set_budget(payload)["ok"]:
+            if not set_budget(payload, kind)["ok"]:
                 oversized_kinds.add(kind)
         if not oversized_kinds:
             continue
@@ -4236,7 +4283,7 @@ def apply_size_budgets(
         if trimmed:
             oversized_kinds = set()
             for kind, payload in level_shards.items():
-                if isinstance(payload, dict) and not set_budget(payload)["ok"]:
+                if isinstance(payload, dict) and not set_budget(payload, kind)["ok"]:
                     oversized_kinds.add(kind)
         mode_trimmed = False
         for kind in ("cloze", *DRILL_MODES):
@@ -4261,7 +4308,7 @@ def apply_size_budgets(
         for kind, payload in level_shards.items():
             if not isinstance(payload, dict):
                 continue
-            budget = set_budget(payload)
+            budget = set_budget(payload, kind)
             if not budget["ok"]:
                 print(
                     f"WARN: {payload.get('schema', kind)}.{level} remains over size budget "
@@ -4311,6 +4358,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--target", type=int, default=DEFAULT_TARGET)
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
     parser.add_argument("--gzip-limit", type=int, default=DEFAULT_GZIP_LIMIT)
+    parser.add_argument("--cloze-raw-limit", type=int, default=DEFAULT_CLOZE_RAW_LIMIT)
+    parser.add_argument("--cloze-gzip-limit", type=int, default=DEFAULT_CLOZE_GZIP_LIMIT)
     parser.add_argument("--fixture-note", type=str)
     parser.add_argument(
         "--seed-selection",
@@ -4381,6 +4430,8 @@ def main(argv: list[str] | None = None) -> int:
         target=args.target,
         raw_limit=args.raw_limit,
         gzip_limit=args.gzip_limit,
+        cloze_raw_limit=args.cloze_raw_limit,
+        cloze_gzip_limit=args.cloze_gzip_limit,
         fixture_note=args.fixture_note,
         source_label="fixture" if args.vesum_fixture or args.manifest else "atlas.db",
         seed_selection=args.seed_selection,
@@ -4396,7 +4447,14 @@ def main(argv: list[str] | None = None) -> int:
         paronym_pairs=paronym_pairs,
         synonym_verdicts=synonym_verdicts,
     )
-    apply_size_budgets(shards, config.raw_limit, config.gzip_limit)
+    compact_cloze_emit_fields(shards)
+    apply_size_budgets(
+        shards,
+        config.raw_limit,
+        config.gzip_limit,
+        cloze_raw_limit=config.cloze_raw_limit,
+        cloze_gzip_limit=config.cloze_gzip_limit,
+    )
     written = write_shards(shards, args.out_dir)
     for path in written:
         print(path)

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -34,7 +34,7 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 8  # 7→8: compact shards and coverage-first budget trim (#6188)
+PRACTICE_DECK_BUILDER_VERSION = 9  # 8→9: compact cloze emits and measured cloze budget (#6188)
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-1abe24fc3c07802b.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-aac54b85efeb0f07.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-1abe24fc3c07802b",
+  "deck_version": "atlas-practice-v1-aac54b85efeb0f07",
   "package_schema_version": 1,
-  "gz_sha256": "607597b833d90bfc346d89ed7d08faf07ae7ebfbb759936508e3edc684d2fda6",
-  "package_sha256": "70b6a4214201521bb1c66029028ecbc501518de3516838ac8c55a2cb6c81a90f",
-  "gz_bytes": 1511761,
-  "package_bytes": 21295784,
+  "gz_sha256": "a036b64629109cb2cb525d2f8e1d1092a2fd18488825abf589c7c513707b7da1",
+  "package_sha256": "7f8687c2f5c457691b60ab10a22ed608190ccca76d5a9519609a7b88aec9ca45",
+  "gz_bytes": 1583265,
+  "package_bytes": 21509020,
   "file_count": 45,
   "files": [
     {
@@ -14,13 +14,13 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 277557,
-      "sha256": "769655ec5dced0e4a2f2f3bcd01bf004f1a8fb6930e0cbb3f22ea71431b3de82",
+      "bytes": 279090,
+      "sha256": "2b2af61664cf12519e6433c5556271c9d767c9005cd8506e241f3a3d12470a1a",
       "counts": {
         "lexemes": 1470,
-        "cloze": 875,
-        "clozeEligibleLexemes": 874,
-        "clozeCoverage": 0.5946
+        "cloze": 921,
+        "clozeEligibleLexemes": 883,
+        "clozeCoverage": 0.6007
       }
     },
     {
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533438,
-      "sha256": "6d8cda246d178fd2ab0f44f894613ff790004df22d5388b43db7ff054ac1896e"
+      "sha256": "ec7555f525668dbf78af58672519f33df5081830e2e6dfc514d36f77ba5e9052"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1599805,
-      "sha256": "9d63190f84588166a338e097daf367d44e54d0ab1afe8d15c1e4e8d5b12533fa"
+      "bytes": 1542706,
+      "sha256": "977f98a687c8feabc6ccf4806370922648d18efce9045f94e22a739a354ad1d1"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 349915,
-      "sha256": "164a58708ec6f78d8fc14c66d42ef267439bee379901c493720f4a2acbc27474"
+      "sha256": "fa3be00541a84596842151d52e8ea1d8adfb7101c31e0bc1dd9ce65685261b8f"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 370047,
-      "sha256": "db13428285be9a2197b238bd13660110fe486b26441d2f00931c255ef636d85a"
+      "sha256": "448f32d31c1decc1fdcc0eccaa9cf080121689647b7c54584e0c759a78dbc47f"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 615568,
-      "sha256": "362e2fc3f9ad8438df939861365e12fa26e3c76e9bf9e7512d2c54de9294f06f"
+      "sha256": "00928ce58c53163de32315f633bb9b0854b5cd428cd8c3eab60b80deb77ab289"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "fa7de2feacf1f536cf41f1d8a48c9388a8af1c29e878b6be8aef0b44d96b1b6b"
+      "sha256": "2e8a225094299eb07d69f041d3203d2485b0a68aa5015de49c4672aef784e3ec"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 257,
-      "sha256": "fd18e0f8c262b26699a776d80aae5092c77e4d0fe716d904ec27544d473cb3a9"
+      "sha256": "fba46afe92bc358437afddd2a0e4378f1e81bca389edd7cb5bd42b61987577b2"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,20 +85,20 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 3491,
-      "sha256": "ae7fb52a3eb76519404aa612fb526c8619bc7bfb6195a3d692df2afeb991806c"
+      "sha256": "632d957715386f4513c5e9b97c7bdd63a2023b1661052a05d73bc6bf11dd8c79"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 285431,
-      "sha256": "4055d57f0e8a6c612aa62b22f4a66333f7c0b5245aab809c75658838e9237450",
+      "bytes": 289558,
+      "sha256": "c287f6c9b01935c1a546ef3b237b8049fa65ab7fa0331be6dc33441b220e33ac",
       "counts": {
         "lexemes": 1444,
-        "cloze": 855,
-        "clozeEligibleLexemes": 855,
-        "clozeCoverage": 0.5921
+        "cloze": 948,
+        "clozeEligibleLexemes": 948,
+        "clozeCoverage": 0.6565
       }
     },
     {
@@ -107,15 +107,15 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 536102,
-      "sha256": "b6d399402d7d5d9b50e55d0e1cb51fc31991a1488cb824d87c0f02a351153525"
+      "sha256": "6a04960a4c5208d4e26e46f72513cb5fd6036fdf83f550f142acf478bd33c087"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1598431,
-      "sha256": "9b6979e9a06259cf5e2e43a00efdae25445d3507fba9548ac3db773c785e46e3"
+      "bytes": 1640254,
+      "sha256": "9d8ce44dfa7a5a73815cea5625645023cb31af8827aa8e2413dbf3f089626e62"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 390102,
-      "sha256": "650ae9a207af0fe50afb00f585034ed3a6b7fe3289d2eb1a4128f872aae8fdb3"
+      "sha256": "b5d7a4862dc282e16ae8c88e5e9b3108b914cca89a5f4b5a27460ee83dfd3d5f"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1026094,
-      "sha256": "b1b185838720ed971b36e5888bea37f7d53cae44f0d05a216e1a9575871ea1d4"
+      "sha256": "eb1255d1c709618e12766be95a58f6bc8febfcc7482be7935a6c583d8b87afc5"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 567900,
-      "sha256": "5bdb82282765f3507c8c62b61a88eca533d56973c4692e8db8c9de478feabe64"
+      "sha256": "de6c340a1d55abd8c97175e9e6014294c5de78b202897790ff8673b8a6f9272f"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,7 +147,7 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "b5e564c84fa4cc8edf935baad9cc2df8b406f4f7c460b2f498c959d14ab0ec29"
+      "sha256": "a588ccb754655b7d1db3de2528a657e04f9ad7e3ca2eb096cc141d2640d5bb1d"
     },
     {
       "path": "practice-heritage.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-heritage",
       "bytes": 33411,
-      "sha256": "e27fb8b1cac1486f353a425d813541d8d0267103f80fc316cd6acf8af610b070"
+      "sha256": "d26c57a5b60c37edd816182c5db8a815d533fa954cfe8d41ecb04c06e1d37236"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,20 +163,20 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 3454,
-      "sha256": "ca0df33eec695efe452e92a4fa477578953c07336a8ab7c4f5b0a7ea2e234d58"
+      "sha256": "40d2b3cee78984511cb122ccb0f746dc1efbcf2c072e18d31b1614e8cd8ca6e3"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 318708,
-      "sha256": "889545dd9ce9b94e0e403f91aaec37383d46354e7c2a23f8c58166be4c144db0",
+      "bytes": 330254,
+      "sha256": "d9255c75d815230714d76a581def98cec9638cae28f51e071474c25010324cd8",
       "counts": {
         "lexemes": 1617,
-        "cloze": 862,
-        "clozeEligibleLexemes": 862,
-        "clozeCoverage": 0.5331
+        "cloze": 1121,
+        "clozeEligibleLexemes": 1121,
+        "clozeCoverage": 0.6933
       }
     },
     {
@@ -185,15 +185,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 634474,
-      "sha256": "9a34ac17395cde2fa062a748955d971cc6d51dc75bfd9d3058825d646c648c82"
+      "sha256": "07dc2600a527fe1c54cec9237604c8f43407bf41884db1bb49c84801dbb8ca1c"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1599162,
-      "sha256": "df94a8b8b1c7df946af31b0a96f63ea478b3fca9b421d83106dbaad636fd82a6"
+      "bytes": 1949044,
+      "sha256": "15f7cec3a89d2c2661caa8eb1ec51da77b07e2eb4bd8782e247967d5d7a625dc"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 451935,
-      "sha256": "961598850847714ea3b587c99bc9bcc6bc3e8330ccb35b0c1f2d6dc2c4d3ec04"
+      "sha256": "7f29f11f8f446ad856f1dd38dd8a72747fe66a17d1f49166932a964285098e5f"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1363476,
-      "sha256": "194967be7a4c7791b997734e826e7a559dececda8f1343f7bc8f50c1041dc88e"
+      "sha256": "a7e618451b97e81a0ae74d75b57bdba91d87d4749b59b1c14963730153426927"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 785386,
-      "sha256": "badfd043a509c6ab778fc25ada149fade4dace3a015396e0703096e7133f49ef"
+      "sha256": "777ef17e38cf9ad466b7097b6ab43ff85907abbd066c41a4e6ca76daad2b44a8"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,7 +225,7 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 346573,
-      "sha256": "4d979c84f44aec500a96ebfee07d2cfed20ee1bf79abcecb6c2e6214921f3821"
+      "sha256": "6a5947dc70e11215abc015a84078319843fe0725b8f469041f64b4f93d2a0b37"
     },
     {
       "path": "practice-heritage.B1.json",
@@ -233,15 +233,15 @@
       "level": "B1",
       "schema": "atlas-practice-heritage",
       "bytes": 74730,
-      "sha256": "bee20d5cb8b658045d6712209217215beff3fc46c25d73880fc063595867fd60"
+      "sha256": "be9de5425bac210a65c2ec87a0a67d327a078c84e13130440104be9c18cf9fa1"
     },
     {
       "path": "practice-paronym.B1.json",
       "kind": "paronym",
       "level": "B1",
       "schema": "atlas-practice-paronym",
-      "bytes": 2501,
-      "sha256": "9f5476638393bdda21218bf1978eb3e73c25e9cfdd725f229dfac8f00c2a98eb"
+      "bytes": 2500,
+      "sha256": "f24634aeff61d897e242034f7a3159b6ce28cddaa02eac8a95267dbfca8444b5"
     },
     {
       "path": "practice-index.B2.json",
@@ -249,7 +249,7 @@
       "level": "B2",
       "schema": "atlas-practice-index",
       "bytes": 193363,
-      "sha256": "1c9b8762822c8ba22f5339b491b144df9792c4454633b6fac9ab3c59f24a813a",
+      "sha256": "3ea5c668e0414e23ac579ab9601011f7a16483aace3b7da2d6fcaeb4b1fef0e8",
       "counts": {
         "lexemes": 940,
         "cloze": 597,
@@ -263,15 +263,15 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 381338,
-      "sha256": "60a7a10bafec73a7ffa4358ee5ae58c2519d850dc7cfc63c337bf23013d560f0"
+      "sha256": "da3704e94ad2276fdb508c23ceddd07271d621afdce0c418e7f7ff4242b10e8e"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1146140,
-      "sha256": "6361bafb0f0e4863bb65fb0d078f8af03a62a8ce1fcaf318f04ac4bf99d5ec74"
+      "bytes": 1049692,
+      "sha256": "799c58aaee5c55f375e31016b02f9385e0138fdae3278dfb3d23101ecd33989c"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 281264,
-      "sha256": "34e0fd567f82a1b2936489aa699d47d54c8afddb06df3c0e71e4c14a3995e2d2"
+      "sha256": "aa57478f72289b05515b56341290692aba4c7ad5ecd5076fd1c5664ba8c7d8a3"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 799654,
-      "sha256": "7f3557edd36874816c2921d09e38f4bf4660108f0444a493839255b1311dff3d"
+      "sha256": "aefb23f746d939a6c20842487818267a187b4d4081bc6de71065eb276b6fc845"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 507721,
-      "sha256": "29c5f36697523d3eed8dc0099feb322579b8617712b586d65033857e25092060"
+      "sha256": "eab35e092c32a457645698256257d06bb6adcff88d2084beeaf68588744c60d7"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 76291,
-      "sha256": "af636f913e12e917048d623b6b8c149ab9e553ddb97b1b420a118f65665d4ff9"
+      "sha256": "d58a35a487c6f77c3395f51ad5dbc10e0dea5e2cc762b13b1a8761c608d28719"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 11098,
-      "sha256": "f9ec444af865f8a3d4d20304b4ed392ac0e48a5ff2bebbb7af263dfd65e3318d"
+      "sha256": "e285dce9f9234d210af6cb185bda37f936fa6fcf23771c25d81df9818891044d"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "ae9c60b72b4ecf66c2df218ddce1cc8d55fd967741d99b518f662029b2e80716"
+      "sha256": "ce9eeece8c4a41095118fe2b1e89146d2e2efa9522e36b83984d516ff985a9f9"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 103866,
-      "sha256": "f988d454cb3f1c07e5dc603b852b472cf4357fad9cc00cde68a02174d5899b21",
+      "sha256": "31cc691b7bb2cd15ffc55e73859b6ed2f1121f30de57eebee6da1398de28470c",
       "counts": {
         "lexemes": 529,
         "cloze": 149,
@@ -341,15 +341,15 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 212786,
-      "sha256": "52fed1b83e93b22b8acd7bd66985cfe551d310d568516ccabb3aca530b080747"
+      "sha256": "f63d6c10accbe06d0dd5d4956198ba391a990deb67debf76eba5abdbe0de3774"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 288168,
-      "sha256": "6f72eaf911d9a3b4ca3661263bf494390e1a956813dae80c44efb859b0bd9b36"
+      "bytes": 264247,
+      "sha256": "074856c69ee6dd27276edb39b12190a35c6bf119290157139b2ff4f98f3aa676"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 154306,
-      "sha256": "48071989f97c0785fa17775f2d546d70d8661bc3bf6ff4068d4bc41d872db416"
+      "sha256": "4f37aa7b8c227468d272b755fab4299fb9d07636fb84463a71e928908194cdc1"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 418175,
-      "sha256": "aaa21d99afb02541e7249d7fdcc6380252aedcd34f433a86c6e11fcaf560cf7e"
+      "sha256": "78902582ea495c803a6dd95e37c462afccd459888184ed93bb8a49239a028506"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 299425,
-      "sha256": "c2e0d524e4ffad9ec9072d85ace4e4c563f49782b8277e962b39f3af5c78791b"
+      "sha256": "a92b103f73ff249fca94df15acdd2da8aaeb75c6af4221ba1dee12a39a3d021c"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 30629,
-      "sha256": "18199a946b94a2c374e44b02a50c6de621f3a66eabb4a65a12deb3ed4872ac60"
+      "sha256": "594f682ae24bc6ac63e4207f1fae969bbc780f8876c9e1966a424d06152e947d"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 2060,
-      "sha256": "53bb6742a29a03398ae61d78dd7792288d33e940021a31c3ba3e4e46a3017663"
+      "sha256": "da5948ef07e0feb09e66684d1f7ebbb986604fccc1bdf73a4d6d202cc592c0f9"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 2357,
-      "sha256": "e2c455f1967e1e3b77f9a8a6cba1187bc72b125a411e1e958a0d3dff02aebe66"
+      "sha256": "d9ea4be22566d436009cc1a973fafdde6900b0ae2e934576cbbe911efa9cbbd6"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -28,6 +28,7 @@ from scripts.audit.generate_practice_deck import (
     _stress_position,
     apply_size_budgets,
     build_practice_shards,
+    compact_cloze_emit_fields,
     main,
     merge_practice_seed_entries,
     read_cloze_sources,
@@ -1147,6 +1148,28 @@ def test_shard_json_is_compact_and_budget_matches_written_bytes(tmp_path: Path) 
     assert b"\n  " not in emitted
     assert json.loads(emitted) == payload
     assert budget["rawBytes"] == len(emitted)
+
+
+def test_cloze_emit_compacts_builder_diagnostics_without_dropping_runtime_fields() -> None:
+    shards = _build()
+    cloze_items = shards["A1"]["cloze"]["cloze"]
+    retained_alt = cloze_items[0]
+    dropped_alt = cloze_items[1]
+    retained_alt["acceptedAlt"] = ["книгу"]
+    dropped_alt["acceptedAlt"] = []
+
+    compact_cloze_emit_fields(shards)
+
+    assert retained_alt["acceptedAlt"] == ["книгу"]
+    assert "acceptedAlt" not in dropped_alt
+    for item in cloze_items:
+        assert all(field not in item for field in ("number", "cefr", "lemma"))
+        for option in item["options"]:
+            assert "strategy" not in option
+            assert all(
+                key in option
+                for key in ("optionId", "label", "lemmaId", "kind", "case", "pos")
+            )
 
 
 def test_size_budget_cloze_trim_prioritizes_unique_lemmas(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- Compact cloze emit (drop builder-only fields: empty `acceptedAlt`, `number`/`cefr`/`lemma`, option `strategy`).
- Raise **cloze-only** size budget to measured headroom: raw 2.0MB / gzip 210k (other modes stay 1.6MB / 180k).
- Publish deck **`atlas-practice-v1-aac54b85efeb0f07`**.

## Coverage evidence

| Level | After #6217 | This PR |
| --- | ---: | ---: |
| A1 | 874 / 0.595 | **883 / 0.601** |
| A2 | 855 / 0.592 | **948 / 0.657** |
| B1 | 862 / 0.533 | **1121 / 0.693** |
| B2 | 597 / 0.635 | 597 / 0.635 |
| C1 | 149 / 0.282 | 149 / 0.282 |
| **sum** | **3337 / 6000 (~56%)** | **3698 / 6000 (~62%)** |

Quality gates from #6212 retained. Residual still open for #6188 (not full list).

## Test plan
- [x] pytest test_generate_practice_deck (78)
- [ ] CI + GLM CF

X-Agent: codex/6188-coverage-residual