### PR TITLE
fix(practice): recover safe inventory identity clozes

### DIFF
--- a/docs/practice/cloze-residual-taxonomy.md
+++ b/docs/practice/cloze-residual-taxonomy.md
@@ -2,84 +2,116 @@
 
 Run date: 2026-08-02
 
-Scope: hydrated release `atlas-practice-v1-4369ff38d9b16567`, the A1-C1
+Scope: hydrated release `atlas-practice-v1-72aefaf645e8d390`, the A1-C1
 `practice-lexemes.*.json` shards, the base sentence inventory, and its additive
-`lexicon-sentence-inventory.residual.json` sidecar. This is a current-state
-taxonomy, not a completion claim for #6188.
+`lexicon-sentence-inventory.residual.json` sidecar. The before comparison is
+the v12 build from release `atlas-practice-v1-4369ff38d9b16567`; this is a
+current-state taxonomy, not a completion claim for #6188.
 
 ## Current coverage
 
-The release has 4,264 cloze-eligible practice lemmas out of 6,000. The
-uncovered set is therefore 1,736 lemmas.
+The published v13 release has 4,440 cloze-eligible practice lemmas out of
+6,000. The uncovered set is therefore 1,560 lemmas.
 
 | Level | Practice lemmas | Cloze-eligible | Residual | Coverage |
 | --- | ---: | ---: | ---: | ---: |
-| A1 | 1,470 | 1,005 | 465 | 68.37% |
-| A2 | 1,444 | 1,097 | 347 | 75.97% |
-| B1 | 1,617 | 1,279 | 338 | 79.10% |
-| B2 | 940 | 700 | 240 | 74.47% |
-| C1 | 529 | 183 | 346 | 34.59% |
-| **All** | **6,000** | **4,264** | **1,736** | **71.07%** |
+| A1 | 1,470 | 1,080 | 390 | 73.47% |
+| A2 | 1,444 | 1,154 | 290 | 79.92% |
+| B1 | 1,617 | 1,296 | 321 | 80.15% |
+| B2 | 940 | 723 | 217 | 76.91% |
+| C1 | 529 | 187 | 342 | 35.35% |
+| **All** | **6,000** | **4,440** | **1,560** | **74.00%** |
 
 The inventory contains 5,135 base rows and 51 sidecar rows. They are 5,186
 unique inventory IDs; 5,185 intersect the current Practice set. Within the
-1,736 residual lemmas, 923 have an inventory row and 813 have no inventory row.
-The inventory reader accepts 618 of those 923 residual rows as blankable
-candidates and rejects 305 before the builder stage.
+1,560 final residual lemmas, 442 have an inventory-reader candidate and 1,118
+have no candidate. The 442 includes function/multiword IDs that are assigned
+to those higher-precedence buckets below.
+
+## #6188 before/after measurement
+
+The v12 builder measured the original 509 inventory-present residual IDs as
+follows. The categories are mutually exclusive: a quality-gate rejection is
+classified before VESUM, and an option failure is classified only after a raw
+cloze item exists.
+
+| Builder snapshot | Quality gate empty | Identity-option fail | VESUM miss | Level mismatch | Other | Safe raw candidates |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| v12, before fix | 4 | 300 | 205 | 0 | 0 | 0 |
+| v13, same 509 IDs, before budget | 4 | 75 | 205 | 0 | 0 | 225 |
+
+The v13 change only renders normalized dictionary decoys at the source
+surface's initial-capital state before applying the existing length, POS,
+CEFR, answer-leak, and option validators. It does not lower any quality gate.
+All 225 recovered option sets validated before budgeting. The published deck
+retains 222 of those original-509 cards; three are in the B1 budget-trimmed
+residual.
+
+The published coverage change is 4,264 to 4,440 eligible lemmas (+176) and
+1,736 to 1,560 residual lemmas (-176). B1 is the only level that needed
+budget trimming: the no-budget v13 B1 cloze payload measured 2,336,106 raw /
+250,806 gzip bytes, while the published payload is within the 2,250,000 /
+240,000 limits. The 60 final `would_emit-still-trimmed` IDs comprise the three
+original-509 cards plus 57 previously published B1 IDs displaced by the
+larger v13 payload.
 
 ## Mutually exclusive partition
 
 The buckets below use this precedence: `function-POS`, then `multiword-id`,
 then `no public sentence`, then the remaining inventory-reader candidates.
