### PR TITLE
docs(entire): onboard public source pilot (#6165)

### DIFF
--- a/.entire/phase05-allowlist.json
+++ b/.entire/phase05-allowlist.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "checkpoint_endpoints": [
+    {
+      "github_repo": "learn-ukrainian/entire-checkpoints-private"
+    }
+  ]
+}

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,9 @@
+{
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "learn-ukrainian/entire-checkpoints-private"
+    }
+  },
+  "telemetry": false
+}

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -17,3 +17,7 @@ The public issue receipt in #6165 records the checkpoint identifier, source
 commit, private destination ref, leakage verdict, retry result, and authenticated
 Entire activity result without reproducing a prompt, response, transcript, or
 generated summary.
+
+Before rollout, run
+`.venv/bin/python scripts/entire/validate_checkpoint_routing.py` to prove that
+the product setting and egress allowlist still name one identical destination.

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -1,0 +1,15 @@
+# Public source Entire pilot
+
+This receipt onboards `learn-ukrainian/learn-ukrainian.github.io` as the source
+repository for a bounded Entire 0.8.42 canary.
+
+Checkpoint bodies are stored only in the private
+`learn-ukrainian/entire-checkpoints-private` repository. The public product
+origin must retain zero `entire/*` refs and zero session bodies. Entire remains
+optional and non-authoritative; GitHub, Fleet Comms, Monitor, rollover, leases,
+and formal review remain authoritative.
+
+The public issue receipt in #6165 records the checkpoint identifier, source
+commit, private destination ref, leakage verdict, retry result, and authenticated
+Entire activity result without reproducing a prompt, response, transcript, or
+generated summary.

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -9,6 +9,10 @@ origin must retain zero `entire/*` refs and zero session bodies. Entire remains
 optional and non-authoritative; GitHub, Fleet Comms, Monitor, rollover, leases,
 and formal review remain authoritative.
 
+The committed `.entire/settings.json` is the body-free project binding Entire.io
+uses to locate the separate checkpoint repository. Agent enablement and PII or
+custom redaction rules remain local to each explicitly enabled worktree.
+
 The public issue receipt in #6165 records the checkpoint identifier, source
 commit, private destination ref, leakage verdict, retry result, and authenticated
 Entire activity result without reproducing a prompt, response, transcript, or

--- a/scripts/entire/validate_checkpoint_routing.py
+++ b/scripts/entire/validate_checkpoint_routing.py
@@ -1,0 +1,31 @@
+"""Validate that Entire product routing matches the public egress allowlist."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def validate(root: Path) -> str | None:
+    settings = json.loads((root / ".entire/settings.json").read_text())
+    allowlist = json.loads((root / ".entire/phase05-allowlist.json").read_text())
+    try:
+        remote = settings["strategy_options"]["checkpoint_remote"]
+        endpoints = allowlist["checkpoint_endpoints"]
+        allowed_repo = endpoints[0]["github_repo"]
+    except (IndexError, KeyError, TypeError):
+        return "checkpoint routing has an incomplete schema"
+    if remote.get("provider") != "github":
+        return "checkpoint_remote.provider must be github"
+    if len(endpoints) != 1:
+        return "checkpoint_endpoints must contain exactly one destination"
+    if remote.get("repo") != allowed_repo:
+        return "checkpoint_remote.repo does not match the egress allowlist"
+    return None
+
+
+if __name__ == "__main__":
+    failure = validate(Path.cwd())
+    if failure:
+        raise SystemExit(f"Entire checkpoint routing invalid: {failure}")
+    print("Entire checkpoint routing is consistent.")

--- a/tests/test_entire_checkpoint_routing.py
+++ b/tests/test_entire_checkpoint_routing.py
@@ -29,6 +29,10 @@ def test_accepts_matching_single_private_destination(tmp_path: Path) -> None:
     assert validate(tmp_path) is None
 
 
+def test_live_public_config_is_consistent() -> None:
+    assert validate(Path(__file__).resolve().parents[1]) is None
+
+
 def test_rejects_routing_drift(tmp_path: Path) -> None:
     _write_config(tmp_path, configured="org/private", allowed=["org/other"])
 

--- a/tests/test_entire_checkpoint_routing.py
+++ b/tests/test_entire_checkpoint_routing.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.entire.validate_checkpoint_routing import validate
+
+
+def _write_config(root: Path, *, configured: str, allowed: list[str]) -> None:
+    entire = root / ".entire"
+    entire.mkdir()
+    (entire / "settings.json").write_text(
+        json.dumps(
+            {
+                "strategy_options": {
+                    "checkpoint_remote": {"provider": "github", "repo": configured}
+                }
+            }
+        )
+    )
+    (entire / "phase05-allowlist.json").write_text(
+        json.dumps({"checkpoint_endpoints": [{"github_repo": repo} for repo in allowed]})
+    )
+
+
+def test_accepts_matching_single_private_destination(tmp_path: Path) -> None:
+    _write_config(tmp_path, configured="org/private", allowed=["org/private"])
+
+    assert validate(tmp_path) is None
+
+
+def test_rejects_routing_drift(tmp_path: Path) -> None:
+    _write_config(tmp_path, configured="org/private", allowed=["org/other"])
+
+    assert validate(tmp_path) == (
+        "checkpoint_remote.repo does not match the egress allowlist"
+    )
+
+
+def test_rejects_multiple_destinations(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        configured="org/private",
+        allowed=["org/private", "org/other"],
+    )
+
+    assert validate(tmp_path) == (
+        "checkpoint_endpoints must contain exactly one destination"
+    )


### PR DESCRIPTION
## Summary

- onboard the public `learn-ukrainian/learn-ukrainian.github.io` source repository for a bounded Entire 0.8.42 canary
- keep checkpoint bodies exclusively in `learn-ukrainian/entire-checkpoints-private`
- add a public body-free containment receipt and exact destination allowlist

## Evidence

- checkpoint: `4d6e806472a2`
- source commit: `06f64e95995ed2e996dbdf516757914b8d45551d`
- private checkpoint ref: `41b0be486d099e8417bdbcda0388d1a18770a1bc`
- delta scan: 5 new blobs / 138,684 bytes, zero violations
- public product origin: zero `entire/*` refs
- retry: source, local checkpoint, and remote checkpoint heads unchanged
- exact CLI: Entire 0.8.42
- public Entire mirror: EU / ready

No prompt, response, transcript, tool output, or generated summary body is reproduced in this PR. Entire remains optional and non-authoritative.

Refs #6165
Refs #4707