### PR TITLE
docs(agents): auto-load entire-context at cold start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,29 @@ Stream leases are already claimed by launchers.
 
 ---
 
+## Entire context recall — automatic intake (binding; ADR-018)
+
+**Do not wait for the operator to mention Entire / entire.io.** Skill
+`entire-context` (`agents_extensions/shared/skills/entire-context/SKILL.md`).
+
+On non-trivial work, before prioritization or dispatch:
+
+```bash
+.venv/bin/python -m scripts.entire_context status
+.venv/bin/python -m scripts.entire_context search --query "<task keywords>"
+# if locators inform the plan:
+.venv/bin/python -m scripts.entire_context record-use \
+  --task-id <task> --consumer <harness> --purpose <planning|handoff|review|debug> \
+  --locator-id <clink_…>
+```
+
+Body-free only; no load-bearing `entire` CLI network search; supplemental to GH /
+Fleet Comms / Monitor / formal CF. Skip only pure one-liners or when the module is
+missing/disabled (state once). Grok seats also load a stronger always-on copy of
+this duty from `~/.grok/Agents.md`.
+
+---
+
 ## Project Research Registry — Orchestrator Duty (binding)
 
 Before every delegated task, the accountable orchestrator must deliberately classify

--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -1,10 +1,26 @@
 ---
 name: entire-context
-description: Provider-neutral recall over the public body-free context-link index (ADR-018). Invoke at task intake when prior work may matter, before consequential design changes, when explaining a commit or ACP discussion, and when preparing a bounded handoff. Works identically for Codex, Kimi, GLM, Claude, and other harnesses; GitHub, Fleet Comms, Monitor, session streams, rollover, and formal review remain authoritative.
+description: >
+  ALWAYS run at cold start / task intake for non-trivial work (no operator prompt
+  required). Provider-neutral body-free context-link recall (ADR-018): status,
+  search-past-work, explain-change, prepare-handoff, record-use. Also use before
+  consequential design changes, when explaining a commit or ACP discussion, and
+  when preparing a handoff. Works for Codex, Kimi, GLM, Claude, Grok, and other
+  harnesses. GitHub, Fleet Comms, Monitor, session streams, rollover, and formal
+  review remain authoritative. Never skip search on multi-step drives.
+when-to-use: >
+  session start; cold start; orient; task intake; continue; resume; handoff;
+  what happened; prior work; explain commit; ACP discussion; epic drive; before
+  dispatch; before design change; entire; entire.io; entire-context; memory
 effort: low
 ---
 
 # Entire context recall (public, body-free)
+
+**Automatic intake:** On any non-trivial task, run `status` + `search` (and
+`record-use` when locators inform the plan) **before** prioritization or
+dispatch. Do not wait for the operator to say “use Entire.” Skip only for pure
+one-line questions or when the module is missing/disabled (note that once).
 
 This skill is the canonical agent-facing contract for the public context layer.
 It runs one provider-neutral CLI — `python -m scripts.entire_context` — over the


### PR DESCRIPTION
## Summary
Make **entire-context** automatic so seats do not wait for the operator to mention Entire/entire.io.

- Skill frontmatter: ALWAYS at cold start; `when-to-use` triggers expanded
- `AGENTS.md`: binding intake (`status` + `search` + `record-use`)

Operator also has always-on duty in `~/.grok/Agents.md` (local, not in this PR).

X-Agent: grok/entire-context-auto-skill