-This prevents overlaps from inflating the total. `multiword-id` means a
-multi-token or slash-form `lemmaPlain` shape; apostrophe-bearing single words
-are not counted as multiword. `no public sentence` includes both
-the 813 no-inventory residuals and the 305 inventory rows that the public
-inventory reader cannot turn into one blankable sentence. It means “no current
-public blankable sentence,” not “this lemma can never be sourced.”
+Within that final candidate set, the published builder-funnel result is split
+into `inventory-present-build-empty` and `would_emit-still-trimmed`. This
+prevents overlaps from inflating the total. `multiword-id` means a multi-token
+or slash-form `lemmaPlain` shape; apostrophe-bearing single words are not
+counted as multiword. `no public sentence` includes the 1,118 no-candidate
+residuals and inventory rows rejected before the remaining builder funnel. It
+means “no current public blankable sentence,” not “this lemma can never be
+sourced.”
 
 | Bucket | Count | Definition in this snapshot |
 | --- | ---: | --- |
-| function-POS | 121 | Residual lexeme `pos` is in the builder’s function-POS set. |
+| function-POS | 110 | Residual lexeme `pos` is in the builder’s function-POS set. |
 | multiword-id | 170 | Multi-token/slash-form residual after the function-POS precedence rule. |
-| no public sentence | 936 | No inventory row, or a row rejected by the public inventory reader, after the two precedence rules. |
-| inventory-present-build-empty | 509 | Inventory reader candidate remains, but no current published cloze is present after function/multiword exclusion. This is a combined residual funnel bucket, not a claim that every row has one identical root cause. |
-| would_emit-still-trimmed | 0 | No current published cloze shard reports an over-budget payload; all five `sizeBudget.ok` values are true. This does not claim that a future no-budget rebuild would add no cards. |
+| no public sentence | 936 | No current candidate remains after the function/multiword precedence rules. |
+| inventory-present-build-empty | 284 | Remaining inventory candidates rejected by the v13 quality, VESUM, level, or option gates: 4 quality-gate empty, 75 identity-option fail, 205 VESUM miss, 0 level mismatch, and 0 other. |
+| would_emit-still-trimmed | 60 | A no-budget v13 trace produced a valid cloze/options set, but the default budget omitted the ID from the published index. All five published `sizeBudget.ok` values remain true. |
 | other | 0 | No unclassified residual remains after the stated partition. |
-| **Total** | **1,736** | **Exact residual set.** |
+| **Total** | **1,560** | **Exact residual set.** |
 
 The function-POS and multiword classifications overlap in three raw IDs; the
 precedence rule assigns those three to `function-POS`. The multiword bucket has
-173 raw shape matches before that rule and 170 primary assignments. The
-inventory-present bucket is intentionally conservative: it does not turn the
-historical 299 quality-gate-empty and 311 identity-option failures recorded in
-the earlier builder trace into a new “done” bar.
+173 raw shape matches before that rule and 170 primary assignments. The final
+inventory-present candidate set is 344 IDs: 4 quality-gate empty, 75
+identity-option failures, 205 VESUM misses, and 60 valid-but-budget-trimmed
+IDs. The 284/60 split above keeps the budget residual separate from genuine
+builder-empty failures.
 
 ## Budget check
 
-The hydrated cloze shard metadata is below the current per-level limits of
-2,250,000 raw bytes and 240,000 gzip bytes:
+The published hydrated cloze shard metadata is below the current per-level
+limits of 2,250,000 raw bytes and 240,000 gzip bytes:
 
 | Level | Raw bytes | Gzip bytes | `sizeBudget.ok` |
 | --- | ---: | ---: | --- |
-| A1 | 1,746,501 | 190,859 | true |
-| A2 | 1,880,605 | 201,728 | true |
-| B1 | 2,203,585 | 237,023 | true |
-| B2 | 1,217,519 | 131,160 | true |
-| C1 | 320,810 | 35,093 | true |
+| A1 | 1,871,315 | 204,492 | true |
+| A2 | 1,979,290 | 211,996 | true |
+| B1 | 2,218,308 | 237,387 | true |
+| B2 | 1,257,264 | 135,573 | true |
+| C1 | 327,274 | 35,679 | true |
 
-The current maximum is B1, with 46,415 raw bytes and 2,977 gzip bytes of
-metadata-reported headroom. Thus there is no tool evidence for a currently
-still-trimmed bucket. A future deck rebuild must remeasure the untrimmed and
-post-budget sets rather than treating this zero as permanent.
+The current maximum is B1, with 31,692 raw bytes and 2,613 gzip bytes of
+metadata-reported headroom. The post-budget payloads fit, but the no-budget
+trace above proves that 60 cards remain capacity-trimmed; a future deck build
+must remeasure both the untrimmed and post-budget sets.
 
-## Residual-only textbook FTS probe
+## Residual-only textbook FTS probe (baseline evidence)
 
