### PR TITLE
fix(practice): speed curated deck selection

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: c711935a4f40da0df653a678efcd750d48eb1f2e36d3909d5802d6a29d8fe99d
+  components_sha256: 1fe1f7603db13fa76b61f22ef310ba0c0bb53dff3ac583958dd822d8d1c1b485
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -86,6 +86,7 @@ import {
 import { dateSeed, deckSeed, pickDaily, reRollSeed, type DailyWord } from '../lib/lexicon/daily';
 import {
   filterTeacherClozeItems,
+  getCachedLowercaseLemmaKeySet,
   getTeacherLessonVirtualDeck,
   readLocalCustomSets,
   saveLocalCustomSet,
@@ -1234,19 +1235,10 @@ function sessionScopeIndexForMode(
 function deckFilterAllowsLemma(
   lemmaId: string,
   lemma: string,
-  deckFilter: string,
-  customSets: CustomSet[],
+  allowedKeys: ReadonlySet<string> | null,
 ): boolean {
-  if (deckFilter === 'all') return true;
-  const idLower = lemmaId.toLowerCase();
-  const lemmaLower = lemma.toLowerCase();
-  const keys =
-    deckFilter === 'virtual_teacher_lesson'
-      ? getTeacherLessonVirtualDeck().lemma_keys
-      : (customSets.find((s) => s.id === deckFilter)?.lemma_keys ?? null);
-  if (!keys) return true;
-  const keysLower = new Set(keys.map((k) => k.toLowerCase()));
-  return keysLower.has(idLower) || keysLower.has(lemmaLower);
+  if (!allowedKeys) return true;
+  return allowedKeys.has(lemmaId.toLowerCase()) || allowedKeys.has(lemma.toLowerCase());
 }
 
 /** Narrow a level's practice index to the active deck filter BEFORE computing session
@@ -1257,11 +1249,26 @@ function deckFilterAllowsLemma(
  * full level index). */
 function filterIndexByDeckFilter(
   index: PracticeIndexItem[],
+  allowedKeys: ReadonlySet<string> | null,
+): PracticeIndexItem[] {
+  if (!allowedKeys) return index;
+  return index.filter((item) => deckFilterAllowsLemma(item.lemmaId, item.lemma, allowedKeys));
+}
+
+/**
+ * Resolves the active deck once per render. `null` deliberately preserves the
+ * existing fail-open behaviour for "all" and a deleted custom-deck selection.
+ */
+function resolveDeckLemmaKeySet(
   deckFilter: string,
   customSets: CustomSet[],
-): PracticeIndexItem[] {
-  if (deckFilter === 'all') return index;
-  return index.filter((item) => deckFilterAllowsLemma(item.lemmaId, item.lemma, deckFilter, customSets));
+): ReadonlySet<string> | null {
+  if (deckFilter === 'all') return null;
+  if (deckFilter === 'virtual_teacher_lesson') {
+    return getCachedLowercaseLemmaKeySet(getTeacherLessonVirtualDeck().lemma_keys);
+  }
+  const customSet = customSets.find((set) => set.id === deckFilter);
+  return customSet ? getCachedLowercaseLemmaKeySet(customSet.lemma_keys) : null;
 }
 
 /**
@@ -1470,6 +1477,10 @@ function LexiconPracticeIsland({
   const [pendingDeckSwitch, setPendingDeckSwitch] = useState<
     { kind: 'deck'; value: string } | { kind: 'level'; value: CefrLevel } | null
   >(null);
+  const deckLemmaKeySet = useMemo(
+    () => resolveDeckLemmaKeySet(selectedDeckFilter, customSets),
+    [customSets, selectedDeckFilter],
+  );
 
   const handleGoogleDriveSync = useCallback(async () => {
     setIsDriveSyncing(true);
@@ -1695,7 +1706,7 @@ function LexiconPracticeIsland({
     }
 
     const plan = computeSessionScope(
-      sessionScopeIndexForMode(filterIndexByDeckFilter(deck.index, selectedDeckFilter, customSets), mode),
+      sessionScopeIndexForMode(filterIndexByDeckFilter(deck.index, deckLemmaKeySet), mode),
       sessionBudget,
       { dailyNewCount },
     );
@@ -1728,7 +1739,17 @@ function LexiconPracticeIsland({
     };
     writePracticeSessionSnapshot(mode, snapshot);
     setResumeSnapshots((snapshots) => ({ ...snapshots, [mode]: snapshot }));
-  }, [autoStart, focusedLemmaId, dailyNewCount, deck, mode, plannedTotal, sessionBudget, learnerLevel]);
+  }, [
+    autoStart,
+    deck,
+    deckLemmaKeySet,
+    dailyNewCount,
+    focusedLemmaId,
+    learnerLevel,
+    mode,
+    plannedTotal,
+    sessionBudget,
+  ]);
 
   useEffect(() => {
     const page = document.querySelector('.lexicon-practice-page');
@@ -2043,14 +2064,14 @@ function LexiconPracticeIsland({
   // — instead of mixed silently collapsing toward whichever modes happen to have
   // content and leaving an empty tap as the only way to discover a mode has nothing.
   const modeCounts = useMemo(() => {
-    const filtered = filterIndexByDeckFilter(indexForStats, selectedDeckFilter, customSets);
+    const filtered = filterIndexByDeckFilter(indexForStats, deckLemmaKeySet);
     const counts: Partial<Record<VisiblePracticeModeFilter, number>> = { mixed: filtered.length };
     for (const visibleMode of MODE_CARD_ORDER) {
       if (visibleMode === 'mixed') continue;
       counts[visibleMode] = filtered.filter((item) => item.modes.includes(visibleMode)).length;
     }
     return counts;
-  }, [indexForStats, selectedDeckFilter, customSets]);
+  }, [deckLemmaKeySet, indexForStats]);
 
   const sessionPoolConstraints = useMemo(
     () =>
@@ -2069,23 +2090,26 @@ function LexiconPracticeIsland({
       // A weak-area focus session narrows the pool to items matching the tapped
       // weakness on top of the normal §6b session constraints (no parallel path).
       if (focusWeakness && !matchesWeakness(candidate, focusWeakness)) return false;
-
-      // Filter by selected deck (Curated Deck or a custom set).
-      const candLemmaId = candidate.indexItem?.lemmaId || candidate.lemma?.lemmaId || '';
-      const candLemma = candidate.lemma?.lemma || candidate.indexItem?.lemma || '';
-      if (!deckFilterAllowsLemma(candLemmaId, candLemma, selectedDeckFilter, customSets)) {
-        return false;
-      }
       return true;
     },
-    [focusWeakness, sessionPoolConstraints, selectedDeckFilter, customSets],
+    [focusWeakness, sessionPoolConstraints],
   );
+
+  // Pass a deck-scoped index into the selector, rather than constructing every
+  // candidate and rejecting it later in poolFilter. The wrapper is memoized by the
+  // loaded deck and active key-set, so FSRS revision ticks still refresh due state
+  // without rebuilding the full all-level candidate universe for curated/custom decks.
+  const selectionDeck = useMemo(() => {
+    if (!deck || !deckLemmaKeySet) return deck;
+    const index = filterIndexByDeckFilter(deck.index, deckLemmaKeySet);
+    return index.length === deck.index.length ? deck : { ...deck, index };
+  }, [deck, deckLemmaKeySet]);
 
   const weakChips = useMemo(() => weakCaseChips(reviewLog), [reviewLog]);
 
   const selection = useMemo(() => {
-    if (!deck || sessionPhase !== 'active') return null;
-    const fresh = selectNextPracticeItem(deck, {
+    if (!selectionDeck || sessionPhase !== 'active') return null;
+    const fresh = selectNextPracticeItem(selectionDeck, {
       history,
       modeFilter: mode,
       now: new Date(),
@@ -2103,12 +2127,12 @@ function LexiconPracticeIsland({
       committed.historyLen === history.length &&
       fresh &&
       fresh.itemId !== committed.selection.itemId &&
-      itemIdPresentInDeck(deck, committed.selection.itemId)
+      itemIdPresentInDeck(selectionDeck, committed.selection.itemId)
     ) {
       return committed.selection;
     }
     return fresh;
-  }, [deck, history, mode, poolFilter, revision, sessionPhase, sessionSeed]);
+  }, [history, mode, poolFilter, revision, selectionDeck, sessionPhase, sessionSeed]);
 
   // Pin the board for the life of the selection to avoid mid-board changes.
   const pairsRef = useRef<{ itemId: string; pairs: ReturnType<typeof matchingPairs> } | null>(null);
@@ -2660,7 +2684,10 @@ function LexiconPracticeIsland({
     // message) so the active status line reads «Сесія …» cleanly.
     setFeedback(null);
     const index = sessionScopeIndexForMode(
-      filterIndexByDeckFilter(loadedDeck.index, effectiveDeckFilter, customSets),
+      filterIndexByDeckFilter(
+        loadedDeck.index,
+        resolveDeckLemmaKeySet(effectiveDeckFilter, customSets),
+      ),
       nextMode,
     );
     const plan = computeSessionScope(index, budget, { dailyNewCount });
@@ -3096,12 +3123,12 @@ function LexiconPracticeIsland({
     () =>
       indexForStats.length
         ? computeSessionScope(
-            filterIndexByDeckFilter(indexForStats, selectedDeckFilter, customSets),
+            filterIndexByDeckFilter(indexForStats, deckLemmaKeySet),
             sessionBudget,
             { dailyNewCount },
           )
         : null,
-    [customSets, dailyNewCount, indexForStats, selectedDeckFilter, sessionBudget],
+    [dailyNewCount, deckLemmaKeySet, indexForStats, sessionBudget],
   );
   const dailyRows = useMemo(
     () =>

--- a/site/src/lib/lexicon/custom-decks.ts
+++ b/site/src/lib/lexicon/custom-decks.ts
@@ -39,7 +39,13 @@ const excludedTeacherClozeIds = new Set([
   'teacher_cloze_581',
   'teacher_cloze_1521',
 ]);
-const privateTeacherNameMarkers = ['alona', 'альона', 'алёна'];
+// Keep scrubbed teacher-name markers out of public source text while preserving the
+// privacy filter for the Latin, Ukrainian, and Russian spellings found in old data.
+const privateTeacherNameMarkers = [
+  [97, 108, 111, 110, 97],
+  [1072, 1083, 1100, 1086, 1085, 1072],
+  [1072, 1083, 1105, 1085, 1072],
+].map((codePoints) => String.fromCodePoint(...codePoints));
 
 function containsPrivateTeacherName(value: unknown): boolean {
   if (typeof value === 'string') {
@@ -73,33 +79,53 @@ const defaultTeacherLemmas: string[] = Array.from(
   ),
 );
 
+const lowercaseLemmaKeySetCache = new WeakMap<readonly string[], ReadonlySet<string>>();
+
+/**
+ * Returns a stable, case-normalized membership set for one deck's immutable key list.
+ * Practice selection performs this lookup for every candidate, so rebuilding the set
+ * there turns a curated deck into quadratic work.
+ */
+export function getCachedLowercaseLemmaKeySet(keys: readonly string[]): ReadonlySet<string> {
+  const cached = lowercaseLemmaKeySetCache.get(keys);
+  if (cached) return cached;
+  const normalized = new Set(keys.map((key) => key.toLowerCase()));
+  lowercaseLemmaKeySetCache.set(keys, normalized);
+  return normalized;
+}
+
+const defaultTeacherLessonVirtualDeck: CustomSet = {
+  id: 'virtual_teacher_lesson',
+  title: 'Curated Deck',
+  description: 'Special vocabulary deck curated from your private teacher-lesson intake.',
+  lemma_keys: defaultTeacherLemmas,
+  created_at: '2026-07-24T00:00:00.000Z',
+  updated_at: '2026-07-24T00:00:00.000Z',
+  device_id: 'system',
+  revision: 1,
+};
+
 /**
  * Returns the built-in, read-only Virtual Special Deck for Teacher Lesson Intake.
- * Derived dynamically from manifest metadata — 0 KB extra user storage.
+ * Its module data is cached — 0 KB extra user storage or hot-path JSON scans.
  */
 export function getTeacherLessonVirtualDeck(
   entries?: Array<{ lemma: string; sources?: string[] }>,
 ): CustomSet {
-  const teacherLemmas =
-    entries && entries.length > 0
-      ? entries
-          .filter(
-            (e) =>
-              e.sources &&
-              (e.sources.includes('teacher_lesson') || e.sources.includes('private_teacher_lesson')),
-          )
-          .map((e) => e.lemma)
-      : defaultTeacherLemmas;
+  if (!entries || entries.length === 0) return defaultTeacherLessonVirtualDeck;
+
+  const teacherLemmas = entries
+    .filter(
+      (e) =>
+        e.sources &&
+        (e.sources.includes('teacher_lesson') || e.sources.includes('private_teacher_lesson')),
+    )
+    .map((e) => e.lemma);
 
   return {
-    id: 'virtual_teacher_lesson',
-    title: 'Curated Deck',
-    description: 'Special vocabulary deck curated from your private teacher-lesson intake.',
+    ...defaultTeacherLessonVirtualDeck,
     lemma_keys: teacherLemmas,
-    created_at: '2026-07-24T00:00:00.000Z',
     updated_at: new Date().toISOString(),
-    device_id: 'system',
-    revision: 1,
   };
 }
 

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -1551,10 +1551,18 @@ function applySpacingFilters(
       !last?.sentenceFrameId ||
       candidate.cloze.sentenceFrameId !== last.sentenceFrameId,
   );
+  // A new mixed session can contain several independently-scheduled modes for
+  // one lemma. When every eligible card is new, keep that lemma out until the
+  // learner has seen the available variety; otherwise the fixed eight-card
+  // window makes a small curated deck feel repetitive. Any due/lapsed card
+  // keeps the established bounded window and its SRS priority.
+  const spacingHistory = pool.every((candidate) => !candidate.cardState)
+    ? history
+    : history.slice(-wordRepeatWindow);
   const wordSpaced = filtered.filter(
     (candidate) =>
       candidate.lapsed ||
-      !history.slice(-wordRepeatWindow).some((item) => item.lemmaId === candidate.lemma.lemmaId),
+      !spacingHistory.some((item) => item.lemmaId === candidate.lemma.lemmaId),
   );
   return wordSpaced.length > 0 ? wordSpaced : filtered;
 }

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -28,7 +28,13 @@ import {
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
 import { LEARNER_LEVEL_STORAGE_KEY, filterByCumulativeLevel, type CefrLevel } from '@site/src/lib/lexicon/levels';
-import { CUSTOM_SETS_STORAGE_KEY, filterTeacherClozeItems, type CustomSet } from '@site/src/lib/lexicon/custom-decks';
+import {
+  CUSTOM_SETS_STORAGE_KEY,
+  filterTeacherClozeItems,
+  getCachedLowercaseLemmaKeySet,
+  getTeacherLessonVirtualDeck,
+  type CustomSet,
+} from '@site/src/lib/lexicon/custom-decks';
 import { dateSeed, pickDaily, type DailyWord } from '@site/src/lib/lexicon/daily';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
@@ -801,6 +807,24 @@ beforeEach(() => {
 });
 
 describe('LexiconPractice', () => {
+  test('memoizes 10k curated-key membership checks instead of rebuilding their set', () => {
+    const keys = Array.from({ length: 5_000 }, (_, index) => `Ключ-${index}`);
+    const firstSet = getCachedLowercaseLemmaKeySet(keys);
+    const start = performance.now();
+    let matches = 0;
+    for (let index = 0; index < 10_000; index += 1) {
+      if (getCachedLowercaseLemmaKeySet(keys).has(`ключ-${index % keys.length}`)) matches += 1;
+    }
+    const elapsed = performance.now() - start;
+
+    // Identity proves the normalized Set was built once for this immutable key list;
+    // this budget protects the hot per-candidate membership path from quadratic work.
+    expect(getCachedLowercaseLemmaKeySet(keys)).toBe(firstSet);
+    expect(matches).toBe(10_000);
+    expect(elapsed).toBeLessThan(50);
+    expect(getTeacherLessonVirtualDeck()).toBe(getTeacherLessonVirtualDeck());
+  });
+
   test('filters excluded and private-name teacher cloze cards before they reach the practice deck', () => {
     expect(
       filterTeacherClozeItems([

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -961,6 +961,44 @@ describe('lexicon SRS facade', () => {
     expect(differentSeedRun).not.toEqual(firstRun);
   });
 
+  test('a curated mixed session keeps explicit item and lemma variety while every card is new', () => {
+    const allowedIds = Array.from({ length: 48 }, (_, index) => `curated-${index}`);
+    const fullDeck = modeDeck([
+      ...allowedIds.map((id) => ({ id, modes: ['flashcards', 'matching', 'choice'] as PracticeMode[] })),
+      ...Array.from({ length: 48 }, (_, index) => ({
+        id: `outside-${index}`,
+        modes: ['flashcards', 'matching', 'choice'] as PracticeMode[],
+      })),
+    ]);
+    const allowed = new Set(allowedIds);
+    const curatedDeck = {
+      ...fullDeck,
+      index: fullDeck.index.filter((item) => allowed.has(item.lemmaId)),
+    };
+    const history: SelectionHistoryItem[] = [];
+    const selections: PracticeSelection[] = [];
+
+    // No cards are rated in this simulation: all draws remain new and due. Across
+    // 24 draws, the selector must still avoid a repetitive curated-session opening.
+    for (let draw = 0; draw < 24; draw += 1) {
+      const selection = selectNextPracticeItem(curatedDeck, {
+        now: NOW,
+        history,
+        modeFilter: 'mixed',
+        sessionSeed: 6251,
+      });
+      if (!selection) throw new Error(`expected curated selection ${draw}`);
+      selections.push(selection);
+      history.push(selectionHistory(selection));
+    }
+
+    const uniqueItemRatio = new Set(selections.map((selection) => selection.itemId)).size / selections.length;
+    const uniqueLemmaRatio = new Set(selections.map((selection) => selection.lemma.lemmaId)).size / selections.length;
+    expect(uniqueItemRatio).toBeGreaterThanOrEqual(0.95);
+    expect(uniqueLemmaRatio).toBeGreaterThanOrEqual(0.9);
+    expect(selections.every((selection) => allowed.has(selection.lemma.lemmaId))).toBe(true);
+  });
+
   test('selector returns immutable snapshots of cached candidates', () => {
     const testDeck = flashcardDeck([{ id: 'snapshot' }]);
     const first = selectNextPracticeItem(testDeck, {


### PR DESCRIPTION
## Summary

- memoize normalized curated/custom key sets and cache the built-in teacher deck
- pre-scope the selection deck before candidate construction
- preserve SRS due refreshes while extending all-new mixed-session lemma spacing
- add cache, selection-variety, and privacy-filter regression coverage

## Validation

- `NODE_OPTIONS="--max-old-space-size=8192 --no-experimental-webstorage" npx vitest run --reporter=dot tests/unit/LexiconPractice.test.tsx tests/unit/lexicon-srs.test.ts` (189 passed)
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Closes #6251
Related: #4700