### PR TITLE
fix(acp): separate protocol and answer bounds

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -307,6 +307,13 @@ unrestricted loop, hidden failover, or retry. Each model call is capped at 300
 seconds, the whole conversation at 1,200 seconds, and content at 160k reliable
 tokens or 512 KiB.
 
+Raw ACP JSON-RPC traffic and parsed answer content have separate hard bounds.
+Each enabled participant may emit at most a 16 MiB protocol envelope so a
+valid terminal frame is not killed by provider-specific progress events. The
+strict parser then admits at most 512 KiB of answer text to the caller or
+fleet-authority receipt. Exceeding either bound fails terminally without a
+provider retry or bridge fallback.
+
 Replay suppression is durable and occurs before scheduling. An orphaned
 reservation is terminal: never retry it. The single-host repository admission
 file lock covers the conversation, including model I/O; no SQLite transaction

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -238,6 +238,14 @@ ACPX_PARTICIPANT_EFFORTS: dict[str, str] = {
     "glm": "high",
 }
 
+# Raw ACPX JSON-RPC traffic has a separate, larger bound in runner.py because
+# provider protocol envelopes can be much larger than their final answer.
+# Never let that envelope allowance become an answer/body allowance: this cap
+# is applied after strict NDJSON parsing and before a Result can reach the
+# fleet-authority receipt.
+ACPX_PARSED_RESPONSE_LIMIT_BYTES = 512 * 1024
+
+
 @dataclass(frozen=True)
 class AcpxTransportProvenance:
     """Runner-sealed provenance for one ACP inter-agent invocation.
@@ -1142,9 +1150,19 @@ class AcpxAdapter:
                 f"acpx exec exited rc={returncode} despite stopReason={final_stop_reason!r}", stderr
             )
 
+        response = "".join(message_chunks)
+        response_bytes = len(response.encode("utf-8"))
+        if response_bytes > ACPX_PARSED_RESPONSE_LIMIT_BYTES:
+            return self._closed(
+                "parsed ACP response exceeds "
+                f"{ACPX_PARSED_RESPONSE_LIMIT_BYTES}-byte content limit "
+                f"(observed={response_bytes})",
+                stderr,
+            )
+
         return ParseResult(
             ok=True,
-            response="".join(message_chunks),
+            response=response,
             stderr_excerpt=None,
             rate_limited=False,
             session_id=None,

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -133,13 +133,13 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
         "acpx-transport",
     }
 )
-_ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 256 * 1024
-# Native OpenCode ACP emits a larger JSON-RPC envelope than the text-only and
-# built-in seats. Keep it bounded, but above the production-observed 4,204,632
-# bytes that otherwise killed a valid concise GLM response before its terminal
-# frame arrived (#6159). The parsed response and formal verdict retain their
-# separate, tighter content/evidence bounds.
-_ACPX_GLM_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
+# ACP transports can emit a large JSON-RPC envelope around a concise answer.
+# Production observations now include GLM at 4,204,632 bytes (#6159), plus
+# Kimi and Grok crossing the former 256 KiB cap before their terminal frames
+# (#6235). Keep every enabled ACP route bounded by the same proven envelope;
+# the adapter independently caps parsed answer text before it can be returned
+# to fleet authority.
+_ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
@@ -184,8 +184,6 @@ def _streamed_output_limit(*, agent_name: str, entrypoint: str) -> int | None:
         agent_name in acpx_seats
         and entrypoint in {"acpx-pilot-shadow", "acpx-discuss", "acpx-transport"}
     ):
-        if agent_name == "acpx-glm-shadow":
-            return _ACPX_GLM_OUTPUT_LIMIT_BYTES
         return _ACPX_DIRECT_OUTPUT_LIMIT_BYTES
     return None
 

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -26,6 +26,7 @@ import pytest
 
 from scripts.agent_runtime.adapters import acpx as acpx_module
 from scripts.agent_runtime.adapters.acpx import (
+    ACPX_PARSED_RESPONSE_LIMIT_BYTES,
     ACPX_SUPPORTED_PARTICIPANTS,
     AcpxAdapter,
     AcpxAgyShadowAdapter,
@@ -747,6 +748,30 @@ def test_parse_response_recognizes_max_tokens_stop_reason():
     assert result.ok is True
     assert result.response == "Hello world."
     assert result.stderr_excerpt is None
+
+
+def test_parse_response_rejects_oversized_answer_before_authority_receipt():
+    adapter = AcpxAdapter()
+    oversized = "я" * (ACPX_PARSED_RESPONSE_LIMIT_BYTES // 2 + 1)
+    stdout = (
+        '{"jsonrpc":"2.0","method":"session/update","params":{"update":'
+        '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"'
+        + oversized
+        + '"}}}}\n'
+        '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}\n'
+    )
+
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.response == ""
+    assert "parsed ACP response exceeds" in result.stderr_excerpt
+    assert str(ACPX_PARSED_RESPONSE_LIMIT_BYTES) in result.stderr_excerpt
 
 
 def test_parse_response_multiple_stop_reason_results_fails_closed():

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4331,6 +4331,40 @@ def test_acpx_direct_route_output_limit_kills_child_and_raises_typed_error(
     assert error.value.observed_bytes > error.value.limit_bytes
 
 
+def test_acpx_protocol_envelope_above_legacy_cap_reaches_terminal(tmp_path):
+    from agent_runtime.adapters.acpx import AcpxAdapter
+
+    child = (
+        "import json; "
+        "print(json.dumps({'jsonrpc':'2.0','method':'progress','params':"
+        "{'text':'x'*(300*1024)}})); "
+        "print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':"
+        "{'update':{'sessionUpdate':'agent_message_chunk','content':"
+        "{'type':'text','text':'ok'}}}})); "
+        "print(json.dumps({'jsonrpc':'2.0','id':2,'result':"
+        "{'stopReason':'end_turn'}}))"
+    )
+    execution = _execute_invocation_plan(
+        agent_name="acpx-grok-shadow",
+        adapter=AcpxAdapter(),
+        plan=InvocationPlan(cmd=[_TEST_PYTHON, "-c", child], cwd=tmp_path),
+        prompt="fixture",
+        mode="read-only",
+        cwd=tmp_path,
+        model="fixture",
+        task_id="fixture",
+        session_id=None,
+        entrypoint="acpx-transport",
+        hard_timeout=30,
+        stall_timeout=30,
+    )
+
+    assert len(execution.stdout_text.encode("utf-8")) > 256 * 1024
+    assert execution.kill_reason is None
+    assert execution.parse.ok is True
+    assert execution.parse.response == "ok"
+
+
 def test_non_acpx_route_has_no_streamed_output_limit(tmp_path, monkeypatch):
     from agent_runtime import runner as runtime_runner
 
@@ -4370,14 +4404,19 @@ def test_non_acpx_route_has_no_streamed_output_limit(tmp_path, monkeypatch):
     assert execution.returncode == 0
 
 
-def test_glm_acp_route_has_a_separate_bounded_protocol_envelope():
+@pytest.mark.parametrize(
+    "agent_name",
+    [
+        "acpx-codex-shadow",
+        "acpx-grok-shadow",
+        "acpx-kimi-shadow",
+        "acpx-glm-shadow",
+    ],
+)
+def test_acp_routes_share_a_bounded_protocol_envelope(agent_name):
     from agent_runtime import runner as runtime_runner
 
     assert runtime_runner._streamed_output_limit(
-        agent_name="acpx-glm-shadow",
+        agent_name=agent_name,
         entrypoint="acpx-discuss",
     ) == 16 * 1024 * 1024
-    assert runtime_runner._streamed_output_limit(
-        agent_name="acpx-kimi-shadow",
-        entrypoint="acpx-discuss",
-    ) == 256 * 1024


### PR DESCRIPTION
Closes #6235.

## Summary

- raise the bounded raw ACP JSON-RPC envelope to the already-proven 16 MiB ceiling for every enabled participant;
- independently reject parsed answer text above 512 KiB before it can reach a caller or fleet-authority receipt;
- add deterministic coverage for a concise answer inside a protocol stream larger than the former 256 KiB limit;
- document the separate protocol and content boundaries.

## Production evidence

Before the change, the same bounded consultation terminated at 262,144 bytes on both Kimi and Grok. On this exact change:

- Kimi authority job `authority-job_48ddffd45fd941deb17613d9c29403fc` completed with terminal SHA `890a9f9bea917b9737b0acc6b3e1345d9abc89fd421d3f4af6b65d900a0a6b51`.
- Grok authority job `authority-job_1921ea477a2d471987abcdf46c2cb7fc` completed with terminal SHA `80b6c955671ac430e77cfb39e20a9989a1d9f3b45c28dc85b745da630aab0721`.

No provider retry or bridge fallback occurred.

## Verification

- `287 passed`: `tests/test_agent_runtime.py` + `tests/agent_runtime/test_acpx_adapter.py`
- Ruff clean
- Markdownlint clean
- OPSEC clean
- X-Agent trailer clean
- `git diff --check` clean
- read-only Claude Sonnet 5 cross-family review: `NO_FINDINGS`

## Non-goals

No plane-mode, provider/model, retry/fallback, formal-review eligibility, Gemma, dataset, or GPU changes.
