### PR TITLE
feat(entire): capture standalone Kimi Code sessions

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -6,5 +6,6 @@
       "repo": "learn-ukrainian/entire-checkpoints-private"
     }
   },
-  "telemetry": false
+  "telemetry": false,
+  "external_agents": true
 }

--- a/.github/workflows/entire-kimi-agent.yml
+++ b/.github/workflows/entire-kimi-agent.yml
@@ -1,0 +1,40 @@
+name: Entire Kimi external agent
+
+on:
+  pull_request:
+    paths:
+      - ".entire/settings.json"
+      - ".github/workflows/entire-kimi-agent.yml"
+      - "scripts/entire/external_agents/entire-agent-kimi/**"
+      - "scripts/entire/install_kimi_external_agent.sh"
+  push:
+    branches:
+      - main
+    paths:
+      - ".entire/settings.json"
+      - ".github/workflows/entire-kimi-agent.yml"
+      - "scripts/entire/external_agents/entire-agent-kimi/**"
+      - "scripts/entire/install_kimi_external_agent.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.26.0"
+          cache-dependency-path: scripts/entire/external_agents/entire-agent-kimi/go.mod
+      - name: Unit and race tests
+        working-directory: scripts/entire/external_agents/entire-agent-kimi
+        run: go test -race ./...
+      - name: Build protocol binary
+        working-directory: scripts/entire/external_agents/entire-agent-kimi
+        run: go build -trimpath -o entire-agent-kimi ./cmd/entire-agent-kimi
+      - name: Entire protocol-v1 compliance
+        uses: entireio/external-agents-tests@3220ca8cc7ba2fbfc5a951ce4a5937ca1a5ca26e
+        with:
+          binary-path: scripts/entire/external_agents/entire-agent-kimi/entire-agent-kimi

