### PR TITLE
feat(entire): connect live recall projection

### DIFF
--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: entire-context
-description: Provider-neutral recall over the public body-free context-link index (ADR-018, Phase 2). Invoke when a task needs to find prior public work, explain why a commit or ACP discussion exists, or prepare a bounded handoff capsule for another seat. Works identically for Codex, Kimi, GLM, Claude, and other harnesses — no model-specific semantics, no Entire plugin, no Entire CLI call. Local-only; GitHub, Fleet Comms, Monitor, session streams, rollover, and formal review remain authoritative.
+description: Provider-neutral recall over the public body-free context-link index (ADR-018). Invoke at task intake when prior work may matter, before consequential design changes, when explaining a commit or ACP discussion, and when preparing a bounded handoff. Works identically for Codex, Kimi, GLM, Claude, and other harnesses; GitHub, Fleet Comms, Monitor, session streams, rollover, and formal review remain authoritative.
 effort: low
 ---
 
@@ -32,8 +32,9 @@ it never mutates them.
 
 ## Commands
 
-All commands are local and read-only except the two explicit `bootstrap-*`
-index commands, which write only to the projection SQLite file.
+Recall commands are local and read-only. Explicit `bootstrap-*`,
+`reconcile-acp`, and `record-use` commands write only to the rebuildable local
+projection; `refresh-provider-status` writes only a sanitized local cache.
 
 ```bash
 # Projection state (body-free aggregate)
@@ -43,6 +44,9 @@ index commands, which write only to the projection SQLite file.
 .venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha> [--repo PATH] [--namespace NS]
 .venv/bin/python -m scripts.entire_context bootstrap-acp conversation_<32hex> [--git-sha SHA] [--acp-root PATH]
 .venv/bin/python -m scripts.entire_context bootstrap-rollover --agent <agent> --lineage-id <lineage> --rollover-id <rollover> [--rollover-root PATH]
+
+# Recover terminal ACP receipts missed by the automatic post-commit callback
+.venv/bin/python -m scripts.entire_context reconcile-acp --acp-root PATH
 
 # search-past-work: ranked verified locator cards (<= 10 results, <= 500 scanned)
 .venv/bin/python -m scripts.entire_context search --query "<needle>" [--repo PATH] [--acp-root PATH]
@@ -55,6 +59,12 @@ index commands, which write only to the projection SQLite file.
 # prepare-handoff: bounded capsule of verified locators/excerpts (<= 5 items, <= 8 KiB)
 .venv/bin/python -m scripts.entire_context handoff --locator-id clink_<64hex> [--locator-id ...]
 .venv/bin/python -m scripts.entire_context handoff --query "<needle>"
+
+# After verified locators actually informed the task, attest that use explicitly
+.venv/bin/python -m scripts.entire_context record-use --task-id <task> --consumer <harness> --purpose <category> --locator-id clink_<64hex> [--locator-id ...]
+
+# Explicit Entire 0.8.42 probe for Monitor's sanitized local cache
+.venv/bin/python -m scripts.entire_context refresh-provider-status [--repo PATH]
 ```
 
 Resolution flags: `--repo` (default: cwd) supplies the local git repository;
@@ -63,7 +73,9 @@ Resolution flags: `--repo` (default: cwd) supplies the local git repository;
 registry state root. Without an ACP root, ACP links fail closed as
 `source_missing`; without a rollover root, rollover links fail closed as
 `source_missing`. `--db` or
-`ENTIRE_CONTEXT_DB` overrides the projection path. `--consumer <label>` may be
+`ENTIRE_CONTEXT_DB` overrides the projection path. By default every linked
+worktree resolves the same primary-checkout `batch_state/entire-context/v1`
+projection through Git's common directory. `--consumer <label>` may be
 passed by any harness; it is validated, never persisted, and never echoed, so
 all harnesses receive byte-identical results for identical invocations.
 An ACP `--git-sha` join is admitted only when hashing that exact SHA matches
@@ -96,6 +108,23 @@ closed as `digest_mismatch`.
 5. Ranking is deterministic and Unicode-casefold based with `locator_id` as
    the final tie-break, so identical fixtures give identical results to every
    harness.
+6. Search delivery is not evidence of use. When verified cards materially
+   informed intake, architecture, implementation, explanation, review, or
+   handoff, run `record-use` with the exact task, harness, purpose, and locator
+   IDs. The body-free idempotent receipt is the only basis for Monitor's
+   `use.proven` state.
+
+## Harness semantics
+
+- Entire integrates with the **host harness**, not each model label. Kimi or
+  GLM running inside Claude Code use the installed `claude-code` integration;
+  those models running inside OpenCode use the installed `opencode`
+  integration.
+- Codex CLI and Codex Desktop first use the installed native `codex`
+  integration and the same project hooks. Do not invent a `codex-gui` agent.
+- Add an external `entire-agent-<harness>` adapter only after a source-blind
+  canary proves that the actual unsupported harness has no native capture
+  path. A model name alone is never evidence that an adapter is required.
 
 ## Failure posture
 

--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -12,6 +12,7 @@ import errno
 import fcntl
 import hashlib
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -50,6 +51,8 @@ from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.contracts import new_id
 from scripts.fleet_comms.message_plane import default_plane_root
 from scripts.guardrails.worktree_containment import classify_repo_path
+
+logger = logging.getLogger(__name__)
 
 PARTICIPANTS = ("codex", "grok")
 SUPPORTED_PARTICIPANTS = frozenset(ACPX_SUPPORTED_PARTICIPANTS)
