### PR TITLE
fix(practice): normalize residual identity POS aliases

### DIFF
--- a/docs/practice/cloze-residual-taxonomy.md
+++ b/docs/practice/cloze-residual-taxonomy.md
@@ -2,30 +2,30 @@
 
 Run date: 2026-08-02
 
-Scope: hydrated release `atlas-practice-v1-72aefaf645e8d390`, the A1-C1
+Scope: hydrated release `atlas-practice-v1-b39bcdd93d232ad7`, the A1-C1
 `practice-lexemes.*.json` shards, the base sentence inventory, and its additive
 `lexicon-sentence-inventory.residual.json` sidecar. The before comparison is
-the v12 build from release `atlas-practice-v1-4369ff38d9b16567`; this is a
-current-state taxonomy, not a completion claim for #6188.
+the v13 release `atlas-practice-v1-72aefaf645e8d390`; this is a current-state
+taxonomy, not a completion claim for #6188.
 
 ## Current coverage
 
-The published v13 release has 4,440 cloze-eligible practice lemmas out of
-6,000. The uncovered set is therefore 1,560 lemmas.
+The published v14 release has 4,475 cloze-eligible practice lemmas out of
+6,000. The uncovered set is therefore 1,525 lemmas.
 
 | Level | Practice lemmas | Cloze-eligible | Residual | Coverage |
 | --- | ---: | ---: | ---: | ---: |
-| A1 | 1,470 | 1,080 | 390 | 73.47% |
-| A2 | 1,444 | 1,154 | 290 | 79.92% |
-| B1 | 1,617 | 1,296 | 321 | 80.15% |
-| B2 | 940 | 723 | 217 | 76.91% |
+| A1 | 1,470 | 1,103 | 367 | 75.03% |
+| A2 | 1,444 | 1,164 | 280 | 80.61% |
+| B1 | 1,617 | 1,295 | 322 | 80.09% |
+| B2 | 940 | 726 | 214 | 77.23% |
 | C1 | 529 | 187 | 342 | 35.35% |
-| **All** | **6,000** | **4,440** | **1,560** | **74.00%** |
+| **All** | **6,000** | **4,475** | **1,525** | **74.58%** |
 
 The inventory contains 5,135 base rows and 51 sidecar rows. They are 5,186
 unique inventory IDs; 5,185 intersect the current Practice set. Within the
-1,560 final residual lemmas, 442 have an inventory-reader candidate and 1,118
-have no candidate. The 442 includes function/multiword IDs that are assigned
+1,525 final residual lemmas, 407 have an inventory-reader candidate and 1,118
+have no candidate. The 407 includes function/multiword IDs that are assigned
 to those higher-precedence buckets below.
 
 ## #6188 before/after measurement
@@ -39,21 +39,32 @@ cloze item exists.
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | v12, before fix | 4 | 300 | 205 | 0 | 0 | 0 |
 | v13, same 509 IDs, before budget | 4 | 75 | 205 | 0 | 0 | 225 |
+| v14 alias trace, same 344 IDs, before budget | 4 | 36 | 205 | 0 | 0 | 99 |
 
 The v13 change only renders normalized dictionary decoys at the source
 surface's initial-capital state before applying the existing length, POS,
 CEFR, answer-leak, and option validators. It does not lower any quality gate.
-All 225 recovered option sets validated before budgeting. The published deck
-retains 222 of those original-509 cards; three are in the B1 budget-trimmed
+All 225 recovered option sets validated before budgeting. The v13 published
+deck retained 222 of those original-509 cards; three were in the B1
+budget-trimmed residual.
+
+The v14 follow-up normalizes only unambiguous manifest POS aliases already
+covered by the existing option buckets: `infinitive` and `imperative` to verb,
+`numr` to numeral, and `intj` to interjection. The authority-consistent,
+VESUM-backed build over the 344 post-precedence candidate IDs measured 36
+remaining identity-option failures and 99 valid no-budget candidates. The
+published pointer is now `atlas-practice-v1-b39bcdd93d232ad7`; no quality,
+VESUM, function-identity, length, or size limit was changed. The published
+v14 deck retains 33 of those 99 valid candidates and leaves 66 in the budget
 residual.
 
