### PR TITLE
docs(foundry): align control plane and local proof path

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -9,7 +9,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Last refreshed** | 2026-08-02 (corpus verdict CONTINUE; #6171 now separates local model learning from raw-source and publication capabilities) |
+| **Last refreshed** | 2026-08-02 (corpus verdict CONTINUE; #6171 is the required tool/recipe lane; an Apple-Silicon proof is conditional and separately authorized) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Help people and AI produce measurably better, authentically Ukrainian language through decolonized learning products and reusable, evidence-backed open-model infrastructure. Quality non-negotiable. |
@@ -30,7 +30,8 @@ stream must trace to this chain:
 3. **Reusable community infrastructure**: audited, provenance-rich source data;
    the Ukrainian Data Foundry's admitted real data, contextual language-contact
    diagnostics, evidence-backed silver corrections with optional human-gold
-   upgrades, model-ready exports, and causal open-weight evidence (#6164;
+   upgrades, model-ready exports, and optional open-weight compatibility
+   evidence (#6164;
    completed foundation #6056); and
    narrow, contamination-resistant public evaluation (closed #2156; frozen
    future design preserved in closed #6057).
@@ -65,7 +66,7 @@ is the single source of truth for membership (auditor:
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
-| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: apply the [CONTINUE corpus-usability decision](research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md), separate local learning from raw-source/publication permissions, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, and ship a corpus-portable clean-Ukrainian tool, training recipe, and reproducible release candidate; paid model treatment is optional |
+| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: apply the [CONTINUE corpus-usability decision](research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md), separate local learning from raw-source/publication permissions, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, and ship a corpus-portable clean-Ukrainian tool, training recipe, and reproducible release candidate; any local or rented model proof is a separately authorized validation lane |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -97,7 +98,7 @@ epic-board state and bind only once that stream's driver (State: the operator) c
 | --- | --- | --- | --- |
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
 | eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
-| open-model-data | ACTIVE | Execute #6171: package the production detector/evidence/views as a corpus-portable clean-Ukrainian tool, ship the model-neutral training recipe and validated cost formula, and reproduce the no-training release candidate in a clean environment. #6170 is parked optional compatibility validation and is not a prerequisite. | A stranger can run the admitted-source, contextual interference/calque/grammar/morphology, protected-variation, silver-evidence, disjoint-view, tokenizer, recipe, and evaluation-firewall path on a bounded consumer-owned corpus; committed receipts prove the clean run and limitations. No accelerator, model weights, paid reviewers, or human-gold claim is required. Publication remains operator-gated. |
+| open-model-data | ACTIVE | Execute #6171: package the production detector/evidence/views as a corpus-portable clean-Ukrainian tool, ship the model-neutral training recipe and validated cost formula, and reproduce the no-training release candidate in a clean environment. #6170 remains parked; after #6171, an exact-RAM Apple-Silicon QLoRA run is the preferred zero-rental-cost proof candidate, subject to a separate authorization. | A stranger can run the admitted-source, contextual interference/calque/grammar/morphology, protected-variation, silver-evidence, disjoint-view, tokenizer, recipe, and evaluation-firewall path on a bounded consumer-owned corpus; committed receipts prove the clean run and limitations. No accelerator, model weights, paid reviewers, or human-gold claim is required. Publication remains operator-gated. |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |

--- a/docs/runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md
+++ b/docs/runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md
@@ -159,7 +159,7 @@ epochs, and an explicit `training_authorized: false` state. The existing
 `training_recipe_config_v1` and `training_recipe_manifest_v1` contracts are
 preparation contracts; generating them does not start training.
 
-A proper program normally separates three experiments:
+If a separately authorized model experiment occurs, keep these roles separate:
 
 1. continued pretraining on destination-admitted human-authored text;
 2. optional correction/instruction or preference tuning on eligible,
@@ -167,8 +167,8 @@ A proper program normally separates three experiments:
 3. evaluation on mechanically isolated grammar, calque, interference,
    morphology, no-change, and protected-variation inventories.
 
-Do not combine these into one run: otherwise a result cannot identify which
-data treatment helped or caused harm.
+Do not combine these roles in an authorized run: otherwise a result cannot
+identify which data treatment helped or caused harm.
 
 ### 7. Reproduce without an accelerator
 
@@ -222,6 +222,56 @@ efficient; their hourly costs multiply. Full-parameter continued pretraining
 has a very different memory and compute envelope from QLoRA. The exact clean
 microbenchmark and model revision must replace this table before any spending
 decision.
+
+## Could the proof run on an unused M1?
+
+Yes, if the proof uses a Gemma 4 size that matches the machine's unified memory
+and uses an Apple-Silicon training stack. It does not mean the current Gemma 4
+31B CUDA treatment can be copied to the Mac.
+
+Google's current
+[Gemma 4 memory table](https://ai.google.dev/gemma/docs/core#parameter-sizes-and-quantization)
+gives approximate Q4 inference loads of 2.9 GB for E2B, 4.5 GB for E4B,
+6.7 GB for 12B, 14.4 GB for 26B A4B, and 17.5 GB for 31B. Context and
+fine-tuning add memory beyond those values. Record the exact M1 variant,
+unified memory, free storage, and macOS version before selecting anything.
+
+| M1 unified memory | First candidate | What it can establish |
+| ---: | --- | --- |
+| 8 GB | Gemma 4 E2B Q4 | Whether the complete local pipeline can execute at all |
+| 16 GB | Gemma 4 E4B Q4; E2B fallback | A real small-model Ukrainian before/after proof; not 31B compatibility |
+| 32 GB | Gemma 4 12B Q4; E4B fallback | A stronger local proof if peak memory and reload pass |
+| 64 GB or more | Benchmark 12B first; consider 31B second | 31B remains conditional on measured training memory and speed |
+
+Apple's [MLX-LM](https://github.com/ml-explore/mlx-lm) supports LoRA and QLoRA
+on Apple silicon. Release `v0.31.2` added Gemma 4 support, while the
+[MLX-LM LoRA guide](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md)
+documents quantized-model training and memory controls. The existing #6170
+runner is not portable: it pins CUDA, an NVIDIA L40S, BitsAndBytes NF4, and a
+31B checkpoint. Preserve that runner and create a separately pinned MLX path
+only after the exact Mac and checkpoint are approved.
+
+A useful local proof has five measured steps:
+
+1. capture machine, model, tokenizer, framework, quantization, and storage
+   receipts;
+2. run the frozen baseline evaluation and protected-variation probes;
+3. perform a synthetic one-step update, save, restart, reload, and re-evaluate
+   only as a hardware preflight;
+4. train on a real, stratified Foundry slice and compare the reloaded adapter
+   with the untouched checkpoint on exactly the same held-out evidence; and
+5. run a full-corpus pass only if the measured throughput, peak memory, and
+   preliminary Ukrainian result justify its wall time.
+
+The fourth step is the minimum linguistic proof. A successful synthetic update
+alone proves only that MLX can write and reload an adapter.
+
+Gemma 4 is the first candidate because the project already has its tokenizer,
+baseline, and treatment contracts. Another Western open-weight model is a
+fallback only if the same frozen Ukrainian baseline, tokenizer diagnostics,
+memory preflight, and license check make it a more credible proof target. A
+fallback result validates the Foundry path for that model; it does not prove a
+Gemma 4 treatment.
 
 For scale, Lapa reports about 30 billion filtered pretraining tokens and a
 56-H100 training setup for its Gemma 3 adaptation. Our 139-million-token

--- a/docs/runbooks/ukrainian-data-foundry-corpus-admission.md
+++ b/docs/runbooks/ukrainian-data-foundry-corpus-admission.md
@@ -5,15 +5,24 @@ a local, content-blind row manifest and a portable aggregate receipt. It is an
 admission-disposition step, never training, publication, acquisition, OCR, or
 rights certification.
 
+> **Implementation status after #6248:** this runbook records the frozen
+> 2026-08-01 capability-combined admission run. The later
+> [corpus-usability decision](../research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md)
+> approves the retained human-authored corpus for local research and continued
+> model learning after required preprocessing. #6171 must still separate that
+> local-learning decision from raw-source redistribution, dataset publication,
+> and model publication in the executable contract.
+
 ## Inputs and boundaries
 
 The checked-in configuration is
 `data/projects/open_model_data/admission/public_external_full_corpus_admission_v1.json`.
 It binds the four public/external families to the frozen profile denominator:
 189,150 rows and 50,298,925 lexical words. A public location, corpus
-membership, author death, or a family name is not permission. Three families
-remain unresolved. On 2026-08-01, the operator accepted exactly the 1,029-row
-Ukrainian Wikipedia family for the source-admission destination
+membership, author death, or a family name is not permission. In the frozen
+v1 output, three families remained unresolved because the runner required one
+combined disposition. On 2026-08-01, the operator accepted exactly the
+1,029-row Ukrainian Wikipedia family for the source-admission destination
 `open_weight_ukrainian_continued_pretraining_text_v1`. The recorded acceptance
 does not authorize payload export, training, upload, model release, dataset
 redistribution, or publication.
@@ -122,8 +131,8 @@ local and uncommitted.
 | Admitted Wikipedia `source_record_v1` manifest | 1,029 | 2,865,506 | `6b91e718622911a5a2c9a907e53dee7f3cf4c2805b0d3350c49e619f5422da68` |
 | Aggregate admission receipt | 189,150 | 50,298,925 | `1359e2d2067795c4246be93cb4187d708b22a9d7af406e089d5ac087095c09d4` |
 | Operator decision packet | 1 accepted family | 1,029 rows | `53b12ed59d06929ed3218b3243f07b4aa0724812935b725e2999d44c726444cd` |
-| `admitted` | 1,029 | 2,865,506 | Wikipedia only |
-| `unresolved` | 188,121 | 47,433,419 | Literary, public-textbook, and external-article families |
+| `admitted` in the frozen v1 run | 1,029 | 2,865,506 | Wikipedia only |
+| `unresolved` in the frozen v1 run | 188,121 | 47,433,419 | Literary, public-textbook, and external-article families |
 | Evaluation exact/near exclusions | 0 | 0 | Frozen registry applied |
 
 All 1,029 generated source records satisfy the frozen JSON contract and now
@@ -161,6 +170,9 @@ The accepted scope retains all attribution, share-alike, modification,
 no-additional-restrictions, lineage, and downstream-review obligations. It
 advances only to separately controlled exporter and training gates.
 
-The other 188,121 rows remain unresolved. Acceptance does not authorize export,
-training, upload, model release, redistribution, or publication and does not
-emit `training_eligible`.
+The other 188,121 rows remain unresolved in the frozen v1 output. #6248 later
+approved those retained human-authored families for the distinct local-learning
+capability after preprocessing; that decision does not authorize export,
+upload, model release, redistribution, or publication. Until #6171 implements
+capability-specific admission, this runner still does not emit them as
+`training_eligible`.

--- a/docs/runbooks/ukrainian-data-foundry-model-views.md
+++ b/docs/runbooks/ukrainian-data-foundry-model-views.md
@@ -49,9 +49,12 @@ a model, or run training.
 ## Phase 3 real production result
 
 The first real production instantiation uses the operator-accepted Ukrainian
-Wikipedia continued-pretraining family. It does not replace the larger
-literary, textbook, historical, or external-article inventories; those remain
-separately gated until their exact rights and destination evidence is complete.
+Wikipedia continued-pretraining family. It is the frozen v1 implementation,
+not the current program limit. The later #6248 usability decision approves the
+retained literary, textbook, historical, and external-article corpus for local
+model learning after required preprocessing. #6171 must still separate that
+local capability from raw redistribution and publication, restore retained
+locators, and export the larger faithful and modern-learning views.
 
 `model_ready_view_production.py prepare-payloads` joins all 1,029 admitted
 source records to their exact `sources.db` content hashes and the complete
@@ -104,14 +107,16 @@ admitted Wikipedia payload scope (423 protected and 978 unresolved); these
 payload categories overlap because one article can contain both kinds of span.
 They are not interchangeable counts.
 
-The final phase-3 feasibility verdict is `REVISE`: real control and
+The historical phase-3 feasibility verdict is `REVISE`: real control and
 loss-masked continued-pretraining inputs, evaluation isolation, protected/no-
 change inventory, recipes, and tokenizer diagnostics exist, but an exact
-treatment preregistration and operator compute ceiling do not. #6170 may start
-only after those two present-tense gates are frozen. The current recipe
-manifests retain `training_authorized: false` and `execution_state: not_run`.
-Projected training runtime and cost remain null—not zero—until #6170 pins the
-hardware, treatment, and ceiling; local artifact storage is measured exactly.
+treatment preregistration and operator compute ceiling do not. #6170 is now
+parked optional validation and may reopen only after those two present-tense
+gates are frozen. The current recipe manifests retain
+`training_authorized: false` and `execution_state: not_run`. Projected training
+runtime and cost remain null—not zero—until an exact local or rented runner
+pins the hardware, treatment, and ceiling; local artifact storage is measured
+exactly.
 
 ## Required inputs
 

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -74,10 +74,11 @@ experiment. It must never be reported as human gold, native-speaker acceptance,
 reviewer reliability, or proof that every proposed correction is correct.
 
 The Foundry can credibly promise reusable preparation, diagnostics, evidence,
-and a controlled test of whether those artifacts help. It cannot promise in
-advance that a treatment will make an LLM fluent. The cheapest falsifying check
-always precedes a more expensive run, and a failed prerequisite or null result
-is reported immediately rather than converted into more work.
+and, if separately authorized, a controlled test of whether those artifacts
+help. It cannot promise in advance that a treatment will make an LLM fluent.
+The cheapest falsifying check always precedes a more expensive run, and a
+failed prerequisite or null result is reported immediately rather than
+converted into more work.
 
 ## GitHub execution homes
 
@@ -324,12 +325,14 @@ later decisions. The project verdict is **CONTINUE**.
    controls. Reproduce the complete no-training path in a clean independent
    environment (#6171). The canonical recipe and cost model are documented in
    the [clean-Ukrainian runbook](../runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md).
-7. Keep the preregistered Gemma 4 treatment (#6170) parked as optional,
-   present-tense operator-gated compatibility validation. It is not a
-   prerequisite for #6171, and neither model download nor accelerator spend is
-   authorized. If it is ever activated, first replace planning estimates with
-   an exact microbenchmark and report null, mixed, unsafe, or negative results
-   as valid terminal outcomes.
+7. Keep the preregistered Gemma 4 31B cloud treatment (#6170) parked as
+   optional, present-tense operator-gated compatibility validation. After
+   #6171, inventory the operator's unused M1 and prefer a smaller Gemma 4
+   Apple-Silicon QLoRA candidate when it can prove the complete path without
+   rental cost. Neither route is a prerequisite for #6171, and neither model
+   download nor training is authorized. Before either route runs, replace
+   planning estimates with an exact model, revision, tokenizer, machine,
+   framework, memory, throughput, evaluation, and stop-rule record.
 8. Use frozen v0.1.1 and compatible licensed external human-authored
    evaluations for recipe validation and any optional future experiment. The
    reviewer-intensive v0.2
@@ -337,6 +340,45 @@ later decisions. The project verdict is **CONTINUE**.
    suitable consented evidence without becoming a project staffing dependency.
    Public evaluation gold remains mechanically isolated from every training or
    tuning view.
+
+### Optional local Apple-Silicon proof after #6171
+
+The proof question is whether the shipped Foundry path changes a model's
+measured Ukrainian behavior, not whether a particular large checkpoint can be
+forced onto a laptop. The first zero-rental-cost candidate is the operator's
+unused M1, after its exact chip variant, unified memory, free storage, and macOS
+version are recorded.
+
+Google's current
+[Gemma 4 memory table](https://ai.google.dev/gemma/docs/core#parameter-sizes-and-quantization)
+lists approximate Q4 inference loads of 2.9 GB for E2B, 4.5 GB for E4B,
+6.7 GB for 12B, 14.4 GB for 26B A4B, and 17.5 GB for 31B. Those figures cover
+base weights and loading overhead, not context or fine-tuning. The 31B model
+therefore cannot be a 16 GB M1 training target, and the A4B model does not fit
+like a 4B model because all 26 billion parameters must remain loaded.
+
+Candidate routing is conditional rather than a model selection:
+
+| M1 unified memory | First Gemma 4 candidate to benchmark | Boundary |
+| ---: | --- | --- |
+| 8 GB | E2B Q4 | Runtime preflight and short full-path proof only until peak memory is measured |
+| 16 GB | E4B Q4; E2B fallback | 31B is excluded; 12B requires a measured margin before consideration |
+| 32 GB | 12B Q4; E4B fallback | Prefer 12B only if one-step training, reload, and evaluation fit safely |
+| 64 GB or more | 12B first; 31B may be benchmarked | Do not choose 31B before its measured speed and peak-memory cost justify it |
+
+Apple's [MLX-LM](https://github.com/ml-explore/mlx-lm) supports Apple-Silicon
+LoRA and QLoRA; release `v0.31.2` added Gemma 4, and the
+[LoRA guide](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md)
+documents quantized-model training. The existing #6170 runner is CUDA/L40S
+specific and must remain unchanged. A local proof needs a separately pinned
+MLX runner and a new tokenizer receipt for the selected checkpoint.
+
+The first meaningful local result must traverse the complete path: frozen
+baseline evaluation, real stratified Foundry data, adapter training, clean
+reload, the same held-out evaluation, and protected-variation checks. A
+synthetic one-step update is only the hardware preflight. A full-corpus pass is
+considered only after the exact local throughput turns the existing token count
+into an acceptable wall-time estimate.
 
 The accountable orchestrator continues through the #6171 no-training release
 candidate. A merged implementation PR is progress, not a stopping condition.


### PR DESCRIPTION
Closes no issue; advances #6171 under #6164.

## What changed

- keeps #6171 as the required clean-Ukrainian tool, model-ready views, recipe, cost, and clean-reproduction lane;
- distinguishes the frozen Wikipedia-only v1 implementation from the later full-corpus local-learning decision in #6248;
- documents an optional, separately authorized Apple-Silicon QLoRA full-path proof after #6171;
- records RAM-gated Gemma 4 candidates from the current official memory table;
- preserves #6170 as the parked CUDA/L40S Gemma 4 31B experiment;
- states that a synthetic optimizer step is only a hardware preflight, while a meaningful proof requires real Foundry data and before/after held-out Ukrainian evaluation.

## Why

The control plane had two sources of drift: old runbooks could still be read as limiting local learning to Wikipedia, and the new unused-M1 question had no durable place in the roadmap. This change aligns the strategy, workstream, recipe, admission, and model-view documentation without authorizing a model download or training run.

## Validation

- `npx --no-install markdownlint-cli2` on all five changed Markdown files: 0 errors
- `git diff --check`: pass
- staged OPSEC scan: 5 files, zero leaks
- agent trailer audit: pass
- scope: five documentation files only

No model was downloaded, trained, evaluated, uploaded, or published. No corpus payload was changed.