### PR TITLE
feat(foundry): add bounded Gemma hardware probe

### DIFF
--- a/data/projects/open_model_data/contracts/gemma_hardware_probe_authorization_v1.schema.json
+++ b/data/projects/open_model_data/contracts/gemma_hardware_probe_authorization_v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/gemma_hardware_probe_authorization_v1.schema.json",
+  "title": "Operator authorization for the exact Gemma L40S hardware probe v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "probe_id", "plan", "runner", "operator_decision", "authorization", "boundaries"],
+  "properties": {
+    "schema_version": {"const": "gemma_hardware_probe_authorization_v1"},
+    "probe_id": {"const": "gemma4-it-l40s-hf-jobs-hardware-probe-v1"},
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256"],
+      "properties": {
+        "logical_path": {"const": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json"},
+        "bytes": {"const": 2537},
+        "sha256": {"const": "c78684279f5f34ff7b2c567e88182b4f8bcf6c154f570c12a6e72c492b4eef69"}
+      }
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256"],
+      "properties": {
+        "logical_path": {"const": "scripts/projects/open_model_data/gemma_hardware_probe.py"},
+        "bytes": {"const": 58901},
+        "sha256": {"const": "bd8f973570140b32e7e3c8f74f80f905dea4afd02cb09f2061b4f13213e32504"}
+      }
+    },
+    "operator_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved", "source", "approved_at"],
+      "properties": {
+        "approved": {"const": true},
+        "source": {"type": "string", "minLength": 10},
+        "approved_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_download_authorized", "provider_job_launch_authorized", "provider", "hardware_flavor", "timeout_seconds", "maximum_provider_charge_usd", "operator_all_inclusive_ceiling_eur", "paid_attempts"],
+      "properties": {
+        "model_download_authorized": {"const": true},
+        "provider_job_launch_authorized": {"const": true},
+        "provider": {"const": "Hugging Face Jobs"},
+        "hardware_flavor": {"const": "l40sx1"},
+        "timeout_seconds": {"const": 3600},
+        "maximum_provider_charge_usd": {"const": 1.8},
+        "operator_all_inclusive_ceiling_eur": {"const": 3},
+        "paid_attempts": {"const": 1}
+      }
+    },
+    "boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["synthetic_fixture_only", "treatment_data_authorized", "evaluation_data_authorized", "stage_1_treatment_authorized", "model_quality_claim_authorized", "model_or_checkpoint_upload_authorized", "data_upload_authorized", "publication_authorized", "private_job_script_transport_authorized"],
+      "properties": {
+        "synthetic_fixture_only": {"const": true},
+        "treatment_data_authorized": {"const": false},
+        "evaluation_data_authorized": {"const": false},
+        "stage_1_treatment_authorized": {"const": false},
+        "model_quality_claim_authorized": {"const": false},
+        "model_or_checkpoint_upload_authorized": {"const": false},
+        "data_upload_authorized": {"const": false},
+        "publication_authorized": {"const": false},
+        "private_job_script_transport_authorized": {"const": true}
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/gemma_hardware_probe_plan_v1.schema.json
+++ b/data/projects/open_model_data/contracts/gemma_hardware_probe_plan_v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/gemma_hardware_probe_plan_v1.schema.json",
+  "title": "Gemma L40S hardware-validation non-treatment probe plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "probe_id", "issue", "state", "purpose", "reference_treatment", "model", "snapshot_manifest", "provider", "operator_ceiling", "execution", "boundaries", "claims"],
+  "properties": {
+    "schema_version": {"const": "gemma_hardware_probe_plan_v1"},
+    "probe_id": {"const": "gemma4-it-l40s-hf-jobs-hardware-probe-v1"},
+    "issue": {"const": 6170},
+    "state": {"const": "frozen_pending_operator_authorization"},
+    "purpose": {"const": "hardware_validation_non_treatment"},
+    "reference_treatment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256", "relationship"],
+      "properties": {
+        "logical_path": {"const": "data/projects/open_model_data/treatments/gemma4_it_wikipedia_mask_ablation_preregistration_v1.json"},
+        "bytes": {"const": 9948},
+        "sha256": {"const": "274ea63558fbd50ccdfe352a44dadcac0c37e224c589b5f9244d3fffe24f9aee"},
+        "relationship": {"const": "reference_only_not_amended_not_a_stage_1_execution"}
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier", "revision", "loader_class", "processor_class"],
+      "properties": {
+        "identifier": {"const": "google/gemma-4-31B-it"},
+        "revision": {"const": "842da3794eaa0b77d5f08bae87a17459d91ff475"},
+        "loader_class": {"const": "transformers.AutoModelForMultimodalLM"},
+        "processor_class": {"const": "transformers.AutoProcessor"}
+      }
+    },
+    "snapshot_manifest": {"$ref": "#/$defs/snapshot_manifest"},
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "hardware_flavor", "gpu_count", "gpu_name", "exposed_ports", "timeout_seconds", "billing_usd_per_minute", "maximum_provider_charge_usd", "paid_attempts"],
+      "properties": {
+        "provider": {"const": "Hugging Face Jobs"},
+        "hardware_flavor": {"const": "l40sx1"},
+        "gpu_count": {"const": 1},
+        "gpu_name": {"const": "NVIDIA L40S"},
+        "exposed_ports": {"const": false},
+        "timeout_seconds": {"const": 3600},
+        "billing_usd_per_minute": {"const": 0.03},
+        "maximum_provider_charge_usd": {"const": 1.8},
+        "paid_attempts": {"const": 1}
+      }
+    },
+    "operator_ceiling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "amount_eur", "all_inclusive"],
+      "properties": {
+        "currency": {"const": "EUR"},
+        "amount_eur": {"const": 3},
+        "all_inclusive": {"const": true}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixture", "sequence_length", "quantization", "adapter", "optimizer_steps_before_checkpoint", "optimizer_steps_after_clean_process_resume", "checkpoint_contents"],
+      "properties": {
+        "fixture": {"const": "deterministic_synthetic_token_ids_no_source_or_evaluation_data"},
+        "sequence_length": {"const": 4096},
+        "quantization": {"const": "4bit_nf4_bf16_double_quantization"},
+        "adapter": {"const": "qlora_rank16_alpha32_dropout0.05"},
+        "optimizer_steps_before_checkpoint": {"const": 1},
+        "optimizer_steps_after_clean_process_resume": {"const": 1},
+        "checkpoint_contents": {"const": "disposable_adapter_optimizer_rng"}
+      }
+    },
+    "boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["treatment_data_used", "evaluation_data_used", "treatment_stage_1_performed", "model_quality_evaluation_performed", "model_or_checkpoint_upload_performed", "data_upload_performed", "publication_performed", "private_job_script_transport_allowed"],
+      "properties": {
+        "treatment_data_used": {"const": false},
+        "evaluation_data_used": {"const": false},
+        "treatment_stage_1_performed": {"const": false},
+        "model_quality_evaluation_performed": {"const": false},
+        "model_or_checkpoint_upload_performed": {"const": false},
+        "data_upload_performed": {"const": false},
+        "publication_performed": {"const": false},
+        "private_job_script_transport_allowed": {"const": true}
+      }
+    },
+    "claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "prohibited"],
+      "properties": {
+        "allowed": {"const": ["exact_snapshot_l40s_fit_throughput_and_disposable_checkpoint_resume_mechanics"]},
+        "prohibited": {"const": ["stage_1_treatment_completion", "causal_loss_mask_evidence", "model_quality", "general_ukrainian_fluency", "deployment_readiness", "model_or_checkpoint_publication"]}
+      }
+    }
+  },
+  "$defs": {
+    "snapshot_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256"],
+      "properties": {
+        "logical_path": {"const": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json"},
+        "bytes": {"const": 1994},
+        "sha256": {"const": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1"}
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/gemma_hardware_probe_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/gemma_hardware_probe_receipt_v1.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/gemma_hardware_probe_receipt_v1.schema.json",
+  "title": "Gemma L40S hardware-validation non-treatment probe receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "probe_id", "plan", "authorization_sha256", "status", "attempt", "provider_job", "runtime", "environment", "gpu", "snapshot_verification", "throughput", "training_probe", "checkpoint_resume", "facts"],
+  "properties": {
+    "schema_version": {"const": "gemma_hardware_probe_receipt_v1"},
+    "probe_id": {"const": "gemma4-it-l40s-hf-jobs-hardware-probe-v1"},
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256"],
+      "properties": {
+        "logical_path": {"const": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json"},
+        "bytes": {"const": 2537},
+        "sha256": {"const": "c78684279f5f34ff7b2c567e88182b4f8bcf6c154f570c12a6e72c492b4eef69"}
+      }
+    },
+    "authorization_sha256": {"$ref": "#/$defs/sha256"},
+    "status": {"enum": ["completed", "aborted"]},
+    "attempt": {"const": 1},
+    "provider_job": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "job_id", "job_status", "hardware_flavor", "exposed_ports", "timeout_seconds", "billing_usd_per_minute", "maximum_provider_charge_usd", "provider_evidence_reconciled", "provider_running_seconds", "provider_derived_cost_usd", "actual_invoice_cost_usd", "actual_invoice_cost_eur"],
+      "properties": {
+        "provider": {"const": "Hugging Face Jobs"},
+        "job_id": {"type": "string", "minLength": 1},
+        "job_status": {"enum": ["worker_completed_pending_provider_reconciliation", "worker_aborted_pending_provider_reconciliation", "COMPLETED", "CANCELED", "ERROR", "DELETED"]},
+        "hardware_flavor": {"const": "l40sx1"},
+        "exposed_ports": {"const": false},
+        "timeout_seconds": {"const": 3600},
+        "billing_usd_per_minute": {"const": 0.03},
+        "maximum_provider_charge_usd": {"const": 1.8},
+        "provider_evidence_reconciled": {"type": "boolean"},
+        "provider_running_seconds": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 3600}, {"type": "null"}]},
+        "provider_derived_cost_usd": {"anyOf": [{"type": "number", "minimum": 0, "maximum": 1.8}, {"type": "null"}]},
+        "actual_invoice_cost_usd": {"type": "null"},
+        "actual_invoice_cost_eur": {"type": "null"}
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at", "ended_at", "wall_seconds", "provider_timeout_enforced"],
+      "properties": {
+        "started_at": {"type": "string", "format": "date-time"},
+        "ended_at": {"type": "string", "format": "date-time"},
+        "wall_seconds": {"type": "number", "minimum": 0, "maximum": 3600},
+        "provider_timeout_enforced": {"const": true}
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "packages_sha256", "cuda_runtime", "cuda_driver", "runner_sha256"],
+      "properties": {
+        "python": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "packages_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "cuda_runtime": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "cuda_driver": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+        "runner_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]}
+      }
+    },
+    "gpu": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["count", "name", "total_memory_bytes", "peak_allocated_bytes", "peak_reserved_bytes"],
+      "properties": {
+        "count": {"enum": [0, 1]},
+        "name": {"anyOf": [{"const": "NVIDIA L40S"}, {"type": "null"}]},
+        "total_memory_bytes": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]},
+        "peak_allocated_bytes": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]},
+        "peak_reserved_bytes": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]}
+      }
+    },
+    "snapshot_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest", "all_files_sha256_match", "all_files_bytes_match"],
+      "properties": {
+        "manifest": {"$ref": "#/$defs/snapshot_manifest"},
+        "all_files_sha256_match": {"anyOf": [{"type": "boolean"}, {"type": "null"}]},
+        "all_files_bytes_match": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}
+      }
+    },
+    "throughput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixture_sha256", "sequence_length", "tokens_processed", "elapsed_seconds", "tokens_per_second"],
+      "properties": {
+        "fixture_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "sequence_length": {"anyOf": [{"const": 4096}, {"const": 0}, {"type": "null"}]},
+        "tokens_processed": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]},
+        "elapsed_seconds": {"anyOf": [{"type": "number", "minimum": 0}, {"type": "null"}]},
+        "tokens_per_second": {"anyOf": [{"type": "number", "minimum": 0}, {"type": "null"}]}
+      }
+    },
+    "training_probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["quantization", "adapter", "optimizer_steps_before_checkpoint", "optimizer_steps_after_resume", "loss_before_checkpoint", "loss_after_resume", "nonfinite_detected"],
+      "properties": {
+        "quantization": {"const": "4bit_nf4_bf16_double_quantization"},
+        "adapter": {"const": "qlora_rank16_alpha32_dropout0.05"},
+        "optimizer_steps_before_checkpoint": {"type": "integer", "minimum": 0, "maximum": 1},
+        "optimizer_steps_after_resume": {"type": "integer", "minimum": 0, "maximum": 1},
+        "loss_before_checkpoint": {"anyOf": [{"type": "number", "minimum": 0}, {"type": "null"}]},
+        "loss_after_resume": {"anyOf": [{"type": "number", "minimum": 0}, {"type": "null"}]},
+        "nonfinite_detected": {"type": "boolean"}
+      }
+    },
+    "checkpoint_resume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["process_boundary", "adapter", "optimizer", "rng", "reload_passed"],
+      "properties": {
+        "process_boundary": {"type": "boolean"},
+        "adapter": {"anyOf": [{"$ref": "#/$defs/output_artifact"}, {"type": "null"}]},
+        "optimizer": {"anyOf": [{"$ref": "#/$defs/output_artifact"}, {"type": "null"}]},
+        "rng": {"anyOf": [{"$ref": "#/$defs/output_artifact"}, {"type": "null"}]},
+        "reload_passed": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}
+      }
+    },
+    "facts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purpose", "treatment_data_used", "evaluation_data_used", "treatment_stage_1_performed", "model_quality_evaluation_performed", "model_or_checkpoint_upload_performed", "data_upload_performed", "publication_performed", "private_job_script_transport_used", "synthetic_adapter_optimizer_updates_performed"],
+      "properties": {
+        "purpose": {"const": "hardware_validation_non_treatment"},
+        "treatment_data_used": {"const": false},
+        "evaluation_data_used": {"const": false},
+        "treatment_stage_1_performed": {"const": false},
+        "model_quality_evaluation_performed": {"const": false},
+        "model_or_checkpoint_upload_performed": {"const": false},
+        "data_upload_performed": {"const": false},
+        "publication_performed": {"const": false},
+        "private_job_script_transport_used": {"type": "boolean"},
+        "synthetic_adapter_optimizer_updates_performed": {"type": "boolean"}
+      }
+    },
+    "abort_reason": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "completed"}}, "required": ["status"]},
+      "then": {
+        "required": ["abort_reason"],
+        "properties": {
+          "abort_reason": {"type": "null"},
+          "gpu": {"properties": {"count": {"const": 1}, "name": {"const": "NVIDIA L40S"}, "total_memory_bytes": {"type": "integer", "minimum": 1}, "peak_allocated_bytes": {"type": "integer", "minimum": 0}, "peak_reserved_bytes": {"type": "integer", "minimum": 0}}},
+          "environment": {"properties": {"python": {"type": "string", "minLength": 1}, "packages_sha256": {"$ref": "#/$defs/sha256"}, "cuda_runtime": {"type": "string", "minLength": 1}, "cuda_driver": {"type": "string", "minLength": 1}, "runner_sha256": {"$ref": "#/$defs/sha256"}}},
+          "snapshot_verification": {"properties": {"all_files_sha256_match": {"const": true}, "all_files_bytes_match": {"const": true}}},
+          "throughput": {"properties": {"fixture_sha256": {"$ref": "#/$defs/sha256"}, "sequence_length": {"const": 4096}, "tokens_processed": {"type": "integer", "minimum": 1}, "elapsed_seconds": {"type": "number", "exclusiveMinimum": 0}, "tokens_per_second": {"type": "number", "exclusiveMinimum": 0}}},
+          "training_probe": {"properties": {"optimizer_steps_before_checkpoint": {"const": 1}, "optimizer_steps_after_resume": {"const": 1}, "loss_before_checkpoint": {"type": "number", "minimum": 0}, "loss_after_resume": {"type": "number", "minimum": 0}, "nonfinite_detected": {"const": false}}},
+          "checkpoint_resume": {"properties": {"process_boundary": {"const": true}, "adapter": {"$ref": "#/$defs/output_artifact"}, "optimizer": {"$ref": "#/$defs/output_artifact"}, "rng": {"$ref": "#/$defs/output_artifact"}, "reload_passed": {"const": true}}}
+        }
+      },
+      "else": {"required": ["abort_reason"], "properties": {"abort_reason": {"type": "string", "minLength": 1}}}
+    },
+    {
+      "if": {"properties": {"provider_job": {"properties": {"provider_evidence_reconciled": {"const": true}}, "required": ["provider_evidence_reconciled"]}}, "required": ["provider_job"]},
+      "then": {"properties": {"provider_job": {"properties": {"job_status": {"enum": ["COMPLETED", "CANCELED", "ERROR", "DELETED"]}, "provider_running_seconds": {"type": "integer", "minimum": 0, "maximum": 3600}, "provider_derived_cost_usd": {"type": "number", "minimum": 0, "maximum": 1.8}}}}},
+      "else": {"properties": {"provider_job": {"properties": {"job_status": {"enum": ["worker_completed_pending_provider_reconciliation", "worker_aborted_pending_provider_reconciliation"]}, "provider_running_seconds": {"type": "null"}, "provider_derived_cost_usd": {"type": "null"}}}}}
+    },
+    {
+      "if": {"properties": {"status": {"const": "completed"}, "provider_job": {"properties": {"provider_evidence_reconciled": {"const": true}}, "required": ["provider_evidence_reconciled"]}}, "required": ["status", "provider_job"]},
+      "then": {"properties": {"provider_job": {"properties": {"job_status": {"const": "COMPLETED"}}}}}
+    }
+  ],
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "snapshot_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_path", "bytes", "sha256"],
+      "properties": {
+        "logical_path": {"const": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json"},
+        "bytes": {"const": 1994},
+        "sha256": {"const": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1"}
+      }
+    },
+    "output_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bytes", "sha256"],
+      "properties": {"bytes": {"type": "integer", "minimum": 1}, "sha256": {"$ref": "#/$defs/sha256"}}
+    }
+  }
+}