-The residual-only probe used the complete hydrated Practice target set, removed
-both the base inventory and its `.residual.json` sibling, and searched up to
-250 ranked textbook chunks per target. The two database arguments below refer
-to the machine-local read-only canonical source/VESUM data; their absolute link
-targets are deliberately not recorded in this public evidence.
+The pre-v13 residual-only probe used the complete v12 hydrated Practice target
+set, removed both the base inventory and its `.residual.json` sibling, and
+searched up to 250 ranked textbook chunks per target. The two database
+arguments below refer to the machine-local read-only canonical source/VESUM
+data; their absolute link targets are deliberately not recorded in this public
+evidence.
 
 ```bash
 .venv/bin/python -m scripts.audit.generate_sentence_inventory \
@@ -99,32 +131,33 @@ sentence inventory residual targets: 815 of 6000
 sentence inventory: 0 rows
 ```
 
-The 815 targets include two lemmas already covered by a non-inventory cloze
-source; the current uncovered no-inventory residual is 813. A separate
-shape-only probe with VESUM disabled found 64 candidate rows, but the
-quality-gated VESUM run found zero. Those 64 unverified rows are not a
-mineable tranche. No new rows were added to the residual sidecar and no deck
-publish was run.
+The 815 targets included two lemmas already covered by a non-inventory cloze
+source; the v12 uncovered no-inventory residual was 813. A separate shape-only
+probe with VESUM disabled found 64 candidate rows, but the quality-gated VESUM
+run found zero. Those 64 unverified rows are not a mineable tranche. This
+evidence predates the v13 builder-only change; no new rows were added to the
+residual sidecar.
 
 ## Named impossibles and next work
 
-- **No public blankable sentence (936 primary assignments):** the current
-  inventory either has no row or rejects the available row before cloze
-  construction. The next useful source work is a new public, rights-aware
-  corpus or a dedicated, reviewed textbook end-dictionary extractor; FTS alone
-  did not yield a quality-gated tranche here.
-- **Function-POS (121):** automatic identity clozes remain gated by the current
+- **No public blankable sentence (936 primary assignments):** no current
+  inventory candidate remains after the function/multiword precedence rules.
+  The next useful source work is a new public, rights-aware corpus or a
+  dedicated, reviewed textbook end-dictionary extractor; the baseline FTS
+  probe did not yield a quality-gated tranche here.
+- **Function-POS (110):** automatic identity clozes remain gated by the current
   function-POS policy. Any exception needs an explicitly reviewed exercise
   contract, not a blanket gate removal.
 - **Multiword IDs (170):** these need a multiword-aware cloze/source contract.
   Treating a phrase or paired-form ID as one single-token identity answer would
   violate the existing blankability and option-quality gates.
-- **Inventory-present-build-empty (509):** these are the next code/data funnel
-  to instrument per lemma. The current evidence does not authorize lowering
-  VESUM, source, capitalization, or option gates.
-- **Still-trimmed (0):** no current budget pressure is demonstrated. Do not
-  raise limits or claim recovered coverage without a fresh untrimmed/post-budget
-  comparison.
+- **Inventory-present-build-empty (284):** the remaining failures are 4
+  quality-gate empty, 75 identity-option fail, and 205 VESUM miss. The current
+  evidence does not authorize lowering VESUM, source, capitalization, or option
+  gates.
+- **Still-trimmed (60):** these are valid no-budget candidates omitted by the
+  current B1 size budget. Do not raise limits or claim their coverage without a
+  fresh quality review and untrimmed/post-budget comparison.
 
 The next mineable tranche remains **not established**. The residual sidecar
 pattern from #6230 and the quality gates from #6212 remain unchanged.
@@ -135,7 +168,7 @@ Hydrate the pinned release:
 
 ```bash
 .venv/bin/python -m scripts.practice_deck.io
-# Hydrated Atlas practice deck atlas-practice-v1-4369ff38d9b16567 (45 shards).
+# Hydrated Atlas practice deck atlas-practice-v1-72aefaf645e8d390 (45 shards).
 ```
 
 Read the published coverage counts:
@@ -152,14 +185,17 @@ The residual-set and inventory-reader measurement used the builder’s
 five hydrated cloze shards, and both inventory files. It produced:
 
 ```text
-residual 1736 raw_inventory 923 reader 618 no_reader 305 no_inventory 813
-function 121 function_raw 118 function_reader 109 function_no_inventory 3 function_no_reader 9
+residual 1560 inventory_reader_candidates 442 no_candidate 1118
+function 110 function_candidate 98 function_no_candidate 12
 multiword_shape 173 multiword_raw 0 multiword_reader 0 multiword_no_inventory 173 overlap_function 3
-partition {'no public sentence': 936, 'inventory-present-build-empty': 509,
-           'multiword-id': 170, 'function-POS': 121,
-           'would_emit-still-trimmed': 0, 'other': 0}
-partition_sum 1736
+partition {'no public sentence': 936, 'inventory-present-build-empty': 284,
+           'multiword-id': 170, 'function-POS': 110,
+           'would_emit-still-trimmed': 60, 'other': 0}
+partition_sum 1560
 ```
 
 The budget check read each hydrated `practice-cloze.<level>.json` payload’s
-`sizeBudget` object and confirmed `ok=true` for A1 through C1.
+`sizeBudget` object and confirmed `ok=true` for A1 through C1. The separate
+no-budget build trace produced 60 valid option sets absent from the final
+published index, which is why `would_emit-still-trimmed` is nonzero even though
+the published payload metadata is truthful.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1275,6 +1275,16 @@ def _make_no_pair_options(
     )
     if is_inventory_identity:
         decoys = _eligible_dictionary_decoys(answer, lexemes, cloze.get("form"))
