### PR TITLE
fix(telemetry): converge bridge usage across worktrees

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1535,6 +1535,11 @@ HTTP route telemetry. A valid invocation records `started` before authority or
 provider work. Its terminal result increments `succeeded` or `failed`; a
 process termination or crash remains visible as `unfinished`.
 
+Linked dispatch worktrees resolve this store through Git's primary checkout,
+so their invocations converge on the same fleet-wide local evidence plane read
+by the supervised Monitor API. Disposable worktree removal does not remove or
+fragment the observation history.
+
 The recorder persists only the normalized target (`agy`, `claude`, `codex`,
 `cursor`, `deepseek`, `glm`, `grok`, `kimi`, or `pool`), a fixed caller family,
 counts, and first/last timestamps. It never stores prompts, task IDs,

--- a/scripts/common/repo_root.py
+++ b/scripts/common/repo_root.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 
 def main_checkout_root(repo_root: Path) -> Path:
-    """Return the primary checkout root that owns the shared .git dir."""
+    """Return the primary checkout root that owns the shared ``.git`` dir.
+
+    Only a ``gitdir:`` target with Git's exact ``.git/worktrees/<name>`` shape
+    redirects a path. Primary checkouts, release snapshots, and every other
+    malformed or non-Git root remain anchored to themselves.
+    """
     git_path = repo_root / ".git"
     if git_path.is_dir():
         return repo_root

--- a/scripts/telemetry/legacy_bridge.py
+++ b/scripts/telemetry/legacy_bridge.py
@@ -20,10 +20,21 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
+from scripts.common.repo_root import main_checkout_root
+
 logger = logging.getLogger(__name__)
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DB_PATH = _REPO_ROOT / "data" / "telemetry" / "legacy_comms_routes.db"
+_SOURCE_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _shared_telemetry_db_path(source_repo_root: Path | None = None) -> Path:
+    """Anchor one fleet-wide store to the primary checkout, never a worktree."""
+    source_root = (source_repo_root or _SOURCE_REPO_ROOT).resolve()
+    primary_root = main_checkout_root(source_root)
+    return primary_root / "data" / "telemetry" / "legacy_comms_routes.db"
+
+
+_DB_PATH = _shared_telemetry_db_path()
 _RETENTION_DAYS = 90
 _WINDOWS = {
     "1h": timedelta(hours=1),

--- a/tests/test_legacy_bridge_telemetry.py
+++ b/tests/test_legacy_bridge_telemetry.py
@@ -48,6 +48,21 @@ def _store_bytes(path: Path) -> bytes:
     )
 
 
+def test_default_store_resolves_from_a_linked_worktree_to_the_primary_checkout(
+    tmp_path: Path,
+) -> None:
+    primary = tmp_path / "primary"
+    worktree = tmp_path / "dispatch" / "task"
+    worktree_git_dir = primary / ".git" / "worktrees" / "task"
+    worktree_git_dir.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+
+    assert legacy_bridge._shared_telemetry_db_path(worktree) == (
+        primary / "data" / "telemetry" / "legacy_comms_routes.db"
+    )
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [

--- a/tests/test_legacy_bridge_telemetry.py
+++ b/tests/test_legacy_bridge_telemetry.py
@@ -63,6 +63,21 @@ def test_default_store_resolves_from_a_linked_worktree_to_the_primary_checkout(
     )
 
 
+def test_release_snapshot_store_uses_its_primary_data_symlink(tmp_path: Path) -> None:
+    primary_data = tmp_path / "primary" / "data"
+    (primary_data / "telemetry").mkdir(parents=True)
+    release = tmp_path / "release"
+    release.mkdir()
+    (release / "data").symlink_to(primary_data, target_is_directory=True)
+
+    path = legacy_bridge._shared_telemetry_db_path(release)
+
+    assert path == release / "data" / "telemetry" / "legacy_comms_routes.db"
+    assert path.resolve() == (
+        primary_data / "telemetry" / "legacy_comms_routes.db"
+    ).resolve()
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [


### PR DESCRIPTION
## Summary

- anchor direct bridge telemetry to the primary checkout shared runtime store
- preserve release-snapshot compatibility through the existing data symlink
- add a linked-worktree regression test and document the shared evidence plane

This is the root-cause corrective follow-up to #6228 for the #6106 direct bridge telemetry slice. The true post-deploy canary found that dispatch worktrees wrote ephemeral worktree-local databases while the supervised Monitor API read the primary database.

## Verification

- 335 focused and adjacent tests passed
- Ruff and Python compile checks passed
- staged OPSEC audit passed with zero leaks
- X-Agent trailer audit passed
- real GLM dispatch-worktree canary reached the production Monitor API shared store; persisted DB/WAL/SHM contained none of the prompt, task, model, or sentinel markers

## Scope

No schema, endpoint, retention, privacy, or provider behavior changes. #6106 remains open for the next approved migration slice.