-The published coverage change is 4,264 to 4,440 eligible lemmas (+176) and
-1,736 to 1,560 residual lemmas (-176). B1 is the only level that needed
-budget trimming: the no-budget v13 B1 cloze payload measured 2,336,106 raw /
-250,806 gzip bytes, while the published payload is within the 2,250,000 /
-240,000 limits. The 60 final `would_emit-still-trimmed` IDs comprise the three
-original-509 cards plus 57 previously published B1 IDs displaced by the
-larger v13 payload.
+Against the pinned v13 hydration, the published v14 deck measures 4,440 to
+4,475 eligible lemmas (+35) and 1,560 to 1,525 residual lemmas (-35). B1 is
+the only level that needed budget trimming: the no-budget v14 B1 cloze payload
+measured 2,344,437 raw / 251,462 gzip bytes, while the published payload is
+within the 2,250,000 / 240,000 limits. The 66 final
+`would_emit-still-trimmed` IDs are valid no-budget candidates omitted by the
+current B1 budget.
 
 ## Mutually exclusive partition
 
@@ -70,20 +81,20 @@ sourced.”
 
 | Bucket | Count | Definition in this snapshot |
 | --- | ---: | --- |
-| function-POS | 110 | Residual lexeme `pos` is in the builder’s function-POS set. |
+| function-POS | 108 | Residual lexeme `pos` is in the builder's function-POS set. |
 | multiword-id | 170 | Multi-token/slash-form residual after the function-POS precedence rule. |
 | no public sentence | 936 | No current candidate remains after the function/multiword precedence rules. |
-| inventory-present-build-empty | 284 | Remaining inventory candidates rejected by the v13 quality, VESUM, level, or option gates: 4 quality-gate empty, 75 identity-option fail, 205 VESUM miss, 0 level mismatch, and 0 other. |
-| would_emit-still-trimmed | 60 | A no-budget v13 trace produced a valid cloze/options set, but the default budget omitted the ID from the published index. All five published `sizeBudget.ok` values remain true. |
+| inventory-present-build-empty | 245 | Remaining inventory candidates rejected by the v14 quality, VESUM, level, or option gates: 4 quality-gate empty, 36 identity-option fail, 205 VESUM miss, 0 level mismatch, and 0 other. |
+| would_emit-still-trimmed | 66 | A no-budget v14 trace produced a valid cloze/options set, but the default budget omitted the ID from the published index. All five published `sizeBudget.ok` values remain true. |
 | other | 0 | No unclassified residual remains after the stated partition. |
-| **Total** | **1,560** | **Exact residual set.** |
+| **Total** | **1,525** | **Exact residual set.** |
 
 The function-POS and multiword classifications overlap in three raw IDs; the
 precedence rule assigns those three to `function-POS`. The multiword bucket has
 173 raw shape matches before that rule and 170 primary assignments. The final
-inventory-present candidate set is 344 IDs: 4 quality-gate empty, 75
-identity-option failures, 205 VESUM misses, and 60 valid-but-budget-trimmed
-IDs. The 284/60 split above keeps the budget residual separate from genuine
+inventory-present candidate set is 311 IDs: 4 quality-gate empty, 36
+identity-option failures, 205 VESUM misses, and 66 valid-but-budget-trimmed
+IDs. The 245/66 split above keeps the budget residual separate from genuine
 builder-empty failures.
 
 ## Budget check
@@ -93,15 +104,15 @@ limits of 2,250,000 raw bytes and 240,000 gzip bytes:
 
 | Level | Raw bytes | Gzip bytes | `sizeBudget.ok` |
 | --- | ---: | ---: | --- |
-| A1 | 1,871,315 | 204,492 | true |
-| A2 | 1,979,290 | 211,996 | true |
-| B1 | 2,218,308 | 237,387 | true |
-| B2 | 1,257,264 | 135,573 | true |
-| C1 | 327,274 | 35,679 | true |
+| A1 | 1,910,346 | 208,380 | true |
+| A2 | 1,996,446 | 213,580 | true |
+| B1 | 2,215,600 | 236,912 | true |
+| B2 | 1,262,065 | 135,932 | true |
+| C1 | 327,248 | 35,686 | true |
 
