### PR TITLE
docs(foundry): freeze the no-training delivery path

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -9,7 +9,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Last refreshed** | 2026-08-02 (corpus verdict CONTINUE; #6171 is the required tool/recipe lane; an Apple-Silicon proof is conditional and separately authorized) |
+| **Last refreshed** | 2026-08-02 (corpus verdict CONTINUE; #6171 is the sole required Foundry lane; the project stops before model download, rental, or training) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Help people and AI produce measurably better, authentically Ukrainian language through decolonized learning products and reusable, evidence-backed open-model infrastructure. Quality non-negotiable. |
@@ -30,8 +30,7 @@ stream must trace to this chain:
 3. **Reusable community infrastructure**: audited, provenance-rich source data;
    the Ukrainian Data Foundry's admitted real data, contextual language-contact
    diagnostics, evidence-backed silver corrections with optional human-gold
-   upgrades, model-ready exports, and optional open-weight compatibility
-   evidence (#6164;
+   upgrades, model-ready exports, and consumer-runnable recipes (#6164;
    completed foundation #6056); and
    narrow, contamination-resistant public evaluation (closed #2156; frozen
    future design preserved in closed #6057).
@@ -66,7 +65,7 @@ is the single source of truth for membership (auditor:
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
-| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: apply the [CONTINUE corpus-usability decision](research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md), separate local learning from raw-source/publication permissions, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, and ship a corpus-portable clean-Ukrainian tool, training recipe, and reproducible release candidate; any local or rented model proof is a separately authorized validation lane |
+| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: apply the [CONTINUE corpus-usability decision](research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md), separate downstream model-learning eligibility from raw-source/publication permissions, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, and ship a corpus-portable clean-Ukrainian tool, consumer training recipe, and reproducible no-training release candidate; project-funded or project-operated model training is out of scope |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -98,7 +97,7 @@ epic-board state and bind only once that stream's driver (State: the operator) c
 | --- | --- | --- | --- |
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
 | eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
-| open-model-data | ACTIVE | Execute #6171: package the production detector/evidence/views as a corpus-portable clean-Ukrainian tool, ship the model-neutral training recipe and validated cost formula, and reproduce the no-training release candidate in a clean environment. #6170 remains parked; after #6171, an exact-RAM Apple-Silicon QLoRA run is the preferred zero-rental-cost proof candidate, subject to a separate authorization. | A stranger can run the admitted-source, contextual interference/calque/grammar/morphology, protected-variation, silver-evidence, disjoint-view, tokenizer, recipe, and evaluation-firewall path on a bounded consumer-owned corpus; committed receipts prove the clean run and limitations. No accelerator, model weights, paid reviewers, or human-gold claim is required. Publication remains operator-gated. |
+| open-model-data | ACTIVE | Execute #6171: package the production detector/evidence/views as a corpus-portable clean-Ukrainian tool, ship the model-neutral consumer training recipe and validated cost formula, and reproduce the no-training release candidate in a clean environment. Closed #6170 is historical and not planned; it is not a next step. | A stranger can run the admitted-source, contextual interference/calque/grammar/morphology, protected-variation, silver-evidence, disjoint-view, tokenizer, recipe, cost, and evaluation-firewall path on a bounded consumer-owned corpus; committed receipts prove the clean run and limitations. The project stops before an optimizer, accelerator rental, model-weight download, adapter, or model upload. Publication remains operator-gated. |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |

--- a/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/UKRAINIAN_DATA_FOUNDRY_ARCHITECTURE.md
@@ -5,7 +5,7 @@
 > (production successor to completed foundation
 > [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056))
 > **Architecture issue:** [#6119](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6119)
-> **Recorded:** 2026-07-31; production execution chain refreshed 2026-08-01
+> **Recorded:** 2026-07-31; delivery boundary refreshed 2026-08-02
 > **Does not authorize:** model training, fine-tuning, weight publication,
 > dataset upload or release, redistribution, researcher outreach, private-data
 > disclosure, or OCR
@@ -26,7 +26,8 @@ The Foundry's job is to make evidence and boundaries explicit:
 - what VESUM can and cannot attest about its forms;
 - which passages need contextual grammar, calque, collocation, or
   Russian-interference review;
-- which decisions were made by qualified Ukrainian humans; and
+- which decisions are evidence-graded silver, protected, unresolved, or
+  optional qualified-human gold; and
 - which mechanically disjoint view, if any, may consume the record.
 
 It is not a project-owned general-purpose model and does not claim that one
@@ -46,7 +47,9 @@ VESUM morphology and unknown-form evidence
         ↓
 Grammar · calque · collocation · Russian-interference candidates
         ↓
-Qualified Ukrainian-human adjudication
+Evidence-tiered silver · protection · unresolved routing
+        ↓
+Optional qualified Ukrainian-human gold upgrade
         ↓
 Mechanically separate training · correction · preference · evaluation views
         ↓
@@ -190,35 +193,37 @@ multilingual candidates are protected from automatic correction. Grammar,
 calque, collocation, government, syntax, and semantic layers may consume these
 candidates later, but must retain their provenance and uncertainty.
 
-### 5. Qualified adjudication
+### 5. Evidence-tiered decisions and optional human gold
 
-Only a separate correction-data contract may promote a candidate. It must
-record qualified Ukrainian-human reviewer evidence, independent first-pass
-decisions, conflict handling, citations, rationale, uncertainty, protected
-variation, and export disposition.
+Only a separate correction-data contract may promote a candidate. The
+production path records source-specific evidence, rationale, uncertainty,
+protected variation, evidence grade, and destination-specific disposition as
+silver. It never labels automated or model-supported evidence as human gold.
+Qualified Ukrainian-human review remains an optional upgrade path.
 
-The promotion path is fail closed:
+The silver promotion path is fail closed:
 
 ```text
 profiled candidate
   → provenance and rights screened
   → exact/near-duplicate and evaluation contamination clear
-  → independent qualified Ukrainian-human reviews
-  → conflict resolved by a distinct qualified Ukrainian human or unresolved
+  → source-specific evidence and protection rules applied
+  → silver evidence grade or unresolved
   → destination-specific export eligibility
 ```
 
-An unresolved or protected record remains non-exportable. Synthetic fixtures
-and model outputs cannot stand in for qualified human decisions.
+An unresolved record remains non-exportable to labeled-learning views. A
+protected record remains a keep/no-change example only where its destination
+contract permits that role. Synthetic fixtures and model outputs cannot stand
+in for qualified human decisions or be called human gold.
 
 The implemented #6121 boundary is the
 [correction-factory runbook](../runbooks/ukrainian-data-foundry-correction-factory.md).
-Its four versioned schemas and deterministic CLI enforce original span
-preservation, source-specific evidence, evaluation-contamination joins, two
-independent Ukrainian-human first passes, a distinct third-human conflict
-path, and fail-closed handoff. Every resulting record remains explicitly
-ineligible for model training or export; #6122 owns that separate consumer
-boundary.
+Its versioned contracts and deterministic CLI enforce original span
+preservation, source-specific evidence, evaluation-contamination joins,
+optional human-gold review, and fail-closed handoff. The completed #6168
+evidence factory adds the production silver/protection path without claiming
+human gold; consumer eligibility remains a separate destination decision.
 
 ### 6. Consumer views
 
@@ -235,7 +240,7 @@ A non-evaluation view requires all of the following:
 - exact and near-duplicate disposition;
 - contamination checks against all frozen evaluation inventories and derived
   rules; and
-- the required qualified adjudication state for that destination.
+- the required evidence or adjudication state for that destination.
 
 Failure or absence at any gate yields an investigation, private, evaluation,
 unresolved, or excluded state—not `training_eligible`.
@@ -372,42 +377,19 @@ any step above. Dataset release, upload, redistribution, model training, weight
 publication, private-data disclosure, researcher contact, and OCR each require
 separate present-tense authorization.
 
-## Phase 2–4 production execution chain
+## Phase 2–4 delivery state
 
-The v1 interfaces are foundations, not delivery of the Foundry's ultimate
-outcome. At the start of Phase 2, the corpus profiler covers 189,150 records and
-50,298,925 lexical words, but no real record is training-admitted and the only
-end-to-end correction is a synthetic fixture. Production therefore proceeds
-through the following hard-gated chain under #6164:
+Issues #6166–#6169 are complete: corpus admission evidence, the full-corpus
+contextual detector, evidence-tiered silver/protection data, and real disjoint
+consumer views now exist. Closed #6170 preserves a historical treatment design
+but is not planned and is not part of the delivery chain.
 
-1. [#6166](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6166)
-   resolves source, edition, acquisition, rights, permitted-use, origin, and
-   contamination evidence for every real corpus family and admits useful-scale
-   real data where the evidence permits it.
-2. [#6167](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6167)
-   runs a contextual detector across the complete corpus and preserves the
-   difference between Russian quotation, modern interference, phonetic
-   rendering, mixed or historical language, protected Ukrainian variation,
-   and uncertainty.
-3. [#6168](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6168)
-   freezes sampling and stopping rules before labeling, then obtains two
-   independent qualified-Ukrainian-human judgments plus distinct conflict
-   adjudication. Model judgments never substitute for this gate.
-4. [#6169](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6169)
-   emits real disjoint consumer views with lineage, benchmark isolation,
-   tokenizer diagnostics, and loss-mask evidence.
-5. [#6170](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6170)
-   runs one operator-approved, preregistered open-weight treatment and causal
-   ablation only after real data, frozen gold, an exact model revision, and a
-   compute budget exist.
-6. [#6171](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6171)
-   packages the corpus-portable, rights-safe release candidate and requires a
-   clean independent reproduction before publication is considered.
-
-Admission and full-corpus detection begin in parallel. Later stages consume
-their frozen evidence in order. The orchestrator does not stop at intermediate
-PR merges; only the source-family admission, qualified-human review, exact
-training preregistration/budget, and final publication approvals are deliberate
-human gates. No arbitrary row count, agreement score, tokenizer ratio,
-significance threshold, or effect size may be invented to replace evidence-led
-criteria frozen in the owning issue.
+Issue #6171 is the sole remaining Foundry lane. It must correct the executable
+capability separation, restore retained source locators, expose one bounded
+consumer JSONL adapter and one public CLI, preserve every contextual and
+protected-variation route, emit deterministic model-ready views and receipts,
+and reproduce the whole bounded path from a clean environment. The project
+then stops before model download, accelerator rental, optimizer execution,
+adapter creation, upload, or publication. Optional qualified-human gold and
+downstream model results may strengthen later evidence, but neither blocks the
+Foundry release.

--- a/docs/research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md
+++ b/docs/research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md
@@ -18,8 +18,8 @@ The corpus is sufficient to:
 1. build and validate the corpus-portable clean-Ukrainian tool;
 2. prepare a high-value Ukrainian adaptation mixture for an existing open
    model; and
-3. run a controlled continued-training experiment if the operator later
-   approves a model, revision, hardware, and budget.
+3. give downstream teams deterministic model-ready views, evaluation controls,
+   cost arithmetic, and a reproducible training recipe.
 
 It is not large enough to train a competitive general foundation model from
 scratch. It also cannot automatically turn every detector candidate into a
@@ -76,18 +76,19 @@ describe different retained units rather than a lost-text discrepancy.
 | Intended use | Decision | Conditions |
 | --- | --- | --- |
 | Run the clean-Ukrainian detector and evidence tool | **Use now** | Preserve uncertainty; VESUM absence alone is never an error verdict |
-| Continue training an existing open model locally | **Use after preprocessing** | Deduplicate, stratify, filter/mask damage, preserve lineage, and isolate evaluation |
+| Continue training an existing open model downstream | **Use after preprocessing** | Deduplicate, stratify, filter/mask damage, preserve lineage, and isolate evaluation |
 | Prepare a reproducible training recipe for another Ukrainian team | **Use now** | Emit manifests and receipts without embedding private paths or republishing source files |
 | Train a general foundation model from scratch | **Do not use as the only corpus** | The roughly 139-million-token planning scale is far below foundation-model scale |
 | Create automatic correction/preference gold | **Not from raw detector output** | Use evidence-graded silver; call it gold only after adequate validation |
-| Publish raw books or textbook PDFs | **Separate decision** | Not required for local learning, derived receipts, tool publication, or the recipe |
+| Publish raw books or textbook PDFs | **Separate decision** | Not required for downstream learning, derived receipts, tool publication, or the recipe |
 | Publish weights or an adapter | **Separate decision** | Evaluate capability, regressions, memorization, obligations, and release terms first |
 
-The operator has approved the retained human-authored source corpus for local
-research and model-learning work toward the project goal. This decision does
+The operator has approved the retained human-authored source corpus for
+downstream research and model-learning work toward the project goal. This
+decision does
 not claim a blanket right to rehost the raw source books, publish a dataset, or
 release weights. Those are separate capabilities and must not be used to block
-the local training lane.
+an otherwise approved downstream model-learning view.
 
 ## Required learning mixture
 
@@ -134,16 +135,17 @@ multilingual and resource-constrained settings. See
 
 ## Execution order from this decision
 
-1. Correct the current admission/export contract so local model training,
-   raw-source redistribution, dataset publication, and weight publication are
-   independent capabilities.
+1. Correct the current admission/export contract so downstream model-learning
+   eligibility, raw-source redistribution, dataset publication, and weight
+   publication are independent capabilities.
 2. Restore raw literary locators into generated source records and reconcile
    the remaining textbook filename variations against retained PDFs and URLs.
 3. Produce modern-learning and faithful-source views with OCR, historical, and
    quoted-language masks; keep source text immutable.
 4. Measure exact tokenizer counts and run the complete no-accelerator recipe.
-5. Only after those artifacts pass validation, propose an optional bounded
-   model experiment with an exact cost and stop rule for operator approval.
+5. Hand the validated artifacts, cost method, and limitations to downstream
+   teams that have their own compute; the Foundry project stops before model
+   download, accelerator rental, or optimizer execution.
 
 No new broad corpus acquisition is required before steps 1–4. No paid training
 is required to finish the tool and recipe.

--- a/docs/runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md
+++ b/docs/runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md
@@ -2,8 +2,8 @@
 
 > **Owner:** [#6171](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6171)
 > under [Foundry Phase 2–4 #6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
-> **Status:** Release contract; paid training is optional and is not on the
-> critical path
+> **Status:** No-training release contract; project-funded or project-operated
+> model training is out of scope
 > **Does not authorize:** model download, accelerator rental, training, upload,
 > dataset publication, or automatic rewriting of source text
 
@@ -53,14 +53,15 @@ project's synthetic and translated collections. The
 verified all 137,723 raw literary rows against retained source locators and
 core metadata, and verified the textbook family against 158 chunk files, 170
 PDFs, the selection ledger, downloader, and page-URL map. The operator has
-approved these retained human-authored families for local research and model
-learning toward the project goal.
+approved these retained human-authored families for downstream research and
+model learning toward the project goal.
 
-Local model learning, raw-source redistribution, public dataset release, and
-public weight or adapter release are independent capabilities. The last three
-remain separately gated; they do not block preparation or local continued
-training. The existing exporter still implements the older combined gate and
-must be corrected before it can emit the newly approved local-training view.
+Downstream model learning, raw-source redistribution, public dataset release,
+and public weight or adapter release are independent capabilities. The last
+three remain separately gated; they do not block preparation or downstream
+continued training. The existing exporter still implements the older combined
+gate and must be corrected before it can emit the newly approved downstream
+training-eligible view.
 
 Historical and literary text must not be flattened into contemporary standard
 Ukrainian. A training consumer receives explicit strata and chooses the mixture:
@@ -82,9 +83,9 @@ the only copy.
 
 Validate source identity, provenance, privacy, human or synthetic origin,
 contamination, and the exact destination. Record permissions separately for
-local model training, raw-source redistribution, dataset publication, and
+downstream model learning, raw-source redistribution, dataset publication, and
 model publication; an unknown redistribution status must not be converted into
-a denial of an independently approved local-training use. Keep machine-
+a denial of an independently approved downstream-learning use. Keep machine-
 generated lessons, translations, and synthetic research evidence in separate
 origins. Do not promote benchmark text or its derivatives into a training
 view.
@@ -159,7 +160,7 @@ epochs, and an explicit `training_authorized: false` state. The existing
 `training_recipe_config_v1` and `training_recipe_manifest_v1` contracts are
 preparation contracts; generating them does not start training.
 
-If a separately authorized model experiment occurs, keep these roles separate:
+A downstream consumer should keep these roles separate:
 
 1. continued pretraining on destination-admitted human-authored text;
 2. optional correction/instruction or preference tuning on eligible,
@@ -167,7 +168,7 @@ If a separately authorized model experiment occurs, keep these roles separate:
 3. evaluation on mechanically isolated grammar, calque, interference,
    morphology, no-change, and protected-variation inventories.
 
-Do not combine these roles in an authorized run: otherwise a result cannot
+Do not combine these roles in one run: otherwise a result cannot
 identify which data treatment helped or caused harm.
 
 ### 7. Reproduce without an accelerator
@@ -176,9 +177,10 @@ From a fresh checkout or clean environment, rebuild schemas, receipts,
 admissions, detector regression cases, silver evidence, views, recipe
 manifests, tokenizer diagnostics where tokenizer files are locally available,
 and evaluation-firewall checks. This no-training reproduction is the required
-release gate. A trained adapter is an optional later artifact.
+and final project release gate. A downstream consumer may train from the frozen
+artifacts, but the Foundry project does not produce the adapter.
 
-## How long and how much would training take?
+## Consumer-side time and cost interface
 
 The recipe makes the cost measurable; it does not make one unmeasured price
 honest. For a particular checkpoint and hardware configuration:
@@ -191,7 +193,8 @@ compute cost = wall-clock hours × accelerator count × provider price per hour
 Add storage, data transfer, evaluation inference, taxes, and a declared failed-
 run allowance separately. Measure aggregate throughput with the exact model,
 sequence length, precision, optimizer, and adapter/full-parameter policy before
-approving the full run.
+approving its run. These calculations are a consumer planning surface, not a
+Foundry spending plan.
 
 The pinned Gemma 4 IT tokenizer produced 7,696,734 non-special tokens from
 2,778,111 lexical words in the 1,028-record, deduplicated training-eligible
@@ -201,9 +204,10 @@ one long near-duplicate, as recorded in the
 [model-view runbook](ukrainian-data-foundry-model-views.md). Applying the
 post-dedup observed ratio to the pre-dedup 50,298,925-word corpus inventory
 gives a rough **planning extrapolation of about 139.35 million tokens for one
-pass**. It is not a current training artifact: the exact local-training views
-have not yet been exported, their deduplication and masking will change the
-denominator, and literary/historical genres may tokenize differently.
+pass**. It is not a current training artifact: the exact downstream
+training-eligible views have not yet been exported, their deduplication and
+masking will change the denominator, and literary/historical genres may
+tokenize differently.
 
 Using Hugging Face Jobs list prices retrieved on 2026-08-02 of USD 2.50/hour
 for one A100 80 GB and USD 1.80/hour for one L40S 48 GB, a one-GPU, one-epoch
@@ -223,55 +227,13 @@ has a very different memory and compute envelope from QLoRA. The exact clean
 microbenchmark and model revision must replace this table before any spending
 decision.
 
-## Could the proof run on an unused M1?
+## Downstream model use
 
-Yes, if the proof uses a Gemma 4 size that matches the machine's unified memory
-and uses an Apple-Silicon training stack. It does not mean the current Gemma 4
-31B CUDA treatment can be copied to the Mac.
-
-Google's current
-[Gemma 4 memory table](https://ai.google.dev/gemma/docs/core#parameter-sizes-and-quantization)
-gives approximate Q4 inference loads of 2.9 GB for E2B, 4.5 GB for E4B,
-6.7 GB for 12B, 14.4 GB for 26B A4B, and 17.5 GB for 31B. Context and
-fine-tuning add memory beyond those values. Record the exact M1 variant,
-unified memory, free storage, and macOS version before selecting anything.
-
-| M1 unified memory | First candidate | What it can establish |
-| ---: | --- | --- |
-| 8 GB | Gemma 4 E2B Q4 | Whether the complete local pipeline can execute at all |
-| 16 GB | Gemma 4 E4B Q4; E2B fallback | A real small-model Ukrainian before/after proof; not 31B compatibility |
-| 32 GB | Gemma 4 12B Q4; E4B fallback | A stronger local proof if peak memory and reload pass |
-| 64 GB or more | Benchmark 12B first; consider 31B second | 31B remains conditional on measured training memory and speed |
-
-Apple's [MLX-LM](https://github.com/ml-explore/mlx-lm) supports LoRA and QLoRA
-on Apple silicon. Release `v0.31.2` added Gemma 4 support, while the
-[MLX-LM LoRA guide](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md)
-documents quantized-model training and memory controls. The existing #6170
-runner is not portable: it pins CUDA, an NVIDIA L40S, BitsAndBytes NF4, and a
-31B checkpoint. Preserve that runner and create a separately pinned MLX path
-only after the exact Mac and checkpoint are approved.
-
-A useful local proof has five measured steps:
-
-1. capture machine, model, tokenizer, framework, quantization, and storage
-   receipts;
-2. run the frozen baseline evaluation and protected-variation probes;
-3. perform a synthetic one-step update, save, restart, reload, and re-evaluate
-   only as a hardware preflight;
-4. train on a real, stratified Foundry slice and compare the reloaded adapter
-   with the untouched checkpoint on exactly the same held-out evidence; and
-5. run a full-corpus pass only if the measured throughput, peak memory, and
-   preliminary Ukrainian result justify its wall time.
-
-The fourth step is the minimum linguistic proof. A successful synthetic update
-alone proves only that MLX can write and reload an adapter.
-
-Gemma 4 is the first candidate because the project already has its tokenizer,
-baseline, and treatment contracts. Another Western open-weight model is a
-fallback only if the same frozen Ukrainian baseline, tokenizer diagnostics,
-memory preflight, and license check make it a more credible proof target. A
-fallback result validates the Foundry path for that model; it does not prove a
-Gemma 4 treatment.
+The release does not select, download, fine-tune, or publish a model. A consumer
+with compute selects its checkpoint and records the exact revision, tokenizer,
+framework, precision, hardware, throughput, objective, evaluation, and stop
+rules in the non-authorizing recipe. The consumer then owns the training run,
+its costs, and any model or adapter release decision.
 
 For scale, Lapa reports about 30 billion filtered pretraining tokens and a
 56-H100 training setup for its Gemma 3 adaptation. Our 139-million-token
@@ -280,7 +242,7 @@ valuable for its curated textbooks, literature, historical strata, provenance,
 and failure evidence; it is not by itself a replacement for a tens-of-billions-
 of-tokens language corpus.
 
-## Why Gemma 4 can lead and still make bad Ukrainian
+## Why the Foundry remains model-neutral
 
 Gemma 4 can improve an aggregate Ukrainian leaderboard because it is a newer
 general model with stronger reasoning, instruction following, architecture,
@@ -301,14 +263,13 @@ protected-variation evidence, data views, tokenizer census, and training recipe
 can be rerun for Gemma 4, Gemma 5, or another open model. A local adapter ages
 quickly; the means to prepare and measure Ukrainian transfer forward.
 
-## Decision rule
+## Project completion rule
 
 Ship the tool, contracts, recipes, clean-run receipt, limitations, and consumer
-guide first. Do not wait for paid training. Consider a model run only when a
-specific team or operator needs compatibility evidence for an exact current
-checkpoint, the admitted data are large enough for the named question, a
-microbenchmark supplies the real cost, and present-tense authorization covers
-that exact spend. A newer model release changes the checkpoint, not this plan.
+guide, then close #6171. The project does not run a model as a release gate or
+follow-up milestone. A downstream team's later model result may validate the
+recipe externally, but it does not reopen the Foundry implementation plan. A
+newer model release changes a consumer checkpoint, not this plan.
 
 ## Primary references
 

--- a/docs/runbooks/ukrainian-data-foundry-model-views.md
+++ b/docs/runbooks/ukrainian-data-foundry-model-views.md
@@ -110,9 +110,9 @@ They are not interchangeable counts.
 The historical phase-3 feasibility verdict is `REVISE`: real control and
 loss-masked continued-pretraining inputs, evaluation isolation, protected/no-
 change inventory, recipes, and tokenizer diagnostics exist, but an exact
-treatment preregistration and operator compute ceiling do not. #6170 is now
-parked optional validation and may reopen only after those two present-tense
-gates are frozen. The current recipe manifests retain
+treatment preregistration and operator compute ceiling do not. #6170 is closed
+as not planned and retained only as historical preregistration evidence. The
+current recipe manifests retain
 `training_authorized: false` and `execution_state: not_run`. Projected training
 runtime and cost remain null—not zero—until an exact local or rented runner
 pins the hardware, treatment, and ceiling; local artifact storage is measured

--- a/docs/runbooks/ukrainian-data-foundry-treatment.md
+++ b/docs/runbooks/ukrainian-data-foundry-treatment.md
@@ -2,22 +2,20 @@
 
 > **Owner:** [#6170](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6170)
 > under [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
-> **Status:** Parked optional compatibility experiment; not a prerequisite for
-> the clean-Ukrainian tool, training recipe, or release candidate in #6171
-> **Current boundary:** Stage 0 is reproducible and no-cost. A separately
-> bounded, non-treatment hardware validation is specified below but cannot
-> launch: local Hugging Face authentication/model access is not configured and
-> its exact probe authorization artifact is absent. Model-weight download and
-> treatment training still require the exact operator authorization receipt.
+> **Status:** Archived historical preregistration; #6170 is closed as not
+> planned and this is not a future #6164 execution lane
+> **Archived boundary:** No project action is planned. The details below record
+> the frozen historical design; they are not a current hardware, download, or
+> training queue.
 
-This runbook preserves a reproducible experiment design; it is not the Foundry
-critical path. No model download, hardware probe, accelerator rental, or
-training is currently planned or authorized. The required deliverable is the
-model-neutral [clean-Ukrainian tool and training recipe](ukrainian-data-foundry-clean-ukrainian-recipe.md).
-If a future operator explicitly activates this exact Gemma revision, first
-refresh provider pricing and replace throughput estimates with a measured
-microbenchmark. Otherwise the preregistration remains useful frozen evidence
-and no further action is required.
+This runbook preserves a reproducible historical experiment design; it is not
+the Foundry critical path or backlog. No model download, hardware probe,
+accelerator rental, or training is planned under #6164. The required deliverable
+is the model-neutral
+[clean-Ukrainian tool and consumer recipe](ukrainian-data-foundry-clean-ukrainian-recipe.md).
+The preregistration remains frozen evidence and no further project action is
+required. A downstream team may design its own experiment from the released
+consumer artifacts without reopening #6170.
 
 ## What this experiment can decide
 
@@ -126,11 +124,17 @@ fails. A hard process kill in the instruction-scale interval between the
 optimizer call returning and the Python flag assignment cannot be proven after
 the fact; that residual is reported conservatively rather than inferred.
 
-Launch remains impossible until both blockers are cleared: local Hugging Face
-authentication and access to the exact model are not configured, and an exact
-operator authorization artifact for this one-attempt probe does not exist.
+## Archived command record — non-operational
 
-Once that exact authorization exists, validate it without launching anything:
+At archival, launch remained blocked because local Hugging Face authentication,
+exact-model access, and an operator authorization artifact did not exist.
+
+> **Do not run these commands under closed #6170.** Reuse requires a new issue,
+> new present-tense operator scope, and a newly reviewed design. The blocks are
+> retained only to document what the historical preregistration specified.
+
+The historical design would first have validated authorization without
+launching anything:
 
 ```bash
 .venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \
@@ -140,9 +144,12 @@ Once that exact authorization exists, validate it without launching anything:
   --output batch_state/6170/hf-probe-preparation.json
 ```
 
-The only paid entry point is the separate `launch` command. It creates one
-detached Job with the frozen 3,600-second provider timeout and records the Job
-ID immediately:
+The historical paid entry point was the separate `launch` command. It would
+have created one detached Job with the frozen 3,600-second provider timeout and
+recorded the Job ID immediately.
+
+> **Historical command—do not execute.** Closed #6170 cannot authorize a paid
+> job; a new issue and new operator approval would be required.
 
 ```bash
 .venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \
@@ -165,13 +172,17 @@ idempotency key, so this authorization is deliberately single-operator and must
 not be launched concurrently from different hosts; sequential cross-host reuse
 is rejected by the provider authorization-hash label.
 
-After that Job reaches a terminal state, collect its logs, provider inspection,
-resource-statistics observation, and completed-or-aborted worker receipt. The
-collector rejects non-terminal state, flavor/label/endpoint drift, duration
+Had that Job reached a terminal state, the historical collector would have
+recorded its logs, provider inspection, resource-statistics observation, and
+completed-or-aborted worker receipt. The collector rejects non-terminal state,
+flavor/label/endpoint drift, duration
 over 3,600 seconds, a mismatched runner, or a server-derived compute charge over
 USD 1.80. The receipt records the provider-derived charge from server-reported
 running seconds; it leaves invoice-exact USD/EUR fields null because the Jobs
 inspection API does not return the settled invoice:
+
+> **Historical command—do not execute.** It documents the archived evidence
+> contract and is not a current collection instruction.
 
 ```bash
 .venv/bin/python -m scripts.projects.open_model_data.gemma_hardware_probe \

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -10,8 +10,9 @@
 > that this is a solo project with neither budget nor access to a three-person
 > Ukrainian review panel and directed the Foundry to remove that unavailable
 > labour from the critical path. On 2026-08-02, the operator directed the
-> Foundry to ship the clean-Ukrainian preparation tool and training recipe
-> before considering optional paid model validation.
+> Foundry to ship the clean-Ukrainian preparation tool and consumer training
+> recipe without project-funded or project-operated model training. Training
+> belongs to downstream teams that choose to use the released artifacts.
 > **Recorded:** 2026-07-30; Foundry direction and existing-asset baseline
 > refreshed 2026-08-02
 > **Applies to:** Ukrainian model evaluation, dataset work, training-data
@@ -41,15 +42,18 @@ Curated data, provenance, evaluation, and tooling transfer to every new model
 generation.
 
 This direction prioritizes transferable data, grammar, lexical naturalness,
-and evidence over owning model weights. A bounded model treatment is permitted
-only to test whether those artifacts help. The accepted boundary between public
-evaluation gold, private product data, and training data remains intact.
+and evidence over owning or producing model weights. Project completion stops
+before model download, accelerator rental, optimizer execution, adapter
+production, or weight upload. A downstream team may independently use the
+Foundry recipe and report results, but that is consumer validation rather than
+a Foundry execution lane. The accepted boundary between public evaluation gold,
+private product data, and training data remains intact.
 
 ## Solo-operator execution model
 
 The Foundry must be executable by one operator. It cannot make paid or donated
-review labour a prerequisite for useful source preparation, model-ready data,
-or a bounded causal experiment.
+review labour or accelerator access a prerequisite for useful source
+preparation, model-ready data, or a complete release.
 
 The production evidence lanes are therefore distinct:
 
@@ -74,11 +78,10 @@ experiment. It must never be reported as human gold, native-speaker acceptance,
 reviewer reliability, or proof that every proposed correction is correct.
 
 The Foundry can credibly promise reusable preparation, diagnostics, evidence,
-and, if separately authorized, a controlled test of whether those artifacts
-help. It cannot promise in advance that a treatment will make an LLM fluent.
-The cheapest falsifying check always precedes a more expensive run, and a
-failed prerequisite or null result is reported immediately rather than
-converted into more work.
+model-ready views, evaluation isolation, and reproducible consumer recipes. It
+cannot promise that a downstream treatment will make an LLM fluent. Consumer
+training results are external evidence and are never a prerequisite for closing
+the Foundry release.
 
 ## GitHub execution homes
 
@@ -86,9 +89,9 @@ converted into more work.
   owns Foundry Phase 2–4: real corpus admission, production contextual
   language-contact detection, evidence-backed silver with an optional
   qualified-human upgrade, real model-ready exports, a model-neutral clean-
-  Ukrainian tool, reproducible training recipe, and release
-  candidate. An open-weight treatment is an optional compatibility check, not
-  a completion dependency. Closed
+  Ukrainian tool, reproducible consumer training recipe, and no-training
+  release candidate. Project-operated open-weight treatment is out of scope.
+  Closed
   [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
   owns the completed interfaces, profiler, exporters, recipes, and synthetic
   reference build on which this production program depends.
@@ -264,7 +267,8 @@ FOLK package versions with Git recovery locators.
 
 This inventory preceded the current capability-specific decision. Its zero
 source-record admissions and zero redistribution-cleared assets described the
-old combined gate, not corpus authenticity or local training fitness. It keeps
+old combined gate, not corpus authenticity or downstream training fitness. It
+keeps
 human-authored, machine-generated direct Ukrainian, machine-translated,
 private-reference, evaluation-only, and unknown-origin material mechanically
 separate. The invalid 5,000-record export may locate an underlying work but
@@ -276,7 +280,8 @@ The subsequent
 found source locators and core metadata on all 137,723 raw literary rows and
 reconciled the textbook family to retained chunks, PDFs, acquisition code,
 selection metadata, and page URLs. The operator approved these retained human-
-authored sources for local research and continued model learning. Raw-source
+authored sources for downstream research and continued model learning.
+Raw-source
 redistribution, dataset publication, and model publication remain independent
 later decisions. The project verdict is **CONTINUE**.
 
@@ -293,99 +298,42 @@ later decisions. The project verdict is **CONTINUE**.
   reconstructing original-source evidence; it is not provenance authority or a
   candidate training collection.
 
-### Immediate work
+### Completed foundations and sole remaining lane
 
-1. Replace the combined admission disposition with capability-specific states:
-   local research/model learning, raw-source redistribution, dataset release,
-   and model release. Apply the operator-approved local-training decision to
-   the retained human-authored corpus while preserving later release gates
-   (#6171).
-2. Preserve and use the completed production detector's 739,564 contextual
-   candidates across Russian quotation, modern interference, phonetic Russian,
-   mixed, historical, protected, and uncertain routes (#6167). VESUM absence
-   remains one signal rather than a verdict.
-3. Produce real evidence-graded silver correction, retention, protection, and
-   unresolved records without requiring reviewer labour (#6168). Preserve the
-   existing blind human campaign as an optional gold-upgrade path and add an
-   optional, privacy-safe Hramatka feedback intake.
-4. Restore raw literary locators lost during ingestion, reconcile remaining
-   textbook filename variations, and start the approved local source-text
-   continued-pretraining view immediately. Add separately manifested silver
-   correction, preference, and quality-filter views only when their evidence
-   and destination gates pass (#6169). Never fill a view with benchmark or
-   fixture data.
-5. Package the production detector, evidence factory, model-view exporters,
-   tokenizer diagnostics, and evaluation firewall as one corpus-portable
-   clean-Ukrainian tool. It must cover the Foundry's calque, grammar, and
-   morphology axes, incorporate Oleksiy's recorded ULIF synonym-source
-   recommendation, and protect historical, regional, dialectal, and quoted
-   material (#6171).
-6. Ship a model-neutral, stranger-runnable training recipe with exact
-   admission, mixture, tokenizer, split, objective, evaluation, cost, and stop
-   controls. Reproduce the complete no-training path in a clean independent
-   environment (#6171). The canonical recipe and cost model are documented in
-   the [clean-Ukrainian runbook](../runbooks/ukrainian-data-foundry-clean-ukrainian-recipe.md).
-7. Keep the preregistered Gemma 4 31B cloud treatment (#6170) parked as
-   optional, present-tense operator-gated compatibility validation. After
-   #6171, inventory the operator's unused M1 and prefer a smaller Gemma 4
-   Apple-Silicon QLoRA candidate when it can prove the complete path without
-   rental cost. Neither route is a prerequisite for #6171, and neither model
-   download nor training is authorized. Before either route runs, replace
-   planning estimates with an exact model, revision, tokenizer, machine,
-   framework, memory, throughput, evaluation, and stop-rule record.
-8. Use frozen v0.1.1 and compatible licensed external human-authored
-   evaluations for recipe validation and any optional future experiment. The
-   reviewer-intensive v0.2
-   acquisition may resume only if Hramatka or a future collaboration supplies
-   suitable consented evidence without becoming a project staffing dependency.
-   Public evaluation gold remains mechanically isolated from every training or
-   tuning view.
+The production corpus audit, admission baseline, full-corpus detector,
+evidence-grade silver/protection factory, separate model views, tokenizer
+diagnostics, and reference build are complete under #6166–#6169. PR #6248
+supplies the later corpus-usability decision that defines #6171's remaining
+capability-separation work. Together they establish that the project has the
+source material and component interfaces needed to finish the Foundry.
 
-### Optional local Apple-Silicon proof after #6171
+Issue #6171 is the sole remaining Foundry execution lane. It must, in order:
 
-The proof question is whether the shipped Foundry path changes a model's
-measured Ukrainian behavior, not whether a particular large checkpoint can be
-forced onto a laptop. The first zero-rental-cost candidate is the operator's
-unused M1, after its exact chip variant, unified memory, free storage, and macOS
-version are recorded.
+1. separate downstream local-learning eligibility from raw-source
+   redistribution, dataset publication, and model publication in the executable
+   admission contract, while restoring retained source locators;
+2. expose one bounded consumer-owned JSONL input and one documented public CLI
+   over admission, contextual language contact, evidence, model views,
+   tokenizer diagnostics, cost calculation, and the evaluation firewall;
+3. preserve original text and the Russian-quotation, modern-interference,
+   phonetic-Russian, mixed, historical, regional, dialectal, protected, OCR,
+   other-language, and unresolved routes;
+4. expose the calque, grammar/government, morphology/OOV, VESUM, R2U, ULIF, and
+   heritage evidence surfaces without promoting any one source to an automatic
+   verdict;
+5. emit deterministic faithful-source, modern-learning, silver correction,
+   preference, filter, evaluation, tokenizer, recipe, and limitation receipts
+   with benchmark contamination denied; and
+6. reproduce the complete bounded path in a fresh environment with no model
+   download, accelerator, optimizer, hidden database, or project-private path.
 
-Google's current
-[Gemma 4 memory table](https://ai.google.dev/gemma/docs/core#parameter-sizes-and-quantization)
-lists approximate Q4 inference loads of 2.9 GB for E2B, 4.5 GB for E4B,
-6.7 GB for 12B, 14.4 GB for 26B A4B, and 17.5 GB for 31B. Those figures cover
-base weights and loading overhead, not context or fine-tuning. The 31B model
-therefore cannot be a 16 GB M1 training target, and the A4B model does not fit
-like a 4B model because all 26 billion parameters must remain loaded.
-
-Candidate routing is conditional rather than a model selection:
-
-| M1 unified memory | First Gemma 4 candidate to benchmark | Boundary |
-| ---: | --- | --- |
-| 8 GB | E2B Q4 | Runtime preflight and short full-path proof only until peak memory is measured |
-| 16 GB | E4B Q4; E2B fallback | 31B is excluded; 12B requires a measured margin before consideration |
-| 32 GB | 12B Q4; E4B fallback | Prefer 12B only if one-step training, reload, and evaluation fit safely |
-| 64 GB or more | 12B first; 31B may be benchmarked | Do not choose 31B before its measured speed and peak-memory cost justify it |
-
-Apple's [MLX-LM](https://github.com/ml-explore/mlx-lm) supports Apple-Silicon
-LoRA and QLoRA; release `v0.31.2` added Gemma 4, and the
-[LoRA guide](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md)
-documents quantized-model training. The existing #6170 runner is CUDA/L40S
-specific and must remain unchanged. A local proof needs a separately pinned
-MLX runner and a new tokenizer receipt for the selected checkpoint.
-
-The first meaningful local result must traverse the complete path: frozen
-baseline evaluation, real stratified Foundry data, adapter training, clean
-reload, the same held-out evaluation, and protected-variation checks. A
-synthetic one-step update is only the hardware preflight. A full-corpus pass is
-considered only after the exact local throughput turns the existing token count
-into an acceptable wall-time estimate.
-
-The accountable orchestrator continues through the #6171 no-training release
-candidate. A merged implementation PR is progress, not a stopping condition.
-Work pauses only at a source-family admission decision or final publication
-approval named on #6164. Paid training is outside the critical path and begins
-only through a new present-tense model/revision/budget authorization. Choosing
-to claim human gold pauses only that optional upgrade lane.
+The project stops at that no-training release. Closed #6170 is retained only as
+historical preregistration evidence and is not a future Foundry task. Downstream
+teams with compute may select a model, run the frozen recipe on their own
+corpus, and return results if they choose; the Foundry neither funds nor
+operates that work. The reviewer-intensive v0.2 acquisition remains closed as
+not planned. Public evaluation gold remains mechanically isolated from every
+model-learning or derived-rule view.
 
 ### Completed Foundry v1 reference build
 
@@ -402,7 +350,7 @@ fixture reviewers are not qualified-human evidence and all four fixture rows
 remain training-ineligible. Separately, the older combined gate admitted 1,029
 real Ukrainian Wikipedia records / 2,865,506 lexical words for the declared
 continued-pretraining destination. The later usability decision approves the
-retained human-authored corpus for local research and model learning after
+retained human-authored corpus for downstream research and model learning after
 required preprocessing; it does not authorize raw-source, dataset, adapter, or
 weight publication.
 
@@ -420,16 +368,20 @@ After a usable reference build exists, it may be validated with Lapa,
 - failure-focused evaluation with protected legitimate variation; and
 - evidence-backed annotation guidelines.
 
-External feedback may prioritize later adapters, acquisition, or release work.
+External feedback may prioritize later evidence adapters, acquisition, or
+release work.
 It is not a prerequisite for building the architecture, full-corpus profiler,
-silver correction intake, separate exporters, recipes, experiment, or reference
-validation. Hramatka teacher feedback follows the same optional-evidence rule.
+silver correction intake, separate exporters, recipes, or reference validation.
+Hramatka teacher feedback follows the same optional-evidence rule.
 
-## Model-running policy
+## Downstream validation policy
 
-Model baselines are experiments, not the mission.
+The Foundry project does not run model baselines or training experiments. It
+ships frozen artifacts that let a downstream team run them without asking this
+project to operate or fund compute.
 
-Run a model only when the result answers a named question, such as:
+A downstream result is useful evidence only when it answers a named question,
+such as:
 
 - Does a new open-weight generation remove a specific failure category?
 - Does a tokenizer change improve Ukrainian fertility and downstream quality?
@@ -438,9 +390,9 @@ Run a model only when the result answers a named question, such as:
 - Does a detailed Ukrainian prompt expose a capability that a generic prompt
   hides?
 
-Open-weight models are the primary integration target because researchers can
-inspect, reproduce, adapt, and redistribute their work. Closed models remain
-useful as comparison ceilings, candidate annotators, or prompt-sensitivity
+Open-weight consumers are the primary integration target because researchers
+can inspect, reproduce, and adapt their work. Closed models remain useful to
+consumers as comparison ceilings, candidate annotators, or prompt-sensitivity
 probes. A closed-model score is not itself a durable community contribution.
 
 Do not compare scores across different benchmarks as if they measured the same


### PR DESCRIPTION
## What changed

- makes #6171 the sole remaining Foundry execution lane;
- states the project ends at the portable tool, model-ready views, evaluation
  firewall, cost method, and downstream consumer recipe;
- removes Apple-Silicon and project-operated training from the live plan;
- makes qualified-human gold and Hramatka feedback optional evidence upgrades;
- marks #6170 as closed historical evidence and makes its retained commands
  explicitly non-operational; and
- aligns the architecture, North Star, corpus decision, workstreams, and
  runbooks to the same six-step delivery path.

## GitHub control plane

Issues #6164, #6171, #6170, #6166, and #6169 were updated in place. #6171 is
now the native and uniquely owned child of #6164. The stream audit no longer
lists #6171 as pending native linkage. Unrelated global orphans and multi-homed
issues were not changed.

## Why

The repository retained conflicting instructions to run a local M1 or cloud
model experiment and to require unavailable human reviewers. Those directions
contradicted the operator's final decision: build the means for downstream
teams to prepare and evaluate clean Ukrainian, then stop before training.

## Verification

- targeted Markdownlint: 7 files, 0 errors
- `git diff --check`
- staged and commit-range OPSEC scans
- agent-trailer validation
- issue-stream audit plus live issue-state verification
- Claude Sonnet 5 independent cross-family review
  - first pass: five findings, all fixed
  - exact corrected diff: `VERDICT: PASS`, no findings
- sealed immutable-head Gemini 3.6 Flash high review: `APPROVED`
- complete GitHub CI

This PR changes control-plane documentation only. It leaves issues 6164 and
6171 open for the actual #6171 product implementation.