### PR TITLE
docs(entire): repair public checkpoint association (#6165)

### DIFF
--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -21,3 +21,6 @@ generated summary.
 Before rollout, run
 `.venv/bin/python scripts/entire/validate_checkpoint_routing.py` to prove that
 the product setting and egress allowlist still name one identical destination.
+
+The deployed source commit must carry `Entire-Checkpoint` as a real Git trailer.
+Escaped newline text is not a trailer and will not enter Entire's activity index.


### PR DESCRIPTION
Repairs the public Entire source association after #6244 encoded newline escapes as literal text in the squash body. The branch commit carries a real Entire-Checkpoint trailer and documents the requirement.

Refs #6165