### PR TITLE
fix(monitor): spawn refresh worker from live runtime

### DIFF
--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import yaml
 
+from scripts.api.config import LIVE_REPO_ROOT
+
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_PATH = ROOT / "scripts" / "config" / "issue_streams.yaml"
 CACHE_PATH = ROOT / "batch_state" / "issue_stream_audit.json"
@@ -377,8 +379,14 @@ def public_refresh_view(state: dict) -> dict:
 # Scheduler + worker
 # --------------------------------------------------------------------------- #
 def _venv_python() -> str:
-    """Path to the venv Python binary for spawning the detached worker."""
-    return str(ROOT / ".venv" / "bin" / "python")
+    """Path to the live checkout's venv for the detached worker.
+
+    The supervised API imports this module from an immutable release snapshot,
+    which intentionally has no ``.venv``.  The supervisor-provided live root
+    owns the approved interpreter while ``ROOT`` remains the worker's snapshot
+    cwd so the detached process executes the exact deployed code.
+    """
+    return str(LIVE_REPO_ROOT / ".venv" / "bin" / "python")
 
 
 def _spawn_worker(run_id: str) -> bool:

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -674,6 +674,32 @@ def test_schedule_refresh_is_single_flight_and_preserves_previous_outcome(
     assert json.loads(state_path.read_text(encoding="utf-8"))["run_id"] == first["run_id"]
 
 
+def test_spawn_worker_uses_live_interpreter_and_snapshot_code(tmp_path, monkeypatch):
+    live_root = tmp_path / "live"
+    snapshot_root = tmp_path / "release"
+    captured = {}
+
+    def _popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(issue_stream_audit, "LIVE_REPO_ROOT", live_root)
+    monkeypatch.setattr(issue_stream_audit, "ROOT", snapshot_root)
+    monkeypatch.setattr(issue_stream_audit.subprocess, "Popen", _popen)
+
+    assert issue_stream_audit._spawn_worker("run-1") is True
+    assert captured["argv"] == [
+        str(live_root / ".venv" / "bin" / "python"),
+        "-m",
+        "scripts.orchestration.issue_stream_audit",
+        "--refresh-worker",
+        "run-1",
+    ]
+    assert captured["kwargs"]["cwd"] == str(snapshot_root)
+    assert captured["kwargs"]["start_new_session"] is True
+
+
 def test_concurrent_schedulers_spawn_exactly_one_worker(tmp_path, monkeypatch):
     _refresh_paths(tmp_path, monkeypatch)
     entered = threading.Event()


### PR DESCRIPTION
## Summary

- resolve the detached issue-stream worker interpreter from the supervisor-authoritative live checkout
- keep the worker cwd on the immutable release snapshot so it executes the exact deployed code
- add a topology regression test covering live interpreter + snapshot cwd

## Root cause

PR #6221 passed worktree canaries but the supervised API runs from `.runtime/api/releases/<sha>`, which intentionally has no `.venv`. `_venv_python()` therefore targeted a nonexistent snapshot interpreter and both automatic and explicit refreshes ended as `spawn_failed`. The launchd supervisor already exports validated `LEARN_UK_REPO_ROOT`; `scripts.api.config.LIVE_REPO_ROOT` is the existing canonical child-tool root.

## Verification

- 111 focused tests passed
- 201 broader tests passed; 6 intentional skips
- Ruff, diff, agent-trailer, and OPSEC checks passed
- actual immutable-snapshot canary: HTTP 200, `scheduled` -> `idle/succeeded`, `generated_at` advanced from `1785618660` to `1785625213`, forbidden internal-field count zero

Fresh independent cross-family review is pending on this exact head; auto-merge will be armed only after that gate passes.

Fixes #6145