-The current maximum is B1, with 31,692 raw bytes and 2,613 gzip bytes of
+The current maximum is B1, with 34,400 raw bytes and 3,088 gzip bytes of
 metadata-reported headroom. The post-budget payloads fit, but the no-budget
-trace above proves that 60 cards remain capacity-trimmed; a future deck build
+trace above proves that 66 cards remain capacity-trimmed; a future deck build
 must remeasure both the untrimmed and post-budget sets.
 
 ## Residual-only textbook FTS probe (baseline evidence)
@@ -145,17 +156,17 @@ residual sidecar.
   The next useful source work is a new public, rights-aware corpus or a
   dedicated, reviewed textbook end-dictionary extractor; the baseline FTS
   probe did not yield a quality-gated tranche here.
-- **Function-POS (110):** automatic identity clozes remain gated by the current
+- **Function-POS (108):** automatic identity clozes remain gated by the current
   function-POS policy. Any exception needs an explicitly reviewed exercise
   contract, not a blanket gate removal.
 - **Multiword IDs (170):** these need a multiword-aware cloze/source contract.
   Treating a phrase or paired-form ID as one single-token identity answer would
   violate the existing blankability and option-quality gates.
-- **Inventory-present-build-empty (284):** the remaining failures are 4
-  quality-gate empty, 75 identity-option fail, and 205 VESUM miss. The current
-  evidence does not authorize lowering VESUM, source, capitalization, or option
-  gates.
-- **Still-trimmed (60):** these are valid no-budget candidates omitted by the
+- **Inventory-present-build-empty (245 in the published v14 snapshot):** the
+  published build retains 4 quality-gate empty, 36 identity-option fail, and
+  205 VESUM miss. The current evidence does not authorize lowering VESUM,
+  source, capitalization, or option gates.
+- **Still-trimmed (66):** these are valid no-budget candidates omitted by the
   current B1 size budget. Do not raise limits or claim their coverage without a
   fresh quality review and untrimmed/post-budget comparison.
 
@@ -164,11 +175,11 @@ pattern from #6230 and the quality gates from #6212 remain unchanged.
 
 ## Commands and evidence used
 
-Hydrate the pinned release:
+Hydrate the published release:
 
 ```bash
 .venv/bin/python -m scripts.practice_deck.io
-# Hydrated Atlas practice deck atlas-practice-v1-72aefaf645e8d390 (45 shards).
+# Hydrated Atlas practice deck atlas-practice-v1-b39bcdd93d232ad7 (45 shards).
 ```
 
 Read the published coverage counts:
@@ -185,17 +196,17 @@ The residual-set and inventory-reader measurement used the builder’s
 five hydrated cloze shards, and both inventory files. It produced:
 
 ```text
-residual 1560 inventory_reader_candidates 442 no_candidate 1118
-function 110 function_candidate 98 function_no_candidate 12
+residual 1525 inventory_reader_candidates 407 no_candidate 1118
+function 108 function_candidate 96 function_no_candidate 12
 multiword_shape 173 multiword_raw 0 multiword_reader 0 multiword_no_inventory 173 overlap_function 3
-partition {'no public sentence': 936, 'inventory-present-build-empty': 284,
-           'multiword-id': 170, 'function-POS': 110,
-           'would_emit-still-trimmed': 60, 'other': 0}
-partition_sum 1560
+partition {'no public sentence': 936, 'inventory-present-build-empty': 245,
+           'multiword-id': 170, 'function-POS': 108,
+           'would_emit-still-trimmed': 66, 'other': 0}
+partition_sum 1525
 ```
 
 The budget check read each hydrated `practice-cloze.<level>.json` payload’s
 `sizeBudget` object and confirmed `ok=true` for A1 through C1. The separate
-no-budget build trace produced 60 valid option sets absent from the final
+no-budget build trace produced 66 valid option sets absent from the final
 published index, which is why `would_emit-still-trimmed` is nonzero even though
 the published payload metadata is truthful.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1100,6 +1100,20 @@ def _option_pos_bucket(pos: Any) -> str:
     if not value:
         return ""
     normalized = value.casefold()
