### PR TITLE
feat(entire): resolve typed local evidence

### DIFF
--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -60,6 +60,11 @@ projection; `refresh-provider-status` writes only a sanitized local cache.
 .venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha> [--repo PATH] [--namespace NS]
 .venv/bin/python -m scripts.entire_context bootstrap-acp conversation_<32hex> [--git-sha SHA] [--acp-root PATH]
 .venv/bin/python -m scripts.entire_context bootstrap-rollover --agent <agent> --lineage-id <lineage> --rollover-id <rollover> [--rollover-root PATH]
+.venv/bin/python -m scripts.entire_context bootstrap-github-issue <number> [--issue-cache PATH] [--repo PATH]
+.venv/bin/python -m scripts.entire_context bootstrap-github-pr <number> --head-sha <40-hex-sha> --repository <owner/repo> [--fleet-root PATH] [--repo PATH]
+.venv/bin/python -m scripts.entire_context bootstrap-formal-review <review-id> [--fleet-root PATH]
+.venv/bin/python -m scripts.entire_context bootstrap-fleet-receipt <request-id> [--fleet-root PATH]
+.venv/bin/python -m scripts.entire_context bootstrap-monitor-run <lease-token> [--monitor-root PATH]
 
 # Recover terminal ACP receipts missed by the automatic post-commit callback
 .venv/bin/python -m scripts.entire_context reconcile-acp --acp-root PATH
@@ -88,7 +93,9 @@ Resolution flags: `--repo` (default: cwd) supplies the local git repository;
 `--rollover-root` or `ENTIRE_CONTEXT_ROLLOVER_ROOT` supplies the rollover
 registry state root. Without an ACP root, ACP links fail closed as
 `source_missing`; without a rollover root, rollover links fail closed as
-`source_missing`. `--db` or
+`source_missing`. `--fleet-root`, `--monitor-root`, and `--issue-cache` select
+existing local canonical stores for fixtures or operators; otherwise linked
+worktrees use the primary shared `batch_state` stores. `--db` or
 `ENTIRE_CONTEXT_DB` overrides the projection path. By default every linked
 worktree resolves the same primary-checkout `batch_state/entire-context/v1`
 projection through Git's common directory. `--consumer <label>` may be
@@ -105,8 +112,30 @@ closed as `digest_mismatch`.
 | `git_commit` | Real | Read-only local git plumbing: parents, touched paths, committer timestamp, author. No commit subject/body. |
 | `acp_conversation` | Real | Existing terminal receipt verifier (`verify_discussion_receipt`), metadata-only, `content_included: false`. |
 | `rollover` | Real | Existing read-only registry verifier (`rollover_registry.load_record`): strict body-free projection of schema/key, lifecycle state/boundary, sub-lifecycle states, `cleanup_authorized`, timestamps, and non-body routing (stream epic, issue number, lifecycle state). |
-| `github_issue` / `github_pr` | Unsupported | No local canonical store verifiable without network; fails closed. |
-| `fleet_receipt` / `formal_review` / `monitor_run` | Unsupported | No local canonical store verifiable without protected-rail access; fails closed. |
+| `github_issue` | Real | Fresh `issue_stream_audit.json`: exact open issue plus one unique stream/epic membership. Cache freshness is verification evidence, never locator identity. No body or title. |
+| `github_pr` | Real | Completed local formal-review job, matching durable `github_publications` row for the exact head and gate context, plus a local Git commit object. |
+| `formal_review` | Real | Completed job; read-only hash-verified sealed verdict strictly parsed and bound again to its job. Exposes only review/repository/PR/head/gate/state/verdict/model/family/harness/attempt/publication state. |
+| `fleet_receipt` | Real | Exact terminal Fleet `requests` row only; no invocation specification or messages. |
+| `monitor_run` | Real | Exact terminal Agent Process Monitor lease only; no PID or process-create time. |
+
+All resolver source reads are local and read-only. SQLite opens with URI
+`mode=ro`; resolvers never migrate, change WAL mode, prune, start a service,
+or call GitHub, Fleet, Monitor, Entire, or the network. Missing, malformed,
+nonterminal, stale, unpublished, hash-mismatched, or digest-drifted inputs are
+omitted fail-closed.
+
+## Product prompt workflow and optional Entire tools
+
+For product-style prompts, invoke the local body-free workflow in this order:
+`search` for search-past-work, `explain-change` for an exact provenance path,
+and `handoff` for a bounded capsule. Use the `.venv/bin/python` commands above;
+they are the canonical recall path.
+
+Native `entire blame --json` is allowed only for local attribution. Prompt-
+bearing `entire why`, cloud `entire search`, generated recap, investigate
+findings, and Entire review are optional manual tools. They never automatically
+enter a canonical capsule. Entire review is supplemental and never satisfies
+the Fleet formal-review gate.
 
 ## How to consume results
 

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -42,3 +42,25 @@ the product setting and egress allowlist still name one identical destination.
 
 The deployed source commit must carry `Entire-Checkpoint` as a real Git trailer.
 Escaped newline text is not a trailer and will not enter Entire's activity index.
+
+## Product workflow boundary
+
+Product-style prompts use the local body-free context workflow: search-past-work,
+explain-change, and prepare-handoff through `.venv/bin/python -m
+scripts.entire_context`. These commands read local verified projections and
+produce locator cards or bounded capsules; they do not invoke Entire or the
+network.
+
+Native `entire blame --json` is allowed for local attribution. Prompt-bearing
+`entire why`, cloud `entire search`, generated recap, investigate findings, and
+Entire review remain optional manual tools. None automatically enters a canonical
+capsule. Entire review is supplemental and never satisfies the Fleet
+formal-review gate.
+
+The typed local resolver inventory is deliberately narrow: an open GitHub issue
+must have exactly one fresh issue-stream membership; a GitHub PR needs a
+completed local formal-review job, matching durable publication receipt, and
+local head commit; formal review requires a hash-verified sealed verdict; Fleet
+and Monitor require exact terminal receipts. Resolver reads use existing local
+caches only, including SQLite URI `mode=ro`; they do not migrate, change WAL,
+prune, start services, or contact GitHub, Fleet, Monitor, or Entire.

--- a/scripts/api/entire_context_router.py
+++ b/scripts/api/entire_context_router.py
@@ -9,9 +9,14 @@ from typing import Any
 
 from fastapi import APIRouter, Query
 
-from scripts.entire_context.paths import projection_path
+from scripts.entire_context.paths import projection_path, shared_repository_root
 from scripts.entire_context.provider import load_provider_status
 from scripts.entire_context.recall import RecallInputError, search_past_work
+from scripts.entire_context.resolvers import (
+    default_fleet_root,
+    default_issue_cache,
+    default_monitor_root,
+)
 from scripts.entire_context.store import ContextLinkStore
 from scripts.fleet_comms.message_plane import default_plane_root
 
@@ -26,6 +31,12 @@ def _repo_root() -> Path:
         project_root=Path(PROJECT_ROOT),
         live_repo_root=Path(LIVE_REPO_ROOT),
     )
+
+
+def _rollover_root(root: Path) -> Path:
+    """Resolve the existing shared rollover registry, with an explicit service override."""
+    configured = os.environ.get("ENTIRE_CONTEXT_ROLLOVER_ROOT")
+    return Path(configured) if configured else shared_repository_root(root)
 
 
 def _projection_status(root: Path) -> dict[str, Any]:
@@ -98,7 +109,10 @@ def entire_context_search(
             q,
             repo=root,
             acp_root=acp_root,
-            rollover_root=None,
+            rollover_root=_rollover_root(root),
+            fleet_root=default_fleet_root(root),
+            monitor_root=default_monitor_root(root),
+            issue_cache_path=default_issue_cache(root),
             limit=limit,
         )
     except RecallInputError as exc:

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -46,10 +46,19 @@ from .recall import (
 )
 from .reconcile import MAX_RECONCILE_ROWS, reconcile_terminal_acp_receipts
 from .resolvers import (
+    DEFAULT_GATE_KIND,
     REASON_SOURCE_MISSING,
     ResolutionError,
+    default_fleet_root,
+    default_issue_cache,
+    default_monitor_root,
     resolve_acp_conversation,
+    resolve_fleet_receipt,
+    resolve_formal_review,
     resolve_git_commit,
+    resolve_github_issue,
+    resolve_github_pr,
+    resolve_monitor_run,
     resolve_rollover,
 )
 from .store import AdmitOutcome, ContextLinkStore
@@ -61,6 +70,9 @@ EXIT_REFUSED = 2
 ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
 ENV_ACP_ROOT = "ENTIRE_CONTEXT_ACP_ROOT"
 ENV_ROLLOVER_ROOT = "ENTIRE_CONTEXT_ROLLOVER_ROOT"
+ENV_FLEET_ROOT = "ENTIRE_CONTEXT_FLEET_ROOT"
+ENV_MONITOR_ROOT = "ENTIRE_CONTEXT_MONITOR_ROOT"
+ENV_ISSUE_CACHE = "ENTIRE_CONTEXT_ISSUE_CACHE"
 
 
 def _emit(payload: dict[str, Any]) -> None:
@@ -232,6 +244,36 @@ def _resolve_rollover_root(args: argparse.Namespace) -> Path | None:
     return Path(env) if env else None
 
 
+def _resolve_fleet_root(args: argparse.Namespace) -> Path | None:
+    explicit = getattr(args, "fleet_root", None)
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get(ENV_FLEET_ROOT)
+    if env:
+        return Path(env)
+    return default_fleet_root(_resolve_repo(args))
+
+
+def _resolve_monitor_root(args: argparse.Namespace) -> Path | None:
+    explicit = getattr(args, "monitor_root", None)
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get(ENV_MONITOR_ROOT)
+    if env:
+        return Path(env)
+    return default_monitor_root(_resolve_repo(args))
+
+
+def _resolve_issue_cache(args: argparse.Namespace) -> Path | None:
+    explicit = getattr(args, "issue_cache", None)
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get(ENV_ISSUE_CACHE)
+    if env:
+        return Path(env)
+    return default_issue_cache(_resolve_repo(args))
+
+
 def _consumer_error(args: argparse.Namespace) -> dict[str, Any] | None:
     """Validate the optional consumer label; it is never persisted or echoed."""
     consumer = getattr(args, "consumer", None)
@@ -323,6 +365,91 @@ def cmd_bootstrap_rollover(args: argparse.Namespace) -> int:
     return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
 
 
+def _admit_typed_resolution(args: argparse.Namespace, resolution) -> int:
+    """Admit a completed local typed resolution using the normal idempotent gate."""
+    try:
+        result = ContextLinkStore(_resolve_db(args)).admit(
+            resolution.link,
+            resolution.verification,
+            actor=args.actor,
+        )
+    except (SchemaError, sqlite3.Error, KeyError, TypeError, ValueError):
+        _emit(_unavailable_payload(_resolve_db(args), "projection_unreadable"))
+        return EXIT_REFUSED
+    payload = result.to_dict()
+    if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED):
+        payload["excerpt"] = resolution.excerpt
+    _emit(payload)
+    return EXIT_OK if result.outcome in (AdmitOutcome.PROMOTED, AdmitOutcome.ALREADY_PROMOTED) else EXIT_REFUSED
+
+
+def cmd_bootstrap_github_issue(args: argparse.Namespace) -> int:
+    """Resolve an exact open issue through the fresh local membership cache."""
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_github_issue(
+            args.issue_number,
+            cache_path=_resolve_issue_cache(args),
+            repo=_resolve_repo(args),
+            namespace=args.namespace,
+        )
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    return _admit_typed_resolution(args, resolution)
+
+
+def cmd_bootstrap_github_pr(args: argparse.Namespace) -> int:
+    """Resolve an exact reviewed local PR head and its durable publication."""
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_github_pr(
+            args.repository,
+            args.pr_number,
+            args.head_sha,
+            gate_kind=args.gate_kind,
+            fleet_root=_resolve_fleet_root(args),
+            repo=_resolve_repo(args),
+        )
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    return _admit_typed_resolution(args, resolution)
+
+
+def cmd_bootstrap_formal_review(args: argparse.Namespace) -> int:
+    """Resolve one completed, sealed local formal-review job."""
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_formal_review(args.review_id, fleet_root=_resolve_fleet_root(args))
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    return _admit_typed_resolution(args, resolution)
+
+
+def cmd_bootstrap_fleet_receipt(args: argparse.Namespace) -> int:
+    """Resolve one terminal Fleet request row without reading its body fields."""
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_fleet_receipt(args.request_id, fleet_root=_resolve_fleet_root(args))
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    return _admit_typed_resolution(args, resolution)
+
+
+def cmd_bootstrap_monitor_run(args: argparse.Namespace) -> int:
+    """Resolve one terminal Agent Process Monitor lease locally."""
+    if _disabled():
+        return _refused("projection_disabled")
+    try:
+        resolution = resolve_monitor_run(args.lease_token, monitor_root=_resolve_monitor_root(args))
+    except ResolutionError as exc:
+        return _refused(exc.reason)
+    return _admit_typed_resolution(args, resolution)
+
+
 def cmd_search(args: argparse.Namespace) -> int:
     """search-past-work: ranked, re-verified, body-free locator cards."""
     db_path, early = _guard(args)