--- a/docs/entire/KIMI-EXTERNAL-AGENT.md
+++ b/docs/entire/KIMI-EXTERNAL-AGENT.md
@@ -1,0 +1,90 @@
+# Kimi Code external-agent decision and evidence
+
+## Decision
+
+Use one external Entire agent only for the standalone Kimi Code CLI. Do not
+create `kimi-in-claude`, `glm-in-claude`, `glm-opencode`, or `codex-gui`
+agents. Entire integration follows the host harness that owns the lifecycle
+and transcript:
+
+| Execution surface | Entire agent |
+| --- | --- |
+| Kimi or GLM model inside Claude Code | `claude-code` |
+| GLM model inside OpenCode | `opencode` |
+| Codex Desktop or Codex CLI | `codex` |
+| Standalone `kimi` CLI | `kimi` external agent |
+
+This is the smallest root-cause bridge because a source-blind standalone Kimi
+K3 canary completed successfully but produced no Entire session, while the
+native Claude Code, OpenCode, and Codex paths already exist.
+
+## Black-box evidence
+
+The installed Kimi Code version is `0.31.1`. Read-only inspection of native
+session metadata established:
+
+- user-level config: `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`;
+- session index: `session_index.jsonl` with `sessionId`, `sessionDir`, and
+  `workDir`;
+- transcript: `<sessionDir>/agents/main/wire.jsonl`;
+- model identity: `config.update.modelAlias`, `llm.request.modelAlias`, and
+  `usage.record.model` (observed `kimi-code/k3`);
+- prompt records: `turn.prompt.input[]` text parts;
+- modified-file records: `context.append_loop_event` → `tool.call` → native
+  `Write`/`Edit` `args.path`;
+- usage records: `inputOther`, `inputCacheRead`, `inputCacheCreation`, and
+  `output`.
+
+No prompt or transcript body was copied into this public document. The
+adapter reads the native source only when Entire invokes its protocol.
+
+## Lifecycle mapping
+
+| Kimi hook | Entire protocol event |
+| --- | --- |
+| `SessionStart` | `SessionStart` (1) |
+| `UserPromptSubmit` | `TurnStart` (2) |
+| `Stop` | `TurnEnd` (3) |
+| `PreCompact` | `Compaction` (4) |
+| `SessionEnd` | `SessionEnd` (5) |
+
+`PostCompact` is intentionally not installed because `PreCompact` already
+creates the protocol compaction boundary. Subagent events remain undeclared:
+the current public hook payload names an agent but lacks a stable child-run ID
+needed for honest attribution.
+
+## Safety and rollout contract
+
+- Entire CLI remains pinned to `0.8.42`.
+- External-agent discovery is explicitly enabled in `.entire/settings.json`.
+- The binary name is `entire-agent-kimi`, protocol version 1.
+- Hooks are fail-open when Entire is absent or returns an error.
+- Installation is atomic and contention-safe, preserves all bytes outside one
+  marked block, and requires `--force` for managed-block drift.
+- Session IDs and references are traversal checked.
+- Public source-repository checkpoints continue to route only to
+  `learn-ukrainian/entire-checkpoints-private`; public shadow refs are
+  forbidden.
+- Entire remains a non-load-bearing journal/provenance layer. GitHub, Fleet
+  Comms, Monitor, rollover, and formal review remain authoritative.
+
+## Verification gates
+
+The merge gate requires:
+
+1. Go unit and race tests, including concurrent hook installation and exact
+   config restoration.
+2. The upstream `entireio/external-agents-tests` protocol-v1 suite.
+3. A source-blind real Kimi K3 lifecycle canary with actual model attribution.
+4. Retry, outage/fail-open, multiple-worktree, checkpoint, explain/blame, and
+   private-routing canaries.
+5. Independent cross-family review and green repository CI.
+
+Sources: [Entire agent overview](https://docs.entire.io/agents/overview),
+[external plugins](https://docs.entire.io/agents/external-agent-plugins/overview),
+[protocol architecture](https://docs.entire.io/agents/external-agent-plugins/architecture),
+[lifecycle](https://docs.entire.io/agents/external-agent-plugins/lifecycle),
+[commands](https://docs.entire.io/agents/external-agent-plugins/commands),
+[data model](https://docs.entire.io/agents/external-agent-plugins/data-model),
+[reference implementations](https://github.com/entireio/external-agents), and
+[Kimi hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks).

--- a/scripts/entire/external_agents/entire-agent-kimi/AGENT.md
+++ b/scripts/entire/external_agents/entire-agent-kimi/AGENT.md
@@ -1,0 +1,21 @@
+# Kimi Code protocol notes
+
+Authoritative upstream contracts:
+
+- Entire external-agent protocol v1:
+  <https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md>
+- Entire external-agent reference implementations and test workflow:
+  <https://github.com/entireio/external-agents>
+- Kimi Code hooks:
+  <https://moonshotai.github.io/kimi-code/en/customization/hooks>
+- Kimi Code sessions:
+  <https://moonshotai.github.io/kimi-code/en/guides/sessions.html>
+
+Do not create model-specific variants. The registry name is the standalone
+harness, `kimi`; model identity comes from the native wire records.
+
+Keep protocol behavior stateless. Do not add network calls, public checkpoint
+routing, transcript summaries, or a second session store. Kimi's native
+`wire.jsonl` remains the session source. The managed hook block is the only
+allowed mutation outside the repository and must stay byte-preserving,
+idempotent, atomic, contention-safe, and fail-open.

--- a/scripts/entire/external_agents/entire-agent-kimi/README.md
+++ b/scripts/entire/external_agents/entire-agent-kimi/README.md
@@ -1,0 +1,49 @@
+# Entire external agent for Kimi Code
+
+This preview adapter adds Entire protocol-v1 capture for the standalone
+`kimi` CLI. It is intentionally not used for Kimi or GLM models hosted by
+Claude Code, for GLM hosted by OpenCode, or for Codex Desktop/CLI; those use
+Entire's native `claude-code`, `opencode`, and `codex` integrations.
+
+The adapter reads Kimi Code's native `session_index.jsonl` and
+`agents/main/wire.jsonl`, preserves the actual model alias (for example
+`kimi-code/k3`), extracts native prompt/file/token evidence, and installs a
+single managed block in the user-level Kimi `config.toml`. Hook commands are
+fail-open so an absent or unavailable Entire CLI cannot block Kimi.
+
+## Build and verify
+
+```bash
+go test -race ./...
+go build -trimpath -o entire-agent-kimi ./cmd/entire-agent-kimi
+AGENT_BINARY="$PWD/entire-agent-kimi" external-agents-tests ./...
+```
+
+From the repository root, the project installer builds and atomically places
+the binary on `PATH`:
+
+```bash
+scripts/entire/install_kimi_external_agent.sh
+```
+
+Then install the lifecycle hooks once:
+
+```bash
+entire-agent-kimi install-hooks
+entire-agent-kimi are-hooks-installed
+```
+
+`uninstall-hooks` removes only the managed block and restores every surrounding
+configuration byte. A drifted managed block requires explicit `--force` repair.
+
+## Security boundary
+
+- Session references must remain under Kimi's session root or the current
+  repository root used by the protocol compliance harness.
+- Session IDs reject separators and traversal.
+- Hook installation preserves credentials and unrelated Kimi settings.
+- Entire checkpoints remain routed to
+  `learn-ukrainian/entire-checkpoints-private`; no public Entire refs are
+  created.
+- Subagent attribution is not declared because current Kimi hook payloads do
+  not expose a stable child-run identifier.

--- a/scripts/entire/external_agents/entire-agent-kimi/cmd/entire-agent-kimi/main.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/cmd/entire-agent-kimi/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/kimi"
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/protocol"
+)
+
+func main() {
+	if err := protocol.Run(kimi.New(), os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/go.mod
+++ b/scripts/entire/external_agents/entire-agent-kimi/go.mod
@@ -1,0 +1,3 @@
+module github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi
+
+go 1.26.0

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/agent.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/agent.go
@@ -1,0 +1,285 @@
+package kimi
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/protocol"
+)
+
+const (
+	agentName     = "kimi"
+	agentType     = "Kimi Code"
+	stubSessionID = "kimi-session"
+)
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,191}$`)
+
+type Agent struct{ LookPath func(string) (string, error) }
+
+func New() *Agent { return &Agent{LookPath: exec.LookPath} }
+
+func (a *Agent) Info() protocol.Info {
+	return protocol.Info{
+		ProtocolVersion: protocol.Version,
+		Name:            agentName,
+		Type:            agentType,
+		Description:     "Kimi Code CLI external-agent integration for Entire",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".kimi-code"},
+		ProtectedFiles:  []string{"config.toml", "session_index.jsonl"},
+		HookNames:       []string{"session-start", "turn-start", "turn-end", "compaction", "session-end"},
+		Capabilities: protocol.Capabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			TokenCalculator:    true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	lookPath := a.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	_, err := lookPath("kimi")
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInput) string {
+	if input != nil && validSessionID(input.SessionID) {
+		return input.SessionID
+	}
+	return stubSessionID
+}
+
+func (a *Agent) GetSessionDir(_ string) (string, error) {
+	return filepath.Join(kimiHome(), "sessions"), nil
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) (string, error) {
+	if !validSessionID(sessionID) {
+		return "", fmt.Errorf("invalid Kimi session id")
+	}
+	if found, ok := lookupSession(sessionID); ok {
+		return found, nil
+	}
+	if strings.TrimSpace(sessionDir) == "" {
+		sessionDir = filepath.Join(kimiHome(), "sessions")
+	}
+	dir, err := filepath.Abs(sessionDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".entire-sidecars", sessionID+".jsonl"), nil
+}
+
+func (a *Agent) ReadSession(input *protocol.HookInput) (protocol.Session, error) {
+	if input == nil {
+		return protocol.Session{}, fmt.Errorf("hook input is required")
+	}
+	id := a.GetSessionID(input)
+	ref := input.SessionRef
+	var err error
+	if strings.TrimSpace(ref) == "" {
+		dir, dirErr := a.GetSessionDir(protocol.RepoRoot())
+		if dirErr != nil {
+			return protocol.Session{}, dirErr
+		}
+		ref, err = a.ResolveSessionFile(dir, id)
+		if err != nil {
+			return protocol.Session{}, err
+		}
+	}
+	if err := validateSessionRef(ref); err != nil {
+		return protocol.Session{}, err
+	}
+	data, err := os.ReadFile(ref)
+	if errors.Is(err, os.ErrNotExist) {
+		data = nil
+	} else if err != nil {
+		return protocol.Session{}, err
+	}
+	files, _, err := a.ExtractModifiedFiles(ref, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		files = []string{}
+	} else if err != nil {
+		return protocol.Session{}, err
+	}
+	return protocol.Session{
+		SessionID:     id,
+		AgentName:     agentName,
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    ref,
+		StartTime:     sessionStartTime(ref),
+		NativeData:    data,
+		ModifiedFiles: nonNil(files),
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+func (a *Agent) WriteSession(session protocol.Session) error {
+	if !validSessionID(session.SessionID) {
+		return fmt.Errorf("invalid Kimi session id")
+	}
+	if err := validateSessionRef(session.SessionRef); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
+		return err
+	}
+	return atomicWrite(session.SessionRef, session.NativeData, 0o600)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	if err := validateSessionRef(sessionRef); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(sessionRef)
+}
+
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if !validSessionID(sessionID) {
+		return "kimi --continue"
+	}
+	return "kimi --session " + sessionID
+}
+
+func validSessionID(value string) bool { return sessionIDPattern.MatchString(value) }
+
+func kimiHome() string {
+	if value := strings.TrimSpace(os.Getenv("KIMI_CODE_HOME")); value != "" {
+		if abs, err := filepath.Abs(value); err == nil {
+			return abs
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".kimi-code")
+	}
+	return filepath.Join(home, ".kimi-code")
+}
+
+type sessionIndexRecord struct {
+	SessionID  string `json:"sessionId"`
+	SessionDir string `json:"sessionDir"`
+	WorkDir    string `json:"workDir"`
+}
+
+func lookupSession(sessionID string) (string, bool) {
+	f, err := os.Open(filepath.Join(kimiHome(), "session_index.jsonl"))
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+	root := filepath.Join(kimiHome(), "sessions")
+	var matched string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	for scanner.Scan() {
+		var record sessionIndexRecord
+		if json.Unmarshal(scanner.Bytes(), &record) != nil || record.SessionID != sessionID {
+			continue
+		}
+		dir := record.SessionDir
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(kimiHome(), dir)
+		}
+		wire := filepath.Join(filepath.Clean(dir), "agents", "main", "wire.jsonl")
+		if pathWithin(wire, root) {
+			matched = wire
+		}
+	}
+	return matched, matched != ""
+}
+
+func validateSessionRef(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("session_ref is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	sessionsRoot := filepath.Join(kimiHome(), "sessions")
+	if pathWithin(abs, sessionsRoot) {
+		return nil
+	}
+	if pathWithin(abs, protocol.RepoRoot()) {
+		return nil
+	}
+	return fmt.Errorf("session_ref escapes Kimi session storage")
+}
+
+func pathWithin(path, root string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func sessionStartTime(ref string) string {
+	statePath := filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(ref))), "state.json")
+	data, err := os.ReadFile(statePath)
+	if err == nil {
+		var state struct {
+			CreatedAt float64 `json:"createdAt"`
+		}
+		if json.Unmarshal(data, &state) == nil && state.CreatedAt > 0 {
+			return time.UnixMilli(int64(state.CreatedAt)).UTC().Format(time.RFC3339)
+		}
+	}
+	if info, err := os.Stat(ref); err == nil {
+		return info.ModTime().UTC().Format(time.RFC3339)
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".entire-kimi-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func nonNil(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/agent_test.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/agent_test.go
@@ -1,0 +1,252 @@
+package kimi
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/protocol"
+)
+
+const fixtureSessionID = "session_12345678-1234-1234-1234-123456789abc"
+
+func TestNativeWireResolutionAndAnalysis(t *testing.T) {
+	agent, wire, repo := fixtureAgent(t)
+	dir, err := agent.GetSessionDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := agent.ResolveSessionFile(dir, fixtureSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != wire {
+		t.Fatalf("resolved %q, want %q", resolved, wire)
+	}
+
+	position, err := agent.GetTranscriptPosition(wire)
+	if err != nil || position <= 0 {
+		t.Fatalf("position=%d err=%v", position, err)
+	}
+	files, current, err := agent.ExtractModifiedFiles(wire, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current != position {
+		t.Fatalf("current=%d, want %d", current, position)
+	}
+	if got := strings.Join(files, ","); got != "src/main.go,src/new.go" {
+		t.Fatalf("files=%q", got)
+	}
+	prompts, err := agent.ExtractPrompts(wire, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Implement the adapter" {
+		t.Fatalf("prompts=%v", prompts)
+	}
+	data, err := os.ReadFile(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err := agent.CalculateTokens(data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.InputTokens != 120 || usage.CacheReadTokens != 40 || usage.CacheCreationTokens != 3 || usage.OutputTokens != 21 || usage.APICallCount != 1 {
+		t.Fatalf("usage=%+v", usage)
+	}
+}
+
+func TestHookMappingUsesNativeModel(t *testing.T) {
+	agent, wire, _ := fixtureAgent(t)
+	payload := map[string]any{
+		"hook_event_name": "UserPromptSubmit",
+		"session_id":      fixtureSessionID,
+		"cwd":             protocol.RepoRoot(),
+		"prompt":          []map[string]string{{"type": "text", "text": "Use Kimi natively"}},
+	}
+	data, _ := json.Marshal(payload)
+	event, err := agent.ParseHook("turn-start", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Type != 2 || event.SessionID != fixtureSessionID || event.SessionRef != wire {
+		t.Fatalf("event=%+v", event)
+	}
+	if event.Prompt != "Use Kimi natively" {
+		t.Fatalf("prompt=%q", event.Prompt)
+	}
+	if event.Model != "kimi-code/k3" {
+		t.Fatalf("model=%q", event.Model)
+	}
+
+	for hook, want := range map[string]int{"session-start": 1, "turn-end": 3, "compaction": 4, "session-end": 5} {
+		mapped, err := agent.ParseHook(hook, data)
+		if err != nil || mapped.Type != want {
+			t.Fatalf("hook=%s type=%v err=%v", hook, mapped, err)
+		}
+	}
+}
+
+func TestOffsetAtJSONLBoundary(t *testing.T) {
+	agent, wire, _ := fixtureAgent(t)
+	before, err := os.Stat(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendLine(t, wire, `{"type":"turn.prompt","input":[{"type":"text","text":"Second prompt"}]}`)
+	appendLine(t, wire, `{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":7,"inputCacheRead":2,"inputCacheCreation":1,"output":4}}`)
+	prompts, err := agent.ExtractPrompts(wire, int(before.Size()))
+	if err != nil || len(prompts) != 1 || prompts[0] != "Second prompt" {
+		t.Fatalf("prompts=%v err=%v", prompts, err)
+	}
+	data, _ := os.ReadFile(wire)
+	usage, err := agent.CalculateTokens(data, int(before.Size()))
+	if err != nil || usage.InputTokens != 7 || usage.OutputTokens != 4 || usage.APICallCount != 1 {
+		t.Fatalf("usage=%+v err=%v", usage, err)
+	}
+}
+
+func TestHookInstallPreservesConfigAndIsConcurrentIdempotent(t *testing.T) {
+	agent, _, _ := fixtureAgent(t)
+	config := configPath()
+	original := []byte("default_model = \"kimi-code/k3\"\n[providers.kimi]\napi_key = \"credential-canary\"")
+	if err := os.WriteFile(config, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 12
+	var wg sync.WaitGroup
+	counts := make(chan int, workers)
+	errorsSeen := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			count, err := agent.InstallHooks(false, false)
+			counts <- count
+			errorsSeen <- err
+		}()
+	}
+	wg.Wait()
+	close(counts)
+	close(errorsSeen)
+	for err := range errorsSeen {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	installed := 0
+	for count := range counts {
+		installed += count
+	}
+	if installed != len(hookSpecs) {
+		t.Fatalf("installed total=%d", installed)
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("hooks not reported installed")
+	}
+	withHooks, _ := os.ReadFile(config)
+	if !bytes.Contains(withHooks, original) || bytes.Count(withHooks, []byte(blockBegin)) != 1 {
+		t.Fatal("config bytes were not preserved")
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	restored, _ := os.ReadFile(config)
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("uninstall changed original bytes\ngot: %q\nwant: %q", restored, original)
+	}
+}
+
+func TestDriftRequiresForceAndTraversalFailsClosed(t *testing.T) {
+	agent, _, _ := fixtureAgent(t)
+	config := configPath()
+	block := managedBlock(false)
+	block = bytes.Replace(block, []byte("timeout = 30"), []byte("timeout = 29"), 1)
+	if err := os.WriteFile(config, block, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agent.InstallHooks(false, false); err == nil {
+		t.Fatal("drifted block did not fail")
+	}
+	if _, err := agent.InstallHooks(false, true); err != nil {
+		t.Fatal(err)
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("force did not repair block")
+	}
+	if _, err := agent.ResolveSessionFile(filepath.Join(kimiHome(), "sessions"), "../escape"); err == nil {
+		t.Fatal("invalid session id accepted")
+	}
+	if _, err := agent.ReadTranscript(filepath.Join(kimiHome(), "outside.jsonl")); err == nil {
+		t.Fatal("outside transcript accepted")
+	}
+}
+
+func TestSessionRoundTripUsesValidatedStorage(t *testing.T) {
+	agent, _, repo := fixtureAgent(t)
+	dir, _ := agent.GetSessionDir(repo)
+	ref, err := agent.ResolveSessionFile(dir, "session_roundtrip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := protocol.Session{SessionID: "session_roundtrip", AgentName: agentName, RepoPath: repo, SessionRef: ref, StartTime: "2026-08-02T00:00:00Z", NativeData: []byte("{\"fixture\":true}"), ModifiedFiles: []string{}, NewFiles: []string{}, DeletedFiles: []string{}}
+	if err := agent.WriteSession(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := agent.ReadSession(&protocol.HookInput{SessionID: want.SessionID, SessionRef: ref})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.NativeData, want.NativeData) || got.SessionRef != ref {
+		t.Fatalf("roundtrip=%+v", got)
+	}
+}
+
+func fixtureAgent(t *testing.T) (*Agent, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	sessionDir := filepath.Join(home, "sessions", "wd_fixture", fixtureSessionID)
+	wire := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	if err := os.MkdirAll(filepath.Dir(wire), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture := strings.Join([]string{
+		`{"type":"metadata","protocol_version":1}`,
+		`{"type":"config.update","modelAlias":"kimi-code/k3"}`,
+		`{"type":"turn.prompt","input":[{"type":"text","text":"Implement the adapter"}]}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.call","name":"Write","args":{"path":"src/new.go"}}}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.call","name":"Edit","args":{"path":"src/main.go"}}}`,
+		`{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":120,"inputCacheRead":40,"inputCacheCreation":3,"output":21}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(wire, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	index := map[string]string{"sessionId": fixtureSessionID, "sessionDir": sessionDir, "workDir": repo}
+	data, _ := json.Marshal(index)
+	if err := os.WriteFile(filepath.Join(home, "session_index.jsonl"), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return New(), wire, repo
+}
+
+func appendLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/hooks.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/hooks.go
@@ -1,0 +1,288 @@
+package kimi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/protocol"
+)
+
+const (
+	blockBegin = "# BEGIN learn-ukrainian Entire Kimi hooks v1 separator="
+	blockEnd   = "# END learn-ukrainian Entire Kimi hooks v1"
+)
+
+var hookSpecs = []struct{ event, hook string }{
+	{"SessionStart", "session-start"},
+	{"UserPromptSubmit", "turn-start"},
+	{"Stop", "turn-end"},
+	{"PreCompact", "compaction"},
+	{"SessionEnd", "session-end"},
+}
+
+type rawHook struct {
+	HookEventName string          `json:"hook_event_name"`
+	HookType      string          `json:"hook_type"`
+	SessionID     string          `json:"session_id"`
+	SessionRef    string          `json:"session_ref"`
+	Timestamp     string          `json:"timestamp"`
+	CWD           string          `json:"cwd"`
+	Source        string          `json:"source"`
+	Reason        string          `json:"reason"`
+	Trigger       string          `json:"trigger"`
+	UserPrompt    string          `json:"user_prompt"`
+	Prompt        json.RawMessage `json:"prompt"`
+}
+
+func (a *Agent) ParseHook(hook string, input []byte) (*protocol.Event, error) {
+	var raw rawHook
+	if len(bytes.TrimSpace(input)) > 0 {
+		if err := json.Unmarshal(input, &raw); err != nil {
+			return nil, fmt.Errorf("parse Kimi hook: %w", err)
+		}
+	}
+	if !validSessionID(raw.SessionID) {
+		raw.SessionID = stubSessionID
+	}
+	ref := raw.SessionRef
+	if strings.TrimSpace(ref) == "" {
+		dir, _ := a.GetSessionDir(protocol.RepoRoot())
+		var err error
+		ref, err = a.ResolveSessionFile(dir, raw.SessionID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	timestamp := raw.Timestamp
+	if _, err := time.Parse(time.RFC3339, timestamp); err != nil {
+		timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	event := &protocol.Event{
+		SessionID:  raw.SessionID,
+		SessionRef: ref,
+		Timestamp:  timestamp,
+		Model:      latestModel(ref),
+		Metadata:   map[string]string{"agent": agentName},
+	}
+	if raw.CWD != "" {
+		event.Metadata["cwd"] = raw.CWD
+	}
+	if raw.Source != "" {
+		event.Metadata["source"] = raw.Source
+	}
+	if raw.Reason != "" {
+		event.Metadata["reason"] = raw.Reason
+	}
+	if raw.Trigger != "" {
+		event.Metadata["trigger"] = raw.Trigger
+	}
+	if raw.HookEventName != "" {
+		event.Metadata["hook_event_name"] = raw.HookEventName
+	}
+	switch hook {
+	case "session-start":
+		event.Type = 1
+	case "turn-start":
+		event.Type = 2
+		event.Prompt = hookPrompt(raw)
+	case "turn-end":
+		event.Type = 3
+	case "compaction":
+		event.Type = 4
+	case "session-end":
+		event.Type = 5
+	default:
+		return nil, nil
+	}
+	return event, nil
+}
+
+func hookPrompt(raw rawHook) string {
+	if strings.TrimSpace(raw.UserPrompt) != "" {
+		return raw.UserPrompt
+	}
+	var direct string
+	if json.Unmarshal(raw.Prompt, &direct) == nil && strings.TrimSpace(direct) != "" {
+		return direct
+	}
+	var parts []contentPart
+	if json.Unmarshal(raw.Prompt, &parts) != nil {
+		return ""
+	}
+	var text []string
+	for _, part := range parts {
+		if part.Type == "text" && strings.TrimSpace(part.Text) != "" {
+			text = append(text, part.Text)
+		}
+	}
+	return strings.Join(text, "\n")
+}
+
+func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
+	path := configPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return 0, err
+	}
+	release, err := acquireConfigLock(path + ".entire-kimi.lock")
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	original, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		original = nil
+	} else if err != nil {
+		return 0, err
+	}
+	without, found, exact, err := removeManagedBlock(original)
+	if err != nil {
+		return 0, err
+	}
+	if found && exact && !force {
+		return 0, nil
+	}
+	if found && !exact && !force {
+		return 0, fmt.Errorf("managed Entire Kimi hook block drifted; rerun with --force")
+	}
+	if found {
+		original = without
+	}
+	separatorInserted := len(original) > 0 && original[len(original)-1] != '\n'
+	updated := append([]byte(nil), original...)
+	if separatorInserted {
+		updated = append(updated, '\n')
+	}
+	updated = append(updated, managedBlock(separatorInserted)...)
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := atomicWrite(path, updated, mode); err != nil {
+		return 0, err
+	}
+	return len(hookSpecs), nil
+}
+
+func (a *Agent) UninstallHooks() error {
+	path := configPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	release, err := acquireConfigLock(path + ".entire-kimi.lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+	original, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	updated, found, _, err := removeManagedBlock(original)
+	if err != nil || !found {
+		return err
+	}
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	return atomicWrite(path, updated, mode)
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	data, err := os.ReadFile(configPath())
+	if err != nil {
+		return false
+	}
+	_, found, exact, err := removeManagedBlock(data)
+	return err == nil && found && exact
+}
+
+func configPath() string { return filepath.Join(kimiHome(), "config.toml") }
+
+func managedBlock(separatorInserted bool) []byte {
+	separator := "existing"
+	if separatorInserted {
+		separator = "inserted"
+	}
+	var b strings.Builder
+	b.WriteString(blockBegin + separator + "\n")
+	for _, spec := range hookSpecs {
+		b.WriteString("[[hooks]]\n")
+		b.WriteString("event = \"")
+		b.WriteString(spec.event)
+		b.WriteString("\"\n")
+		b.WriteString("command = \"sh -c 'command -v entire >/dev/null 2>&1 || exit 0; entire hooks kimi ")
+		b.WriteString(spec.hook)
+		b.WriteString(" || true'\"\n")
+		b.WriteString("timeout = 30\n\n")
+	}
+	b.WriteString(blockEnd + "\n")
+	return []byte(b.String())
+}
+
+func removeManagedBlock(data []byte) ([]byte, bool, bool, error) {
+	start := bytes.Index(data, []byte(blockBegin))
+	if start < 0 {
+		return append([]byte(nil), data...), false, false, nil
+	}
+	if bytes.Index(data[start+len(blockBegin):], []byte(blockBegin)) >= 0 {
+		return nil, false, false, fmt.Errorf("multiple Entire Kimi hook blocks")
+	}
+	lineEndRel := bytes.IndexByte(data[start:], '\n')
+	if lineEndRel < 0 {
+		return nil, true, false, nil
+	}
+	lineEnd := start + lineEndRel
+	header := string(data[start:lineEnd])
+	separatorInserted := strings.HasSuffix(header, "inserted")
+	separatorExisting := strings.HasSuffix(header, "existing")
+	endRel := bytes.Index(data[lineEnd+1:], []byte(blockEnd))
+	if endRel < 0 {
+		return nil, true, false, nil
+	}
+	end := lineEnd + 1 + endRel + len(blockEnd)
+	if end < len(data) && data[end] == '\n' {
+		end++
+	}
+	exact := false
+	if separatorInserted || separatorExisting {
+		expected := managedBlock(separatorInserted)
+		exact = bytes.Equal(data[start:end], expected)
+	}
+	removeStart := start
+	if separatorInserted && start > 0 && data[start-1] == '\n' {
+		removeStart--
+	}
+	updated := append([]byte(nil), data[:removeStart]...)
+	updated = append(updated, data[end:]...)
+	return updated, true, exact, nil
+}
+
+func acquireConfigLock(path string) (func(), error) {
+	for attempt := 0; attempt < 100; attempt++ {
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+			_ = file.Close()
+			return func() { _ = os.Remove(path) }, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		if info, statErr := os.Stat(path); statErr == nil && time.Since(info.ModTime()) > time.Minute {
+			_ = os.Remove(path)
+			continue
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("timed out waiting for Kimi config lock")
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/transcript.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/kimi/transcript.go
@@ -1,0 +1,252 @@
+package kimi
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/learn-ukrainian/learn-ukrainian.github.io/scripts/entire/external_agents/entire-agent-kimi/internal/protocol"
+)
+
+type wireRecord struct {
+	Type       string          `json:"type"`
+	ModelAlias string          `json:"modelAlias"`
+	Model      string          `json:"model"`
+	Input      []contentPart   `json:"input"`
+	Event      json.RawMessage `json:"event"`
+	Usage      usageRecord     `json:"usage"`
+}
+
+type contentPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+type usageRecord struct {
+	InputOther         int `json:"inputOther"`
+	InputCacheRead     int `json:"inputCacheRead"`
+	InputCacheCreation int `json:"inputCacheCreation"`
+	Output             int `json:"output"`
+}
+type loopEvent struct {
+	Type string                     `json:"type"`
+	Name string                     `json:"name"`
+	Args map[string]json.RawMessage `json:"args"`
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	if err := validateSessionRef(path); err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return int(info.Size()), nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	data, position, err := transcriptRange(path, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	seen := map[string]struct{}{}
+	for _, record := range parseWireRecords(data) {
+		if record.Type != "context.append_loop_event" {
+			continue
+		}
+		var event loopEvent
+		if json.Unmarshal(record.Event, &event) != nil || event.Type != "tool.call" {
+			continue
+		}
+		if event.Name != "Write" && event.Name != "Edit" {
+			continue
+		}
+		raw, ok := event.Args["path"]
+		if !ok {
+			continue
+		}
+		var value string
+		if json.Unmarshal(raw, &value) != nil {
+			continue
+		}
+		if normalized, ok := normalizeRepoPath(value); ok {
+			seen[normalized] = struct{}{}
+		}
+	}
+	files := make([]string, 0, len(seen))
+	for value := range seen {
+		files = append(files, value)
+	}
+	sort.Strings(files)
+	return files, position, nil
+}
+
+func (a *Agent) ExtractPrompts(path string, offset int) ([]string, error) {
+	data, _, err := transcriptRange(path, offset)
+	if err != nil {
+		return nil, err
+	}
+	prompts := []string{}
+	for _, record := range parseWireRecords(data) {
+		if record.Type != "turn.prompt" {
+			continue
+		}
+		var parts []string
+		for _, part := range record.Input {
+			if part.Type == "text" && strings.TrimSpace(part.Text) != "" {
+				parts = append(parts, part.Text)
+			}
+		}
+		if len(parts) > 0 {
+			prompts = append(prompts, strings.Join(parts, "\n"))
+		}
+	}
+	return prompts, nil
+}
+
+func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsage, error) {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(data) {
+		return protocol.TokenUsage{}, nil
+	}
+	partialLine := offset > 0 && data[offset-1] != '\n'
+	data = data[offset:]
+	if partialLine {
+		if next := bytes.IndexByte(data, '\n'); next >= 0 {
+			data = data[next+1:]
+		} else {
+			return protocol.TokenUsage{}, nil
+		}
+	}
+	var total protocol.TokenUsage
+	for _, record := range parseWireRecords(data) {
+		if record.Type != "usage.record" {
+			continue
+		}
+		total.InputTokens += max(record.Usage.InputOther, 0)
+		total.CacheReadTokens += max(record.Usage.InputCacheRead, 0)
+		total.CacheCreationTokens += max(record.Usage.InputCacheCreation, 0)
+		total.OutputTokens += max(record.Usage.Output, 0)
+		total.APICallCount++
+	}
+	return total, nil
+}
+
+func transcriptRange(path string, offset int) ([]byte, int, error) {
+	if err := validateSessionRef(path); err != nil {
+		return nil, 0, err
+	}
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	position := int(info.Size())
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= position {
+		return nil, position, nil
+	}
+	partialLine := false
+	if offset > 0 {
+		if _, err := f.Seek(int64(offset-1), io.SeekStart); err != nil {
+			return nil, 0, err
+		}
+		var previous [1]byte
+		if _, err := io.ReadFull(f, previous[:]); err != nil {
+			return nil, 0, err
+		}
+		partialLine = previous[0] != '\n'
+	}
+	if _, err := f.Seek(int64(offset), io.SeekStart); err != nil {
+		return nil, 0, err
+	}
+	data, err := io.ReadAll(io.LimitReader(f, 64*1024*1024))
+	if err != nil {
+		return nil, 0, err
+	}
+	if partialLine {
+		if next := bytes.IndexByte(data, '\n'); next >= 0 {
+			data = data[next+1:]
+		} else {
+			data = nil
+		}
+	}
+	return data, position, nil
+}
+
+func parseWireRecords(data []byte) []wireRecord {
+	records := []wireRecord{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		var record wireRecord
+		if json.Unmarshal(scanner.Bytes(), &record) == nil {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func latestModel(path string) string {
+	if err := validateSessionRef(path); err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	model := ""
+	for _, record := range parseWireRecords(data) {
+		if record.ModelAlias != "" {
+			model = record.ModelAlias
+		}
+		if record.Type == "usage.record" && record.Model != "" {
+			model = record.Model
+		}
+	}
+	return model
+}
+
+func normalizeRepoPath(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+	root, err := filepath.Abs(protocol.RepoRoot())
+	if err != nil {
+		return "", false
+	}
+	path := filepath.Clean(value)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil || !pathWithin(abs, root) {
+		return "", false
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil || rel == "." {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/protocol/protocol.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/protocol/protocol.go
@@ -1,0 +1,255 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+type Agent interface {
+	Info() Info
+	Detect() DetectResponse
+	GetSessionID(*HookInput) string
+	GetSessionDir(string) (string, error)
+	ResolveSessionFile(string, string) (string, error)
+	ReadSession(*HookInput) (Session, error)
+	WriteSession(Session) error
+	ReadTranscript(string) ([]byte, error)
+	ParseHook(string, []byte) (*Event, error)
+	InstallHooks(bool, bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+	GetTranscriptPosition(string) (int, error)
+	ExtractModifiedFiles(string, int) ([]string, int, error)
+	ExtractPrompts(string, int) ([]string, error)
+	CalculateTokens([]byte, int) (TokenUsage, error)
+	FormatResumeCommand(string) string
+}
+
+func WriteJSON(w io.Writer, value any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(value)
+}
+
+func readJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func Run(agent Agent, args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: entire-agent-kimi <subcommand> [args]")
+	}
+	switch args[0] {
+	case "info":
+		return WriteJSON(stdout, agent.Info())
+	case "detect":
+		return WriteJSON(stdout, agent.Detect())
+	case "get-session-id":
+		in, err := readJSON[HookInput](stdin)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, SessionIDResponse{SessionID: agent.GetSessionID(in)})
+	case "get-session-dir":
+		fs := newFlags("get-session-dir")
+		repo := fs.String("repo-path", "", "repo path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		dir, err := agent.GetSessionDir(*repo)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, SessionDirResponse{SessionDir: dir})
+	case "resolve-session-file":
+		fs := newFlags("resolve-session-file")
+		dir := fs.String("session-dir", "", "session dir")
+		id := fs.String("session-id", "", "session id")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		path, err := agent.ResolveSessionFile(*dir, *id)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, SessionFileResponse{SessionFile: path})
+	case "read-session":
+		in, err := readJSON[HookInput](stdin)
+		if err != nil {
+			return err
+		}
+		session, err := agent.ReadSession(in)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, session)
+	case "write-session":
+		session, err := readJSON[Session](stdin)
+		if err != nil {
+			return err
+		}
+		return agent.WriteSession(*session)
+	case "read-transcript":
+		fs := newFlags("read-transcript")
+		ref := fs.String("session-ref", "", "session ref")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		data, err := agent.ReadTranscript(*ref)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(data)
+		return err
+	case "chunk-transcript":
+		fs := newFlags("chunk-transcript")
+		max := fs.Int("max-size", 0, "max size")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *max <= 0 {
+			return fmt.Errorf("max-size must be positive")
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+		chunks := make([][]byte, 0, (len(data) / *max)+1)
+		if len(data) == 0 {
+			chunks = append(chunks, []byte{})
+		}
+		for start := 0; start < len(data); start += *max {
+			end := min(start+*max, len(data))
+			chunks = append(chunks, append([]byte(nil), data[start:end]...))
+		}
+		return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+	case "reassemble-transcript":
+		in, err := readJSON[ChunkResponse](stdin)
+		if err != nil {
+			return err
+		}
+		for _, chunk := range in.Chunks {
+			if _, err := stdout.Write(chunk); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "format-resume-command":
+		fs := newFlags("format-resume-command")
+		id := fs.String("session-id", "", "session id")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		return WriteJSON(stdout, ResumeResponse{Command: agent.FormatResumeCommand(*id)})
+	case "parse-hook":
+		fs := newFlags("parse-hook")
+		hook := fs.String("hook", "", "hook")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+		event, err := agent.ParseHook(*hook, data)
+		if err != nil {
+			return err
+		}
+		if event == nil {
+			_, err = io.WriteString(stdout, "null\n")
+			return err
+		}
+		return WriteJSON(stdout, event)
+	case "install-hooks":
+		fs := newFlags("install-hooks")
+		localDev := fs.Bool("local-dev", false, "local dev")
+		force := fs.Bool("force", false, "force")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		count, err := agent.InstallHooks(*localDev, *force)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, HooksInstalledResponse{HooksInstalled: count})
+	case "uninstall-hooks":
+		return agent.UninstallHooks()
+	case "are-hooks-installed":
+		return WriteJSON(stdout, HookStatusResponse{Installed: agent.AreHooksInstalled()})
+	case "get-transcript-position":
+		fs := newFlags("get-transcript-position")
+		path := fs.String("path", "", "path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		position, err := agent.GetTranscriptPosition(*path)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, PositionResponse{Position: position})
+	case "extract-modified-files":
+		fs := newFlags("extract-modified-files")
+		path := fs.String("path", "", "path")
+		offset := fs.Int("offset", 0, "offset")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		files, position, err := agent.ExtractModifiedFiles(*path, *offset)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: position})
+	case "extract-prompts":
+		fs := newFlags("extract-prompts")
+		ref := fs.String("session-ref", "", "session ref")
+		offset := fs.Int("offset", 0, "offset")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		prompts, err := agent.ExtractPrompts(*ref, *offset)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+	case "extract-summary":
+		return WriteJSON(stdout, ExtractSummaryResponse{Summary: "", HasSummary: false})
+	case "calculate-tokens":
+		fs := newFlags("calculate-tokens")
+		offset := fs.Int("offset", 0, "offset")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+		usage, err := agent.CalculateTokens(data, *offset)
+		if err != nil {
+			return err
+		}
+		return WriteJSON(stdout, usage)
+	default:
+		return fmt.Errorf("unknown subcommand: %s", args[0])
+	}
+}
+
+func newFlags(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs
+}

--- a/scripts/entire/external_agents/entire-agent-kimi/internal/protocol/types.go
+++ b/scripts/entire/external_agents/entire-agent-kimi/internal/protocol/types.go
@@ -1,0 +1,117 @@
+package protocol
+
+import "encoding/json"
+
+const Version = 1
+
+type Capabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type Info struct {
+	ProtocolVersion int          `json:"protocol_version"`
+	Name            string       `json:"name"`
+	Type            string       `json:"type"`
+	Description     string       `json:"description"`
+	IsPreview       bool         `json:"is_preview"`
+	ProtectedDirs   []string     `json:"protected_dirs"`
+	ProtectedFiles  []string     `json:"protected_files,omitempty"`
+	HookNames       []string     `json:"hook_names"`
+	Capabilities    Capabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+type ResumeResponse struct {
+	Command string `json:"command"`
+}
+type HooksInstalledResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+type HookStatusResponse struct {
+	Installed bool `json:"installed"`
+}
+type PositionResponse struct {
+	Position int `json:"position"`
+}
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+type TokenUsage struct {
+	InputTokens         int         `json:"input_tokens"`
+	CacheCreationTokens int         `json:"cache_creation_tokens"`
+	CacheReadTokens     int         `json:"cache_read_tokens"`
+	OutputTokens        int         `json:"output_tokens"`
+	APICallCount        int         `json:"api_call_count"`
+	SubagentTokens      *TokenUsage `json:"subagent_tokens"`
+}
+
+type HookInput struct {
+	HookType   string          `json:"hook_type"`
+	SessionID  string          `json:"session_id"`
+	SessionRef string          `json:"session_ref"`
+	Timestamp  string          `json:"timestamp"`
+	UserPrompt string          `json:"user_prompt,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage `json:"tool_input,omitempty"`
+	RawData    map[string]any  `json:"raw_data,omitempty"`
+}
+
+type Session struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type Event struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/scripts/entire/install_kimi_external_agent.sh
+++ b/scripts/entire/install_kimi_external_agent.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+module_dir="${repo_root}/scripts/entire/external_agents/entire-agent-kimi"
+install_dir="${ENTIRE_KIMI_INSTALL_DIR:-${HOME}/.local/bin}"
+go_command="${ENTIRE_KIMI_GO:-}"
+
+if [[ -z "${go_command}" ]]; then
+  go_command="$(command -v go || true)"
+fi
+if [[ -z "${go_command}" || ! -x "${go_command}" ]]; then
+  echo "Go 1.26+ is required; set ENTIRE_KIMI_GO to the Go executable" >&2
+  exit 1
+fi
+
+scratch_dir="$(mktemp -d)"
+trap 'rm -rf "${scratch_dir}"' EXIT
+
+(
+  cd "${module_dir}"
+  "${go_command}" test -race ./...
+  "${go_command}" build -trimpath -o "${scratch_dir}/entire-agent-kimi" ./cmd/entire-agent-kimi
+)
+
+mkdir -p "${install_dir}"
+install -m 0755 "${scratch_dir}/entire-agent-kimi" "${install_dir}/entire-agent-kimi"
+"${install_dir}/entire-agent-kimi" info >/dev/null
+echo "Installed ${install_dir}/entire-agent-kimi"

--- a/tests/test_entire_native_onboarding.py
+++ b/tests/test_entire_native_onboarding.py
@@ -39,6 +39,7 @@ def test_entire_settings_are_pinned_private_and_nontelemetric() -> None:
     settings = json.loads(ENTIRE_SETTINGS.read_text(encoding="utf-8"))
     assert settings == {
         "enabled": True,
+        "external_agents": True,
         "strategy_options": {
             "checkpoint_remote": {
                 "provider": "github",


### PR DESCRIPTION
Closes #6260.

## Outcome

Adds the one externally unsupported Entire harness proven by source-blind canaries: the standalone `kimi` CLI. It does **not** invent model/UI agents:

- Kimi/GLM hosted by Claude Code remain `claude-code`.
- GLM hosted by OpenCode remains `opencode`.
- Codex Desktop and Codex CLI remain `codex`.
- Only direct Kimi Code is `kimi` through `entire-agent-kimi`.

Entire CLI remains pinned to stable 0.8.42. Public source checkpoints continue to route only to `learn-ukrainian/entire-checkpoints-private`; telemetry is off and public Entire refs remain forbidden.

## Implementation

- Protocol-v1 Kimi Code external-agent binary with lifecycle hooks, native session/index resolution, wire transcript reading, model attribution, prompt/file extraction, token accounting, resume formatting, and safe session restoration.
- Atomic, contention-safe and idempotent user-level Kimi hook installation. Uninstall restores every surrounding config byte; drift requires explicit `--force`.
- Fail-open hook commands and path/session traversal gates.
- Dedicated pinned CI workflow using the upstream Entire compliance suite.
- Durable host-harness decision and black-box evidence document.

## Verification

- Go unit + race tests: PASS.
- `go vet`: PASS.
- Upstream `entireio/external-agents-tests` protocol-v1 suite: PASS (hooks, mandatory, optional/token, subagent gate, transcript analyzer).
- 166 Entire/native/context Python tests: PASS.
- actionlint, shellcheck, markdownlint, `git diff --check`: PASS.
- OPSEC staged/revision scans: zero leaks.
- Agent trailer lint: PASS.

### Real source-blind Kimi K3 canary

- Native Kimi session: `session_5edcfe8f-a7d6-4ad3-beb6-c2c46a56a03a`.
- Entire agent/model: `Kimi Code` / `kimi-code/k3`.
- Lifecycle: SessionStart → TurnStart → TurnEnd → SessionEnd; terminal state `ended`.
- Resume used the same session ID and completed a second turn without file mutation.
- Checkpoint: `6046032162ad` on canary commit `3d2be7a352521b66c8db17e250c0451c2173a9be`.
- Commit trailers: `X-Agent: kimi/6260-entire-canary` and `Entire-Checkpoint: 6046032162ad`.
- `entire checkpoint explain --json` reports one Kimi Code / `kimi-code/k3` session, the exact canary file, and token usage without transcript bytes.
- Private checkpoint ref deployed at `94aaccb9fcb04cd797a82a61c00e388e07c8df31`.
- Product origin public Entire ref count: 0.
- Hook install retry: first 5, second 0; uninstall restored the original config SHA byte-for-byte; final install 5.
- Entire-unavailable hook canary exited 0.

Independent cross-family review is required before auto-merge and will be published against the exact PR head.