--- a/data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json
+++ b/data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json
@@ -1,0 +1,72 @@
+{
+  "boundaries": {
+    "data_upload_performed": false,
+    "evaluation_data_used": false,
+    "model_or_checkpoint_upload_performed": false,
+    "model_quality_evaluation_performed": false,
+    "private_job_script_transport_allowed": true,
+    "publication_performed": false,
+    "treatment_data_used": false,
+    "treatment_stage_1_performed": false
+  },
+  "claims": {
+    "allowed": [
+      "exact_snapshot_l40s_fit_throughput_and_disposable_checkpoint_resume_mechanics"
+    ],
+    "prohibited": [
+      "stage_1_treatment_completion",
+      "causal_loss_mask_evidence",
+      "model_quality",
+      "general_ukrainian_fluency",
+      "deployment_readiness",
+      "model_or_checkpoint_publication"
+    ]
+  },
+  "execution": {
+    "adapter": "qlora_rank16_alpha32_dropout0.05",
+    "checkpoint_contents": "disposable_adapter_optimizer_rng",
+    "fixture": "deterministic_synthetic_token_ids_no_source_or_evaluation_data",
+    "optimizer_steps_after_clean_process_resume": 1,
+    "optimizer_steps_before_checkpoint": 1,
+    "quantization": "4bit_nf4_bf16_double_quantization",
+    "sequence_length": 4096
+  },
+  "issue": 6170,
+  "model": {
+    "identifier": "google/gemma-4-31B-it",
+    "loader_class": "transformers.AutoModelForMultimodalLM",
+    "processor_class": "transformers.AutoProcessor",
+    "revision": "842da3794eaa0b77d5f08bae87a17459d91ff475"
+  },
+  "operator_ceiling": {
+    "all_inclusive": true,
+    "amount_eur": 3,
+    "currency": "EUR"
+  },
+  "probe_id": "gemma4-it-l40s-hf-jobs-hardware-probe-v1",
+  "provider": {
+    "billing_usd_per_minute": 0.03,
+    "exposed_ports": false,
+    "gpu_count": 1,
+    "gpu_name": "NVIDIA L40S",
+    "hardware_flavor": "l40sx1",
+    "maximum_provider_charge_usd": 1.8,
+    "paid_attempts": 1,
+    "provider": "Hugging Face Jobs",
+    "timeout_seconds": 3600
+  },
+  "purpose": "hardware_validation_non_treatment",
+  "reference_treatment": {
+    "bytes": 9948,
+    "logical_path": "data/projects/open_model_data/treatments/gemma4_it_wikipedia_mask_ablation_preregistration_v1.json",
+    "relationship": "reference_only_not_amended_not_a_stage_1_execution",
+    "sha256": "274ea63558fbd50ccdfe352a44dadcac0c37e224c589b5f9244d3fffe24f9aee"
+  },
+  "schema_version": "gemma_hardware_probe_plan_v1",
+  "snapshot_manifest": {
+    "bytes": 1994,
+    "logical_path": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json",
+    "sha256": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1"
+  },
+  "state": "frozen_pending_operator_authorization"
+}