+        # Dictionary lemmas are normalized lowercase, while an inventory
+        # target may preserve sentence-initial capitalization.  Render the
+        # option labels at the source surface's initial-capital state before
+        # applying the existing length and answer-leak gates; otherwise a
+        # safe same-POS decoy is discarded solely because its dictionary
+        # spelling is lowercase.
+        decoys = [
+            (decoy_lexeme, _match_initial_capitalization(decoy_form, cloze.get("form")))
+            for decoy_lexeme, decoy_form in decoys
+        ]
         answer_length = len(str(cloze.get("form") or ""))
         decoys = [
             candidate
@@ -1412,6 +1422,19 @@ def _initial_capitalization(value: Any) -> bool | None:
         if char.isalpha():
             return char.upper() == char and char.lower() != char
     return None
+
+
+def _match_initial_capitalization(value: str, exemplar: Any) -> str:
+    """Render a dictionary option with the source surface's initial case."""
+    desired = _initial_capitalization(exemplar)
+    if desired is None:
+        return value
+    chars = list(value)
+    for index, char in enumerate(chars):
+        if char.isalpha():
+            chars[index] = char.upper() if desired else char.lower()
+            return "".join(chars)
+    return value
 
 
 def validate_option_set(cloze: dict[str, Any]) -> list[str]:

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -34,7 +34,7 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 12  # 11→12: safe length/capitalization identity decoys (#6188)
+PRACTICE_DECK_BUILDER_VERSION = 13  # 12→13: render normalized identity decoys at source case (#6188)
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-4369ff38d9b16567.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-72aefaf645e8d390.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-4369ff38d9b16567",
+  "deck_version": "atlas-practice-v1-72aefaf645e8d390",
   "package_schema_version": 1,
-  "gz_sha256": "d27fdca8c39e274197a52578382dc3232b295bb990e0d6ac68e55ece275a633b",
-  "package_sha256": "dea931b44e9509033ced19ede0b84d96fe3d1fd1d9cf7a573240d07efedb1dbe",
-  "gz_bytes": 1686416,
-  "package_bytes": 22572590,
+  "gz_sha256": "25d2c2fe7a45a5f8965d6c2102a89186c2eb1b0a5bff164321fc667069fec26c",
+  "package_sha256": "386854af5fa817b68def8fd6a5bd3091b0b46d589613b8b358182ce41e397922",
+  "gz_bytes": 1714310,
+  "package_bytes": 22899565,
   "file_count": 45,
   "files": [
     {
@@ -14,13 +14,13 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 283851,
-      "sha256": "80088326a9325344258994412239ca61227b5a99bbbb566d272275cd48a83bef",
+      "bytes": 286644,
+      "sha256": "fc4b5ed3d3d14ed50f1510aa43750e3a5793dfa33fc1792a64c7c1d27a6ba7b1",
       "counts": {
         "lexemes": 1470,
-        "cloze": 1050,
-        "clozeEligibleLexemes": 1005,
-        "clozeCoverage": 0.6837
+        "cloze": 1125,
+        "clozeEligibleLexemes": 1080,
+        "clozeCoverage": 0.7347
       }
     },
     {
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533438,
-      "sha256": "52f73787d9d4cdfa9ab5b44db3379671960503fbf6633416d1aa9e17ee7f423b"
+      "sha256": "46287a5eff5c17b6e0bb66d94b67ad7063bf864f7760531fb90e2e3887eaf6e5"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1746612,
-      "sha256": "c1a963b5f81199ad6776a2064b7c0847fc132eb499695fde59000cd59fd92965"
+      "bytes": 1871426,
+      "sha256": "2196e767056756cac8b6c5f8e7411db2187495cacf4839b61f30bbacf5088831"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 349915,
-      "sha256": "3cea0d4c897d898e486c71cf53af19a295bda9a5a7586afa615711d063167436"
+      "sha256": "3df9aced4fd837a50f5eaf39baef539b177daa7327709871f46109562e615919"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 370047,
-      "sha256": "c7ed0b1d14adf361f74859637f1b9f401e40ca4004fb8bf97a64fffa7ac77f10"
+      "sha256": "db8f6ea0b15160eceaecfa0226098a5c307fa2a5e91407ba811fb5338369c9c4"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 615568,
-      "sha256": "70ae650d0920c15f96dae0721689fbc7e8c406238800bfe9ebc4ce84c3166426"
+      "sha256": "6c0da804a06e5ab85cec27bc9adcc443c0fdcfd05b6148ce0a5891f9ea71e63e"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "a4fec0ce0f5533e7c92ee6798d8bbeb4d11ba72afab1997b48c884566c04170f"
+      "sha256": "6a3dc8c863f47dd07a568370da64d4bc1c8ed65b966a51f8464728aa77a724ff"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 257,
-      "sha256": "9c2c154cfaad13659fe74f484960dc8144dfa7fecd7510bcb93fdf5ea4f441fe"
+      "sha256": "fd4bfa0f2842390ed7a88a116824ed6ce87ca9f50ff96bd2f70c7a55190f6721"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,20 +85,20 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 3491,
-      "sha256": "5af9fb59280b481454ff2e7cfc107a014e337cbc5318a2d9a87c0a84f54111c9"
+      "sha256": "788e6eddcc91c147a91ef52e7a1f282952a172f6ee7456ec42b6a7b95fbc44ad"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 295229,
-      "sha256": "860d09a33b7bc78f2dd79974625b17447e07dd2f956934742a0c469a310c27c6",
+      "bytes": 297528,
+      "sha256": "ed67dfd5ada3842cd47253f0a0c1d209e1ef4d4d201ff1a2efdf9287fff9264d",
       "counts": {
         "lexemes": 1444,
-        "cloze": 1097,
-        "clozeEligibleLexemes": 1097,
-        "clozeCoverage": 0.7597
+        "cloze": 1154,
+        "clozeEligibleLexemes": 1154,
+        "clozeCoverage": 0.7992
       }
     },
     {
@@ -107,15 +107,15 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 536102,
-      "sha256": "dfeb3ae195f5180c8090cd32e29fc329a61bba9bce0e436f34dc56fd2705cd1c"
+      "sha256": "c31885463e58b2d6617b3e13705845a96f0366f468adab0545be456512180713"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1880716,
-      "sha256": "581508cf8f1c0f5718fd364a95357ae60cc831174ba514ebb7cdea18bc211d3c"
+      "bytes": 1979401,
+      "sha256": "946c768f3c76715ad17795361a6a68f4d7e8aecde85508cf29a6ca2a08aaad2e"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 390102,
-      "sha256": "33bab514e94981d7d25101ec1850bfb066d3ca0fb4d2c2cf0801d26f349a1144"
+      "sha256": "4e8f159872c49315c26c4cffc2cc0595ee9978cb5a8a8074a618a0bb977ecf09"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1026094,
-      "sha256": "a7e2b706763849132773816ae52d328e5a9ce40b4aa8911b4e1532b4d1e4ce5c"
+      "sha256": "576b3e0fc32e7987b75dcf8fe641e33d38500ee21171ddafd22bd012a562d824"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 567900,
-      "sha256": "4bd4f3488e7ad4988fe07960e8b1a7e13d489c651bbfdbc61ce8059c57624dea"
+      "sha256": "eb819c8d76445d7e517ca5727fd0d3517aeed8abacd6955f04c8ab20c1f4091c"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,7 +147,7 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "bffad7c3d52436946793dd0e753db66fc9a71169dc1dd794bd1790ca29ae9b35"
+      "sha256": "af5ffe250bfe3fe4b3cda9cf8fac760002509f685cf9bc18365287ece1edb934"
     },
     {
       "path": "practice-heritage.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-heritage",
       "bytes": 33411,
-      "sha256": "ee6be7563f9f8954984d62e62594b37593a88958a50c32c3179354bcdeb000da"
+      "sha256": "a34b971c6c5489271567486a176f58c85d38994f5552c8bc7649fee2ca36bcda"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,20 +163,20 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 3454,
-      "sha256": "b95aa29114c2457a70a970a04a18f7abfaf8f6d3e8b128e9923f8cf38ed648c1"
+      "sha256": "c3fa39466de4afbdc03bb8006ae22c26fbcfe19bdb9ca7c17d12eebf73adcd07"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 336386,
-      "sha256": "db0bde627f014e6a1ed03499a21194c80c148f762aa80e0b181abf154791b644",
+      "bytes": 336598,
+      "sha256": "503154b739f0cd6d29f3bd21783a36fa4c0bc98dc14e24ff873f278eb775b521",
       "counts": {
         "lexemes": 1617,
-        "cloze": 1279,
-        "clozeEligibleLexemes": 1279,
-        "clozeCoverage": 0.791
+        "cloze": 1296,
+        "clozeEligibleLexemes": 1296,
+        "clozeCoverage": 0.8015
       }
     },
     {
@@ -185,15 +185,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 634474,
-      "sha256": "2de1155f972b74f1096c4d8364ec375ac3f0bea014c58fff445dd69c6abd504d"
+      "sha256": "12659e635fe6f0b2092b347c14eade86f88445c257b802166047b83cddf5974a"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 2203696,
-      "sha256": "ee30800e8e281d475db8934b5ef4ca25bd9833464f360dfaa5a92c9fe956e9a7"
+      "bytes": 2218308,
+      "sha256": "5c24f1855f8435850fb832be02eb1afd96d1b34b4e0212a22143db643ab37066"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 451935,
-      "sha256": "a061b8788a927cc79ac89472a4058db089ffafb75513f236a581fdc06aec0370"
+      "sha256": "8609179304cec87b86b7ebde55fd7bb0b146dd5913e7a8904618219cac70c95b"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1363476,
-      "sha256": "18827d7ebbbb3e250429d05558f56437edeeaadb0fbf22b2ba357858633a1a94"
+      "sha256": "67fb2d13c4b8de5a6bf4c252665dcd3fd1ee2fc70b37a7f58bbdcf3a1e68dd2b"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 785386,
-      "sha256": "e9cc538a25f47ae4804a63dc7b47b6ef3ca9fb771d0754bb392a238c2c408ae4"
+      "sha256": "47cd21734124040875ba55f8fb1f2370edef1d6653517b4474d55377ef112fc9"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,7 +225,7 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 346573,
-      "sha256": "fe53abb4477fb8eda1a727afe923cfd673e2ca303c0dd8884d6030b796e58be8"
+      "sha256": "84cb66f9f3691276d4b35cec4f1cec67df6b18eb4777ad6c4b3c5f437ddf49e0"
     },
     {
       "path": "practice-heritage.B1.json",
@@ -233,28 +233,28 @@
       "level": "B1",
       "schema": "atlas-practice-heritage",
       "bytes": 74730,
-      "sha256": "5a77a320172fe128045a7857dde42129ba6ab57954877db0a65880eca110dd7a"
+      "sha256": "a298dc15cff13e3cbc7edb2fe89ec8e14f9e1f9e14ff67f0fcfd48e99dfb29d2"
     },
     {
       "path": "practice-paronym.B1.json",
       "kind": "paronym",
       "level": "B1",
       "schema": "atlas-practice-paronym",
-      "bytes": 2500,
-      "sha256": "eaa1c75fd3f0f8ac2996924cf71ac9b082845c3c5efab1350c9fce52b0999798"
+      "bytes": 2501,
+      "sha256": "c620d35bbf31e01396648101d35c86a6deabb0dafad01c4754af777176f7c79a"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 197369,
-      "sha256": "de87b07655bbff2d4cce2d0b8b0b432e28df72c477f23e0a6c2a48b0af8522ab",
+      "bytes": 198306,
+      "sha256": "54efd2b766e317ff5a9d8fec3b121168952fd30cfd4f565d5227191b38f68d3b",
       "counts": {
         "lexemes": 940,
-        "cloze": 700,
-        "clozeEligibleLexemes": 700,
-        "clozeCoverage": 0.7447
+        "cloze": 723,
+        "clozeEligibleLexemes": 723,
+        "clozeCoverage": 0.7691
       }
     },
     {
@@ -263,15 +263,15 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 381338,
-      "sha256": "f25637a1d74f4d374e5d821f6f29d87c4ec5b3283c026aa38a4072f837322327"
+      "sha256": "191e506b17ba2b6d2f7e2548fc4d2afbe5e69fb16be0ccfd40091d39107802e7"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1217630,
-      "sha256": "5c508b06f5b31c70aa8391c2c5b7772600bb35c259c37865a34087e7ca837fb2"
+      "bytes": 1257375,
+      "sha256": "180aa845af1792a45ea5bbd4ad8c8092bcb5d2dbae939d9b8e839ecd09eddc8c"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 281264,
-      "sha256": "5ea35c2576aa7d4ca1e8a49e9ed68a0a2d4642faea0817ad23ed524a47061f73"
+      "sha256": "42a0597fc8673bdc228e8e1d6e0113c092d17a38b945f4f206b580fd3f50f4ac"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 799654,
-      "sha256": "36dce1af840b02edfa4871969a187033c6d82ebac498463453e79cef76d05525"
+      "sha256": "bf9d15820bd2d652a2a8ceb2b5e885a3168d8d26479319b9c4edf7c523e538ad"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 507721,
-      "sha256": "0a3ed8819e8b1797e15f93182ac6acd41f23a488b8f682ecd1e1126f0882c0d1"
+      "sha256": "0b4295606891ded11d3452cde77f7e9fcf879f45fba50c2e7fd71047a6012766"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 76291,
-      "sha256": "f0f149e21f2f6d2b65e9c79fab8f78e0ac09142f832f80e4f2c816070bfe020a"
+      "sha256": "bf1e26556f870ee564f5f58d50bcfa300a21aa957311933091aa1aa1ce55feb7"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 11098,
-      "sha256": "748ec68d99ff6708e7cfa6e764364fdaa54432085e8edf2946d80444ac8e4a06"
+      "sha256": "14ef0c076011423dcf08b8c85cdaa5b5aaaad0797fc2ddfc28282fc9abc869fe"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,20 +319,20 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "f3e929a8727e2e29e80f6076facdd75cc123b98b0c0fad676cbd51a0d93943d1"
+      "sha256": "9fa24adeec0e6909834028261dfc288b3f56727346334d98a45b14f5083e619a"
     },
     {
       "path": "practice-index.C1.json",
       "kind": "index",
       "level": "C1",
       "schema": "atlas-practice-index",
-      "bytes": 105202,
-      "sha256": "171aa21cc94335a2b9633656c6f8bbe8cfc5864b9e6c32e43cd4df0923a3e868",
+      "bytes": 105355,
+      "sha256": "a07deb979a6ef70f4d525ba29d7e92da7668c11e5a3c8e2ddb80e5bcbc2d4cb1",
       "counts": {
         "lexemes": 529,
-        "cloze": 183,
-        "clozeEligibleLexemes": 183,
-        "clozeCoverage": 0.3459
+        "cloze": 187,
+        "clozeEligibleLexemes": 187,
+        "clozeCoverage": 0.3535
       }
     },
     {
@@ -341,15 +341,15 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 212786,
-      "sha256": "6bef3b2f075ffb16d47fbc98f7c6c26ae95312287e89e1beb65e93ffacfe935f"
+      "sha256": "04c366a1519ba8a724017a49455dd2e7a838892122ccc2c1111c45aba73e4cd1"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 320919,
-      "sha256": "1c387ff70863ae127705a959c682723cfb6ad4fd6dd7eb87d383cf93915eb385"
+      "bytes": 327383,
+      "sha256": "bca0baec9d0a08b49a2ba796198b6e4295d5dc9d0e1943d7b821393212646a9b"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 154306,
-      "sha256": "325f4d69c504381c682e1f51f45735be3efdbfcb4d05e4ebf0a11486a8fe91ae"
+      "sha256": "f5301080bd959e5bcab26be7070d0d6da412e1c65eba86ef4c9efc15b3d19b0f"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 418175,
-      "sha256": "a85dd48103ff6c2243d9f72ca0fae15cc1895252e3b0d5c89e076c19c18783f5"
+      "sha256": "ba2767b35ff5fc57cb64031d73ceff9c2f9deb2b25bdb9caa3d3f73ca0bb8aa6"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 299425,
-      "sha256": "6f59a141f2f265999e0c9e66bdeb42eeb8a80b2518b62d05beae2d978baa1c3d"
+      "sha256": "10a867d8e35b5687957ffde7717d3b13ee12a8ece33a202108cf0306c5bd9e0c"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 30629,
-      "sha256": "15190790b361f8f6657bd9c3cd92e693519813af556a20292cf623049cd78d80"
+      "sha256": "540180902ef0b2fdc676b003494762a5f9f064b7c6cfd0318ee0eb297acc1707"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 2060,
-      "sha256": "e1b5d1aa37e6d7800aaedd43fbada6278ee0d152e598989f22f4b8a536dcdc84"
+      "sha256": "944b49973b5a3573a00a1e2fa7e77716471f244e4b4f714a36639882d41b6014"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 2357,
-      "sha256": "426cc650cac3e1f706a3f016d373e73695d5abf85aea02e811f5b625804a7c9b"
+      "sha256": "1cf530692cebe18f226208f4b0bdb999e7df43b7e5d7b609cd2a114673fca015"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1856,6 +1856,29 @@ def test_inventory_identity_decoys_use_attested_surface_capitalization() -> None
     assert validate_option_set({**cloze, "options": options}) == []
 
 
+def test_inventory_identity_decoys_render_normalized_lemmas_at_source_case() -> None:
+    lexemes = _fixture_lexemes()
+    answer = next(lexeme for lexeme in lexemes if lexeme["lemmaId"] == "knyha")
+    cloze = {
+        "clozeId": "knyha:inventory:normalized-case",
+        "form": "Книга",
+        "lemma": "книга",
+        "provenance": {"status": "sentence_inventory"},
+        "caseRule": {"ruleId": "nominative_identification"},
+    }
+
+    options = generate_practice_deck._make_no_pair_options(
+        cloze, answer, lexemes, random.Random(0)
+    )
+
+    assert len(options) == 4
+    assert all(
+        generate_practice_deck._initial_capitalization(option["label"])
+        for option in options
+    )
+    assert validate_option_set({**cloze, "options": options}) == []
+
+
 def test_sentence_inventory_identity_cloze_scales_across_levels_and_pos(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Fixed the largest safe mechanical failure in the inventory identity funnel: normalized dictionary decoys are rendered at the source surface's initial-capital state before the existing length and option-quality gates run.
- Bumped `PRACTICE_DECK_BUILDER_VERSION` from 12 to 13, regenerated and published the deck, and committed the pointer in the same PR.
- Updated `docs/practice/cloze-residual-taxonomy.md` with the final pointer-backed coverage, budget, and residual partition.

## Before / after coverage

| Level | v12 eligible / residual / coverage | v13 published eligible / residual / coverage |
| --- | ---: | ---: |
| A1 | 1,005 / 465 / 68.37% | 1,080 / 390 / 73.47% |
| A2 | 1,097 / 347 / 75.97% | 1,154 / 290 / 79.92% |
| B1 | 1,279 / 338 / 79.10% | 1,296 / 321 / 80.15% |
| B2 | 700 / 240 / 74.47% | 723 / 217 / 76.91% |
| C1 | 183 / 346 / 34.59% | 187 / 342 / 35.35% |
| **All** | **4,264 / 1,736 / 71.07%** | **4,440 / 1,560 / 74.00%** |

Tool-quoted v13 pointer metrics:

```text
A1 1470 1125 1080 0.7347
A2 1444 1154 1154 0.7992
B1 1617 1296 1296 0.8015
B2 940 723 723 0.7691
C1 529 187 187 0.3535
```

The exact original 509-ID funnel was measured as:

```text
                 quality  identity  VESUM  level  other  safe-before-budget
v12 before fix          4       300    205      0      0                   0
v13 before budget       4        75    205      0      0                 225
```

All 225 recovered option sets passed the existing validators. 222 are in the
published deck; 3 remain in the B1 budget-trimmed residual. The final residual
partition is 110 function-POS, 170 multiword, 936 no public sentence, 284
genuine inventory-present builder-empty, 60 valid-but-budget-trimmed, and 0
other (1,560 total). No VESUM, source, capitalization, or option-quality gate
was lowered.

## Publish evidence

- Deck version: `atlas-practice-v1-72aefaf645e8d390`
- Pointer: `site/src/data/lexicon-practice-deck.pointer.json`
- Published gzip: 1,714,310 bytes, SHA-256 `25d2c2fe7a45a5f8965d6c2102a89186c2eb1b0a5bff164321fc667069fec26c`
- `make practice-deck-publish` completed successfully.
- Hydration completed with `Hydrated Atlas practice deck atlas-practice-v1-72aefaf645e8d390 (45 shards).`
- `gh release view` confirmed the immutable release asset at the pointer URL.

## Verification

- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py scripts/practice_deck/io.py tests/test_generate_practice_deck.py` → exit 0
- `.venv/bin/pytest -q tests/test_generate_practice_deck.py` → exit 0, 84 passed
- `node_modules/.bin/markdownlint-cli2 docs/practice/cloze-residual-taxonomy.md` → exit 0, 0 errors
- `git diff --check` → exit 0
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → exit 0
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → exit 0

## Residual honesty

This does not close the full residual. The 205 VESUM misses, 4 function quality
gates, 75 remaining identity-option failures, 936 no-public-sentence IDs, and
60 budget-trimmed IDs remain explicitly accounted for. The baseline FTS probe
found no new quality-gated source rows, so no source inventory was expanded.