@@ -340,6 +467,9 @@ def cmd_search(args: argparse.Namespace) -> int:
             repo=_resolve_repo(args),
             acp_root=_resolve_acp_root(args),
             rollover_root=_resolve_rollover_root(args),
+            fleet_root=_resolve_fleet_root(args),
+            monitor_root=_resolve_monitor_root(args),
+            issue_cache_path=_resolve_issue_cache(args),
             limit=args.limit,
             scan_limit=args.scan_limit,
         )
@@ -373,6 +503,9 @@ def cmd_explain_change(args: argparse.Namespace) -> int:
             repo=_resolve_repo(args),
             acp_root=_resolve_acp_root(args),
             rollover_root=_resolve_rollover_root(args),
+            fleet_root=_resolve_fleet_root(args),
+            monitor_root=_resolve_monitor_root(args),
+            issue_cache_path=_resolve_issue_cache(args),
         )
     except RecallInputError as exc:
         _emit({"error": str(exc)})
@@ -408,6 +541,9 @@ def cmd_handoff(args: argparse.Namespace) -> int:
                 repo=_resolve_repo(args),
                 acp_root=_resolve_acp_root(args),
                 rollover_root=_resolve_rollover_root(args),
+                fleet_root=_resolve_fleet_root(args),
+                monitor_root=_resolve_monitor_root(args),
+                issue_cache_path=_resolve_issue_cache(args),
                 limit=MAX_RESULTS,
             )
             locator_ids.extend(card["locator_id"] for card in search["results"])
@@ -419,6 +555,9 @@ def cmd_handoff(args: argparse.Namespace) -> int:
             repo=_resolve_repo(args),
             acp_root=_resolve_acp_root(args),
             rollover_root=_resolve_rollover_root(args),
+            fleet_root=_resolve_fleet_root(args),
+            monitor_root=_resolve_monitor_root(args),
+            issue_cache_path=_resolve_issue_cache(args),
         )
     except RecallInputError as exc:
         _emit({"error": str(exc)})
