### PR TITLE
fix(acp): harden authority coordination

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -42,6 +42,10 @@ button, input, select { font: inherit; }
 .field { display: grid; gap: 4px; min-width: 0; }.field label { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }.field input, .field select { border: 1px solid var(--border); border-radius: 3px; min-width: 0; padding: 7px 8px; }
 .filter-note { align-self: end; color: var(--text3); font-size: 11px; line-height: 1.35; max-width: 170px; padding-bottom: 5px; }
 .operations-grid { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0 0 18px; }
+.legacy-diagnostics { background: rgba(168, 132, 43, .06); border: 1px solid var(--border); margin: 0 0 18px; }
+.legacy-diagnostics summary { cursor: pointer; font-family: Charter, Georgia, serif; font-size: 18px; font-weight: 700; padding: 13px 16px; }
+.legacy-diagnostics > p { color: var(--text3); font-size: 12px; line-height: 1.45; margin: -4px 16px 14px; }
+.legacy-diagnostics .operations-grid { margin: 0; padding: 0 16px 16px; }
 .operations-stats { background: var(--border); display: grid; gap: 1px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .operation-stat { background: var(--bg2); padding: 14px 16px; }
 .operation-stat strong { display: block; font-family: Charter, Georgia, serif; font-size: 25px; line-height: 1; }
@@ -107,31 +111,35 @@ button, input, select { font: inherit; }
     <div class="field"><label for="filter-state">State</label><input id="filter-state" placeholder="queued, complete…" oninput="queueRefresh()"></div>
     <div class="field"><label for="filter-pr">PR</label><input id="filter-pr" inputmode="numeric" placeholder="6159" oninput="queueRefresh()"></div>
     <div class="field"><label for="filter-conversation">Conversation</label><input id="filter-conversation" placeholder="opaque ID" oninput="queueRefresh()"></div>
-    <div class="filter-note">Filters only narrow the observer’s GET requests. They never signal or alter the plane.</div>
+    <div class="filter-note">Filters narrow current authority evidence only. Historical compatibility diagnostics remain unfiltered.</div>
   </section>
 
-  <section class="operations-grid" aria-label="Read-only fleet operations">
-    <article class="panel ledger cyan" aria-labelledby="broker-operations-heading">
-      <div class="panel-head"><h3 id="broker-operations-heading">Broker health</h3><p>Read-only · no migrations or cleanup</p></div>
-      <div id="broker-operations-content" class="empty">Loading sanitized broker health…</div>
-    </article>
-    <article class="panel ledger orange" aria-labelledby="zombie-operations-heading">
-      <div class="panel-head"><h3 id="zombie-operations-heading">Zombie signals</h3><p>Bounded counts · identifiers omitted</p></div>
-      <div id="zombie-operations-content" class="empty">Loading sanitized zombie signals…</div>
-    </article>
-    <article class="panel ledger purple" aria-labelledby="batch-operations-heading">
-      <div class="panel-head"><h3 id="batch-operations-heading">Batch progress</h3><p>Bounded tracks · logs and commands omitted</p></div>
-      <div id="batch-operations-content" class="empty">Loading sanitized batch progress…</div>
-    </article>
-  </section>
+  <details class="legacy-diagnostics">
+    <summary>Historical compatibility diagnostics — excluded from authority health</summary>
+    <p id="legacy-requests-note">Legacy broker and scanner data remain readable for retirement work. They do not describe current ACP authority health.</p>
+    <section class="operations-grid" aria-label="Historical compatibility diagnostics">
+      <article class="panel ledger cyan" aria-labelledby="broker-operations-heading">
+        <div class="panel-head"><h3 id="broker-operations-heading">Legacy broker archive</h3><p>Historical · read-only · excluded from health</p></div>
+        <div id="broker-operations-content" class="empty">Loading sanitized legacy broker data…</div>
+      </article>
+      <article class="panel ledger orange" aria-labelledby="zombie-operations-heading">
+        <div class="panel-head"><h3 id="zombie-operations-heading">Legacy broker signals</h3><p>Historical detector · identifiers omitted</p></div>
+        <div id="zombie-operations-content" class="empty">Loading sanitized legacy signals…</div>
+      </article>
+      <article class="panel ledger purple" aria-labelledby="batch-operations-heading">
+        <div class="panel-head"><h3 id="batch-operations-heading">Legacy batch scanner</h3><p>Compatibility view · logs and commands omitted</p></div>
+        <div id="batch-operations-content" class="empty">Loading sanitized scanner data…</div>
+      </article>
+    </section>
+  </details>
 
   <section class="grid">
     <article class="panel ledger" aria-labelledby="requests-heading">
-      <div class="panel-head"><h3 id="requests-heading">Request ledger</h3><p>Queued → running → terminal</p></div>
+      <div class="panel-head"><h3 id="requests-heading">Authority requests</h3><p>Current fleet-comms jobs · queued → terminal</p></div>
       <div id="requests-content" class="empty">Loading requests…</div>
     </article>
     <article class="panel ledger cyan" aria-labelledby="authority-heading">
-      <div class="panel-head"><h3 id="authority-heading">Authority queue</h3><p>Metadata only · payloads and results remain sealed</p></div>
+      <div class="panel-head"><h3 id="authority-heading">Authority queue</h3><p>Safe failure codes · payloads and results remain sealed</p></div>
       <div id="authority-content" class="empty">Loading authority jobs…</div>
     </article>
     <article class="panel ledger blue" aria-labelledby="reviews-heading">
@@ -160,7 +168,7 @@ button, input, select { font: inherit; }
     <table><thead><tr><th>Source</th><th>Agent</th><th>Via</th></tr></thead></table>
   </template>
 
-  <p class="footnote"><strong>Authority posture:</strong> the Fleet Observer is the consolidated evidence surface for durable requests, messages, ACP conversations, formal reviews, deliveries, retries, dead letters, and sanitized operations health. The operations panels are observational only: they cannot clean queues, expire delivery, start providers, or mutate fleet state. Legacy Channels and Comms URLs redirect here during the compatibility soak.</p>
+  <p class="footnote"><strong>Authority posture:</strong> the Fleet Observer is the consolidated evidence surface. Current request counts and health come only from fleet-comms authority jobs and authority dead letters. The collapsed compatibility section preserves legacy evidence for retirement work but never changes the current health verdict. This page cannot clean queues, retry providers, or mutate fleet state.</p>
 </main>
 
 <script>
@@ -202,9 +210,9 @@ function filters() {
   };
 }
 