@@ -1233,9 +1236,27 @@ def run_discussion(**kwargs: Any) -> dict[str, Any]:
     root = Path(root_arg) if root_arg is not None else default_plane_root(repo_root=Path(kwargs["cwd"]))
     controller = AcpxDiscussionController(root=root)
     try:
-        return controller.run(**kwargs)
+        result = controller.run(**kwargs)
     finally:
         controller.close()
+    if result.get("state") == "COMPLETE":
+        try:
+            # Local import avoids making ACP depend on the optional projection
+            # during module initialization. The authoritative ACP terminal
+            # commit has already completed; this callback is strictly
+            # best-effort and cannot change the discussion result.
+            from scripts.entire_context.reconcile import project_terminal_acp_receipt
+
+            project_terminal_acp_receipt(
+                conversation_id=str(result["conversation_id"]),
+                acp_root=root,
+                repo_root=Path(kwargs["cwd"]),
+            )
+        except Exception as exc:
+            logger.warning(
+                "optional ACP context projection failed: %s", type(exc).__name__
+            )
+    return result
 
 
 def recover_expired_discussions(*, root: Path) -> list[str]:

--- a/scripts/api/entire_context_router.py
+++ b/scripts/api/entire_context_router.py
@@ -1,0 +1,118 @@
+"""Read-only Monitor surface for Entire capture and local context recall."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from scripts.entire_context.paths import projection_path
+from scripts.entire_context.provider import load_provider_status
+from scripts.entire_context.recall import RecallInputError, search_past_work
+from scripts.entire_context.store import ContextLinkStore
+from scripts.fleet_comms.message_plane import default_plane_root
+
+from .config import LIVE_REPO_ROOT, PROJECT_ROOT
+from .repository_authority import preparation_data_root
+
+router = APIRouter(tags=["entire-context"])
+
+
+def _repo_root() -> Path:
+    return preparation_data_root(
+        project_root=Path(PROJECT_ROOT),
+        live_repo_root=Path(LIVE_REPO_ROOT),
+    )
+
+
+def _projection_status(root: Path) -> dict[str, Any]:
+    db_path = projection_path(root)
+    if not db_path.is_file():
+        return {"available": False, "reason": "projection_missing"}
+    try:
+        status = ContextLinkStore(db_path).status()
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        return {"available": False, "reason": "projection_unreadable"}
+    return {"available": True, **status}
+
+
+@router.get("/status")
+def entire_context_status() -> dict[str, Any]:
+    """Truthfully distinguish capture, recall availability, and proven use."""
+    root = _repo_root()
+    projection = _projection_status(root)
+    provider = load_provider_status(root)
+    counts = projection.get("counts", {}) if projection.get("available") else {}
+    installed_agents = provider.get("installed_agents", []) if provider.get("available") else []
+    return {
+        "schema": "entire-context-monitor.v1",
+        "body_free": True,
+        "authoritative": False,
+        "capture": {
+            "configured": provider.get("enabled") is True,
+            "installed_agents": installed_agents,
+            "native_agent_installed": bool(installed_agents),
+            "provider_status_available": provider.get("available") is True,
+        },
+        "recall": {
+            "available": projection.get("available") is True
+            and int(counts.get("promoted", 0)) > 0,
+            "promoted_links": int(counts.get("promoted", 0)),
+            "projection": projection,
+        },
+        "use": {
+            "proven": projection.get("available") is True
+            and int(projection.get("use_receipts", 0)) > 0,
+            "receipts": int(projection.get("use_receipts", 0)),
+            "last_use_at": projection.get("last_use_at"),
+            "by_consumer": projection.get("uses_by_consumer", {}),
+        },
+        "provider": provider,
+    }
+
+
+@router.get("/search")
+def entire_context_search(
+    q: str = Query(min_length=1, max_length=256),
+    limit: int = Query(default=5, ge=1, le=10),
+) -> dict[str, Any]:
+    """Return reverified local locator cards; never call Entire or the network."""
+    root = _repo_root()
+    status = _projection_status(root)
+    if status.get("available") is not True:
+        return {
+            "schema": "ec-search.v1",
+            "available": False,
+            "reason": status.get("reason", "projection_unavailable"),
+            "results": [],
+        }
+    acp_root = Path(
+        os.environ.get("ENTIRE_CONTEXT_ACP_ROOT", default_plane_root(repo_root=root))
+    )
+    try:
+        payload = search_past_work(
+            ContextLinkStore(projection_path(root)),
+            q,
+            repo=root,
+            acp_root=acp_root,
+            rollover_root=None,
+            limit=limit,
+        )
+    except RecallInputError as exc:
+        return {
+            "schema": "ec-search.v1",
+            "available": True,
+            "error": str(exc),
+            "results": [],
+        }
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        return {
+            "schema": "ec-search.v1",
+            "available": False,
+            "reason": "projection_unreadable",
+            "results": [],
+        }
+    return {"available": True, **payload}

--- a/scripts/api/ops_router.py
+++ b/scripts/api/ops_router.py
@@ -9,10 +9,12 @@ from pathlib import Path
 from fastapi import APIRouter
 
 from .config import PROJECT_ROOT
+from .entire_context_router import router as entire_context_router
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["ops"])
+router.include_router(entire_context_router, prefix="/entire-context")
 
 DEFAULT_PLAN_DIR = PROJECT_ROOT / "batch_state" / "fleet-comms" / "retention"
 

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -70,6 +70,18 @@ class PageContract:
 
 ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
     RouteContract(
+        "/api/ops/entire-context",
+        "prefix",
+        "http",
+        "Body-free capture, local recall, and explicit agent-use evidence.",
+        "Rebuildable local context-link SQLite projection plus an explicitly refreshed sanitized Entire 0.8.42 CLI status cache.",
+        "Projection and provider-cache reads are live per request; provider responses expose cache age/staleness and never invoke Entire synchronously.",
+        ("agents", "Monitor", "operators"),
+        "Complements canonical Git, ACP, rollover, Fleet, and formal-review sources; it never replaces them.",
+        "high if capture, recall delivery, and proven agent use are conflated",
+        "keep as a non-authoritative locator and observability surface",
+    ),
+    RouteContract(
         "/api/contracts/routes",
         "exact",
         "http",

--- a/scripts/entire_context/__init__.py
+++ b/scripts/entire_context/__init__.py
@@ -16,9 +16,10 @@ This package implements the local-only slice of the Entire context layer:
   LLM-facing result or handoff capsule (:mod:`.recall`);
 - a provider-neutral CLI (``python -m scripts.entire_context``).
 
-Nothing in this package calls Entire, GitHub, Fleet, ACP providers, Monitor,
-or the network, and nothing here mutates any canonical authority system. The
-projection is disposable and disabled/non-load-bearing by default.
+Recall, reconciliation, and Monitor reads call no Entire, GitHub, Fleet, ACP
+provider, or network service and mutate no canonical authority system. The
+explicit provider-status refresh is the sole Entire CLI call and writes only a
+sanitized local cache. The projection is disposable and non-load-bearing.
 """
 
 from .model import (

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -2,11 +2,14 @@
 
 Phase-1 commands: ``status``, ``lookup``, ``explain``, ``rebuild``, ``admit``.
 Phase-2 commands: ``bootstrap-git``, ``bootstrap-acp``, ``search``,
-``explain-change``, ``handoff``.
+``explain-change``, ``handoff``. Live commands: ``reconcile-acp``,
+``record-use``, and explicit ``refresh-provider-status``.
 
-Every command is local-only: none of them calls Entire, GitHub, Fleet, ACP
-providers, Monitor, or the network. Resolution uses read-only local ``git``
-plumbing and the body-free ACP terminal receipt verifier. A missing or
+Recall and projection commands are local-only: none calls Entire, GitHub,
+Fleet, ACP providers, Monitor, or the network. The explicit provider-status
+refresh is the sole Entire CLI call and writes an allowlisted cache. Resolution
+uses read-only local ``git`` plumbing and the body-free ACP terminal receipt
+verifier. A missing or
 disabled projection is reported as a body-free status payload, never as a
 traceback, and read commands never create local state. Query text and
 consumer labels are accepted but never persisted or echoed, so Codex, Kimi,
@@ -31,6 +34,8 @@ from .model import (
     canonical_json,
     validate_identity,
 )
+from .paths import projection_path
+from .provider import refresh_provider_status
 from .recall import (
     MAX_RESULTS,
     MAX_SCAN_ROWS,
@@ -39,6 +44,7 @@ from .recall import (
     prepare_handoff,
     search_past_work,
 )
+from .reconcile import MAX_RECONCILE_ROWS, reconcile_terminal_acp_receipts
 from .resolvers import (
     REASON_SOURCE_MISSING,
     ResolutionError,
@@ -52,8 +58,6 @@ EXIT_OK = 0
 EXIT_NOT_FOUND = 1
 EXIT_REFUSED = 2
 
-DEFAULT_DB_RELATIVE = Path("batch_state") / "entire-context" / "v1" / "context-links.sqlite3"
-ENV_DB = "ENTIRE_CONTEXT_DB"
 ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
 ENV_ACP_ROOT = "ENTIRE_CONTEXT_ACP_ROOT"
 ENV_ROLLOVER_ROOT = "ENTIRE_CONTEXT_ROLLOVER_ROOT"
@@ -64,12 +68,7 @@ def _emit(payload: dict[str, Any]) -> None:
 
 
 def _resolve_db(args: argparse.Namespace) -> Path:
-    if getattr(args, "db", None):
-        return Path(args.db)
-    env = os.environ.get(ENV_DB)
-    if env:
-        return Path(env)
-    return Path.cwd() / DEFAULT_DB_RELATIVE
+    return projection_path(Path.cwd(), getattr(args, "db", None))
 
 
 def _disabled() -> bool:
@@ -433,6 +432,49 @@ def cmd_handoff(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_record_use(args: argparse.Namespace) -> int:
+    """Persist an explicit agent attestation after verified recall informed work."""
+    db_path, early = _guard(args)
+    if early is not None:
+        _emit(early)
+        return EXIT_REFUSED
+    try:
+        receipt = ContextLinkStore(db_path).record_use(
+            task_id=args.task_id,
+            consumer=args.consumer,
+            purpose=args.purpose,
+            locator_ids=args.locator_id,
+        )
+    except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit({"outcome": "refused", "reason": "use_receipt_invalid"})
+        return EXIT_REFUSED
+    _emit({"outcome": "recorded", **receipt})
+    return EXIT_OK
+
+
+def cmd_reconcile_acp(args: argparse.Namespace) -> int:
+    """Recover complete ACP terminal receipts missed by the live callback."""
+    acp_root = _resolve_acp_root(args)
+    if acp_root is None:
+        return _refused("source_missing")
+    payload = reconcile_terminal_acp_receipts(
+        acp_root=acp_root,
+        repo_root=_resolve_repo(args),
+        db_path=_resolve_db(args),
+        limit=args.limit,
+        actor=args.actor,
+    )
+    _emit(payload)
+    return EXIT_OK if payload["outcome"] == "reconciled" else EXIT_REFUSED
+
+
+def cmd_refresh_provider_status(args: argparse.Namespace) -> int:
+    """Explicitly refresh the sanitized Entire CLI cache used by Monitor."""
+    payload = refresh_provider_status(_resolve_repo(args))
+    _emit(payload)
+    return EXIT_OK if payload.get("available") is True else EXIT_REFUSED
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m scripts.entire_context",
@@ -447,7 +489,7 @@ def build_parser() -> argparse.ArgumentParser:
         command.add_argument(
             "--db",
             default=None,
-            help=f"Projection SQLite path (default: {ENV_DB} or {DEFAULT_DB_RELATIVE})",
+            help="Projection SQLite path (default: shared primary batch_state projection)",
         )
 
     status = sub.add_parser("status", help="Body-free aggregate projection status")
@@ -606,6 +648,48 @@ def build_parser() -> argparse.ArgumentParser:
     add_resolution_flags(handoff)
     add_db_flag(handoff)
     handoff.set_defaults(func=cmd_handoff)
+
+    record_use = sub.add_parser(
+        "record-use",
+        help="Record an explicit body-free attestation that verified recall informed a task",
+    )
+    record_use.add_argument("--task-id", required=True, help="Exact path-safe task identity")
+    record_use.add_argument("--consumer", required=True, help="Harness identity (codex, kimi, glm, ...)")
+    record_use.add_argument(
+        "--purpose",
+        required=True,
+        help="Path-safe use category such as intake, architecture, implementation, or handoff",
+    )
+    record_use.add_argument(
+        "--locator-id",
+        action="append",
+        required=True,
+        help="Verified promoted locator that informed the task (repeatable, max 10)",
+    )
+    add_db_flag(record_use)
+    record_use.set_defaults(func=cmd_record_use)
+
+    reconcile_acp = sub.add_parser(
+        "reconcile-acp",
+        help="Idempotently project terminal COMPLETE ACP receipts missed by the live callback",
+    )
+    reconcile_acp.add_argument(
+        "--acp-root",
+        default=None,
+        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT})",
+    )
+    reconcile_acp.add_argument("--repo", default=None, help="Repository/worktree used to resolve shared state")
+    reconcile_acp.add_argument("--actor", default="acp-reconcile", help="Body-free actor identity")
+    reconcile_acp.add_argument("--limit", type=int, default=MAX_RECONCILE_ROWS, help="Max receipts (cap 500)")
+    add_db_flag(reconcile_acp)
+    reconcile_acp.set_defaults(func=cmd_reconcile_acp)
+
+    provider_status = sub.add_parser(
+        "refresh-provider-status",
+        help="Explicit bounded Entire 0.8.42 status probe; writes a sanitized local cache",
+    )
+    provider_status.add_argument("--repo", default=None, help="Source repository (default: cwd)")
+    provider_status.set_defaults(func=cmd_refresh_provider_status)
 
     return parser
 

--- a/scripts/entire_context/model.py
+++ b/scripts/entire_context/model.py
@@ -96,6 +96,7 @@ FORBIDDEN_VALUE_PATTERNS = (
 )
 
 OPAQUE_RUN_RE = re.compile(r"[A-Za-z0-9_+-]+")
+PATH_OPAQUE_RUN_RE = re.compile(r"[A-Za-z0-9+-]+")
 GIT_EVIDENCE_LOCATOR_RE = re.compile(r"^git:commit/[0-9a-f]{40}$")
 
 MAX_STRING_BYTES = 1024
@@ -217,9 +218,29 @@ def validate_facets(facets: dict[str, Any]) -> None:
             if len(value) > MAX_LIST_ITEMS:
                 raise SchemaError(f"facet {key!r} rejected by list-size rule")
             for item in value:
-                _validate_scalar(key, item, reject_long_opaque=True)
+                if key == "touched_paths":
+                    _validate_touched_path(item)
+                else:
+                    _validate_scalar(key, item, reject_long_opaque=True)
         else:
             _validate_scalar(key, value, reject_long_opaque=True)
+
+
+def _validate_touched_path(value: Any) -> None:
+    """Allow real semantic Git paths without admitting opaque path tokens."""
+    _validate_scalar("touched_paths", value, reject_long_opaque=False)
+    if not isinstance(value, str):
+        raise SchemaError("field 'touched_paths' must be a string")
+    if value.startswith("/") or "\\" in value or any(
+        segment in {"", ".", ".."} for segment in value.split("/")
+    ):
+        raise SchemaError("field 'touched_paths' must be a relative Git path")
+    opaque_runs = [match.group(0) for match in PATH_OPAQUE_RUN_RE.finditer(value)]
+    split_runs = [run for run in opaque_runs if len(run) >= 16]
+    if any(len(run) >= 48 for run in opaque_runs) or (
+        len(split_runs) >= 2 and sum(map(len, split_runs)) >= 48
+    ):
+        raise SchemaError("field 'touched_paths' rejected by long-opaque-token rule")
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/entire_context/paths.py
+++ b/scripts/entire_context/paths.py
@@ -1,0 +1,60 @@
+"""Shared runtime paths for the rebuildable Entire context projection."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+DEFAULT_STATE_RELATIVE = Path("batch_state") / "entire-context" / "v1"
+DEFAULT_DB_NAME = "context-links.sqlite3"
+DEFAULT_PROVIDER_STATUS_NAME = "provider-status.json"
+ENV_DB = "ENTIRE_CONTEXT_DB"
+
+
+def shared_repository_root(cwd: Path | str) -> Path:
+    """Return the primary checkout shared by all linked worktrees.
+
+    Git's common directory is the stable local join: in a linked worktree it
+    points back to the primary checkout's ``.git`` directory. A non-repository
+    caller safely falls back to its own working directory.
+    """
+    root = Path(cwd).expanduser().resolve()
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return root
+    if completed.returncode != 0:
+        return root
+    common_dir = Path(completed.stdout.strip()).expanduser().resolve()
+    return common_dir.parent if common_dir.name == ".git" else root
+
+
+def state_directory(cwd: Path | str) -> Path:
+    return shared_repository_root(cwd) / DEFAULT_STATE_RELATIVE
+
+
+def projection_path(cwd: Path | str, explicit: Path | str | None = None) -> Path:
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+    configured = os.environ.get(ENV_DB)
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return state_directory(cwd) / DEFAULT_DB_NAME
+
+
+def provider_status_path(cwd: Path | str) -> Path:
+    return state_directory(cwd) / DEFAULT_PROVIDER_STATUS_NAME

--- a/scripts/entire_context/provider.py
+++ b/scripts/entire_context/provider.py
@@ -1,0 +1,156 @@
+"""Explicit Entire 0.8.42 status refresh and read-only cache access."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .model import SchemaError, validate_identity
+from .paths import provider_status_path
+
+REQUIRED_ENTIRE_VERSION = "0.8.42"
+PROVIDER_STATUS_MAX_AGE_SECONDS = 900
+
+
+def _now_text() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["entire", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _agent_id(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = "-".join(value.strip().lower().split())
+    try:
+        validate_identity(normalized, field_name="agent")
+    except SchemaError:
+        return None
+    return normalized
+
+
+def refresh_provider_status(
+    repo_root: Path,
+    *,
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    """Run an explicit bounded CLI probe and persist only allowlisted fields."""
+    root = Path(repo_root).expanduser().resolve()
+    target = output_path or provider_status_path(root)
+    try:
+        version_result = _run(root, "version")
+    except (OSError, subprocess.TimeoutExpired):
+        return {"available": False, "reason": "entire_cli_unavailable"}
+    version_line = version_result.stdout.splitlines()[0] if version_result.stdout else ""
+    version = version_line.removeprefix("Entire CLI ").strip()
+    if version_result.returncode != 0 or version != REQUIRED_ENTIRE_VERSION:
+        return {
+            "available": False,
+            "reason": "entire_version_mismatch",
+            "required_version": REQUIRED_ENTIRE_VERSION,
+        }
+    try:
+        status_result = _run(root, "status", "--json")
+        raw = json.loads(status_result.stdout) if status_result.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        raw = None
+    if not isinstance(raw, dict):
+        return {"available": False, "reason": "entire_status_unavailable"}
+    agents = [agent_id for agent in raw.get("agents", []) if (agent_id := _agent_id(agent))]
+    active_sessions = []
+    for session in raw.get("active_sessions", []):
+        if not isinstance(session, dict):
+            continue
+        agent = _agent_id(session.get("agent"))
+        status = session.get("status")
+        if agent is not None and status in {"active", "ended", "unknown"}:
+            active_sessions.append({"agent": agent, "status": status})
+    payload = {
+        "schema": "entire-provider-status.v1",
+        "available": True,
+        "generated_at": _now_text(),
+        "version": version,
+        "required_version": REQUIRED_ENTIRE_VERSION,
+        "enabled": raw.get("enabled") is True,
+        "installed_agents": sorted(set(agents)),
+        "active_sessions": sorted(
+            active_sessions, key=lambda item: (item["agent"], item["status"])
+        ),
+        "source": "entire-cli",
+    }
+    _atomic_write(target, payload)
+    return payload
+
+
+def load_provider_status(
+    repo_root: Path,
+    *,
+    status_path: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Read the sanitized local cache without invoking Entire or the network."""
+    target = status_path or provider_status_path(repo_root)
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {"available": False, "reason": "provider_status_missing"}
+    if not isinstance(payload, dict) or payload.get("schema") != "entire-provider-status.v1":
+        return {"available": False, "reason": "provider_status_unreadable"}
+    try:
+        generated = datetime.fromisoformat(str(payload["generated_at"]).replace("Z", "+00:00"))
+        age = max(0, int(((now or datetime.now(UTC)) - generated).total_seconds()))
+    except (KeyError, TypeError, ValueError):
+        return {"available": False, "reason": "provider_status_unreadable"}
+    safe = {
+        key: payload[key]
+        for key in (
+            "schema",
+            "available",
+            "generated_at",
+            "version",
+            "required_version",
+            "enabled",
+            "installed_agents",
+            "active_sessions",
+            "source",
+        )
+        if key in payload
+    }
+    safe.update(
+        {
+            "age_seconds": age,
+            "stale": age > PROVIDER_STATUS_MAX_AGE_SECONDS,
+        }
+    )
+    return safe

--- a/scripts/entire_context/reconcile.py
+++ b/scripts/entire_context/reconcile.py
@@ -1,0 +1,115 @@
+"""Fail-open projection of canonical, terminal ACP receipts.
+
+ACP commits its own lifecycle first. This module runs only after that terminal
+commit and writes to the disposable context-link projection; projection
+failure can never change ACP state or its returned result.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .paths import projection_path
+from .resolvers import ResolutionError, resolve_acp_conversation
+from .store import AdmitOutcome, ContextLinkStore
+
+ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
+MAX_RECONCILE_ROWS = 500
+
+
+def _disabled() -> bool:
+    return os.environ.get(ENV_DISABLED, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def project_terminal_acp_receipt(
+    *,
+    conversation_id: str,
+    acp_root: Path,
+    repo_root: Path,
+    db_path: Path | None = None,
+    actor: str = "acp-runtime",
+) -> dict[str, Any]:
+    """Project one exact terminal receipt idempotently after ACP completion."""
+    if _disabled():
+        return {"outcome": "skipped", "reason": "projection_disabled"}
+    try:
+        resolution = resolve_acp_conversation(
+            conversation_id,
+            acp_root=Path(acp_root),
+        )
+        result = ContextLinkStore(
+            projection_path(repo_root, db_path)
+        ).admit(resolution.link, resolution.verification, actor=actor)
+    except ResolutionError as exc:
+        return {"outcome": "skipped", "reason": exc.reason}
+    except (OSError, sqlite3.Error, KeyError, TypeError, ValueError):
+        return {"outcome": "skipped", "reason": "projection_unavailable"}
+    return result.to_dict()
+
+
+def _terminal_complete_ids(acp_root: Path, *, limit: int) -> list[str]:
+    db_path = Path(acp_root).expanduser().resolve() / "comms.sqlite3"
+    if not db_path.is_file():
+        return []
+    capped = max(0, min(int(limit), MAX_RECONCILE_ROWS))
+    with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:
+        rows = connection.execute(
+            "SELECT event.conversation_id FROM acp_conversation_events AS event"
+            " WHERE event.sequence = ("
+            "SELECT MAX(latest.sequence) FROM acp_conversation_events AS latest"
+            " WHERE latest.conversation_id = event.conversation_id"
+            ") AND event.state = 'COMPLETE'"
+            " ORDER BY event.conversation_id LIMIT ?",
+            (capped,),
+        ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def reconcile_terminal_acp_receipts(
+    *,
+    acp_root: Path,
+    repo_root: Path,
+    db_path: Path | None = None,
+    limit: int = MAX_RECONCILE_ROWS,
+    actor: str = "acp-reconcile",
+) -> dict[str, Any]:
+    """Recover any terminal ACP receipts missed by the post-commit callback."""
+    if _disabled():
+        return {"outcome": "skipped", "reason": "projection_disabled"}
+    try:
+        conversation_ids = _terminal_complete_ids(acp_root, limit=limit)
+    except sqlite3.Error:
+        return {"outcome": "skipped", "reason": "source_unreadable"}
+    counts = {
+        AdmitOutcome.PROMOTED.value: 0,
+        AdmitOutcome.ALREADY_PROMOTED.value: 0,
+        "skipped": 0,
+    }
+    reasons: dict[str, int] = {}
+    for conversation_id in conversation_ids:
+        result = project_terminal_acp_receipt(
+            conversation_id=conversation_id,
+            acp_root=acp_root,
+            repo_root=repo_root,
+            db_path=db_path,
+            actor=actor,
+        )
+        outcome = str(result["outcome"])
+        counts[outcome] = counts.get(outcome, 0) + 1
+        reason = str(result.get("reason") or "")
+        if reason:
+            reasons[reason] = reasons.get(reason, 0) + 1
+    return {
+        "outcome": "reconciled",
+        "examined": len(conversation_ids),
+        "counts": counts,
+        "reasons": dict(sorted(reasons.items())),
+    }

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -12,6 +12,7 @@ caller-supplied database file.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from contextlib import contextmanager, suppress
@@ -65,6 +66,16 @@ CREATE TABLE IF NOT EXISTS context_links (
     promoted_at TEXT,
     tombstone_reason TEXT
 );
+CREATE TABLE IF NOT EXISTS use_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    consumer TEXT NOT NULL,
+    purpose TEXT NOT NULL,
+    locator_ids_json TEXT NOT NULL,
+    recorded_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_use_receipts_recorded_at
+    ON use_receipts(recorded_at, receipt_id);
 """
 
 
@@ -389,11 +400,92 @@ class ContextLinkStore:
                 "SELECT state, COUNT(*) AS n FROM context_links GROUP BY state ORDER BY state"
             ).fetchall()
             events = connection.execute("SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM link_events").fetchone()
+            uses = connection.execute(
+                "SELECT COUNT(*) AS n, MAX(recorded_at) AS last_at FROM use_receipts"
+            ).fetchone()
+            use_consumers = connection.execute(
+                "SELECT consumer, COUNT(*) AS n FROM use_receipts"
+                " GROUP BY consumer ORDER BY consumer"
+            ).fetchall()
         return {
             "schema_version": SCHEMA_VERSION,
             "counts": {str(row["state"]): int(row["n"]) for row in counts},
             "events": int(events["n"]) if events else 0,
             "last_event_at": events["last_at"] if events else None,
+            "use_receipts": int(uses["n"]) if uses else 0,
+            "last_use_at": uses["last_at"] if uses else None,
+            "uses_by_consumer": {
+                str(row["consumer"]): int(row["n"]) for row in use_consumers
+            },
+        }
+
+    def record_use(
+        self,
+        *,
+        task_id: str,
+        consumer: str,
+        purpose: str,
+        locator_ids: list[str] | tuple[str, ...],
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Record an explicit, body-free agent-use attestation.
+
+        This is deliberately separate from search and handoff. A search result
+        proves only delivery; a use receipt is written only when the caller
+        explicitly attests that the verified locators informed its work.
+        Replays of the same task/consumer/purpose/locator set are idempotent.
+        """
+        validate_identity(task_id, field_name="task_id")
+        validate_identity(consumer, field_name="consumer")
+        validate_identity(purpose, field_name="purpose")
+        normalized = tuple(sorted(set(locator_ids)))
+        if not normalized or len(normalized) > 10:
+            raise SchemaError("locator_ids must contain between 1 and 10 unique locators")
+        if any(LOCATOR_ID_RE.fullmatch(locator_id) is None for locator_id in normalized):
+            raise SchemaError("locator_ids contains an invalid locator")
+        material = {
+            "schema": "entire-context-use.v1",
+            "task_id": task_id,
+            "consumer": consumer,
+            "purpose": purpose,
+            "locator_ids": list(normalized),
+        }
+        receipt_id = "ecuse_" + hashlib.sha256(
+            canonical_json(material).encode("utf-8")
+        ).hexdigest()
+        timestamp = isoformat_z(now or utc_now())
+        with self._transaction() as connection:
+            rows = connection.execute(
+                "SELECT locator_id FROM context_links"
+                f" WHERE state = 'promoted' AND locator_id IN ({','.join('?' for _ in normalized)})",
+                normalized,
+            ).fetchall()
+            promoted = {str(row["locator_id"]) for row in rows}
+            if promoted != set(normalized):
+                raise SchemaError("use receipt requires promoted locators")
+            cursor = connection.execute(
+                "INSERT OR IGNORE INTO use_receipts("
+                "receipt_id, task_id, consumer, purpose, locator_ids_json, recorded_at"
+                ") VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    receipt_id,
+                    task_id,
+                    consumer,
+                    purpose,
+                    canonical_json(list(normalized)),
+                    timestamp,
+                ),
+            )
+            stored = connection.execute(
+                "SELECT recorded_at FROM use_receipts WHERE receipt_id = ?",
+                (receipt_id,),
+            ).fetchone()
+        return {
+            "schema": "entire-context-use.v1",
+            "receipt_id": receipt_id,
+            "created": cursor.rowcount == 1,
+            "locator_count": len(normalized),
+            "recorded_at": str(stored["recorded_at"]),
         }
 
     # ── recall candidate scan and provenance joins ─────────────────────────────

--- a/tests/test_entire_context.py
+++ b/tests/test_entire_context.py
@@ -257,6 +257,29 @@ def test_long_natural_language_facet_remains_allowed() -> None:
     assert ContextLink.from_dict(payload).facets == payload["facets"]
 
 
+def test_real_semantic_long_touched_path_remains_allowed() -> None:
+    payload = make_link().to_dict()
+    path = "docs/research/EXISTING_CORPUS_ASSET_RECOVERY_AND_LINEAGE_AUDIT.md"
+    payload["facets"] = {"touched_paths": [path]}
+    assert ContextLink.from_dict(payload).facets == {"touched_paths": [path]}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "docs/" + "A" * 64 + ".md",
+        "docs/" + "A" * 24 + "_" + "B" * 24 + ".md",
+        "../outside.md",
+        "/absolute/path.md",
+    ],
+)
+def test_touched_paths_reject_opaque_or_nonrelative_values(path: str) -> None:
+    payload = make_link().to_dict()
+    payload["facets"] = {"touched_paths": [path]}
+    with pytest.raises(SchemaError):
+        ContextLink.from_dict(payload)
+
+
 @pytest.mark.parametrize("field", ["canonical_id", "entire_checkpoint_id"])
 def test_non_facet_identity_fields_reject_token_like_values(field: str) -> None:
     payload = make_link().to_dict()

--- a/tests/test_entire_context_live.py
+++ b/tests/test_entire_context_live.py
@@ -1,0 +1,222 @@
+"""Live projection, explicit-use, provider-cache, and Monitor acceptance tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.agent_runtime import acpx_discuss
+from scripts.api import entire_context_router
+from scripts.api.main import app
+from scripts.entire_context import provider, reconcile
+from scripts.entire_context.model import (
+    ContextLink,
+    LinkKind,
+    VerificationEvidence,
+    VerificationStatus,
+    isoformat_z,
+)
+from scripts.entire_context.paths import projection_path, shared_repository_root
+from scripts.entire_context.store import ContextLinkStore
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _promoted_store(tmp_path: Path) -> tuple[ContextLinkStore, ContextLink]:
+    store = ContextLinkStore(tmp_path / "context-links.sqlite3")
+    digest = "sha256:" + "a" * 64
+    sha = "1" * 40
+    link = ContextLink(
+        kind=LinkKind.GIT_COMMIT,
+        canonical_namespace="git:example/repo",
+        canonical_id=sha,
+        canonical_digest=digest,
+        git_sha=sha,
+        facets={"repository": "example/repo"},
+    )
+    verification = VerificationEvidence(
+        verifier="git",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"git:commit/{sha}",
+        checked_at=isoformat_z(datetime.now(UTC)),
+    )
+    store.admit(link, verification, actor="test")
+    return store, link
+
+
+def test_projection_path_is_shared_across_linked_worktrees(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    primary.mkdir()
+    _run_git(primary, "init", "-q")
+    _run_git(primary, "config", "user.email", "test@example.invalid")
+    _run_git(primary, "config", "user.name", "tester")
+    (primary / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _run_git(primary, "add", "seed.txt")
+    _run_git(primary, "commit", "-qm", "seed")
+    _run_git(primary, "worktree", "add", "-q", "-b", "linked", str(linked))
+
+    assert shared_repository_root(linked) == primary.resolve()
+    assert projection_path(linked) == projection_path(primary)
+
+
+def test_use_receipt_is_explicit_idempotent_and_separate_from_search(tmp_path: Path) -> None:
+    store, link = _promoted_store(tmp_path)
+    before = store.status()
+    first = store.record_use(
+        task_id="task-6183",
+        consumer="codex",
+        purpose="architecture",
+        locator_ids=[link.locator_id],
+    )
+    second = store.record_use(
+        task_id="task-6183",
+        consumer="codex",
+        purpose="architecture",
+        locator_ids=[link.locator_id],
+    )
+    after = store.status()
+
+    assert before["use_receipts"] == 0
+    assert first["created"] is True
+    assert second["created"] is False
+    assert first["receipt_id"] == second["receipt_id"]
+    assert after["use_receipts"] == 1
+    assert after["uses_by_consumer"] == {"codex": 1}
+
+
+def test_acp_wrapper_projects_only_after_complete_and_never_changes_result(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[dict] = []
+
+    class FakeController:
+        def __init__(self, *, root: Path) -> None:
+            self.root = root
+
+        def run(self, **_kwargs):
+            return {
+                "conversation_id": "conversation_" + "1" * 32,
+                "state": "COMPLETE",
+                "classification": "complete",
+            }
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(acpx_discuss, "AcpxDiscussionController", FakeController)
+    monkeypatch.setattr(
+        reconcile,
+        "project_terminal_acp_receipt",
+        lambda **kwargs: calls.append(kwargs) or {"outcome": "promoted"},
+    )
+
+    result = acpx_discuss.run_discussion(root=tmp_path / "plane", cwd=tmp_path)
+
+    assert result["state"] == "COMPLETE"
+    assert len(calls) == 1
+    assert calls[0]["conversation_id"] == result["conversation_id"]
+
+
+def test_acp_projection_failure_is_fail_open(tmp_path: Path, monkeypatch) -> None:
+    class FakeController:
+        def __init__(self, *, root: Path) -> None:
+            self.root = root
+
+        def run(self, **_kwargs):
+            return {
+                "conversation_id": "conversation_" + "2" * 32,
+                "state": "COMPLETE",
+            }
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(acpx_discuss, "AcpxDiscussionController", FakeController)
+    monkeypatch.setattr(
+        reconcile,
+        "project_terminal_acp_receipt",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("projection failed")),
+    )
+
+    assert acpx_discuss.run_discussion(root=tmp_path / "plane", cwd=tmp_path)["state"] == "COMPLETE"
+
+
+def test_provider_refresh_is_allowlisted_cached_and_version_pinned(
+    tmp_path: Path, monkeypatch
+) -> None:
+    def fake_run(_root: Path, *args: str):
+        if args == ("version",):
+            return subprocess.CompletedProcess(
+                ["entire", "version"], 0, "Entire CLI 0.8.42\nGo version: hidden\n", ""
+            )
+        raw = {
+            "enabled": True,
+            "agents": ["Codex", "Claude Code"],
+            "active_sessions": [{"agent": "Codex", "status": "ended", "body": "forbidden"}],
+            "prompt": "forbidden",
+        }
+        return subprocess.CompletedProcess(
+            ["entire", "status", "--json"], 0, json.dumps(raw), ""
+        )
+
+    target = tmp_path / "provider.json"
+    monkeypatch.setattr(provider, "_run", fake_run)
+    refreshed = provider.refresh_provider_status(tmp_path, output_path=target)
+    loaded = provider.load_provider_status(
+        tmp_path,
+        status_path=target,
+        now=datetime.now(UTC) + timedelta(seconds=901),
+    )
+
+    assert refreshed["version"] == "0.8.42"
+    assert refreshed["installed_agents"] == ["claude-code", "codex"]
+    assert "prompt" not in target.read_text(encoding="utf-8")
+    assert "forbidden" not in target.read_text(encoding="utf-8")
+    assert loaded["stale"] is True
+
+
+def test_monitor_status_distinguishes_capture_recall_and_use(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store, link = _promoted_store(tmp_path)
+    store.record_use(
+        task_id="task-6183",
+        consumer="codex",
+        purpose="implementation",
+        locator_ids=[link.locator_id],
+    )
+    monkeypatch.setenv("ENTIRE_CONTEXT_DB", str(store.db_path))
+    monkeypatch.setattr(entire_context_router, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        entire_context_router,
+        "load_provider_status",
+        lambda _root: {
+            "available": True,
+            "enabled": True,
+            "installed_agents": ["Codex"],
+        },
+    )
+
+    response = TestClient(app).get("/api/ops/entire-context/status")
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["capture"]["native_agent_installed"] is True
+    assert payload["recall"]["available"] is True
+    assert payload["use"]["proven"] is True
+    assert payload["use"]["by_consumer"] == {"codex": 1}
+    assert "projection_path" not in response.text


### PR DESCRIPTION
## Outcome

Connects the public body-free context layer to live agent work without making Entire authoritative. Capture, recall availability, and explicit agent use are now separate observable states.

## Changes

- share the rebuildable projection across linked worktrees via Git common-dir resolution
- project ACP COMPLETE receipts after canonical terminal commit and reconcile missed receipts idempotently
- add explicit body-free `record-use` receipts; search delivery alone never counts as use
- add exact Entire 0.8.42 sanitized provider-status caching
- expose read-only `/api/ops/entire-context/{status,search}` without synchronous Entire/network calls
- document host-harness routing: Claude-hosted Kimi/GLM use Claude Code; Codex Desktop uses Codex; adapters require failed native canaries
- fix valid underscore-semantic Git paths being falsely rejected while preserving opaque/credential rejection

## Verification

- 204 focused tests passed
- Ruff clean
- skill metadata lint and deploy dry-run passed
- source-blind bootstrap → search → explicit-use → status canary passed (`body_free=true`)
- agent trailer lint passed
- OPSEC leakage lint passed over all 14 changed files

Cross-family formal review is pending and remains a merge blocker.

Closes #6254
Refs #6183
Parent #4707.