@@ -544,6 +683,21 @@ def build_parser() -> argparse.ArgumentParser:
             ),
         )
         command.add_argument(
+            "--fleet-root",
+            default=None,
+            help=f"Fleet Comms root (default: {ENV_FLEET_ROOT} or shared primary batch_state)",
+        )
+        command.add_argument(
+            "--monitor-root",
+            default=None,
+            help=f"Agent Monitor state root (default: {ENV_MONITOR_ROOT} or shared primary batch_state)",
+        )
+        command.add_argument(
+            "--issue-cache",
+            default=None,
+            help=f"Issue-stream audit cache (default: {ENV_ISSUE_CACHE} or shared primary batch_state)",
+        )
+        command.add_argument(
             "--consumer",
             default=None,
             help="Optional harness label (codex, kimi, glm, ...); validated, never persisted or echoed",
@@ -601,6 +755,62 @@ def build_parser() -> argparse.ArgumentParser:
     bootstrap_rollover.add_argument("--actor", default="cli", help="Body-free actor identity")
     add_db_flag(bootstrap_rollover)
     bootstrap_rollover.set_defaults(func=cmd_bootstrap_rollover)
+
+    bootstrap_issue = sub.add_parser(
+        "bootstrap-github-issue",
+        help="Resolve one exact open issue from the fresh local membership cache",
+    )
+    bootstrap_issue.add_argument("issue_number", type=int, help="Exact positive GitHub issue number")
+    bootstrap_issue.add_argument("--namespace", default=None, help="Canonical GitHub namespace override")
+    bootstrap_issue.add_argument("--repo", default=None, help="Local git repository (default: cwd)")
+    bootstrap_issue.add_argument("--issue-cache", default=None, help="Fresh local issue-stream-audit JSON cache")
+    bootstrap_issue.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_issue)
+    bootstrap_issue.set_defaults(func=cmd_bootstrap_github_issue)
+
+    bootstrap_pr = sub.add_parser(
+        "bootstrap-github-pr",
+        help="Resolve an exact reviewed local PR head and durable publication receipt",
+    )
+    bootstrap_pr.add_argument("pr_number", type=int, help="Exact positive pull-request number")
+    bootstrap_pr.add_argument("--head-sha", required=True, help="Exact local 40-hex reviewed commit")
+    bootstrap_pr.add_argument("--repository", required=True, help="Exact owner/repository identity")
+    bootstrap_pr.add_argument("--gate-kind", default=DEFAULT_GATE_KIND, help="Formal-review gate kind")
+    bootstrap_pr.add_argument("--fleet-root", default=None, help="Fleet Comms root")
+    bootstrap_pr.add_argument("--repo", default=None, help="Local git repository (default: cwd)")
+    bootstrap_pr.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_pr)
+    bootstrap_pr.set_defaults(func=cmd_bootstrap_github_pr)
+
+    bootstrap_review = sub.add_parser(
+        "bootstrap-formal-review",
+        help="Resolve one completed sealed local formal-review job",
+    )
+    bootstrap_review.add_argument("review_id", help="Exact formal-review identifier")
+    bootstrap_review.add_argument("--fleet-root", default=None, help="Fleet Comms root")
+    bootstrap_review.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_review)
+    bootstrap_review.set_defaults(func=cmd_bootstrap_formal_review)
+
+    bootstrap_receipt = sub.add_parser(
+        "bootstrap-fleet-receipt",
+        help="Resolve one exact terminal Fleet request receipt",
+    )
+    bootstrap_receipt.add_argument("request_id", help="Exact Fleet request identifier")
+    bootstrap_receipt.add_argument("--fleet-root", default=None, help="Fleet Comms root")
+    bootstrap_receipt.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_receipt)
+    bootstrap_receipt.set_defaults(func=cmd_bootstrap_fleet_receipt)
+
+    bootstrap_monitor = sub.add_parser(
+        "bootstrap-monitor-run",
+        help="Resolve one exact terminal Agent Process Monitor lease",
+    )
+    bootstrap_monitor.add_argument("lease_token", help="Exact monitor lease token")
+    bootstrap_monitor.add_argument("--monitor-root", default=None, help="Agent Monitor state root")
+    bootstrap_monitor.add_argument("--actor", default="cli", help="Body-free actor identity")
+    add_db_flag(bootstrap_monitor)
+    bootstrap_monitor.set_defaults(func=cmd_bootstrap_monitor_run)
 
     search = sub.add_parser(
         "search",

--- a/scripts/entire_context/recall.py
+++ b/scripts/entire_context/recall.py
@@ -142,6 +142,9 @@ def _verified_card(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None,
+    fleet_root: Path | None,
+    monitor_root: Path | None,
+    issue_cache_path: Path | None,
     now: datetime | None,
 ) -> dict[str, Any]:
     """Re-check promotion state and re-resolve/recompute the canonical digest."""
@@ -149,7 +152,16 @@ def _verified_card(
     if fresh is None:
         raise GateReject(REASON_TOMBSTONED)
     try:
-        excerpt = reverify_link(fresh, repo=repo, acp_root=acp_root, rollover_root=rollover_root, now=now)
+        excerpt = reverify_link(
+            fresh,
+            repo=repo,
+            acp_root=acp_root,
+            rollover_root=rollover_root,
+            fleet_root=fleet_root,
+            monitor_root=monitor_root,
+            issue_cache_path=issue_cache_path,
+            now=now,
+        )
     except ResolutionError as exc:
         raise GateReject(exc.reason) from exc
     return {
@@ -179,6 +191,9 @@ def search_past_work(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None = None,
+    fleet_root: Path | None = None,
+    monitor_root: Path | None = None,
+    issue_cache_path: Path | None = None,
     limit: int = MAX_RESULTS,
     scan_limit: int = MAX_SCAN_ROWS,
     now: datetime | None = None,
@@ -204,7 +219,17 @@ def search_past_work(
             break
         locator_id = entry.link["locator_id"]
         try:
-            card = _verified_card(store, entry.link, repo=repo, acp_root=acp_root, rollover_root=rollover_root, now=now)
+            card = _verified_card(
+                store,
+                entry.link,
+                repo=repo,
+                acp_root=acp_root,
+                rollover_root=rollover_root,
+                fleet_root=fleet_root,
+                monitor_root=monitor_root,
+                issue_cache_path=issue_cache_path,
+                now=now,
+            )
         except GateReject as exc:
             if len(omitted) < MAX_SEARCH_OMISSIONS:
                 omitted.append(_omitted(locator_id, exc.reason))
@@ -271,6 +296,9 @@ def explain_change(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None = None,
+    fleet_root: Path | None = None,
+    monitor_root: Path | None = None,
+    issue_cache_path: Path | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Traverse typed provenance joins from an exact seed identifier.
@@ -315,7 +343,15 @@ def explain_change(
     for node_id in sorted(nodes):
         try:
             verified[node_id] = _verified_card(
-                store, nodes[node_id], repo=repo, acp_root=acp_root, rollover_root=rollover_root, now=now
+                store,
+                nodes[node_id],
+                repo=repo,
+                acp_root=acp_root,
+                rollover_root=rollover_root,
+                fleet_root=fleet_root,
+                monitor_root=monitor_root,
+                issue_cache_path=issue_cache_path,
+                now=now,
             )
         except GateReject as exc:
             omitted.append(_omitted(node_id, exc.reason))
@@ -351,6 +387,9 @@ def prepare_handoff(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None = None,
+    fleet_root: Path | None = None,
+    monitor_root: Path | None = None,
+    issue_cache_path: Path | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Build a bounded capsule of verified locator cards and excerpts.
@@ -396,7 +435,17 @@ def prepare_handoff(
             append_omission(locator_id, REASON_SOURCE_MISSING)
             continue
         try:
-            card = _verified_card(store, link, repo=repo, acp_root=acp_root, rollover_root=rollover_root, now=now)
+            card = _verified_card(
+                store,
+                link,
+                repo=repo,
+                acp_root=acp_root,
+                rollover_root=rollover_root,
+                fleet_root=fleet_root,
+                monitor_root=monitor_root,
+                issue_cache_path=issue_cache_path,
+                now=now,
+            )
         except GateReject as exc:
             append_omission(locator_id, exc.reason)
             continue

--- a/scripts/entire_context/resolvers.py
+++ b/scripts/entire_context/resolvers.py
@@ -4,9 +4,10 @@ Every resolver maps one exact, caller-supplied identifier to a body-free
 canonical projection: a deterministic digest over public metadata, never over
 subjects, prompts, transcripts, or any composed text. Resolution is fully
 local — read-only ``git`` plumbing, the existing body-free ACP terminal
-receipt verifier, and the existing read-only rollover-registry verifier — and
-fails closed: a source that cannot be verified raises
-:class:`ResolutionError` with a machine reason and nothing is fabricated.
+receipt verifier, the existing read-only rollover-registry verifier, and
+read-only SQLite over existing canonical Fleet/Monitor caches — and fails
+closed: a source that cannot be verified raises :class:`ResolutionError` with
+a machine reason and nothing is fabricated.
 
 Real resolvers in this slice:
 
@@ -24,16 +25,42 @@ Real resolvers in this slice:
   non-body routing (stream epic, issue number, lifecycle state). Titles,
   task/thread IDs, reasons, filesystem paths, history, receipts, evidence, and
   nested native/readback payloads are excluded.
+- ``github_issue`` — an exact issue number resolves against the fresh local
+  ``batch_state/issue_stream_audit.json`` cache. Projects issue number and
+  unique stream/epic membership only. Cache freshness is verification evidence,
+  never locator identity; no issue body or title is read.
+- ``github_pr`` — an exact ``(repository, pr_number, head_sha, gate_kind)``
+  quadruple resolves against a completed formal-review job plus its durable
+  ``github_publications`` row in the Fleet Comms SQLite store, and verifies the
+  head commit exists in local Git. Projects repository, PR number, head SHA,
+  gate/state, and publication timestamp/context only.
+- ``formal_review`` — an exact review ID resolves against a completed
+  formal-review job in the Fleet Comms SQLite store, loads and hash-checks the
+  sealed-verdict blob read-only, parses it with the existing strict parser, and
+  re-checks job binding. Projects review ID, repository, PR, head SHA, gate,
+  state, verdict token, model/family/harness, attempt count/completion states,
+  and publication state only. Never exposes artifact IDs or payload
+  text/findings.
+- ``fleet_receipt`` — an exact request ID resolves against one canonical
+  ``requests`` row in the Fleet Comms SQLite store. Projects request ID,
+  requested/resolved recipient, terminal state, completion state, and
+  expiry/created/updated timestamps only. Never reads or exposes invocation
+  JSON or message bodies.
+- ``monitor_run`` — an exact lease token resolves against a terminal
+  ``agent_leases`` row in the Agent Process Monitor SQLite store. Projects
+  lease ID, agent ID, task name, terminal status, created/last-heartbeat
+  timestamps, and a bounded RAM bucket only. Excludes PID and process-create
+  time.
 
-``github_issue``, ``github_pr``, ``fleet_receipt``, ``formal_review``, and
-``monitor_run`` remain explicitly unsupported here: this slice has no local
-canonical store for them that is verifiable without network access or
-protected-rail mutation, so they fail closed with ``unsupported_kind`` instead
-of fabricating coverage.
+All SQLite reads use URI ``mode=ro``; no migrations, WAL changes, pruning, or
+service calls are performed.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import math
 import re
 import sqlite3
 import subprocess
@@ -47,6 +74,7 @@ from scripts.agent_runtime.acpx_discuss import (
     AcpxDiscussionNotFoundError,
     verify_discussion_receipt,
 )
+from scripts.fleet_comms.review_publication import parse_sealed_verdict_payload
 from scripts.orchestration.task_family.rollover_registry import (
     load_record as load_rollover_record,
 )
@@ -64,17 +92,37 @@ from .model import (
     VerificationStatus,
     canonical_json,
     isoformat_z,
+    parse_timestamp,
     sha256_text,
     utc_now,
     validate_facets,
+    validate_identity,
 )
+from .paths import shared_repository_root
 
 GIT_TIMEOUT_SECONDS = 30
 
 ACP_CONVERSATION_ID_RE = re.compile(r"^conversation_[0-9a-f]{32}$")
+GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+GITHUB_ORIGIN_RE = re.compile(
+    r"^(?:git@github\.com:|ssh://git@github\.com/|https://github\.com/)"
+    r"(?P<repository>[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*?)(?:\.git)?/?$"
+)
 
 #: Kinds with a real local resolver in this slice. Everything else fails closed.
-SUPPORTED_RESOLVER_KINDS = frozenset({LinkKind.GIT_COMMIT, LinkKind.ACP_CONVERSATION, LinkKind.ROLLOVER})
+SUPPORTED_RESOLVER_KINDS = frozenset(
+    {
+        LinkKind.GIT_COMMIT,
+        LinkKind.ACP_CONVERSATION,
+        LinkKind.ROLLOVER,
+        LinkKind.GITHUB_ISSUE,
+        LinkKind.GITHUB_PR,
+        LinkKind.FORMAL_REVIEW,
+        LinkKind.FLEET_RECEIPT,
+        LinkKind.MONITOR_RUN,
+    }
+)
 
 #: Body-free machine reasons a resolution or re-verification can end with.
 REASON_SOURCE_MISSING = "source_missing"
@@ -82,6 +130,27 @@ REASON_DIGEST_MISMATCH = "digest_mismatch"
 REASON_PARTIAL_TERMINAL = "partial_terminal"
 REASON_UNSUPPORTED_KIND = "unsupported_kind"
 REASON_RESOLUTION_ERROR = "resolution_error"
+REASON_PUBLICATION_MISSING = "publication_missing"
+
+#: Maximum age (seconds) for the issue-stream-audit cache before it is stale.
+MAX_ISSUE_CACHE_AGE_SECONDS = 3600
+#: Maximum acceptable clock skew (cache generated_at ahead of wall-clock).
+MAX_CACHE_SKEW_SECONDS = 300
+
+#: Terminal request states in the Fleet Comms ``requests`` table.
+_TERMINAL_REQUEST_STATES = frozenset(
+    {"complete", "incomplete", "failed", "expired", "dead_lettered"}
+)
+_REQUEST_STATES = frozenset({"queued", "running", *_TERMINAL_REQUEST_STATES})
+
+#: Terminal lease statuses in the Agent Process Monitor ``agent_leases`` table.
+_TERMINAL_LEASE_STATUSES = frozenset({"RELEASED", "EXPIRED"})
+_COMPLETION_STATES = frozenset({"complete", "length_limited", "transport_incomplete", "failed"})
+_REQUEST_COMPLETION_STATES = frozenset({*_COMPLETION_STATES, "unknown"})
+_FORMAL_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED", "BLOCKED"})
+_FORMAL_JOB_STATES = frozenset({"open", "running", "complete", "failed", "blocked"})
+_EARLIEST_TIMESTAMP = 946_684_800  # 2000-01-01T00:00:00Z
+_LATEST_TIMESTAMP = 4_102_444_800  # 2100-01-01T00:00:00Z
 
 
 class ResolutionError(ValueError):
@@ -131,7 +200,7 @@ def _run_git(repo: Path, *args: str) -> str:
     return completed.stdout
 
 
-def _origin_namespace(repo: Path) -> str | None:
+def _origin_url(repo: Path) -> str | None:
     try:
         completed = subprocess.run(
             ["git", "-C", str(repo), "config", "--get", "remote.origin.url"],
@@ -144,7 +213,13 @@ def _origin_namespace(repo: Path) -> str | None:
         return None
     if completed.returncode != 0:
         return None
-    url = completed.stdout.strip()
+    return completed.stdout.strip() or None
+
+
+def _origin_namespace(repo: Path) -> str | None:
+    url = _origin_url(repo)
+    if url is None:
+        return None
     match = re.search(r"[:/]([A-Za-z0-9._-]+/[A-Za-z0-9._-]+?)(?:\.git)?$", url)
     if match is None:
         return None
@@ -515,6 +590,942 @@ def resolve_rollover(
 # ── typed dispatch and re-verification gate ──────────────────────────────────
 
 
+def _open_readonly_sqlite(db_path: Path) -> sqlite3.Connection:
+    """Open one SQLite database read-only via URI ``mode=ro``; fail closed."""
+    path = Path(db_path).expanduser().resolve()
+    if not path.is_file():
+        raise ResolutionError(REASON_SOURCE_MISSING)
+    try:
+        connection = sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "sqlite unreadable") from exc
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+#: Default formal-review gate kind / publication context used by Fleet Comms.
+DEFAULT_GATE_KIND = "cross-family-review"
+DEFAULT_STATUS_CONTEXT = "fleet/cross-family-review"
+
+#: Relative path segments for canonical local stores under the primary checkout.
+_FLEET_COMMS_REL = Path("batch_state") / "fleet-comms" / "v1"
+_MONITOR_DB_NAME = "agent_monitor.sqlite3"
+_ISSUE_CACHE_NAME = "issue_stream_audit.json"
+
+
+def default_fleet_root(repo: Path | str) -> Path:
+    """Resolve the shared Fleet Comms plane root beneath the primary checkout."""
+    return shared_repository_root(repo) / _FLEET_COMMS_REL
+
+
+def default_monitor_root(repo: Path | str) -> Path:
+    """Resolve the shared Agent Process Monitor state root beneath the primary checkout."""
+    return shared_repository_root(repo) / "batch_state"
+
+
+def default_monitor_db(repo: Path | str) -> Path:
+    """Resolve the shared Agent Process Monitor database beneath its state root."""
+    return default_monitor_root(repo) / _MONITOR_DB_NAME
+
+
+def default_issue_cache(repo: Path | str) -> Path:
+    """Resolve the shared issue-stream-audit cache beneath the primary checkout."""
+    return shared_repository_root(repo) / "batch_state" / _ISSUE_CACHE_NAME
+
+
+def _fleet_db_path(fleet_root: Path | str) -> Path:
+    return Path(fleet_root).expanduser().resolve() / "comms.sqlite3"
+
+
+def _blob_path_for(fleet_root: Path, digest: str) -> Path:
+    """Compute the content-addressed sealed-verdict blob path (matches ArtifactStore)."""
+    lowered = digest.lower()
+    return Path(fleet_root).expanduser().resolve() / "blobs" / "sha256" / lowered[:2] / lowered
+
+
+def _github_namespace(repo: Path) -> str:
+    """Derive ``github:<owner/repo>`` from a public local origin, or fail closed."""
+    origin = _origin_url(Path(repo))
+    match = GITHUB_ORIGIN_RE.fullmatch(origin or "")
+    if match is not None:
+        return "github:" + match.group("repository")
+    raise ResolutionError(REASON_SOURCE_MISSING, "public GitHub origin unavailable")
+
+
+def _github_repository(namespace: str) -> str:
+    """Validate an explicit ``github:<owner/repo>`` namespace and return its repository."""
+    if not namespace.startswith("github:"):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "github namespace is required")
+    repository = namespace.removeprefix("github:")
+    if not GITHUB_REPOSITORY_RE.fullmatch(repository):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "github namespace must identify owner/repository")
+    return repository
+
+
+def _repository_from_namespace(namespace: str) -> str:
+    """Extract ``<owner/repo>`` from a ``github:<owner/repo>`` namespace."""
+    return _github_repository(namespace)
+
+
+def _ram_bucket(reserved_mb: int) -> str:
+    """Bound the exact reserved-RAM value into a coarse bucket."""
+    if reserved_mb <= 0:
+        return "none"
+    if reserved_mb <= 512:
+        return "small"
+    if reserved_mb <= 1024:
+        return "medium"
+    if reserved_mb <= 2048:
+        return "large"
+    return "xlarge"
+
+
+def _require_identity(value: object, *, field: str) -> str:
+    """Accept one projected identifier only when the shared body-free guard does."""
+    if not isinstance(value, str):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is not an identity")
+    try:
+        validate_identity(value, field_name=field)
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is not body-free") from exc
+    return value
+
+
+def _require_state(value: object, *, field: str, allowed: frozenset[str]) -> str:
+    """Require one finite, documented state token before projection."""
+    if not isinstance(value, str) or value not in allowed:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is not an allowed state")
+    return value
+
+
+def _require_timestamp(value: object, *, field: str) -> str:
+    """Validate and canonicalize a bounded ISO-8601 timestamp for projection."""
+    text = _require_identity(value, field=field)
+    try:
+        parsed = parse_timestamp(text)
+    except (TypeError, ValueError) as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is not a timestamp") from exc
+    epoch = parsed.timestamp()
+    if not math.isfinite(epoch) or not _EARLIEST_TIMESTAMP <= epoch <= _LATEST_TIMESTAMP:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is outside the supported range")
+    return isoformat_z(parsed)
+
+
+def _require_epoch(value: object, *, field: str) -> float:
+    """Validate a finite Unix epoch in the same bounded timestamp range."""
+    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is not a finite timestamp")
+    epoch = float(value)
+    if not _EARLIEST_TIMESTAMP <= epoch <= _LATEST_TIMESTAMP:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"{field} is outside the supported range")
+    return epoch
+
+
+def _require_monitor_ram(value: object) -> int:
+    """Validate the monitor's bounded reservation before collapsing it to a bucket."""
+    if isinstance(value, bool) or not isinstance(value, int) or not 64 <= value <= 3072:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "reserved_ram_mb is not an allowed reservation")
+    return value
+
+
+# ── github_issue ─────────────────────────────────────────────────────────────
+
+
+def _parse_issue_number(identifier: str) -> int:
+    """Parse ``issue/<number>`` or a bare positive integer into an issue number."""
+    text = identifier.strip()
+    if text.startswith("issue/"):
+        text = text[len("issue/"):]
+    if not text.isdigit():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue canonical_id must be issue/<number>")
+    number = int(text)
+    if number <= 0:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue number must be positive")
+    return number
+
+
+def github_issue_projection(
+    issue_number: int,
+    *,
+    stream_epic: int,
+    stream: str,
+    via: str,
+) -> dict[str, Any]:
+    """Body-free identity projection of one verified open issue.
+
+    Cache freshness proves that the membership was checked, but is not part of
+    the issue identity.  In particular, a harmless cache refresh must not
+    create a new locator or tombstone a previously verified issue link.
+    """
+    return {
+        "schema": "github-issue-projection.v1",
+        "issue_number": issue_number,
+        "stream_epic": stream_epic,
+        "stream": stream,
+        "via": via,
+    }
+
+
+def github_issue_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def resolve_github_issue(
+    issue_number: int,
+    *,
+    cache_path: Path,
+    repo: Path,
+    namespace: str | None = None,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve one exact issue number against the fresh local stream-audit cache.
+
+    Reads ``batch_state/issue_stream_audit.json`` read-only. A stale, missing,
+    or malformed cache, or a closed/missing/orphaned/multi-homed issue fails
+    closed. Projects issue number and unique stream/epic membership only;
+    cache freshness is verification evidence, never identity.
+    """
+    if not isinstance(issue_number, int) or issue_number <= 0:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue number must be a positive integer")
+    path = Path(cache_path).expanduser().resolve()
+    if not path.is_file():
+        raise ResolutionError(REASON_SOURCE_MISSING)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        report = json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache unreadable") from exc
+    if not isinstance(report, dict):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache malformed")
+
+    generated_at = report.get("generated_at")
+    if (
+        isinstance(generated_at, bool)
+        or not isinstance(generated_at, int | float)
+        or not math.isfinite(generated_at)
+    ):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache missing generated_at")
+    moment = now or utc_now()
+    now_epoch = moment.timestamp()
+    if now_epoch + MAX_CACHE_SKEW_SECONDS < generated_at:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache future-skewed")
+    if now_epoch - generated_at > MAX_ISSUE_CACHE_AGE_SECONDS:
+        raise ResolutionError(REASON_PARTIAL_TERMINAL, "issue cache stale")
+
+    open_numbers = report.get("open_issue_numbers")
+    if not isinstance(open_numbers, list) or not all(
+        isinstance(number, int) and not isinstance(number, bool) and number > 0
+        for number in open_numbers
+    ):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache missing open_issue_numbers")
+    open_set = set(open_numbers)
+    if issue_number not in open_set:
+        raise ResolutionError(REASON_SOURCE_MISSING)
+
+    index = report.get("effective_membership")
+    if not isinstance(index, dict):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue cache missing effective_membership")
+    entry = index.get(str(issue_number))
+    if not isinstance(entry, dict):
+        raise ResolutionError(REASON_SOURCE_MISSING)
+    epics = entry.get("epics")
+    streams = entry.get("streams")
+    via = entry.get("via")
+    unique = entry.get("unique_stream")
+    if (
+        not isinstance(epics, list)
+        or len(epics) != 1
+        or not isinstance(epics[0], int)
+        or isinstance(epics[0], bool)
+        or epics[0] <= 0
+        or not isinstance(streams, list)
+        or len(streams) != 1
+        or not isinstance(streams[0], str)
+        or not streams[0]
+        or via not in {"native", "body"}
+        or unique is not True
+    ):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "issue is ambiguous or not uniquely owned")
+    stream_epic = epics[0]
+    stream = _require_identity(streams[0], field="stream")
+    via_value = via
+
+    resolved_namespace = namespace or _github_namespace(Path(repo))
+    _github_repository(resolved_namespace)
+    canonical_id = f"issue/{issue_number}"
+    projection = github_issue_projection(
+        issue_number,
+        stream_epic=stream_epic,
+        stream=stream,
+        via=via_value,
+    )
+    digest = github_issue_projection_digest(projection)
+    facets: dict[str, Any] = {
+        "source_kind": "github_issue",
+        "stream_epic": stream_epic,
+        "state": "open",
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.GITHUB_ISSUE,
+            canonical_namespace=resolved_namespace,
+            canonical_id=canonical_id,
+            canonical_digest=digest,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="issue-stream-cache",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"issue-cache:issue/{issue_number}",
+        checked_at=isoformat_z(moment),
+    )
+    excerpt = {
+        "source": f"issue-cache:issue/{issue_number}",
+        **projection,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── github_pr ────────────────────────────────────────────────────────────────
+
+
+def _split_github_pr_canonical_id(identifier: str) -> tuple[int, str]:
+    """Split ``pr/<pr_number>/<gate_kind>`` into ``(pr_number, gate_kind)``."""
+    parts = identifier.split("/", 2)
+    if len(parts) != 3 or parts[0] != "pr" or not parts[1].isdigit():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "github_pr canonical_id must be pr/<number>/<gate>")
+    number = int(parts[1])
+    if number <= 0:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "pr number must be positive")
+    if not parts[2].strip():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "gate_kind must be non-empty")
+    return number, parts[2]
+
+
+def github_pr_projection(
+    *,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    gate_kind: str,
+    job_state: str,
+    published: bool,
+    publication_context: str,
+    published_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema": "github-pr-projection.v1",
+        "repository": repository,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "gate_kind": gate_kind,
+        "job_state": job_state,
+        "published": published,
+        "publication_context": publication_context,
+        "published_at": published_at,
+    }
+
+
+def github_pr_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def resolve_github_pr(
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    *,
+    gate_kind: str = DEFAULT_GATE_KIND,
+    fleet_root: Path,
+    repo: Path,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve a PR/head pair from a completed formal-review job + publication row.
+
+    Reads the Fleet Comms SQLite store read-only (``mode=ro``), verifies the
+    job is complete and has a durable ``github_publications`` row, and verifies
+    the exact head commit exists in local Git. Never exposes publication IDs
+    or artifact/raw captures.
+    """
+    if not repository or not GITHUB_REPOSITORY_RE.fullmatch(repository):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "repository must identify owner/repository")
+    _require_identity(repository, field="repository")
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "pr_number must be a positive integer")
+    sha = head_sha.lower()
+    if not GIT_SHA_RE.fullmatch(sha):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "head_sha must be a full 40-hex commit SHA")
+    gate_kind = _require_state(gate_kind, field="gate_kind", allowed=frozenset({DEFAULT_GATE_KIND}))
+    moment = now or utc_now()
+    db_path = _fleet_db_path(Path(fleet_root))
+
+    # Verify the head commit exists in local Git.
+    object_type = _run_git(Path(repo), "cat-file", "-t", sha).strip()
+    if object_type != "commit":
+        raise ResolutionError(REASON_SOURCE_MISSING, "head_sha is not a local commit")
+
+    connection = _open_readonly_sqlite(db_path)
+    try:
+        try:
+            job_row = connection.execute(
+                "SELECT review_id, repository, pr_number, head_sha, gate_kind, state,"
+                " sealed_verdict_artifact_id, created_at"
+                " FROM formal_review_jobs"
+                " WHERE repository = ? AND pr_number = ? AND head_sha = ? AND gate_kind = ?",
+                (repository, pr_number, sha, gate_kind),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "formal_review_jobs unreadable") from exc
+        if job_row is None:
+            raise ResolutionError(REASON_SOURCE_MISSING)
+        job_state = _require_state(job_row["state"], field="job_state", allowed=_FORMAL_JOB_STATES)
+        if job_state != "complete":
+            raise ResolutionError(REASON_PARTIAL_TERMINAL)
+        review_id = _require_identity(job_row["review_id"], field="review_id")
+        try:
+            pub_row = connection.execute(
+                "SELECT status_context, published_at FROM github_publications"
+                " WHERE review_id = ? AND head_sha = ? AND status_context = ?",
+                (review_id, sha, DEFAULT_STATUS_CONTEXT),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "github_publications unreadable") from exc
+        if pub_row is None:
+            raise ResolutionError(REASON_PUBLICATION_MISSING)
+    finally:
+        connection.close()
+
+    published_context = _require_state(
+        pub_row["status_context"], field="publication_context", allowed=frozenset({DEFAULT_STATUS_CONTEXT})
+    )
+    published_at = _require_timestamp(pub_row["published_at"], field="published_at")
+    namespace = f"github:{repository}"
+    canonical_id = f"pr/{pr_number}/{gate_kind}"
+    projection = github_pr_projection(
+        repository=repository,
+        pr_number=pr_number,
+        head_sha=sha,
+        gate_kind=gate_kind,
+        job_state=job_state,
+        published=True,
+        publication_context=published_context,
+        published_at=published_at,
+    )
+    digest = github_pr_projection_digest(projection)
+    facets: dict[str, Any] = {
+        "source_kind": "github_pr",
+        "repository": repository,
+        "state": job_state,
+        "event_ts": published_at,
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.GITHUB_PR,
+            canonical_namespace=namespace,
+            canonical_id=canonical_id,
+            canonical_digest=digest,
+            git_sha=sha,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="fleet-formal-review",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"fleet:pr/{pr_number}/head/{sha}",
+        checked_at=isoformat_z(moment),
+    )
+    excerpt = {
+        "source": f"fleet:pr/{pr_number}/head/{sha}",
+        **projection,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── formal_review ────────────────────────────────────────────────────────────
+
+
+def formal_review_projection(
+    *,
+    review_id: str,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    gate_kind: str,
+    job_state: str,
+    verdict: str,
+    model: str,
+    family: str,
+    harness: str,
+    attempt_count: int,
+    completion_states: list[str],
+    published: bool,
+    publication_context: str | None,
+    published_at: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema": "formal-review-projection.v1",
+        "review_id": review_id,
+        "repository": repository,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "gate_kind": gate_kind,
+        "job_state": job_state,
+        "verdict": verdict,
+        "model": model,
+        "family": family,
+        "harness": harness,
+        "attempt_count": attempt_count,
+        "completion_states": completion_states,
+        "published": published,
+        "publication_context": publication_context,
+        "published_at": published_at,
+    }
+
+
+def formal_review_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def resolve_formal_review(
+    review_id: str,
+    *,
+    fleet_root: Path,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve a completed formal-review job, hash-check its sealed verdict, and project.
+
+    Reads the Fleet Comms SQLite store read-only, loads the sealed-verdict blob
+    from the content-addressed store, hash-checks it, parses it with the
+    existing strict parser, and re-checks job binding. Never exposes sealed /
+    snapshot / raw artifact IDs or payload text / findings.
+    """
+    if not review_id or not review_id.strip():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "review_id is required")
+    rid = _require_identity(review_id.strip(), field="review_id")
+    moment = now or utc_now()
+    root = Path(fleet_root).expanduser().resolve()
+    db_path = _fleet_db_path(root)
+
+    connection = _open_readonly_sqlite(db_path)
+    try:
+        try:
+            job_row = connection.execute(
+                "SELECT review_id, repository, pr_number, head_sha, gate_kind, state,"
+                " sealed_verdict_artifact_id, created_at"
+                " FROM formal_review_jobs WHERE review_id = ?",
+                (rid,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "formal_review_jobs unreadable") from exc
+        if job_row is None:
+            raise ResolutionError(REASON_SOURCE_MISSING)
+        job_state = _require_state(job_row["state"], field="job_state", allowed=_FORMAL_JOB_STATES)
+        if job_state != "complete":
+            raise ResolutionError(REASON_PARTIAL_TERMINAL)
+        sealed_artifact_id = job_row["sealed_verdict_artifact_id"]
+        if sealed_artifact_id is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "job has no sealed verdict")
+        try:
+            art_row = connection.execute(
+                "SELECT sha256 FROM artifacts WHERE artifact_id = ?",
+                (str(sealed_artifact_id),),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "artifacts unreadable") from exc
+        if art_row is None:
+            raise ResolutionError(REASON_SOURCE_MISSING)
+        try:
+            pub_row = connection.execute(
+                "SELECT head_sha, status_context, published_at FROM github_publications WHERE review_id = ?",
+                (rid,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "github_publications unreadable") from exc
+        try:
+            attempt_rows = connection.execute(
+                "SELECT attempt_number, completion_state FROM formal_review_attempts"
+                " WHERE review_id = ? ORDER BY attempt_number",
+                (rid,),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "formal_review_attempts unreadable") from exc
+    finally:
+        connection.close()
+
+    # Hash-check the sealed-verdict blob read-only (never via ArtifactStore).
+    digest_hex = str(art_row["sha256"]).lower()
+    if not SHA256_HEX_RE.fullmatch(digest_hex):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "sealed-verdict digest is malformed")
+    blob_path = _blob_path_for(root, digest_hex)
+    if not blob_path.is_file():
+        raise ResolutionError(REASON_SOURCE_MISSING, "sealed-verdict blob missing")
+    try:
+        blob_bytes = blob_path.read_bytes()
+    except OSError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "sealed-verdict blob unreadable") from exc
+    if hashlib.sha256(blob_bytes).hexdigest() != digest_hex:
+        raise ResolutionError(REASON_DIGEST_MISMATCH, "sealed-verdict blob digest drift")
+
+    # Parse with the existing strict parser and re-check job binding.
+    try:
+        sealed = parse_sealed_verdict_payload(blob_bytes)
+    except Exception as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "sealed-verdict parse failed") from exc
+    job_repo = job_row["repository"]
+    if not isinstance(job_repo, str) or not GITHUB_REPOSITORY_RE.fullmatch(job_repo):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "repository must identify owner/repository")
+    _require_identity(job_repo, field="repository")
+    job_pr = job_row["pr_number"]
+    if isinstance(job_pr, bool) or not isinstance(job_pr, int) or job_pr <= 0:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "pr_number must be a positive integer")
+    job_sha = str(job_row["head_sha"]).lower()
+    if not GIT_SHA_RE.fullmatch(job_sha):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "head_sha must be a full 40-hex commit SHA")
+    job_gate = _require_state(job_row["gate_kind"], field="gate_kind", allowed=frozenset({DEFAULT_GATE_KIND}))
+    sealed_review_id = _require_identity(sealed.review_id, field="sealed_review_id")
+    sealed_repository = sealed.repository
+    if not GITHUB_REPOSITORY_RE.fullmatch(sealed_repository):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "sealed repository must identify owner/repository")
+    _require_identity(sealed_repository, field="sealed_repository")
+    sealed_verdict = _require_state(sealed.verdict, field="verdict", allowed=_FORMAL_VERDICTS)
+    sealed_model = _require_identity(sealed.model, field="model")
+    sealed_family = _require_identity(sealed.family, field="family")
+    sealed_harness = _require_identity(sealed.harness, field="harness")
+    if (
+        sealed_review_id != rid
+        or sealed_repository != job_repo
+        or sealed.pr_number != job_pr
+        or sealed.head_sha.lower() != job_sha
+        or sealed.gate_kind != job_gate
+    ):
+        raise ResolutionError(REASON_DIGEST_MISMATCH, "sealed-verdict job binding drift")
+
+    published = pub_row is not None
+    publication_context = (
+        _require_state(pub_row["status_context"], field="publication_context", allowed=frozenset({DEFAULT_STATUS_CONTEXT}))
+        if pub_row is not None
+        else None
+    )
+    published_at = _require_timestamp(pub_row["published_at"], field="published_at") if pub_row is not None else None
+    if pub_row is not None:
+        publication_head = str(pub_row["head_sha"]).lower()
+        if not GIT_SHA_RE.fullmatch(publication_head):
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "publication head is not a full commit SHA")
+        if publication_head != job_sha:
+            raise ResolutionError(REASON_DIGEST_MISMATCH, "publication head drift")
+    completion_states = [
+        _require_state(row["completion_state"], field="completion_state", allowed=_COMPLETION_STATES)
+        for row in attempt_rows
+    ]
+    canonical_id = rid
+    namespace = "fleet:formal-reviews"
+    projection = formal_review_projection(
+        review_id=rid,
+        repository=job_repo,
+        pr_number=job_pr,
+        head_sha=job_sha,
+        gate_kind=job_gate,
+        job_state=job_state,
+        verdict=sealed_verdict,
+        model=sealed_model,
+        family=sealed_family,
+        harness=sealed_harness,
+        attempt_count=len(attempt_rows),
+        completion_states=completion_states,
+        published=published,
+        publication_context=publication_context,
+        published_at=published_at,
+    )
+    digest = formal_review_projection_digest(projection)
+    facets: dict[str, Any] = {
+        "source_kind": "formal_review",
+        "repository": job_repo,
+        "state": job_state,
+        "model": sealed_model,
+        "harness": sealed_harness,
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.FORMAL_REVIEW,
+            canonical_namespace=namespace,
+            canonical_id=canonical_id,
+            canonical_digest=digest,
+            git_sha=job_sha,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="fleet-formal-review",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"fleet:review/{rid}",
+        checked_at=isoformat_z(moment),
+    )
+    excerpt = {
+        "source": f"fleet:review/{rid}",
+        **projection,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── fleet_receipt ────────────────────────────────────────────────────────────
+
+
+def fleet_receipt_projection(
+    *,
+    request_id: str,
+    requested_recipient: str,
+    resolved_recipient: str,
+    state: str,
+    completion_state: str,
+    expires_at: str,
+    created_at: str,
+    updated_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema": "fleet-receipt-projection.v1",
+        "request_id": request_id,
+        "requested_recipient": requested_recipient,
+        "resolved_recipient": resolved_recipient,
+        "state": state,
+        "completion_state": completion_state,
+        "expires_at": expires_at,
+        "created_at": created_at,
+        "updated_at": updated_at,
+    }
+
+
+def fleet_receipt_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def resolve_fleet_receipt(
+    request_id: str,
+    *,
+    fleet_root: Path,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve one canonical ``requests`` row from the Fleet Comms SQLite store.
+
+    Projects request ID, requested/resolved recipient, terminal state,
+    completion state, and expiry/created/updated timestamps only. Never reads
+    or exposes invocation JSON or message bodies. Nonterminal state or unknown
+    completion fails closed.
+    """
+    if not request_id or not request_id.strip():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "request_id is required")
+    rid = _require_identity(request_id.strip(), field="request_id")
+    moment = now or utc_now()
+    db_path = _fleet_db_path(Path(fleet_root))
+
+    connection = _open_readonly_sqlite(db_path)
+    try:
+        try:
+            row = connection.execute(
+                "SELECT request_id, requested_recipient, resolved_recipient, state,"
+                " completion_state, expires_at, created_at, updated_at"
+                " FROM requests WHERE request_id = ?",
+                (rid,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "requests unreadable") from exc
+    finally:
+        connection.close()
+    if row is None:
+        raise ResolutionError(REASON_SOURCE_MISSING)
+
+    state = _require_state(row["state"], field="request_state", allowed=_REQUEST_STATES)
+    completion = _require_state(row["completion_state"], field="completion_state", allowed=_REQUEST_COMPLETION_STATES)
+    if state not in _TERMINAL_REQUEST_STATES:
+        raise ResolutionError(REASON_PARTIAL_TERMINAL)
+    if completion == "unknown":
+        raise ResolutionError(REASON_PARTIAL_TERMINAL)
+    requested_recipient = _require_identity(row["requested_recipient"], field="requested_recipient")
+    resolved_recipient = _require_identity(row["resolved_recipient"], field="resolved_recipient")
+    expires_at = _require_timestamp(row["expires_at"], field="expires_at")
+    created_at = _require_timestamp(row["created_at"], field="created_at")
+    updated_at = _require_timestamp(row["updated_at"], field="updated_at")
+    if (
+        parse_timestamp(updated_at) < parse_timestamp(created_at)
+        or parse_timestamp(expires_at) < parse_timestamp(created_at)
+    ):
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "request timestamps are inconsistent")
+
+    canonical_id = rid
+    namespace = "fleet:requests"
+    projection = fleet_receipt_projection(
+        request_id=rid,
+        requested_recipient=requested_recipient,
+        resolved_recipient=resolved_recipient,
+        state=state,
+        completion_state=completion,
+        expires_at=expires_at,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    digest = fleet_receipt_projection_digest(projection)
+    facets: dict[str, Any] = {
+        "source_kind": "fleet_receipt",
+        "state": state,
+        "event_ts": updated_at,
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.FLEET_RECEIPT,
+            canonical_namespace=namespace,
+            canonical_id=canonical_id,
+            canonical_digest=digest,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="fleet-requests",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"fleet:request/{rid}",
+        checked_at=isoformat_z(moment),
+    )
+    excerpt = {
+        "source": f"fleet:request/{rid}",
+        **projection,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
+# ── monitor_run ──────────────────────────────────────────────────────────────
+
+
+def monitor_run_projection(
+    *,
+    lease_token: str,
+    agent_id: str,
+    task_name: str,
+    status: str,
+    created_at: float,
+    last_heartbeat: float,
+    ram_bucket: str,
+) -> dict[str, Any]:
+    return {
+        "schema": "monitor-run-projection.v1",
+        "lease_token": lease_token,
+        "agent_id": agent_id,
+        "task_name": task_name,
+        "status": status,
+        "created_at": created_at,
+        "last_heartbeat": last_heartbeat,
+        "ram_bucket": ram_bucket,
+    }
+
+
+def monitor_run_projection_digest(projection: dict[str, Any]) -> str:
+    return "sha256:" + sha256_text(canonical_json(projection))
+
+
+def resolve_monitor_run(
+    lease_token: str,
+    *,
+    monitor_root: Path,
+    now: datetime | None = None,
+) -> Resolution:
+    """Resolve a terminal Agent Process Monitor lease row as a local run receipt.
+
+    Projects lease ID, agent ID, task name, terminal status,
+    created/last-heartbeat timestamps, and a bounded RAM bucket only. Excludes
+    PID and process-create time. Active/nonterminal rows fail closed.
+    """
+    if not lease_token or not lease_token.strip():
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "lease_token is required")
+    token = _require_identity(lease_token.strip(), field="lease_token")
+    moment = now or utc_now()
+    db_path = Path(monitor_root).expanduser().resolve() / _MONITOR_DB_NAME
+
+    connection = _open_readonly_sqlite(db_path)
+    try:
+        try:
+            row = connection.execute(
+                "SELECT lease_token, agent_id, task_name, status, created_at,"
+                " last_heartbeat, reserved_ram_mb"
+                " FROM agent_leases WHERE lease_token = ?",
+                (token,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise ResolutionError(REASON_RESOLUTION_ERROR, "agent_leases unreadable") from exc
+    finally:
+        connection.close()
+    if row is None:
+        raise ResolutionError(REASON_SOURCE_MISSING)
+
+    status = _require_state(
+        row["status"], field="lease_status", allowed=frozenset({"APPROVED", *_TERMINAL_LEASE_STATUSES})
+    )
+    if status not in _TERMINAL_LEASE_STATUSES:
+        raise ResolutionError(REASON_PARTIAL_TERMINAL)
+
+    agent_id = _require_identity(row["agent_id"], field="agent_id")
+    task_name = _require_identity(row["task_name"], field="task_name")
+    created_at = _require_epoch(row["created_at"], field="created_at")
+    last_heartbeat = _require_epoch(row["last_heartbeat"], field="last_heartbeat")
+    if last_heartbeat < created_at:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, "last_heartbeat precedes created_at")
+    reserved_mb = _require_monitor_ram(row["reserved_ram_mb"])
+    canonical_id = token
+    namespace = "monitor:leases"
+    projection = monitor_run_projection(
+        lease_token=token,
+        agent_id=agent_id,
+        task_name=task_name,
+        status=status,
+        created_at=created_at,
+        last_heartbeat=last_heartbeat,
+        ram_bucket=_ram_bucket(reserved_mb),
+    )
+    digest = monitor_run_projection_digest(projection)
+    facets: dict[str, Any] = {
+        "source_kind": "monitor_run",
+        "state": status.lower(),
+        "event_ts": str(last_heartbeat),
+    }
+    validate_facets(facets)
+    try:
+        link = ContextLink(
+            kind=LinkKind.MONITOR_RUN,
+            canonical_namespace=namespace,
+            canonical_id=canonical_id,
+            canonical_digest=digest,
+            facets=facets,
+        )
+        link.validate()
+    except SchemaError as exc:
+        raise ResolutionError(REASON_RESOLUTION_ERROR, f"projection violates body-free schema: {exc}") from exc
+    verification = VerificationEvidence(
+        verifier="monitor-lease",
+        canonical_digest=digest,
+        status=VerificationStatus.VERIFIED,
+        evidence_locator=f"monitor:lease/{token}",
+        checked_at=isoformat_z(moment),
+    )
+    excerpt = {
+        "source": f"monitor:lease/{token}",
+        **projection,
+    }
+    return Resolution(link=link, verification=verification, excerpt=excerpt)
+
+
 def resolve_bootstrap(
     kind: LinkKind,
     identifier: str,
@@ -522,6 +1533,9 @@ def resolve_bootstrap(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None = None,
+    fleet_root: Path | None = None,
+    monitor_root: Path | None = None,
+    issue_cache_path: Path | None = None,
     namespace: str | None = None,
     git_sha: str | None = None,
     now: datetime | None = None,
@@ -538,6 +1552,36 @@ def resolve_bootstrap(
             raise ResolutionError(REASON_SOURCE_MISSING, "no rollover registry root available")
         agent, lineage_id, rollover_id = _split_rollover_canonical_id(identifier)
         return resolve_rollover(agent, lineage_id, rollover_id, state_root=rollover_root, now=now)
+    if kind is LinkKind.GITHUB_ISSUE:
+        issue_number = _parse_issue_number(identifier)
+        cache = issue_cache_path or default_issue_cache(repo)
+        return resolve_github_issue(issue_number, cache_path=cache, repo=repo, namespace=namespace, now=now)
+    if kind is LinkKind.GITHUB_PR:
+        if fleet_root is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "no fleet comms root available")
+        pr_number, gate_kind = _split_github_pr_canonical_id(identifier)
+        repository = _repository_from_namespace(namespace or _github_namespace(repo))
+        return resolve_github_pr(
+            repository,
+            pr_number,
+            str(git_sha or ""),
+            gate_kind=gate_kind,
+            fleet_root=fleet_root,
+            repo=repo,
+            now=now,
+        )
+    if kind is LinkKind.FORMAL_REVIEW:
+        if fleet_root is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "no fleet comms root available")
+        return resolve_formal_review(identifier, fleet_root=fleet_root, now=now)
+    if kind is LinkKind.FLEET_RECEIPT:
+        if fleet_root is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "no fleet comms root available")
+        return resolve_fleet_receipt(identifier, fleet_root=fleet_root, now=now)
+    if kind is LinkKind.MONITOR_RUN:
+        if monitor_root is None:
+            raise ResolutionError(REASON_SOURCE_MISSING, "no monitor root available")
+        return resolve_monitor_run(identifier, monitor_root=monitor_root, now=now)
     raise ResolutionError(REASON_UNSUPPORTED_KIND, kind.value)
 
 
@@ -547,6 +1591,9 @@ def reverify_link(
     repo: Path,
     acp_root: Path | None,
     rollover_root: Path | None = None,
+    fleet_root: Path | None = None,
+    monitor_root: Path | None = None,
+    issue_cache_path: Path | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Re-resolve one stored link and recompute its canonical digest.
@@ -559,22 +1606,30 @@ def reverify_link(
         kind = LinkKind(str(link["kind"]))
     except ValueError as exc:
         raise ResolutionError(REASON_UNSUPPORTED_KIND, str(link.get("kind"))) from exc
+    stored_namespace = str(link["canonical_namespace"])
+    stored_git_sha = link.get("git_sha")
     resolution = resolve_bootstrap(
         kind,
         str(link["canonical_id"]),
         repo=repo,
         acp_root=acp_root,
         rollover_root=rollover_root,
-        namespace=str(link["canonical_namespace"]),
-        git_sha=link.get("git_sha") if kind is LinkKind.ACP_CONVERSATION else None,
+        fleet_root=fleet_root,
+        monitor_root=monitor_root,
+        issue_cache_path=issue_cache_path,
+        namespace=stored_namespace,
+        git_sha=stored_git_sha if kind in (LinkKind.ACP_CONVERSATION, LinkKind.GITHUB_PR) else None,
         now=now,
     )
     fresh = resolution.link
-    # Git namespaces may be explicit organizational labels, so re-resolution
-    # deliberately preserves them instead of pretending to derive them anew.
-    # ACP and rollover namespaces are canonical resolver output and can be
-    # compared.
-    namespace_mismatch = kind not in (LinkKind.GIT_COMMIT,) and fresh.canonical_namespace != link["canonical_namespace"]
+    # Git and github namespaces may be explicit organizational labels, so
+    # re-resolution preserves them instead of deriving them anew. ACP,
+    # rollover, formal-review, fleet-receipt, and monitor namespaces are
+    # canonical resolver output and are compared.
+    namespace_mismatch = (
+        kind not in (LinkKind.GIT_COMMIT, LinkKind.GITHUB_ISSUE)
+        and fresh.canonical_namespace != stored_namespace
+    )
     if fresh.canonical_digest != link["canonical_digest"] or namespace_mismatch:
         raise ResolutionError(REASON_DIGEST_MISMATCH)
     return resolution.excerpt

--- a/tests/test_entire_context_live.py
+++ b/tests/test_entire_context_live.py
@@ -21,6 +21,12 @@ from scripts.entire_context.model import (
     isoformat_z,
 )
 from scripts.entire_context.paths import projection_path, shared_repository_root
+from scripts.entire_context.resolvers import (
+    default_fleet_root,
+    default_issue_cache,
+    default_monitor_root,
+    resolve_github_issue,
+)
 from scripts.entire_context.store import ContextLinkStore
 
 
@@ -220,3 +226,72 @@ def test_monitor_status_distinguishes_capture_recall_and_use(
     assert payload["use"]["proven"] is True
     assert payload["use"]["by_consumer"] == {"codex": 1}
     assert "projection_path" not in response.text
+
+
+def test_monitor_search_reverifies_typed_issue_from_shared_local_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Monitor search supplies shared typed roots and omits stale issue evidence."""
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    primary.mkdir()
+    _run_git(primary, "init", "-q")
+    _run_git(primary, "config", "user.email", "test@example.invalid")
+    _run_git(primary, "config", "user.name", "tester")
+    (primary / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _run_git(primary, "add", "seed.txt")
+    _run_git(primary, "commit", "-qm", "seed")
+    _run_git(primary, "worktree", "add", "-q", "-b", "linked", str(linked))
+
+    issue_cache = default_issue_cache(linked)
+    issue_cache.parent.mkdir(parents=True)
+    report = {
+        "generated_at": datetime.now(UTC).timestamp(),
+        "open_issue_numbers": [6183],
+        "effective_membership": {
+            "6183": {"epics": [4707], "streams": ["infra"], "via": "native", "unique_stream": True}
+        },
+    }
+    issue_cache.write_text(json.dumps(report), encoding="utf-8")
+    store = ContextLinkStore(projection_path(linked))
+    resolution = resolve_github_issue(
+        6183,
+        cache_path=issue_cache,
+        repo=linked,
+        namespace="github:learn-ukrainian/learn-ukrainian.github.io",
+    )
+    admitted = store.admit(resolution.link, resolution.verification, actor="test")
+
+    observed: dict[str, Path] = {}
+    real_search = entire_context_router.search_past_work
+
+    def observe_search(*args, **kwargs):
+        observed["fleet_root"] = kwargs["fleet_root"]
+        observed["monitor_root"] = kwargs["monitor_root"]
+        observed["issue_cache_path"] = kwargs["issue_cache_path"]
+        observed["rollover_root"] = kwargs["rollover_root"]
+        return real_search(*args, **kwargs)
+
+    monkeypatch.setattr(entire_context_router, "_repo_root", lambda: linked)
+    monkeypatch.setattr(entire_context_router, "search_past_work", observe_search)
+    response = TestClient(app).get("/api/ops/entire-context/search", params={"q": "6183"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [card["kind"] for card in payload["results"]] == ["github_issue"]
+    assert observed == {
+        "fleet_root": default_fleet_root(primary),
+        "monitor_root": default_monitor_root(primary),
+        "issue_cache_path": default_issue_cache(primary),
+        "rollover_root": primary.resolve(),
+    }
+    override = tmp_path / "rollover-override"
+    monkeypatch.setenv("ENTIRE_CONTEXT_ROLLOVER_ROOT", str(override))
+    assert entire_context_router._rollover_root(linked) == override
+    monkeypatch.delenv("ENTIRE_CONTEXT_ROLLOVER_ROOT")
+
+    report["generated_at"] = 0
+    issue_cache.write_text(json.dumps(report), encoding="utf-8")
+    stale = TestClient(app).get("/api/ops/entire-context/search", params={"q": "6183"}).json()
+    assert stale["results"] == []
+    assert stale["omitted"] == [{"locator_id": admitted.locator_id, "reason": "partial_terminal"}]

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -44,13 +44,22 @@ from scripts.entire_context.recall import (
 )
 from scripts.entire_context.resolvers import (
     REASON_DIGEST_MISMATCH,
+    REASON_PARTIAL_TERMINAL,
+    REASON_PUBLICATION_MISSING,
     REASON_RESOLUTION_ERROR,
     REASON_SOURCE_MISSING,
-    REASON_UNSUPPORTED_KIND,
     ResolutionError,
+    default_monitor_db,
+    default_monitor_root,
+    github_pr_projection,
     resolve_acp_conversation,
     resolve_bootstrap,
+    resolve_fleet_receipt,
+    resolve_formal_review,
     resolve_git_commit,
+    resolve_github_issue,
+    resolve_github_pr,
+    resolve_monitor_run,
     resolve_rollover,
     rollover_projection,
     rollover_projection_digest,
@@ -755,7 +764,7 @@ def test_acp_commit_join_requires_canonical_correlation(tmp_path: Path, git_repo
     assert excinfo.value.reason == REASON_DIGEST_MISMATCH
 
 
-def test_unsupported_kind_fails_closed(tmp_path: Path, git_repo: dict[str, object]) -> None:
+def test_github_issue_missing_fresh_cache_fails_closed(tmp_path: Path, git_repo: dict[str, object]) -> None:
     with pytest.raises(ResolutionError) as excinfo:
         resolve_bootstrap(
             LinkKind.GITHUB_ISSUE,
@@ -763,28 +772,7 @@ def test_unsupported_kind_fails_closed(tmp_path: Path, git_repo: dict[str, objec
             repo=git_repo["repo"],
             acp_root=None,
         )
-    assert excinfo.value.reason == REASON_UNSUPPORTED_KIND
-
-    # A promoted link of an unsupported kind is omitted from recall, never emitted.
-    store = make_store(tmp_path)
-    link = ContextLink(
-        kind=LinkKind.GITHUB_ISSUE,
-        canonical_namespace="github:learn-ukrainian/learn-ukrainian.github.io",
-        canonical_id="issue/6183",
-        canonical_digest="sha256:" + "c" * 64,
-    )
-    verification = VerificationEvidence(
-        verifier="test",
-        canonical_digest=link.canonical_digest,
-        status=VerificationStatus.VERIFIED,
-        evidence_locator="github:issue/6183",
-        checked_at=isoformat_z(utc_now()),
-    )
-    admitted = store.admit(link, verification, actor="test")
-    assert admitted.outcome is AdmitOutcome.PROMOTED
-    result = recall.search_past_work(store, "6183", repo=tmp_path, acp_root=None)
-    assert result["results"] == []
-    assert result["omitted"] == [{"locator_id": admitted.locator_id, "reason": REASON_UNSUPPORTED_KIND}]
+    assert excinfo.value.reason == REASON_SOURCE_MISSING
 
 
 def test_entire_cli_is_never_invoked(
@@ -1635,24 +1623,473 @@ def test_rollover_canaries_never_leak(tmp_path: Path) -> None:
     _assert_no_rollover_canaries(combined)
 
 
-def test_remaining_unsupported_kinds_still_fail_closed(tmp_path: Path) -> None:
-    """Every kind except git/acp/rollover fails closed with unsupported_kind."""
-    for kind in (
-        LinkKind.GITHUB_ISSUE,
-        LinkKind.GITHUB_PR,
-        LinkKind.FLEET_RECEIPT,
-        LinkKind.FORMAL_REVIEW,
-        LinkKind.MONITOR_RUN,
+def _write_typed_source_fixtures(tmp_path: Path, head_sha: str) -> tuple[Path, Path, Path]:
+    """Create canonical local-only cache/store fixtures with body canaries."""
+    fleet_root = tmp_path / "fleet"
+    blob_root = fleet_root / "blobs" / "sha256"
+    fleet_root.mkdir()
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE formal_review_jobs (
+                review_id TEXT PRIMARY KEY, repository TEXT NOT NULL, pr_number INTEGER NOT NULL,
+                head_sha TEXT NOT NULL, gate_kind TEXT NOT NULL, state TEXT NOT NULL,
+                sealed_verdict_artifact_id TEXT, created_at TEXT NOT NULL
+            );
+            CREATE TABLE formal_review_attempts (
+                review_attempt_id TEXT PRIMARY KEY, review_id TEXT NOT NULL, attempt_number INTEGER NOT NULL,
+                completion_state TEXT NOT NULL, raw_capture_artifact_id TEXT, created_at TEXT NOT NULL
+            );
+            CREATE TABLE github_publications (
+                publication_id TEXT PRIMARY KEY, review_id TEXT NOT NULL, head_sha TEXT NOT NULL,
+                status_context TEXT NOT NULL, published_at TEXT NOT NULL
+            );
+            CREATE TABLE artifacts (artifact_id TEXT PRIMARY KEY, sha256 TEXT NOT NULL);
+            CREATE TABLE requests (
+                request_id TEXT PRIMARY KEY, requested_recipient TEXT NOT NULL,
+                resolved_recipient TEXT NOT NULL, state TEXT NOT NULL, completion_state TEXT NOT NULL,
+                expires_at TEXT NOT NULL, invocation_spec_json TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+            );
+            """
+        )
+        review_id = "review_" + "a" * 32
+        sealed = {
+            "review_id": review_id,
+            "repository": "learn-ukrainian/learn-ukrainian.github.io",
+            "pr_number": 6183,
+            "head_sha": head_sha,
+            "gate_kind": "cross-family-review",
+            "verdict": "APPROVED",
+            "model": "gpt-5.6-terra",
+            "family": "openai",
+            "harness": "codex",
+            "private_payload_canary": "typed-secret-canary",
+        }
+        sealed_bytes = json.dumps(sealed).encode("utf-8")
+        sealed_digest = hashlib.sha256(sealed_bytes).hexdigest()
+        blob_path = blob_root / sealed_digest[:2] / sealed_digest
+        blob_path.parent.mkdir(parents=True)
+        blob_path.write_bytes(sealed_bytes)
+        connection.execute(
+            "INSERT INTO formal_review_jobs VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                review_id,
+                "learn-ukrainian/learn-ukrainian.github.io",
+                6183,
+                head_sha,
+                "cross-family-review",
+                "complete",
+                "artifact_sealed_canary",
+                "2026-08-02T10:00:00Z",
+            ),
+        )
+        connection.execute("INSERT INTO artifacts VALUES (?, ?)", ("artifact_sealed_canary", sealed_digest))
+        connection.execute(
+            "INSERT INTO formal_review_attempts VALUES (?, ?, ?, ?, ?, ?)",
+            ("attempt_1", review_id, 1, "complete", "artifact_raw_canary", "2026-08-02T10:01:00Z"),
+        )
+        connection.execute(
+            "INSERT INTO github_publications VALUES (?, ?, ?, ?, ?)",
+            ("publication_1", review_id, head_sha, "fleet/cross-family-review", "2026-08-02T10:02:00Z"),
+        )
+        connection.execute(
+            "INSERT INTO requests VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "request_" + "b" * 32,
+                "codex",
+                "agy",
+                "complete",
+                "complete",
+                "2026-08-02T10:30:00Z",
+                '{"prompt":"fleet-prompt-canary"}',
+                "2026-08-02T10:03:00Z",
+                "2026-08-02T10:04:00Z",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    monitor_root = tmp_path / "monitor"
+    monitor_root.mkdir()
+    connection = sqlite3.connect(monitor_root / "agent_monitor.sqlite3")
+    try:
+        connection.execute(
+            """CREATE TABLE agent_leases (
+                lease_token TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_name TEXT NOT NULL,
+                pid INTEGER NOT NULL, process_create_time REAL NOT NULL, reserved_ram_mb INTEGER NOT NULL,
+                status TEXT NOT NULL, created_at REAL NOT NULL, last_heartbeat REAL NOT NULL
+            )"""
+        )
+        connection.execute(
+            "INSERT INTO agent_leases VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "lease_" + "c" * 32,
+                "codex/6183",
+                "typed-recall",
+                424242,
+                111.25,
+                1024,
+                "RELEASED",
+                1_754_000_000.0,
+                1_754_000_010.0,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    issue_cache = tmp_path / "issue_stream_audit.json"
+    issue_cache.write_text(
+        json.dumps(
+            {
+                "generated_at": utc_now().timestamp(),
+                "open_issue_numbers": [6183],
+                "effective_membership": {
+                    "6183": {"epics": [4707], "streams": ["infra"], "via": "native", "unique_stream": True}
+                },
+                "issue_body_canary": "github-body-canary",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return fleet_root, monitor_root, issue_cache
+
+
+def test_typed_local_resolvers_bootstrap_reverify_and_keep_issue_locator_stable(
+    tmp_path: Path,
+    git_repo: dict[str, object],
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All typed caches pass bootstrap → search → explain → handoff without bodies."""
+    repo = Path(git_repo["repo"])
+    head_sha = str(git_repo["sha2"])
+    fleet_root, monitor_root, issue_cache = _write_typed_source_fixtures(tmp_path, head_sha)
+    db = str(tmp_path / "db.sqlite3")
+    review_id = "review_" + "a" * 32
+    request_id = "request_" + "b" * 32
+    lease_token = "lease_" + "c" * 32
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    marker = tmp_path / "entire-was-called"
+    stub = bin_dir / "entire"
+    stub.write_text('#!/bin/sh\n/bin/touch "$ENTIRE_STUB_MARKER"\nexit 1\n', encoding="utf-8")
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("ENTIRE_STUB_MARKER", str(marker))
+    before_sources = {
+        "fleet": _snapshot_files(fleet_root),
+        "monitor": _snapshot_files(monitor_root),
+        "issue_cache": issue_cache.stat().st_mtime_ns,
+    }
+
+    commands = (
+        ("bootstrap-github-issue", "6183", "--repo", str(repo), "--issue-cache", str(issue_cache), "--db", db),
+        (
+            "bootstrap-github-pr", "6183", "--head-sha", head_sha,
+            "--repository", "learn-ukrainian/learn-ukrainian.github.io", "--fleet-root", str(fleet_root),
+            "--repo", str(repo), "--db", db,
+        ),
+        ("bootstrap-formal-review", review_id, "--fleet-root", str(fleet_root), "--db", db),
+        ("bootstrap-fleet-receipt", request_id, "--fleet-root", str(fleet_root), "--db", db),
+        ("bootstrap-monitor-run", lease_token, "--monitor-root", str(monitor_root), "--db", db),
+    )
+    locators: list[str] = []
+    for command in commands:
+        code, out = run_cli(capsys, *command)
+        assert code == 0
+        payload = json.loads(out)
+        assert payload["outcome"] == "promoted"
+        assert_body_free(out)
+        assert "424242" not in out
+        assert "111.25" not in out
+        locators.append(payload["locator_id"])
+    assert _snapshot_files(fleet_root) == before_sources["fleet"]
+    assert _snapshot_files(monitor_root) == before_sources["monitor"]
+    assert issue_cache.stat().st_mtime_ns == before_sources["issue_cache"]
+    assert not marker.exists()
+
+    # A renewed cache verifies the same issue identity rather than minting a new locator.
+    report = json.loads(issue_cache.read_text(encoding="utf-8"))
+    report["generated_at"] = utc_now().timestamp()
+    issue_cache.write_text(json.dumps(report), encoding="utf-8")
+    code, out = run_cli(capsys, *commands[0])
+    assert code == 0
+    assert json.loads(out)["outcome"] == "already_promoted"
+    assert json.loads(out)["locator_id"] == locators[0]
+
+    for locator_id in locators:
+        code, out = run_cli(
+            capsys,
+            "explain-change",
+            "--locator-id", locator_id,
+            "--repo", str(repo),
+            "--fleet-root", str(fleet_root),
+            "--monitor-root", str(monitor_root),
+            "--issue-cache", str(issue_cache),
+            "--db", db,
+        )
+        assert code == 0
+        assert json.loads(out)["found"] is True
+        assert_body_free(out)
+
+    for needle, kind in zip(
+        ("6183", "6183", review_id, request_id, lease_token),
+        ("github_issue", "github_pr", "formal_review", "fleet_receipt", "monitor_run"),
+        strict=True,
     ):
+        code, out = run_cli(
+            capsys,
+            "search", "--query", needle, "--repo", str(repo), "--fleet-root", str(fleet_root),
+            "--monitor-root", str(monitor_root), "--issue-cache", str(issue_cache), "--db", db,
+        )
+        assert code == 0
+        assert kind in {card["kind"] for card in json.loads(out)["results"]}
+        assert_body_free(out)
+
+    handoff_args = ["handoff", "--repo", str(repo), "--fleet-root", str(fleet_root), "--monitor-root", str(monitor_root), "--issue-cache", str(issue_cache), "--db", db]
+    for locator_id in locators:
+        handoff_args.extend(("--locator-id", locator_id))
+    code, out = run_cli(capsys, *handoff_args)
+    assert code == 0
+    assert {item["kind"] for item in json.loads(out)["items"]} == {
+        "github_issue", "github_pr", "formal_review", "fleet_receipt", "monitor_run"
+    }
+    assert_body_free(out)
+
+
+def test_github_namespace_and_monitor_default_paths_fail_closed_or_stay_unambiguous(
+    tmp_path: Path, git_repo: dict[str, object]
+) -> None:
+    """Only real github.com origins can derive a public typed GitHub identity."""
+    cache = tmp_path / "issue_stream_audit.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "generated_at": utc_now().timestamp(),
+                "open_issue_numbers": [6183],
+                "effective_membership": {
+                    "6183": {"epics": [4707], "streams": ["infra"], "via": "native", "unique_stream": True}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    repo = Path(git_repo["repo"])
+    assert resolve_github_issue(6183, cache_path=cache, repo=repo).link.canonical_namespace == (
+        "github:learn-ukrainian/learn-ukrainian.github.io"
+    )
+    git(repo, "remote", "set-url", "origin", "git@github.com:learn-ukrainian/learn-ukrainian.github.io.git")
+    assert resolve_github_issue(6183, cache_path=cache, repo=repo).link.canonical_namespace == (
+        "github:learn-ukrainian/learn-ukrainian.github.io"
+    )
+    for origin in ("https://gitlab.com/example/private.git", str(tmp_path / "local-remote.git")):
+        git(repo, "remote", "set-url", "origin", origin)
         with pytest.raises(ResolutionError) as excinfo:
-            resolve_bootstrap(
-                kind,
-                "test-identifier",
-                repo=tmp_path,
-                acp_root=None,
-                rollover_root=None,
-            )
-        assert excinfo.value.reason == REASON_UNSUPPORTED_KIND
+            resolve_github_issue(6183, cache_path=cache, repo=repo)
+        assert excinfo.value.reason == REASON_SOURCE_MISSING
+    git(repo, "remote", "remove", "origin")
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_issue(6183, cache_path=cache, repo=repo)
+    assert excinfo.value.reason == REASON_SOURCE_MISSING
+    assert resolve_github_issue(
+        6183,
+        cache_path=cache,
+        repo=tmp_path,
+        namespace="github:learn-ukrainian/learn-ukrainian.github.io",
+    ).link.canonical_namespace == "github:learn-ukrainian/learn-ukrainian.github.io"
+
+    assert default_monitor_db(tmp_path) == default_monitor_root(tmp_path) / "agent_monitor.sqlite3"
+    projection = github_pr_projection(
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        pr_number=6183,
+        head_sha="e" * 40,
+        gate_kind="cross-family-review",
+        job_state="complete",
+        published=True,
+        publication_context="fleet/cross-family-review",
+        published_at="2026-08-02T10:00:00Z",
+    )
+    assert list(projection).count("head_sha") == 1
+
+
+def test_typed_resolvers_reject_publication_drift_and_nonterminal_sources(
+    tmp_path: Path, git_repo: dict[str, object]
+) -> None:
+    """Publication head/context, terminal state, and malformed cache all fail closed."""
+    repo = Path(git_repo["repo"])
+    head_sha = str(git_repo["sha2"])
+    fleet_root, monitor_root, issue_cache = _write_typed_source_fixtures(tmp_path, head_sha)
+    review_id = "review_" + "a" * 32
+    request_id = "request_" + "b" * 32
+    lease_token = "lease_" + "c" * 32
+
+    # The successful baseline is intentional: it proves the later mutations are the rejection cause.
+    assert resolve_github_pr(
+        "learn-ukrainian/learn-ukrainian.github.io", 6183, head_sha, fleet_root=fleet_root, repo=repo
+    ).excerpt["published"] is True
+    assert resolve_formal_review(review_id, fleet_root=fleet_root).excerpt["verdict"] == "APPROVED"
+
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute("UPDATE github_publications SET head_sha = ?", ("d" * 40,))
+        connection.execute("UPDATE requests SET state = 'running'")
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_pr(
+            "learn-ukrainian/learn-ukrainian.github.io", 6183, head_sha, fleet_root=fleet_root, repo=repo
+        )
+    assert excinfo.value.reason == REASON_PUBLICATION_MISSING
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute(
+            "UPDATE github_publications SET head_sha = ?, status_context = ?",
+            (head_sha, "unexpected-context"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_pr(
+            "learn-ukrainian/learn-ukrainian.github.io", 6183, head_sha, fleet_root=fleet_root, repo=repo
+        )
+    assert excinfo.value.reason == REASON_PUBLICATION_MISSING
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_fleet_receipt(request_id, fleet_root=fleet_root)
+    assert excinfo.value.reason == REASON_PARTIAL_TERMINAL
+
+    connection = sqlite3.connect(monitor_root / "agent_monitor.sqlite3")
+    try:
+        connection.execute("UPDATE agent_leases SET status = 'APPROVED'")
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_monitor_run(lease_token, monitor_root=monitor_root)
+    assert excinfo.value.reason == REASON_PARTIAL_TERMINAL
+
+    issue_cache.write_text(
+        json.dumps({"generated_at": utc_now().timestamp(), "open_issue_numbers": ["6183"]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_issue(6183, cache_path=issue_cache, repo=repo)
+    assert excinfo.value.reason == REASON_RESOLUTION_ERROR
+
+    issue_cache.write_text('{"generated_at": 0}', encoding="utf-8")
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_issue(6183, cache_path=issue_cache, repo=repo)
+    assert excinfo.value.reason == REASON_PARTIAL_TERMINAL
+
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute(
+            "UPDATE github_publications SET status_context = ?",
+            ("fleet/cross-family-review",),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    # The formal job is independently resolved from its sealed, hash-checked verdict.
+    assert resolve_formal_review(review_id, fleet_root=fleet_root).excerpt["verdict"] == "APPROVED"
+    blob = next(path for path in (fleet_root / "blobs" / "sha256").rglob("*") if path.is_file())
+    blob.write_bytes(b"sealed-verdict-drift")
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_formal_review(review_id, fleet_root=fleet_root)
+    assert excinfo.value.reason == REASON_DIGEST_MISMATCH
+
+
+def test_typed_resolvers_refuse_unsafe_database_values_without_echo(
+    tmp_path: Path, git_repo: dict[str, object]
+) -> None:
+    """Projected DB/cache values pass the shared identity guard before output."""
+    repo = Path(git_repo["repo"])
+    head_sha = str(git_repo["sha2"])
+    fleet_root, monitor_root, issue_cache = _write_typed_source_fixtures(tmp_path, head_sha)
+    review_id = "review_" + "a" * 32
+    request_id = "request_" + "b" * 32
+    lease_token = "lease_" + "c" * 32
+
+    report = json.loads(issue_cache.read_text(encoding="utf-8"))
+    report["effective_membership"]["6183"]["streams"] = ["free form stream canary"]
+    issue_cache.write_text(json.dumps(report), encoding="utf-8")
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_github_issue(6183, cache_path=issue_cache, repo=repo)
+    assert excinfo.value.reason == REASON_RESOLUTION_ERROR
+    assert "free form stream canary" not in str(excinfo.value)
+
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute("UPDATE requests SET requested_recipient = ?", ("x" * 64,))
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_fleet_receipt(request_id, fleet_root=fleet_root)
+    assert excinfo.value.reason == REASON_RESOLUTION_ERROR
+    assert "x" * 64 not in str(excinfo.value)
+
+    connection = sqlite3.connect(monitor_root / "agent_monitor.sqlite3")
+    try:
+        connection.execute("UPDATE agent_leases SET task_name = ?", ("free form task canary",))
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_monitor_run(lease_token, monitor_root=monitor_root)
+    assert excinfo.value.reason == REASON_RESOLUTION_ERROR
+    assert "free form task canary" not in str(excinfo.value)
+
+    blob = next(path for path in (fleet_root / "blobs" / "sha256").rglob("*") if path.is_file())
+    sealed = json.loads(blob.read_text(encoding="utf-8"))
+    sealed["model"] = "ghp_" + "x" * 20
+    mutated = json.dumps(sealed).encode("utf-8")
+    mutated_digest = hashlib.sha256(mutated).hexdigest()
+    mutated_blob = fleet_root / "blobs" / "sha256" / mutated_digest[:2] / mutated_digest
+    mutated_blob.parent.mkdir(parents=True)
+    mutated_blob.write_bytes(mutated)
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute("UPDATE artifacts SET sha256 = ?", (mutated_digest,))
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_formal_review(review_id, fleet_root=fleet_root)
+    assert excinfo.value.reason == REASON_RESOLUTION_ERROR
+    assert sealed["model"] not in str(excinfo.value)
+
+    mismatched = json.dumps(
+        {
+            "review_id": review_id,
+            "repository": "learn-ukrainian/learn-ukrainian.github.io",
+            "pr_number": 6183,
+            "head_sha": "e" * 40,
+            "gate_kind": "cross-family-review",
+            "verdict": "APPROVED",
+            "model": "gpt-5.6-terra",
+            "family": "openai",
+            "harness": "codex",
+        }
+    ).encode("utf-8")
+    mismatched_digest = hashlib.sha256(mismatched).hexdigest()
+    mismatched_blob = fleet_root / "blobs" / "sha256" / mismatched_digest[:2] / mismatched_digest
+    mismatched_blob.parent.mkdir(parents=True)
+    mismatched_blob.write_bytes(mismatched)
+    connection = sqlite3.connect(fleet_root / "comms.sqlite3")
+    try:
+        connection.execute("UPDATE artifacts SET sha256 = ?", (mismatched_digest,))
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_formal_review(review_id, fleet_root=fleet_root)
+    assert excinfo.value.reason == REASON_DIGEST_MISMATCH
 
 
 def test_rollover_resolution_never_invokes_entire_or_writes_state_root(


### PR DESCRIPTION
## Outcome

Completes the remaining public typed-resolver slice of #6183 without making Entire authoritative or load-bearing.

## What changed

- resolve fresh, uniquely-owned GitHub issues from the local issue-stream cache
- resolve reviewed PR heads from the local formal-review job and durable GitHub publication receipt
- resolve hash-verified sealed formal-review receipts
- resolve terminal Fleet request receipts without invocation/message bodies
- resolve terminal Agent Process Monitor leases without PID/process-create time
- wire all typed roots, including rollover, through the read-only Monitor search API
- document the official Entire product-workflow mapping:
  - local body-free `search`, `explain-change`, and `handoff` remain the canonical automatic agent path
  - native `entire blame --json` is allowed for local attribution
  - prompt-bearing `why`, cloud `search`, generated recap/investigate/review stay optional/manual and never enter canonical capsules
  - Entire review is supplemental and never satisfies the Fleet formal-review gate

All SQLite access uses URI `mode=ro`; resolvers do not migrate, change WAL, prune, start services, call Entire, or use the network.

## Live evidence

- fresh #6183 membership → `clink_05e386...53ee`
- PR #6261 exact reviewed head → `clink_f30916...f9d3`
- sealed GLM review `review_564cc26869f143faa3c9bebb69a5094f` → `clink_85017e...e280`
- controlled terminal Fleet request → `clink_65a807...c94e`; request body/raw capture absent from output
- real Monitor register→release lease → `clink_7a2c11...9819`; PID/process-create time absent
- PR → commit → formal-review traversal returned three verified nodes and six typed edges
- retries were idempotent (`already_promoted`)

## Verification

- 179 targeted tests across the five Entire suites plus Monitor route contracts
- Ruff
- skill metadata lint
- `git diff --check`
- OPSEC leakage lint
- X-Agent trailer lint
- mandatory pre-submit guard scan

Refs #6183