--- a/docs/runbooks/ukrainian-data-foundry-treatment.md
+++ b/docs/runbooks/ukrainian-data-foundry-treatment.md
@@ -2,8 +2,11 @@
 
 > **Owner:** [#6170](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6170)
 > under [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
-> **Current boundary:** Stage 0 is reproducible and no-cost; model-weight
-> download and training still require the exact operator authorization receipt
+> **Current boundary:** Stage 0 is reproducible and no-cost. A separately
+> bounded, non-treatment hardware validation is specified below but cannot
+> launch: local Hugging Face authentication/model access is not configured and
+> its exact probe authorization artifact is absent. Model-weight download and
+> treatment training still require the exact operator authorization receipt.
 
 ## What this experiment can decide
 
@@ -77,6 +80,100 @@ The source-bearing probe JSONL stays in ignored local state. The committed
 receipt binds its SHA-256, counts, source views, common split, limitations, and
 no-training/no-publication state.
 
+## Pre-Stage-1 hardware validation
+
+This is a single, paid hardware-validation attempt only. It is not a treatment
+run, does not consume corpus or evaluation data, and produces no causal or
+quality claim. Passing it neither authorizes nor satisfies the frozen Stage 1
+requirement for an A100 or H100.
+
+The validation uses a [Hugging Face Job](https://huggingface.co/docs/huggingface_hub/guides/jobs)
+with the `l40sx1` flavor. Hugging Face documents this flavor as one 48 GB
+NVIDIA L40S with 8 vCPUs, 62 GB RAM, and 380 GB ephemeral storage at USD
+0.03/minute; `timeout=3600` is mandatory and exact. Its maximum provider
+compute charge is therefore USD 1.80, within the operator's EUR 3 ceiling.
+Hugging Face is selected for this narrow probe because its Job timeout stops
+the running job and its billing; this is a bounded-provider-control choice,
+not a comparison of provider quality. See the official [Jobs pricing and
+billing](https://huggingface.co/docs/hub/en/jobs-pricing) and [Job
+configuration](https://huggingface.co/docs/hub/en/jobs-configuration) guidance
+for hardware and timeout behavior.
+
+The disposable job must use a deterministic synthetic fixture only, then run
+the frozen 4-bit NF4/BF16 QLoRA configuration at its actual sequence length of
+4,096 for exactly one optimizer step. It must save a disposable adapter
+checkpoint, start a clean process, and reload/resume from that checkpoint. It
+must not read any Foundry corpus, held-out evaluation, safety inventory, or
+other evaluation data; it must not upload or publish any artifact. The required
+evidence is hardware identity, peak VRAM, step/runtime timing, checkpoint
+save/reload result, timeout setting, and final Job status.
+
+Each child phase records an in-memory step fact immediately after
+`optimizer.step()` and then atomically writes and fsyncs the same fact before
+checkpoint work. The error channel preserves the in-memory fact if marker I/O
+fails. A hard process kill in the instruction-scale interval between the
+optimizer call returning and the Python flag assignment cannot be proven after
+the fact; that residual is reported conservatively rather than inferred.
+
+Launch remains impossible until both blockers are cleared: local Hugging Face
+authentication and access to the exact model are not configured, and an exact
+operator authorization artifact for this one-attempt probe does not exist.
+
+Once that exact authorization exists, validate it without launching anything:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \
+  prepare \
+  --authorization batch_state/6170/gemma-hardware-probe.authorization.json \
+  --hf-cli .venv/bin/hf \
+  --output batch_state/6170/hf-probe-preparation.json
+```
+
+The only paid entry point is the separate `launch` command. It creates one
+detached Job with the frozen 3,600-second provider timeout and records the Job
+ID immediately:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \
+  launch \
+  --authorization batch_state/6170/gemma-hardware-probe.authorization.json \
+  --hf-cli .venv/bin/hf
+```
+
+Before claiming the attempt, the launcher queries all provider Jobs for the
+exact authorization hash and fails closed if any match exists. It then creates
+both a host-global authorization-hash claim shared by local worktrees and
+`batch_state/6170/hf-probe-launch.json`, queries the provider a second time, and
+creates a private read-only upload snapshot whose bytes are verified against the
+authorization immediately before the provider call. The HF CLI uploads that
+snapshot, not the mutable working-tree script. If either claim or snapshot
+already exists, launch fails closed. A launch failure still consumes this
+one-attempt authorization, because the provider may have accepted a Job even
+when its response was lost. Hugging Face Jobs does not expose an atomic
+idempotency key, so this authorization is deliberately single-operator and must
+not be launched concurrently from different hosts; sequential cross-host reuse
+is rejected by the provider authorization-hash label.
+
+After that Job reaches a terminal state, collect its logs, provider inspection,
+resource-statistics observation, and completed-or-aborted worker receipt. The
+collector rejects non-terminal state, flavor/label/endpoint drift, duration
+over 3,600 seconds, a mismatched runner, or a server-derived compute charge over
+USD 1.80. The receipt records the provider-derived charge from server-reported
+running seconds; it leaves invoice-exact USD/EUR fields null because the Jobs
+inspection API does not return the settled invoice:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \
+  collect \
+  --job-id "$(jq -r .job_id batch_state/6170/hf-probe-launch.json)" \
+  --authorization batch_state/6170/gemma-hardware-probe.authorization.json \
+  --hf-cli .venv/bin/hf \
+  --output-directory batch_state/6170/hf-probe-evidence
+```
+
+All three output locations are ignored runtime evidence. They are not dataset,
+model, or evaluation artifacts and must not be committed.
+
 ## Economic ladder
 
 Google documents that tuning needs substantially more compute and memory than
@@ -102,6 +199,35 @@ USD 1.39–1.49 per hour and 80 GB H100s at USD 2.89–2.99 per hour. Runtime is
 still an estimate until Stage 1 measures this exact Gemma 4 QLoRA path. No
 provider account, machine, or weight download is authorized merely by the
 preregistration.
+
+## Evaluation sensitivity boundary
+
+The frozen 677-item evaluator already implements the preregistered 10,000-draw
+paired sentence bootstrap. Its saved Gemma 4 baseline has edit F0.5 `0.19335`
+and exact-sentence accuracy `73/677` (`10.78%`). The set can detect a useful
+multi-point change; it cannot turn a small or null result into proof that the
+treatment has no effect.
+
+For exact-sentence accuracy, let `q` be the fraction of items on which only one
+of the paired arms is exactly correct. The normal planning approximation for
+80% power with a two-sided 95% rule is
+`(1.96 + 0.842) × sqrt(q / 677)`. This gives:
+
+| Assumed paired discordance | Approximate detectable difference | Net sentences |
+| ---: | ---: | ---: |
+| 5% | 2.41 percentage points | 17 |
+| 10% | 3.40 percentage points | 24 |
+| 15% | 4.17 percentage points | 29 |
+| 20% | 4.82 percentage points | 33 |
+| 30% | 5.90 percentage points | 40 |
+
+For F0.5, the existing baseline and cross-model scale checks put the practical
+sensitivity around 3–5 F0.5 points unless the two treatment arms are very
+highly correlated. This is a planning bound, not a new acceptance threshold.
+The L40S hardware validation is unaffected because it makes no efficacy claim.
+Before any multi-seed paid efficacy program, the preregistration still needs a
+seed-level aggregation rule and an explicit practical-effect interpretation so
+seeds cannot be selected after scores are visible.
 
 ## Reproduce Stage 0
 

--- a/scripts/projects/open_model_data/gemma_hardware_probe.py
+++ b/scripts/projects/open_model_data/gemma_hardware_probe.py
@@ -1,0 +1,1430 @@
+#!/usr/bin/env python3
+"""Run the bounded, non-treatment Gemma 4 L40S hardware probe.
+
+The local launcher validates an exact operator authorization before it can
+create a Hugging Face Job. The remote worker uses only deterministic synthetic
+token IDs, writes no Hub artifact, and produces a machine-readable receipt in
+its logs. The provider-enforced timeout is the economic backstop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import multiprocessing
+import os
+import platform
+import re
+import subprocess
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+
+def _resolve_root(script_path: Path) -> Path:
+    """Resolve the repository root locally and a harmless base remotely."""
+    resolved = script_path.resolve()
+    for candidate in resolved.parents:
+        if (candidate / "data/projects/open_model_data/contracts").is_dir():
+            return candidate
+    return resolved.parent
+
+
+ROOT = _resolve_root(Path(__file__))
+CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
+PLAN_SCHEMA = CONTRACTS / "gemma_hardware_probe_plan_v1.schema.json"
+AUTH_SCHEMA = CONTRACTS / "gemma_hardware_probe_authorization_v1.schema.json"
+RECEIPT_SCHEMA = CONTRACTS / "gemma_hardware_probe_receipt_v1.schema.json"
+PLAN_PATH = ROOT / "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json"
+ATTEMPT_LEDGER_PATH = ROOT / "batch_state/6170/hf-probe-launch.json"
+EXPECTED_PLAN_SHA256 = "c78684279f5f34ff7b2c567e88182b4f8bcf6c154f570c12a6e72c492b4eef69"
+MODEL_IDENTIFIER = "google/gemma-4-31B-it"
+MODEL_REVISION = "842da3794eaa0b77d5f08bae87a17459d91ff475"
+PROBE_ID = "gemma4-it-l40s-hf-jobs-hardware-probe-v1"
+RECEIPT_MARKER = "GEMMA_HARDWARE_PROBE_RECEIPT="
+JOB_ID_PATTERN = re.compile(r"(?<![0-9a-f])[0-9a-f]{24}(?![0-9a-f])")
+REQUIRED_PACKAGES = (
+    "accelerate==1.14.0",
+    "bitsandbytes==0.50.0",
+    "huggingface_hub==1.25.1",
+    "peft==0.20.0",
+    "torch==2.13.0",
+    "transformers==5.14.1",
+)
+SNAPSHOT_FILES = {
+    "chat_template.jinja": (18683, "ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4"),
+    "config.json": (4621, "e967dd38bc5cfd38bd09a995a7bf4a754075df2b46aba68f7fbb5a791e6d8dd1"),
+    "generation_config.json": (208, "d4226bbe3117d2d253ba4609720ba82c6c4ce4627a9a6ae05387c78983ac03de"),
+    "model-00001-of-00002.safetensors": (
+        49784788364,
+        "eeef8791537bc04f110967c513149e037d2a9ae97d49add7291ebfa62806bbfa",
+    ),
+    "model-00002-of-00002.safetensors": (
+        12761549884,
+        "018912220f559f7025d60333e0996183cd538aa77ad6f4988a89ce47be681f10",
+    ),
+    "model.safetensors.index.json": (
+        120246,
+        "d4aff3b976d69c123a29d1c085d7ba4de1ac3f4ca1726a7f81e1b11462a64ea2",
+    ),
+    "processor_config.json": (1689, "32bdf45d2ad4cc29a0822ddd157a182de76644f0419a6228d151495256e9813c"),
+    "tokenizer.json": (32169626, "cc8d3a0ce36466ccc1278bf987df5f71db1719b9ca6b4118264f45cb627bfe0f"),
+    "tokenizer_config.json": (3082, "9f4fec4b1dc6ecddf8f4a92e9caea5971c0e67d81309f3f9066a2bee8c362633"),
+}
+
+
+class HardwareProbeError(RuntimeError):
+    """The bounded hardware probe cannot safely proceed."""
+
+
+class ProbeExecutionError(HardwareProbeError):
+    """A worker failure carrying already-persisted partial probe evidence."""
+
+    def __init__(self, message: str, *, partial_evidence: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.partial_evidence = dict(partial_evidence)
+
+
+class PhaseExecutionError(HardwareProbeError):
+    """A child-phase failure carrying a durable optimizer-step marker."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase_evidence: Mapping[str, Any] | None,
+        process_started: bool,
+    ) -> None:
+        super().__init__(message)
+        self.phase_evidence = dict(phase_evidence or {})
+        self.process_started = process_started
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HardwareProbeError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise HardwareProbeError(f"expected JSON object in {path}")
+    return value
+
+
+def validate_schema(value: Mapping[str, Any], schema_path: Path, *, label: str) -> None:
+    from jsonschema import Draft202012Validator, FormatChecker
+
+    schema = read_json(schema_path)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(value),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise HardwareProbeError(f"{label} schema error at {location}: {error.message}")
+
+
+def write_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    write_atomic_bytes(path, payload)
+
+
+def write_atomic_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_temp_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(raw_temp_path)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _assert_artifact(binding: Mapping[str, Any]) -> Path:
+    path = ROOT / str(binding["logical_path"])
+    if not path.is_file():
+        raise HardwareProbeError(f"missing bound artifact: {binding['logical_path']}")
+    if path.stat().st_size != int(binding["bytes"]) or sha256_file(path) != str(binding["sha256"]):
+        raise HardwareProbeError(f"bound artifact drift: {binding['logical_path']}")
+    return path
+
+
+def validate_plan_authorization(plan_path: Path, authorization_path: Path) -> tuple[dict[str, Any], str]:
+    plan = read_json(plan_path)
+    validate_schema(plan, PLAN_SCHEMA, label="hardware-probe plan")
+    plan_sha256 = sha256_file(plan_path)
+    if plan_sha256 != EXPECTED_PLAN_SHA256:
+        raise HardwareProbeError("hardware-probe plan differs from the runner-bound plan")
+    _assert_artifact(plan["snapshot_manifest"])
+    _assert_artifact(plan["reference_treatment"])
+
+    authorization = read_json(authorization_path)
+    validate_schema(authorization, AUTH_SCHEMA, label="hardware-probe authorization")
+    if authorization["plan"]["sha256"] != plan_sha256:
+        raise HardwareProbeError("authorization is not bound to the exact hardware-probe plan")
+    _assert_artifact(authorization["plan"])
+    _assert_artifact(authorization["runner"])
+    expected = plan["provider"]
+    approved = authorization["authorization"]
+    comparisons = {
+        "provider": expected["provider"],
+        "hardware_flavor": expected["hardware_flavor"],
+        "timeout_seconds": expected["timeout_seconds"],
+        "maximum_provider_charge_usd": expected["maximum_provider_charge_usd"],
+        "paid_attempts": expected["paid_attempts"],
+    }
+    for field, expected_value in comparisons.items():
+        if approved[field] != expected_value:
+            raise HardwareProbeError(f"authorization {field} differs from the frozen plan")
+    if approved["operator_all_inclusive_ceiling_eur"] != plan["operator_ceiling"]["amount_eur"]:
+        raise HardwareProbeError("authorization operator ceiling differs from the frozen plan")
+    return plan, sha256_file(authorization_path)
+
+
+def build_hf_job_command(
+    *,
+    plan_path: Path,
+    authorization_path: Path,
+    hf_cli: Path,
+    script_path: Path | None = None,
+) -> list[str]:
+    plan, authorization_sha256 = validate_plan_authorization(plan_path, authorization_path)
+    if not hf_cli.is_file() or not os.access(hf_cli, os.X_OK):
+        raise HardwareProbeError(f"Hugging Face CLI is not executable: {hf_cli}")
+    script = script_path or Path(__file__).resolve()
+    if not script.is_file():
+        raise HardwareProbeError(f"hardware-probe worker script is missing: {script}")
+    provider = plan["provider"]
+    command = [
+        str(hf_cli),
+        "jobs",
+        "uv",
+        "run",
+        "--detach",
+        "--timeout",
+        f"{provider['timeout_seconds']}s",
+        "--flavor",
+        str(provider["hardware_flavor"]),
+        "--secrets",
+        "HF_TOKEN",
+        "--name",
+        "gemma4-it-l40s-probe-6170",
+        "--label",
+        "issue=6170",
+        "--label",
+        f"probe_id={PROBE_ID}",
+        "--label",
+        f"plan_sha256={EXPECTED_PLAN_SHA256}",
+        "--label",
+        f"authorization_sha256={authorization_sha256}",
+        "--label",
+        f"timeout_seconds={provider['timeout_seconds']}",
+        "--python",
+        "3.12",
+    ]
+    for package in REQUIRED_PACKAGES:
+        command.extend(("--with", package))
+    command.extend(
+        (
+            str(script),
+            "worker",
+            "--plan-sha256",
+            EXPECTED_PLAN_SHA256,
+            "--authorization-sha256",
+            authorization_sha256,
+        )
+    )
+    return command
+
+
+def safe_job_command(
+    command: Sequence[str],
+    *,
+    script_path: Path,
+    script_placeholder: str,
+) -> list[str]:
+    return [
+        "<HF_CLI>"
+        if index == 0
+        else script_placeholder if value == str(script_path) else value
+        for index, value in enumerate(command)
+    ]
+
+
+def parse_job_id(output: str) -> str:
+    matches = JOB_ID_PATTERN.findall(output.lower())
+    if len(set(matches)) != 1:
+        raise HardwareProbeError("Hugging Face Jobs launch did not return exactly one job ID")
+    return matches[0]
+
+
+def require_hf_auth(hf_cli: str) -> None:
+    auth_probe = subprocess.run(
+        [hf_cli, "auth", "whoami"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if auth_probe.returncode:
+        raise HardwareProbeError("Hugging Face authentication is not configured")
+
+
+def _parse_json_array(payload: str, *, label: str) -> list[dict[str, Any]]:
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise HardwareProbeError(f"{label} is invalid JSON: {exc}") from exc
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise HardwareProbeError(f"{label} must be a JSON array of objects")
+    return value
+
+
+def require_no_provider_attempt(*, hf_cli: str, authorization_sha256: str) -> None:
+    """Fail before launch if the provider already knows this authorization."""
+    result = subprocess.run(
+        [
+            hf_cli,
+            "jobs",
+            "list",
+            "--all",
+            "--limit",
+            "0",
+            "--label",
+            f"authorization_sha256={authorization_sha256}",
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        raise HardwareProbeError("cannot establish the provider-side paid-attempt state")
+    jobs = _parse_json_array(result.stdout, label="provider paid-attempt query")
+    if jobs:
+        raise HardwareProbeError("provider already has a job for this exact authorization")
+
+
+def launch_job(command: Sequence[str]) -> str:
+    require_hf_auth(command[0])
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown launch error"
+        raise HardwareProbeError(f"Hugging Face Job launch failed: {message}")
+    return parse_job_id(f"{result.stdout}\n{result.stderr}")
+
+
+def claim_paid_attempt(path: Path, claim: Mapping[str, Any]) -> None:
+    """Claim the only authorized paid attempt before the provider call."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(claim, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise HardwareProbeError(f"paid-attempt ledger already exists: {path}") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def host_global_attempt_claim_path(authorization_sha256: str) -> Path:
+    if not re.fullmatch(r"[a-f0-9]{64}", authorization_sha256):
+        raise HardwareProbeError("cannot derive a host-global claim for an invalid authorization hash")
+    return (
+        Path(tempfile.gettempdir())
+        / "learn-ukrainian-hf-probe-claims"
+        / f"{authorization_sha256}.json"
+    )
+
+
+def create_authorized_runner_snapshot(
+    *,
+    authorization_path: Path,
+    output_directory: Path,
+) -> Path:
+    """Create a private read-only copy that remains stable while HF uploads it."""
+    _, authorization_sha256 = validate_plan_authorization(PLAN_PATH, authorization_path)
+    authorization = read_json(authorization_path)
+    binding = authorization["runner"]
+    source = _assert_artifact(binding)
+    payload = source.read_bytes()
+    if len(payload) != binding["bytes"] or sha256_bytes(payload) != binding["sha256"]:
+        raise HardwareProbeError("authorized runner changed while creating its upload snapshot")
+    snapshot = output_directory / f"gemma-hardware-probe-{authorization_sha256}.authorized.py"
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(snapshot, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o400)
+    except FileExistsError as exc:
+        raise HardwareProbeError("authorized runner upload snapshot already exists") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        snapshot.unlink(missing_ok=True)
+        raise
+    if snapshot.stat().st_size != binding["bytes"] or sha256_file(snapshot) != binding["sha256"]:
+        raise HardwareProbeError("authorized runner upload snapshot verification failed")
+    return snapshot
+
+
+def verify_authorized_runner_snapshot(*, snapshot: Path, authorization_path: Path) -> None:
+    authorization = read_json(authorization_path)
+    binding = authorization["runner"]
+    try:
+        snapshot_stat = snapshot.stat()
+        snapshot_sha256 = sha256_file(snapshot)
+    except OSError as exc:
+        raise HardwareProbeError(f"cannot verify authorized runner upload snapshot: {exc}") from exc
+    if snapshot_stat.st_size != binding["bytes"] or snapshot_sha256 != binding["sha256"]:
+        raise HardwareProbeError("authorized runner upload snapshot drift")
+    if snapshot_stat.st_mode & 0o222:
+        raise HardwareProbeError("authorized runner upload snapshot is writable")
+
+
+def reconcile_provider_receipt(
+    *,
+    receipt: Mapping[str, Any],
+    inspection: Mapping[str, Any],
+    job_id: str,
+    authorization_sha256: str,
+    authorization: Mapping[str, Any],
+    wait_returncode: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Bind worker evidence to the terminal job facts returned by HF Jobs."""
+    if inspection.get("id") != job_id:
+        raise HardwareProbeError("provider inspection job ID drift")
+    if inspection.get("flavor") != "l40sx1":
+        raise HardwareProbeError("provider inspection hardware-flavor drift")
+    labels = inspection.get("labels")
+    if not isinstance(labels, dict):
+        raise HardwareProbeError("provider inspection is missing job labels")
+    required_labels = {
+        "authorization_sha256": authorization_sha256,
+        "issue": "6170",
+        "plan_sha256": EXPECTED_PLAN_SHA256,
+        "probe_id": PROBE_ID,
+        "timeout_seconds": "3600",
+    }
+    if any(labels.get(key) != value for key, value in required_labels.items()):
+        raise HardwareProbeError("provider inspection label drift")
+    status = inspection.get("status")
+    if not isinstance(status, dict):
+        raise HardwareProbeError("provider inspection is missing job status")
+    stage = status.get("stage")
+    terminal_stages = {"COMPLETED", "CANCELED", "ERROR", "DELETED"}
+    if stage not in terminal_stages:
+        raise HardwareProbeError("provider job has not reached a terminal state")
+    if (wait_returncode == 0) != (stage == "COMPLETED"):
+        raise HardwareProbeError("provider wait result disagrees with terminal job status")
+    if status.get("expose_urls") or status.get("ssh_url"):
+        raise HardwareProbeError("provider inspection reports an exposed endpoint")
+    durations = inspection.get("durations")
+    if not isinstance(durations, dict):
+        raise HardwareProbeError("provider inspection is missing server-side durations")
+    running_seconds = durations.get("running_secs")
+    if not isinstance(running_seconds, int) or isinstance(running_seconds, bool):
+        raise HardwareProbeError("provider running duration is missing or invalid")
+    if not 0 <= running_seconds <= 3600:
+        raise HardwareProbeError("provider running duration exceeds the authorized timeout")
+    provider_derived_cost_usd = round(running_seconds * 0.03 / 60, 6)
+    if provider_derived_cost_usd > 1.8:
+        raise HardwareProbeError("provider-derived charge exceeds the authorized maximum")
+    if receipt.get("authorization_sha256") != authorization_sha256:
+        raise HardwareProbeError("provider receipt authorization drift")
+    environment = receipt.get("environment")
+    if not isinstance(environment, dict) or environment.get("runner_sha256") != authorization["runner"]["sha256"]:
+        raise HardwareProbeError("provider receipt runner drift")
+    if receipt.get("status") == "completed" and stage != "COMPLETED":
+        raise HardwareProbeError("completed worker receipt disagrees with provider failure status")
+
+    reconciled = json.loads(canonical_json(receipt))
+    reconciled["provider_job"].update(
+        {
+            "job_status": stage,
+            "provider_derived_cost_usd": provider_derived_cost_usd,
+            "provider_evidence_reconciled": True,
+            "provider_running_seconds": running_seconds,
+        }
+    )
+    evidence = {
+        "authorization_sha256": authorization_sha256,
+        "exposed_endpoints": False,
+        "hardware_flavor": inspection["flavor"],
+        "job_id": job_id,
+        "labels": required_labels,
+        "provider_derived_cost_usd": provider_derived_cost_usd,
+        "provider_running_seconds": running_seconds,
+        "provider_stage": stage,
+        "timeout_seconds": 3600,
+        "wait_returncode": wait_returncode,
+    }
+    return reconciled, evidence
+
+
+def collect_job(
+    *,
+    job_id: str,
+    hf_cli: Path,
+    authorization_path: Path,
+    output_directory: Path,
+) -> dict[str, Any]:
+    if not JOB_ID_PATTERN.fullmatch(job_id):
+        raise HardwareProbeError("invalid Hugging Face Job ID")
+    _, authorization_sha256 = validate_plan_authorization(PLAN_PATH, authorization_path)
+    authorization = read_json(authorization_path)
+    if not hf_cli.is_file() or not os.access(hf_cli, os.X_OK):
+        raise HardwareProbeError(f"Hugging Face CLI is not executable: {hf_cli}")
+    require_hf_auth(str(hf_cli))
+    wait_result = subprocess.run(
+        [str(hf_cli), "jobs", "wait", "--timeout", "75m", job_id],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    inspect_result = subprocess.run(
+        [str(hf_cli), "jobs", "inspect", "--json", job_id],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    stats_result = subprocess.run(
+        [str(hf_cli), "jobs", "stats", job_id],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    logs_result = subprocess.run(
+        [str(hf_cli), "jobs", "logs", job_id],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output_directory.mkdir(parents=True, exist_ok=True)
+    write_atomic_bytes(output_directory / "provider-wait.stdout.txt", wait_result.stdout.encode("utf-8"))
+    write_atomic_bytes(output_directory / "provider-wait.stderr.txt", wait_result.stderr.encode("utf-8"))
+    write_atomic_bytes(output_directory / "provider-inspect.json", inspect_result.stdout.encode("utf-8"))
+    write_atomic_bytes(output_directory / "provider-stats.stdout.txt", stats_result.stdout.encode("utf-8"))
+    write_atomic_bytes(output_directory / "provider-stats.stderr.txt", stats_result.stderr.encode("utf-8"))
+    write_atomic_bytes(output_directory / "provider-logs.txt", logs_result.stdout.encode("utf-8"))
+    if inspect_result.returncode or logs_result.returncode:
+        raise HardwareProbeError("provider evidence collection failed")
+    inspections = _parse_json_array(inspect_result.stdout, label="provider inspection")
+    if len(inspections) != 1:
+        raise HardwareProbeError("provider inspection did not return exactly one job")
+    marked = [
+        line.split(RECEIPT_MARKER, 1)[1].strip() for line in logs_result.stdout.splitlines() if RECEIPT_MARKER in line
+    ]
+    if len(marked) != 1:
+        raise HardwareProbeError("provider logs do not contain exactly one hardware-probe receipt")
+    try:
+        receipt = json.loads(marked[0])
+    except json.JSONDecodeError as exc:
+        raise HardwareProbeError(f"provider receipt is invalid JSON: {exc}") from exc
+    if not isinstance(receipt, dict):
+        raise HardwareProbeError("provider receipt is not a JSON object")
+    validate_schema(receipt, RECEIPT_SCHEMA, label="hardware-probe receipt")
+    if receipt["provider_job"]["job_id"] != job_id:
+        raise HardwareProbeError("provider receipt job ID drift")
+    receipt, provider_evidence = reconcile_provider_receipt(
+        receipt=receipt,
+        inspection=inspections[0],
+        job_id=job_id,
+        authorization_sha256=authorization_sha256,
+        authorization=authorization,
+        wait_returncode=wait_result.returncode,
+    )
+    provider_evidence["stats_command_succeeded"] = stats_result.returncode == 0
+    validate_schema(receipt, RECEIPT_SCHEMA, label="reconciled hardware-probe receipt")
+    write_atomic(output_directory / "provider-evidence.json", provider_evidence)
+    write_atomic(output_directory / "worker-receipt.json", receipt)
+    return receipt
+
+
+def _artifact(path: Path) -> dict[str, Any]:
+    if path.is_file():
+        return {"bytes": path.stat().st_size, "sha256": sha256_file(path)}
+    if not path.is_dir():
+        raise HardwareProbeError(f"missing checkpoint artifact: {path}")
+    digest = hashlib.sha256()
+    total_bytes = 0
+    for child in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+        relative = child.relative_to(path).as_posix().encode("utf-8")
+        payload_hash = sha256_file(child).encode("ascii")
+        size = child.stat().st_size
+        digest.update(relative + b"\0" + str(size).encode("ascii") + b"\0" + payload_hash + b"\n")
+        total_bytes += size
+    if total_bytes <= 0:
+        raise HardwareProbeError(f"empty checkpoint artifact: {path}")
+    return {"bytes": total_bytes, "sha256": digest.hexdigest()}
+
+
+def verify_snapshot(model_directory: Path) -> None:
+    for relative, (expected_bytes, expected_sha256) in SNAPSHOT_FILES.items():
+        path = model_directory / relative
+        if not path.is_file():
+            raise HardwareProbeError(f"model snapshot file missing: {relative}")
+        if path.stat().st_size != expected_bytes:
+            raise HardwareProbeError(f"model snapshot byte drift: {relative}")
+        if sha256_file(path) != expected_sha256:
+            raise HardwareProbeError(f"model snapshot hash drift: {relative}")
+
+
+def download_snapshot(target: Path) -> None:
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        repo_id=MODEL_IDENTIFIER,
+        revision=MODEL_REVISION,
+        local_dir=target,
+        allow_patterns=sorted(SNAPSHOT_FILES),
+    )
+    verify_snapshot(target)
+
+
+def _runtime_package_digest() -> str:
+    versions: list[str] = []
+    for requirement in REQUIRED_PACKAGES:
+        name, expected = requirement.split("==", 1)
+        actual = importlib.metadata.version(name)
+        if actual != expected:
+            raise HardwareProbeError(f"package drift: {name} is {actual}, expected {expected}")
+        versions.append(requirement)
+    return sha256_bytes(("\n".join(versions) + "\n").encode("utf-8"))
+
+
+def _gpu_evidence() -> dict[str, Any]:
+    import torch
+
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        raise HardwareProbeError("probe requires exactly one CUDA GPU")
+    name = torch.cuda.get_device_name(0)
+    if name != "NVIDIA L40S":
+        raise HardwareProbeError(f"wrong GPU: {name}")
+    total_memory = int(torch.cuda.get_device_properties(0).total_memory)
+    if total_memory < 45 * 1024**3:
+        raise HardwareProbeError(f"insufficient L40S memory: {total_memory} bytes")
+    return {"count": 1, "name": name, "total_memory_bytes": total_memory}
+
+
+def _cuda_evidence() -> tuple[str, str]:
+    import torch
+
+    runtime = str(torch.version.cuda or "unknown")
+    result = subprocess.run(
+        ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    driver = result.stdout.strip()
+    if result.returncode or not driver:
+        raise HardwareProbeError("cannot resolve the NVIDIA driver version")
+    return runtime, driver
+
+
+def _fixed_fixture(tokenizer: Any, *, sequence_length: int) -> dict[str, Any]:
+    import torch
+
+    sentence = "Це суто синтетичне речення для перевірки обчислювального шляху без навчальних даних. "
+    encoded = tokenizer(
+        sentence * (sequence_length * 2),
+        add_special_tokens=True,
+        max_length=sequence_length,
+        padding="max_length",
+        return_attention_mask=True,
+        return_special_tokens_mask=True,
+        return_tensors="pt",
+        truncation=True,
+    )
+    input_ids = encoded["input_ids"]
+    attention_mask = encoded["attention_mask"]
+    special_tokens_mask = encoded["special_tokens_mask"]
+    if tuple(input_ids.shape) != (1, sequence_length) or int(attention_mask.sum()) != sequence_length:
+        raise HardwareProbeError("synthetic fixture did not produce one full-length sequence")
+    labels = input_ids.clone()
+    labels[(attention_mask == 0) | (special_tokens_mask != 0)] = -100
+    fixture_sha256 = sha256_bytes(input_ids.numpy().tobytes())
+    return {
+        "attention_mask": attention_mask.to("cuda:0"),
+        "fixture_sha256": fixture_sha256,
+        "input_ids": input_ids.to("cuda:0"),
+        "labels": labels.to("cuda:0"),
+        "tokens": int(attention_mask.sum()),
+        "torch": torch,
+    }
+
+
+def _load_probe_model(model_directory: Path, *, checkpoint_directory: Path | None) -> tuple[Any, Any]:
+    import torch
+    from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+    from transformers import AutoModelForMultimodalLM, AutoProcessor, BitsAndBytesConfig
+
+    quantization = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_compute_dtype=torch.bfloat16,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+    )
+    processor = AutoProcessor.from_pretrained(model_directory, local_files_only=True)
+    model = AutoModelForMultimodalLM.from_pretrained(
+        model_directory,
+        device_map={"": 0},
+        local_files_only=True,
+        quantization_config=quantization,
+        torch_dtype=torch.bfloat16,
+    )
+    model.config.use_cache = False
+    model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=True)
+    if checkpoint_directory is None:
+        model = get_peft_model(
+            model,
+            LoraConfig(
+                r=16,
+                lora_alpha=32,
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+            ),
+        )
+    else:
+        model = PeftModel.from_pretrained(model, checkpoint_directory / "adapter", is_trainable=True)
+    return processor, model
+
+
+def _phase_child(
+    result_queue: Any,
+    *,
+    model_directory: str,
+    checkpoint_input: str | None,
+    checkpoint_output: str,
+    progress_marker: str,
+    global_step: int,
+) -> None:
+    phase_evidence: dict[str, Any] | None = None
+    try:
+        import torch
+        from bitsandbytes.optim import PagedAdamW8bit
+
+        torch.manual_seed(6170)
+        torch.cuda.manual_seed_all(6170)
+        torch.cuda.reset_peak_memory_stats()
+        input_checkpoint = Path(checkpoint_input) if checkpoint_input else None
+        processor, model = _load_probe_model(Path(model_directory), checkpoint_directory=input_checkpoint)
+        fixture = _fixed_fixture(processor.tokenizer, sequence_length=4096)
+        optimizer = PagedAdamW8bit(
+            (parameter for parameter in model.parameters() if parameter.requires_grad),
+            lr=1e-5,
+            weight_decay=0.1,
+        )
+        if input_checkpoint is not None:
+            step = json.loads((input_checkpoint / "step.json").read_text(encoding="utf-8"))
+            if int(step["global_step"]) != global_step:
+                raise HardwareProbeError("checkpoint global-step drift")
+            optimizer.load_state_dict(
+                torch.load(input_checkpoint / "optimizer.pt", map_location="cpu", weights_only=True)
+            )
+            rng_state = torch.load(input_checkpoint / "rng.pt", map_location="cpu", weights_only=True)
+            torch.set_rng_state(rng_state["cpu"])
+            torch.cuda.set_rng_state_all(rng_state["cuda"])
+        model.train()
+        optimizer.zero_grad(set_to_none=True)
+        started = time.monotonic()
+        output = model(
+            input_ids=fixture["input_ids"],
+            attention_mask=fixture["attention_mask"],
+            labels=fixture["labels"],
+        )
+        loss = output.loss
+        if loss is None or not torch.isfinite(loss):
+            raise HardwareProbeError("non-finite probe loss")
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(
+            (parameter for parameter in model.parameters() if parameter.requires_grad),
+            max_norm=1.0,
+        )
+        phase_evidence = {
+            "fixture_sha256": fixture["fixture_sha256"],
+            "global_step": global_step + 1,
+            "loss": float(loss.detach().cpu()),
+            "optimizer_step_performed": False,
+            "tokens": fixture["tokens"],
+        }
+        optimizer.step()
+        phase_evidence["optimizer_step_performed"] = True
+        write_atomic(Path(progress_marker), phase_evidence)
+        torch.cuda.synchronize()
+        elapsed = time.monotonic() - started
+        target = Path(checkpoint_output)
+        target.mkdir(parents=True, exist_ok=False)
+        adapter_path = target / "adapter"
+        model.save_pretrained(adapter_path, safe_serialization=True)
+        optimizer_path = target / "optimizer.pt"
+        rng_path = target / "rng.pt"
+        step_path = target / "step.json"
+        torch.save(optimizer.state_dict(), optimizer_path)
+        torch.save(
+            {"cpu": torch.get_rng_state(), "cuda": torch.cuda.get_rng_state_all()},
+            rng_path,
+        )
+        step_path.write_text(canonical_json({"global_step": global_step + 1}) + "\n", encoding="utf-8")
+        result_queue.put(
+            {
+                "adapter": _artifact(adapter_path),
+                "checkpoint": _artifact(target),
+                "elapsed_seconds": elapsed,
+                "fixture_sha256": fixture["fixture_sha256"],
+                "global_step": global_step + 1,
+                "loss": float(loss.detach().cpu()),
+                "optimizer": _artifact(optimizer_path),
+                "peak_allocated_bytes": int(torch.cuda.max_memory_allocated()),
+                "peak_reserved_bytes": int(torch.cuda.max_memory_reserved()),
+                "rng": _artifact(rng_path),
+                "tokens": fixture["tokens"],
+            }
+        )
+    except BaseException as exc:  # child must return one durable failure message
+        result_queue.put(
+            {
+                "error": f"{type(exc).__name__}: {exc}",
+                "phase_evidence": phase_evidence,
+            }
+        )
+        raise
+
+
+def run_phase_process(
+    *,
+    model_directory: Path,
+    checkpoint_input: Path | None,
+    checkpoint_output: Path,
+    global_step: int,
+    deadline_monotonic: float,
+) -> dict[str, Any]:
+    progress_marker = checkpoint_output.parent / f".{checkpoint_output.name}.optimizer-step.json"
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue(maxsize=1)
+    process = context.Process(
+        target=_phase_child,
+        kwargs={
+            "result_queue": result_queue,
+            "model_directory": str(model_directory),
+            "checkpoint_input": str(checkpoint_input) if checkpoint_input else None,
+            "checkpoint_output": str(checkpoint_output),
+            "progress_marker": str(progress_marker),
+            "global_step": global_step,
+        },
+    )
+    try:
+        process.start()
+    except BaseException as exc:
+        raise PhaseExecutionError(
+            f"probe child could not start: {type(exc).__name__}: {exc}",
+            phase_evidence=None,
+            process_started=False,
+        ) from exc
+    remaining = max(0.0, deadline_monotonic - time.monotonic())
+    process.join(timeout=remaining)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=10)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
+        phase_evidence = read_json(progress_marker) if progress_marker.is_file() else None
+        raise PhaseExecutionError(
+            "probe child exceeded the internal deadline",
+            phase_evidence=phase_evidence,
+            process_started=True,
+        )
+    try:
+        result = result_queue.get(timeout=2)
+    except Empty as exc:
+        phase_evidence = read_json(progress_marker) if progress_marker.is_file() else None
+        raise PhaseExecutionError(
+            f"probe child exited {process.exitcode} without evidence",
+            phase_evidence=phase_evidence,
+            process_started=True,
+        ) from exc
+    if process.exitcode != 0 or "error" in result:
+        phase_evidence = (
+            read_json(progress_marker)
+            if progress_marker.is_file()
+            else result.get("phase_evidence")
+        )
+        raise PhaseExecutionError(
+            str(result.get("error", f"probe child exited {process.exitcode}")),
+            phase_evidence=phase_evidence,
+            process_started=True,
+        )
+    phase_evidence = read_json(progress_marker) if progress_marker.is_file() else None
+    if not phase_evidence or phase_evidence.get("global_step") != global_step + 1:
+        raise PhaseExecutionError(
+            "probe child returned without the durable optimizer-step marker",
+            phase_evidence=phase_evidence,
+            process_started=True,
+        )
+    return result
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _completed_worker_receipt(
+    *,
+    authorization_sha256: str,
+    job_id: str,
+    started_at: str,
+    started_monotonic: float,
+    packages_sha256: str,
+    gpu: Mapping[str, Any],
+    cuda_runtime: str,
+    cuda_driver: str,
+    first: Mapping[str, Any],
+    second: Mapping[str, Any],
+) -> dict[str, Any]:
+    if first["fixture_sha256"] != second["fixture_sha256"]:
+        raise HardwareProbeError("synthetic fixture changed across the process boundary")
+    wall_seconds = time.monotonic() - started_monotonic
+    if wall_seconds > 3600:
+        raise HardwareProbeError("worker exceeded the provider timeout envelope")
+    total_step_seconds = float(first["elapsed_seconds"]) + float(second["elapsed_seconds"])
+    tokens_processed = int(first["tokens"]) + int(second["tokens"])
+    return {
+        "abort_reason": None,
+        "attempt": 1,
+        "authorization_sha256": authorization_sha256,
+        "checkpoint_resume": {
+            "adapter": first["adapter"],
+            "optimizer": first["optimizer"],
+            "process_boundary": True,
+            "reload_passed": second["global_step"] == 2,
+            "rng": first["rng"],
+        },
+        "environment": {
+            "cuda_driver": cuda_driver,
+            "cuda_runtime": cuda_runtime,
+            "packages_sha256": packages_sha256,
+            "python": platform.python_version(),
+            "runner_sha256": sha256_file(Path(__file__).resolve()),
+        },
+        "facts": {
+            "data_upload_performed": False,
+            "evaluation_data_used": False,
+            "model_or_checkpoint_upload_performed": False,
+            "model_quality_evaluation_performed": False,
+            "private_job_script_transport_used": True,
+            "publication_performed": False,
+            "purpose": "hardware_validation_non_treatment",
+            "synthetic_adapter_optimizer_updates_performed": True,
+            "treatment_data_used": False,
+            "treatment_stage_1_performed": False,
+        },
+        "gpu": {
+            **gpu,
+            "peak_allocated_bytes": max(first["peak_allocated_bytes"], second["peak_allocated_bytes"]),
+            "peak_reserved_bytes": max(first["peak_reserved_bytes"], second["peak_reserved_bytes"]),
+        },
+        "plan": {
+            "bytes": 2537,
+            "logical_path": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json",
+            "sha256": EXPECTED_PLAN_SHA256,
+        },
+        "probe_id": PROBE_ID,
+        "provider_job": {
+            "actual_invoice_cost_eur": None,
+            "actual_invoice_cost_usd": None,
+            "billing_usd_per_minute": 0.03,
+            "exposed_ports": False,
+            "hardware_flavor": "l40sx1",
+            "job_id": job_id,
+            "job_status": "worker_completed_pending_provider_reconciliation",
+            "maximum_provider_charge_usd": 1.8,
+            "provider": "Hugging Face Jobs",
+            "provider_derived_cost_usd": None,
+            "provider_evidence_reconciled": False,
+            "provider_running_seconds": None,
+            "timeout_seconds": 3600,
+        },
+        "runtime": {
+            "ended_at": _iso_now(),
+            "provider_timeout_enforced": True,
+            "started_at": started_at,
+            "wall_seconds": wall_seconds,
+        },
+        "schema_version": "gemma_hardware_probe_receipt_v1",
+        "snapshot_verification": {
+            "all_files_bytes_match": True,
+            "all_files_sha256_match": True,
+            "manifest": {
+                "bytes": 1994,
+                "logical_path": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json",
+                "sha256": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1",
+            },
+        },
+        "status": "completed",
+        "throughput": {
+            "elapsed_seconds": total_step_seconds,
+            "fixture_sha256": first["fixture_sha256"],
+            "sequence_length": 4096,
+            "tokens_per_second": tokens_processed / total_step_seconds,
+            "tokens_processed": tokens_processed,
+        },
+        "training_probe": {
+            "adapter": "qlora_rank16_alpha32_dropout0.05",
+            "loss_after_resume": second["loss"],
+            "loss_before_checkpoint": first["loss"],
+            "nonfinite_detected": False,
+            "optimizer_steps_after_resume": 1,
+            "optimizer_steps_before_checkpoint": 1,
+            "quantization": "4bit_nf4_bf16_double_quantization",
+        },
+    }
+
+
+def run_worker(*, plan_sha256: str, authorization_sha256: str) -> dict[str, Any]:
+    if plan_sha256 != EXPECTED_PLAN_SHA256:
+        raise HardwareProbeError("worker plan hash differs from the frozen plan")
+    if not re.fullmatch(r"[a-f0-9]{64}", authorization_sha256):
+        raise HardwareProbeError("worker authorization hash is invalid")
+    if os.environ.get("ACCELERATOR") != "l40sx1":
+        raise HardwareProbeError("Hugging Face Jobs accelerator does not match l40sx1")
+    job_id = os.environ.get("JOB_ID", "")
+    if not JOB_ID_PATTERN.fullmatch(job_id):
+        raise HardwareProbeError("missing or invalid Hugging Face Job ID")
+
+    started_at = _iso_now()
+    started = time.monotonic()
+    deadline = started + 3300
+    packages_sha256 = _runtime_package_digest()
+    gpu = _gpu_evidence()
+    cuda_runtime, cuda_driver = _cuda_evidence()
+    work_directory = Path(tempfile.mkdtemp(prefix="gemma4-hardware-probe-"))
+    model_directory = work_directory / "model"
+    download_snapshot(model_directory)
+    partial_evidence = {
+        "cuda_driver": cuda_driver,
+        "cuda_runtime": cuda_runtime,
+        "gpu": gpu,
+        "packages_sha256": packages_sha256,
+        "python": platform.python_version(),
+        "runner_sha256": sha256_file(Path(__file__).resolve()),
+        "snapshot_verified": True,
+    }
+    try:
+        first = run_phase_process(
+            model_directory=model_directory,
+            checkpoint_input=None,
+            checkpoint_output=work_directory / "checkpoint-step-1",
+            global_step=0,
+            deadline_monotonic=deadline,
+        )
+    except PhaseExecutionError as exc:
+        partial_evidence["first_progress"] = exc.phase_evidence
+        raise ProbeExecutionError(
+            f"first phase failed: {type(exc).__name__}: {exc}",
+            partial_evidence=partial_evidence,
+        ) from exc
+    partial_evidence["first"] = first
+    try:
+        write_atomic(work_directory / "partial-progress.json", partial_evidence)
+        second = run_phase_process(
+            model_directory=model_directory,
+            checkpoint_input=work_directory / "checkpoint-step-1",
+            checkpoint_output=work_directory / "checkpoint-step-2",
+            global_step=1,
+            deadline_monotonic=deadline,
+        )
+        partial_evidence["resume_process_started"] = True
+        partial_evidence["second"] = second
+        return _completed_worker_receipt(
+            authorization_sha256=authorization_sha256,
+            job_id=job_id,
+            started_at=started_at,
+            started_monotonic=started,
+            packages_sha256=packages_sha256,
+            gpu=gpu,
+            cuda_runtime=cuda_runtime,
+            cuda_driver=cuda_driver,
+            first=first,
+            second=second,
+        )
+    except BaseException as exc:
+        if isinstance(exc, PhaseExecutionError):
+            partial_evidence["resume_process_started"] = exc.process_started
+            partial_evidence["second_progress"] = exc.phase_evidence
+        raise ProbeExecutionError(
+            f"worker failed after the first optimizer step: {type(exc).__name__}: {exc}",
+            partial_evidence=partial_evidence,
+        ) from exc
+
+
+def aborted_worker_receipt(
+    *,
+    authorization_sha256: str,
+    abort_reason: str,
+    started_at: str,
+    started_monotonic: float,
+    partial_evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Represent a provider-job failure without inventing unavailable evidence."""
+    partial = dict(partial_evidence or {})
+    first = partial.get("first") if isinstance(partial.get("first"), dict) else None
+    second = partial.get("second") if isinstance(partial.get("second"), dict) else None
+    first_progress = (
+        partial.get("first_progress") if isinstance(partial.get("first_progress"), dict) else None
+    )
+    second_progress = (
+        partial.get("second_progress") if isinstance(partial.get("second_progress"), dict) else None
+    )
+    first_step_completed = bool(first and first.get("global_step") == 1)
+    second_step_completed = bool(second and second.get("global_step") == 2)
+    first_step_performed = first_step_completed or bool(
+        first_progress
+        and first_progress.get("global_step") == 1
+        and first_progress.get("optimizer_step_performed") is True
+    )
+    second_step_performed = second_step_completed or bool(
+        second_progress
+        and second_progress.get("global_step") == 2
+        and second_progress.get("optimizer_step_performed") is True
+    )
+    first_observation = first if first_step_completed else first_progress
+    second_observation = second if second_step_completed else second_progress
+    gpu = partial.get("gpu") if isinstance(partial.get("gpu"), dict) else {}
+    elapsed_seconds = None
+    if first_step_completed and (not second_step_performed or second_step_completed):
+        elapsed_seconds = float(first["elapsed_seconds"]) + (
+            float(second["elapsed_seconds"]) if second_step_completed else 0.0
+        )
+    tokens_processed = sum(
+        int(observation["tokens"])
+        for observation in (first_observation, second_observation)
+        if observation and observation.get("optimizer_step_performed", True) is True
+    ) or None
+    job_id = os.environ.get("JOB_ID", "unavailable")
+    valid_authorization_sha256 = (
+        authorization_sha256 if re.fullmatch(r"[a-f0-9]{64}", authorization_sha256) else "0" * 64
+    )
+    return {
+        "abort_reason": abort_reason,
+        "attempt": 1,
+        "authorization_sha256": valid_authorization_sha256,
+        "checkpoint_resume": {
+            "adapter": first.get("adapter") if first_step_completed else None,
+            "optimizer": first.get("optimizer") if first_step_completed else None,
+            "process_boundary": bool(partial.get("resume_process_started")),
+            "reload_passed": second_step_performed if first_step_performed else None,
+            "rng": first.get("rng") if first_step_completed else None,
+        },
+        "environment": {
+            "cuda_driver": partial.get("cuda_driver"),
+            "cuda_runtime": partial.get("cuda_runtime"),
+            "packages_sha256": partial.get("packages_sha256"),
+            "python": partial.get("python"),
+            "runner_sha256": partial.get("runner_sha256") or sha256_file(Path(__file__).resolve()),
+        },
+        "facts": {
+            "data_upload_performed": False,
+            "evaluation_data_used": False,
+            "model_or_checkpoint_upload_performed": False,
+            "model_quality_evaluation_performed": False,
+            "private_job_script_transport_used": True,
+            "publication_performed": False,
+            "purpose": "hardware_validation_non_treatment",
+            "synthetic_adapter_optimizer_updates_performed": first_step_performed or second_step_performed,
+            "treatment_data_used": False,
+            "treatment_stage_1_performed": False,
+        },
+        "gpu": {
+            "count": int(gpu.get("count", 0)),
+            "name": gpu.get("name"),
+            "peak_allocated_bytes": (
+                max(first["peak_allocated_bytes"], second["peak_allocated_bytes"])
+                if second_step_completed
+                else first.get("peak_allocated_bytes") if first_step_completed else None
+            ),
+            "peak_reserved_bytes": (
+                max(first["peak_reserved_bytes"], second["peak_reserved_bytes"])
+                if second_step_completed
+                else first.get("peak_reserved_bytes") if first_step_completed else None
+            ),
+            "total_memory_bytes": gpu.get("total_memory_bytes"),
+        },
+        "plan": {
+            "bytes": 2537,
+            "logical_path": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json",
+            "sha256": EXPECTED_PLAN_SHA256,
+        },
+        "probe_id": PROBE_ID,
+        "provider_job": {
+            "actual_invoice_cost_eur": None,
+            "actual_invoice_cost_usd": None,
+            "billing_usd_per_minute": 0.03,
+            "exposed_ports": False,
+            "hardware_flavor": "l40sx1",
+            "job_id": job_id,
+            "job_status": "worker_aborted_pending_provider_reconciliation",
+            "maximum_provider_charge_usd": 1.8,
+            "provider": "Hugging Face Jobs",
+            "provider_derived_cost_usd": None,
+            "provider_evidence_reconciled": False,
+            "provider_running_seconds": None,
+            "timeout_seconds": 3600,
+        },
+        "runtime": {
+            "ended_at": _iso_now(),
+            "provider_timeout_enforced": True,
+            "started_at": started_at,
+            "wall_seconds": max(0.0, min(3600.0, time.monotonic() - started_monotonic)),
+        },
+        "schema_version": "gemma_hardware_probe_receipt_v1",
+        "snapshot_verification": {
+            "all_files_bytes_match": True if partial.get("snapshot_verified") else None,
+            "all_files_sha256_match": True if partial.get("snapshot_verified") else None,
+            "manifest": {
+                "bytes": 1994,
+                "logical_path": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json",
+                "sha256": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1",
+            },
+        },
+        "status": "aborted",
+        "throughput": {
+            "elapsed_seconds": elapsed_seconds,
+            "fixture_sha256": first_observation.get("fixture_sha256") if first_observation else None,
+            "sequence_length": 4096 if first_step_performed else None,
+            "tokens_per_second": (
+                tokens_processed / elapsed_seconds
+                if elapsed_seconds is not None and elapsed_seconds > 0 and tokens_processed is not None
+                else None
+            ),
+            "tokens_processed": tokens_processed,
+        },
+        "training_probe": {
+            "adapter": "qlora_rank16_alpha32_dropout0.05",
+            "loss_after_resume": second_observation.get("loss") if second_observation else None,
+            "loss_before_checkpoint": first_observation.get("loss") if first_observation else None,
+            "nonfinite_detected": False,
+            "optimizer_steps_after_resume": 1 if second_step_performed else 0,
+            "optimizer_steps_before_checkpoint": 1 if first_step_performed else 0,
+            "quantization": "4bit_nf4_bf16_double_quantization",
+        },
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--plan", type=Path, default=PLAN_PATH)
+    prepare.add_argument("--authorization", type=Path, required=True)
+    prepare.add_argument("--hf-cli", type=Path, default=Path(".venv/bin/hf"))
+    prepare.add_argument("--output", type=Path)
+    launch = subparsers.add_parser("launch")
+    launch.add_argument("--plan", type=Path, default=PLAN_PATH)
+    launch.add_argument("--authorization", type=Path, required=True)
+    launch.add_argument("--hf-cli", type=Path, default=Path(".venv/bin/hf"))
+    collect = subparsers.add_parser("collect")
+    collect.add_argument("--job-id", required=True)
+    collect.add_argument("--authorization", type=Path, required=True)
+    collect.add_argument("--hf-cli", type=Path, default=Path(".venv/bin/hf"))
+    collect.add_argument("--output-directory", type=Path, required=True)
+    worker = subparsers.add_parser("worker")
+    worker.add_argument("--plan-sha256", required=True)
+    worker.add_argument("--authorization-sha256", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "worker":
+        started_at = _iso_now()
+        started_monotonic = time.monotonic()
+        try:
+            receipt = run_worker(
+                plan_sha256=args.plan_sha256,
+                authorization_sha256=args.authorization_sha256,
+            )
+        except BaseException as exc:
+            receipt = aborted_worker_receipt(
+                authorization_sha256=args.authorization_sha256,
+                abort_reason=f"{type(exc).__name__}: {exc}",
+                started_at=started_at,
+                started_monotonic=started_monotonic,
+                partial_evidence=getattr(exc, "partial_evidence", None),
+            )
+            print(f"{RECEIPT_MARKER}{canonical_json(receipt)}")
+            return 2
+        print(f"{RECEIPT_MARKER}{canonical_json(receipt)}")
+        return 0
+    if args.command == "collect":
+        try:
+            receipt = collect_job(
+                job_id=args.job_id,
+                hf_cli=args.hf_cli,
+                authorization_path=args.authorization,
+                output_directory=args.output_directory,
+            )
+        except HardwareProbeError as exc:
+            print(f"hardware probe collection failed: {exc}")
+            return 2
+        print(canonical_json(receipt))
+        return 0
+    try:
+        command = build_hf_job_command(
+            plan_path=args.plan,
+            authorization_path=args.authorization,
+            hf_cli=args.hf_cli,
+        )
+        safe_command = safe_job_command(
+            command,
+            script_path=Path(__file__).resolve(),
+            script_placeholder="<WORKTREE_RUNNER>",
+        )
+        prepared = {
+            "authorization_sha256": sha256_file(args.authorization),
+            "command": safe_command,
+            "model_call_performed": False,
+            "paid_job_launched": False,
+            "plan_sha256": EXPECTED_PLAN_SHA256,
+            "probe_id": PROBE_ID,
+        }
+        if args.command == "prepare":
+            if args.output:
+                write_atomic(args.output, prepared)
+            print(canonical_json(prepared))
+            return 0
+        require_hf_auth(command[0])
+        require_no_provider_attempt(
+            hf_cli=command[0],
+            authorization_sha256=prepared["authorization_sha256"],
+        )
+        launch_started_at = _iso_now()
+        global_claim_path = host_global_attempt_claim_path(prepared["authorization_sha256"])
+        claim_paid_attempt(
+            global_claim_path,
+            {
+                **prepared,
+                "claim_scope": "host_global_all_worktrees",
+                "launch_started_at": launch_started_at,
+                "status": "host_global_launch_claimed_before_provider_call",
+            },
+        )
+        claim_paid_attempt(
+            ATTEMPT_LEDGER_PATH,
+            {
+                **prepared,
+                "launch_started_at": launch_started_at,
+                "maximum_provider_charge_usd": 1.8,
+                "paid_attempt_claimed": True,
+                "provider_timeout_seconds": 3600,
+                "status": "launch_claimed_before_provider_call",
+            },
+        )
+        require_no_provider_attempt(
+            hf_cli=command[0],
+            authorization_sha256=prepared["authorization_sha256"],
+        )
+        authorized_runner_snapshot = create_authorized_runner_snapshot(
+            authorization_path=args.authorization,
+            output_directory=ATTEMPT_LEDGER_PATH.parent,
+        )
+        command = build_hf_job_command(
+            plan_path=args.plan,
+            authorization_path=args.authorization,
+            hf_cli=args.hf_cli,
+            script_path=authorized_runner_snapshot,
+        )
+        verify_authorized_runner_snapshot(
+            snapshot=authorized_runner_snapshot,
+            authorization_path=args.authorization,
+        )
+        prepared = {
+            **prepared,
+            "command": safe_job_command(
+                command,
+                script_path=authorized_runner_snapshot,
+                script_placeholder="<AUTHORIZED_RUNNER_SNAPSHOT>",
+            ),
+            "command_source": "private_read_only_authorized_snapshot",
+        }
+        ready_claim = {
+            **prepared,
+            "launch_started_at": launch_started_at,
+            "maximum_provider_charge_usd": 1.8,
+            "paid_attempt_claimed": True,
+            "provider_timeout_seconds": 3600,
+            "status": "authorized_snapshot_verified_before_provider_call",
+        }
+        write_atomic(global_claim_path, {**ready_claim, "claim_scope": "host_global_all_worktrees"})
+        write_atomic(ATTEMPT_LEDGER_PATH, ready_claim)
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        if result.returncode:
+            failure = {
+                **prepared,
+                "launch_started_at": launch_started_at,
+                "maximum_provider_charge_usd": 1.8,
+                "paid_attempt_claimed": True,
+                "provider_timeout_seconds": 3600,
+                "status": "provider_launch_failed_no_retry_authorized",
+            }
+            write_atomic(ATTEMPT_LEDGER_PATH, failure)
+            write_atomic(global_claim_path, {**failure, "claim_scope": "host_global_all_worktrees"})
+            raise HardwareProbeError("Hugging Face Job launch failed after the paid attempt was claimed")
+        job_id = parse_job_id(f"{result.stdout}\n{result.stderr}")
+        launch_receipt = {
+            **prepared,
+            "job_id": job_id,
+            "paid_job_launched": True,
+            "provider_timeout_seconds": 3600,
+            "maximum_provider_charge_usd": 1.8,
+            "paid_attempt_claimed": True,
+            "status": "provider_job_created",
+        }
+        write_atomic(ATTEMPT_LEDGER_PATH, launch_receipt)
+        write_atomic(global_claim_path, {**launch_receipt, "claim_scope": "host_global_all_worktrees"})
+        print(canonical_json(launch_receipt))
+        return 0
+    except HardwareProbeError as exc:
+        print(f"hardware probe failed: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gemma_hardware_probe.py
+++ b/tests/test_gemma_hardware_probe.py
@@ -1,0 +1,901 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+
+from scripts.projects.open_model_data import gemma_hardware_probe as probe
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
+PLAN_PATH = ROOT / "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json"
+
+
+def _authorization() -> dict:
+    return {
+        "authorization": {
+            "hardware_flavor": "l40sx1",
+            "maximum_provider_charge_usd": 1.8,
+            "model_download_authorized": True,
+            "operator_all_inclusive_ceiling_eur": 3,
+            "paid_attempts": 1,
+            "provider": "Hugging Face Jobs",
+            "provider_job_launch_authorized": True,
+            "timeout_seconds": 3600,
+        },
+        "boundaries": {
+            "data_upload_authorized": False,
+            "evaluation_data_authorized": False,
+            "model_or_checkpoint_upload_authorized": False,
+            "model_quality_claim_authorized": False,
+            "private_job_script_transport_authorized": True,
+            "publication_authorized": False,
+            "stage_1_treatment_authorized": False,
+            "synthetic_fixture_only": True,
+            "treatment_data_authorized": False,
+        },
+        "operator_decision": {
+            "approved": True,
+            "approved_at": "2026-08-02T00:00:00Z",
+            "source": "operator approval fixture for a non-paid unit test",
+        },
+        "plan": {
+            "bytes": 2537,
+            "logical_path": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json",
+            "sha256": probe.EXPECTED_PLAN_SHA256,
+        },
+        "probe_id": probe.PROBE_ID,
+        "runner": {
+            "bytes": 58901,
+            "logical_path": "scripts/projects/open_model_data/gemma_hardware_probe.py",
+            "sha256": "bd8f973570140b32e7e3c8f74f80f905dea4afd02cb09f2061b4f13213e32504",
+        },
+        "schema_version": "gemma_hardware_probe_authorization_v1",
+    }
+
+
+def _write_authorization(tmp_path: Path, value: dict | None = None) -> Path:
+    path = tmp_path / "authorization.json"
+    path.write_text(json.dumps(value or _authorization(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_committed_probe_schemas_and_plan_validate() -> None:
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+    for schema_name in (
+        "gemma_hardware_probe_plan_v1.schema.json",
+        "gemma_hardware_probe_authorization_v1.schema.json",
+        "gemma_hardware_probe_receipt_v1.schema.json",
+    ):
+        schema = json.loads((CONTRACTS / schema_name).read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+    schema = json.loads((CONTRACTS / "gemma_hardware_probe_plan_v1.schema.json").read_text(encoding="utf-8"))
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(plan)
+    assert probe.sha256_file(PLAN_PATH) == probe.EXPECTED_PLAN_SHA256
+    assert plan["provider"] == {
+        "billing_usd_per_minute": 0.03,
+        "exposed_ports": False,
+        "gpu_count": 1,
+        "gpu_name": "NVIDIA L40S",
+        "hardware_flavor": "l40sx1",
+        "maximum_provider_charge_usd": 1.8,
+        "paid_attempts": 1,
+        "provider": "Hugging Face Jobs",
+        "timeout_seconds": 3600,
+    }
+    assert plan["boundaries"]["treatment_data_used"] is False
+    assert plan["boundaries"]["evaluation_data_used"] is False
+    assert plan["claims"]["prohibited"][0] == "stage_1_treatment_completion"
+
+
+def test_exact_authorization_builds_one_bounded_hf_job(tmp_path: Path) -> None:
+    authorization_path = _write_authorization(tmp_path)
+    fake_hf = tmp_path / "hf"
+    fake_hf.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake_hf.chmod(0o700)
+    command = probe.build_hf_job_command(
+        plan_path=PLAN_PATH,
+        authorization_path=authorization_path,
+        hf_cli=fake_hf,
+    )
+    joined = " ".join(command)
+    assert command[:4] == [str(fake_hf), "jobs", "uv", "run"]
+    assert command.count("--detach") == 1
+    assert command[command.index("--timeout") + 1] == "3600s"
+    assert command[command.index("--flavor") + 1] == "l40sx1"
+    assert command[command.index("--secrets") + 1] == "HF_TOKEN"
+    assert f"authorization_sha256={probe.sha256_file(authorization_path)}" in command
+    assert "timeout_seconds=3600" in command
+    assert "--expose" not in command
+    assert "batch_state" not in joined
+    assert "ua_eval_harness" not in joined
+    assert command[-5:] == [
+        "worker",
+        "--plan-sha256",
+        probe.EXPECTED_PLAN_SHA256,
+        "--authorization-sha256",
+        probe.sha256_file(authorization_path),
+    ]
+    safe = probe.safe_job_command(
+        command,
+        script_path=Path(probe.__file__).resolve(),
+        script_placeholder="<WORKTREE_RUNNER>",
+    )
+    assert safe[0] == "<HF_CLI>"
+    assert "<WORKTREE_RUNNER>" in safe
+    assert str(Path(probe.__file__).resolve()) not in safe
+
+
+def test_remote_script_path_resolves_without_parent_index_failure() -> None:
+    assert probe._resolve_root(Path("/data/gemma_hardware_probe.py")) == Path("/data")
+
+
+def test_authorized_runner_upload_snapshot_is_private_bound_and_drift_checked(tmp_path: Path) -> None:
+    authorization_path = _write_authorization(tmp_path)
+    snapshot = probe.create_authorized_runner_snapshot(
+        authorization_path=authorization_path,
+        output_directory=tmp_path / "runtime",
+    )
+    assert snapshot.read_bytes() == Path(probe.__file__).read_bytes()
+    assert snapshot.stat().st_mode & 0o222 == 0
+    probe.verify_authorized_runner_snapshot(
+        snapshot=snapshot,
+        authorization_path=authorization_path,
+    )
+    snapshot.chmod(0o600)
+    snapshot.write_bytes(b"drift")
+    with pytest.raises(probe.HardwareProbeError, match="snapshot drift"):
+        probe.verify_authorized_runner_snapshot(
+            snapshot=snapshot,
+            authorization_path=authorization_path,
+        )
+
+
+def test_launch_executes_and_ledgers_the_authorized_snapshot_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorization_path = _write_authorization(tmp_path)
+    fake_hf = tmp_path / "hf"
+    fake_hf.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake_hf.chmod(0o700)
+    ledger = tmp_path / "batch/launch.json"
+    global_claim = tmp_path / "global/claim.json"
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(
+            returncode=0,
+            stdout="id: 6a2bd1f1871c005b5352ad31",
+            stderr="",
+        )
+
+    monkeypatch.setattr(probe, "ATTEMPT_LEDGER_PATH", ledger)
+    monkeypatch.setattr(probe, "host_global_attempt_claim_path", lambda _: global_claim)
+    monkeypatch.setattr(probe, "require_hf_auth", lambda _: None)
+    monkeypatch.setattr(probe, "require_no_provider_attempt", lambda **_: None)
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert (
+        probe.main(
+            [
+                "launch",
+                "--authorization",
+                str(authorization_path),
+                "--hf-cli",
+                str(fake_hf),
+            ]
+        )
+        == 0
+    )
+    actual_command = calls[0]
+    assert str(Path(probe.__file__).resolve()) not in actual_command
+    assert any(argument.endswith(".authorized.py") for argument in actual_command)
+    local_receipt = json.loads(ledger.read_text(encoding="utf-8"))
+    host_receipt = json.loads(global_claim.read_text(encoding="utf-8"))
+    assert local_receipt["command_source"] == "private_read_only_authorized_snapshot"
+    assert "<AUTHORIZED_RUNNER_SNAPSHOT>" in local_receipt["command"]
+    assert host_receipt["command"] == local_receipt["command"]
+    assert host_receipt["job_id"] == "6a2bd1f1871c005b5352ad31"
+
+
+def test_plan_or_authorization_drift_fails_before_provider_call(tmp_path: Path) -> None:
+    authorization = _authorization()
+    authorization["authorization"]["timeout_seconds"] = 7200
+    authorization_path = _write_authorization(tmp_path, authorization)
+    with pytest.raises(probe.HardwareProbeError, match="schema error"):
+        probe.validate_plan_authorization(PLAN_PATH, authorization_path)
+
+    runner_drift = _authorization()
+    runner_drift["runner"]["sha256"] = "f" * 64
+    with pytest.raises(probe.HardwareProbeError, match="schema error"):
+        probe.validate_plan_authorization(PLAN_PATH, _write_authorization(tmp_path, runner_drift))
+
+    drifted_plan = tmp_path / "plan.json"
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+    plan["provider"]["paid_attempts"] = 2
+    drifted_plan.write_text(json.dumps(plan, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(probe.HardwareProbeError, match=r"schema error|runner-bound"):
+        probe.validate_plan_authorization(drifted_plan, _write_authorization(tmp_path))
+
+
+def test_job_id_parser_requires_exactly_one_identifier() -> None:
+    assert probe.parse_job_id("Job started\nid: 6a2bd1f1871c005b5352ad31\n") == "6a2bd1f1871c005b5352ad31"
+    with pytest.raises(probe.HardwareProbeError, match="exactly one"):
+        probe.parse_job_id("no job here")
+    with pytest.raises(probe.HardwareProbeError, match="exactly one"):
+        probe.parse_job_id(f"6a2bd1f1871c005b5352ad31 {'b' * 24}")
+
+
+def test_launch_fails_closed_when_hf_auth_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(returncode=1, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    with pytest.raises(probe.HardwareProbeError, match="authentication is not configured"):
+        probe.launch_job(["/safe/hf", "jobs", "uv", "run"])
+    assert calls == [["/safe/hf", "auth", "whoami"]]
+
+
+def test_launch_uses_secret_reference_not_token_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+    results = iter(
+        (
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+            SimpleNamespace(returncode=0, stdout="id: 6a2bd1f1871c005b5352ad31", stderr=""),
+        )
+    )
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        calls.append(command)
+        return next(results)
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    monkeypatch.setenv("HF_TOKEN", "hf_secret_must_not_appear")
+    command = ["/safe/hf", "jobs", "uv", "run", "--secrets", "HF_TOKEN"]
+    assert probe.launch_job(command) == "6a2bd1f1871c005b5352ad31"
+    assert all("hf_secret_must_not_appear" not in argument for call in calls for argument in call)
+
+
+def test_paid_attempt_claim_is_exclusive_and_durable(tmp_path: Path) -> None:
+    ledger = tmp_path / "launch.json"
+    first = {"status": "launch_claimed_before_provider_call", "attempt": 1}
+    probe.claim_paid_attempt(ledger, first)
+    assert json.loads(ledger.read_text(encoding="utf-8")) == first
+    with pytest.raises(probe.HardwareProbeError, match="already exists"):
+        probe.claim_paid_attempt(ledger, {"status": "duplicate"})
+    assert json.loads(ledger.read_text(encoding="utf-8")) == first
+
+
+def test_provider_attempt_query_blocks_reused_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def empty_run(command: list[str], **_: object) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(returncode=0, stdout="[]\n", stderr="")
+
+    monkeypatch.setattr(probe.subprocess, "run", empty_run)
+    probe.require_no_provider_attempt(hf_cli="/safe/hf", authorization_sha256="a" * 64)
+    assert calls[0][-3:] == ["--label", "authorization_sha256=" + "a" * 64, "--json"]
+
+    monkeypatch.setattr(
+        probe.subprocess,
+        "run",
+        lambda *_, **__: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps([{"id": "6a2bd1f1871c005b5352ad31"}]),
+            stderr="",
+        ),
+    )
+    with pytest.raises(probe.HardwareProbeError, match="already has a job"):
+        probe.require_no_provider_attempt(hf_cli="/safe/hf", authorization_sha256="a" * 64)
+
+
+def test_collector_persists_and_validates_one_job_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = "6a2bd1f1871c005b5352ad31"
+    authorization_path = _write_authorization(tmp_path)
+    authorization_sha256 = probe.sha256_file(authorization_path)
+    monkeypatch.setenv("JOB_ID", job_id)
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256=authorization_sha256,
+        abort_reason="HardwareProbeError: synthetic unit-test abort",
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+    )
+    fake_hf = tmp_path / "hf"
+    fake_hf.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake_hf.chmod(0o700)
+    results = iter(
+        (
+            SimpleNamespace(returncode=2, stdout="aborted\n", stderr=""),
+            SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "durations": {"running_secs": 20},
+                            "flavor": "l40sx1",
+                            "id": job_id,
+                            "labels": {
+                                "authorization_sha256": authorization_sha256,
+                                "issue": "6170",
+                                "plan_sha256": probe.EXPECTED_PLAN_SHA256,
+                                "probe_id": probe.PROBE_ID,
+                                "timeout_seconds": "3600",
+                            },
+                            "status": {"stage": "ERROR"},
+                        }
+                    ]
+                )
+                + "\n",
+                stderr="",
+            ),
+            SimpleNamespace(returncode=1, stdout="", stderr="metrics unavailable after exit"),
+            SimpleNamespace(returncode=0, stdout=f"{probe.RECEIPT_MARKER}{probe.canonical_json(receipt)}\n", stderr=""),
+        )
+    )
+    monkeypatch.setattr(probe, "require_hf_auth", lambda _: None)
+    monkeypatch.setattr(probe.subprocess, "run", lambda *_, **__: next(results))
+    output_directory = tmp_path / "evidence"
+    collected = probe.collect_job(
+        job_id=job_id,
+        hf_cli=fake_hf,
+        authorization_path=authorization_path,
+        output_directory=output_directory,
+    )
+    assert collected["provider_job"]["job_status"] == "ERROR"
+    assert collected["provider_job"]["provider_running_seconds"] == 20
+    assert collected["provider_job"]["provider_derived_cost_usd"] == 0.01
+    assert collected["provider_job"]["provider_evidence_reconciled"] is True
+    assert json.loads((output_directory / "worker-receipt.json").read_text(encoding="utf-8")) == collected
+    provider_evidence = json.loads((output_directory / "provider-evidence.json").read_text(encoding="utf-8"))
+    assert provider_evidence["stats_command_succeeded"] is False
+
+
+def test_snapshot_verification_rejects_missing_byte_and_hash_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(probe, "SNAPSHOT_FILES", {"tiny.bin": (3, probe.sha256_bytes(b"abc"))})
+    with pytest.raises(probe.HardwareProbeError, match="missing"):
+        probe.verify_snapshot(tmp_path)
+    target = tmp_path / "tiny.bin"
+    target.write_bytes(b"ab")
+    with pytest.raises(probe.HardwareProbeError, match="byte drift"):
+        probe.verify_snapshot(tmp_path)
+    target.write_bytes(b"abd")
+    with pytest.raises(probe.HardwareProbeError, match="hash drift"):
+        probe.verify_snapshot(tmp_path)
+    target.write_bytes(b"abc")
+    probe.verify_snapshot(tmp_path)
+
+
+def test_phase_watchdog_terminates_child_at_internal_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace(
+        exitcode=None,
+        alive=True,
+        killed=False,
+        terminated=False,
+    )
+    process.start = lambda: None
+    process.join = lambda timeout=None: None
+    process.is_alive = lambda: process.alive
+
+    def terminate() -> None:
+        process.terminated = True
+        process.alive = False
+
+    def kill() -> None:
+        process.killed = True
+        process.alive = False
+
+    process.terminate = terminate
+    process.kill = kill
+    context = SimpleNamespace(
+        Queue=lambda maxsize: SimpleNamespace(),
+        Process=lambda **kwargs: process,
+    )
+    monkeypatch.setattr(probe.multiprocessing, "get_context", lambda _: context)
+    with pytest.raises(probe.HardwareProbeError, match="internal deadline"):
+        probe.run_phase_process(
+            model_directory=tmp_path / "model",
+            checkpoint_input=None,
+            checkpoint_output=tmp_path / "checkpoint",
+            global_step=0,
+            deadline_monotonic=probe.time.monotonic() - 1,
+        )
+    assert process.terminated is True
+    assert process.killed is False
+
+
+def test_phase_spawn_failure_does_not_claim_a_process_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace()
+    process.start = lambda: (_ for _ in ()).throw(OSError("spawn failed"))
+    context = SimpleNamespace(
+        Queue=lambda maxsize: SimpleNamespace(),
+        Process=lambda **kwargs: process,
+    )
+    monkeypatch.setattr(probe.multiprocessing, "get_context", lambda _: context)
+    with pytest.raises(probe.PhaseExecutionError, match="could not start") as captured:
+        probe.run_phase_process(
+            model_directory=tmp_path / "model",
+            checkpoint_input=tmp_path / "checkpoint-step-1",
+            checkpoint_output=tmp_path / "checkpoint-step-2",
+            global_step=1,
+            deadline_monotonic=probe.time.monotonic() + 10,
+        )
+    assert captured.value.process_started is False
+
+
+def test_phase_error_queue_preserves_step_when_marker_write_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    progress = {
+        "fixture_sha256": "c" * 64,
+        "global_step": 1,
+        "loss": 1.25,
+        "optimizer_step_performed": True,
+        "tokens": 4096,
+    }
+    process = SimpleNamespace(exitcode=1)
+    process.start = lambda: None
+    process.join = lambda timeout=None: None
+    process.is_alive = lambda: False
+    result_queue = SimpleNamespace(
+        get=lambda timeout: {
+            "error": "OSError: marker fsync failed",
+            "phase_evidence": progress,
+        }
+    )
+    context = SimpleNamespace(
+        Queue=lambda maxsize: result_queue,
+        Process=lambda **kwargs: process,
+    )
+    monkeypatch.setattr(probe.multiprocessing, "get_context", lambda _: context)
+    with pytest.raises(probe.PhaseExecutionError, match="marker fsync failed") as captured:
+        probe.run_phase_process(
+            model_directory=tmp_path / "model",
+            checkpoint_input=None,
+            checkpoint_output=tmp_path / "checkpoint-step-1",
+            global_step=0,
+            deadline_monotonic=probe.time.monotonic() + 10,
+        )
+    assert captured.value.process_started is True
+    assert captured.value.phase_evidence == progress
+
+
+def test_worker_rejects_wrong_accelerator_before_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACCELERATOR", "a100-large")
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    with pytest.raises(probe.HardwareProbeError, match="accelerator"):
+        probe.run_worker(
+            plan_sha256=probe.EXPECTED_PLAN_SHA256,
+            authorization_sha256="a" * 64,
+        )
+
+
+def test_intra_phase_failure_receipts_durable_optimizer_step_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    progress = {
+        "fixture_sha256": "c" * 64,
+        "global_step": 1,
+        "loss": 1.25,
+        "optimizer_step_performed": True,
+        "tokens": 4096,
+    }
+    monkeypatch.setenv("ACCELERATOR", "l40sx1")
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    monkeypatch.setattr(probe, "_runtime_package_digest", lambda: "d" * 64)
+    monkeypatch.setattr(
+        probe,
+        "_gpu_evidence",
+        lambda: {"count": 1, "name": "NVIDIA L40S", "total_memory_bytes": 48 * 1024**3},
+    )
+    monkeypatch.setattr(probe, "_cuda_evidence", lambda: ("13.0", "580.1"))
+    monkeypatch.setattr(probe, "download_snapshot", lambda _: None)
+    monkeypatch.setattr(
+        probe,
+        "run_phase_process",
+        lambda **_: (_ for _ in ()).throw(
+            probe.PhaseExecutionError(
+                "checkpoint write failed",
+                phase_evidence=progress,
+                process_started=True,
+            )
+        ),
+    )
+    monkeypatch.setattr(probe.tempfile, "mkdtemp", lambda **_: str(tmp_path / "worker-intra-phase"))
+    (tmp_path / "worker-intra-phase").mkdir()
+
+    with pytest.raises(probe.ProbeExecutionError) as captured:
+        probe.run_worker(
+            plan_sha256=probe.EXPECTED_PLAN_SHA256,
+            authorization_sha256="a" * 64,
+        )
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256="a" * 64,
+        abort_reason=str(captured.value),
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+        partial_evidence=captured.value.partial_evidence,
+    )
+    _receipt_validator().validate(receipt)
+    assert receipt["training_probe"]["optimizer_steps_before_checkpoint"] == 1
+    assert receipt["training_probe"]["optimizer_steps_after_resume"] == 0
+    assert receipt["training_probe"]["loss_before_checkpoint"] == 1.25
+    assert receipt["checkpoint_resume"]["adapter"] is None
+    assert receipt["checkpoint_resume"]["process_boundary"] is False
+    assert receipt["throughput"]["tokens_processed"] == 4096
+
+
+def test_resume_failure_receipts_the_completed_first_optimizer_step(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = {"bytes": 7, "sha256": "b" * 64}
+    first = {
+        "adapter": artifact,
+        "checkpoint": artifact,
+        "elapsed_seconds": 4.0,
+        "fixture_sha256": "c" * 64,
+        "global_step": 1,
+        "loss": 1.25,
+        "optimizer": artifact,
+        "peak_allocated_bytes": 10,
+        "peak_reserved_bytes": 20,
+        "rng": artifact,
+        "tokens": 4096,
+    }
+    phases = iter((first, probe.HardwareProbeError("resume exploded")))
+
+    def phase(**_: object) -> dict:
+        value = next(phases)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    monkeypatch.setenv("ACCELERATOR", "l40sx1")
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    monkeypatch.setattr(probe, "_runtime_package_digest", lambda: "d" * 64)
+    monkeypatch.setattr(
+        probe,
+        "_gpu_evidence",
+        lambda: {"count": 1, "name": "NVIDIA L40S", "total_memory_bytes": 48 * 1024**3},
+    )
+    monkeypatch.setattr(probe, "_cuda_evidence", lambda: ("13.0", "580.1"))
+    monkeypatch.setattr(probe, "download_snapshot", lambda _: None)
+    monkeypatch.setattr(probe, "run_phase_process", phase)
+    monkeypatch.setattr(probe.tempfile, "mkdtemp", lambda **_: str(tmp_path / "worker"))
+    (tmp_path / "worker").mkdir()
+
+    with pytest.raises(probe.ProbeExecutionError) as captured:
+        probe.run_worker(
+            plan_sha256=probe.EXPECTED_PLAN_SHA256,
+            authorization_sha256="a" * 64,
+        )
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256="a" * 64,
+        abort_reason=str(captured.value),
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+        partial_evidence=captured.value.partial_evidence,
+    )
+    _receipt_validator().validate(receipt)
+    assert receipt["training_probe"]["optimizer_steps_before_checkpoint"] == 1
+    assert receipt["training_probe"]["optimizer_steps_after_resume"] == 0
+    assert receipt["training_probe"]["loss_before_checkpoint"] == 1.25
+    assert receipt["facts"]["synthetic_adapter_optimizer_updates_performed"] is True
+    assert receipt["checkpoint_resume"]["adapter"] == artifact
+    assert receipt["checkpoint_resume"]["reload_passed"] is False
+    assert json.loads((tmp_path / "worker/partial-progress.json").read_text(encoding="utf-8"))["first"] == first
+
+
+def test_successful_worker_assembles_a_valid_completed_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = {"bytes": 7, "sha256": "b" * 64}
+    first = {
+        "adapter": artifact,
+        "checkpoint": artifact,
+        "elapsed_seconds": 4.0,
+        "fixture_sha256": "c" * 64,
+        "global_step": 1,
+        "loss": 1.25,
+        "optimizer": artifact,
+        "peak_allocated_bytes": 10,
+        "peak_reserved_bytes": 20,
+        "rng": artifact,
+        "tokens": 4096,
+    }
+    second = {
+        **first,
+        "elapsed_seconds": 3.0,
+        "global_step": 2,
+        "loss": 1.0,
+        "peak_allocated_bytes": 11,
+        "peak_reserved_bytes": 21,
+    }
+    phases = iter((first, second))
+    monkeypatch.setenv("ACCELERATOR", "l40sx1")
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    monkeypatch.setattr(probe, "_runtime_package_digest", lambda: "d" * 64)
+    monkeypatch.setattr(
+        probe,
+        "_gpu_evidence",
+        lambda: {"count": 1, "name": "NVIDIA L40S", "total_memory_bytes": 48 * 1024**3},
+    )
+    monkeypatch.setattr(probe, "_cuda_evidence", lambda: ("13.0", "580.1"))
+    monkeypatch.setattr(probe, "download_snapshot", lambda _: None)
+    monkeypatch.setattr(probe, "run_phase_process", lambda **_: next(phases))
+    monkeypatch.setattr(probe.tempfile, "mkdtemp", lambda **_: str(tmp_path / "worker-success"))
+    (tmp_path / "worker-success").mkdir()
+
+    receipt = probe.run_worker(
+        plan_sha256=probe.EXPECTED_PLAN_SHA256,
+        authorization_sha256="a" * 64,
+    )
+    _receipt_validator().validate(receipt)
+    assert receipt["status"] == "completed"
+    assert receipt["checkpoint_resume"]["process_boundary"] is True
+    assert receipt["checkpoint_resume"]["reload_passed"] is True
+    assert receipt["checkpoint_resume"]["adapter"] == first["adapter"]
+    assert receipt["training_probe"]["optimizer_steps_before_checkpoint"] == 1
+    assert receipt["training_probe"]["optimizer_steps_after_resume"] == 1
+    assert receipt["throughput"]["tokens_processed"] == 8192
+
+
+def test_post_second_validation_failure_receipts_both_optimizer_steps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = {"bytes": 7, "sha256": "b" * 64}
+    first = {
+        "adapter": artifact,
+        "checkpoint": artifact,
+        "elapsed_seconds": 4.0,
+        "fixture_sha256": "c" * 64,
+        "global_step": 1,
+        "loss": 1.25,
+        "optimizer": artifact,
+        "peak_allocated_bytes": 10,
+        "peak_reserved_bytes": 20,
+        "rng": artifact,
+        "tokens": 4096,
+    }
+    second = {
+        **first,
+        "elapsed_seconds": 3.0,
+        "fixture_sha256": "e" * 64,
+        "global_step": 2,
+        "loss": 1.0,
+        "peak_allocated_bytes": 11,
+        "peak_reserved_bytes": 21,
+    }
+    phases = iter((first, second))
+    monkeypatch.setenv("ACCELERATOR", "l40sx1")
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    monkeypatch.setattr(probe, "_runtime_package_digest", lambda: "d" * 64)
+    monkeypatch.setattr(
+        probe,
+        "_gpu_evidence",
+        lambda: {"count": 1, "name": "NVIDIA L40S", "total_memory_bytes": 48 * 1024**3},
+    )
+    monkeypatch.setattr(probe, "_cuda_evidence", lambda: ("13.0", "580.1"))
+    monkeypatch.setattr(probe, "download_snapshot", lambda _: None)
+    monkeypatch.setattr(probe, "run_phase_process", lambda **_: next(phases))
+    monkeypatch.setattr(probe.tempfile, "mkdtemp", lambda **_: str(tmp_path / "worker-post-second"))
+    (tmp_path / "worker-post-second").mkdir()
+
+    with pytest.raises(probe.ProbeExecutionError) as captured:
+        probe.run_worker(
+            plan_sha256=probe.EXPECTED_PLAN_SHA256,
+            authorization_sha256="a" * 64,
+        )
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256="a" * 64,
+        abort_reason=str(captured.value),
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+        partial_evidence=captured.value.partial_evidence,
+    )
+    _receipt_validator().validate(receipt)
+    assert receipt["training_probe"]["optimizer_steps_before_checkpoint"] == 1
+    assert receipt["training_probe"]["optimizer_steps_after_resume"] == 1
+    assert receipt["training_probe"]["loss_after_resume"] == 1.0
+    assert receipt["checkpoint_resume"]["process_boundary"] is True
+    assert receipt["checkpoint_resume"]["reload_passed"] is True
+    assert receipt["throughput"]["tokens_processed"] == 8192
+
+
+def _receipt_validator() -> Draft202012Validator:
+    schema = json.loads((CONTRACTS / "gemma_hardware_probe_receipt_v1.schema.json").read_text(encoding="utf-8"))
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def test_early_worker_abort_is_receipted_without_fabricated_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JOB_ID", "6a2bd1f1871c005b5352ad31")
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256="a" * 64,
+        abort_reason="HardwareProbeError: wrong GPU",
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+    )
+    _receipt_validator().validate(receipt)
+    assert receipt["status"] == "aborted"
+    assert receipt["gpu"]["name"] is None
+    assert receipt["environment"]["cuda_driver"] is None
+    assert receipt["provider_job"]["provider_derived_cost_usd"] is None
+    assert receipt["checkpoint_resume"]["adapter"] is None
+
+
+def test_completed_receipt_requires_real_evidence_but_allows_pending_cost() -> None:
+    artifact = {"bytes": 1, "sha256": "b" * 64}
+    receipt = {
+        "abort_reason": None,
+        "attempt": 1,
+        "authorization_sha256": "a" * 64,
+        "checkpoint_resume": {
+            "adapter": artifact,
+            "optimizer": artifact,
+            "process_boundary": True,
+            "reload_passed": True,
+            "rng": artifact,
+        },
+        "environment": {
+            "cuda_driver": "580.1",
+            "cuda_runtime": "13.0",
+            "packages_sha256": "c" * 64,
+            "python": "3.12.8",
+            "runner_sha256": "d" * 64,
+        },
+        "facts": {
+            "data_upload_performed": False,
+            "evaluation_data_used": False,
+            "model_or_checkpoint_upload_performed": False,
+            "model_quality_evaluation_performed": False,
+            "private_job_script_transport_used": True,
+            "publication_performed": False,
+            "purpose": "hardware_validation_non_treatment",
+            "synthetic_adapter_optimizer_updates_performed": True,
+            "treatment_data_used": False,
+            "treatment_stage_1_performed": False,
+        },
+        "gpu": {
+            "count": 1,
+            "name": "NVIDIA L40S",
+            "peak_allocated_bytes": 1,
+            "peak_reserved_bytes": 1,
+            "total_memory_bytes": 48 * 1024**3,
+        },
+        "plan": {
+            "bytes": 2537,
+            "logical_path": "data/projects/open_model_data/treatments/gemma4_it_l40s_hf_jobs_probe_plan_v1.json",
+            "sha256": probe.EXPECTED_PLAN_SHA256,
+        },
+        "probe_id": probe.PROBE_ID,
+        "provider_job": {
+            "actual_invoice_cost_eur": None,
+            "actual_invoice_cost_usd": None,
+            "billing_usd_per_minute": 0.03,
+            "exposed_ports": False,
+            "hardware_flavor": "l40sx1",
+            "job_id": "6a2bd1f1871c005b5352ad31",
+            "job_status": "worker_completed_pending_provider_reconciliation",
+            "maximum_provider_charge_usd": 1.8,
+            "provider": "Hugging Face Jobs",
+            "provider_derived_cost_usd": None,
+            "provider_evidence_reconciled": False,
+            "provider_running_seconds": None,
+            "timeout_seconds": 3600,
+        },
+        "runtime": {
+            "ended_at": "2026-08-02T00:10:00Z",
+            "provider_timeout_enforced": True,
+            "started_at": "2026-08-02T00:00:00Z",
+            "wall_seconds": 600,
+        },
+        "schema_version": "gemma_hardware_probe_receipt_v1",
+        "snapshot_verification": {
+            "all_files_bytes_match": True,
+            "all_files_sha256_match": True,
+            "manifest": {
+                "bytes": 1994,
+                "logical_path": "data/projects/open_model_data/treatments/gemma4_it_model_snapshot_manifest_v1.json",
+                "sha256": "f0552bd6ee21764a0fc8c62b76d8458775f4f5e4969d701cf4c0d35c2f86fba1",
+            },
+        },
+        "status": "completed",
+        "throughput": {
+            "elapsed_seconds": 10,
+            "fixture_sha256": "e" * 64,
+            "sequence_length": 4096,
+            "tokens_per_second": 819.2,
+            "tokens_processed": 8192,
+        },
+        "training_probe": {
+            "adapter": "qlora_rank16_alpha32_dropout0.05",
+            "loss_after_resume": 1.1,
+            "loss_before_checkpoint": 1.2,
+            "nonfinite_detected": False,
+            "optimizer_steps_after_resume": 1,
+            "optimizer_steps_before_checkpoint": 1,
+            "quantization": "4bit_nf4_bf16_double_quantization",
+        },
+    }
+    validator = _receipt_validator()
+    validator.validate(receipt)
+    reconciled = json.loads(json.dumps(receipt))
+    reconciled["provider_job"].update(
+        {
+            "job_status": "COMPLETED",
+            "provider_derived_cost_usd": 0.3,
+            "provider_evidence_reconciled": True,
+            "provider_running_seconds": 600,
+        }
+    )
+    validator.validate(reconciled)
+    receipt["provider_job"]["provider_derived_cost_usd"] = 0
+    with pytest.raises(ValidationError, match="not of type 'null'"):
+        validator.validate(receipt)
+
+
+def test_provider_reconciliation_rejects_runner_drift() -> None:
+    receipt = probe.aborted_worker_receipt(
+        authorization_sha256="a" * 64,
+        abort_reason="unit-test abort",
+        started_at="2026-08-02T00:00:00Z",
+        started_monotonic=probe.time.monotonic(),
+    )
+    inspection = {
+        "durations": {"running_secs": 10},
+        "flavor": "l40sx1",
+        "id": "6a2bd1f1871c005b5352ad31",
+        "labels": {
+            "authorization_sha256": "a" * 64,
+            "issue": "6170",
+            "plan_sha256": probe.EXPECTED_PLAN_SHA256,
+            "probe_id": probe.PROBE_ID,
+            "timeout_seconds": "3600",
+        },
+        "status": {"stage": "ERROR"},
+    }
+    with pytest.raises(probe.HardwareProbeError, match="runner drift"):
+        probe.reconcile_provider_receipt(
+            receipt=receipt,
+            inspection=inspection,
+            job_id="6a2bd1f1871c005b5352ad31",
+            authorization_sha256="a" * 64,
+            authorization={"runner": {"sha256": "f" * 64}},
+            wait_returncode=2,
+        )
+
+
+def test_atomic_writer_is_byte_stable(tmp_path: Path) -> None:
+    path = tmp_path / "receipt.json"
+    value = {"z": 1, "а": "українська"}
+    probe.write_atomic(path, value)
+    first = path.read_bytes()
+    probe.write_atomic(path, value)
+    assert path.read_bytes() == first
+    assert json.loads(first) == value


### PR DESCRIPTION
Advances #6170 without authorizing or running treatment.

## What this freezes

- one non-treatment Hugging Face Jobs L40S hardware probe for immutable `google/gemma-4-31B-it`
- one paid attempt, 3,600-second provider timeout, USD 1.80 provider maximum, EUR 3 all-inclusive operator ceiling
- synthetic 4,096-token fixture only; one QLoRA step, checkpoint, clean-process reload, and one resumed step
- exact operator-authorization, plan, receipt, snapshot, cost, attempt, and runner bindings
- fail-closed provider reconciliation and explicit no-corpus/no-eval/no-quality-claim boundaries

## Safety and evidence

- provider-side authorization-hash duplicate query plus host-global/worktree exclusive claims
- private read-only verified runner upload snapshot
- durable and in-memory optimizer-step evidence across child failures
- provider terminal state, L40S flavor, labels, endpoints, duration, and provider-derived cost reconciliation
- null invoice-exact cost fields unless an invoice is actually available

## Verification

- 33 integrated hardware/treatment/evaluation tests
- Ruff plus explicit F821
- Python compilation
- three schemas and frozen plan validation
- Markdownlint
- OPSEC and gitleaks
- X-Agent trailer and diff checks
- clean exact-tree adversarial Codex helper review (same-family; not the formal gate)

No model download, provider job, model call, training, dataset/evaluation use, upload, publication, or spend occurred. The paid entry point remains blocked on a separate exact operator authorization and local Hugging Face authentication.