+    # The hydrated manifest uses these standard shorthand/form labels for
+    # lexical categories already represented by the broader buckets below.
+    # Keep this list deliberately narrow: semantic labels such as
+    # ``predicative`` and ``sequence word`` remain separate until their
+    # exercise contract is reviewed.
+    if normalized in {
+        "imperative",
+        "infinitive",
+    }:
+        return "verb"
+    if normalized == "intj":
+        return "interjection"
+    if normalized == "numr":
+        return "numeral"
     if "pronoun" in normalized or normalized in {"pron", "negative pronoun"}:
         return "pronoun"
     if "adverb" in normalized or normalized == "adv":

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -34,7 +34,7 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 13  # 12→13: render normalized identity decoys at source case (#6188)
+PRACTICE_DECK_BUILDER_VERSION = 14  # 13→14: normalize unambiguous identity-option POS aliases (#6188)
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-72aefaf645e8d390.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-b39bcdd93d232ad7.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-72aefaf645e8d390",
+  "deck_version": "atlas-practice-v1-b39bcdd93d232ad7",
   "package_schema_version": 1,
-  "gz_sha256": "25d2c2fe7a45a5f8965d6c2102a89186c2eb1b0a5bff164321fc667069fec26c",
-  "package_sha256": "386854af5fa817b68def8fd6a5bd3091b0b46d589613b8b358182ce41e397922",
-  "gz_bytes": 1714310,
-  "package_bytes": 22899565,
+  "gz_sha256": "a59f50037f0ec7746663ae60551257ecea7f3a02c3028af2c959501eaa4b234b",
+  "package_sha256": "df711b64a632fef79d21dbecd790120bebab8a99f5388be981c4f3ca0c310730",
+  "gz_bytes": 1720167,
+  "package_bytes": 22966366,
   "file_count": 45,
   "files": [
     {
@@ -14,13 +14,13 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 286644,
-      "sha256": "fc4b5ed3d3d14ed50f1510aa43750e3a5793dfa33fc1792a64c7c1d27a6ba7b1",
+      "bytes": 287513,
+      "sha256": "228bf75eaac9369a01d512a6a6d3a764846ea07f4eb27724b31109e04d51be58",
       "counts": {
         "lexemes": 1470,
-        "cloze": 1125,
-        "clozeEligibleLexemes": 1080,
-        "clozeCoverage": 0.7347
+        "cloze": 1148,
+        "clozeEligibleLexemes": 1103,
+        "clozeCoverage": 0.7503
       }
     },
     {
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533438,
-      "sha256": "46287a5eff5c17b6e0bb66d94b67ad7063bf864f7760531fb90e2e3887eaf6e5"
+      "sha256": "2ba6e89590bffeea7603650e241efbe56b5f9b37e8441a86e6131c3becb0ca5e"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1871426,
-      "sha256": "2196e767056756cac8b6c5f8e7411db2187495cacf4839b61f30bbacf5088831"
+      "bytes": 1910457,
+      "sha256": "014bc1119b1e8f59600456b3a8d6d1ac56a73410690b417041b079738feac791"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 349915,
-      "sha256": "3df9aced4fd837a50f5eaf39baef539b177daa7327709871f46109562e615919"
+      "sha256": "e16b751fb6477f1c82fba44ea19ef15be18019a68a980b836fec205a53e815a7"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 370047,
-      "sha256": "db8f6ea0b15160eceaecfa0226098a5c307fa2a5e91407ba811fb5338369c9c4"
+      "sha256": "830fd449a04aaa756511cc4773b70eadd5a4f4ffaf7f2daa8c2681d0e107f022"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 615568,
-      "sha256": "6c0da804a06e5ab85cec27bc9adcc443c0fdcfd05b6148ce0a5891f9ea71e63e"
+      "sha256": "44c950b9ca7d8fa2878605ece23370662a324c0155737d01f234de70a93b9d2e"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "6a3dc8c863f47dd07a568370da64d4bc1c8ed65b966a51f8464728aa77a724ff"
+      "sha256": "6df1daede7c276b502c912d66cc11006a4c34eb4ecd770d87f75717ad8d284bb"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 257,
-      "sha256": "fd4bfa0f2842390ed7a88a116824ed6ce87ca9f50ff96bd2f70c7a55190f6721"
+      "sha256": "a3bd92ac4d2cdc30a2133ff16c1d70cc739bf9f1647d8fe27cdc5832bb1984af"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,20 +85,20 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 3491,
-      "sha256": "788e6eddcc91c147a91ef52e7a1f282952a172f6ee7456ec42b6a7b95fbc44ad"
+      "sha256": "04f454e4ef39269ab665d7e6b2fcd2df75c23241a0788d7e0e7471bce4019c09"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 297528,
-      "sha256": "ed67dfd5ada3842cd47253f0a0c1d209e1ef4d4d201ff1a2efdf9287fff9264d",
+      "bytes": 297933,
+      "sha256": "23f2c40c56cbfc90371bedb5d7a709ff8e81e542f1ce5db84d8dba8b0e3dd975",
       "counts": {
         "lexemes": 1444,
-        "cloze": 1154,
-        "clozeEligibleLexemes": 1154,
-        "clozeCoverage": 0.7992
+        "cloze": 1164,
+        "clozeEligibleLexemes": 1164,
+        "clozeCoverage": 0.8061
       }
     },
     {
@@ -107,15 +107,15 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 536102,
-      "sha256": "c31885463e58b2d6617b3e13705845a96f0366f468adab0545be456512180713"
+      "sha256": "80fda9cc18bacf57532ca8a613997c72f8c997bc012c3b270acb1c6313ab60c9"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1979401,
-      "sha256": "946c768f3c76715ad17795361a6a68f4d7e8aecde85508cf29a6ca2a08aaad2e"
+      "bytes": 1996557,
+      "sha256": "1826880e20a89bd7785622a74ecfafdfbbbfde58996534035da495cd8b46dbb0"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 390102,
-      "sha256": "4e8f159872c49315c26c4cffc2cc0595ee9978cb5a8a8074a618a0bb977ecf09"
+      "sha256": "80e6944535c0f89f6d74306fa823b63f4e74a780aa4eaeac759d32d027ef42c4"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1026094,
-      "sha256": "576b3e0fc32e7987b75dcf8fe641e33d38500ee21171ddafd22bd012a562d824"
+      "sha256": "5d2efc3a177507f3f9b9aefcf85a6ecdd0f729d29ba1523aafbcf34df09b78a9"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 567900,
-      "sha256": "eb819c8d76445d7e517ca5727fd0d3517aeed8abacd6955f04c8ab20c1f4091c"
+      "sha256": "0701ab70d3175a0181f11bceab40498180121b2e08fa5fc568d1ef5cbd87c6df"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,7 +147,7 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "af5ffe250bfe3fe4b3cda9cf8fac760002509f685cf9bc18365287ece1edb934"
+      "sha256": "f4a5d8947cbde06100418a90ccdef3b3d9fc89b4f780c56ee1be0b684502107f"
     },
     {
       "path": "practice-heritage.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-heritage",
       "bytes": 33411,
-      "sha256": "a34b971c6c5489271567486a176f58c85d38994f5552c8bc7649fee2ca36bcda"
+      "sha256": "6026c420ad24c183f31b67fe55b36bd9e0f9369546aeb24b44a6c542136f48f3"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,20 +163,20 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 3454,
-      "sha256": "c3fa39466de4afbdc03bb8006ae22c26fbcfe19bdb9ca7c17d12eebf73adcd07"
+      "sha256": "471cd73b579ce697094865caf957d9a5e841cb8036b37a5c01da1a9d5a53ab3a"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 336598,
-      "sha256": "503154b739f0cd6d29f3bd21783a36fa4c0bc98dc14e24ff873f278eb775b521",
+      "bytes": 336538,
+      "sha256": "ec4b14dba5c2fc3b5900870fdce2f6649412460a44ed14897c28ff7f7c66bba7",
       "counts": {
         "lexemes": 1617,
-        "cloze": 1296,
-        "clozeEligibleLexemes": 1296,
-        "clozeCoverage": 0.8015
+        "cloze": 1295,
+        "clozeEligibleLexemes": 1295,
+        "clozeCoverage": 0.8009
       }
     },
     {
@@ -185,15 +185,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 634474,
-      "sha256": "12659e635fe6f0b2092b347c14eade86f88445c257b802166047b83cddf5974a"
+      "sha256": "a7a1d710354230c6840d7231edcbfc967b8b725261024e11f2a2578829c06958"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 2218308,
-      "sha256": "5c24f1855f8435850fb832be02eb1afd96d1b34b4e0212a22143db643ab37066"
+      "bytes": 2215600,
+      "sha256": "9615a026e41855258346f913653292e007dab6861057e5b847f72d8d13d94cf8"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 451935,
-      "sha256": "8609179304cec87b86b7ebde55fd7bb0b146dd5913e7a8904618219cac70c95b"
+      "sha256": "566a61a1bd0fd0711f582c59830a1eadfd3985a881fb5235f4fde8cdd96d0d89"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1363476,
-      "sha256": "67fb2d13c4b8de5a6bf4c252665dcd3fd1ee2fc70b37a7f58bbdcf3a1e68dd2b"
+      "sha256": "5b5c054e07d8611c74412f67f9659eebcfdc0171dfad42f49c951faf97591831"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 785386,
-      "sha256": "47cd21734124040875ba55f8fb1f2370edef1d6653517b4474d55377ef112fc9"
+      "sha256": "0bd530aec194b6440b20d7e21c87c644666e4038ca0e32d3f87b7bf8979afe22"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,7 +225,7 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 346573,
-      "sha256": "84cb66f9f3691276d4b35cec4f1cec67df6b18eb4777ad6c4b3c5f437ddf49e0"
+      "sha256": "8b2675fbfba191fa6f24baa02dc8f1a03dac053ade7f0bada2b9c7cfe40abd83"
     },
     {
       "path": "practice-heritage.B1.json",
@@ -233,7 +233,7 @@
       "level": "B1",
       "schema": "atlas-practice-heritage",
       "bytes": 74730,
-      "sha256": "a298dc15cff13e3cbc7edb2fe89ec8e14f9e1f9e14ff67f0fcfd48e99dfb29d2"
+      "sha256": "60eb861c7e754a63eb585804fd6596f26b81b8aef2d5071eb813e96b003cbf0f"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -241,20 +241,20 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 2501,
-      "sha256": "c620d35bbf31e01396648101d35c86a6deabb0dafad01c4754af777176f7c79a"
+      "sha256": "0aca8cdf7d840167842ac9b716a4dffc41c7b37dc106d296c49130694152d032"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 198306,
-      "sha256": "54efd2b766e317ff5a9d8fec3b121168952fd30cfd4f565d5227191b38f68d3b",
+      "bytes": 198429,
+      "sha256": "a971d5977ca5e504f63f12ae8576f750695b7c78271fef7a2802b7b6a5dcfa42",
       "counts": {
         "lexemes": 940,
-        "cloze": 723,
-        "clozeEligibleLexemes": 723,
-        "clozeCoverage": 0.7691
+        "cloze": 726,
+        "clozeEligibleLexemes": 726,
+        "clozeCoverage": 0.7723
       }
     },
     {
@@ -263,15 +263,15 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 381338,
-      "sha256": "191e506b17ba2b6d2f7e2548fc4d2afbe5e69fb16be0ccfd40091d39107802e7"
+      "sha256": "07800a3c7a92ebc6c600485e65f00707d68fb3c616dbb26ae7ef325eb3604a08"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1257375,
-      "sha256": "180aa845af1792a45ea5bbd4ad8c8092bcb5d2dbae939d9b8e839ecd09eddc8c"
+      "bytes": 1262176,
+      "sha256": "17bee3aee1dfaa10bb3eba629730f9845d6e2d9e046472b305fafcb3fc6feef8"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 281264,
-      "sha256": "42a0597fc8673bdc228e8e1d6e0113c092d17a38b945f4f206b580fd3f50f4ac"
+      "sha256": "b251d63b71d4da62cb1423422afd89d44060b34de43acaa3ff94cccf1492cab1"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 799654,
-      "sha256": "bf9d15820bd2d652a2a8ceb2b5e885a3168d8d26479319b9c4edf7c523e538ad"
+      "sha256": "06acd70b4e0203b9949cdf9d8a186ba48cd7a5801921ffd2878987196da6e47f"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 507721,
-      "sha256": "0b4295606891ded11d3452cde77f7e9fcf879f45fba50c2e7fd71047a6012766"
+      "sha256": "0bffe99010787d765bee500377ccabff8b62fcbbe8f200c12e7f65a83e527fef"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 76291,
-      "sha256": "bf1e26556f870ee564f5f58d50bcfa300a21aa957311933091aa1aa1ce55feb7"
+      "sha256": "d3d18d6ee5c5a3ccdea5af75c14216017729cd88883f76cf74285fe2c438b642"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 11098,
-      "sha256": "14ef0c076011423dcf08b8c85cdaa5b5aaaad0797fc2ddfc28282fc9abc869fe"
+      "sha256": "e88c53cffdc4741ec84e4aee119b4dad13b92890ce4383bbc39787bc947af66f"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "9fa24adeec0e6909834028261dfc288b3f56727346334d98a45b14f5083e619a"
+      "sha256": "778ddeb0551f8574f2bb6f6879aed5f7e90bad44bdb9a997c1f13addf55a8539"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 105355,
-      "sha256": "a07deb979a6ef70f4d525ba29d7e92da7668c11e5a3c8e2ddb80e5bcbc2d4cb1",
+      "sha256": "8727272a70fa196898718e4498db84583d4a58494a0a2b935fdea2a260312e00",
       "counts": {
         "lexemes": 529,
         "cloze": 187,
@@ -341,15 +341,15 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 212786,
-      "sha256": "04c366a1519ba8a724017a49455dd2e7a838892122ccc2c1111c45aba73e4cd1"
+      "sha256": "a3ddc43753856227adbd05af31c0cb25d61bd6d767ee3156f00f3c48c4a860e7"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 327383,
-      "sha256": "bca0baec9d0a08b49a2ba796198b6e4295d5dc9d0e1943d7b821393212646a9b"
+      "bytes": 327357,
+      "sha256": "bf48fd2423a2ddc6e3218bec4ccba399811c7f7b1a8cb2b64efcf526c4dd35ab"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 154306,
-      "sha256": "f5301080bd959e5bcab26be7070d0d6da412e1c65eba86ef4c9efc15b3d19b0f"
+      "sha256": "c113a6a5a1a4da63672c842f8dabf164d0b7266a8e29b0d213a0b74e41b3f34d"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 418175,
-      "sha256": "ba2767b35ff5fc57cb64031d73ceff9c2f9deb2b25bdb9caa3d3f73ca0bb8aa6"
+      "sha256": "561cb0cc18f1c4c781eefce25a69b5cb47c24358a01d3cb571c17ab2980caec2"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 299425,
-      "sha256": "10a867d8e35b5687957ffde7717d3b13ee12a8ece33a202108cf0306c5bd9e0c"
+      "sha256": "f938f296e0d8fda99569a4a6b1b69db4dc409fc1dfd92b16528d8e2076ce68bd"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 30629,
-      "sha256": "540180902ef0b2fdc676b003494762a5f9f064b7c6cfd0318ee0eb297acc1707"
+      "sha256": "598a01b3f744f5288837d7ab5cdb50e51c30edfb097f01bfb1d5f8794158feae"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 2060,
-      "sha256": "944b49973b5a3573a00a1e2fa7e77716471f244e4b4f714a36639882d41b6014"
+      "sha256": "939dc9c89d6bbe7c43ab245aa0cddd2591a15af5ff4e69b6abe3dc99288e003a"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 2357,
-      "sha256": "1cf530692cebe18f226208f4b0bdb999e7df43b7e5d7b609cd2a114673fca015"
+      "sha256": "fab386de32be300bab7ce04f91524ce8d014dfe4d9b4edf55925aa6f53845ef6"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1879,6 +1879,21 @@ def test_inventory_identity_decoys_render_normalized_lemmas_at_source_case() -> 
     assert validate_option_set({**cloze, "options": options}) == []
 
 
+@pytest.mark.parametrize(
+    ("manifest_pos", "expected_bucket"),
+    [
+        ("infinitive", "verb"),
+        ("imperative", "verb"),
+        ("numr", "numeral"),
+        ("intj", "interjection"),
+    ],
+)
+def test_option_pos_bucket_normalizes_unambiguous_manifest_aliases(
+    manifest_pos: str, expected_bucket: str
+) -> None:
+    assert generate_practice_deck._option_pos_bucket(manifest_pos) == expected_bucket
+
+
 def test_sentence_inventory_identity_cloze_scales_across_levels_and_pos(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Normalize the exact manifest POS aliases `infinitive` and `imperative` to `verb`, `numr` to `numeral`, and `intj` to `interjection` in the existing identity-option bucket logic.
- Keep the #6212 quality, VESUM, function-POS, length, answer-leak, option, CEFR, and size-budget gates unchanged.
- Publish the v14 practice-deck pointer and update the residual taxonomy with authority-consistent measurements.

## Tool-quoted coverage metrics

Before, hydrated v13 release `atlas-practice-v1-72aefaf645e8d390`:

```text
hydrated deck lexemes 6000 cloze_eligible 4440 residual 1560
function 110 function_candidate 98 function_no_candidate 12
multiword_shape 173 multiword_reader 0 multiword_no_inventory 173 overlap_function 3
```

After, published v14 release `atlas-practice-v1-b39bcdd93d232ad7`:

```text
A1 1470 1103 0.7503
A2 1444 1164 0.8061
B1 1617 1295 0.8009
B2 940 726 0.7723
C1 529 187 0.3535
hydrated deck lexemes 6000 cloze_eligible 4475 residual 1525
function 108 function_candidate 96 function_no_candidate 12
multiword_shape 173 multiword_reader 0 multiword_no_inventory 173 overlap_function 3
partition_sum 1525
```

| Level | Before eligible | Before coverage | After eligible | After coverage |
| --- | ---: | ---: | ---: | ---: |
| A1 | 1,080 | 73.47% | 1,103 | 75.03% |
| A2 | 1,154 | 79.92% | 1,164 | 80.61% |
| B1 | 1,296 | 80.15% | 1,295 | 80.09% |
| B2 | 723 | 76.91% | 726 | 77.23% |
| C1 | 187 | 35.35% | 187 | 35.35% |
| **All** | **4,440** | **74.00%** | **4,475** | **74.58%** |

Current mutually exclusive residual partition:

```text
function-POS 108
multiword-id 170
no public sentence 936
inventory-present-build-empty 245 (quality 4, identity 36, VESUM 205)
would_emit-still-trimmed 66
other 0
total 1525
```

The no-budget v14 B1 trace measured `1361` items at `2344437` raw / `251462` gzip bytes. The published B1 payload is `2215600` raw / `236912` gzip bytes and remains within both size limits.

## Publish and verification

```text
publish.py -> exit 0: Atlas practice deck pointer published: atlas-practice-v1-b39bcdd93d232ad7 45 shards
practice_deck.io -> exit 0: Hydrated Atlas practice deck atlas-practice-v1-b39bcdd93d232ad7 (45 shards).
.venv/bin/ruff check ... -> exit 0: All checks passed!
.venv/bin/pytest -q tests/test_generate_practice_deck.py tests/test_practice_deck_io.py tests/test_publish_practice_deck.py -> exit 0: 108 passed in 2.09s
node_modules/.bin/markdownlint-cli2 docs/practice/cloze-residual-taxonomy.md -> exit 0: 0 error(s)
git diff --check -> exit 0
lint_agent_trailer.py -> exit 0
lint_opsec_leaks.py -> exit 0
```

## Residual honesty

This PR does not claim full coverage. The remaining named buckets are 936 without a current public blankable sentence, 108 function-POS IDs, 170 multiword IDs, 245 inventory-present build-empty IDs consisting of 4 quality-gate empties, 36 identity-option failures, and 205 VESUM misses, plus 66 valid candidates still trimmed by the existing B1 size budget. No quality or acceptance threshold was lowered. Cross-family review and final disposition remain with the orchestrator.