-function query(base, allowed) {
+function query(base, allowed, fixed = {}) {
   const values = filters();
-  const params = new URLSearchParams({ limit: '12' });
+  const params = new URLSearchParams({ limit: '12', ...fixed });
   allowed.forEach(key => { if (values[key]) params.set(key, values[key]); });
   return `${base}?${params}`;
 }
@@ -237,10 +245,12 @@ function summaryDetail(bucket) {
 
 function renderHealth(health) {
   const mode = short(health.mode, 'unknown').replaceAll('_', ' ');
-  const enabled = health.enabled === true;
+  const authority = health.authority_health || {};
+  const authorityState = short(authority.state, 'unavailable').replaceAll('_', ' ');
+  const healthy = authority.ok === true;
   document.getElementById('plane-mode').textContent = `${mode} · durable authority`;
-  document.getElementById('plane-status').textContent = health.schema?.db_exists ? `Schema v${short(health.schema.applied_version, 'not applied')} observed` : 'Durable database not present yet';
-  document.getElementById('plane-dot').className = `signal-dot ${enabled ? 'live' : 'warn'}`;
+  document.getElementById('plane-status').textContent = health.schema?.db_exists ? `Authority ${authorityState} · ${short(authority.jobs?.total, '0')} jobs in the last ${short(authority.window?.hours, '24')}h` : 'Durable database not present yet';
+  document.getElementById('plane-dot').className = `signal-dot ${healthy ? 'live' : 'warn'}`;
 }
 
 function renderOverview(data) {
@@ -254,6 +264,8 @@ function renderOverview(data) {
   document.getElementById('reviews-detail').textContent = summaryDetail(counts.reviews?.by_state);
   document.getElementById('acp-detail').textContent = counts.acp_conversations?.total ? 'Event timelines available' : 'No durable ACP rows yet';
   document.getElementById('dead-detail').textContent = counts.dead_letters?.total ? 'Follow-up evidence available' : 'No dead letters observed';
+  const legacy = counts.legacy_requests || {};
+  document.getElementById('legacy-requests-note').textContent = `${short(legacy.total, '0')} legacy request rows remain readable for compatibility and are excluded from current authority health.`;
 }
 
 function renderOperations(data) {
@@ -281,13 +293,13 @@ function renderOperations(data) {
 }
 
 function renderRequests(data) {
-  const rows = (data.requests || []).map(item => `<tr><td class="mono">${escapeHtml(item.request_id)}</td><td>${pill(item.state)}</td><td>${escapeHtml(short(item.requested_recipient))} → ${escapeHtml(short(item.resolved_recipient))}</td><td>${escapeHtml(short(item.source))}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`);
-  document.getElementById('requests-content').innerHTML = table(['Request', 'State', 'Endpoint', 'Source', 'Updated'], rows, 'No requests match the current observer filters.');
+  const rows = (data.jobs || []).map(item => `<tr><td class="mono">${escapeHtml(item.job_id)}</td><td>${pill(item.state)}</td><td>${escapeHtml(short(item.agent))}</td><td>${escapeHtml(short(item.source))}<br><span class="muted mono">${escapeHtml(short(item.task_id))}</span></td><td>${escapeHtml(item.failure ? `${item.failure.phase} · ${item.failure.code.replaceAll('_', ' ')}` : '—')}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`);
+  document.getElementById('requests-content').innerHTML = table(['Request', 'State', 'Agent', 'Source / task', 'Failure', 'Updated'], rows, 'No authority requests match the current observer filters.');
 }
 
 function renderAuthorityJobs(data) {
-  const rows = (data.jobs || []).map(item => `<tr><td class="mono">${escapeHtml(item.job_id)}</td><td>${pill(item.kind)}</td><td>${pill(item.state)}</td><td>${escapeHtml(short(item.source))}</td><td>${escapeHtml(short(item.agent))}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`);
-  document.getElementById('authority-content').innerHTML = table(['Job', 'Kind', 'State', 'Source', 'Agent', 'Updated'], rows, 'No authority jobs match the current observer filters.');
+  const rows = (data.jobs || []).map(item => `<tr><td class="mono">${escapeHtml(item.job_id)}</td><td>${pill(item.kind)}</td><td>${pill(item.state)}</td><td>${escapeHtml(short(item.source))}</td><td>${escapeHtml(short(item.agent))}</td><td>${escapeHtml(item.failure ? `${item.failure.phase} · ${item.failure.code.replaceAll('_', ' ')}` : '—')}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`);
+  document.getElementById('authority-content').innerHTML = table(['Job', 'Kind', 'State', 'Source', 'Agent', 'Failure', 'Updated'], rows, 'No authority jobs match the current observer filters.');
 }
 
 function renderReviews(data) {
@@ -321,7 +333,7 @@ async function refreshFleet() {
     const common = ['state', 'agent', 'source', 'conversation'];
     const [health, overview, operations, requests, authorityJobs, reviews, acp, deadLetters, activity, messages] = await Promise.all([
       fetchJson('/api/fleet/health'), fetchJson('/api/fleet/overview'), fetchJson('/api/fleet/operations'),
-      fetchJson(query('/api/fleet/requests', ['kind', ...common])),
+      fetchJson(query('/api/fleet/authority/jobs', ['state', 'agent', 'source', 'conversation'], { kind: 'request' })),
       fetchJson(query('/api/fleet/authority/jobs', ['kind', 'state', 'agent', 'source', 'pr', 'conversation'])),
       fetchJson(query('/api/fleet/reviews', ['kind', 'state', 'source', 'pr'])),
       fetchJson(query('/api/fleet/acp/conversations', common)),

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -314,6 +314,25 @@ strict parser then admits at most 512 KiB of answer text to the caller or
 fleet-authority receipt. Exceeding either bound fails terminally without a
 provider retry or bridge fallback.
 
+Calls initiated from the protected primary checkout keep the same containment
+guard. The compatibility entrypoints create a short-lived detached,
+`--no-checkout` worktree below `.worktrees/dispatch/acp/`, execute there, and
+remove it on exit. Git locks the worktree for the call lifetime so scheduled
+hygiene cannot prune it between participant completion and synthesis. They do
+not weaken or bypass primary-checkout protection.
+
+Route pins are strict admission inputs. An omitted pin or the exact configured
+model/effort is accepted; a conflicting model or effort fails visibly before a
+provider call. No ACP entrypoint silently normalizes a caller's conflicting
+route.
+
+Authority jobs record failures with only a closed phase, code, and retryable
+flag. Raw prompts, responses, exception text, stderr, paths, and credentials
+remain outside the observer projection. A discussion enqueue atomically creates
+the authority job, its one ACP conversation reservation, and the initial
+`CREATED` event; the controller must adopt that exact reservation rather than
+creating a second conversation.
+
 Replay suppression is durable and occurs before scheduling. An orphaned
 reservation is terminal: never retry it. The single-host repository admission
 file lock covers the conversation, including model I/O; no SQLite transaction

--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -562,6 +562,64 @@ class AcpxDiscussionController:
         )
         return self._replay(conversation_id)
 
+    def _adopt_authority_reservation(
+        self,
+        conversation_id: str,
+        *,
+        task_digest: str,
+        correlation_digest: str,
+        idempotency_digest: str,
+        rounds: int,
+        participants: tuple[str, ...],
+        source: str | None,
+    ) -> str:
+        """Adopt the exact reservation created atomically with an authority job."""
+        if _CONVERSATION_ID.fullmatch(conversation_id) is None:
+            raise AcpxDiscussionError("reserved conversation_id is not canonical")
+        row = self.conn.execute(
+            """SELECT acp.task_digest, acp.correlation_digest,
+                      acp.idempotency_digest, acp.rounds_requested,
+                      acp.participants_json, conversation.source
+               FROM acp_conversations AS acp
+               JOIN conversations AS conversation
+                 ON conversation.conversation_id = acp.conversation_id
+               WHERE acp.conversation_id = ?""",
+            (conversation_id,),
+        ).fetchone()
+        if row is None:
+            raise AcpxDiscussionError("reserved ACP conversation was not found")
+        try:
+            reserved_participants = tuple(json.loads(str(row[4])))
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise AcpxDiscussionError("reserved ACP participants are invalid") from exc
+        expected = (
+            task_digest,
+            correlation_digest,
+            idempotency_digest,
+            rounds,
+            tuple(sorted(participants)),
+            source or "operator",
+        )
+        observed = (
+            str(row[0]),
+            str(row[1]),
+            str(row[2]),
+            int(row[3]),
+            reserved_participants,
+            str(row[5]),
+        )
+        if observed != expected:
+            raise AcpxDiscussionError("reserved ACP conversation does not match invocation")
+        events = self.conn.execute(
+            """SELECT sequence, event_type, state
+               FROM acp_conversation_events
+               WHERE conversation_id = ? ORDER BY sequence""",
+            (conversation_id,),
+        ).fetchall()
+        if len(events) != 1 or tuple(events[0]) != (1, "CREATED", "CREATED"):
+            raise AcpxDiscussionError("reserved ACP conversation has invalid initial state")
+        return conversation_id
+
     def recover_expired_reservations(self, *, now: datetime | None = None) -> list[str]:
         """Terminalize expired nonterminal reservations without provider I/O.
 
@@ -581,7 +639,14 @@ class AcpxDiscussionController:
                FROM acp_conversations AS acp
                JOIN conversations AS conversation
                  ON conversation.conversation_id = acp.conversation_id
-               WHERE conversation.source = 'acpx-discuss'"""
+               WHERE conversation.source = 'acpx-discuss'
+                  OR EXISTS (
+                      SELECT 1 FROM acp_conversation_events AS initial
+                      WHERE initial.conversation_id = acp.conversation_id
+                        AND initial.sequence = 1
+                        AND initial.event_type = 'CREATED'
+                        AND initial.metadata_json = '{"authority_reserved":true}'
+                  )"""
         ).fetchall()
         recovered: list[str] = []
         for row in rows:
@@ -819,6 +884,7 @@ class AcpxDiscussionController:
         efforts: Mapping[str, str] | None = None,
         source: str | None = None,
         initiator: str | None = None,
+        reserved_conversation_id: str | None = None,
     ) -> dict[str, Any]:
         if os.environ.get(TRANSPORT_ENV, "off").strip().lower() != "active":
             raise AcpxDiscussionError("LU_ACPX_TRANSPORT=active is required by acp-discuss")
@@ -890,6 +956,7 @@ class AcpxDiscussionController:
                 models=model_overrides,
                 efforts=effort_overrides,
                 source=transport_source,
+                reserved_conversation_id=reserved_conversation_id,
             )
 
     def _run_admitted(
@@ -906,18 +973,33 @@ class AcpxDiscussionController:
         models: Mapping[str, str],
         efforts: Mapping[str, str],
         source: str | None,
+        reserved_conversation_id: str | None,
     ) -> dict[str, Any]:
         started = self.clock()
         deadline = started + WHOLE_TIMEOUT_SECONDS
         deadline_at = (datetime.now(UTC) + timedelta(seconds=WHOLE_TIMEOUT_SECONDS)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        conversation_id, replay = self._reserve(
-            task_digest=_digest(task_id),
-            correlation_digest=_digest(correlation_id),
-            idempotency_digest=idempotency_digest,
-            rounds=rounds,
-            participants=participants,
-            deadline_at=deadline_at,
-        )
+        task_digest = _digest(task_id)
+        correlation_digest = _digest(correlation_id)
+        if reserved_conversation_id is None:
+            conversation_id, replay = self._reserve(
+                task_digest=task_digest,
+                correlation_digest=correlation_digest,
+                idempotency_digest=idempotency_digest,
+                rounds=rounds,
+                participants=participants,
+                deadline_at=deadline_at,
+            )
+        else:
+            conversation_id = self._adopt_authority_reservation(
+                reserved_conversation_id,
+                task_digest=task_digest,
+                correlation_digest=correlation_digest,
+                idempotency_digest=idempotency_digest,
+                rounds=rounds,
+                participants=participants,
+                source=source,
+            )
+            replay = None
         if replay is not None:
             return replay
         if self.cancelled():

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -96,6 +96,85 @@ def _replay_result(raw: bytes) -> object:
     )
 
 
+def _failure_metadata(
+    *, error: BaseException | None = None, result: object | None = None
+) -> dict[str, object]:
+    """Classify a terminal ACP failure without persisting free text."""
+    if error is not None:
+        error_name = type(error).__name__
+        error_text = str(error).casefold()
+        if error_name in {"AgentTimeoutError", "AgentStalledError"}:
+            return {"phase": "transport", "code": "timeout", "retryable": True}
+        if error_name == "RateLimitedError":
+            return {"phase": "provider", "code": "rate_limited", "retryable": True}
+        if error_name == "AgentUnavailableError":
+            return {
+                "phase": "provider",
+                "code": "provider_unavailable",
+                "retryable": True,
+            }
+        if error_name == "AgentOutputLimitError":
+            return {
+                "phase": "transport",
+                "code": "protocol_output_limit",
+                "retryable": False,
+            }
+        if "protected primary checkout" in error_text:
+            return {
+                "phase": "admission",
+                "code": "primary_cwd_rejected",
+                "retryable": False,
+            }
+        if "model pin" in error_text or "registered model" in error_text:
+            return {
+                "phase": "admission",
+                "code": "route_model_conflict",
+                "retryable": False,
+            }
+        if "effort pin" in error_text or "registered effort" in error_text:
+            return {
+                "phase": "admission",
+                "code": "route_effort_conflict",
+                "retryable": False,
+            }
+        if "state event" in error_text or "initial state" in error_text:
+            return {
+                "phase": "admission",
+                "code": "conversation_state_missing",
+                "retryable": False,
+            }
+        if error_name in {"AcpxShadowRefusalError", "AcpExecutionWorkspaceError"}:
+            return {
+                "phase": "admission",
+                "code": "adapter_refused",
+                "retryable": False,
+            }
+        return {"phase": "transport", "code": "transport_error", "retryable": False}
+
+    outcome = str(getattr(result, "transport_outcome", "") or "").casefold()
+    if outcome == "rate_limited" or bool(getattr(result, "rate_limited", False)):
+        return {"phase": "provider", "code": "rate_limited", "retryable": True}
+    return {"phase": "result_parse", "code": "result_invalid", "retryable": False}
+
+
+def _discussion_failure_metadata(payload: object) -> dict[str, object]:
+    """Classify a non-complete discussion from its bounded outcome vocabulary."""
+    outcomes: set[str] = set()
+    if isinstance(payload, dict):
+        rows = payload.get("participant_outcomes")
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict) and isinstance(row.get("outcome"), str):
+                    outcomes.add(row["outcome"].casefold())
+    if "timeout" in outcomes or "stalled" in outcomes:
+        return {"phase": "transport", "code": "timeout", "retryable": True}
+    if "rate_limited" in outcomes:
+        return {"phase": "provider", "code": "rate_limited", "retryable": True}
+    if "error" in outcomes:
+        return {"phase": "provider", "code": "unknown", "retryable": False}
+    return {"phase": "postprocess", "code": "result_invalid", "retryable": False}
+
+
 def _idempotency_key(
     *, participant: str, task_id: str, content: str, model: str | None, effort: str | None
 ) -> str:
@@ -227,18 +306,21 @@ def _run_compat_ask_impl(
             previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
             os.environ["LU_ACPX_TRANSPORT"] = "active"
             try:
-                result = invoke_inter_agent(
-                    participant,
-                    prompt,
-                    cwd=REPO_ROOT,
-                    task_id=task_id,
-                    correlation_id=task_id,
-                    idempotency_key=key,
-                    source=source,
-                    model=model,
-                    effort=effort,
-                    hard_timeout=hard_timeout,
-                )
+                from ._acp_execution import acp_execution_cwd
+
+                with acp_execution_cwd(REPO_ROOT, task_id=task_id) as execution_cwd:
+                    result = invoke_inter_agent(
+                        participant,
+                        prompt,
+                        cwd=execution_cwd,
+                        task_id=task_id,
+                        correlation_id=task_id,
+                        idempotency_key=key,
+                        source=source,
+                        model=model,
+                        effort=effort,
+                        hard_timeout=hard_timeout,
+                    )
             except BaseException as exc:
                 authority.finish_job(
                     job.job_id,
@@ -262,6 +344,7 @@ def _run_compat_ask_impl(
                         },
                         sort_keys=True,
                     ).encode("utf-8"),
+                    failure=_failure_metadata(error=exc),
                 )
                 raise
             finally:
@@ -275,6 +358,11 @@ def _run_compat_ask_impl(
                 fence_token=lease.fence_token,
                 state="complete" if bool(getattr(result, "ok", False)) else "failed",
                 result=_result_receipt(result),
+                failure=(
+                    None
+                    if bool(getattr(result, "ok", False))
+                    else _failure_metadata(result=result)
+                ),
             )
     response = str(getattr(result, "response", ""))
     if output_path:

--- a/scripts/ai_agent_bridge/_acp_execution.py
+++ b/scripts/ai_agent_bridge/_acp_execution.py
@@ -1,0 +1,124 @@
+"""Isolated cwd selection for bounded ACP provider transport.
+
+ACP adapters keep their primary-checkout refusal. Compatibility callers that
+start from the human/service checkout receive a short-lived detached,
+no-checkout worktree instead of weakening that guard or inventing a trusted
+caller bypass.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+import shutil
+import subprocess
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+from scripts.common.git_context import sanitized_git_env
+from scripts.guardrails.worktree_containment import (
+    classify_repo_path,
+    resolve_main_root,
+)
+
+logger = logging.getLogger(__name__)
+
+_SAFE_TASK = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class AcpExecutionWorkspaceError(RuntimeError):
+    """ACP could not obtain or release its isolated execution cwd."""
+
+
+def _git_binary() -> str:
+    binary = shutil.which("git")
+    if binary is None:
+        raise AcpExecutionWorkspaceError("git_binary_unavailable")
+    return str(Path(binary).resolve())
+
+
+def _run_git(main_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_git_binary(), "-C", str(main_root), *args],
+        cwd=main_root,
+        env=sanitized_git_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@contextlib.contextmanager
+def acp_execution_cwd(repo_root: Path, *, task_id: str) -> Iterator[Path]:
+    """Yield a non-primary registered worktree for one bounded ACP call.
+
+    Existing worktree callers are unchanged. A primary-root caller gets a
+    unique detached worktree with no checkout, so the runtime gains only the
+    Git/worktree identity required by ACP admission—not another source copy.
+    """
+    resolved = repo_root.resolve()
+    path_class = classify_repo_path(resolved, cwd=resolved)
+    if path_class in {"dispatch_worktree", "other_worktree"}:
+        yield resolved
+        return
+    if path_class != "primary_checkout":
+        raise AcpExecutionWorkspaceError("acp_repo_root_must_be_a_registered_checkout")
+
+    main_root = resolve_main_root(resolved)
+    label = _SAFE_TASK.sub("-", task_id).strip("-._")[:32] or "task"
+    workspace = main_root / ".worktrees" / "dispatch" / "acp" / f"runtime-{label}-{uuid.uuid4().hex[:10]}"
+    workspace.parent.mkdir(parents=True, exist_ok=True)
+    created = False
+    add = _run_git(
+        main_root,
+        "worktree",
+        "add",
+        "--detach",
+        "--no-checkout",
+        str(workspace),
+        "HEAD",
+    )
+    if add.returncode != 0:
+        detail = " ".join((add.stderr or add.stdout).split())[:240]
+        raise AcpExecutionWorkspaceError(f"acp_execution_worktree_create_failed: {detail or 'git worktree add failed'}")
+    created = True
+    lock = _run_git(
+        main_root,
+        "worktree",
+        "lock",
+        "--reason",
+        f"active ACP execution {label}",
+        str(workspace),
+    )
+    if lock.returncode != 0:
+        _run_git(main_root, "worktree", "remove", "--force", str(workspace))
+        detail = " ".join((lock.stderr or lock.stdout).split())[:240]
+        raise AcpExecutionWorkspaceError(
+            f"acp_execution_worktree_lock_failed: {detail or 'git worktree lock failed'}"
+        )
+    try:
+        if classify_repo_path(workspace, cwd=workspace) not in {
+            "dispatch_worktree",
+            "other_worktree",
+        }:
+            raise AcpExecutionWorkspaceError("acp_execution_worktree_not_registered")
+        yield workspace
+    finally:
+        if created:
+            unlock = _run_git(main_root, "worktree", "unlock", str(workspace))
+            remove = _run_git(main_root, "worktree", "remove", "--force", str(workspace))
+            if remove.returncode != 0 and workspace.exists():
+                logger.error(
+                    "ACP execution worktree cleanup failed for %s: %s",
+                    workspace,
+                    " ".join((remove.stderr or remove.stdout).split())[:240],
+                )
+            elif unlock.returncode != 0 and workspace.exists():
+                logger.error(
+                    "ACP execution worktree unlock failed for %s: %s",
+                    workspace,
+                    " ".join((unlock.stderr or unlock.stdout).split())[:240],
+                )

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1630,6 +1630,7 @@ def _handle_discuss(args) -> int:
         if caller_attribution.initiator != "unknown"
         else None
     )
+    discussion_source = runtime_initiator or "operator"
 
     # ── post the root question ────────────────────────────────────
     # NOTE: do NOT pass to_agents here — discuss handles fanout itself
@@ -1641,13 +1642,13 @@ def _handle_discuss(args) -> int:
     try:
         authority.create_channel(args.channel)
         root = authority.publish_message(
-            sender=runtime_initiator or "operator",
+            sender=discussion_source,
             body=body,
             channel=args.channel,
             recipients=with_agents,
             kind="discussion-root",
             provenance={
-                "Source": runtime_initiator or "operator",
+                "Source": discussion_source,
                 "Agent": "ab-discuss",
                 "Via": "acp",
             },
@@ -1658,15 +1659,32 @@ def _handle_discuss(args) -> int:
         deadline_at = (datetime.now(UTC) + timedelta(seconds=1800)).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
+        task_channel = re.sub(r"[^A-Za-z0-9._:-]+", "-", args.channel).strip("-._:")
+        task_digest = hashlib.sha256(correlation_id.encode("utf-8")).hexdigest()[:10]
+        acp_task_id = f"discuss-{task_channel[:48] or 'channel'}-{task_digest}"
+        discussion_budget: dict[str, int] = {}
+        if acp_routine:
+            from agent_runtime.acpx_discuss import (
+                CONTENT_BUDGET_BYTES,
+                TOKEN_BUDGET,
+            )
+
+            discussion_budget = {
+                "token_budget": TOKEN_BUDGET,
+                "content_budget_bytes": CONTENT_BUDGET_BYTES,
+            }
         authority_job = authority.enqueue_discussion(
             channel=args.channel,
             prompt=body,
             participants=with_agents,
             rounds=max_rounds,
-            task_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+            task_digest=hashlib.sha256(acp_task_id.encode("utf-8")).hexdigest(),
             correlation_id=correlation_id,
             deadline_at=deadline_at,
             idempotency_key=f"ab-discuss:{correlation_id}",
+            source=discussion_source,
+            task_id=acp_task_id,
+            **discussion_budget,
         )
         if authority_job.state in {"complete", "failed", "expired", "dead_lettered"}:
             replay = authority.read_job_result(authority_job.job_id)
@@ -1706,6 +1724,9 @@ def _handle_discuss(args) -> int:
             return 1
         from agent_runtime.acpx_discuss import run_discussion
 
+        from ._acp_compat import _discussion_failure_metadata, _failure_metadata
+        from ._acp_execution import acp_execution_cwd
+
         acp_rounds = max_rounds
         try:
             if lease is None:
@@ -1724,19 +1745,21 @@ def _handle_discuss(args) -> int:
             previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
             os.environ["LU_ACPX_TRANSPORT"] = "active"
             try:
-                payload = run_discussion(
-                    prompt=acp_prompt,
-                    cwd=REPO_ROOT,
-                    task_id=f"discuss-{correlation_id[:8]}",
-                    correlation_id=correlation_id,
-                    idempotency_key=f"ab-discuss:{correlation_id}",
-                    rounds=acp_rounds,
-                    participants=tuple(with_agents),
-                    models=agent_models or None,
-                    efforts=agent_efforts or None,
-                    source=runtime_initiator,
-                    initiator=runtime_initiator,
-                )
+                with acp_execution_cwd(REPO_ROOT, task_id=acp_task_id) as execution_cwd:
+                    payload = run_discussion(
+                        prompt=acp_prompt,
+                        cwd=execution_cwd,
+                        task_id=acp_task_id,
+                        correlation_id=correlation_id,
+                        idempotency_key=f"ab-discuss:{correlation_id}",
+                        rounds=acp_rounds,
+                        participants=tuple(with_agents),
+                        models=agent_models or None,
+                        efforts=agent_efforts or None,
+                        source=discussion_source,
+                        initiator=discussion_source,
+                        reserved_conversation_id=authority_job.subject_id,
+                    )
             finally:
                 if previous_transport is None:
                     os.environ.pop("LU_ACPX_TRANSPORT", None)
@@ -1755,6 +1778,7 @@ def _handle_discuss(args) -> int:
                         {"error": type(exc).__name__, "transport": "acp"},
                         sort_keys=True,
                     ).encode("utf-8"),
+                    failure=_failure_metadata(error=exc),
                 )
             print(f"❌ ACP discussion failed without bridge retry: {exc}", file=sys.stderr)
             return 1
@@ -1770,6 +1794,11 @@ def _handle_discuss(args) -> int:
                     fence_token=lease.fence_token,
                     state="complete" if state == "COMPLETE" else "failed",
                     result=json.dumps(payload, sort_keys=True).encode("utf-8"),
+                    failure=(
+                        None
+                        if state == "COMPLETE"
+                        else _discussion_failure_metadata(payload)
+                    ),
                 )
                 completed_authority.publish_message(
                     sender="acp-controller",

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -17,7 +17,7 @@ import sqlite3
 from collections import Counter
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +43,7 @@ MAX_DETAIL_ROWS = 100
 MAX_ACP_SCAN = 500
 MAX_ACTIVITY_SCAN = 500
 MAX_OPERATIONS_ITEMS = 50
+AUTHORITY_HEALTH_WINDOW_HOURS = 24
 
 _ZOMBIE_TYPES = frozenset(
     {"stale_message", "pingpong", "error_loop", "orphan_pid", "corrupt_pid"}
@@ -50,6 +51,25 @@ _ZOMBIE_TYPES = frozenset(
 _ZOMBIE_SEVERITIES = frozenset({"warning", "critical"})
 _BATCH_HEALTH = frozenset({"complete", "healthy", "stalled", "dead", "unknown"})
 _TRACK_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$")
+_SAFE_FAILURE_PHASES = frozenset(
+    {"admission", "transport", "provider", "result_parse", "postprocess"}
+)
+_SAFE_FAILURE_CODES = frozenset(
+    {
+        "adapter_refused",
+        "conversation_state_missing",
+        "primary_cwd_rejected",
+        "protocol_output_limit",
+        "provider_unavailable",
+        "rate_limited",
+        "result_invalid",
+        "route_effort_conflict",
+        "route_model_conflict",
+        "timeout",
+        "transport_error",
+        "unknown",
+    }
+)
 
 _SAFE_METADATA_KEYS = frozenset(
     {
@@ -362,6 +382,100 @@ def _count_by_state(connection: sqlite3.Connection, table: str, column: str) -> 
     return {_safe_text(row[0], fallback="unknown"): int(row[1]) for row in rows}
 
 
+def _count_by_state_where(
+    connection: sqlite3.Connection,
+    table: str,
+    column: str,
+    *,
+    where: str,
+    params: tuple[Any, ...] = (),
+) -> dict[str, int]:
+    if not _table_exists(connection, table):
+        return {}
+    try:
+        rows = connection.execute(
+            f"SELECT {column}, COUNT(*) FROM {table} WHERE {where} "
+            f"GROUP BY {column} ORDER BY {column}",
+            params,
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+    return {_safe_text(row[0], fallback="unknown"): int(row[1]) for row in rows}
+
+
+def _authority_health_snapshot(
+    connection: sqlite3.Connection | None,
+    *,
+    now: datetime | None = None,
+    availability: str = "available",
+) -> dict[str, Any]:
+    """Derive current health only from a fixed authority evidence window."""
+    observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+    since = observed_at - timedelta(hours=AUTHORITY_HEALTH_WINDOW_HOURS)
+    window = {
+        "hours": AUTHORITY_HEALTH_WINDOW_HOURS,
+        "since": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "until": observed_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    unavailable = {
+        "state": "unavailable",
+        "ok": False,
+        "availability": availability,
+        "window": window,
+        "jobs": {"total": 0, "by_state": {}},
+        "overdue_nonterminal": 0,
+        "dead_letters": 0,
+    }
+    if connection is None or not _table_exists(connection, "authority_jobs"):
+        return unavailable
+    try:
+        states = _count_by_state_where(
+            connection,
+            "authority_jobs",
+            "state",
+            where="updated_at >= ?",
+            params=(window["since"],),
+        )
+        overdue = int(
+            connection.execute(
+                """SELECT COUNT(*) FROM authority_jobs
+                   WHERE state IN ('queued', 'running')
+                     AND deadline_at IS NOT NULL AND deadline_at < ?""",
+                (window["until"],),
+            ).fetchone()[0]
+        )
+        dead_letters = 0
+        if _table_exists(connection, "authority_dead_letters"):
+            dead_letters = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM authority_dead_letters WHERE created_at >= ?",
+                    (window["since"],),
+                ).fetchone()[0]
+            )
+    except sqlite3.Error:
+        logger.warning("Fleet observer could not derive authority health")
+        return unavailable
+    total = sum(states.values())
+    failures = sum(
+        states.get(name, 0) for name in ("failed", "expired", "dead_lettered")
+    )
+    if failures or overdue or dead_letters:
+        state = "degraded"
+    elif total:
+        state = "healthy"
+    else:
+        state = "idle"
+    return {
+        "state": state,
+        "ok": state in {"healthy", "idle"},
+        "availability": "available",
+        "window": window,
+        "jobs": {"total": total, "by_state": states},
+        "overdue_nonterminal": overdue,
+        "dead_letters": dead_letters,
+    }
+
+
 def _non_negative_int(value: Any) -> int:
     """Normalize legacy numeric fields without reflecting arbitrary values."""
     if isinstance(value, bool):
@@ -640,11 +754,26 @@ async def fleet_operations() -> dict[str, Any]:
 def fleet_health() -> dict[str, Any]:
     """Read-only health, mode, schema, and current authority posture."""
     status = _safe_plane_status()
+    with _read_connection() as (connection, availability):
+        authority_health = (
+            _authority_health_snapshot(connection, availability=availability)
+            if status["mode"] == "authority"
+            else {
+                "state": "not_applicable",
+                "ok": True,
+                "availability": availability,
+                "window": None,
+                "jobs": {"total": 0, "by_state": {}},
+                "overdue_nonterminal": 0,
+                "dead_letters": 0,
+            }
+        )
     return {
-        "ok": True,
+        "ok": bool(status["enabled"]) and bool(authority_health["ok"]),
         "observer": "fleet-comms-v1",
         "read_only": True,
         "writes_enabled": False,
+        "authority_health": authority_health,
         **status,
     }
 
@@ -660,6 +789,7 @@ def fleet_overview() -> dict[str, Any]:
         "health": status,
         "counts": {
             "requests": {"total": 0, "by_state": {}},
+            "legacy_requests": {"total": 0, "by_state": {}},
             "messages": {"total": 0, "by_kind": {}},
             "reviews": {"total": 0, "by_state": {}},
             "dead_letters": {"total": 0},
@@ -673,11 +803,31 @@ def fleet_overview() -> dict[str, Any]:
             result["availability"] = availability
             return result
         counts = result["counts"]
-        request_states = _count_by_state(connection, "requests", "state")
+        legacy_request_states = _count_by_state(connection, "requests", "state")
+        if status["mode"] == "authority":
+            request_states = _count_by_state_where(
+                connection,
+                "authority_jobs",
+                "state",
+                where="job_kind = 'request'",
+            )
+            request_source = "authority_jobs"
+        else:
+            request_states = legacy_request_states
+            request_source = "legacy_requests"
         message_kinds = _count_by_state(connection, "comms_messages", "kind")
         review_states = _count_by_state(connection, "formal_review_jobs", "state")
         authority_job_states = _count_by_state(connection, "authority_jobs", "state")
-        counts["requests"] = {"total": sum(request_states.values()), "by_state": request_states}
+        counts["requests"] = {
+            "total": sum(request_states.values()),
+            "by_state": request_states,
+            "source": request_source,
+        }
+        counts["legacy_requests"] = {
+            "total": sum(legacy_request_states.values()),
+            "by_state": legacy_request_states,
+            "excluded_from_authority_health": True,
+        }
         counts["messages"] = {"total": sum(message_kinds.values()), "by_kind": message_kinds}
         counts["reviews"] = {"total": sum(review_states.values()), "by_state": review_states}
         counts["authority_jobs"] = {
@@ -698,6 +848,11 @@ def fleet_overview() -> dict[str, Any]:
         result["availability"] = "available" if any(
             section["total"] for section in counts.values()
         ) else "empty"
+        result["authority_health"] = (
+            _authority_health_snapshot(connection)
+            if status["mode"] == "authority"
+            else None
+        )
     return result
 
 
@@ -967,6 +1122,7 @@ def _authority_job_item(row: sqlite3.Row) -> dict[str, Any]:
         agent=data.get("message_sender") or default_agent,
         via="queue",
     )
+    failure = _safe_authority_failure(data.get("terminal_event_metadata_json"))
     return {
         "job_id": data["job_id"],
         "kind": job_kind,
@@ -977,6 +1133,8 @@ def _authority_job_item(row: sqlite3.Row) -> dict[str, Any]:
         "state": data["state"],
         "deadline_at": data.get("deadline_at"),
         "attempt_count": int(data.get("attempt_count") or 0),
+        "task_id": metadata.get("task_id"),
+        "failure": failure,
         "created_at": data["created_at"],
         "updated_at": data["updated_at"],
         "completed_at": data.get("completed_at"),
@@ -985,6 +1143,31 @@ def _authority_job_item(row: sqlite3.Row) -> dict[str, Any]:
         "read_only": True,
         **provenance,
     }
+
+
+def _safe_authority_failure(value: Any) -> dict[str, Any] | None:
+    """Project only the closed body-free failure record from a terminal event."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        event_metadata = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(event_metadata, dict):
+        return None
+    failure = event_metadata.get("failure")
+    if not isinstance(failure, dict) or set(failure) != {"phase", "code", "retryable"}:
+        return None
+    phase = failure.get("phase")
+    code = failure.get("code")
+    retryable = failure.get("retryable")
+    if (
+        phase not in _SAFE_FAILURE_PHASES
+        or code not in _SAFE_FAILURE_CODES
+        or not isinstance(retryable, bool)
+    ):
+        return None
+    return {"phase": phase, "code": code, "retryable": retryable}
 
 
 @router.get("/authority/jobs")
@@ -1026,16 +1209,21 @@ def fleet_authority_jobs(
         has_metadata = _table_exists(connection, "authority_message_metadata")
         has_conversations = _table_exists(connection, "conversations")
         has_reviews = _table_exists(connection, "formal_review_jobs")
+        has_job_events = _table_exists(connection, "authority_job_events")
         from_sql = " FROM authority_jobs AS job"
         message_sender_select = "NULL AS message_sender"
         conversation_select = "NULL AS conversation_id"
         conversation_source_select = "NULL AS conversation_source"
         provenance_select = "NULL AS authority_provenance_json"
         review_select = "NULL AS review_id, NULL AS pr_number"
+        terminal_metadata_select = "NULL AS terminal_event_metadata_json"
         if has_messages:
             from_sql += (
                 " LEFT JOIN comms_messages AS message"
-                " ON job.job_kind = 'request' AND message.message_id = job.subject_id"
+                " ON (job.job_kind = 'request' AND message.message_id = job.subject_id)"
+                " OR (job.job_kind = 'discussion'"
+                " AND message.conversation_id = job.subject_id"
+                " AND message.kind = 'discussion')"
             )
             message_sender_select = "message.sender AS message_sender"
             conversation_select = "message.conversation_id AS conversation_id"
@@ -1067,6 +1255,13 @@ def fleet_authority_jobs(
                 " ON job.job_kind = 'formal_review' AND review.review_id = job.subject_id"
             )
             review_select = "review.review_id AS review_id, review.pr_number AS pr_number"
+        if has_job_events:
+            terminal_metadata_select = (
+                "(SELECT event.metadata_json FROM authority_job_events AS event "
+                "WHERE event.job_id = job.job_id AND event.event_type = 'finished' "
+                "ORDER BY event.created_at DESC, event.rowid DESC LIMIT 1) "
+                "AS terminal_event_metadata_json"
+            )
         clauses: list[str] = []
         params: list[Any] = []
         if kind is not None:
@@ -1141,7 +1336,7 @@ def fleet_authority_jobs(
                 "SELECT job.job_id, job.job_kind, job.subject_id, job.state, job.deadline_at, "
                 "job.attempt_count, job.created_at, job.updated_at, job.completed_at, "
                 f"{message_sender_select}, {conversation_select}, {conversation_source_select}, "
-                f"{provenance_select}, {review_select}"
+                f"{provenance_select}, {review_select}, {terminal_metadata_select}"
             ),
             from_sql=from_sql,
             clauses=clauses,

--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -44,6 +44,25 @@ _JOB_TERMINAL = frozenset({"complete", "failed", "expired", "dead_lettered"})
 _DELIVERY_TERMINAL = frozenset({"acknowledged", "failed", "expired", "dead_lettered"})
 _WAKE_STATES = {"emitted": 0, "received": 1, "consumed": 2}
 _AUTHORITY_SCHEMA_VERSION = 5
+_FAILURE_PHASES = frozenset(
+    {"admission", "transport", "provider", "result_parse", "postprocess"}
+)
+_FAILURE_CODES = frozenset(
+    {
+        "adapter_refused",
+        "conversation_state_missing",
+        "primary_cwd_rejected",
+        "protocol_output_limit",
+        "provider_unavailable",
+        "rate_limited",
+        "result_invalid",
+        "route_effort_conflict",
+        "route_model_conflict",
+        "timeout",
+        "transport_error",
+        "unknown",
+    }
+)
 
 
 def _utc_now() -> datetime:
@@ -101,6 +120,25 @@ def _safe_json_mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
     if not isinstance(loaded, dict):  # pragma: no cover - dict(value) guarantees this
         raise AuthorityServiceError("metadata_must_be_object")
     return loaded
+
+
+def _safe_failure_metadata(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Validate one body-free terminal failure record."""
+    if value is None:
+        return None
+    loaded = _safe_json_mapping(value)
+    if set(loaded) != {"phase", "code", "retryable"}:
+        raise AuthorityServiceError("failure_metadata_fields_invalid")
+    phase = loaded.get("phase")
+    code = loaded.get("code")
+    retryable = loaded.get("retryable")
+    if phase not in _FAILURE_PHASES:
+        raise AuthorityServiceError("failure_phase_invalid")
+    if code not in _FAILURE_CODES:
+        raise AuthorityServiceError("failure_code_invalid")
+    if not isinstance(retryable, bool):
+        raise AuthorityServiceError("failure_retryable_must_be_boolean")
+    return {"phase": phase, "code": code, "retryable": retryable}
 
 
 class AuthorityServiceError(RuntimeError):
@@ -520,9 +558,10 @@ class AuthorityService:
         key = idempotency_key or new_id("authority-request-key")
         recipient_name = _nonempty(recipient, field="recipient")
         self._ensure_channel(channel)
+        request_metadata = _safe_json_mapping(metadata)
         payload = {
             "recipient": recipient_name,
-            "metadata": _safe_json_mapping(metadata),
+            "metadata": request_metadata,
             "message_body_sha256": _sha256_bytes(body.encode("utf-8")),
         }
         with self._write_transaction():
@@ -530,13 +569,21 @@ class AuthorityService:
             if existing is not None:
                 self._assert_job_payload(existing, payload)
                 return existing
+            provenance: dict[str, Any] = {
+                "Source": sender,
+                "Agent": recipient_name,
+                "Via": "queue",
+            }
+            task_id = request_metadata.get("task_id")
+            if isinstance(task_id, str) and task_id.strip():
+                provenance["task_id"] = task_id.strip()[:160]
             message = self._publish_message_tx(
                 sender=sender,
                 body=body,
                 channel=channel,
                 recipients=(recipient_name,),
                 kind="request",
-                provenance={"Source": sender, "Agent": recipient_name, "Via": "queue"},
+                provenance=provenance,
                 deadline_at=deadline_at,
                 idempotency_key=f"request-message:{key}",
             )
@@ -560,6 +607,8 @@ class AuthorityService:
         deadline_at: str,
         token_budget: int = 8_000,
         content_budget_bytes: int = 24_000,
+        source: str = "authority-discussion",
+        task_id: str | None = None,
         idempotency_key: str | None = None,
     ) -> AuthorityJob:
         """Queue a bounded (one-to-three round) discussion without invoking it."""
@@ -574,6 +623,8 @@ class AuthorityService:
             raise AuthorityServiceError("discussion_budget_must_be_nonnegative")
         digest = _nonempty(task_digest, field="task_digest")
         correlation = _nonempty(correlation_id, field="correlation_id")
+        source_name = _nonempty(source, field="source")
+        task_name = _nonempty(task_id, field="task_id") if task_id is not None else None
         deadline = self._normalize_deadline(deadline_at)
         self._ensure_channel(channel_name)
         payload = {
@@ -584,6 +635,8 @@ class AuthorityService:
             "prompt_sha256": _sha256_bytes(prompt.encode("utf-8")),
             "token_budget": token_budget,
             "content_budget_bytes": content_budget_bytes,
+            "source": source_name,
+            "task_id": task_name,
         }
         with self._write_transaction():
             existing = self._find_job_by_key_tx("discussion", key)
@@ -594,8 +647,8 @@ class AuthorityService:
             now = _iso()
             self._conn.execute(
                 """INSERT INTO conversations(conversation_id, created_at, source, title)
-                   VALUES (?, ?, 'authority-discussion', ?)""",
-                (conversation_id, now, channel_name),
+                   VALUES (?, ?, ?, ?)""",
+                (conversation_id, now, source_name, channel_name),
             )
             self._conn.execute(
                 """INSERT INTO acp_conversations(
@@ -616,6 +669,25 @@ class AuthorityService:
                     content_budget_bytes,
                 ),
             )
+            self._conn.execute(
+                """INSERT INTO acp_conversation_events(
+                    event_id, conversation_id, sequence, event_type, state,
+                    metadata_json, created_at
+                ) VALUES (?, ?, 1, 'CREATED', 'CREATED', ?, ?)""",
+                (
+                    new_id("acp-event"),
+                    conversation_id,
+                    _canonical_json({"authority_reserved": True}),
+                    now,
+                ),
+            )
+            provenance: dict[str, Any] = {
+                "Source": source_name,
+                "Agent": "acp-controller",
+                "Via": "queue",
+            }
+            if task_name is not None:
+                provenance["task_id"] = task_name[:160]
             self._publish_message_tx(
                 sender="authority-service",
                 body=prompt,
@@ -624,7 +696,7 @@ class AuthorityService:
                 kind="discussion",
                 conversation_id=conversation_id,
                 correlation_id=correlation,
-                provenance={"Source": "authority", "Agent": "authority-service", "Via": "queue"},
+                provenance=provenance,
                 deadline_at=deadline,
                 idempotency_key=f"discussion-message:{key}",
             )
@@ -887,6 +959,7 @@ class AuthorityService:
         state: Literal["complete", "failed"],
         result: bytes | None = None,
         result_artifact_id: str | None = None,
+        failure: Mapping[str, Any] | None = None,
         now: str | None = None,
     ) -> AuthorityJob:
         """Terminalize a lease once; exact replay is harmless, divergence fails."""
@@ -894,6 +967,9 @@ class AuthorityService:
             raise AuthorityServiceError("invalid_job_terminal_state")
         if (result is not None) and (result_artifact_id is not None):
             raise AuthorityServiceError("provide_result_or_result_artifact_id_not_both")
+        failure_metadata = _safe_failure_metadata(failure)
+        if state == "complete" and failure_metadata is not None:
+            raise AuthorityServiceError("complete_job_cannot_have_failure_metadata")
         jid = _nonempty(job_id, field="job_id")
         worker = _nonempty(worker_id, field="worker_id")
         if fence_token < 1:
@@ -923,7 +999,12 @@ class AuthorityService:
                    WHERE job_id = ?""",
                 (state, artifact.artifact_id if artifact else None, terminal_sha, now_value, now_value, jid),
             )
-            self._append_job_event_tx(jid, fence_token, "finished", state, {"worker_id": worker})
+            event_metadata: dict[str, Any] = {"worker_id": worker}
+            if failure_metadata is not None:
+                event_metadata["failure"] = failure_metadata
+            self._append_job_event_tx(
+                jid, fence_token, "finished", state, event_metadata
+            )
             return self.get_job(jid)
 
     def reclaim_expired_jobs(self, *, now: str | None = None) -> int:

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 import sqlite3
 import subprocess
@@ -14,6 +15,7 @@ from scripts.agent_runtime import acpx_discuss
 from scripts.agent_runtime.errors import AgentTimeoutError
 from scripts.agent_runtime.result import Result
 from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.authority import AuthorityService
 from scripts.fleet_comms.message_plane import default_plane_root
 from scripts.guardrails.worktree_containment import resolve_main_root
 
@@ -95,6 +97,98 @@ def test_two_participants_are_parallel_and_completed_replay_makes_no_calls(tmp_p
     edges = {(str(row[0]), str(row[1])) for row in rows}
     assert {("root", "codex"), ("root", "grok"), ("codex", "root"), ("grok", "root"), ("codex", "grok"), ("grok", "codex")} <= edges
     assert any(row[2] is not None for row in rows)
+
+
+def test_controller_adopts_exact_authority_reservation_without_second_conversation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "plane"
+    prompt = "Compare the bounded fixture."
+    task_id = "task-6243"
+    correlation_id = "correlation-6243"
+    idempotency_key = "discussion-6243"
+    with AuthorityService(root=root) as service:
+        job = service.enqueue_discussion(
+            channel="acp-health",
+            prompt=prompt,
+            participants=("kimi", "glm"),
+            rounds=1,
+            task_digest=hashlib.sha256(task_id.encode()).hexdigest(),
+            correlation_id=correlation_id,
+            deadline_at="2036-06-01T01:00:00Z",
+            source="codex",
+            task_id=task_id,
+            idempotency_key=idempotency_key,
+        )
+
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda agent, *_a, **_k: _result(agent, f"{agent} evidence"),
+        lambda agent, *_a, **_k: _result(agent, "synthesis"),
+    )
+    try:
+        payload = controller.run(
+            prompt=prompt,
+            cwd=Path.cwd(),
+            task_id=task_id,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            rounds=1,
+            participants=("kimi", "glm"),
+            source="codex",
+            reserved_conversation_id=job.subject_id,
+        )
+        conversation_count = controller.conn.execute(
+            "SELECT COUNT(*) FROM acp_conversations"
+        ).fetchone()[0]
+        created_count = controller.conn.execute(
+            """SELECT COUNT(*) FROM acp_conversation_events
+               WHERE conversation_id = ? AND event_type = 'CREATED'""",
+            (job.subject_id,),
+        ).fetchone()[0]
+    finally:
+        controller.close()
+
+    assert payload["conversation_id"] == job.subject_id
+    assert payload["classification"] == "complete"
+    assert conversation_count == 1
+    assert created_count == 1
+
+
+def test_expired_authority_reservation_uses_existing_terminal_orphan_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "plane"
+    with AuthorityService(root=root) as service:
+        job = service.enqueue_discussion(
+            channel="acp-health",
+            prompt="Recover without calling providers.",
+            participants=("kimi", "glm"),
+            rounds=1,
+            task_digest=hashlib.sha256(b"task-6243-orphan").hexdigest(),
+            correlation_id="correlation-6243-orphan",
+            deadline_at="2000-01-01T00:00:00Z",
+            source="codex",
+            task_id="task-6243-orphan",
+            idempotency_key="discussion-6243-orphan",
+        )
+
+    controller = _controller(
+        tmp_path,
+        monkeypatch,
+        lambda *_a, **_k: pytest.fail("orphan recovery must not call a participant"),
+        lambda *_a, **_k: pytest.fail("orphan recovery must not synthesize"),
+    )
+    try:
+        with acpx_discuss._discussion_admission(controller.store.root):
+            recovered = controller.recover_expired_reservations()
+        terminal = controller._state(job.subject_id)
+    finally:
+        controller.close()
+
+    assert recovered == [job.subject_id]
+    assert terminal == "PARTIAL_COMPLETE"
 
 
 def test_enabled_nondefault_pair_uses_fixed_acp_seats_and_persists_participants(

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.adapters.claude import ClaudeAdapter
 from ai_agent_bridge import _channels, _channels_cli, _cli, _db
+from ai_agent_bridge._acp_compat import _discussion_failure_metadata
 
 
 def _clear_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -85,6 +86,8 @@ def test_discuss_round_four_prompt_preserves_root_and_all_thread_replies(
     assert observed["rounds"] == 3
     assert observed["participants"] == ("codex", "claude")
     assert root_body in str(observed["prompt"])
+    assert str(observed["task_id"]).startswith("discuss-architecture-")
+    assert str(observed["reserved_conversation_id"]).startswith("conversation_")
 
 
 def test_discuss_claude_subagent_uses_restricted_tools_without_plan_mode(
@@ -103,6 +106,22 @@ def test_discuss_claude_subagent_uses_restricted_tools_without_plan_mode(
     assert "--permission-mode" not in plan.cmd
     assert "--tools" in plan.cmd
     assert plan.cmd[plan.cmd.index("--tools") + 1] == "Read,Grep,Glob,LS"
+
+
+def test_discussion_timeout_maps_to_body_free_retryable_failure() -> None:
+    failure = _discussion_failure_metadata(
+        {
+            "classification": "partial",
+            "participant_outcomes": [
+                {"participant": "glm", "outcome": "ok"},
+                {"participant": "kimi", "outcome": "timeout"},
+            ],
+            "synthesis": "raw response must not enter failure metadata",
+        }
+    )
+
+    assert failure == {"phase": "transport", "code": "timeout", "retryable": True}
+    assert "response" not in str(failure)
 
 
 def test_ask_codex_without_from_fails_when_sender_cannot_be_inferred(

--- a/tests/ai_agent_bridge/test_acp_execution.py
+++ b/tests/ai_agent_bridge/test_acp_execution.py
@@ -1,0 +1,49 @@
+"""Deterministic isolation coverage for primary-root ACP compatibility calls."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.ai_agent_bridge._acp_execution import acp_execution_cwd
+from scripts.guardrails.worktree_containment import classify_repo_path
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_primary_root_call_uses_and_removes_detached_no_checkout_worktree(
+    tmp_path: Path,
+) -> None:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-b", "main")
+    _git(primary, "config", "user.name", "ACP Test")
+    _git(primary, "config", "user.email", "acp@example.invalid")
+    (primary / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    _git(primary, "add", "tracked.txt")
+    _git(primary, "commit", "-m", "fixture")
+
+    with acp_execution_cwd(primary, task_id="task-6243") as workspace:
+        assert workspace != primary
+        assert workspace.is_relative_to(primary / ".worktrees" / "dispatch" / "acp")
+        assert classify_repo_path(workspace, cwd=workspace) == "dispatch_worktree"
+        assert {item.name for item in workspace.iterdir()} == {".git"}
+        listed = _git(primary, "worktree", "list", "--porcelain").stdout
+        assert str(workspace) in listed
+        assert "locked active ACP execution task-6243" in listed
+
+        _git(primary, "worktree", "prune", "--expire", "now")
+        after_prune = _git(primary, "worktree", "list", "--porcelain").stdout
+        assert str(workspace) in after_prune
+        assert workspace.exists()
+
+    assert not workspace.exists()
+    listed = _git(primary, "worktree", "list", "--porcelain").stdout
+    assert str(workspace) not in listed

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -142,6 +142,54 @@ def test_request_message_persists_initiating_source_and_target_agent(tmp_path: P
     assert message.provenance == {"Source": "codex", "Agent": "agy", "Via": "queue"}
 
 
+def test_discussion_enqueue_atomically_creates_initial_state_and_provenance(
+    tmp_path: Path,
+) -> None:
+    root = _root(tmp_path)
+    with AuthorityService(root=root) as service:
+        job = service.enqueue_discussion(
+            channel="bounded-consultation",
+            prompt="Compare the two bounded options.",
+            participants=("kimi", "glm"),
+            rounds=2,
+            task_digest=_sha("task-6243"),
+            correlation_id="correlation-6243",
+            deadline_at="2036-06-01T01:00:00Z",
+            source="codex",
+            task_id="task-6243",
+            idempotency_key="discussion-6243",
+        )
+        conversation = service.store.connection.execute(
+            "SELECT source FROM conversations WHERE conversation_id = ?",
+            (job.subject_id,),
+        ).fetchone()
+        events = service.store.connection.execute(
+            """SELECT sequence, event_type, state, metadata_json
+               FROM acp_conversation_events WHERE conversation_id = ?""",
+            (job.subject_id,),
+        ).fetchall()
+        message = service.store.connection.execute(
+            """SELECT metadata.provenance_json
+               FROM comms_messages AS message
+               JOIN authority_message_metadata AS metadata
+                 ON metadata.message_id = message.message_id
+               WHERE message.conversation_id = ? AND message.kind = 'discussion'""",
+            (job.subject_id,),
+        ).fetchone()
+
+    assert conversation is not None and conversation["source"] == "codex"
+    assert len(events) == 1
+    assert tuple(events[0][:3]) == (1, "CREATED", "CREATED")
+    assert json.loads(events[0]["metadata_json"]) == {"authority_reserved": True}
+    assert message is not None
+    assert json.loads(message["provenance_json"]) == {
+        "Agent": "acp-controller",
+        "Source": "codex",
+        "Via": "queue",
+        "task_id": "task-6243",
+    }
+
+
 def test_exact_claim_and_terminal_result_replay_do_not_take_unrelated_work(tmp_path: Path) -> None:
     root = _root(tmp_path)
     with AuthorityService(root=root) as service:
@@ -210,6 +258,60 @@ def test_failed_job_retry_preserves_identity_and_attempt_history(tmp_path: Path)
             )
         ]
         assert events == ["enqueued", "claimed", "finished", "retried", "claimed"]
+
+
+def test_failed_job_event_accepts_only_closed_body_free_failure_metadata(
+    tmp_path: Path,
+) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job = service.enqueue_request(
+            recipient="glm",
+            body="bounded request",
+            idempotency_key="safe-failure",
+        )
+        lease = service.claim_job(job.job_id, "worker", now="2036-06-01T00:00:00Z")
+        service.finish_job(
+            job.job_id,
+            worker_id="worker",
+            fence_token=lease.fence_token,
+            state="failed",
+            failure={"phase": "provider", "code": "rate_limited", "retryable": True},
+            now="2036-06-01T00:00:01Z",
+        )
+        terminal = service.store.connection.execute(
+            """SELECT metadata_json FROM authority_job_events
+               WHERE job_id = ? AND event_type = 'finished'""",
+            (job.job_id,),
+        ).fetchone()
+
+        second = service.enqueue_request(
+            recipient="kimi",
+            body="another bounded request",
+            idempotency_key="unsafe-failure",
+        )
+        second_lease = service.claim_job(
+            second.job_id, "worker", now="2036-06-01T00:00:02Z"
+        )
+        with pytest.raises(AuthorityServiceError, match="failure_metadata_fields_invalid"):
+            service.finish_job(
+                second.job_id,
+                worker_id="worker",
+                fence_token=second_lease.fence_token,
+                state="failed",
+                failure={
+                    "phase": "provider",
+                    "code": "unknown",
+                    "retryable": False,
+                    "exception": "password=must-not-persist",
+                },
+                now="2036-06-01T00:00:03Z",
+            )
+
+    assert terminal is not None
+    assert json.loads(terminal["metadata_json"]) == {
+        "failure": {"code": "rate_limited", "phase": "provider", "retryable": True},
+        "worker_id": "worker",
+    }
 
 
 def test_expired_job_retry_keeps_dead_letter_receipt(tmp_path: Path) -> None:

--- a/tests/test_fleet_dashboard_contract.py
+++ b/tests/test_fleet_dashboard_contract.py
@@ -24,7 +24,7 @@ def test_fleet_page_is_a_read_only_consolidated_observer() -> None:
     assert "/api/fleet/health" in html
     assert "/api/fleet/overview" in html
     assert "/api/fleet/operations" in html
-    assert "/api/fleet/requests" in html
+    assert "/api/fleet/requests" not in html
     assert "/api/fleet/authority/jobs" in html
     assert "/api/fleet/messages" in html
     assert "/api/fleet/reviews" in html
@@ -34,10 +34,16 @@ def test_fleet_page_is_a_read_only_consolidated_observer() -> None:
     assert "<th>Agent</th>" in html
     assert "<th>Via</th>" in html
     assert "Refresh data" in html
-    assert "Read-only fleet operations" in html
-    assert "no migrations or cleanup" in html
+    assert "Historical compatibility diagnostics" in html
+    assert "Historical · read-only · excluded from health" in html
     assert "identifiers omitted" in html
     assert "logs and commands omitted" in html
+    assert "Authority requests" in html
+    assert "Historical compatibility diagnostics — excluded from authority health" in html
+    assert "Legacy broker archive" in html
+    assert "health.authority_health" in html
+    assert "item.failure.phase" in html
+    assert "{ kind: 'request' }" in html
     assert "<form" not in html
     assert "method: 'POST'" not in html
     assert 'method: "POST"' not in html

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -138,7 +138,7 @@ def _seed_plane(root: Path) -> None:
                 provenance_json, imported_source, created_at
             ) VALUES (
                 'authority-message', NULL, 'authority-thread', NULL, '{}',
-                '{"Source":"legacy-bridge","Agent":"codex","Via":"queue"}',
+                '{"Source":"legacy-bridge","Agent":"codex","Via":"queue","task_id":"task-authority-1"}',
                 'legacy-bridge', '2026-08-01T12:07:00Z'
             );
 
@@ -240,6 +240,16 @@ def test_plane_health_and_overview_expose_active_authority_posture(
     assert health["cutover"] == "authority_active"
     assert overview["authority"] == health["authority"]
     assert overview["cutover"] == health["cutover"]
+    assert overview["counts"]["requests"] == {
+        "total": 1,
+        "by_state": {"queued": 1},
+        "source": "authority_jobs",
+    }
+    assert overview["counts"]["legacy_requests"] == {
+        "total": 1,
+        "by_state": {"complete": 1},
+        "excluded_from_authority_health": True,
+    }
     assert overview["counts"]["dead_letters"]["total"] == 1
 
     dead_letters = client.get(
@@ -249,6 +259,46 @@ def test_plane_health_and_overview_expose_active_authority_posture(
     assert dead_letters["total"] == 1
     assert dead_letters["dead_letters"][0]["reason"] == "attempts_exhausted"
     assert dead_letters["dead_letters"][0]["via"] == "queue"
+
+
+def test_authority_health_uses_only_recent_authority_evidence(
+    fleet_root: Path,
+) -> None:
+    _seed_plane(fleet_root)
+    observed_at = fleet_router.datetime(2026, 8, 2, 12, 0, tzinfo=fleet_router.UTC)
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute(
+            """UPDATE authority_jobs
+               SET state = 'failed', updated_at = '2026-08-02T11:00:00Z',
+                   completed_at = '2026-08-02T11:00:00Z'"""
+        )
+        connection.execute(
+            "UPDATE authority_dead_letters SET created_at = '2026-07-01T00:00:00Z'"
+        )
+        connection.commit()
+        degraded = fleet_router._authority_health_snapshot(
+            connection, now=observed_at
+        )
+
+        connection.execute(
+            """UPDATE authority_jobs
+               SET updated_at = '2026-07-01T00:00:00Z',
+                   completed_at = '2026-07-01T00:00:00Z'"""
+        )
+        connection.commit()
+        idle = fleet_router._authority_health_snapshot(connection, now=observed_at)
+    finally:
+        connection.close()
+
+    assert degraded["state"] == "degraded"
+    assert degraded["ok"] is False
+    assert degraded["jobs"] == {"total": 1, "by_state": {"failed": 1}}
+    assert degraded["dead_letters"] == 0
+    assert idle["state"] == "idle"
+    assert idle["ok"] is True
+    assert idle["jobs"] == {"total": 0, "by_state": {}}
 
 
 def test_message_and_request_filters_are_stable_and_bodies_are_bounded(
@@ -363,9 +413,50 @@ def test_discussion_review_and_dead_letter_metadata_stay_read_only(
     assert authority_job["source"] == "legacy-bridge"
     assert authority_job["agent"] == "codex"
     assert authority_job["via"] == "queue"
+    assert authority_job["task_id"] == "task-authority-1"
+    assert authority_job["failure"] is None
     assert authority_job["payload_content"] == "omitted"
     assert "payload_artifact_id" not in authority_job
     assert "idempotency_key" not in authority_job
+
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute(
+            """INSERT INTO authority_job_events(
+                event_id, job_id, fence_token, event_type, state, metadata_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "authority-event-finished",
+                "authority-job-1",
+                1,
+                "finished",
+                "failed",
+                json.dumps(
+                    {
+                        "failure": {
+                            "phase": "provider",
+                            "code": "provider_unavailable",
+                            "retryable": True,
+                        },
+                        "raw_error": "password=must-not-leak",
+                    }
+                ),
+                "2026-08-01T12:09:00Z",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    failed_projection = client.get(
+        "/api/fleet/authority/jobs", params={"kind": "request"}
+    ).json()["jobs"][0]
+    assert failed_projection["failure"] == {
+        "phase": "provider",
+        "code": "provider_unavailable",
+        "retryable": True,
+    }
+    assert "must-not-leak" not in json.dumps(failed_projection)
 
     review_detail = client.get("/api/fleet/reviews/review-1")
     assert review_detail.status_code == 200


### PR DESCRIPTION
## Summary

- atomically reserve ACP discussions in the authority store and let the controller adopt that exact reservation
- make primary-checkout compatibility calls safe through a locked ephemeral worktree
- persist source/task attribution and a closed privacy-safe failure taxonomy
- derive Runtime API and Fleet dashboard health from current authority jobs while retaining legacy rows only as clearly excluded historical diagnostics
- document the operational contract and strict route pins

## Decision

Kimi K3 and GLM-5.2 independently converged on the same bounded design: one atomic reservation plus CREATED event, controller adoption, strict provider pins, body-free typed failures, and no new queue or cleanup subsystem.

This intentionally does **not** retire dispatch/delegate execution, formal review, channels/inbox, or file handoffs. Those remain distinct capabilities rather than hidden compatibility fallbacks.

## Verification

- 124 targeted tests passed after rebase
- Ruff, Python compilation, markdownlint, OPSEC, commit-trailer, diff, and forbidden-artifact checks passed
- primary-root ACP one-shot persisted complete authority attribution without leaving a worktree
- live Kimi+GLM discussion completed as `conversation_782b03299d1a48e2bde2c638227348c6`
- identical replay completed in 0.49 seconds without provider calls
- authority API and in-app Fleet dashboard verified populated, degraded, source/task, safe-failure, and excluded-legacy states

Closes #6243
