### PR TITLE
fix(practice): mine residual textbook sentence inventory

### DIFF
--- a/docs/practice/daily-sentence-inventory.md
+++ b/docs/practice/daily-sentence-inventory.md
@@ -17,10 +17,13 @@ Regenerate it from the hydrated Practice lexeme shards with:
 
 The default target set is all A1-C1 `practice-lexemes.*.json` shards under
 `site/public/lexicon/`; the extractor searches textbook FTS for an exact
-practice-lemma surface, accepts only short sentence-shaped matches with a
-VESUM-attested verb, rejects a VESUM-identified leading imperative exercise
-command, and keeps one blankable sentence per target lemma. The inventory
-records the source label, locator, and licence status for every row.
+practice-lemma surface, ranks Ukrainian-language textbooks (`ukrmova` and
+`bukvar`) first, and examines up to 250 ranked chunks so worksheet noise does
+not hide a later usable sentence. It accepts only short sentence-shaped
+matches with a VESUM-attested verb, rejects a VESUM-identified leading
+imperative exercise command, and keeps one blankable sentence per target
+lemma. The inventory records the source label, locator, and licence status for
+every row.
 `--include-ulp` may add ULP fallback rows, but its provenance is intentionally
 only the safe source-family label — never a local file, transcript id, URL, or
 private locator. `targetForm` preserves the exact source capitalization so the

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1145,7 +1145,7 @@ def _eligible_dictionary_decoys(
         if _headword(lexeme["gloss"]) == answer_head:
             continue
         label = _clean_text(lexeme.get("lemma"))
-        if not label or _plain(label) in seen_labels:
+        if not label or _meaning_label_is_phrase(label) or _plain(label) in seen_labels:
             continue
         seen_labels.add(_plain(label))
         candidates.append((lexeme, label))
@@ -1288,29 +1288,32 @@ def _make_no_pair_options(
         rng.shuffle(decoys)
         answer_cap = _initial_capitalization(cloze.get("form"))
         selected_decoys: list[tuple[dict[str, Any], str]] = []
-        matching_cap: list[tuple[dict[str, Any], str]] = []
-        if answer_cap is not None:
-            # Preserve the capitalization gate while making the selection
-            # surface-aware: one matching-capitalization decoy is enough to
-            # prevent a sentence-initial answer from being revealed, even
-            # when fewer than three matching candidates exist.
-            matching_cap = [
+        # A greedy scan can choose a long decoy first and then strand the
+        # card with fewer than three compatible labels.  Search the small
+        # length windows that contain the answer instead; candidates were
+        # shuffled above, so the first valid window remains seeded and varied.
+        for lower_length in range(max(1, answer_length - 3), answer_length + 1):
+            upper_length = lower_length + 3
+            window = [
                 candidate
                 for candidate in decoys
-                if _initial_capitalization(candidate[1]) == answer_cap
+                if lower_length <= len(candidate[1]) <= upper_length
             ]
-            if matching_cap:
-                selected_decoys.append(matching_cap[0])
-                decoys = [candidate for candidate in decoys if candidate != matching_cap[0]]
-        for candidate in decoys:
-            labels = [cloze["form"], *(item[1] for item in selected_decoys), candidate[1]]
-            if max(map(len, labels)) - min(map(len, labels)) > 3:
-                continue
-            selected_decoys.append(candidate)
-            if len(selected_decoys) == 3:
+            if answer_cap is not None:
+                matching_cap = [
+                    candidate
+                    for candidate in window
+                    if _initial_capitalization(candidate[1]) == answer_cap
+                ]
+                if not matching_cap:
+                    continue
+                first = matching_cap[0]
+                selected_decoys = [first, *(candidate for candidate in window if candidate != first)]
+            else:
+                selected_decoys = window
+            if len(selected_decoys) >= 3:
+                selected_decoys = selected_decoys[:3]
                 break
-        if answer_cap is not None and not matching_cap:
-            selected_decoys = []
         if len(selected_decoys) < 3:
             return []
         rng.shuffle(selected_decoys)

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -3806,6 +3806,20 @@ def read_sentence_inventory(path: Path | None) -> list[dict[str, Any]]:
     rows = payload.get("rows")
     if not isinstance(rows, list):
         raise ValueError("sentence inventory rows must be a list")
+    # Small additive residual inventories stay CF-reviewable as separate files
+    # while the multi-MB base inventory remains stable on main.
+    residual_path = path.with_name(path.stem + ".residual" + path.suffix)
+    if residual_path.exists():
+        residual_payload = json.loads(residual_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(residual_payload, dict)
+            or residual_payload.get("schema") != "atlas-sentence-inventory"
+        ):
+            raise ValueError("residual sentence inventory must use atlas-sentence-inventory schema")
+        residual_rows = residual_payload.get("rows")
+        if not isinstance(residual_rows, list):
+            raise ValueError("residual sentence inventory rows must be a list")
+        rows = [*rows, *residual_rows]
     try:
         provenance_path = path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
     except ValueError:

--- a/scripts/audit/generate_sentence_inventory.py
+++ b/scripts/audit/generate_sentence_inventory.py
@@ -21,6 +21,11 @@ DEFAULT_SOURCES_DB = Path("data/sources.db")
 DEFAULT_VESUM_DB = Path("data/vesum.db")
 DEFAULT_OUT = Path("site/src/data/lexicon-sentence-inventory.json")
 PRACTICE_LEVELS = ("A1", "A2", "B1", "B2", "C1")
+# Textbook FTS often ranks exercise prompts and dictionary fragments ahead of a
+# usable sentence.  Search far enough past that noise to make a residual
+# result meaningful, while keeping common function-word queries bounded.
+TEXTBOOK_SEARCH_LIMIT = 250
+PREFERRED_TEXTBOOK_SUBJECTS = ("ukrmova", "bukvar")
 APOSTROPHE_TRANSLATION = str.maketrans(
     {
         "’": "'",
@@ -40,7 +45,7 @@ NON_UKRAINIAN_ALPHA_RE = re.compile(r"[^\W\d_А-ЩЬЮЯЄІЇҐа-щьюяєі�
 COMBINING_MARK_RE = re.compile(r"[\u0300-\u036f]")
 MIDWORD_JOIN_RE = re.compile(r"[а-щьюяєіїґ][А-ЩЬЮЯЄІЇҐ]")
 ENUMERATION_RE = re.compile(
-    r"(?<!\w)[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+(?:,\s*[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+){3,}[.!?]$"
+    r"(?<!\w)[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+(?:,\s*[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+){2,}[.!?]$"
 )
 TITLE_CASE_RUN_RE = re.compile(
     r"^\s*(?:[А-ЩЬЮЯЄІЇҐ][а-щьюяєіїґ]+\s+){3,}"
@@ -140,6 +145,108 @@ SHORT_TOKEN_RUN_RE = re.compile(
 )
 TRAILING_SINGLE_TOKEN_RE = re.compile(r"(?:^|\s)[А-ЩЬЮЯЄІЇҐ]\s*[.!?]$")
 UPPERCASE_HEADING_RE = re.compile(r"\b[А-ЩЬЮЯЄІЇҐ]{4,}\b")
+DOTTED_OCR_RE = re.compile(
+    r"[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]\.{2,}[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]"
+)
+DIGIT_RE = re.compile(r"\d")
+SEMICOLON_RE = re.compile(r";")
+BROKEN_APOSTROPHE_RE = re.compile(
+    r"[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ][’'][–-]|[–-][’'][А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]"
+)
+# A standalone ``Г`` followed by a lowercase word is an answer-choice marker
+# in the textbook corpus; ordinary one-letter sentence starters such as ``Я``
+# and ``В`` must remain valid.
+LEADING_OPTION_RE = re.compile(r"^\s*Г\s+[а-щьюяєіїґ]")
+LEADING_STRUCTURED_LABEL_RE = re.compile(
+    r"^\s*(?:вид|елементи сюжету|репліка|часи дієслів|"
+    r"доконаний вид|недоконаний вид|теперішній час|минулий час|"
+    r"майбутній час|умова)\b",
+    re.IGNORECASE,
+)
+INTERNAL_CAPITAL_RE = re.compile(r",\s+[А-ЩЬЮЯЄІЇҐ][а-щьюяєіїґ]+\b")
+DIALOGUE_ASIDE_RE = re.compile(r"[—–]\s*[ОАЕІЙУ]\s*,")
+EXPLANATORY_COLON_RE = re.compile(
+    r"\b(?:використовуємо|означають|називають|розрізняють|позначають)\b"
+    r"[^.!?]{0,100}:\s*[А-ЩЬЮЯЄІЇҐ]",
+    re.IGNORECASE,
+)
+COLON_FRAGMENT_RE = re.compile(
+    r"^\s*[А-ЩЬЮЯЄІЇҐ][а-щьюяєіїґ]+"
+    r"(?:\s+(?:та|і|й)\s+[а-щьюяєіїґ]+){0,2}\s*:"
+)
+COLON_LIST_RE = re.compile(
+    r":\s*[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+"
+    r"(?:,\s*[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+){2,}(?:\s+тощо)?[.!?]$"
+)
+ABBREVIATED_END_RE = re.compile(r"\b(?:ім|т|р|ст|с|п)\.$")
+DOUBLE_TERMINAL_RE = re.compile(r"[.!?]{2,}$|[!?]\.$")
+TASK_PROMPT_RE = re.compile(
+    r"\b(?:маєте|треба|потрібно)\s+[а-щьюяєіїґ]+\b",
+    re.IGNORECASE,
+)
+MISSING_BOUNDARY_RE = re.compile(
+    r"(?<=[а-щьюяєіїґ])\s+"
+    r"(?:Як|Щоб|Коли|Але|Тому|Далі|Який)\b"
+)
+DIRECT_SPEECH_RE = re.compile(
+    r"\b(?:спитав|запитав|питає|сказав|каже|відповів|відповіла)\s+"
+    r"[А-ЩЬЮЯЄІЇҐ]"
+)
+NUMERAL_LIST_RE = re.compile(
+    r"\b(?:тисяча|мільйон|мільярд)\b[^.!?]{0,80}"
+    r"\b(?:тисяча|мільйон|мільярд)\b",
+    re.IGNORECASE,
+)
+GRAMMAR_TABLE_RE = re.compile(
+    r"(?:\b(?:теперішній|минулий|майбутній)\b.*"
+    r"\b(?:теперішній|минулий|майбутній)\b|"
+    r"\b(?:доконаний|недоконаний)\b.*\b(?:доконаний|недоконаний)\b|"
+    r"\b(?:доконан|недоконан)\w*\b.*\b(?:доконан|недоконан)\w*\b|"
+    r"\b(?:доконан|недоконан)\w*\b.*\b(?:недоконан|доконан)\w*\b|"
+    r"\b(?:форми часу|види дієслів|дієприслівники|час дієслів)\b.*"
+    r"\b(?:питання|приклади)\b|"
+    r"\bчислівники\b[^.!?]{0,80}\b(?:тисяча|мільйон|мільярд)\b)",
+    re.IGNORECASE,
+)
+MISSING_SHORT_WORDS = frozenset(
+    {
+        "а",
+        "і",
+        "й",
+        "та",
+        "в",
+        "у",
+        "з",
+        "із",
+        "зі",
+        "на",
+        "до",
+        "за",
+        "не",
+        "ні",
+        "по",
+        "о",
+        "як",
+        "що",
+        "це",
+        "то",
+        "є",
+        "час",
+        "слух",
+        "бій",
+        "йти",
+        "іти",
+        "я",
+        "ти",
+        "ми",
+        "ви",
+        "він",
+        "вона",
+        "вони",
+        "нас",
+        "мене",
+    }
+)
 
 TEXTBOOK_LICENSE = {
     "status": "not_openly_licensed",
@@ -189,6 +296,7 @@ def _single_target_surface(sentence: str, lemma: str) -> str | None:
 def _is_source_sentence_noise(
     sentence: str,
     *,
+    lemma: str | None = None,
     vesum: VesumSentenceVerifier | None = None,
 ) -> bool:
     """Reject textbook worksheet, formula, and OCR fragments before mining.
@@ -213,6 +321,18 @@ def _is_source_sentence_noise(
         and vesum.has_imperative(tokens[0])
     ):
         return True
+    if lemma is not None:
+        target = _canonical_surface(lemma)
+        for index, token in enumerate(tokens[:-1]):
+            if _canonical_surface(token) != target:
+                continue
+            following = _canonical_surface(tokens[index + 1])
+            if len(following) <= 4 and following not in MISSING_SHORT_WORDS:
+                # OCR occasionally inserts a space inside a word (for
+                # example ``воло гих``).  Keep ordinary short function words,
+                # but fail closed on an unexpected short continuation of the
+                # exact target surface.
+                return True
     return any(
         (
             CONTROL_CHAR_RE.search(sentence),
@@ -242,6 +362,24 @@ def _is_source_sentence_noise(
             SHORT_TOKEN_RUN_RE.search(sentence),
             TRAILING_SINGLE_TOKEN_RE.search(sentence),
             UPPERCASE_HEADING_RE.search(sentence),
+            DOTTED_OCR_RE.search(sentence),
+            DIGIT_RE.search(sentence),
+            SEMICOLON_RE.search(sentence),
+            BROKEN_APOSTROPHE_RE.search(sentence),
+            LEADING_OPTION_RE.search(sentence),
+            LEADING_STRUCTURED_LABEL_RE.search(sentence),
+            INTERNAL_CAPITAL_RE.search(sentence),
+            DIALOGUE_ASIDE_RE.search(sentence),
+            EXPLANATORY_COLON_RE.search(sentence),
+            COLON_FRAGMENT_RE.search(sentence),
+            COLON_LIST_RE.search(sentence),
+            ABBREVIATED_END_RE.search(sentence),
+            DOUBLE_TERMINAL_RE.search(sentence),
+            GRAMMAR_TABLE_RE.search(sentence),
+            TASK_PROMPT_RE.search(sentence),
+            MISSING_BOUNDARY_RE.search(sentence),
+            DIRECT_SPEECH_RE.search(sentence),
+            NUMERAL_LIST_RE.search(sentence),
         )
     )
 
@@ -323,7 +461,7 @@ def _candidate_sentences(text: str, lemma: str, *, vesum: VesumSentenceVerifier 
         if (
             "http" in sentence.casefold()
             or sentence.count("*") > 1
-            or _is_source_sentence_noise(sentence, vesum=vesum)
+            or _is_source_sentence_noise(sentence, lemma=lemma, vesum=vesum)
         ):
             continue
         if vesum is not None and not vesum.has_verb(tokens):
@@ -338,17 +476,38 @@ def _fts_rows(
     content_table: str,
     lemma: str,
     where_sql: str = "",
+    preferred_subjects: tuple[str, ...] = (),
+    excluded_source_prefixes: tuple[str, ...] = (),
 ) -> Iterable[sqlite3.Row]:
     query = f'"{lemma.replace(chr(34), "")}"'
+    parameters: list[str] = [query]
+    columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({content_table})")}
+    where_parts = [where_sql] if where_sql else []
+    if excluded_source_prefixes and "source_file" in columns:
+        for prefix in excluded_source_prefixes:
+            where_parts.append("AND lower(coalesce(source.source_file, '')) NOT LIKE ?")
+            parameters.append(f"{prefix.casefold()}%")
+    combined_where = " ".join(where_parts)
+    order_prefix = ""
+    # Older fixture databases do not carry the production ``subject`` column.
+    # Keep them valid while preferring Ukrainian-language school books whenever
+    # the hydrated corpus exposes that metadata.
+    if preferred_subjects and "subject" in columns:
+        placeholders = ", ".join("?" for _ in preferred_subjects)
+        order_prefix = (
+            "CASE WHEN lower(coalesce(source.subject, '')) "
+            f"IN ({placeholders}) THEN 0 ELSE 1 END, "
+        )
+        parameters.extend(subject.casefold() for subject in preferred_subjects)
     sql = f"""
         SELECT source.text, source.title, source.chunk_id
         FROM {fts_table} AS fts
         JOIN {content_table} AS source ON source.id = fts.rowid
-        WHERE {fts_table} MATCH ? {where_sql}
-        ORDER BY bm25({fts_table})
-        LIMIT 20
+        WHERE {fts_table} MATCH ? {combined_where}
+        ORDER BY {order_prefix}bm25({fts_table}), source.id
+        LIMIT {TEXTBOOK_SEARCH_LIMIT}
     """
-    yield from conn.execute(sql, (query,))
+    yield from conn.execute(sql, parameters)
 
 
 def _source_sentences(
@@ -368,6 +527,8 @@ def _source_sentences(
             fts_table="textbooks_fts",
             content_table="textbooks",
             lemma=lemma,
+            preferred_subjects=PREFERRED_TEXTBOOK_SUBJECTS,
+            excluded_source_prefixes=("ulp",),
         )
         source_label = "Ukrainian school textbook"
         license_info = TEXTBOOK_LICENSE

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -34,7 +34,7 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 11  # 10→11: use source-preserved inventory capitalization for identity decoys (#6188)
+PRACTICE_DECK_BUILDER_VERSION = 12  # 11→12: safe length/capitalization identity decoys (#6188)
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-d0f484b18d7386f8.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-5b95719533f4ddbc.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-d0f484b18d7386f8",
+  "deck_version": "atlas-practice-v1-5b95719533f4ddbc",
   "package_schema_version": 1,
-  "gz_sha256": "8f3a8220a3e6aa37fefccc741f346dbcf1c418255032931ff6a5666791125cd2",
-  "package_sha256": "407fb8da3fb8884639af98a089c1e0d294aff9b02fbf5ea2735893661c497bee",
-  "gz_bytes": 1684563,
-  "package_bytes": 22548943,
+  "gz_sha256": "35663c2bf5707a22ffa0e8f733c2ea5ac0920ab42c2479e1c9b797bfeb25356c",
+  "package_sha256": "f425aa1fe1354fbdd7336c5e43700340d3abb64e27cbd2bea17c948dff098c27",
+  "gz_bytes": 1684750,
+  "package_bytes": 22548469,
   "file_count": 45,
   "files": [
     {
@@ -15,7 +15,7 @@
       "level": "A1",
       "schema": "atlas-practice-index",
       "bytes": 283725,
-      "sha256": "e263fbc03c31fe0118c09edf50fcfa51bb0939a1677d9484bcb9a1b15d2b2fb5",
+      "sha256": "d89c8dd0573abd6c805e6abf8ddbbcc66ee3cbbaf4db4cad4992bc669c862389",
       "counts": {
         "lexemes": 1470,
         "cloze": 1046,
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533438,
-      "sha256": "c83bfec304a0422d0aa0b926d87fe5f17882f89eab17aea0ca71245adb950151"
+      "sha256": "99e989435cba6bf2cc1655c64792aecaec59c5050d198e34f5cca16a2b6fe915"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1740177,
-      "sha256": "505905d1de8d3902d4b4e5fe3c85826d2da23fe3a17de3a1f5f0f2db6c204a24"
+      "bytes": 1739753,
+      "sha256": "402b68a9af4858b4b258d6f9c3c14ff56a08879397dd1efe6c153afb8b84fc45"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 349915,
-      "sha256": "4a89580941e5678799e73cf9097822ac4aaeddd4e98ef4dcfa418229658d2860"
+      "sha256": "777109b4b81511e9420e8ff9048b88d8378b427e48f3d3721cd2170cc9e50de1"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 370047,
-      "sha256": "addd1f3f694137ee9561aa07ba29114d5b503010a1601b4a825f80df31ea0ba2"
+      "sha256": "955ff81d974a3070c2597739f3de99421a44924095bf09cfc4a25244df33053a"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 615568,
-      "sha256": "87f7fadef067f60e94723867a970936d5c3988a6efeba9d07a28ca86c1161016"
+      "sha256": "29da7ac90bb9e482160c8e061fc9ca1f695637dea51137973a0c0e338d06cd2a"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "20374b0d2a7aa55493e98ab9657e9dd57f87b5d4425a9419ab79d76f5e2b9e2e"
+      "sha256": "71411a14996ff0eab1bb4105fc97506313389243399cac22229723cf418e5dca"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 257,
-      "sha256": "9272f2cc47f8dd3c8c172233ef5977100246178f82995873e27b39ea4ed817bc"
+      "sha256": "2d872c7b46f31f69888844536add27c81870eca147786071352dc075cd1c9225"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,15 +85,15 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 3491,
-      "sha256": "9891e93b36f5da87f37dc12ad94bcd5e48558ba1a6fa642aeeedc605dd7c19f2"
+      "sha256": "fc02a42b8247014414c12223c8f6cb0f5022214ead4165c08ba372243a21be4a"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 295146,
-      "sha256": "de0a4c66e4f2eccaece6e854db74075ac34a709ee46ea8b16c9d0185beb6abcc",
+      "bytes": 295145,
+      "sha256": "cc65d8b78a308683bd74ddc4e34c2a85b0aaf86ae8e78f4fde9136d9e45e2e3b",
       "counts": {
         "lexemes": 1444,
         "cloze": 1095,
@@ -107,15 +107,15 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 536102,
-      "sha256": "2c6803198ae28990813a644be535153b58fceb9925cc2320b03ecc9fee49bec5"
+      "sha256": "f0ee423a557f4bc2ca41f653360473eb3e65444b98130748c3fe46ff7f05e420"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1877951,
-      "sha256": "b6d3e51a0328687d5483db2c755765ee8444529ae5a653fcd5250dbc1abc0955"
+      "bytes": 1877670,
+      "sha256": "bbb1978371d055c55f532cbdc97069a02e8a966418664672e81486f997ae3fcb"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 390102,
-      "sha256": "1735c755fb1b9769eaf46f87ad27da3089bc797fd2a2d16a299177aa9849cf3b"
+      "sha256": "fc399dc3e089ea0a4bfd41463e1e22496030410f07f09dde2147206335719305"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1026094,
-      "sha256": "48595e736b385c5d046e8de15696545884dea55c9fdde0fa9073d2974ea8befd"
+      "sha256": "1d0beffb93a0d73ec44ed34d439cd9c3ae958047f786e6fe83385955cc35e36d"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 567900,
-      "sha256": "b5d6600bc13a8c4530bdf2d10b47f252133af79e0ad6b1d22d843c34f165e373"
+      "sha256": "7a59b04cadde7461b37129e7d2221f9bc2e8bc6a4a9b8184c79f7998cadb94f5"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,7 +147,7 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "c6bf0e54817d96dfa0246fb0289ea7978b50e00298eb2f439dd6967330c1ef54"
+      "sha256": "8a4050566aca88a801e986ceefb17f1af9dc8fafd757f131682de0c80f222855"
     },
     {
       "path": "practice-heritage.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-heritage",
       "bytes": 33411,
-      "sha256": "5d1513103caf4fb2d67ce198fd672a85d3774e852bfcb46b98102924d24c3afe"
+      "sha256": "6ebcaa43b908647f38dbe58fbd8f797579df46bc1fc63ddab6299f34e5ed5d0c"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,15 +163,15 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 3454,
-      "sha256": "390264f0694451d4d7d1be96b223f03c5356c7bdc1dad22159e7b4c25cfc7731"
+      "sha256": "f8a20e92246e3ec525d67b6fca085b46a43875913a57e1ee89e163402069ed6e"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 336167,
-      "sha256": "435509fb2e5807ecf37177cc1d7092c59b30ad903c8d409e2670bf04f112acad",
+      "bytes": 336165,
+      "sha256": "1cd717724572077737a0646aeddf0e978b8ff422f83f348e9bd410cba965f568",
       "counts": {
         "lexemes": 1617,
         "cloze": 1273,
@@ -185,15 +185,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 634474,
-      "sha256": "88751b0a9495637803ae285ec5fdde097b196685520af026c8469b4bbcd88e9b"
+      "sha256": "321eb2a390ffeadd9f410f043b29c3ec96773ddb00347a06f96dc83c9623770b"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 2194352,
-      "sha256": "dc0ad48b015dffd76c0a7f725b708d5a7c61a524713ed8f18dca4637cb443b16"
+      "bytes": 2194290,
+      "sha256": "22bc54e455de3b46c10ff31fa8b3a94a2140cb5cce97dcd6100bb69dbb7ece15"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 451935,
-      "sha256": "bca0983aea21d35f975044332a144f5daf8ea90fcdddd4418122eb0360621417"
+      "sha256": "826e8676f9b59b603d02c0aa397aa5ae99c6f80cb312f9f532860915401edbb1"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1363476,
-      "sha256": "0434738812c6a3b8e19f093427b5e6c1ef10e2352dce24f2ce90914c6aa957d1"
+      "sha256": "f2fb7340d998c69e4bbb289f23e0761afd8a3dfcfd18e62c1a8f58c9ae441bf8"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 785386,
-      "sha256": "8b5cae69bcb82d9a24683fa38a830d2edce3998ef6641cd23ce2a61374e5334e"
+      "sha256": "53aec6cc490fde285d696a90019c462f5ee39c749fca69036c6214d67cb02f83"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,7 +225,7 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 346573,
-      "sha256": "8aae77078a4f819e62ad05b8cb5103de474cee8d6e68a30234e03abcd90c5485"
+      "sha256": "ca121e9a2ba0c66f1a8725d9ee44a5b299425d3f1f6e95b0054b720e15bc982e"
     },
     {
       "path": "practice-heritage.B1.json",
@@ -233,7 +233,7 @@
       "level": "B1",
       "schema": "atlas-practice-heritage",
       "bytes": 74730,
-      "sha256": "09fecf772dac0e2d5b8cf3f27ef28530c738db2b0d759df0e3d4ae25cc7e23c6"
+      "sha256": "27a20639b1562913a1d6dc50b10e0fb4b83bab6ff1852111fd7548a375b10181"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -241,15 +241,15 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 2500,
-      "sha256": "00da875de647af3b2f5ad3924378219768c2b5824c180240a83810ecbc577f23"
+      "sha256": "e6aa1496a57f6c1fead389962fa1c3b294ccab0c1355a60c328dbbb55ec710d2"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 197327,
-      "sha256": "4c1c983cd910eaa41da97f2aa03cdddc7d9a10bade7eea67a330cf48b8df36d4",
+      "bytes": 197329,
+      "sha256": "f77509b365cb423aa13227f6a45217ece70bf6e7a70ed56f73953412148db6d8",
       "counts": {
         "lexemes": 940,
         "cloze": 699,
@@ -263,15 +263,15 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 381338,
-      "sha256": "1c9f06c64f0e04d253821874495b26cfffbfd04c8b0dec00225363b7a327551f"
+      "sha256": "6a3e6fd80133440a857ca715cd08e0f671bcac70b924344ea5a9d91dfca007ea"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1215647,
-      "sha256": "8768bce0c3b3d16a4812759b291170a2ad704f8a8ce956bd8be26cf1823a25e6"
+      "bytes": 1215857,
+      "sha256": "040a306c6a54b1907e720501b75e1bdd2bee8777d35780d960d906a3e6d0f9a9"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 281264,
-      "sha256": "1498b9b198b812e6121db523d3c4eb199fcb7823be5eff12f35155e5c2d093df"
+      "sha256": "de762530b81779e7845f9934ab1e3fbbfb6d41d9e7278ecfe637b55e2f93aac0"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 799654,
-      "sha256": "0ac2b69577b43cb66d394d270785b19841a4d5ec130befea9041564f3db07cf9"
+      "sha256": "676429e31e23de01fb9064dc9c603648268c33efd8414fd4973003b4152f8437"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 507721,
-      "sha256": "ae7bc69575052276cdd4f7da448ff613e46e11430539a0887b5175a69e75b490"
+      "sha256": "524afcb63ae0372452e568f845fa06578ffa8f2aa49e9369a43531bc9174d21f"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 76291,
-      "sha256": "3347b9656c42665d770a985622223660cfc476c862bacaa2b9ad85991ae233c5"
+      "sha256": "9a29fe9752c781d01c4c29d071d7c7aecf1e85241e06f9cdebb8f888675b59b5"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 11098,
-      "sha256": "c6f13ec00a6e9fabb2af6b8765362fdcae6dd218055a7d717e2b73b90639c1a4"
+      "sha256": "1293a2155a572fc91e05b691492bdcd8c07a9c77f3038680c52986bdfd122373"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "6b1566a91b424a482cdd1e080283ca5b8765b40e281e5055b41437919a609982"
+      "sha256": "1579f5aa457dc2eaac50f5ce988f21c75719bc989263e9c9320ca9642be7546e"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 105202,
-      "sha256": "bcaacef99e9aca6ba52475a477d3d685ff3df8de060fdf220dabf5d1d33a5368",
+      "sha256": "5b86690ebded7ba43639a210c011d9fd974a3ef2fa5ebd94736276b9194e9d6a",
       "counts": {
         "lexemes": 529,
         "cloze": 183,
@@ -341,15 +341,15 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 212786,
-      "sha256": "21ccd0bfc3672e229bf124e1188a4a66fa74977952df4132fa8f30c1fed11292"
+      "sha256": "30a12c1f1bd3f32552d91e332788b10dedd1c8f3f2a9633ca00062a9cd17bff7"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 320945,
-      "sha256": "75d76502f956d052047859df363d7692d775bc2c8cdb163293c7b96f22efaeb3"
+      "bytes": 321029,
+      "sha256": "31a677cbc31c60cff845979fa772bfe89e734a517315674d28d4f2d1e2d983bd"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 154306,
-      "sha256": "d2946db710f5a42aa2973cebb04683e1dcedf217b36c7d24e641fdf3e7c6d9b1"
+      "sha256": "43ce05df5a82e2ab8b16e27a460ff2e2d2e31c9357f1a943373938b85f06105e"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 418175,
-      "sha256": "03aeff3c75a438e5c5f32c300eb9642b515ef89639f82c7a7d42a1a7f6b34ec2"
+      "sha256": "4067aa26bff0b724692e8b21850ea6638f57c938a33508421f7a05495c269830"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 299425,
-      "sha256": "2c21959b2e02aacbcdc34f6179ed7cfb7349f676fb35ccbfecd3e1ba2c9e7b9d"
+      "sha256": "792ab3c518106da645a0d5d31fdb38addf1c171184228cd4ad141e9b241fed65"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 30629,
-      "sha256": "39cef0c0b9cc60fb5589ac12300ede48c3114cd9d343e4718a0160cc63a26083"
+      "sha256": "cc26fc2b008f6313a4dab74c2e7c5f4a076b6a56d3163229637c537bf9a27f10"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 2060,
-      "sha256": "304996b4c26f40a6378a4858224acd91f6860c53a7744d6c45ef6eafa8e14899"
+      "sha256": "ed8685c51d16dd36bcd7fb5c4208426b9a78ceb4ab3f1924c4489693f88e6df6"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 2357,
-      "sha256": "c94a7cff1126c4f6cbcd941c40ace7d6f05bc4214c7a0a664a4977269598c32f"
+      "sha256": "b1d8799adf614e1e6064c5ab2ead3b12a58d27b8e6610ca1a68c7919a6ac89ea"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-55ddad29e18c980d.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-d0f484b18d7386f8.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-55ddad29e18c980d",
+  "deck_version": "atlas-practice-v1-d0f484b18d7386f8",
   "package_schema_version": 1,
-  "gz_sha256": "5ab557f6a942b03601167d8edf89b626e3081b2a707525eac2d185b07acd4cc2",
-  "package_sha256": "86fa29a38e03301c53daf772f83056dd5a8703a1f6a1d53afd5f7343d6e8b668",
-  "gz_bytes": 1686310,
-  "package_bytes": 22541672,
+  "gz_sha256": "8f3a8220a3e6aa37fefccc741f346dbcf1c418255032931ff6a5666791125cd2",
+  "package_sha256": "407fb8da3fb8884639af98a089c1e0d294aff9b02fbf5ea2735893661c497bee",
+  "gz_bytes": 1684563,
+  "package_bytes": 22548943,
   "file_count": 45,
   "files": [
     {
@@ -14,13 +14,13 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 283228,
-      "sha256": "35e13fd209ea06e41e8f7623c04b02f5f5587ec48977f712497d7d8710e1b6f8",
+      "bytes": 283725,
+      "sha256": "e263fbc03c31fe0118c09edf50fcfa51bb0939a1677d9484bcb9a1b15d2b2fb5",
       "counts": {
         "lexemes": 1470,
-        "cloze": 1033,
-        "clozeEligibleLexemes": 989,
-        "clozeCoverage": 0.6728
+        "cloze": 1046,
+        "clozeEligibleLexemes": 1002,
+        "clozeCoverage": 0.6816
       }
     },
     {
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533438,
-      "sha256": "4b673eb84a78f61d0996395cffa1af6f40fb14999e37a04e209a753dcf1a654b"
+      "sha256": "c83bfec304a0422d0aa0b926d87fe5f17882f89eab17aea0ca71245adb950151"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1729801,
-      "sha256": "56eef8f5f6c25b66dfbb3b835f0f77b262e912a7f44d6afcc34ea23bada534ce"
+      "bytes": 1740177,
+      "sha256": "505905d1de8d3902d4b4e5fe3c85826d2da23fe3a17de3a1f5f0f2db6c204a24"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 349915,
-      "sha256": "0cfe421a16d178d9fb71f566f7046e3d6c9c655403f506dd22052f97995246c6"
+      "sha256": "4a89580941e5678799e73cf9097822ac4aaeddd4e98ef4dcfa418229658d2860"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 370047,
-      "sha256": "08ec438fb5f1645a7986e84466df4df11097a10fec6f6b23a6bbd3c111c89f8e"
+      "sha256": "addd1f3f694137ee9561aa07ba29114d5b503010a1601b4a825f80df31ea0ba2"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 615568,
-      "sha256": "802bde2d96660aec1c40b5f9b0349a53f1154704427805cf1ec0ca7dc7cff1e4"
+      "sha256": "87f7fadef067f60e94723867a970936d5c3988a6efeba9d07a28ca86c1161016"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "3fc06b8daa6c7e46f6a2d5115e3f2d9c5c86eafe4e2ba9ba2dd3404b9e6d4c7a"
+      "sha256": "20374b0d2a7aa55493e98ab9657e9dd57f87b5d4425a9419ab79d76f5e2b9e2e"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 257,
-      "sha256": "be10bdb55ebe2dd0b61da01c1c7b45cd257469182d8455ecd32336b4c4d73ee5"
+      "sha256": "9272f2cc47f8dd3c8c172233ef5977100246178f82995873e27b39ea4ed817bc"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,20 +85,20 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 3491,
-      "sha256": "ac866df342bad39f25df3a95b7fb927299cc8f6f54bcaa7941ba4f2b41b4ac5b"
+      "sha256": "9891e93b36f5da87f37dc12ad94bcd5e48558ba1a6fa642aeeedc605dd7c19f2"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 294835,
-      "sha256": "0c28d0b6127fd437306176ed049da5cef0b3f07aa582e090f068f285cc0c3646",
+      "bytes": 295146,
+      "sha256": "de0a4c66e4f2eccaece6e854db74075ac34a709ee46ea8b16c9d0185beb6abcc",
       "counts": {
         "lexemes": 1444,
-        "cloze": 1087,
-        "clozeEligibleLexemes": 1087,
-        "clozeCoverage": 0.7528
+        "cloze": 1095,
+        "clozeEligibleLexemes": 1095,
+        "clozeCoverage": 0.7583
       }
     },
     {
@@ -107,15 +107,15 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 536102,
-      "sha256": "c0a40998acf6edbc727807e3cd7aa590b3ee570d082c1a233d83dcd7b3d76f9d"
+      "sha256": "2c6803198ae28990813a644be535153b58fceb9925cc2320b03ecc9fee49bec5"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1875917,
-      "sha256": "289cec7390d36b05ad24636da250a15b848adb34658abc6b8712ce5bafeca930"
+      "bytes": 1877951,
+      "sha256": "b6d3e51a0328687d5483db2c755765ee8444529ae5a653fcd5250dbc1abc0955"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 390102,
-      "sha256": "f7a6dd3ca1ffb7e6ffabf44faeeaaf657fcd62c230d281b35bf4e152c9aac8b6"
+      "sha256": "1735c755fb1b9769eaf46f87ad27da3089bc797fd2a2d16a299177aa9849cf3b"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1026094,
-      "sha256": "f4500aac55b8a6d116c1b2e28caf784d6f256bea265a6b69e73f4f38841d7dba"
+      "sha256": "48595e736b385c5d046e8de15696545884dea55c9fdde0fa9073d2974ea8befd"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 567900,
-      "sha256": "4c8df185ed6fe90d4f8c6b5577a8b52d77bfc508b1941edf501e6760e08d0af6"
+      "sha256": "b5d6600bc13a8c4530bdf2d10b47f252133af79e0ad6b1d22d843c34f165e373"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,7 +147,7 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "944efb666fbc0c044f32ad19a99862fddccc8d689ee4fe1116ca195ed002b046"
+      "sha256": "c6bf0e54817d96dfa0246fb0289ea7978b50e00298eb2f439dd6967330c1ef54"
     },
     {
       "path": "practice-heritage.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-heritage",
       "bytes": 33411,
-      "sha256": "8d085243ac8c54140f7d45ddf6c52d9facc29cee0e01771d3e9cf473a1226b9c"
+      "sha256": "5d1513103caf4fb2d67ce198fd672a85d3774e852bfcb46b98102924d24c3afe"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,20 +163,20 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 3454,
-      "sha256": "98e7c55f504270887bfdfbfb1dc51044522697233d233b715f28d29b6d2f4f94"
+      "sha256": "390264f0694451d4d7d1be96b223f03c5356c7bdc1dad22159e7b4c25cfc7731"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 336003,
-      "sha256": "6a7f11fb39d4a1b4dc66e710965bb7db850e09bedc9ce963ede11dbfd5b283d0",
+      "bytes": 336167,
+      "sha256": "435509fb2e5807ecf37177cc1d7092c59b30ad903c8d409e2670bf04f112acad",
       "counts": {
         "lexemes": 1617,
-        "cloze": 1269,
-        "clozeEligibleLexemes": 1269,
-        "clozeCoverage": 0.7848
+        "cloze": 1273,
+        "clozeEligibleLexemes": 1273,
+        "clozeCoverage": 0.7873
       }
     },
     {
@@ -185,15 +185,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 634474,
-      "sha256": "a920e55124b8aea5038f7cb307e0b29750634457849bd5c8a9f348c86dbbcee1"
+      "sha256": "88751b0a9495637803ae285ec5fdde097b196685520af026c8469b4bbcd88e9b"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 2202015,
-      "sha256": "93dcfcff17ae23d8435059041284964cd331b6e2be376f48269577838e5a31d6"
+      "bytes": 2194352,
+      "sha256": "dc0ad48b015dffd76c0a7f725b708d5a7c61a524713ed8f18dca4637cb443b16"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 451935,
-      "sha256": "67d6c8aabcdf76087eb4ffb4971f346fa199dad2452a4978e0f5d2a6148bfda4"
+      "sha256": "bca0983aea21d35f975044332a144f5daf8ea90fcdddd4418122eb0360621417"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1363476,
-      "sha256": "ef0ded490d7755ab102fbb7f01744d1a7c4879c5e41db28301c615173d26d95b"
+      "sha256": "0434738812c6a3b8e19f093427b5e6c1ef10e2352dce24f2ce90914c6aa957d1"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 785386,
-      "sha256": "3ae4db5a985f4c7c37a15c7575eed8a63ef800958eddfea4b047d0f8ce7bf20b"
+      "sha256": "8b5cae69bcb82d9a24683fa38a830d2edce3998ef6641cd23ce2a61374e5334e"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,7 +225,7 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 346573,
-      "sha256": "a4f20b43f51268f5e1d5a3c4d1714cfbf906f36b8e0789c0d8797c23d91d5e7c"
+      "sha256": "8aae77078a4f819e62ad05b8cb5103de474cee8d6e68a30234e03abcd90c5485"
     },
     {
       "path": "practice-heritage.B1.json",
@@ -233,7 +233,7 @@
       "level": "B1",
       "schema": "atlas-practice-heritage",
       "bytes": 74730,
-      "sha256": "5e20da8fade7e60543c9a38c577ba02845c75190c5dd426c7265cffeb5cd205f"
+      "sha256": "09fecf772dac0e2d5b8cf3f27ef28530c738db2b0d759df0e3d4ae25cc7e23c6"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -241,20 +241,20 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 2500,
-      "sha256": "153187bd74688d7b92e1fc5cf012fd221dd1cc48992b7ac958876da96bd94014"
+      "sha256": "00da875de647af3b2f5ad3924378219768c2b5824c180240a83810ecbc577f23"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 197221,
-      "sha256": "674bced557009e2f2d64865ded44b7cf9274bfa721d7d17c91bb1fbd3fb74a51",
+      "bytes": 197327,
+      "sha256": "4c1c983cd910eaa41da97f2aa03cdddc7d9a10bade7eea67a330cf48b8df36d4",
       "counts": {
         "lexemes": 940,
-        "cloze": 696,
-        "clozeEligibleLexemes": 696,
-        "clozeCoverage": 0.7404
+        "cloze": 699,
+        "clozeEligibleLexemes": 699,
+        "clozeCoverage": 0.7436
       }
     },
     {
@@ -263,15 +263,15 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 381338,
-      "sha256": "f7d8e5893e981ad317f435c808addb714e1b919e5ba4901986e3e4204e540327"
+      "sha256": "1c9f06c64f0e04d253821874495b26cfffbfd04c8b0dec00225363b7a327551f"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1218519,
-      "sha256": "683e3125d5ac21ff01caf5b5d6e5eecffc998a057d84c16e9ce362262cc5e25e"
+      "bytes": 1215647,
+      "sha256": "8768bce0c3b3d16a4812759b291170a2ad704f8a8ce956bd8be26cf1823a25e6"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 281264,
-      "sha256": "2e1972957021954e43864d7970f8242fcb5245da3075625861cd481c363b988f"
+      "sha256": "1498b9b198b812e6121db523d3c4eb199fcb7823be5eff12f35155e5c2d093df"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 799654,
-      "sha256": "156086a27ebf2fe6532c4bfb7f550ddb7692b9716db23f525475a9ae07bdadf1"
+      "sha256": "0ac2b69577b43cb66d394d270785b19841a4d5ec130befea9041564f3db07cf9"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 507721,
-      "sha256": "9922cb235452dfbb9e4981ec224c8854f71855295381db5f30c705ca5a206de2"
+      "sha256": "ae7bc69575052276cdd4f7da448ff613e46e11430539a0887b5175a69e75b490"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 76291,
-      "sha256": "6cf9cc62d6b66f94e6c80591b5cc55c9389dc4703ab287b9d1521e6432cb0764"
+      "sha256": "3347b9656c42665d770a985622223660cfc476c862bacaa2b9ad85991ae233c5"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 11098,
-      "sha256": "a9f81e47c7afe9d0e9c8b79c1f029a78698a3764b4aa0ad49001d2ad733ae412"
+      "sha256": "c6f13ec00a6e9fabb2af6b8765362fdcae6dd218055a7d717e2b73b90639c1a4"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "6e986645d99fca89ddcebde0eea82b569ed65d65bb09b9345941dc7db356335d"
+      "sha256": "6b1566a91b424a482cdd1e080283ca5b8765b40e281e5055b41437919a609982"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 105202,
-      "sha256": "c4aa180c1f9ec8d998881869722900054693c6aa648bfa75f25e98c7cb9679ea",
+      "sha256": "bcaacef99e9aca6ba52475a477d3d685ff3df8de060fdf220dabf5d1d33a5368",
       "counts": {
         "lexemes": 529,
         "cloze": 183,
@@ -341,15 +341,15 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 212786,
-      "sha256": "ba809a0a208fb1b86bf2336069129f315aa72b815d54657cbd0a1560b69fe8a1"
+      "sha256": "21ccd0bfc3672e229bf124e1188a4a66fa74977952df4132fa8f30c1fed11292"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 322395,
-      "sha256": "d4a121fc989f59accd8c11c528df88e9f3442f8e7362307e5a13571474a707ad"
+      "bytes": 320945,
+      "sha256": "75d76502f956d052047859df363d7692d775bc2c8cdb163293c7b96f22efaeb3"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 154306,
-      "sha256": "c8a67c8260c1bfc51053e71a629d243efb397689427b195996726e8892c315f0"
+      "sha256": "d2946db710f5a42aa2973cebb04683e1dcedf217b36c7d24e641fdf3e7c6d9b1"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 418175,
-      "sha256": "b485038718900af5505af3a6196a4806c59c5d64784c57cc3a6a1e128acbcfa0"
+      "sha256": "03aeff3c75a438e5c5f32c300eb9642b515ef89639f82c7a7d42a1a7f6b34ec2"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 299425,
-      "sha256": "40ad0d33770f1839533092eb3c2ab5b44110f85ef28d0c9067680d8d505cc47a"
+      "sha256": "2c21959b2e02aacbcdc34f6179ed7cfb7349f676fb35ccbfecd3e1ba2c9e7b9d"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 30629,
-      "sha256": "90089db5b612adacc5ae4948855e9c6122646032c33421cca42a35eca4383b64"
+      "sha256": "39cef0c0b9cc60fb5589ac12300ede48c3114cd9d343e4718a0160cc63a26083"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 2060,
-      "sha256": "20a3b910a13c7d9a9ce3cde458dc4dca674c8cbf1117d3c9aff1057376171255"
+      "sha256": "304996b4c26f40a6378a4858224acd91f6860c53a7744d6c45ef6eafa8e14899"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 2357,
-      "sha256": "d8cc24776153858b0fb0f348c463a868c01df11b77e44cb0bbc95528e7fe82ce"
+      "sha256": "c94a7cff1126c4f6cbcd941c40ace7d6f05bc4214c7a0a664a4977269598c32f"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/site/src/data/lexicon-sentence-inventory.json
+++ b/site/src/data/lexicon-sentence-inventory.json
@@ -2003,26 +2003,6 @@
       }
     },
     {
-      "lemma": "американка",
-      "lemmaId": "американка",
-      "sentence": "У головних ролях знялися американка Хейлі Стайнфелд і британець Дуглас Бут.",
-      "targetForm": "американка",
-      "cefr": "B1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "9-klas-mystetstvo-masol-2017_s0141",
-        "title": "Сторінка 127"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "аналогічно",
       "lemmaId": "аналогічно",
       "sentence": "Аналогічно в цьому самому записі поля Оклад виберемо функцію Сума.",
@@ -3643,26 +3623,6 @@
       }
     },
     {
-      "lemma": "безумовно",
-      "lemmaId": "безумовно",
-      "sentence": "Безумовно, випускники складуть іспити.",
-      "targetForm": "Безумовно",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0145",
-        "title": "Сторінка 146"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "безхмарний",
       "lemmaId": "безхмарний",
       "sentence": "Розповідати, безхмарний, росхитаний.",
@@ -5076,26 +5036,6 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ukrmova-karaman-2018_s0434",
         "title": "Сторінка 244"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "буквально",
-      "lemmaId": "буквально",
-      "sentence": "З кінця серпня до початку вересня граки буквально окуповують родючі дерева.",
-      "targetForm": "буквально",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0140",
-        "title": "Сторінка 95"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -8363,26 +8303,6 @@
       }
     },
     {
-      "lemma": "вид",
-      "lemmaId": "вид",
-      "sentence": "Суперечку як вид комунікації вперше почали досліджувати давньогрецькі філософи.",
-      "targetForm": "вид",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0271",
-        "title": "Сторінка 184"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "видавати",
       "lemmaId": "видавати",
       "sentence": "Який Прем’єр-міністр України дістав право видавати декрети?",
@@ -8776,26 +8696,6 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-ukrlit-zabolotnyi-2022_s0253",
         "title": "Сторінка 188"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "викладач",
-      "lemmaId": "викладач",
-      "sentence": "Підручники в академії були рукописними, авторськими, бо кожен викладач мусив складати свій курс лекцій.",
-      "targetForm": "викладач",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrajinska-mova-voron-2019_s0106",
-        "title": "Сторінка 75"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -10523,26 +10423,6 @@
       }
     },
     {
-      "lemma": "витрата",
-      "lemmaId": "витрата",
-      "sentence": "Водночас із надходженням сонячного тепла на Землю відбувається і його витрата у вигляді випромінювання.",
-      "targetForm": "витрата",
-      "cefr": "B2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "8-klas-heohrafiya-hilberh-2025_s0112",
-        "title": "Сторінка 81"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "витрати",
       "lemmaId": "витрати",
       "sentence": "Змінні витрати зазвичай належать до прямих витрат.",
@@ -10916,26 +10796,6 @@
         "label": "Ukrainian school textbook",
         "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0125",
         "title": "Сторінка 127"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "вказівка",
-      "lemmaId": "вказівка",
-      "sentence": "У цих словах міститься вказівка на основне питання, що його порушив автор.",
-      "targetForm": "вказівка",
-      "cefr": "B2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0126",
-        "title": "Сторінка 67"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -11856,26 +11716,6 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-3-00-lesson-notes_l0099_w008",
         "title": "Lesson 99: План подорожі (Голосове повідомлення №4) Travel plan (Voice message №4) (part 8/21)"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "воно",
-      "lemmaId": "воно",
-      "sentence": "Воно постало з козацького хутора й виросло до гіганта.",
-      "targetForm": "Воно",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "4-klas-ukrmova-zaharijchuk_s0037",
-        "title": "Сторінка 38"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -18703,26 +18543,6 @@
       }
     },
     {
-      "lemma": "гіркий",
-      "lemmaId": "гіркий",
-      "sentence": "Не тільки вітер доносить до нас гіркий полинний запах нашої історії.",
-      "targetForm": "гіркий",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0007",
-        "title": "Сторінка 8"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "гірше",
       "lemmaId": "гірше",
       "sentence": "Псевдопатріоти засуджують ідеали народовців, їхнє «ходіння в народ» ще гірше за царський уряд.",
@@ -21196,26 +21016,6 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-zarlit-voloschuk-2024_s0196",
         "title": "Сторінка 138"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "доброта",
-      "lemmaId": "доброта",
-      "sentence": "Я знаю: править світом доброта.",
-      "targetForm": "доброта",
-      "cefr": "B1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "9-klas-ukrajinska-mova-voron-2017_s0016",
-        "title": "Сторінка 17"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -34743,26 +34543,6 @@
       }
     },
     {
-      "lemma": "зошит",
-      "lemmaId": "зошит",
-      "sentence": "У портфелі лежав новий зошит.",
-      "targetForm": "зошит",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0087",
-        "title": "Сторінка 86"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "зрадіти",
       "lemmaId": "зрадіти",
       "sentence": "Надмірно турботливі батьки вже встигли зрадіти цій новині, як раптом виявилося, що це фейк.",
@@ -41123,26 +40903,6 @@
       }
     },
     {
-      "lemma": "кухня",
-      "lemmaId": "кухня",
-      "sentence": "Найбільшу популярність Франції принесли мода, парфумерія, мистецтво й кухня.",
-      "targetForm": "кухня",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0017",
-        "title": "Сторінка 19"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "кухонний",
       "lemmaId": "кухонний",
       "sentence": "У штанях, натягнутих нашвидку, з голим торсом, дядько Павло загрозливо тримав у правиці кухонний молоток для відбивання м’яса.",
@@ -42283,26 +42043,6 @@
       }
     },
     {
-      "lemma": "лимон",
-      "lemmaId": "лимон",
-      "sentence": "Як правило, ні лимон, ні апельсин не опадають на першому році життя.",
-      "targetForm": "лимон",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "7-klas-ukrmova-avramenko-2024_s0021",
-        "title": "Сторінка 19"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "лимонад",
       "lemmaId": "лимонад",
       "sentence": "Як приготувати лимонад?",
@@ -42316,26 +42056,6 @@
         "label": "Ukrainian school textbook",
         "locator": "2-klas-ukrmova-bolshakova-2019-1_s0088",
         "title": "Сторінка 87"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "липень",
-      "lemmaId": "липень",
-      "sentence": "У червні червоніють ягоди, липень — час цвітіння липи.",
-      "targetForm": "липень",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "6-klas-ukrmova-litvinova-2023_s0097",
-        "title": "Сторінка 90"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -42956,26 +42676,6 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-hromadianska-gisem-2018_s0332",
         "title": "Сторінка 171"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "лютий",
-      "lemmaId": "лютий",
-      "sentence": "Коли ворог йшов війною, метушилось все, як рій, замикалися ворота, починався лютий бій.",
-      "targetForm": "лютий",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0049",
-        "title": "Сторінка 50"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -43896,26 +43596,6 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-hromadianska-osvita-pometun-2026_s0074",
         "title": "Сторінка 62"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "майбутній",
-      "lemmaId": "майбутній",
-      "sentence": "Після війни майбутній письменник навчався на літературному факультеті Донецького педінституту.",
-      "targetForm": "майбутній",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0117",
-        "title": "Сторінка 119"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -45503,26 +45183,6 @@
       }
     },
     {
-      "lemma": "минулий",
-      "lemmaId": "минулий",
-      "sentence": "За минулий місяць споживацький кошик ще трохи подорожчав.",
-      "targetForm": "минулий",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0045",
-        "title": "Сторінка 34"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "минути",
       "lemmaId": "минути",
       "sentence": "Дещо відокремленим у цій збірці є цикл «Минути», де постають картини світу, в якому живе звичайна людина.",
@@ -46463,26 +46123,6 @@
       }
     },
     {
-      "lemma": "мор",
-      "lemmaId": "мор",
-      "sentence": "Рим пережив мор.",
-      "targetForm": "мор",
-      "cefr": "B2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "8-klas-mystetstvo-komarovska-2025_s0056",
-        "title": "Сторінка 58"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "море",
       "lemmaId": "море",
       "sentence": "І грає, і піниться синєє море.",
@@ -47083,26 +46723,6 @@
       }
     },
     {
-      "lemma": "мільярд",
-      "lemmaId": "мільярд",
-      "sentence": "Ніхто не виграє мільярд доларів у лотерею.",
-      "targetForm": "мільярд",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrmova-karaman-2018_s0479",
-        "title": "Сторінка 267"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "міміка",
       "lemmaId": "міміка",
       "sentence": "У деяких випадках міміка може виявити справжні почуття людини щодо певної ситуації.",
@@ -47156,26 +46776,6 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ekonomika-krupska-2018_s0386",
         "title": "Сторінка 197"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "міністерство",
-      "lemmaId": "міністерство",
-      "sentence": "Міністерство очолює міністр України, який є членом Кабінету Міністрів України.",
-      "targetForm": "Міністерство",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0454",
-        "title": "Сторінка 205"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -48216,26 +47816,6 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-ukrmova-litvinova-2022_s0171",
         "title": "Сторінка 166"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "наголосити",
-      "lemmaId": "наголосити",
-      "sentence": "Вони допомагають наголосити на важливому моменті.",
-      "targetForm": "наголосити",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0081",
-        "title": "Сторінка 54"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -50483,26 +50063,6 @@
       }
     },
     {
-      "lemma": "науково",
-      "lemmaId": "науково",
-      "sentence": "Науково доведено, що втома негативно позначається на імунітеті й обміні речовин, ефективності виконання розумових операцій, зосередженості.",
-      "targetForm": "Науково",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0378",
-        "title": "Сторінка 224"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "нахилитися",
       "lemmaId": "нахилитися",
       "sentence": "Треба нахилитися, щоб із криниці води напитися.",
@@ -52123,26 +51683,6 @@
       }
     },
     {
-      "lemma": "неправда",
-      "lemmaId": "неправда",
-      "sentence": "Може, хтось подумає, ніби казка — неправда.",
-      "targetForm": "неправда",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "5-klas-ukrmova-avramenko-2022_s0160",
-        "title": "Сторінка 155"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "неправильний",
       "lemmaId": "неправильний",
       "sentence": "Мішані числа Пригадаємо, що таке неправильний дріб.",
@@ -53576,26 +53116,6 @@
         "label": "Ukrainian school textbook",
         "locator": "4-klas-ukrayinska-mova-varzatska-2021-1_s0046",
         "title": "Сторінка 48"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "о",
-      "lemmaId": "о",
-      "sentence": "Прокинувся о сьомій годині ранку.",
-      "targetForm": "о",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "4-klas-ukrmova-zaharijchuk_s0116",
-        "title": "Сторінка 117"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -55316,26 +54836,6 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-etyka-meleshchenko-2022_s0200",
         "title": "Сторінка 201"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "одноразовий",
-      "lemmaId": "одноразовий",
-      "sentence": "Так виникає одноразовий сплеск геомагнітного збурення, який триває близько години.",
-      "targetForm": "одноразовий",
-      "cefr": "B1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0382",
-        "title": "Сторінка 237"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -76743,26 +76243,6 @@
       }
     },
     {
-      "lemma": "редактор",
-      "lemmaId": "редактор",
-      "sentence": "Якось трапилося неймовірне: редактор прийняв його повість.",
-      "targetForm": "редактор",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0284",
-        "title": "Сторінка 198"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "редакторка",
       "lemmaId": "редакторка",
       "sentence": "Редакторка: Так, маємо вільне місце, але в нас конкурс.",
@@ -77956,26 +77436,6 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0298",
         "title": "Сторінка 155"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "родовий",
-      "lemmaId": "родовий",
-      "sentence": "Знахідний відмінок виражає повне охоплення предмета дією, а родовий – часткове.",
-      "targetForm": "родовий",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0095",
-        "title": "Сторінка 94"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -80023,26 +79483,6 @@
       }
     },
     {
-      "lemma": "різати",
-      "lemmaId": "різати",
-      "sentence": "Спочатку почав різати слух тон, яким розмовляв наш хлопчик.",
-      "targetForm": "різати",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0234",
-        "title": "Сторінка 173"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "різдвяний",
       "lemmaId": "різдвяний",
       "sentence": "І коли це сталося, чудовий різдвяний ангел із тоненькими білими крильцями та лагідними оченятами весело закружляв над ними...",
@@ -80796,26 +80236,6 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-4-00-lesson-notes_l0150_w011",
         "title": "Lesson 150: Коронавірус в Україні (part 11/18)"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "сантиметр",
-      "lemmaId": "сантиметр",
-      "sentence": "Равлики не розрізняють кольору і бачать предмети на відстані один сантиметр.",
-      "targetForm": "сантиметр",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0119",
-        "title": "Сторінка 121"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -90443,26 +89863,6 @@
       }
     },
     {
-      "lemma": "тема",
-      "lemmaId": "тема",
-      "sentence": "Ця тема із самого початку викличе непідробний інтерес аудиторії.",
-      "targetForm": "тема",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0097",
-        "title": "Сторінка 63"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "темний",
       "lemmaId": "темний",
       "sentence": "До речі, синій колір — темний, а блакитний чи голубий — це світло-синій колір.",
@@ -91236,26 +90636,6 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0189",
         "title": "Сторінка 87"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "то",
-      "lemmaId": "то",
-      "sentence": "А як іти, то йти, — каже хлопець.",
-      "targetForm": "то",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "3-klas-ukrainska-mova-savchuk-2020-2_s0066",
-        "title": "Сторінка 68"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -93303,26 +92683,6 @@
       }
     },
     {
-      "lemma": "узагальнення",
-      "lemmaId": "узагальнення",
-      "sentence": "Інваріант фонеми — це абстрактне поняття, що означає матеріальне узагальнення суттєвих для фонеми ознак.",
-      "targetForm": "узагальнення",
-      "cefr": "A2",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-ukrmova-karaman-2018_s0079",
-        "title": "Сторінка 43"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
       "lemma": "узагальнено-особове",
       "lemmaId": "узагальнено-особове",
       "sentence": "Вид односкладного речення Приклад 1 безособове 2 означено-особове 3 неозначено-особове 4 узагальнено-особове А Вовка пастухом не ставлять.",
@@ -93736,26 +93096,6 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-zabolotnyi-2024_s0225",
         "title": "Сторінка 154"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "умова",
-      "lemmaId": "умова",
-      "sentence": "Вивчення джерел НС воєнного часу — необхідна умова підготовки людей до можливих бойових дій.",
-      "targetForm": "умова",
-      "cefr": "B1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "10-klas-zakhyst-fuka-2023_s0452",
-        "title": "Сторінка 248"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -101974,26 +101314,6 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-zabolotnyi-2024_s0424",
         "title": "Сторінка 279"
-      },
-      "license": {
-        "status": "not_openly_licensed",
-        "useBasis": "short educational quotation with attribution"
-      }
-    },
-    {
-      "lemma": "є",
-      "lemmaId": "є",
-      "sentence": "Чи є відмінність у вживанні абревіатур у художньому й інших стилях?",
-      "targetForm": "є",
-      "cefr": "A1",
-      "uses": [
-        "example"
-      ],
-      "provenance": {
-        "source": "textbook",
-        "label": "Ukrainian school textbook",
-        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0253",
-        "title": "Сторінка 179"
       },
       "license": {
         "status": "not_openly_licensed",

--- a/site/src/data/lexicon-sentence-inventory.json
+++ b/site/src/data/lexicon-sentence-inventory.json
@@ -2003,6 +2003,26 @@
       }
     },
     {
+      "lemma": "американка",
+      "lemmaId": "американка",
+      "sentence": "У головних ролях знялися американка Хейлі Стайнфелд і британець Дуглас Бут.",
+      "targetForm": "американка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0141",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "аналогічно",
       "lemmaId": "аналогічно",
       "sentence": "Аналогічно в цьому самому записі поля Оклад виберемо функцію Сума.",
@@ -3623,6 +3643,26 @@
       }
     },
     {
+      "lemma": "безумовно",
+      "lemmaId": "безумовно",
+      "sentence": "Безумовно, випускники складуть іспити.",
+      "targetForm": "Безумовно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0145",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "безхмарний",
       "lemmaId": "безхмарний",
       "sentence": "Розповідати, безхмарний, росхитаний.",
@@ -5036,6 +5076,26 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ukrmova-karaman-2018_s0434",
         "title": "Сторінка 244"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "буквально",
+      "lemmaId": "буквально",
+      "sentence": "З кінця серпня до початку вересня граки буквально окуповують родючі дерева.",
+      "targetForm": "буквально",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0140",
+        "title": "Сторінка 95"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -8303,6 +8363,26 @@
       }
     },
     {
+      "lemma": "вид",
+      "lemmaId": "вид",
+      "sentence": "Суперечку як вид комунікації вперше почали досліджувати давньогрецькі філософи.",
+      "targetForm": "вид",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0271",
+        "title": "Сторінка 184"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "видавати",
       "lemmaId": "видавати",
       "sentence": "Який Прем’єр-міністр України дістав право видавати декрети?",
@@ -8696,6 +8776,26 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-ukrlit-zabolotnyi-2022_s0253",
         "title": "Сторінка 188"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "викладач",
+      "lemmaId": "викладач",
+      "sentence": "Підручники в академії були рукописними, авторськими, бо кожен викладач мусив складати свій курс лекцій.",
+      "targetForm": "викладач",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0106",
+        "title": "Сторінка 75"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -10423,6 +10523,26 @@
       }
     },
     {
+      "lemma": "витрата",
+      "lemmaId": "витрата",
+      "sentence": "Водночас із надходженням сонячного тепла на Землю відбувається і його витрата у вигляді випромінювання.",
+      "targetForm": "витрата",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0112",
+        "title": "Сторінка 81"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "витрати",
       "lemmaId": "витрати",
       "sentence": "Змінні витрати зазвичай належать до прямих витрат.",
@@ -10796,6 +10916,26 @@
         "label": "Ukrainian school textbook",
         "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0125",
         "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вказівка",
+      "lemmaId": "вказівка",
+      "sentence": "У цих словах міститься вказівка на основне питання, що його порушив автор.",
+      "targetForm": "вказівка",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0126",
+        "title": "Сторінка 67"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -11716,6 +11856,26 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-3-00-lesson-notes_l0099_w008",
         "title": "Lesson 99: План подорожі (Голосове повідомлення №4) Travel plan (Voice message №4) (part 8/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "воно",
+      "lemmaId": "воно",
+      "sentence": "Воно постало з козацького хутора й виросло до гіганта.",
+      "targetForm": "Воно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrmova-zaharijchuk_s0037",
+        "title": "Сторінка 38"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -18543,6 +18703,26 @@
       }
     },
     {
+      "lemma": "гіркий",
+      "lemmaId": "гіркий",
+      "sentence": "Не тільки вітер доносить до нас гіркий полинний запах нашої історії.",
+      "targetForm": "гіркий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0007",
+        "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "гірше",
       "lemmaId": "гірше",
       "sentence": "Псевдопатріоти засуджують ідеали народовців, їхнє «ходіння в народ» ще гірше за царський уряд.",
@@ -21016,6 +21196,26 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-zarlit-voloschuk-2024_s0196",
         "title": "Сторінка 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "доброта",
+      "lemmaId": "доброта",
+      "sentence": "Я знаю: править світом доброта.",
+      "targetForm": "доброта",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0016",
+        "title": "Сторінка 17"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -34543,6 +34743,26 @@
       }
     },
     {
+      "lemma": "зошит",
+      "lemmaId": "зошит",
+      "sentence": "У портфелі лежав новий зошит.",
+      "targetForm": "зошит",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0087",
+        "title": "Сторінка 86"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "зрадіти",
       "lemmaId": "зрадіти",
       "sentence": "Надмірно турботливі батьки вже встигли зрадіти цій новині, як раптом виявилося, що це фейк.",
@@ -40903,6 +41123,26 @@
       }
     },
     {
+      "lemma": "кухня",
+      "lemmaId": "кухня",
+      "sentence": "Найбільшу популярність Франції принесли мода, парфумерія, мистецтво й кухня.",
+      "targetForm": "кухня",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0017",
+        "title": "Сторінка 19"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "кухонний",
       "lemmaId": "кухонний",
       "sentence": "У штанях, натягнутих нашвидку, з голим торсом, дядько Павло загрозливо тримав у правиці кухонний молоток для відбивання м’яса.",
@@ -42043,6 +42283,26 @@
       }
     },
     {
+      "lemma": "лимон",
+      "lemmaId": "лимон",
+      "sentence": "Як правило, ні лимон, ні апельсин не опадають на першому році життя.",
+      "targetForm": "лимон",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-avramenko-2024_s0021",
+        "title": "Сторінка 19"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "лимонад",
       "lemmaId": "лимонад",
       "sentence": "Як приготувати лимонад?",
@@ -42056,6 +42316,26 @@
         "label": "Ukrainian school textbook",
         "locator": "2-klas-ukrmova-bolshakova-2019-1_s0088",
         "title": "Сторінка 87"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "липень",
+      "lemmaId": "липень",
+      "sentence": "У червні червоніють ягоди, липень — час цвітіння липи.",
+      "targetForm": "липень",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0097",
+        "title": "Сторінка 90"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -42676,6 +42956,26 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-hromadianska-gisem-2018_s0332",
         "title": "Сторінка 171"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лютий",
+      "lemmaId": "лютий",
+      "sentence": "Коли ворог йшов війною, метушилось все, як рій, замикалися ворота, починався лютий бій.",
+      "targetForm": "лютий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0049",
+        "title": "Сторінка 50"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -43596,6 +43896,26 @@
         "label": "Ukrainian school textbook",
         "locator": "9-klas-hromadianska-osvita-pometun-2026_s0074",
         "title": "Сторінка 62"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "майбутній",
+      "lemmaId": "майбутній",
+      "sentence": "Після війни майбутній письменник навчався на літературному факультеті Донецького педінституту.",
+      "targetForm": "майбутній",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0117",
+        "title": "Сторінка 119"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -45183,6 +45503,26 @@
       }
     },
     {
+      "lemma": "минулий",
+      "lemmaId": "минулий",
+      "sentence": "За минулий місяць споживацький кошик ще трохи подорожчав.",
+      "targetForm": "минулий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0045",
+        "title": "Сторінка 34"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "минути",
       "lemmaId": "минути",
       "sentence": "Дещо відокремленим у цій збірці є цикл «Минути», де постають картини світу, в якому живе звичайна людина.",
@@ -46123,6 +46463,26 @@
       }
     },
     {
+      "lemma": "мор",
+      "lemmaId": "мор",
+      "sentence": "Рим пережив мор.",
+      "targetForm": "мор",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-mystetstvo-komarovska-2025_s0056",
+        "title": "Сторінка 58"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "море",
       "lemmaId": "море",
       "sentence": "І грає, і піниться синєє море.",
@@ -46723,6 +47083,26 @@
       }
     },
     {
+      "lemma": "мільярд",
+      "lemmaId": "мільярд",
+      "sentence": "Ніхто не виграє мільярд доларів у лотерею.",
+      "targetForm": "мільярд",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0479",
+        "title": "Сторінка 267"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "міміка",
       "lemmaId": "міміка",
       "sentence": "У деяких випадках міміка може виявити справжні почуття людини щодо певної ситуації.",
@@ -46776,6 +47156,26 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-ekonomika-krupska-2018_s0386",
         "title": "Сторінка 197"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "міністерство",
+      "lemmaId": "міністерство",
+      "sentence": "Міністерство очолює міністр України, який є членом Кабінету Міністрів України.",
+      "targetForm": "Міністерство",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0454",
+        "title": "Сторінка 205"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -47816,6 +48216,26 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-ukrmova-litvinova-2022_s0171",
         "title": "Сторінка 166"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наголосити",
+      "lemmaId": "наголосити",
+      "sentence": "Вони допомагають наголосити на важливому моменті.",
+      "targetForm": "наголосити",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0081",
+        "title": "Сторінка 54"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -50063,6 +50483,26 @@
       }
     },
     {
+      "lemma": "науково",
+      "lemmaId": "науково",
+      "sentence": "Науково доведено, що втома негативно позначається на імунітеті й обміні речовин, ефективності виконання розумових операцій, зосередженості.",
+      "targetForm": "Науково",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0378",
+        "title": "Сторінка 224"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "нахилитися",
       "lemmaId": "нахилитися",
       "sentence": "Треба нахилитися, щоб із криниці води напитися.",
@@ -51683,6 +52123,26 @@
       }
     },
     {
+      "lemma": "неправда",
+      "lemmaId": "неправда",
+      "sentence": "Може, хтось подумає, ніби казка — неправда.",
+      "targetForm": "неправда",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0160",
+        "title": "Сторінка 155"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "неправильний",
       "lemmaId": "неправильний",
       "sentence": "Мішані числа Пригадаємо, що таке неправильний дріб.",
@@ -53116,6 +53576,26 @@
         "label": "Ukrainian school textbook",
         "locator": "4-klas-ukrayinska-mova-varzatska-2021-1_s0046",
         "title": "Сторінка 48"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "о",
+      "lemmaId": "о",
+      "sentence": "Прокинувся о сьомій годині ранку.",
+      "targetForm": "о",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrmova-zaharijchuk_s0116",
+        "title": "Сторінка 117"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -54836,6 +55316,26 @@
         "label": "Ukrainian school textbook",
         "locator": "5-klas-etyka-meleshchenko-2022_s0200",
         "title": "Сторінка 201"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "одноразовий",
+      "lemmaId": "одноразовий",
+      "sentence": "Так виникає одноразовий сплеск геомагнітного збурення, який триває близько години.",
+      "targetForm": "одноразовий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0382",
+        "title": "Сторінка 237"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -76243,6 +76743,26 @@
       }
     },
     {
+      "lemma": "редактор",
+      "lemmaId": "редактор",
+      "sentence": "Якось трапилося неймовірне: редактор прийняв його повість.",
+      "targetForm": "редактор",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0284",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "редакторка",
       "lemmaId": "редакторка",
       "sentence": "Редакторка: Так, маємо вільне місце, але в нас конкурс.",
@@ -77436,6 +77956,26 @@
         "label": "Ukrainian school textbook",
         "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0298",
         "title": "Сторінка 155"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "родовий",
+      "lemmaId": "родовий",
+      "sentence": "Знахідний відмінок виражає повне охоплення предмета дією, а родовий – часткове.",
+      "targetForm": "родовий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0095",
+        "title": "Сторінка 94"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -79483,6 +80023,26 @@
       }
     },
     {
+      "lemma": "різати",
+      "lemmaId": "різати",
+      "sentence": "Спочатку почав різати слух тон, яким розмовляв наш хлопчик.",
+      "targetForm": "різати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0234",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "різдвяний",
       "lemmaId": "різдвяний",
       "sentence": "І коли це сталося, чудовий різдвяний ангел із тоненькими білими крильцями та лагідними оченятами весело закружляв над ними...",
@@ -80236,6 +80796,26 @@
         "label": "Ukrainian school textbook",
         "locator": "ulp-4-00-lesson-notes_l0150_w011",
         "title": "Lesson 150: Коронавірус в Україні (part 11/18)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сантиметр",
+      "lemmaId": "сантиметр",
+      "sentence": "Равлики не розрізняють кольору і бачать предмети на відстані один сантиметр.",
+      "targetForm": "сантиметр",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0119",
+        "title": "Сторінка 121"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -89863,6 +90443,26 @@
       }
     },
     {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "Ця тема із самого початку викличе непідробний інтерес аудиторії.",
+      "targetForm": "тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0097",
+        "title": "Сторінка 63"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "темний",
       "lemmaId": "темний",
       "sentence": "До речі, синій колір — темний, а блакитний чи голубий — це світло-синій колір.",
@@ -90636,6 +91236,26 @@
         "label": "Ukrainian school textbook",
         "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0189",
         "title": "Сторінка 87"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "то",
+      "lemmaId": "то",
+      "sentence": "А як іти, то йти, — каже хлопець.",
+      "targetForm": "то",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchuk-2020-2_s0066",
+        "title": "Сторінка 68"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -92683,6 +93303,26 @@
       }
     },
     {
+      "lemma": "узагальнення",
+      "lemmaId": "узагальнення",
+      "sentence": "Інваріант фонеми — це абстрактне поняття, що означає матеріальне узагальнення суттєвих для фонеми ознак.",
+      "targetForm": "узагальнення",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0079",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
       "lemma": "узагальнено-особове",
       "lemmaId": "узагальнено-особове",
       "sentence": "Вид односкладного речення Приклад 1 безособове 2 означено-особове 3 неозначено-особове 4 узагальнено-особове А Вовка пастухом не ставлять.",
@@ -93096,6 +93736,26 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-zabolotnyi-2024_s0225",
         "title": "Сторінка 154"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "умова",
+      "lemmaId": "умова",
+      "sentence": "Вивчення джерел НС воєнного часу — необхідна умова підготовки людей до можливих бойових дій.",
+      "targetForm": "умова",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0452",
+        "title": "Сторінка 248"
       },
       "license": {
         "status": "not_openly_licensed",
@@ -101314,6 +101974,26 @@
         "label": "Ukrainian school textbook",
         "locator": "7-klas-ukrlit-zabolotnyi-2024_s0424",
         "title": "Сторінка 279"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "є",
+      "lemmaId": "є",
+      "sentence": "Чи є відмінність у вживанні абревіатур у художньому й інших стилях?",
+      "targetForm": "є",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0253",
+        "title": "Сторінка 179"
       },
       "license": {
         "status": "not_openly_licensed",

--- a/site/src/data/lexicon-sentence-inventory.residual.json
+++ b/site/src/data/lexicon-sentence-inventory.residual.json
@@ -1,0 +1,687 @@
+{
+  "schema": "atlas-sentence-inventory",
+  "schemaVersion": 1,
+  "note": "Additive residual mine for #6188; merged at inventory read time",
+  "rows": [
+    {
+      "lemma": "американка",
+      "lemmaId": "американка",
+      "sentence": "У головних ролях знялися американка Хейлі Стайнфелд і британець Дуглас Бут.",
+      "targetForm": "американка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0141",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "безумовно",
+      "lemmaId": "безумовно",
+      "sentence": "Безумовно, випускники складуть іспити.",
+      "targetForm": "Безумовно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0145",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "буквально",
+      "lemmaId": "буквально",
+      "sentence": "З кінця серпня до початку вересня граки буквально окуповують родючі дерева.",
+      "targetForm": "буквально",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0140",
+        "title": "Сторінка 95"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вид",
+      "lemmaId": "вид",
+      "sentence": "Суперечку як вид комунікації вперше почали досліджувати давньогрецькі філософи.",
+      "targetForm": "вид",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0271",
+        "title": "Сторінка 184"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "викладач",
+      "lemmaId": "викладач",
+      "sentence": "Підручники в академії були рукописними, авторськими, бо кожен викладач мусив складати свій курс лекцій.",
+      "targetForm": "викладач",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0106",
+        "title": "Сторінка 75"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "витрата",
+      "lemmaId": "витрата",
+      "sentence": "Водночас із надходженням сонячного тепла на Землю відбувається і його витрата у вигляді випромінювання.",
+      "targetForm": "витрата",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0112",
+        "title": "Сторінка 81"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вказівка",
+      "lemmaId": "вказівка",
+      "sentence": "У цих словах міститься вказівка на основне питання, що його порушив автор.",
+      "targetForm": "вказівка",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0126",
+        "title": "Сторінка 67"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "воно",
+      "lemmaId": "воно",
+      "sentence": "Воно постало з козацького хутора й виросло до гіганта.",
+      "targetForm": "Воно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrmova-zaharijchuk_s0037",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "гіркий",
+      "lemmaId": "гіркий",
+      "sentence": "Не тільки вітер доносить до нас гіркий полинний запах нашої історії.",
+      "targetForm": "гіркий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0007",
+        "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "доброта",
+      "lemmaId": "доброта",
+      "sentence": "Я знаю: править світом доброта.",
+      "targetForm": "доброта",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0016",
+        "title": "Сторінка 17"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "зошит",
+      "lemmaId": "зошит",
+      "sentence": "У портфелі лежав новий зошит.",
+      "targetForm": "зошит",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-bolshakova-2019-2_s0087",
+        "title": "Сторінка 86"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кухня",
+      "lemmaId": "кухня",
+      "sentence": "Найбільшу популярність Франції принесли мода, парфумерія, мистецтво й кухня.",
+      "targetForm": "кухня",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0017",
+        "title": "Сторінка 19"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лимон",
+      "lemmaId": "лимон",
+      "sentence": "Як правило, ні лимон, ні апельсин не опадають на першому році життя.",
+      "targetForm": "лимон",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-avramenko-2024_s0021",
+        "title": "Сторінка 19"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "липень",
+      "lemmaId": "липень",
+      "sentence": "У червні червоніють ягоди, липень — час цвітіння липи.",
+      "targetForm": "липень",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0097",
+        "title": "Сторінка 90"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лютий",
+      "lemmaId": "лютий",
+      "sentence": "Коли ворог йшов війною, метушилось все, як рій, замикалися ворота, починався лютий бій.",
+      "targetForm": "лютий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0049",
+        "title": "Сторінка 50"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "майбутній",
+      "lemmaId": "майбутній",
+      "sentence": "Після війни майбутній письменник навчався на літературному факультеті Донецького педінституту.",
+      "targetForm": "майбутній",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0117",
+        "title": "Сторінка 119"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "минулий",
+      "lemmaId": "минулий",
+      "sentence": "За минулий місяць споживацький кошик ще трохи подорожчав.",
+      "targetForm": "минулий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0045",
+        "title": "Сторінка 34"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мор",
+      "lemmaId": "мор",
+      "sentence": "Рим пережив мор.",
+      "targetForm": "мор",
+      "cefr": "B2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-mystetstvo-komarovska-2025_s0056",
+        "title": "Сторінка 58"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мільярд",
+      "lemmaId": "мільярд",
+      "sentence": "Ніхто не виграє мільярд доларів у лотерею.",
+      "targetForm": "мільярд",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0479",
+        "title": "Сторінка 267"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "міністерство",
+      "lemmaId": "міністерство",
+      "sentence": "Міністерство очолює міністр України, який є членом Кабінету Міністрів України.",
+      "targetForm": "Міністерство",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0454",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наголосити",
+      "lemmaId": "наголосити",
+      "sentence": "Вони допомагають наголосити на важливому моменті.",
+      "targetForm": "наголосити",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0081",
+        "title": "Сторінка 54"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "науково",
+      "lemmaId": "науково",
+      "sentence": "Науково доведено, що втома негативно позначається на імунітеті й обміні речовин, ефективності виконання розумових операцій, зосередженості.",
+      "targetForm": "Науково",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0378",
+        "title": "Сторінка 224"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "неправда",
+      "lemmaId": "неправда",
+      "sentence": "Може, хтось подумає, ніби казка — неправда.",
+      "targetForm": "неправда",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0160",
+        "title": "Сторінка 155"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "о",
+      "lemmaId": "о",
+      "sentence": "Прокинувся о сьомій годині ранку.",
+      "targetForm": "о",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrmova-zaharijchuk_s0116",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "одноразовий",
+      "lemmaId": "одноразовий",
+      "sentence": "Так виникає одноразовий сплеск геомагнітного збурення, який триває близько години.",
+      "targetForm": "одноразовий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0382",
+        "title": "Сторінка 237"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "редактор",
+      "lemmaId": "редактор",
+      "sentence": "Якось трапилося неймовірне: редактор прийняв його повість.",
+      "targetForm": "редактор",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0284",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "родовий",
+      "lemmaId": "родовий",
+      "sentence": "Знахідний відмінок виражає повне охоплення предмета дією, а родовий – часткове.",
+      "targetForm": "родовий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0095",
+        "title": "Сторінка 94"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "різати",
+      "lemmaId": "різати",
+      "sentence": "Спочатку почав різати слух тон, яким розмовляв наш хлопчик.",
+      "targetForm": "різати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0234",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сантиметр",
+      "lemmaId": "сантиметр",
+      "sentence": "Равлики не розрізняють кольору і бачать предмети на відстані один сантиметр.",
+      "targetForm": "сантиметр",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0119",
+        "title": "Сторінка 121"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "Ця тема із самого початку викличе непідробний інтерес аудиторії.",
+      "targetForm": "тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0097",
+        "title": "Сторінка 63"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "то",
+      "lemmaId": "то",
+      "sentence": "А як іти, то йти, — каже хлопець.",
+      "targetForm": "то",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchuk-2020-2_s0066",
+        "title": "Сторінка 68"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "узагальнення",
+      "lemmaId": "узагальнення",
+      "sentence": "Інваріант фонеми — це абстрактне поняття, що означає матеріальне узагальнення суттєвих для фонеми ознак.",
+      "targetForm": "узагальнення",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0079",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "умова",
+      "lemmaId": "умова",
+      "sentence": "Вивчення джерел НС воєнного часу — необхідна умова підготовки людей до можливих бойових дій.",
+      "targetForm": "умова",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0452",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "є",
+      "lemmaId": "є",
+      "sentence": "Чи є відмінність у вживанні абревіатур у художньому й інших стилях?",
+      "targetForm": "є",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0253",
+        "title": "Сторінка 179"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    }
+  ]
+}

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1781,6 +1781,52 @@ def test_inventory_identity_decoys_are_seeded_and_length_matched() -> None:
     assert first_decoys != second_decoys
 
 
+def test_inventory_identity_decoys_exclude_phrase_labels() -> None:
+    answer = {
+        "lemmaId": "po-druhe",
+        "lemma": "по-друге",
+        "lemmaPlain": "по-друге",
+        "gloss": "secondly",
+        "pos": "phrase",
+        "cefr": "A2",
+    }
+    clean_decoys = [
+        {
+            "lemmaId": lemma,
+            "lemma": lemma,
+            "gloss": "fixture",
+            "pos": "phrase",
+            "cefr": "A1",
+        }
+        for lemma in ("Привіт", "Нормально", "Чудово")
+    ]
+    phrase_decoys = [
+        {
+            "lemmaId": lemma,
+            "lemma": lemma,
+            "gloss": "fixture",
+            "pos": "phrase",
+            "cefr": "A1",
+        }
+        for lemma in ("Звідки ти?", "Як справи?")
+    ]
+    cloze = {
+        "clozeId": "po-druhe:inventory:1",
+        "form": "По-друге",
+        "lemma": "по-друге",
+        "provenance": {"status": "sentence_inventory"},
+        "caseRule": {"ruleId": "nominative_identification"},
+    }
+
+    options = generate_practice_deck._make_no_pair_options(
+        cloze, answer, [answer, *clean_decoys, *phrase_decoys], random.Random(0)
+    )
+
+    assert len(options) == 4
+    assert all("?" not in option["label"] for option in options)
+    assert validate_option_set({**cloze, "options": options}) == []
+
+
 def test_inventory_identity_decoys_use_attested_surface_capitalization() -> None:
     lexemes = _fixture_lexemes()
     answer = next(lexeme for lexeme in lexemes if lexeme["lemmaId"] == "knyha")

--- a/tests/test_generate_sentence_inventory.py
+++ b/tests/test_generate_sentence_inventory.py
@@ -129,6 +129,84 @@ def test_inventory_can_keep_multiple_unique_sentences_per_lemma(tmp_path) -> Non
     }
 
 
+def test_textbook_search_prefers_language_books_and_skips_ranked_noise(tmp_path) -> None:
+    db = _sources_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("ALTER TABLE textbooks ADD COLUMN subject TEXT DEFAULT 'ukrmova'")
+    conn.execute(
+        "INSERT INTO textbooks (id, chunk_id, title, text, subject) VALUES (?, ?, ?, ?, ?)",
+        (2, "physics-noise", "Physics", "Місто спить, а люди читають.", "fizyka"),
+    )
+    conn.execute(
+        "INSERT INTO textbooks_fts(rowid, title, text) VALUES (?, ?, ?)",
+        (2, "Physics", "Місто спить, а люди читають."),
+    )
+    for row_id in range(3, 23):
+        noise = "Прочитай місто і запиши відповідь."
+        conn.execute(
+            "INSERT INTO textbooks (id, chunk_id, title, text, subject) VALUES (?, ?, ?, ?, ?)",
+            (row_id, f"noise-{row_id}", "Ukrainian textbook", noise, "ukrmova"),
+        )
+        conn.execute(
+            "INSERT INTO textbooks_fts(rowid, title, text) VALUES (?, ?, ?)",
+            (row_id, "Ukrainian textbook", noise),
+        )
+    clean = "Місто спить, а люди читають."
+    conn.execute(
+        "INSERT INTO textbooks (id, chunk_id, title, text, subject) VALUES (?, ?, ?, ?, ?)",
+        (23, "language-clean", "Ukrainian textbook", clean, "ukrmova"),
+    )
+    conn.execute(
+        "INSERT INTO textbooks_fts(rowid, title, text) VALUES (?, ?, ?)",
+        (23, "Ukrainian textbook", clean),
+    )
+    conn.commit()
+    conn.close()
+
+    rows = build_inventory([{"lemma": "місто", "lemmaId": "misto", "cefr": "A1"}], db)
+
+    assert rows[0]["sentence"] == clean
+    assert rows[0]["provenance"]["locator"] == "language-clean"
+
+
+def test_textbook_search_excludes_ulp_mirrors(tmp_path) -> None:
+    db = _sources_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("ALTER TABLE textbooks ADD COLUMN source_file TEXT DEFAULT 'grade-1'")
+    conn.execute("ALTER TABLE textbooks ADD COLUMN subject TEXT DEFAULT 'ukrmova'")
+    conn.execute(
+        "INSERT INTO textbooks (id, chunk_id, title, text, source_file, subject) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            2,
+            "ulp-noise",
+            "Podcast notes",
+            "Публічний транскрипт містить приклади.",
+            "ulp-5-00-lesson-notes",
+            "ukrmova",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO textbooks_fts(rowid, title, text) VALUES (?, ?, ?)",
+        (2, "Podcast notes", "Публічний транскрипт містить приклади."),
+    )
+    clean = "Цей транскрипт містить приклади з підручника."
+    conn.execute(
+        "INSERT INTO textbooks (id, chunk_id, title, text, source_file, subject) VALUES (?, ?, ?, ?, ?, ?)",
+        (3, "language-clean", "Ukrainian textbook", clean, "4-klas-ukrmova", "ukrmova"),
+    )
+    conn.execute(
+        "INSERT INTO textbooks_fts(rowid, title, text) VALUES (?, ?, ?)",
+        (3, "Ukrainian textbook", clean),
+    )
+    conn.commit()
+    conn.close()
+
+    rows = build_inventory([{"lemma": "транскрипт", "lemmaId": "transkript", "cefr": "C1"}], db)
+
+    assert rows[0]["sentence"] == clean
+    assert rows[0]["provenance"]["locator"] == "language-clean"
+
+
 def test_inventory_rejects_non_positive_sentence_cap(tmp_path) -> None:
     with pytest.raises(ValueError, match="max_per_lemma"):
         build_inventory([], _sources_db(tmp_path), max_per_lemma=0)
@@ -174,6 +252,17 @@ def test_candidate_sentences_reject_source_bookkeeping_and_ocr_fragments() -> No
         ("відповідність", "854.• Кожному числу поставили у відповідність відстань від точки."),
         ("скільки", "21.10.• Скільки трицифрових чисел можна записати?"),
         ("ціле", "Кожен елемент візерунка містить нескінченне ціле; • духовні якості переважають."),
+        ("воло", "Воло..ий горіх ще називають гре..им."),
+        ("вид", "Вид односкладного речення Приклад 1 безособове 2 означено-особове."),
+        ("воно", "Г воно доходить до моєї кімнати."),
+        ("о", "Джейн — О, я знаю."),
+        ("умова", "Умова: написання міста має відповідати темі уроку."),
+        ("сім", "Краще один раз побачити, Де сім господинь, там хата не метена."),
+        ("наголосити", "Щоб наголосити на результаті, використовуємо форму: Підсніжники зірвано."),
+        ("мільярд", "Числівники тисяча, мільйон, мільярд відмінюємо як іменники і т."),
+        ("теперішній", "Форми часу: теперішній, минулий та майбутній."),
+        ("репортаж", "Ви маєте зробити репортаж про події."),
+        ("ютуб", "Слова: ютуб, нік, омбудсмен."),
     )
     for lemma, sentence in rejected:
         assert list(_candidate_sentences(sentence, lemma)) == []


### PR DESCRIPTION
## Summary

- Prefer Ukrainian-language textbook subjects (`ukrmova`, `bukvar`), search 250 ranked textbook chunks, and exclude ULP mirrors during textbook mining.
- Add conservative worksheet/OCR/table gates and 34 manually quality-screened textbook rows to the sentence inventory.
- Store the additive mine in `lexicon-sentence-inventory.residual.json`; the deck reader merges this sidecar with the stable base inventory so formal review stays within the sealed-evidence cap.
- Keep identity-decoy selection phrase-free and search compatible length windows so a safe decoy set cannot drop existing coverage.

## Residual evidence

Baseline after #6225: 4,224/6,000 covered; residual 1,776 (`with_inv=913`, `no_inv=863`). The requested re-funnel of the 913 inventory-backed residual is:

| Bucket | Count |
| --- | ---: |
| would emit | 311 |
| build empty | 299 |
| reader / no reader | 303 |

The no-inventory mine examined the full residual target set with textbook preference and fail-closed quality gates. It produced 48 raw candidates; 34 passed the quality screen and merged into the inventory (`5,135 -> 5,169` rows). The candidate deck preserves every baseline-covered lemma and emits 28 of those additions.

| Level | Target | Before | After | Residual after |
| --- | ---: | ---: | ---: | ---: |
| A1 | 1,470 | 989 | 1,002 | 468 |
| A2 | 1,444 | 1,087 | 1,095 | 349 |
| B1 | 1,617 | 1,269 | 1,273 | 344 |
| B2 | 940 | 696 | 699 | 241 |
| C1 | 529 | 183 | 183 | 346 |
| **Total** | **6,000** | **4,224** | **4,252** | **1,748** |

The remaining residual splits into 919 inventory-backed and 829 without inventory. Six mined rows remain fail-closed because the identity option validator cannot form a safe set: `безумовно`, `воно`, `науково`, `о`, `то`, `є` (function-word/adverb/pronoun identity cases). This PR does not close #6188 because substantial residual remains.

## Verification

- `pytest -q tests/test_generate_practice_deck.py tests/test_generate_sentence_inventory.py` — 101 passed.
- `pytest -q tests/test_publish_practice_deck.py tests/test_inventory_existing_assets.py tests/test_practice_deck_io.py` — 27 passed.
- `ruff check` on all changed Python files — passed.
- Publisher dry-run validated the exact 45-shard package and release fingerprint `atlas-practice-v1-5b95719533f4ddbc`; that sidecar-backed release asset is published and the final pointer is committed in `e644cc0671`.
- `git diff --check`, agent-trailer lint, and OPSEC leak lint — passed.

The remaining residual is intentionally not auto-closed as #6188; further no-inventory mining needs additional source-quality decisions.
