### PR TITLE
fix(acp): validate rolling CLI compatibility fleet-wide

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -265,6 +265,7 @@ function renderAcpx(snapshot) {
   const seatSlots = [seats[0], seats[1]];
   const safety = snapshot.safety || {};
   const pins = snapshot.pins || {};
+  const grokCompatibility = (snapshot.compatibility || {}).grok_cli || {};
   const comparison = snapshot.comparison_evidence || {};
   const calls = shadowCallCount(seats);
   const comparisons = Number(comparison.comparisons);
@@ -282,8 +283,11 @@ function renderAcpx(snapshot) {
     ['Duplicates suppressed', comparison.duplicates_suppressed],
     ['Busy refusals', comparison.busy_refusals],
     ['ACPX pin', pins.acpx ? `v${pins.acpx}` : null],
-    ['Grok CLI pin', pins.grok_cli ? `v${pins.grok_cli}` : null],
-    ['Pin validation', pins.validation ? displayLabel(pins.validation) : null],
+    ['ACPX validation', pins.validation ? displayLabel(pins.validation) : null],
+    ['Grok CLI policy', grokCompatibility.contract ? 'Rolling compatibility' : null],
+    ['Grok CLI contract', grokCompatibility.contract],
+    ['Grok validation', grokCompatibility.validation
+      ? displayLabel(grokCompatibility.validation) : null],
     ['Snapshot', formatTs(snapshot.generated_at)],
   ];
   const seatMarkup = seatSlots.map((seat, index) => {

--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -264,8 +264,7 @@ function renderAcpx(snapshot) {
   const seats = normalizeSeats(snapshot);
   const seatSlots = [seats[0], seats[1]];
   const safety = snapshot.safety || {};
-  const pins = snapshot.pins || {};
-  const grokCompatibility = (snapshot.compatibility || {}).grok_cli || {};
+  const compatibility = snapshot.compatibility || {};
   const comparison = snapshot.comparison_evidence || {};
   const calls = shadowCallCount(seats);
   const comparisons = Number(comparison.comparisons);
@@ -282,12 +281,14 @@ function renderAcpx(snapshot) {
     ['Class mismatches', Number.isFinite(mismatches) ? mismatches : null],
     ['Duplicates suppressed', comparison.duplicates_suppressed],
     ['Busy refusals', comparison.busy_refusals],
-    ['ACPX pin', pins.acpx ? `v${pins.acpx}` : null],
-    ['ACPX validation', pins.validation ? displayLabel(pins.validation) : null],
-    ['Grok CLI policy', grokCompatibility.contract ? 'Rolling compatibility' : null],
-    ['Grok CLI contract', grokCompatibility.contract],
-    ['Grok validation', grokCompatibility.validation
-      ? displayLabel(grokCompatibility.validation) : null],
+    ['CLI policy', Object.keys(compatibility).length ? 'Rolling compatibility' : null],
+    ['ACPX contract', compatibility.acpx?.contract],
+    ['AGY contract', compatibility.agy_cli?.contract],
+    ['Grok contract', compatibility.grok_cli?.contract],
+    ['Hermes contract', compatibility.hermes_cli?.contract],
+    ['OpenCode contract', compatibility.opencode_cli?.contract],
+    ['Validation', compatibility.acpx?.validation
+      ? displayLabel(compatibility.acpx.validation) : null],
     ['Snapshot', formatTs(snapshot.generated_at)],
   ];
   const seatMarkup = seatSlots.map((seat, index) => {
@@ -392,7 +393,7 @@ function renderRecent(records) {
     return;
   }
   document.getElementById('recent-content').innerHTML = `<table>
-    <thead><tr><th>Time</th><th>Source</th><th>Agent</th><th>Via</th><th>Model</th><th>Outcome</th><th>Duration</th></tr></thead>
+    <thead><tr><th>Time</th><th>Source</th><th>Agent</th><th>Via</th><th>Model</th><th>Outcome</th><th>Failure</th><th>Duration</th></tr></thead>
     <tbody>${records.map(record => {
       const cls = record.outcome === 'ok' ? 'ok' : record.outcome === 'rate_limited' ? 'warn' : record.outcome === 'timeout' ? 'gray' : 'err';
       return `<tr>
@@ -405,6 +406,7 @@ function renderRecent(records) {
         <td class="mono">${escapeHtml(record.via || record.entrypoint || '—')}</td>
         <td class="mono">${escapeHtml(record.model || '—')}</td>
         <td><span class="pill ${cls}">${escapeHtml(record.outcome || 'unknown')}</span></td>
+        <td class="mono">${escapeHtml(record.failure_code || '—')}</td>
         <td>${formatDuration(record.duration_s)}</td>
       </tr>`;
     }).join('')}</tbody>

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1288,14 +1288,31 @@ with no records reports `no_evidence`; that is not a provider-health claim.
     "posture": "evidence_only",
     "writable": false
   },
-  "pins": {
-    "acpx": "0.13.0",
-    "validation": "before_spawn"
-  },
   "compatibility": {
+    "acpx": {
+      "contract": "json-one-shot-v1",
+      "validation": "before_spawn",
+      "version_policy": "telemetry_only"
+    },
+    "agy_cli": {
+      "contract": "text-plan-sandbox-v1",
+      "validation": "before_spawn",
+      "version_policy": "telemetry_only"
+    },
     "grok_cli": {
       "contract": "agent-stdio-v1",
-      "validation": "before_spawn"
+      "validation": "before_spawn",
+      "version_policy": "telemetry_only"
+    },
+    "hermes_cli": {
+      "contract": "text-oneshot-isolated-v1",
+      "validation": "before_spawn",
+      "version_policy": "telemetry_only"
+    },
+    "opencode_cli": {
+      "contract": "native-acp-pure-v1",
+      "validation": "before_spawn",
+      "version_policy": "telemetry_only"
     }
   },
   "comparison_evidence": {
@@ -1364,12 +1381,13 @@ with no records reports `no_evidence`; that is not a provider-health claim.
 }
 ```
 
-`acpx` remains an exact project dependency. The native Grok CLI intentionally
-has no semver pin: immediately before each spawn, the adapter verifies the
-`agent stdio` command and the model, reasoning-effort, profile, and no-leader
-flags it invokes. Compatible CLI upgrades therefore work without a repository
-change; an incompatible command-surface change is refused before prompt
-delivery. The observed CLI version is retained in per-call telemetry.
+ACPX, Grok, AGY, OpenCode, and Hermes intentionally use command-surface
+compatibility rather than runtime semver pins. Immediately before each spawn,
+the adapter verifies the exact command and flags it invokes. Compatible CLI
+upgrades therefore work without adapter churn; an incompatible surface is
+refused before prompt delivery. Versions remain per-call telemetry only. The
+ACPX manifest range accepts versions from `0.13.0` onward, while the committed
+lockfile keeps installs reproducible until an intentional lock refresh.
 
 ### `GET /api/runtime/acp/conversations`
 
@@ -1414,13 +1432,17 @@ Newest usage records from today's runtime logs, newest first.
 `source` is the initiating orchestrator, while `agent` is the destination and
 `via` is the transport. The runtime persists only bounded identifiers and
 reports legacy or unattributable records as `unknown`; it never guesses the
-caller from the destination agent.
+caller from the destination agent. Failed calls also expose one body-free
+`failure_code`: `adapter_refused`, `protocol_output_limit`,
+`provider_unavailable`, `rate_limited`, `result_invalid`, `timeout`,
+`transport_error`, or `unknown`. Raw stderr, prompts, paths, credentials,
+signals, and provider text remain private.
 
 ```json
 {
   "records": [
-    {"ts": "2026-04-11T00:10:00Z", "source": "claude", "agent": "codex", "via": "delegate", "outcome": "ok"},
-    {"ts": "2026-04-11T00:09:00Z", "source": "codex", "agent": "gemini", "via": "bridge", "outcome": "timeout"}
+    {"ts": "2026-04-11T00:10:00Z", "source": "claude", "agent": "codex", "via": "delegate", "outcome": "ok", "failure_code": null},
+    {"ts": "2026-04-11T00:09:00Z", "source": "codex", "agent": "gemini", "via": "bridge", "outcome": "timeout", "failure_code": "timeout"}
   ]
 }
 ```

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1290,8 +1290,13 @@ with no records reports `no_evidence`; that is not a provider-health claim.
   },
   "pins": {
     "acpx": "0.13.0",
-    "grok_cli": "0.2.118",
     "validation": "before_spawn"
+  },
+  "compatibility": {
+    "grok_cli": {
+      "contract": "agent-stdio-v1",
+      "validation": "before_spawn"
+    }
   },
   "comparison_evidence": {
     "window_days": 7,
@@ -1358,6 +1363,13 @@ with no records reports `no_evidence`; that is not a provider-health claim.
   }
 }
 ```
+
+`acpx` remains an exact project dependency. The native Grok CLI intentionally
+has no semver pin: immediately before each spawn, the adapter verifies the
+`agent stdio` command and the model, reasoning-effort, profile, and no-leader
+flags it invokes. Compatible CLI upgrades therefore work without a repository
+change; an incompatible command-surface change is refused before prompt
+delivery. The observed CLI version is retained in per-call telemetry.
 
 ### `GET /api/runtime/acp/conversations`
 

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -76,7 +76,7 @@ controller-scheduled bounded conversation DAG whose durable state and timeline
 are written through existing fleet-comms. The expanded participant registry is
 not a new coordination plane.
 
-Approved boundary (#6027, #6043, #6078, #6130, #6158):
+Approved boundary (#6027, #6043, #6078, #6130, #6158, #6249):
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow|active`, **default `off`**.
   `shadow` retains the comparison pilot below. `active` is accepted only by
@@ -92,10 +92,12 @@ Approved boundary (#6027, #6043, #6078, #6130, #6158):
   candidates.
 - Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); every adapter refuses to
   spawn on any other resolved version.
-- Custom seats also pin their provider CLIs: Grok `0.2.118`, AGY `1.1.9`,
-  OpenCode/GLM `1.17.13`, and Hermes/DeepSeek `0.18.2`. Provider version
-  parsing is anchored to each reviewed CLI output format, and the project text
-  ACP server is SHA-256 digest-checked before spawn.
+- Grok uses a rolling CLI with the `agent-stdio-v1` compatibility contract:
+  before each spawn, the adapter requires `agent stdio` plus the exact model,
+  reasoning-effort, profile, and no-leader flags it invokes. Its observed
+  version is telemetry, not an allowlist. AGY `1.1.9`, OpenCode/GLM `1.17.13`,
+  and Hermes/DeepSeek `0.18.2` remain version-pinned. The project text ACP
+  server is SHA-256 digest-checked before spawn.
 - Codex participant:
   `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
 - Grok participant:

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -90,14 +90,17 @@ Approved boundary (#6027, #6043, #6078, #6130, #6158, #6249):
   `acpx-glm-shadow`, and `acpx-deepseek-shadow`). They are never returned by
   `available_agents()` and never become dispatch/routing/review/failover
   candidates.
-- Local pin `acpx@0.13.0` (`node_modules/.bin/acpx`); every adapter refuses to
-  spawn on any other resolved version.
-- Grok uses a rolling CLI with the `agent-stdio-v1` compatibility contract:
-  before each spawn, the adapter requires `agent stdio` plus the exact model,
-  reasoning-effort, profile, and no-leader flags it invokes. Its observed
-  version is telemetry, not an allowlist. AGY `1.1.9`, OpenCode/GLM `1.17.13`,
-  and Hermes/DeepSeek `0.18.2` remain version-pinned. The project text ACP
-  server is SHA-256 digest-checked before spawn.
+- The project-local ACPX dependency and every directly invoked provider CLI
+  use rolling compatibility contracts. Before each spawn, the adapter probes
+  the exact command/flag surface it will invoke; observed versions are
+  telemetry, never allowlists. The contracts are `json-one-shot-v1` (ACPX),
+  `agent-stdio-v1` (Grok), `text-plan-sandbox-v1` (AGY),
+  `native-acp-pure-v1` (OpenCode/GLM), and
+  `text-oneshot-isolated-v1` (Hermes/DeepSeek).
+- ACPX built-ins are validated at the ACPX boundary (`<seat> exec --file`);
+  the project does not duplicate ACPX's responsibility by pinning hidden
+  Claude, Kimi, Codex, Cursor, or Pool executables. The project text ACP server
+  remains SHA-256 digest-checked before spawn.
 - Codex participant:
   `tool_config={"acpx_shadow": True, "target_agent": "codex"}`.
 - Grok participant:
@@ -179,9 +182,11 @@ file handoffs, which remain authoritative. The task, participant responses,
 credentials, paths, sessions, tool data, and raw model content do not enter
 metadata APIs.
 
-The shared primary checkout owns the one pinned local `acpx@0.13.0` install;
-dispatch worktrees resolve that install rather than creating a global or
-floating copy. For E2E/replay verification, run the real stdin-only
+The shared primary checkout owns the one project-local ACPX install; dispatch
+worktrees resolve that install rather than creating a global copy. The
+manifest accepts compatible updates from `0.13.0` onward, while the lockfile
+keeps installs reproducible and the runtime capability probe decides whether
+the installed version may execute. For E2E/replay verification, run the real stdin-only
 `acp-discuss` command once from a registered worktree, then repeat the
 identical task, correlation, and idempotency values. The second call must
 replay the recorded terminal disposition without scheduling model work.

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -151,14 +151,16 @@ not permanent routing weights and do not override current CodexBar headroom.
   `acpx-cursor-shadow`, `acpx-pool-shadow`, `acpx-agy-shadow`,
   `acpx-glm-shadow`, and `acpx-deepseek-shadow`; never registered for
   dispatch, routing, review, or failover.
-- Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
-  resolved binary version.
-- The Grok command follows the rolling `agent-stdio-v1` compatibility
-  contract: immediately before spawn it must expose `agent stdio`, `--model`,
-  `--reasoning-effort`, `--agent-profile`, and `--no-leader`. The observed
-  version is recorded but is not an allowlist. AGY `1.1.9`, OpenCode/GLM
-  `1.17.13`, and Hermes/DeepSeek `0.18.2` remain version-pinned. The project
-  text ACP server is digest-checked before use.
+- ACPX, Grok, AGY, OpenCode, and Hermes use rolling compatibility contracts.
+  Immediately before spawn, each adapter checks the exact command and flags
+  it will invoke; versions are recorded for telemetry but are not allowlists.
+  An observed version is diagnostic evidence, not an allowlist or runtime pin.
+  The contracts are `json-one-shot-v1` (ACPX), `agent-stdio-v1` (Grok),
+  `text-plan-sandbox-v1` (AGY), `native-acp-pure-v1` (OpenCode), and
+  `text-oneshot-isolated-v1` (Hermes).
+  ACPX built-ins are checked through their `<seat> exec --file` surface rather
+  than by duplicating pins for the hidden provider executables. The project
+  text ACP server remains digest-checked before use.
 - Every invocation requires a non-empty, bounded, local `task_id`,
   `correlation_id`, and `idempotency_key`, a fixed target from the participant
   registry, and a read-only, non-primary worktree.
@@ -283,9 +285,11 @@ review, and plane-status checks.
 
 ### Shared ACPX install and E2E/replay verification
 
-ACPX is installed once at the shared primary checkout as the pinned local
-`acpx@0.13.0`; a dispatch worktree resolves that primary install and must not
-create its own global or floating ACPX installation. For an E2E/replay check,
+ACPX is installed once at the shared primary checkout as a project-local
+dependency; a dispatch worktree resolves that primary install and must not
+create its own global ACPX installation. The manifest accepts versions from
+`0.13.0` onward, the lockfile preserves reproducibility, and the runtime probe
+rejects incompatible command-surface drift before prompt delivery. For an E2E/replay check,
 run the real stdin-only `acp-discuss` command from a registered worktree with
 one bounded read-only task, then repeat the **identical** task, correlation,
 and idempotency values. The first terminal result is evidence; the second must

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -141,7 +141,7 @@ Gemini 11, OpenCode 6, GLM 4, and AGY 1. The same-day direct-runtime sample
 had Grok 1. This dated evidence justified the second pilot. These are
 not permanent routing weights and do not override current CodexBar headroom.
 
-**Exact contract (#6027, #6043, #6078, #6130, #6158):**
+**Exact contract (#6027, #6043, #6078, #6130, #6158, #6249):**
 
 - Feature flag `LU_ACPX_TRANSPORT=off|shadow|active`, **default `off`**.
   `shadow` is the unchanged comparison pilot. `active` is accepted only by the
@@ -153,10 +153,12 @@ not permanent routing weights and do not override current CodexBar headroom.
   dispatch, routing, review, or failover.
 - Local pin `acpx@0.13.0` — both adapters refuse to spawn on any other
   resolved binary version.
-- Custom participant commands additionally preflight their reviewed provider
-  CLI versions: Grok `0.2.118`, AGY `1.1.9`, OpenCode/GLM `1.17.13`, and
-  Hermes/DeepSeek `0.18.2`. Each version is parsed only from its reviewed CLI
-  output shape, and the project text ACP server is digest-checked before use.
+- The Grok command follows the rolling `agent-stdio-v1` compatibility
+  contract: immediately before spawn it must expose `agent stdio`, `--model`,
+  `--reasoning-effort`, `--agent-profile`, and `--no-leader`. The observed
+  version is recorded but is not an allowlist. AGY `1.1.9`, OpenCode/GLM
+  `1.17.13`, and Hermes/DeepSeek `0.18.2` remain version-pinned. The project
+  text ACP server is digest-checked before use.
 - Every invocation requires a non-empty, bounded, local `task_id`,
   `correlation_id`, and `idempotency_key`, a fixed target from the participant
   registry, and a read-only, non-primary worktree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/showdown": "^2.0.6",
         "@typescript-eslint/eslint-plugin": "^8.49.0",
         "@typescript-eslint/parser": "^8.49.0",
-        "acpx": "0.13.0",
+        "acpx": ">=0.13.0",
         "c8": "^10.1.3",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/showdown": "^2.0.6",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
-    "acpx": "0.13.0",
+    "acpx": ">=0.13.0",
     "c8": "^10.1.3",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -148,12 +148,18 @@ _OPENCODE_DENY_ALL_CONFIG = json.dumps(
     sort_keys=True,
 )
 
-# Exact reviewed native Grok CLI semver for the Grok ACPX shadow seat (#6043).
+# Rolling native Grok CLI compatibility contract for the Grok ACPX seat.
 # Built-in acpx ``grok-build`` is intentionally unused: it expands to
-# ``grok agent stdio`` without a place for parent flags required by Grok
-# 0.2.118 (``--model`` / ``--reasoning-effort`` / ``--no-leader`` must appear
-# before ``stdio``).
-PINNED_GROK_VERSION = "0.2.118"
+# ``grok agent stdio`` without a place for the parent flags required by this
+# adapter. The CLI version is observed for telemetry, but compatibility is
+# decided from the command and flags we actually invoke rather than semver.
+GROK_CLI_COMPATIBILITY_CONTRACT = "agent-stdio-v1"
+_GROK_REQUIRED_AGENT_FLAGS: tuple[str, ...] = (
+    "--model",
+    "--reasoning-effort",
+    "--agent-profile",
+    "--no-leader",
+)
 GROK_SHADOW_MODEL = "grok-4.5"
 GROK_SHADOW_EFFORT = "high"
 _GROK_PROFILE_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "profiles" / "acpx-grok-read-only.md"
@@ -680,12 +686,11 @@ def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
 _GROK_VERSION_RE = re.compile(r"\Agrok\s+(\d+\.\d+\.\d+)(?:\s|$)")
 
 
-@lru_cache(maxsize=4)
 def _probe_grok_version(binary: str) -> str:
-    """Return exact semver from ``<binary> --version``, or "" on any failure.
+    """Return observed semver from ``<binary> --version``, or "" on failure.
 
-    Native Grok 0.2.118 prints ``grok 0.2.118 (<sha>)``. Wrong,
-    missing, or unparseable output fails closed before prompt.
+    This value is telemetry only. Capability validation, not this version
+    string, controls whether the adapter may spawn the CLI.
     """
     try:
         proc = subprocess.run(
@@ -704,6 +709,45 @@ def _probe_grok_version(binary: str) -> str:
     return match.group(1) if match else ""
 
 
+def _probe_grok_help(binary: str, *args: str) -> str:
+    """Return help text for one Grok command, or "" when it is unavailable."""
+    try:
+        proc = subprocess.run(
+            [binary, *args, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+
+
+def _probe_grok_cli_compatibility(binary: str) -> tuple[str, tuple[str, ...]]:
+    """Return ``(observed_version, missing_capabilities)`` for the native CLI.
+
+    The probe runs before every spawn so an in-place CLI upgrade is accepted
+    immediately when it retains the command surface this adapter needs, and
+    refused before prompt delivery when that surface changes incompatibly.
+    """
+    version = _probe_grok_version(binary) or "unknown"
+    agent_help = _probe_grok_help(binary, "agent")
+    stdio_help = _probe_grok_help(binary, "agent", "stdio")
+    missing: list[str] = []
+    if not agent_help:
+        missing.append("agent")
+    else:
+        missing.extend(
+            flag for flag in _GROK_REQUIRED_AGENT_FLAGS if flag not in agent_help
+        )
+    if not stdio_help:
+        missing.append("agent stdio")
+    return version, tuple(missing)
+
+
 def _resolve_grok_binary() -> str:
     """Resolve the installed ``grok`` CLI to an absolute path, or refuse.
 
@@ -714,8 +758,7 @@ def _resolve_grok_binary() -> str:
     if not found:
         raise AcpxShadowRefusalError(
             "AcpxGrokShadowAdapter: grok binary not found on PATH; install the "
-            f"native Grok CLI at exact semver {PINNED_GROK_VERSION} before using "
-            "the acpx-grok-shadow seat"
+            "native Grok CLI before using the acpx-grok-shadow seat"
         )
     resolved = Path(found).resolve()
     if not resolved.is_file():
@@ -745,7 +788,7 @@ def _require_grok_profile() -> str:
 
 
 def _build_grok_agent_command(abs_grok: str, profile_path: str) -> str:
-    """Shell-safe single ``--agent`` value with required Grok 0.2.118 argv order.
+    """Shell-safe single ``--agent`` value with required Grok argv order.
 
     Exact token order (parent flags before ``stdio``)::
 
@@ -1469,9 +1512,8 @@ class AcpxGrokShadowAdapter:
     Builds one confined shape only:
 
     - project-local ``acpx@0.13.0``
-    - custom ``--agent`` command from the absolute installed Grok binary at
-      exact semver :data:`PINNED_GROK_VERSION`, never the built-in
-      ``grok-build`` name
+    - custom ``--agent`` command from the absolute installed Grok binary after
+      a fail-closed capability probe, never the built-in ``grok-build`` name
     - exact hash-pinned project profile with no tools plus an explicit
       write/shell/subagent/web/MCP/memory denylist
     - fixed model/effort ``grok-4.5`` / ``high`` inside that agent command
@@ -1512,7 +1554,7 @@ class AcpxGrokShadowAdapter:
         - ``session_id`` is not None
         - ``cwd`` is the protected primary checkout
         - project-local acpx missing / wrong version
-        - Grok binary missing / wrong / unparseable version
+        - Grok binary missing or lacking the required command/flag surface
         - no-tool profile missing or changed from its reviewed digest
         - caller ``model`` is not ``None`` or ``grok-4.5``
         - caller ``effort`` is not ``None`` or ``high``
@@ -1565,12 +1607,12 @@ class AcpxGrokShadowAdapter:
         acpx_binary = _require_pinned_acpx_binary(adapter_label="AcpxGrokShadowAdapter", cwd=cwd)
 
         grok_binary = _resolve_grok_binary()
-        observed_grok = _probe_grok_version(grok_binary)
-        if observed_grok != PINNED_GROK_VERSION:
+        observed_grok, missing_capabilities = _probe_grok_cli_compatibility(grok_binary)
+        if missing_capabilities:
             raise AcpxShadowRefusalError(
-                f"AcpxGrokShadowAdapter: resolved grok binary reports version "
-                f"{observed_grok!r} (expected pinned {PINNED_GROK_VERSION!r}); "
-                "refusing to spawn on a version mismatch"
+                "AcpxGrokShadowAdapter: resolved grok binary is incompatible with "
+                f"{GROK_CLI_COMPATIBILITY_CONTRACT!r}; missing capabilities: "
+                f"{', '.join(missing_capabilities)}; refusing to spawn"
             )
 
         profile_path = _require_grok_profile()
@@ -1584,7 +1626,8 @@ class AcpxGrokShadowAdapter:
         metadata: dict[str, Any] = {
             "acpx_shadow": tc.get("acpx_transport") is not True,
             "acpx_pinned_version": PINNED_VERSION,
-            "grok_pinned_version": PINNED_GROK_VERSION,
+            "grok_cli_version": observed_grok,
+            "grok_cli_compatibility": GROK_CLI_COMPATIBILITY_CONTRACT,
             "grok_profile_sha256": _GROK_PROFILE_SHA256,
             "target_agent": "grok",
             # Effective values are fixed; never fabricate caller-supplied

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -1,6 +1,6 @@
 """ACPX bounded read-only transport (#6027, #6043, #6078, #6130, #6158).
 
-Wraps the project-local ``acpx@0.13.0`` headless CLI
+Wraps the project-local ``acpx`` headless CLI
 (https://www.npmjs.com/package/acpx) for the Agent Client Protocol (ACP).
 
 Direct-only seats in this module cover the fixed participant registry:
@@ -20,7 +20,7 @@ No seat is registered for model selection, catalog, review eligibility, or
 failover (``cli_available: False``). They are not a second coordination plane:
 fleet-comms remains the durable authority and shadow comparison stays optional.
 
-Contract captured empirically from the pinned local ``acpx@0.13.0`` install
+Contract captured empirically from the local ``acpx@0.13.0`` install
 (``node_modules/acpx``), not guessed:
 
 - ``exec`` is always one-shot and never reuses a saved session or queue
@@ -36,7 +36,7 @@ Contract captured empirically from the pinned local ``acpx@0.13.0`` install
   NDJSON on stdout, one message per line, and suppresses non-JSON noise on
   stderr. On failure the CLI's own top-level handler appends one final
   ``{"jsonrpc":"2.0","id":null,"error":{...,"data":{"acpxCode":...}}}`` line
-  (verified live against the pinned binary: a ``--timeout`` breach produced
+  (verified live against the compatibility-probed binary: a ``--timeout`` breach produced
   exactly this shape with ``data.acpxCode == "TIMEOUT"``, exit code 3; a bad
   ``--agent`` path produced ``data.acpxCode == "RUNTIME"``, exit code 1).
   ``data.acpxCode``/``data.detailCode`` are drawn from
@@ -53,7 +53,7 @@ Contract captured empirically from the pinned local ``acpx@0.13.0`` install
   per-process selectors such as ``ACPX_AUTH_CHAT_GPT=1`` (Codex ChatGPT login)
   and ``ACPX_AUTH_CACHED_TOKEN=1`` (Grok cached native login). Never invent
   additional selectors; never read/store/log credentials. The Grok selector
-  was verified live against the pinned custom ``--agent`` command: the
+  was verified live against the fixed custom ``--agent`` command: the
   selector produced a successful one-shot response, while the same runtime
   path with the selector stripped failed closed as ``AUTH_REQUIRED``.
 
@@ -82,7 +82,6 @@ import subprocess
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -111,16 +110,47 @@ _logger = logging.getLogger(__name__)
 # and unrecognized values refuse to spawn.
 TRANSPORT_ENV = "LU_ACPX_TRANSPORT"
 
-# Exact reviewed version. AC-PIN requires resolving ACPX at one exact
-# version with a deterministic preflight — never a floating "latest".
-PINNED_VERSION = "0.13.0"
+# Rolling compatibility contracts. Versions are observed for telemetry only;
+# every executable is admitted from the exact command/flag surface this module
+# will invoke. A compatible in-place upgrade is accepted immediately, while a
+# changed surface fails before prompt delivery.
+ACPX_CLI_COMPATIBILITY_CONTRACT = "json-one-shot-v1"
+AGY_CLI_COMPATIBILITY_CONTRACT = "text-plan-sandbox-v1"
+OPENCODE_CLI_COMPATIBILITY_CONTRACT = "native-acp-pure-v1"
+HERMES_CLI_COMPATIBILITY_CONTRACT = "text-oneshot-isolated-v1"
 
-# Provider CLI versions validated with the text-only/native ACP participant
-# recipes introduced in #6158. These custom commands are part of the protocol
-# boundary, so an unreviewed CLI update fails before the prompt leaves ACPX.
-PINNED_AGY_VERSION = "1.1.9"
-PINNED_OPENCODE_VERSION = "1.17.13"
-PINNED_HERMES_VERSION = "0.18.2"
+_ACPX_REQUIRED_GLOBAL_FLAGS: tuple[str, ...] = (
+    "--agent",
+    "--cwd",
+    "--format",
+    "--json-strict",
+    "--auth-policy",
+    "--deny-all",
+    "--non-interactive-permissions",
+    "--no-fs",
+    "--no-terminal",
+    "--allowed-tools",
+    "--max-turns",
+    "--prompt-retries",
+    "--model",
+)
+_AGY_REQUIRED_FLAGS: tuple[str, ...] = (
+    "--print",
+    "--mode",
+    "--sandbox",
+    "--disable-slash-commands",
+    "--print-timeout",
+    "--output-format",
+    "--model",
+    "--log-file",
+)
+_OPENCODE_REQUIRED_ACP_FLAGS: tuple[str, ...] = ("--pure",)
+_HERMES_REQUIRED_FLAGS: tuple[str, ...] = (
+    "--ignore-rules",
+    "--oneshot",
+    "--model",
+    "--provider",
+)
 AGY_ACP_MODEL = "gemini-3.6-flash-high"
 CLAUDE_ACP_MODEL = "claude-sonnet-5"
 GLM_ACP_MODEL = "glm-5.2"
@@ -131,15 +161,15 @@ DEEPSEEK_ACP_MODEL = "deepseek-v4-pro"
 # non-secret selector; the value is never a credential.
 GLM_AUTH_OPENCODE_LOGIN_ENV = "ACPX_AUTH_OPENCODE_LOGIN"
 
-# Project-local pinned binary. Deliberately NOT `shutil.which("acpx")`:
+# Project-local dependency binary. Deliberately NOT `shutil.which("acpx")`:
 # global/PATH resolution would let an unrelated or unreviewed global acpx
 # install silently take over. "No global binary authority" per the approved
 # Stage 0/1 contract.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_DEFAULT_PINNED_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
+_DEFAULT_ACPX_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 # Keep this separately patchable for hermetic adapter tests.  An explicit
 # override is authoritative and must never silently fall back to another tree.
-_PINNED_BINARY = _DEFAULT_PINNED_BINARY
+_ACPX_BINARY = _DEFAULT_ACPX_BINARY
 _TEXT_AGENT_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "acp_text_agent.mjs"
 _TEXT_AGENT_SHA256 = "42761e2bd9ab0e66f5e5779826777b46bd0761cc4673e13285e1fc37418ea679"
 _OPENCODE_DENY_ALL_CONFIG = json.dumps(
@@ -416,16 +446,8 @@ class AcpxShadowRefusalError(ValueError):
     """
 
 
-@lru_cache(maxsize=4)
 def _probe_acpx_version(binary: str) -> str:
-    """Return ``<binary> --version`` output, or "" on any probe failure.
-
-    Cached per binary path (mirrors ``ClaudeAdapter._probe_claude_cli_version``)
-    since every shadow invocation re-checks the pin. Returning "" on failure
-    (rather than raising) lets the single version-mismatch branch in
-    ``build_invocation`` handle "binary missing", "binary crashed", and
-    "wrong version" uniformly — all three must fail closed the same way.
-    """
+    """Return ``<binary> --version`` output, or ``"unknown"`` on failure."""
     try:
         proc = subprocess.run(
             [binary, "--version"],
@@ -435,8 +457,50 @@ def _probe_acpx_version(binary: str) -> str:
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    observed = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+    return observed.splitlines()[0][:100] if proc.returncode == 0 and observed else "unknown"
+
+
+def _probe_cli_help(binary: str, *args: str) -> str:
+    """Return one exact command's help surface, or an empty string."""
+    try:
+        proc = subprocess.run(
+            [binary, *args, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
         return ""
-    return (proc.stdout or "").strip()
+    if proc.returncode != 0:
+        return ""
+    return "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+
+
+def _probe_acpx_cli_compatibility(
+    binary: str,
+    *,
+    builtin_agent: str | None,
+) -> tuple[str, tuple[str, ...]]:
+    """Probe the ACPX flags and one-shot surface used by one adapter seat."""
+    version = _probe_acpx_version(binary)
+    root_help = _probe_cli_help(binary)
+    exec_args = (builtin_agent, "exec") if builtin_agent else ("exec",)
+    exec_help = _probe_cli_help(binary, *exec_args)
+    missing: list[str] = []
+    if not root_help:
+        missing.append("root help")
+    else:
+        missing.extend(flag for flag in _ACPX_REQUIRED_GLOBAL_FLAGS if flag not in root_help)
+        if builtin_agent and f"{builtin_agent} " not in root_help:
+            missing.append(f"built-in {builtin_agent}")
+    if not exec_help:
+        missing.append(f"{builtin_agent + ' ' if builtin_agent else ''}exec")
+    elif "--file" not in exec_help:
+        missing.append("exec --file")
+    return version, tuple(missing)
 
 
 def _require_local_metadata_field(
@@ -610,20 +674,25 @@ def _require_non_primary_worktree(cwd: Path, *, adapter_label: str) -> None:
         )
 
 
-def _require_pinned_acpx_binary(*, adapter_label: str, cwd: Path) -> str:
-    """Resolve the exact local ACPX pin, sharing the primary install with worktrees.
+def _require_compatible_acpx_binary(
+    *,
+    adapter_label: str,
+    cwd: Path,
+    builtin_agent: str | None,
+) -> tuple[str, str]:
+    """Resolve and capability-check local ACPX, sharing it with worktrees.
 
     A source worktree normally has no independent ``node_modules`` tree.  If
     this module's default local candidate is absent, resolve the canonical
     primary checkout from the invocation cwd and accept only that checkout's
-    identically pinned binary.  Never consult PATH or a global install.
+    dependency binary. Never consult PATH or a global install.
 
-    Tests may explicitly patch :data:`_PINNED_BINARY`; an override remains
+    Tests may explicitly patch :data:`_ACPX_BINARY`; an override remains
     authoritative so an isolated test cannot accidentally borrow a developer
     checkout's installation.
     """
-    candidate = _PINNED_BINARY
-    if not candidate.is_file() and candidate == _DEFAULT_PINNED_BINARY:
+    candidate = _ACPX_BINARY
+    if not candidate.is_file() and candidate == _DEFAULT_ACPX_BINARY:
         try:
             main_root = resolve_main_root(cwd)
         except NotAGitRepositoryError:
@@ -635,7 +704,7 @@ def _require_pinned_acpx_binary(*, adapter_label: str, cwd: Path) -> str:
 
     if not candidate.is_file():
         primary_hint = ""
-        if _PINNED_BINARY == _DEFAULT_PINNED_BINARY:
+        if _ACPX_BINARY == _DEFAULT_ACPX_BINARY:
             try:
                 primary_hint = (
                     f"; canonical primary candidate is "
@@ -644,18 +713,22 @@ def _require_pinned_acpx_binary(*, adapter_label: str, cwd: Path) -> str:
             except NotAGitRepositoryError:
                 primary_hint = "; cwd is not inside a Git checkout, so no canonical primary install is available"
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: pinned binary not found at {candidate}{primary_hint}; run "
-            f"`npm install acpx@{PINNED_VERSION} --save-exact --save-dev` in the canonical primary checkout. "
+            f"{adapter_label}: project-local acpx binary not found at {candidate}{primary_hint}; run "
+            "`npm install` in the canonical primary checkout. "
             "A global/PATH acpx binary is never used as a substitute."
         )
     binary = str(candidate)
-    observed_version = _probe_acpx_version(binary)
-    if observed_version != PINNED_VERSION:
+    observed_version, missing = _probe_acpx_cli_compatibility(
+        binary,
+        builtin_agent=builtin_agent,
+    )
+    if missing:
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: resolved acpx binary reports version {observed_version!r} "
-            f"(expected pinned {PINNED_VERSION!r}); refusing to spawn on a version mismatch"
+            f"{adapter_label}: resolved acpx binary is incompatible with "
+            f"{ACPX_CLI_COMPATIBILITY_CONTRACT!r}; missing capabilities: "
+            f"{', '.join(missing)}; refusing to spawn"
         )
-    return binary
+    return binary, observed_version
 
 
 def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
@@ -711,19 +784,7 @@ def _probe_grok_version(binary: str) -> str:
 
 def _probe_grok_help(binary: str, *args: str) -> str:
     """Return help text for one Grok command, or "" when it is unavailable."""
-    try:
-        proc = subprocess.run(
-            [binary, *args, "--help"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if proc.returncode != 0:
-        return ""
-    return "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+    return _probe_cli_help(binary, *args)
 
 
 def _probe_grok_cli_compatibility(binary: str) -> tuple[str, tuple[str, ...]]:
@@ -820,7 +881,6 @@ _PROVIDER_VERSION_PATTERNS = {
 }
 
 
-@lru_cache(maxsize=16)
 def _probe_participant_cli_version(binary: str, executable: str) -> str:
     """Return a version anchored to the reviewed provider output format."""
     try:
@@ -842,31 +902,63 @@ def _probe_participant_cli_version(binary: str, executable: str) -> str:
     return match.group(1) if match else ""
 
 
+def _probe_participant_cli_compatibility(
+    binary: str,
+    executable: str,
+) -> tuple[str, tuple[str, ...]]:
+    """Return version telemetry and missing exact command-surface features."""
+    version = _probe_participant_cli_version(binary, executable) or "unknown"
+    if executable == "agy":
+        help_text = _probe_cli_help(binary)
+        required = _AGY_REQUIRED_FLAGS
+        label = "root help"
+    elif executable == "opencode":
+        help_text = _probe_cli_help(binary, "acp")
+        required = _OPENCODE_REQUIRED_ACP_FLAGS
+        label = "acp"
+    elif executable == "hermes":
+        help_text = _probe_cli_help(binary)
+        required = _HERMES_REQUIRED_FLAGS
+        label = "root help"
+    else:  # pragma: no cover - internal callers pass the closed set above
+        return version, ("unsupported executable",)
+    if not help_text:
+        return version, (label,)
+    return version, tuple(flag for flag in required if flag not in help_text)
+
+
+_PARTICIPANT_COMPATIBILITY_CONTRACTS = {
+    "agy": AGY_CLI_COMPATIBILITY_CONTRACT,
+    "opencode": OPENCODE_CLI_COMPATIBILITY_CONTRACT,
+    "hermes": HERMES_CLI_COMPATIBILITY_CONTRACT,
+}
+
+
 def _resolve_participant_binary(
     executable: str,
     *,
     adapter_label: str,
-    expected_version: str,
-) -> str:
-    """Resolve and version-check one provider CLI before constructing argv."""
+) -> tuple[str, str]:
+    """Resolve and capability-check one provider CLI before constructing argv."""
+    contract = _PARTICIPANT_COMPATIBILITY_CONTRACTS[executable]
     found = shutil.which(executable)
     if not found:
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: {executable} binary not found on PATH; expected exact "
-            f"version {expected_version!r}"
+            f"{adapter_label}: {executable} binary not found on PATH; required for "
+            f"compatibility contract {contract!r}"
         )
     resolved = Path(found).resolve()
     if not resolved.is_file():
         raise AcpxShadowRefusalError(
             f"{adapter_label}: resolved {executable} path {resolved} is not a file"
         )
-    observed = _probe_participant_cli_version(str(resolved), executable)
-    if observed != expected_version:
+    observed, missing = _probe_participant_cli_compatibility(str(resolved), executable)
+    if missing:
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: resolved {executable} binary reports version {observed!r} "
-            f"(expected pinned {expected_version!r}); refusing to spawn on a version mismatch"
+            f"{adapter_label}: resolved {executable} binary is incompatible with "
+            f"{contract!r}; missing capabilities: {', '.join(missing)}; refusing to spawn"
         )
-    return str(resolved)
+    return str(resolved), observed
 
 
 def _require_text_agent(*, adapter_label: str) -> str:
@@ -895,13 +987,11 @@ def _build_text_agent_command(
     provider: str,
     model: str,
     executable: str,
-    expected_version: str,
-) -> tuple[str, str]:
-    """Return shell-safe custom ACP command plus observed provider binary."""
-    provider_binary = _resolve_participant_binary(
+) -> tuple[str, str, str]:
+    """Return shell-safe custom ACP command, binary, and version telemetry."""
+    provider_binary, observed_version = _resolve_participant_binary(
         executable,
         adapter_label=adapter_label,
-        expected_version=expected_version,
     )
     node_binary = shutil.which("node")
     if not node_binary:
@@ -925,7 +1015,7 @@ def _build_text_agent_command(
             provider_binary,
         ]
     )
-    return command, provider_binary
+    return command, provider_binary, observed_version
 
 
 class AcpxAdapter:
@@ -974,8 +1064,8 @@ class AcpxAdapter:
         - ``session_id`` is not None (this seat never resumes a session).
         - ``mode`` is not ``"read-only"``.
         - ``cwd`` resolves to the protected primary checkout.
-        - the resolved local binary is missing, unversionable, or reports a
-          version other than :data:`PINNED_VERSION`.
+        - the resolved local binary is missing or lacks the exact ACPX
+          command/flag surface used by this seat.
         - ``task_id``, ``tool_config["correlation_id"]``, or
           ``tool_config["idempotency_key"]`` is missing, blank, oversized, or
           contains characters outside the local-identifier charset (see
@@ -1010,7 +1100,11 @@ class AcpxAdapter:
             )
 
         _require_non_primary_worktree(cwd, adapter_label="AcpxAdapter")
-        binary = _require_pinned_acpx_binary(adapter_label="AcpxAdapter", cwd=cwd)
+        binary, acpx_version = _require_compatible_acpx_binary(
+            adapter_label="AcpxAdapter",
+            cwd=cwd,
+            builtin_agent="codex",
+        )
 
         cmd: list[str] = _confinement_prefix_argv(binary, cwd)
         if model:
@@ -1024,7 +1118,8 @@ class AcpxAdapter:
 
         metadata: dict[str, Any] = {
             "acpx_shadow": tc.get("acpx_transport") is not True,
-            "acpx_pinned_version": PINNED_VERSION,
+            "acpx_cli_version": acpx_version,
+            "acpx_cli_compatibility": ACPX_CLI_COMPATIBILITY_CONTRACT,
             "task_id": validated_task_id,
             "correlation_id": correlation_id,
             "idempotency_key": idempotency_key,
@@ -1047,19 +1142,19 @@ class AcpxAdapter:
         )
 
     @classmethod
-    def _resolve_pinned_binary(cls) -> str:
-        """Resolve the project-local acpx binary path without version probing.
+    def _resolve_acpx_binary(cls) -> str:
+        """Resolve the project-local acpx binary path without probing.
 
-        Kept for callers/tests that only need the path check. Version pin
-        enforcement lives in :func:`_require_pinned_acpx_binary`.
+        Kept for callers/tests that only need the path check. Compatibility
+        enforcement lives in :func:`_require_compatible_acpx_binary`.
         """
-        if not _PINNED_BINARY.is_file():
+        if not _ACPX_BINARY.is_file():
             raise AcpxShadowRefusalError(
-                f"AcpxAdapter: pinned binary not found at {_PINNED_BINARY}; run "
-                f"`npm install acpx@{PINNED_VERSION} --save-exact --save-dev` first. "
+                f"AcpxAdapter: project-local acpx binary not found at {_ACPX_BINARY}; run "
+                "`npm install` first. "
                 "A global/PATH acpx binary is never used as a substitute."
             )
-        return str(_PINNED_BINARY)
+        return str(_ACPX_BINARY)
 
     def parse_response(
         self,
@@ -1174,7 +1269,17 @@ class AcpxAdapter:
             data = final_error.get("data") or {}
             label = data.get("detailCode") or data.get("acpxCode") or "RUNTIME"
             message = final_error.get("message", "acpx error")
-            return self._closed(f"acpx {label}: {message}", stderr)
+            if label == "TIMEOUT":
+                failure_code = "timeout"
+            elif label in {"AUTH_REQUIRED", "AGENT_DISCONNECTED"}:
+                failure_code = "provider_unavailable"
+            else:
+                failure_code = "transport_error"
+            return self._closed(
+                f"acpx {label}: {message}",
+                stderr,
+                failure_code=failure_code,
+            )
 
         if final_stop_reason is _MISSING_STOP_REASON:
             return self._closed(f"acpx exec stream ended without a terminal response (rc={returncode})", stderr)
@@ -1186,11 +1291,17 @@ class AcpxAdapter:
             )
 
         if final_stop_reason == _STOP_REASON_CANCELLED:
-            return self._closed("acpx prompt turn cancelled (stopReason=cancelled)", stderr)
+            return self._closed(
+                "acpx prompt turn cancelled (stopReason=cancelled)",
+                stderr,
+                failure_code="transport_error",
+            )
 
         if returncode != 0:
             return self._closed(
-                f"acpx exec exited rc={returncode} despite stopReason={final_stop_reason!r}", stderr
+                f"acpx exec exited rc={returncode} despite stopReason={final_stop_reason!r}",
+                stderr,
+                failure_code="transport_error",
             )
 
         response = "".join(message_chunks)
@@ -1201,6 +1312,7 @@ class AcpxAdapter:
                 f"{ACPX_PARSED_RESPONSE_LIMIT_BYTES}-byte content limit "
                 f"(observed={response_bytes})",
                 stderr,
+                failure_code="protocol_output_limit",
             )
 
         return ParseResult(
@@ -1214,7 +1326,12 @@ class AcpxAdapter:
         )
 
     @staticmethod
-    def _closed(reason: str, stderr: str) -> ParseResult:
+    def _closed(
+        reason: str,
+        stderr: str,
+        *,
+        failure_code: str = "result_invalid",
+    ) -> ParseResult:
         """Build a fail-closed ``ParseResult`` with a bounded stderr excerpt."""
         tail = (stderr or "").strip()
         excerpt = reason if not tail else f"{reason}\n[acpx stderr]\n{tail}"
@@ -1226,6 +1343,7 @@ class AcpxAdapter:
             session_id=None,
             tokens=None,
             tool_calls=[],
+            failure_code=failure_code,
         )
 
     def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
@@ -1258,7 +1376,7 @@ class _AcpxDiscussionAdapter:
     default_model: str = "acpx-built-in-default"
     supported_modes: frozenset[str] = frozenset({"read-only"})
 
-    def _custom_agent_command(self, cwd: Path) -> str | None:
+    def _custom_agent_command(self, cwd: Path) -> tuple[str, dict[str, Any]] | None:
         _ = cwd
         return None
 
@@ -1316,18 +1434,26 @@ class _AcpxDiscussionAdapter:
             "idempotency_key", tc.get("idempotency_key"), adapter_label=type(self).__name__
         )
         _require_non_primary_worktree(cwd, adapter_label=type(self).__name__)
-        binary = _require_pinned_acpx_binary(adapter_label=type(self).__name__, cwd=cwd)
+        custom_agent = self._custom_agent_command(cwd)
+        builtin_agent = self.target_agent if custom_agent is None else None
+        binary, acpx_version = _require_compatible_acpx_binary(
+            adapter_label=type(self).__name__,
+            cwd=cwd,
+            builtin_agent=builtin_agent,
+        )
         cmd = _confinement_prefix_argv(binary, cwd)
         if self.fixed_model is not None and self.forward_model_to_acpx:
             cmd.extend(["--model", self.acpx_model or self.fixed_model])
-        custom_agent = self._custom_agent_command(cwd)
         if custom_agent is None:
             cmd.extend([self.target_agent, "exec", "-f", "-"])
+            custom_metadata: dict[str, Any] = {}
         else:
-            cmd.extend(["--agent", custom_agent, "exec", "-f", "-"])
+            custom_command, custom_metadata = custom_agent
+            cmd.extend(["--agent", custom_command, "exec", "-f", "-"])
         metadata: dict[str, Any] = {
             "acpx_discussion": True,
-            "acpx_pinned_version": PINNED_VERSION,
+            "acpx_cli_version": acpx_version,
+            "acpx_cli_compatibility": ACPX_CLI_COMPATIBILITY_CONTRACT,
             "target_agent": self.target_agent,
             "task_id": validated_task_id,
             "correlation_id": correlation_id,
@@ -1340,6 +1466,7 @@ class _AcpxDiscussionAdapter:
             metadata["model"] = self.fixed_model
         if self.fixed_effort is not None:
             metadata["effort"] = self.fixed_effort
+        metadata.update(custom_metadata)
         metadata.update(self._extra_metadata())
         if tc.get("acpx_transport") is True:
             # Keep the runner-sealed transport fields authoritative even if a
@@ -1411,21 +1538,18 @@ class AcpxAgyShadowAdapter(_AcpxDiscussionAdapter):
     fixed_effort = "high"
     forward_model_to_acpx = False
 
-    def _custom_agent_command(self, cwd: Path) -> str:
+    def _custom_agent_command(self, cwd: Path) -> tuple[str, dict[str, Any]]:
         _ = cwd
-        command, _binary = _build_text_agent_command(
+        command, _binary, version = _build_text_agent_command(
             adapter_label=type(self).__name__,
             provider="agy",
             model=AGY_ACP_MODEL,
             executable="agy",
-            expected_version=PINNED_AGY_VERSION,
         )
-        return command
-
-    def _extra_metadata(self) -> dict[str, Any]:
-        return {
+        return command, {
             "provider_cli": "agy",
-            "provider_cli_pinned_version": PINNED_AGY_VERSION,
+            "provider_cli_version": version,
+            "provider_cli_compatibility": AGY_CLI_COMPATIBILITY_CONTRACT,
             "text_only_adapter": True,
         }
 
@@ -1440,30 +1564,26 @@ class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
     default_model = fixed_model
     fixed_effort = "high"
 
-    def _custom_agent_command(self, cwd: Path) -> str:
+    def _custom_agent_command(self, cwd: Path) -> tuple[str, dict[str, Any]]:
         _ = cwd
         assert_glm_egress_allowed(type(self).__name__)
-        binary = _resolve_participant_binary(
+        binary, version = _resolve_participant_binary(
             "opencode",
             adapter_label=type(self).__name__,
-            expected_version=PINNED_OPENCODE_VERSION,
         )
-        return shlex.join([binary, "acp", "--pure"])
+        return shlex.join([binary, "acp", "--pure"]), {
+            "provider_cli": "opencode",
+            "provider_cli_version": version,
+            "provider_cli_compatibility": OPENCODE_CLI_COMPATIBILITY_CONTRACT,
+            "provider_route": GLM_ACP_INVOCATION_MODEL,
+            "tool_policy": "deny-all",
+        }
 
     def _env_overrides(self) -> dict[str, str]:
         return {
             GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
             "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
         }
-
-    def _extra_metadata(self) -> dict[str, Any]:
-        return {
-            "provider_cli": "opencode",
-            "provider_cli_pinned_version": PINNED_OPENCODE_VERSION,
-            "provider_route": GLM_ACP_INVOCATION_MODEL,
-            "tool_policy": "deny-all",
-        }
-
 
 class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
     """Text-only, first-party DeepSeek ACP participant via isolated Hermes."""
@@ -1474,7 +1594,7 @@ class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
     default_model = fixed_model
     forward_model_to_acpx = False
 
-    def _custom_agent_command(self, cwd: Path) -> str:
+    def _custom_agent_command(self, cwd: Path) -> tuple[str, dict[str, Any]]:
         _ = cwd
         if is_deepseek_first_party_forbidden_in_ci("deepseek", DEEPSEEK_ACP_MODEL):
             raise AcpxShadowRefusalError(
@@ -1484,19 +1604,16 @@ class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
                     source=type(self).__name__,
                 )
             )
-        command, _binary = _build_text_agent_command(
+        command, _binary, version = _build_text_agent_command(
             adapter_label=type(self).__name__,
             provider="deepseek",
             model=DEEPSEEK_ACP_MODEL,
             executable="hermes",
-            expected_version=PINNED_HERMES_VERSION,
         )
-        return command
-
-    def _extra_metadata(self) -> dict[str, Any]:
-        return {
+        return command, {
             "provider_cli": "hermes",
-            "provider_cli_pinned_version": PINNED_HERMES_VERSION,
+            "provider_cli_version": version,
+            "provider_cli_compatibility": HERMES_CLI_COMPATIBILITY_CONTRACT,
             "provider_route": "deepseek",
             "text_only_adapter": True,
         }
@@ -1511,7 +1628,7 @@ class AcpxGrokShadowAdapter:
 
     Builds one confined shape only:
 
-    - project-local ``acpx@0.13.0``
+    - project-local, compatibility-probed ``acpx``
     - custom ``--agent`` command from the absolute installed Grok binary after
       a fail-closed capability probe, never the built-in ``grok-build`` name
     - exact hash-pinned project profile with no tools plus an explicit
@@ -1553,7 +1670,7 @@ class AcpxGrokShadowAdapter:
         - ``target_agent`` is not ``"grok"``
         - ``session_id`` is not None
         - ``cwd`` is the protected primary checkout
-        - project-local acpx missing / wrong version
+        - project-local acpx missing or lacking the required command surface
         - Grok binary missing or lacking the required command/flag surface
         - no-tool profile missing or changed from its reviewed digest
         - caller ``model`` is not ``None`` or ``grok-4.5``
@@ -1604,7 +1721,11 @@ class AcpxGrokShadowAdapter:
             )
 
         _require_non_primary_worktree(cwd, adapter_label="AcpxGrokShadowAdapter")
-        acpx_binary = _require_pinned_acpx_binary(adapter_label="AcpxGrokShadowAdapter", cwd=cwd)
+        acpx_binary, acpx_version = _require_compatible_acpx_binary(
+            adapter_label="AcpxGrokShadowAdapter",
+            cwd=cwd,
+            builtin_agent=None,
+        )
 
         grok_binary = _resolve_grok_binary()
         observed_grok, missing_capabilities = _probe_grok_cli_compatibility(grok_binary)
@@ -1625,7 +1746,8 @@ class AcpxGrokShadowAdapter:
 
         metadata: dict[str, Any] = {
             "acpx_shadow": tc.get("acpx_transport") is not True,
-            "acpx_pinned_version": PINNED_VERSION,
+            "acpx_cli_version": acpx_version,
+            "acpx_cli_compatibility": ACPX_CLI_COMPATIBILITY_CONTRACT,
             "grok_cli_version": observed_grok,
             "grok_cli_compatibility": GROK_CLI_COMPATIBILITY_CONTRACT,
             "grok_profile_sha256": _GROK_PROFILE_SHA256,

--- a/scripts/agent_runtime/result.py
+++ b/scripts/agent_runtime/result.py
@@ -54,6 +54,9 @@ class ParseResult:
             Hermes adapters populate this with requested_provider/model and
             actual_provider/model so silent provider/model substitution cannot
             disappear between parse, usage telemetry, and delegate state.
+        failure_code: Optional closed, body-free failure classification. ACP
+            adapters use this to preserve diagnostics while privacy-limited
+            usage records discard raw stderr and provider text.
     """
     ok: bool
     response: str
@@ -64,6 +67,7 @@ class ParseResult:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     substitution: dict[str, Any] | None = None
     response_envelope: ResponseEnvelope | None = None
+    failure_code: str | None = None
 
 
 @dataclass(frozen=True)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -140,6 +140,18 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
 # the adapter independently caps parsed answer text before it can be returned
 # to fleet authority.
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
+_SAFE_ACP_FAILURE_CODES = frozenset(
+    {
+        "adapter_refused",
+        "protocol_output_limit",
+        "provider_unavailable",
+        "rate_limited",
+        "result_invalid",
+        "timeout",
+        "transport_error",
+        "unknown",
+    }
+)
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
@@ -764,6 +776,7 @@ def _build_usage_record(
     stderr_excerpt: str | None,
     tokens: int | None,
     substitution: dict[str, Any] | None = None,
+    failure_code: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the usage record dict per design doc § 4.5 schema."""
     # Ensure unbounded strings are capped so the JSON stays under POSIX PIPE_BUF (4KB)
@@ -780,6 +793,13 @@ def _build_usage_record(
     )
     transport = _INTER_AGENT_TRANSPORT.get()
 
+    failure_code = _privacy_safe_failure_code(
+        outcome=outcome,
+        rate_limited=rate_limited,
+        stalled=stalled,
+        returncode=returncode,
+        explicit_code=failure_code,
+    )
     record = {
         "ts": datetime.now(UTC).isoformat(),
         "agent": agent,
@@ -805,6 +825,7 @@ def _build_usage_record(
         "outcome": outcome,
         "rate_limited": rate_limited,
         "stalled": stalled,
+        "failure_code": failure_code,
         "stderr_excerpt": (
             None
             if privacy_limited
@@ -820,6 +841,29 @@ def _build_usage_record(
         # metadata is permitted to supply or overwrite these fields.
         record["transport"] = transport.metadata()
     return record
+
+
+def _privacy_safe_failure_code(
+    *,
+    outcome: str,
+    rate_limited: bool,
+    stalled: bool,
+    returncode: int | None,
+    explicit_code: str | None = None,
+) -> str | None:
+    """Classify a failure without persisting provider text or dynamic detail."""
+    normalized_outcome = str(outcome or "").casefold()
+    if normalized_outcome == "ok":
+        return None
+    if explicit_code in _SAFE_ACP_FAILURE_CODES:
+        return explicit_code
+    if rate_limited or normalized_outcome == "rate_limited":
+        return "rate_limited"
+    if stalled or normalized_outcome in {"timeout", "hard_timeout", "stalled"}:
+        return "timeout"
+
+    code = "transport_error" if returncode not in (None, 0) else "unknown"
+    return code if code in _SAFE_ACP_FAILURE_CODES else "unknown"
 
 
 def _safe_substitution_record(
@@ -1279,6 +1323,7 @@ def _execute_invocation_plan(
                 stalled=False,
                 stderr_excerpt=(f"Popen failed: {type(exc).__name__}: {exc}")[:500],
                 tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
+                failure_code="provider_unavailable",
             )
             write_record(record)
             raise AgentUnavailableError(f"{agent_name!r} Popen failed: {type(exc).__name__}: {exc}") from exc
@@ -1545,6 +1590,7 @@ def _raise_for_kill_reason(
             ),
             tokens=None,
             substitution=record_substitution,
+            failure_code="protocol_output_limit",
         )
         write_record(record)
         raise AgentOutputLimitError(agent_name, limit_bytes, observed_bytes)
@@ -1567,6 +1613,7 @@ def _raise_for_kill_reason(
             stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
             substitution=record_substitution,
+            failure_code="timeout",
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -1613,6 +1660,7 @@ def _raise_for_kill_reason(
             ),
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
             substitution=record_substitution,
+            failure_code="timeout",
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -1655,6 +1703,7 @@ def _raise_for_kill_reason(
             ),
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
             substitution=record_substitution,
+            failure_code="timeout",
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -2323,6 +2372,7 @@ def _invoke_with_runner_failover(
             stderr_excerpt=parse.stderr_excerpt,
             tokens=parse.tokens,
             substitution=substitution,
+            failure_code=parse.failure_code,
         )
         write_record(record)
 
@@ -2667,6 +2717,7 @@ def _invoke_impl(
         stderr_excerpt=parse.stderr_excerpt,
         tokens=parse.tokens,
         substitution=substitution,
+        failure_code=parse.failure_code,
     )
     write_record(record)
 

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -154,6 +154,18 @@ def _failure_metadata(
     outcome = str(getattr(result, "transport_outcome", "") or "").casefold()
     if outcome == "rate_limited" or bool(getattr(result, "rate_limited", False)):
         return {"phase": "provider", "code": "rate_limited", "retryable": True}
+    usage_record = getattr(result, "usage_record", None)
+    code = usage_record.get("failure_code") if isinstance(usage_record, dict) else None
+    if code == "protocol_output_limit":
+        return {"phase": "transport", "code": code, "retryable": False}
+    if code == "timeout":
+        return {"phase": "transport", "code": code, "retryable": True}
+    if code == "provider_unavailable":
+        return {"phase": "provider", "code": code, "retryable": True}
+    if code == "adapter_refused":
+        return {"phase": "admission", "code": code, "retryable": False}
+    if code == "transport_error":
+        return {"phase": "transport", "code": code, "retryable": False}
     return {"phase": "result_parse", "code": "result_invalid", "retryable": False}
 
 

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -25,9 +25,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agent_runtime.adapters.acpx import (
     ACPX_SUPPORTED_PARTICIPANTS,
+    GROK_CLI_COMPATIBILITY_CONTRACT,
     GROK_SHADOW_EFFORT,
     GROK_SHADOW_MODEL,
-    PINNED_GROK_VERSION,
     AcpxAdapter,
     AcpxGrokShadowAdapter,
 )
@@ -414,8 +414,13 @@ def acpx_shadow_overview(*, days: int = 7) -> dict[str, Any]:
         },
         "pins": {
             "acpx": ACPX_PINNED_VERSION,
-            "grok_cli": PINNED_GROK_VERSION,
             "validation": "before_spawn",
+        },
+        "compatibility": {
+            "grok_cli": {
+                "contract": GROK_CLI_COMPATIBILITY_CONTRACT,
+                "validation": "before_spawn",
+            },
         },
         "comparison_evidence": {
             "window_days": window_days,

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -24,15 +24,16 @@ from .config import BATCH_STATE_DIR
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agent_runtime.adapters.acpx import (
+    ACPX_CLI_COMPATIBILITY_CONTRACT,
     ACPX_SUPPORTED_PARTICIPANTS,
+    AGY_CLI_COMPATIBILITY_CONTRACT,
     GROK_CLI_COMPATIBILITY_CONTRACT,
     GROK_SHADOW_EFFORT,
     GROK_SHADOW_MODEL,
+    HERMES_CLI_COMPATIBILITY_CONTRACT,
+    OPENCODE_CLI_COMPATIBILITY_CONTRACT,
     AcpxAdapter,
     AcpxGrokShadowAdapter,
-)
-from agent_runtime.adapters.acpx import (
-    PINNED_VERSION as ACPX_PINNED_VERSION,
 )
 from agent_runtime.adapters.acpx import (
     TRANSPORT_ENV as ACPX_TRANSPORT_ENV,
@@ -56,6 +57,18 @@ USAGE_DIR = BATCH_STATE_DIR / "api_usage"
 _KNOWN_OUTCOMES = ("ok", "error", "timeout", "rate_limited")
 _RUNTIME_ATTRIBUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,99}$")
 _RUNTIME_ATTRIBUTION_SOURCES = frozenset({"explicit", "session_env", "unknown"})
+_RUNTIME_FAILURE_CODES = frozenset(
+    {
+        "adapter_refused",
+        "protocol_output_limit",
+        "provider_unavailable",
+        "rate_limited",
+        "result_invalid",
+        "timeout",
+        "transport_error",
+        "unknown",
+    }
+)
 _ACP_LEGACY_PARTICIPANTS = ("codex", "grok")
 _ACP_ENABLED_PARTICIPANTS = frozenset(ACPX_SUPPORTED_PARTICIPANTS)
 _ACP_STATES = frozenset({
@@ -412,14 +425,31 @@ def acpx_shadow_overview(*, days: int = 7) -> dict[str, Any]:
             "posture": "evidence_only",
             "writable": False,
         },
-        "pins": {
-            "acpx": ACPX_PINNED_VERSION,
-            "validation": "before_spawn",
-        },
         "compatibility": {
+            "acpx": {
+                "contract": ACPX_CLI_COMPATIBILITY_CONTRACT,
+                "validation": "before_spawn",
+                "version_policy": "telemetry_only",
+            },
+            "agy_cli": {
+                "contract": AGY_CLI_COMPATIBILITY_CONTRACT,
+                "validation": "before_spawn",
+                "version_policy": "telemetry_only",
+            },
             "grok_cli": {
                 "contract": GROK_CLI_COMPATIBILITY_CONTRACT,
                 "validation": "before_spawn",
+                "version_policy": "telemetry_only",
+            },
+            "hermes_cli": {
+                "contract": HERMES_CLI_COMPATIBILITY_CONTRACT,
+                "validation": "before_spawn",
+                "version_policy": "telemetry_only",
+            },
+            "opencode_cli": {
+                "contract": OPENCODE_CLI_COMPATIBILITY_CONTRACT,
+                "validation": "before_spawn",
+                "version_policy": "telemetry_only",
             },
         },
         "comparison_evidence": {
@@ -458,6 +488,15 @@ def recent_runtime_records(*, limit: int = 50) -> dict[str, Any]:
         source_task_id = record.get("attribution_task_id")
         if not isinstance(source_task_id, str) or not _RUNTIME_ATTRIBUTION_ID.fullmatch(source_task_id):
             source_task_id = None
+        failure_code = record.get("failure_code")
+        if failure_code not in _RUNTIME_FAILURE_CODES:
+            outcome = record.get("outcome")
+            if outcome in {"timeout", "hard_timeout", "stalled"}:
+                failure_code = "timeout"
+            elif outcome == "rate_limited":
+                failure_code = "rate_limited"
+            else:
+                failure_code = "unknown" if outcome not in {"ok", None} else None
         summaries.append({
             "ts": _isoformat_z(ts) if ts else record.get("ts"),
             "agent": record.get("agent"),
@@ -468,6 +507,7 @@ def recent_runtime_records(*, limit: int = 50) -> dict[str, Any]:
             "source_task_id": source_task_id,
             "model": record.get("model"),
             "outcome": record.get("outcome"),
+            "failure_code": failure_code,
             "duration_s": record.get("duration_s"),
         })
     summaries.sort(key=lambda item: _parse_iso_datetime(item.get("ts")) or datetime.min.replace(tzinfo=UTC), reverse=True)

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1039,13 +1039,23 @@ def test_parse_response_nonzero_exit_with_end_turn_still_fails():
 # ---------------------------------------------------------------------------
 
 
-def _stub_grok(monkeypatch, tmp_path: Path, *, version: str = "0.2.118") -> Path:
-    """Point the Grok seat at a fake absolute grok binary + version probe."""
+def _stub_grok(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    version: str = "0.2.118",
+    missing: tuple[str, ...] = (),
+) -> Path:
+    """Point the Grok seat at a fake binary + compatibility probe."""
     grok = tmp_path / "fake-grok-bin"
     grok.write_text("#!/bin/sh\necho stub-grok\n", encoding="utf-8")
     grok.chmod(0o755)
     monkeypatch.setattr(acpx_module, "_resolve_grok_binary", lambda: str(grok.resolve()))
-    monkeypatch.setattr(acpx_module, "_probe_grok_version", lambda _binary: version)
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_grok_cli_compatibility",
+        lambda _binary: (version, missing),
+    )
     return grok.resolve()
 
 
@@ -1228,23 +1238,41 @@ def test_grok_build_invocation_rejects_acpx_version_mismatch(tmp_path, monkeypat
         _build_grok(adapter, cwd=tmp_path)
 
 
-def test_grok_build_invocation_rejects_grok_version_mismatch(tmp_path, monkeypatch):
+def test_grok_build_invocation_accepts_rolling_cli_version(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
     _stub_binary(monkeypatch, tmp_path)
-    _stub_grok(monkeypatch, tmp_path, version="0.2.100")
+    _stub_grok(monkeypatch, tmp_path, version="0.3.7")
     adapter = AcpxGrokShadowAdapter()
 
-    with pytest.raises(AcpxShadowRefusalError, match="grok binary reports version"):
-        _build_grok(adapter, cwd=tmp_path)
+    plan = _build_grok(adapter, cwd=tmp_path)
+
+    assert plan.metadata["grok_cli_version"] == "0.3.7"
+    assert plan.metadata["grok_cli_compatibility"] == "agent-stdio-v1"
 
 
-def test_grok_build_invocation_rejects_unparseable_grok_version(tmp_path, monkeypatch):
+def test_grok_build_invocation_accepts_unknown_version_when_capabilities_pass(
+    tmp_path, monkeypatch
+):
     _shadow_env(monkeypatch)
     _stub_binary(monkeypatch, tmp_path)
-    _stub_grok(monkeypatch, tmp_path, version="")
+    _stub_grok(monkeypatch, tmp_path, version="unknown")
     adapter = AcpxGrokShadowAdapter()
 
-    with pytest.raises(AcpxShadowRefusalError, match="version"):
+    plan = _build_grok(adapter, cwd=tmp_path)
+
+    assert plan.metadata["grok_cli_version"] == "unknown"
+
+
+def test_grok_build_invocation_rejects_missing_cli_capability(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path)
+    _stub_grok(monkeypatch, tmp_path, version="0.3.7", missing=("--agent-profile",))
+    adapter = AcpxGrokShadowAdapter()
+
+    with pytest.raises(
+        AcpxShadowRefusalError,
+        match="missing capabilities: --agent-profile",
+    ):
         _build_grok(adapter, cwd=tmp_path)
 
 
@@ -1322,7 +1350,8 @@ def test_grok_build_invocation_accepts_none_or_fixed_model_and_effort(tmp_path, 
         assert plan.metadata["model"] == "grok-4.5"
         assert plan.metadata["effort"] == "high"
         assert plan.metadata["target_agent"] == "grok"
-        assert plan.metadata["grok_pinned_version"] == "0.2.118"
+        assert plan.metadata["grok_cli_version"] == "0.2.118"
+        assert plan.metadata["grok_cli_compatibility"] == "agent-stdio-v1"
         assert plan.metadata["acpx_pinned_version"] == "0.13.0"
 
 
@@ -1775,7 +1804,7 @@ def test_grok_profile_is_exact_and_digest_mismatch_fails_closed(tmp_path, monkey
         acpx_module._require_grok_profile()
 
 
-def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path):
+def test_probe_grok_version_parses_semver_or_returns_empty(monkeypatch, tmp_path):
     binary = tmp_path / "grok"
     binary.write_text("#!/bin/sh\n", encoding="utf-8")
     binary.chmod(0o755)
@@ -1791,7 +1820,6 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         "run",
         lambda *_a, **_k: _Proc("grok 0.2.118 (1e1687c1cf6a)\n"),
     )
-    acpx_module._probe_grok_version.cache_clear()
     assert acpx_module._probe_grok_version(str(binary)) == "0.2.118"
 
     monkeypatch.setattr(
@@ -1799,7 +1827,6 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
         "run",
         lambda *_a, **_k: _Proc("not a version string"),
     )
-    acpx_module._probe_grok_version.cache_clear()
     assert acpx_module._probe_grok_version(str(binary)) == ""
 
     monkeypatch.setattr(
@@ -1809,7 +1836,6 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
             "wrapper 9.9.9; grok 0.2.118 (1e1687c1cf6a)\n"
         ),
     )
-    acpx_module._probe_grok_version.cache_clear()
     assert acpx_module._probe_grok_version(str(binary)) == ""
 
     monkeypatch.setattr(
@@ -1821,12 +1847,55 @@ def test_probe_grok_version_parses_semver_and_fails_closed(monkeypatch, tmp_path
             returncode=1,
         ),
     )
-    acpx_module._probe_grok_version.cache_clear()
     assert acpx_module._probe_grok_version(str(binary)) == ""
 
     def _boom(*_a, **_k):
         raise OSError("missing")
 
     monkeypatch.setattr(acpx_module.subprocess, "run", _boom)
-    acpx_module._probe_grok_version.cache_clear()
     assert acpx_module._probe_grok_version(str(binary)) == ""
+
+
+def test_probe_grok_cli_compatibility_checks_required_command_surface(monkeypatch):
+    class _Proc:
+        def __init__(self, stdout: str, returncode: int = 0):
+            self.stdout = stdout
+            self.stderr = ""
+            self.returncode = returncode
+
+    agent_help = " ".join(acpx_module._GROK_REQUIRED_AGENT_FLAGS)
+
+    def _compatible(argv, **_kwargs):
+        if argv[-1] == "--version":
+            return _Proc("grok 0.3.7 (rolling)\n")
+        if argv[1:] == ["agent", "--help"]:
+            return _Proc(agent_help)
+        if argv[1:] == ["agent", "stdio", "--help"]:
+            return _Proc("Run the agent over stdio")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _compatible)
+    assert acpx_module._probe_grok_cli_compatibility("/tmp/grok") == ("0.3.7", ())
+
+    def _missing_profile(argv, **kwargs):
+        proc = _compatible(argv, **kwargs)
+        if argv[1:] == ["agent", "--help"]:
+            proc.stdout = agent_help.replace("--agent-profile", "")
+        return proc
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _missing_profile)
+    assert acpx_module._probe_grok_cli_compatibility("/tmp/grok") == (
+        "0.3.7",
+        ("--agent-profile",),
+    )
+
+    def _missing_stdio(argv, **kwargs):
+        if argv[1:] == ["agent", "stdio", "--help"]:
+            return _Proc("", returncode=2)
+        return _compatible(argv, **kwargs)
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _missing_stdio)
+    assert acpx_module._probe_grok_cli_compatibility("/tmp/grok") == (
+        "0.3.7",
+        ("agent stdio",),
+    )

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -158,8 +158,14 @@ _INVALID_USAGE_NDJSON = (
 )
 
 
-def _stub_binary(monkeypatch, tmp_path: Path, *, version: str = "0.13.0") -> Path:
-    """Point the adapter at a fake pinned binary + version probe.
+def _stub_binary(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    version: str = "0.13.0",
+    missing: tuple[str, ...] = (),
+) -> Path:
+    """Point the adapter at a fake local binary + compatibility probe.
 
     Avoids depending on the real npm-installed ``node_modules/.bin/acpx``
     being present in whatever environment runs this suite.
@@ -167,8 +173,12 @@ def _stub_binary(monkeypatch, tmp_path: Path, *, version: str = "0.13.0") -> Pat
     binary = tmp_path / "fake-acpx-bin"
     binary.write_text("#!/bin/sh\necho stub\n", encoding="utf-8")
     binary.chmod(0o755)
-    monkeypatch.setattr(acpx_module, "_PINNED_BINARY", binary)
-    monkeypatch.setattr(acpx_module, "_probe_acpx_version", lambda _binary: version)
+    monkeypatch.setattr(acpx_module, "_ACPX_BINARY", binary)
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_acpx_cli_compatibility",
+        lambda _binary, *, builtin_agent: (version, missing),
+    )
     return binary
 
 
@@ -254,7 +264,7 @@ def test_build_invocation_succeeds_when_flag_shadow(tmp_path, monkeypatch):
     adapter = AcpxAdapter()
 
     plan = _build(adapter, cwd=tmp_path)
-    assert plan.cmd[0] == str(acpx_module._PINNED_BINARY)
+    assert plan.cmd[0] == str(acpx_module._ACPX_BINARY)
 
 
 def test_build_invocation_active_requires_controller_scope(tmp_path, monkeypatch):
@@ -273,7 +283,7 @@ def test_build_invocation_active_requires_controller_scope(tmp_path, monkeypatch
 
     with acpx_module.active_discussion_scope():
         plan = _build(adapter, cwd=tmp_path, tool_config=tool_config)
-    assert plan.cmd[0] == str(acpx_module._PINNED_BINARY)
+    assert plan.cmd[0] == str(acpx_module._ACPX_BINARY)
 
 
 # ---------------------------------------------------------------------------
@@ -469,32 +479,41 @@ def test_build_invocation_never_uses_session_or_prompt_subcommand(tmp_path, monk
 
 
 # ---------------------------------------------------------------------------
-# Version pin
+# Rolling compatibility
 # ---------------------------------------------------------------------------
 
 
-def test_build_invocation_rejects_version_mismatch(tmp_path, monkeypatch):
+def test_build_invocation_accepts_compatible_future_version(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
-    _stub_binary(monkeypatch, tmp_path, version="0.12.1")
-    adapter = AcpxAdapter()
+    _stub_binary(monkeypatch, tmp_path, version="0.14.7")
 
-    with pytest.raises(AcpxShadowRefusalError, match="version"):
-        _build(adapter, cwd=tmp_path)
+    plan = _build(AcpxAdapter(), cwd=tmp_path)
+
+    assert plan.metadata["acpx_cli_version"] == "0.14.7"
+    assert plan.metadata["acpx_cli_compatibility"] == "json-one-shot-v1"
+
+
+def test_build_invocation_rejects_missing_acpx_capability(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path, version="0.14.7", missing=("--deny-all",))
+
+    with pytest.raises(AcpxShadowRefusalError, match="--deny-all"):
+        _build(AcpxAdapter(), cwd=tmp_path)
 
 
 def test_build_invocation_rejects_missing_binary(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
-    monkeypatch.setattr(acpx_module, "_PINNED_BINARY", tmp_path / "does-not-exist")
+    monkeypatch.setattr(acpx_module, "_ACPX_BINARY", tmp_path / "does-not-exist")
     adapter = AcpxAdapter()
 
-    with pytest.raises(AcpxShadowRefusalError, match="pinned binary not found"):
+    with pytest.raises(AcpxShadowRefusalError, match="project-local acpx binary not found"):
         _build(adapter, cwd=tmp_path)
 
 
 def _set_default_binary_candidate(monkeypatch, candidate: Path) -> None:
     """Make a test-local module candidate eligible for primary fallback."""
-    monkeypatch.setattr(acpx_module, "_DEFAULT_PINNED_BINARY", candidate)
-    monkeypatch.setattr(acpx_module, "_PINNED_BINARY", candidate)
+    monkeypatch.setattr(acpx_module, "_DEFAULT_ACPX_BINARY", candidate)
+    monkeypatch.setattr(acpx_module, "_ACPX_BINARY", candidate)
 
 
 def test_build_invocation_resolves_primary_pin_from_linked_worktree(tmp_path, monkeypatch):
@@ -509,7 +528,11 @@ def test_build_invocation_resolves_primary_pin_from_linked_worktree(tmp_path, mo
     primary_binary.write_text("#!/bin/sh\n", encoding="utf-8")
     primary_binary.chmod(0o755)
     monkeypatch.setattr(acpx_module, "resolve_main_root", lambda cwd: primary)
-    monkeypatch.setattr(acpx_module, "_probe_acpx_version", lambda _binary: "0.13.0")
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_acpx_cli_compatibility",
+        lambda _binary, *, builtin_agent: ("0.13.0", ()),
+    )
 
     plan = _build(AcpxAdapter(), cwd=worktree)
 
@@ -555,7 +578,7 @@ def test_build_invocation_refuses_when_primary_pin_is_missing(tmp_path, monkeypa
         _build(AcpxAdapter(), cwd=tmp_path)
 
 
-def test_build_invocation_rejects_primary_pin_version_mismatch(tmp_path, monkeypatch):
+def test_build_invocation_rejects_primary_binary_capability_drift(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
     candidate = tmp_path / "worktree" / "node_modules" / ".bin" / "acpx"
     primary = tmp_path / "primary"
@@ -565,19 +588,23 @@ def test_build_invocation_rejects_primary_pin_version_mismatch(tmp_path, monkeyp
     primary_binary.chmod(0o755)
     _set_default_binary_candidate(monkeypatch, candidate)
     monkeypatch.setattr(acpx_module, "resolve_main_root", lambda _cwd: primary)
-    monkeypatch.setattr(acpx_module, "_probe_acpx_version", lambda _binary: "0.12.1")
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_acpx_cli_compatibility",
+        lambda _binary, *, builtin_agent: ("0.14.0", ("exec --file",)),
+    )
 
-    with pytest.raises(AcpxShadowRefusalError, match="version"):
+    with pytest.raises(AcpxShadowRefusalError, match="exec --file"):
         _build(AcpxAdapter(), cwd=tmp_path)
 
 
-def test_build_invocation_rejects_unreadable_version_probe(tmp_path, monkeypatch):
+def test_build_invocation_accepts_unknown_version_when_capabilities_pass(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
-    _stub_binary(monkeypatch, tmp_path, version="")
-    adapter = AcpxAdapter()
+    _stub_binary(monkeypatch, tmp_path, version="unknown")
 
-    with pytest.raises(AcpxShadowRefusalError, match="version"):
-        _build(adapter, cwd=tmp_path)
+    plan = _build(AcpxAdapter(), cwd=tmp_path)
+
+    assert plan.metadata["acpx_cli_version"] == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -772,6 +799,7 @@ def test_parse_response_rejects_oversized_answer_before_authority_receipt():
     assert result.response == ""
     assert "parsed ACP response exceeds" in result.stderr_excerpt
     assert str(ACPX_PARSED_RESPONSE_LIMIT_BYTES) in result.stderr_excerpt
+    assert result.failure_code == "protocol_output_limit"
 
 
 def test_parse_response_multiple_stop_reason_results_fails_closed():
@@ -876,6 +904,7 @@ def test_parse_response_timeout_fails_closed():
     assert result.response == ""
     assert "TIMEOUT" in result.stderr_excerpt
     assert result.rate_limited is False
+    assert result.failure_code == "timeout"
 
 
 # ---------------------------------------------------------------------------
@@ -906,6 +935,7 @@ def test_parse_response_agent_disconnected_fails_closed():
     )
     assert result.ok is False
     assert result.response == ""
+    assert result.failure_code == "provider_unavailable"
     assert "AGENT_DISCONNECTED" in result.stderr_excerpt
 
 
@@ -1014,6 +1044,7 @@ def test_parse_response_auth_required_fails_closed():
     assert result.response == ""
     assert "AUTH_REQUIRED" in result.stderr_excerpt
     assert result.rate_limited is False
+    assert result.failure_code == "provider_unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -1133,7 +1164,7 @@ def test_grok_build_invocation_active_requires_controller_scope(tmp_path, monkey
 
     with acpx_module.active_discussion_scope():
         plan = _build_grok(adapter, cwd=tmp_path, tool_config=tool_config)
-    assert plan.cmd[0] == str(acpx_module._PINNED_BINARY)
+    assert plan.cmd[0] == str(acpx_module._ACPX_BINARY)
 
 
 def test_grok_build_invocation_requires_explicit_shadow_marker(tmp_path, monkeypatch):
@@ -1228,14 +1259,23 @@ def test_grok_build_invocation_refuses_primary_checkout(tmp_path, monkeypatch):
         _build_grok(adapter, cwd=tmp_path)
 
 
-def test_grok_build_invocation_rejects_acpx_version_mismatch(tmp_path, monkeypatch):
+def test_grok_build_invocation_accepts_compatible_acpx_version_drift(tmp_path, monkeypatch):
     _shadow_env(monkeypatch)
-    _stub_binary(monkeypatch, tmp_path, version="0.12.1")
+    _stub_binary(monkeypatch, tmp_path, version="0.14.0")
     _stub_grok(monkeypatch, tmp_path)
-    adapter = AcpxGrokShadowAdapter()
 
-    with pytest.raises(AcpxShadowRefusalError, match="version"):
-        _build_grok(adapter, cwd=tmp_path)
+    plan = _build_grok(AcpxGrokShadowAdapter(), cwd=tmp_path)
+
+    assert plan.metadata["acpx_cli_version"] == "0.14.0"
+
+
+def test_grok_build_invocation_rejects_missing_acpx_capability(tmp_path, monkeypatch):
+    _shadow_env(monkeypatch)
+    _stub_binary(monkeypatch, tmp_path, missing=("--agent",))
+    _stub_grok(monkeypatch, tmp_path)
+
+    with pytest.raises(AcpxShadowRefusalError, match="--agent"):
+        _build_grok(AcpxGrokShadowAdapter(), cwd=tmp_path)
 
 
 def test_grok_build_invocation_accepts_rolling_cli_version(tmp_path, monkeypatch):
@@ -1284,7 +1324,7 @@ def test_grok_build_invocation_fixed_command_and_ordering(tmp_path, monkeypatch)
 
     plan = _build_grok(adapter, cwd=tmp_path, prompt="shadow compare prompt")
 
-    assert plan.cmd[0] == str(acpx_module._PINNED_BINARY)
+    assert plan.cmd[0] == str(acpx_module._ACPX_BINARY)
     assert Path(plan.cmd[0]).is_absolute() or plan.cmd[0].startswith(str(tmp_path))
     assert "grok-build" not in plan.cmd
     assert "codex" not in plan.cmd
@@ -1352,7 +1392,8 @@ def test_grok_build_invocation_accepts_none_or_fixed_model_and_effort(tmp_path, 
         assert plan.metadata["target_agent"] == "grok"
         assert plan.metadata["grok_cli_version"] == "0.2.118"
         assert plan.metadata["grok_cli_compatibility"] == "agent-stdio-v1"
-        assert plan.metadata["acpx_pinned_version"] == "0.13.0"
+        assert plan.metadata["acpx_cli_version"] == "0.13.0"
+        assert plan.metadata["acpx_cli_compatibility"] == "json-one-shot-v1"
 
 
 def test_grok_build_invocation_auth_env_sets_cached_token_and_scrubs_xai_keys(
@@ -1657,8 +1698,8 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
     monkeypatch.setattr(acpx_module.shutil, "which", lambda name: binaries.get(name))
     monkeypatch.setattr(
         acpx_module,
-        "_probe_participant_cli_version",
-        lambda _path, _executable: version,
+        "_probe_participant_cli_compatibility",
+        lambda _path, _executable: (version, ()),
     )
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
     for name in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "JENKINS_URL"):
@@ -1689,7 +1730,12 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
     assert provider_binary in " ".join(command_tokens)
     assert plan.cmd[-3:] == ["exec", "-f", "-"]
     assert plan.metadata["model"] == model
-    assert plan.metadata["provider_cli_pinned_version"] == version
+    assert plan.metadata["provider_cli_version"] == version
+    assert plan.metadata["provider_cli_compatibility"] == {
+        "agy": "text-plan-sandbox-v1",
+        "glm": "native-acp-pure-v1",
+        "deepseek": "text-oneshot-isolated-v1",
+    }[participant]
     assert "--deny-all" in plan.cmd
     assert "--no-fs" in plan.cmd
     assert "--no-terminal" in plan.cmd
@@ -1712,7 +1758,7 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
         assert plan.env_overrides == {}
 
 
-def test_new_fleet_discussion_seat_rejects_provider_cli_version_drift(tmp_path, monkeypatch):
+def test_new_fleet_discussion_seat_accepts_provider_cli_version_drift(tmp_path, monkeypatch):
     _stub_binary(monkeypatch, tmp_path)
     agy = tmp_path / "agy"
     node = tmp_path / "node"
@@ -1726,13 +1772,51 @@ def test_new_fleet_discussion_seat_rejects_provider_cli_version_drift(tmp_path, 
     )
     monkeypatch.setattr(
         acpx_module,
-        "_probe_participant_cli_version",
-        lambda _path, _executable: "9.9.9",
+        "_probe_participant_cli_compatibility",
+        lambda _path, _executable: ("9.9.9", ()),
+    )
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+
+    with acpx_module.active_discussion_scope():
+        plan = AcpxAgyShadowAdapter().build_invocation(
+            prompt="ping",
+            mode="read-only",
+            cwd=tmp_path,
+            model="gemini-3.6-flash-high",
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": "agy",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+    assert plan.metadata["provider_cli_version"] == "9.9.9"
+
+
+def test_new_fleet_discussion_seat_rejects_missing_provider_capability(tmp_path, monkeypatch):
+    _stub_binary(monkeypatch, tmp_path)
+    agy = tmp_path / "agy"
+    node = tmp_path / "node"
+    for path in (agy, node):
+        path.write_text("#!/bin/sh\n", encoding="utf-8")
+        path.chmod(0o755)
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str({"agy": agy, "node": node}[name]),
+    )
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_participant_cli_compatibility",
+        lambda _path, _executable: ("2.0.0", ("--sandbox",)),
     )
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
 
     with acpx_module.active_discussion_scope(), pytest.raises(
-        AcpxShadowRefusalError, match="version mismatch"
+        AcpxShadowRefusalError, match="--sandbox"
     ):
         AcpxAgyShadowAdapter().build_invocation(
             prompt="ping",
@@ -1760,6 +1844,83 @@ def test_participant_version_probe_accepts_v_prefix_before_build_stamp(tmp_path)
     binary.chmod(0o755)
 
     assert acpx_module._probe_participant_cli_version(str(binary), "hermes") == "0.18.2"
+
+
+def test_acpx_compatibility_probe_checks_global_and_builtin_exec_surfaces(monkeypatch):
+    class _Proc:
+        def __init__(self, stdout: str, returncode: int = 0):
+            self.stdout = stdout
+            self.stderr = ""
+            self.returncode = returncode
+
+    root_help = " ".join((*acpx_module._ACPX_REQUIRED_GLOBAL_FLAGS, "codex participant"))
+
+    def _compatible(argv, **_kwargs):
+        if argv[-1] == "--version":
+            return _Proc("0.14.7\n")
+        if argv[1:] == ["--help"]:
+            return _Proc(root_help)
+        if argv[1:] == ["codex", "exec", "--help"]:
+            return _Proc("one-shot --file input")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _compatible)
+    assert acpx_module._probe_acpx_cli_compatibility(
+        "/tmp/acpx", builtin_agent="codex"
+    ) == ("0.14.7", ())
+
+    def _missing_json_strict(argv, **kwargs):
+        proc = _compatible(argv, **kwargs)
+        if argv[1:] == ["--help"]:
+            proc.stdout = root_help.replace("--json-strict", "")
+        return proc
+
+    monkeypatch.setattr(acpx_module.subprocess, "run", _missing_json_strict)
+    assert acpx_module._probe_acpx_cli_compatibility(
+        "/tmp/acpx", builtin_agent="codex"
+    ) == ("0.14.7", ("--json-strict",))
+
+
+@pytest.mark.parametrize(
+    ("executable", "help_args", "required_flag"),
+    [
+        ("agy", (), "--sandbox"),
+        ("opencode", ("acp",), "--pure"),
+        ("hermes", (), "--ignore-rules"),
+    ],
+)
+def test_participant_compatibility_probes_exact_invoked_surface(
+    monkeypatch, executable, help_args, required_flag
+):
+    required = {
+        "agy": acpx_module._AGY_REQUIRED_FLAGS,
+        "opencode": acpx_module._OPENCODE_REQUIRED_ACP_FLAGS,
+        "hermes": acpx_module._HERMES_REQUIRED_FLAGS,
+    }[executable]
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_participant_cli_version",
+        lambda _binary, _executable: "9.9.9",
+    )
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_cli_help",
+        lambda _binary, *args: " ".join(required) if args == help_args else "",
+    )
+
+    assert acpx_module._probe_participant_cli_compatibility(
+        f"/tmp/{executable}", executable
+    ) == ("9.9.9", ())
+
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_cli_help",
+        lambda _binary, *args: "usage "
+        + " ".join(flag for flag in required if flag != required_flag),
+    )
+    assert acpx_module._probe_participant_cli_compatibility(
+        f"/tmp/{executable}", executable
+    ) == ("9.9.9", (required_flag,))
 
 
 def test_text_agent_digest_mismatch_refuses_before_spawn(tmp_path, monkeypatch):

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.adapters.claude import ClaudeAdapter
 from ai_agent_bridge import _channels, _channels_cli, _cli, _db
-from ai_agent_bridge._acp_compat import _discussion_failure_metadata
+from ai_agent_bridge._acp_compat import _discussion_failure_metadata, _failure_metadata
 
 
 def _clear_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -122,6 +122,28 @@ def test_discussion_timeout_maps_to_body_free_retryable_failure() -> None:
 
     assert failure == {"phase": "transport", "code": "timeout", "retryable": True}
     assert "response" not in str(failure)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("protocol_output_limit", {"phase": "transport", "code": "protocol_output_limit", "retryable": False}),
+        ("timeout", {"phase": "transport", "code": "timeout", "retryable": True}),
+        ("provider_unavailable", {"phase": "provider", "code": "provider_unavailable", "retryable": True}),
+        ("result_invalid", {"phase": "result_parse", "code": "result_invalid", "retryable": False}),
+    ],
+)
+def test_acp_result_preserves_only_closed_failure_code(code, expected) -> None:
+    result = SimpleNamespace(
+        transport_outcome="error",
+        rate_limited=False,
+        usage_record={"failure_code": code, "stderr_excerpt": "must not persist"},
+    )
+
+    failure = _failure_metadata(result=result)
+
+    assert failure == expected
+    assert "stderr" not in str(failure)
 
 
 def test_ask_codex_without_from_fails_when_sender_cannot_be_inferred(

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -261,6 +261,7 @@ def test_acpx_pilot_usage_records_strip_sensitive_context(
         stalled=False,
         stderr_excerpt="secret stderr",
         tokens=3,
+        failure_code="result_invalid",
     )
 
     for key in (
@@ -280,6 +281,7 @@ def test_acpx_pilot_usage_records_strip_sensitive_context(
     assert record["outcome"] == "error"
     assert record["duration_s"] == 1.25
     assert record["tokens"] == 3
+    assert record["failure_code"] == "result_invalid"
 
 
 def test_usage_attribution_is_explicit_and_privacy_safe(monkeypatch):
@@ -4420,3 +4422,29 @@ def test_acp_routes_share_a_bounded_protocol_envelope(agent_name):
         agent_name=agent_name,
         entrypoint="acpx-discuss",
     ) == 16 * 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    ("outcome", "rate_limited", "stalled", "explicit", "returncode", "expected"),
+    [
+        ("ok", False, False, None, 0, None),
+        ("error", False, False, "protocol_output_limit", -9, "protocol_output_limit"),
+        ("hard_timeout", False, False, None, -9, "timeout"),
+        ("error", False, False, "result_invalid", 1, "result_invalid"),
+        ("error", False, False, "provider_unavailable", None, "provider_unavailable"),
+        ("error", False, False, None, 1, "transport_error"),
+        ("rate_limited", True, False, None, 1, "rate_limited"),
+    ],
+)
+def test_privacy_safe_acp_failure_code_is_closed_and_body_free(
+    outcome, rate_limited, stalled, explicit, returncode, expected
+):
+    from agent_runtime import runner as runtime_runner
+
+    assert runtime_runner._privacy_safe_failure_code(
+        outcome=outcome,
+        rate_limited=rate_limited,
+        stalled=stalled,
+        returncode=returncode,
+        explicit_code=explicit,
+    ) == expected

--- a/tests/test_agent_runtime_acp_transport_cutover.py
+++ b/tests/test_agent_runtime_acp_transport_cutover.py
@@ -197,8 +197,8 @@ def test_adapter_transport_metadata_and_auth_selector_are_non_secret(tmp_path, m
     monkeypatch.setattr(acpx_module, "_require_non_primary_worktree", lambda *_a, **_k: None)
     monkeypatch.setattr(
         acpx_module,
-        "_require_pinned_acpx_binary",
-        lambda **_kwargs: str(tmp_path / "acpx"),
+        "_require_compatible_acpx_binary",
+        lambda **_kwargs: (str(tmp_path / "acpx"), "0.13.0"),
     )
 
     with acpx_module.active_communication_scope(
@@ -239,8 +239,8 @@ def test_adapter_extra_metadata_cannot_override_runner_sealed_provenance(tmp_pat
     monkeypatch.setattr(acpx_module, "_require_non_primary_worktree", lambda *_a, **_k: None)
     monkeypatch.setattr(
         acpx_module,
-        "_require_pinned_acpx_binary",
-        lambda **_kwargs: str(tmp_path / "acpx"),
+        "_require_compatible_acpx_binary",
+        lambda **_kwargs: (str(tmp_path / "acpx"), "0.13.0"),
     )
 
     class SpoofingAdapter(AcpxKimiShadowAdapter):

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -373,7 +373,8 @@ def test_acpx_second_pilot_grok_evidence_and_boundary(onboarding: str, all_owned
     assert "minutes=120" in onboarding
     assert "not permanent routing weights" in lower
     assert "not a new coordination plane" in lower or "not** a new coordination plane" in lower
-    assert "0.2.118" in onboarding
+    assert "agent-stdio-v1" in onboarding
+    assert "observed" in lower and "not an allowlist" in lower
     assert "grok-4.5" in onboarding
     assert "--no-leader" in onboarding
     assert "--agent-profile" in onboarding

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -136,7 +136,9 @@ def test_runtime_page_renders_read_only_acpx_shadow_transport_overview():
     assert "Native runtime authoritative" in html
     assert "ACPX evidence is observational only." in html
     assert "No shadow calls or comparisons in window" in html
-    assert "ACPX pin" in html
+    assert "ACPX contract" in html
+    assert "AGY contract" in html
+    assert "OpenCode contract" in html
     assert "No dispatch authority" in html
     assert 'class="acpx-rail"' in html
     assert "@media (max-width: 820px)" in html

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -247,8 +247,13 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
     }
     assert data["pins"] == {
         "acpx": "0.13.0",
-        "grok_cli": "0.2.118",
         "validation": "before_spawn",
+    }
+    assert data["compatibility"] == {
+        "grok_cli": {
+            "contract": "agent-stdio-v1",
+            "validation": "before_spawn",
+        }
     }
     assert data["safety"]["max_in_flight"] == 1
     assert data["safety"]["explicit_pilot_only"] is True

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -245,15 +245,32 @@ def test_acpx_overview_is_read_only_and_aggregates_hyphenated_seats(
         "posture": "evidence_only",
         "writable": False,
     }
-    assert data["pins"] == {
-        "acpx": "0.13.0",
-        "validation": "before_spawn",
-    }
     assert data["compatibility"] == {
+        "acpx": {
+            "contract": "json-one-shot-v1",
+            "validation": "before_spawn",
+            "version_policy": "telemetry_only",
+        },
+        "agy_cli": {
+            "contract": "text-plan-sandbox-v1",
+            "validation": "before_spawn",
+            "version_policy": "telemetry_only",
+        },
         "grok_cli": {
             "contract": "agent-stdio-v1",
             "validation": "before_spawn",
-        }
+            "version_policy": "telemetry_only",
+        },
+        "hermes_cli": {
+            "contract": "text-oneshot-isolated-v1",
+            "validation": "before_spawn",
+            "version_policy": "telemetry_only",
+        },
+        "opencode_cli": {
+            "contract": "native-acp-pure-v1",
+            "validation": "before_spawn",
+            "version_policy": "telemetry_only",
+        },
     }
     assert data["safety"]["max_in_flight"] == 1
     assert data["safety"]["explicit_pilot_only"] is True
@@ -819,10 +836,12 @@ def test_recent_limits_results(tmp_path, monkeypatch):
     assert records[0]["outcome"] == "timeout"
     assert records[0]["source"] == "unknown"
     assert records[0]["via"] == "dispatch"
+    assert records[0]["failure_code"] == "timeout"
     assert records[1]["agent"] == "gemini"
     assert records[1]["source"] == "codex"
     assert records[1]["source_provenance"] == "explicit"
     assert records[1]["source_task_id"] == "review-6159"
+    assert records[1]["failure_code"] is None
 
 
 def test_runtime_page_labels_caller_source_separately_from_transport():
@@ -831,8 +850,10 @@ def test_runtime_page_labels_caller_source_separately_from_transport():
     assert "<th>Source</th>" in html
     assert "<th>Agent</th>" in html
     assert "<th>Via</th>" in html
+    assert "<th>Failure</th>" in html
     assert "record.source || 'unknown'" in html
     assert "record.via || record.entrypoint" in html
+    assert "record.failure_code || '—'" in html
 
 
 def test_transport_health_returns_sanitized_cached_probe(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #6249

Replaces exact runtime version gates across ACPX, AGY, OpenCode, Hermes, and Grok with before-spawn checks of the exact command surfaces each seat invokes. Versions remain telemetry only; package-lock remains reproducible while package.json permits compatible ACPX refreshes from 0.13.0 onward.

Also adds a closed body-free failure_code to privacy-limited runtime telemetry and the Runtime dashboard, so protocol limits, timeouts, provider availability, parse failures, and transport failures are distinguishable without exposing prompts or stderr.

Kimi and GLM independently reviewed the design through ACP conversation conversation_1cf37ff3bd7e4c57bf80c163b2f2bfc6. Fresh exact-head formal review and final verification will be attached after the expanded changes are pushed.