### PR TITLE
feat(practice): union curated membership sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ CURATED_SEED_LOCAL_SMOKE_TARGET ?= 700
 CURATED_SEED_GOLD_TARGET ?= 40
 CURATED_SEED_GOLD_OUT ?= site/public/lexicon
 CURATED_SEED_GOLD_VESUM_DB ?= data/vesum.db
+CURATED_MEMBERSHIP ?= site/src/data/lexicon-teacher-curated-membership.json
+CURATED_MEMBERSHIP_HOMEWORK ?= .claude/atlas-epic/plans/curated-seed/curated-seed.jsonl
+CURATED_MEMBERSHIP_TEACHER ?= site/src/data/lexicon-teacher-cloze.json
 
-.PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh practice-admit-curated-seed practice-gold-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
+.PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh curated-membership practice-admit-curated-seed practice-gold-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
 
 # Refresh practice JSON API copies + /atlas runtime for local/dev word-page CTA.
 atlas-practice-api-hydrate:
@@ -25,6 +28,13 @@ atlas-export-runtime:
 	  --verify
 
 atlas-local-practice-refresh: atlas-practice-api-hydrate atlas-export-runtime
+
+# A lemma-only public membership overlay: A is resolved with the existing
+# VESUM-attested admission logic, and B contributes exact legacy identifiers
+# only. This target never reads or writes teacher sentence bodies.
+curated-membership:
+	@test -f "$(CURATED_MEMBERSHIP_HOMEWORK)" || { echo "missing private curated homework input" >&2; exit 2; }
+	$(PYTHON) -m scripts.lexicon.curated_membership --homework-seed "$(CURATED_MEMBERSHIP_HOMEWORK)" --teacher-inventory "$(CURATED_MEMBERSHIP_TEACHER)" --manifest site/src/data/lexicon-manifest.json --out "$(CURATED_MEMBERSHIP)"
 
 practice-admit-curated-seed:
 	@test -f "$(CURATED_SEED_INPUT)" || { echo "missing private curated seed input" >&2; exit 2; }
@@ -53,10 +63,10 @@ atlas-publish: atlas
 	$(PYTHON) -m scripts.lexicon.publish_manifest
 
 practice-deck:
-	$(PYTHON) scripts/audit/generate_practice_deck.py
+	$(PYTHON) scripts/audit/generate_practice_deck.py --curated-membership "$(CURATED_MEMBERSHIP)"
 
 practice-deck-publish: practice-deck
-	$(PYTHON) scripts/practice_deck/publish.py
+	$(PYTHON) scripts/practice_deck/publish.py --curated-membership "$(CURATED_MEMBERSHIP)"
 
 open-dataset:
 	$(PYTHON) scripts/lexicon/export_open_dataset.py

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -30,6 +30,10 @@ if str(AUDIT_DIR) not in sys.path:
 
 from lexeme_filter import SURFACE_CLOZE, SURFACE_PRACTICE, is_practice_eligible, is_surface_admitted
 
+from scripts.lexicon.curated_membership import (
+    apply_membership,
+    read_membership,
+)
 from scripts.practice_deck.io import compute_deck_inputs_fingerprint, compute_deck_version
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
@@ -3138,6 +3142,7 @@ def _select_practice_lexemes(
         if (
             isinstance(entry.get("practice_example"), dict)
             or entry.get("local_practice_private_teacher") is True
+            or entry.get("curated_membership") is True
         )
         and is_surface_admitted(entry, SURFACE_PRACTICE)
     ]
@@ -4459,6 +4464,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
     parser.add_argument(
+        "--curated-membership",
+        type=Path,
+        help="Lemma-only Curated Practice A union B membership overlay.",
+    )
+    parser.add_argument(
         "--practice-seed",
         type=Path,
         help="Reviewed practice admission overlay; each row must already exist in Atlas.",
@@ -4507,6 +4517,12 @@ def main(argv: list[str] | None = None) -> int:
         return run_broken_validator_fixtures()
 
     entries = read_manifest(args.manifest) if args.manifest else read_atlas_db(args.atlas_db)
+    if args.curated_membership:
+        entries, membership_report = apply_membership(entries, read_membership(args.curated_membership))
+        print(
+            "curated membership "
+            f"members={membership_report['members']} resolved={membership_report['resolved']}"
+        )
     if args.practice_seed and args.local_practice_seed:
         parser.error("--practice-seed and --local-practice-seed are mutually exclusive")
     if args.practice_seed:

--- a/scripts/audit/lexeme_filter.py
+++ b/scripts/audit/lexeme_filter.py
@@ -111,16 +111,16 @@ def _has_cefr_level(entry: dict[str, Any]) -> bool:
     return _has_text(root_level)
 
 
-def is_practice_eligible(entry: dict[str, Any]) -> bool:
-    """True when *entry* is a clean study card for the practice deck.
+def practice_ineligibility_reason(entry: dict[str, Any]) -> str | None:
+    """Return the policy reason an entry cannot be a practice card, if any.
 
     Lexeme + glossed + curriculum-anchored (course usage or a CEFR level), excluding
     inflected duplicates and surzhyk-to-avoid forms.
     """
     if not is_lexeme_entry(entry):
-        return False
+        return "not_lexeme_entry"
     if not _has_text(entry.get("gloss")):
-        return False
+        return "missing_gloss"
     # Three-way policy for form-derived provenance:
     # 1. Any actual ``form_of`` relation is an alias/form row, so exclude it.
     # 2. ``built_vocabulary_form`` is an alias route by construction, including
@@ -129,11 +129,18 @@ def is_practice_eligible(entry: dict[str, Any]) -> bool:
     #    without ``form_of`` can be canonical lemmas, so admit them when the
     #    remaining practice checks pass.
     if entry.get("form_of"):
-        return False
+        return "form_of"
     if entry.get("primary_source") == "built_vocabulary_form":
-        return False
+        return "built_vocabulary_form"
     if entry.get("primary_source") == SURZHYK_SOURCE:
-        return False
+        return "surzhyk_to_avoid"
     if not is_surface_admitted(entry, SURFACE_PRACTICE):
-        return False
-    return _has_course_usage(entry) or _has_cefr_level(entry)
+        return "surface_not_admitted"
+    if not (_has_course_usage(entry) or _has_cefr_level(entry)):
+        return "missing_curriculum_anchor"
+    return None
+
+
+def is_practice_eligible(entry: dict[str, Any]) -> bool:
+    """True when *entry* is a clean study card for the practice deck."""
+    return practice_ineligibility_reason(entry) is None

--- a/scripts/audit/measure_curated_membership.py
+++ b/scripts/audit/measure_curated_membership.py
@@ -1,0 +1,154 @@
+"""Measure the Curated Practice A union B floor without reading teacher prose."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from scripts.audit.lexeme_filter import practice_ineligibility_reason
+from scripts.lexicon.curated_membership import (
+    DEFAULT_MEMBERSHIP_PATH,
+    _key,
+    apply_membership,
+    build_membership,
+    read_manifest_entries,
+    read_membership,
+    read_teacher_inventory_keys,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TEACHER_INVENTORY = ROOT / "site" / "src" / "data" / "lexicon-teacher-cloze.json"
+DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
+
+
+def _index_items(practice_dir: Path) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for path in sorted(practice_dir.glob("practice-index.*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        level_items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(level_items, list):
+            raise ValueError(f"{path}: index items must be a list")
+        items.extend(item for item in level_items if isinstance(item, dict))
+    return items
+
+
+def _residual_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Count private-source residuals without printing their lemma text."""
+    reasons = Counter(str(row.get("reason") or "unspecified") for row in rows)
+    return {"rows": len(rows), "reasons": dict(sorted(reasons.items()))}
+
+
+def measure_membership(
+    *,
+    homework_seed_path: Path,
+    teacher_inventory_path: Path,
+    manifest_path: Path,
+    membership_path: Path,
+    practice_dir: Path,
+) -> dict[str, Any]:
+    expected_payload, expected_report = build_membership(
+        homework_seed_path=homework_seed_path,
+        teacher_inventory_path=teacher_inventory_path,
+        manifest_path=manifest_path,
+    )
+    actual_members = read_membership(membership_path)
+    expected_members = expected_payload["members"]
+    expected_by_slug = {_key(member["slug"]): member for member in expected_members}
+    actual_by_slug = {_key(member["slug"]): member for member in actual_members}
+    homework_expected = {
+        slug for slug, member in expected_by_slug.items() if "homework" in member["sources"]
+    }
+    manifest_entries, _membership_report = apply_membership(
+        read_manifest_entries(manifest_path), actual_members
+    )
+    entries_by_slug = {
+        _key(entry.get("url_slug")): entry
+        for entry in manifest_entries
+        if _key(entry.get("url_slug"))
+    }
+    ineligible_homework = Counter(
+        reason
+        for slug in homework_expected
+        if (reason := practice_ineligibility_reason(entries_by_slug[slug])) is not None
+    )
+    eligible_homework = {
+        slug
+        for slug in homework_expected
+        if practice_ineligibility_reason(entries_by_slug[slug]) is None
+    }
+    practice_items = _index_items(practice_dir)
+    practice_keys = {
+        _key(item.get("lemmaId"))
+        for item in practice_items
+        if _key(item.get("lemmaId"))
+    }
+    levels: dict[str, dict[str, int]] = {}
+    for item in practice_items:
+        level = str(item.get("cefr") or "")
+        if not level:
+            continue
+        row = levels.setdefault(level, {"lexemes": 0, "flashcards": 0, "matching": 0, "choice": 0})
+        row["lexemes"] += 1
+        modes = item.get("modes")
+        if isinstance(modes, list):
+            for mode in ("flashcards", "matching", "choice"):
+                if mode in modes:
+                    row[mode] += 1
+    return {
+        "schema": "curated-practice-membership-measurement-v1",
+        "homework": {
+            "unique_lemmas": expected_report["homework"]["unique_lemmas"],
+            "public_route_rows": expected_report["homework"]["public_route_rows"],
+            "local_only_rows": expected_report["homework"]["local_only_rows"],
+            "missing_from_curated_keys": len(homework_expected - set(actual_by_slug)),
+            "eligible_routes": len(eligible_homework),
+            "missing_from_practice_indexes": len(eligible_homework - practice_keys),
+            "ineligible_routes": dict(sorted(ineligible_homework.items())),
+        },
+        "teacher_inventory": {
+            "cards": len(read_teacher_inventory_keys(teacher_inventory_path)),
+            "unique_keys": len({_key(value) for value in read_teacher_inventory_keys(teacher_inventory_path)}),
+            "resolved_membership_routes": sum(
+                "teacher_inventory" in member["sources"] for member in actual_members
+            ),
+        },
+        "curated_membership": {"unique_routes": len(actual_members)},
+        "recognition_mode_eligibility": dict(sorted(levels.items())),
+        "unkeyable_homework_residual": {
+            "atlas_failures": _residual_summary(expected_report["homework"]["admission"]["atlas_failures"]),
+            "not_practice_admitted": _residual_summary(
+                expected_report["homework"]["admission"]["practice_skipped_not_admitted"]
+            ),
+            "local_only_no_public_route": expected_report["homework"]["local_only_rows"],
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--homework-seed", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--teacher-inventory", type=Path, default=DEFAULT_TEACHER_INVENTORY)
+    parser.add_argument("--membership", type=Path, default=DEFAULT_MEMBERSHIP_PATH)
+    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args(argv)
+    payload = measure_membership(
+        homework_seed_path=args.homework_seed,
+        teacher_inventory_path=args.teacher_inventory,
+        manifest_path=args.manifest,
+        membership_path=args.membership,
+        practice_dir=args.practice_dir,
+    )
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if args.json_out:
+        args.json_out.write_text(serialized, encoding="utf-8")
+    print(serialized, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/curated_membership.py
+++ b/scripts/lexicon/curated_membership.py
@@ -15,8 +15,6 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from scripts.lexicon.curated_seed_atlas_admission import _read_jsonl, prepare_practice_seed
-
 SCHEMA = "curated-practice-membership-v1"
 DEFAULT_MEMBERSHIP_PATH = Path("site/src/data/lexicon-teacher-curated-membership.json")
 
@@ -71,6 +69,11 @@ def build_membership(
     sometimes carry a last-token cloze target, which must not be promoted as a
     guessed multiword headword.
     """
+    # Deferred: the admission resolver pulls in the VESUM/grow_lexicon chain
+    # (and its `requests` dependency), which callers that only need
+    # apply_membership/read_membership must not have to install.
+    from scripts.lexicon.curated_seed_atlas_admission import _read_jsonl, prepare_practice_seed
+
     homework_rows = _read_jsonl(homework_seed_path)
     practice_seed, homework_report = prepare_practice_seed(homework_rows, manifest_path)
     entries = read_manifest_entries(manifest_path)

--- a/scripts/lexicon/curated_membership.py
+++ b/scripts/lexicon/curated_membership.py
@@ -1,0 +1,222 @@
+"""Build and apply the lemma-only Curated Practice membership union.
+
+The homework seed and the legacy teacher inventory are separate authorities for
+membership.  This module deliberately consumes only lexical identifiers from
+the inventory, never sentence bodies or distractors.  Sentence admission stays
+with the public cloze-source and rights gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import unicodedata
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from scripts.lexicon.curated_seed_atlas_admission import _read_jsonl, prepare_practice_seed
+
+SCHEMA = "curated-practice-membership-v1"
+DEFAULT_MEMBERSHIP_PATH = Path("site/src/data/lexicon-teacher-curated-membership.json")
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _key(value: object) -> str:
+    return unicodedata.normalize("NFC", _text(value)).casefold()
+
+
+def read_manifest_entries(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    entries = payload.get("entries") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        raise ValueError(f"{path}: manifest entries must be a list")
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def read_teacher_inventory_keys(path: Path) -> list[str]:
+    """Read only legacy inventory lemma identifiers, never its prose fields."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cards = payload.get("cloze") if isinstance(payload, dict) else payload
+    if not isinstance(cards, list):
+        raise ValueError(f"{path}: expected a cloze list")
+    return [_text(card.get("lemmaId")) for card in cards if isinstance(card, dict) and _text(card.get("lemmaId"))]
+
+
+def _public_routes(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    routes: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        slug = _text(entry.get("url_slug"))
+        lemma = _text(entry.get("lemma"))
+        if not slug or not lemma:
+            continue
+        routes.setdefault(_key(slug), entry)
+        routes.setdefault(_key(lemma), entry)
+    return routes
+
+
+def build_membership(
+    *,
+    homework_seed_path: Path,
+    teacher_inventory_path: Path,
+    manifest_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a public-route-only A union B membership payload and local report.
+
+    A uses the existing VESUM-attested curated admission resolver.  B is
+    resolved only by an exact canonical Atlas lemma/slug match: legacy cards
+    sometimes carry a last-token cloze target, which must not be promoted as a
+    guessed multiword headword.
+    """
+    homework_rows = _read_jsonl(homework_seed_path)
+    practice_seed, homework_report = prepare_practice_seed(homework_rows, manifest_path)
+    entries = read_manifest_entries(manifest_path)
+    routes = _public_routes(entries)
+    members: dict[str, dict[str, Any]] = {}
+
+    def add(entry: dict[str, Any], source: str) -> None:
+        slug = _text(entry.get("url_slug"))
+        lemma = _text(entry.get("lemma"))
+        if not slug or not lemma:
+            raise ValueError("resolved membership entry requires lemma and url_slug")
+        record = members.setdefault(slug, {"lemma": lemma, "slug": slug, "sources": set()})
+        record["sources"].add(source)
+
+    homework_public = 0
+    homework_local_only = 0
+    for row in practice_seed["entries"]:
+        if row.get("localOnly") is True:
+            homework_local_only += 1
+            continue
+        target = routes.get(_key(row.get("slug")))
+        if target is None:
+            raise ValueError(f"curated homework seed route is absent from manifest: {row.get('slug')!r}")
+        add(target, "homework")
+        homework_public += 1
+
+    teacher_keys = read_teacher_inventory_keys(teacher_inventory_path)
+    teacher_unique = sorted({_key(value) for value in teacher_keys})
+    unresolved_teacher_keys: list[str] = []
+    for key in teacher_unique:
+        target = routes.get(key)
+        if target is None:
+            unresolved_teacher_keys.append(key)
+            continue
+        add(target, "teacher_inventory")
+
+    serialized_members = [
+        {"lemma": record["lemma"], "slug": record["slug"], "sources": sorted(record["sources"])}
+        for _slug, record in sorted(members.items(), key=lambda item: (_key(item[1]["lemma"]), item[0]))
+    ]
+    payload = {
+        "schema": SCHEMA,
+        "schemaVersion": 1,
+        "members": serialized_members,
+    }
+    report = {
+        "schema": "curated-practice-membership-report-v1",
+        "homework": {
+            "rows": len(homework_rows),
+            "unique_lemmas": len({_key(row.get("lemma")) for row in homework_rows if _key(row.get("lemma"))}),
+            "public_route_rows": homework_public,
+            "local_only_rows": homework_local_only,
+            "admission": homework_report,
+        },
+        "teacher_inventory": {
+            "cards": len(teacher_keys),
+            "unique_keys": len(teacher_unique),
+            "resolved_keys": len(teacher_unique) - len(unresolved_teacher_keys),
+            "unresolved_keys": unresolved_teacher_keys,
+        },
+        "membership": {
+            "unique_routes": len(serialized_members),
+            "by_source": dict(
+                sorted(Counter(source for member in serialized_members for source in member["sources"]).items())
+            ),
+        },
+    }
+    return payload, report
+
+
+def read_membership(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"{path}: unsupported curated membership schema")
+    members = payload.get("members")
+    if not isinstance(members, list):
+        raise ValueError(f"{path}: members must be a list")
+    validated: list[dict[str, Any]] = []
+    seen_slugs: set[str] = set()
+    for index, member in enumerate(members):
+        if not isinstance(member, dict):
+            raise ValueError(f"{path}: members[{index}] must be an object")
+        lemma = _text(member.get("lemma"))
+        slug = _text(member.get("slug"))
+        sources = member.get("sources")
+        if not lemma or not slug or not isinstance(sources, list) or not all(_text(source) for source in sources):
+            raise ValueError(f"{path}: members[{index}] requires lemma, slug, and sources")
+        slug_key = _key(slug)
+        if slug_key in seen_slugs:
+            raise ValueError(f"{path}: duplicate membership slug {slug!r}")
+        seen_slugs.add(slug_key)
+        validated.append({"lemma": lemma, "slug": slug, "sources": sorted({_text(source) for source in sources})})
+    return validated
+
+
+def apply_membership(entries: list[dict[str, Any]], members: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Mark exact public Atlas routes as practice members without admitting cloze."""
+    by_slug = {_key(entry.get("url_slug")): index for index, entry in enumerate(entries) if _key(entry.get("url_slug"))}
+    merged = list(entries)
+    unresolved: list[dict[str, str]] = []
+    for member in members:
+        index = by_slug.get(_key(member["slug"]))
+        if index is None:
+            unresolved.append({"slug": member["slug"], "reason": "missing_atlas_route"})
+            continue
+        target = merged[index]
+        if _key(target.get("lemma")) != _key(member["lemma"]):
+            raise ValueError(f"membership lemma does not match Atlas route {member['slug']!r}")
+        admission = target.get("surface_admission")
+        merged_admission = dict(admission) if isinstance(admission, dict) else {}
+        merged_admission["practice"] = True
+        merged[index] = {**target, "surface_admission": merged_admission, "curated_membership": True}
+    if unresolved:
+        raise ValueError(f"curated membership contains {len(unresolved)} unresolved Atlas route(s): {unresolved[:5]}")
+    return merged, {"members": len(members), "resolved": len(members)}
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--homework-seed", type=Path, required=True)
+    parser.add_argument("--teacher-inventory", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=DEFAULT_MEMBERSHIP_PATH)
+    parser.add_argument("--report-out", type=Path)
+    args = parser.parse_args(argv)
+    payload, report = build_membership(
+        homework_seed_path=args.homework_seed,
+        teacher_inventory_path=args.teacher_inventory,
+        manifest_path=args.manifest,
+    )
+    _write_json(args.out, payload)
+    if args.report_out:
+        _write_json(args.report_out, report)
+    print(
+        "curated membership "
+        f"routes={report['membership']['unique_routes']} "
+        f"homework_public={report['homework']['public_route_rows']} "
+        f"teacher_keys={report['teacher_inventory']['unique_keys']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -31,6 +31,7 @@ DEFAULT_SENTENCE_INVENTORY = ROOT / "site" / "src" / "data" / "lexicon-sentence-
 DEFAULT_HERITAGE_PAIRS = ROOT / "data" / "lexicon" / "heritage_pairs.yaml"
 DEFAULT_PARONYM_PAIRS = ROOT / "data" / "lexicon" / "paronym_pairs.yaml"
 DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
+DEFAULT_CURATED_MEMBERSHIP = ROOT / "site" / "src" / "data" / "lexicon-teacher-curated-membership.json"
 DEFAULT_RELEASE_TAG = "atlas-practice-deck"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-practice-deck.json.gz"
@@ -72,6 +73,7 @@ def expected_deck_version(
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
     sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
+    curated_membership_path: Path | None = None,
 ) -> str:
     if not atlas_db_path.exists():
         raise PracticeDeckPublishError(
@@ -88,9 +90,12 @@ def expected_deck_version(
             read_sentence_inventory,
             read_synonym_verdicts,
         )
+        from scripts.lexicon.curated_membership import apply_membership, read_membership
         from scripts.practice_deck.io import compute_deck_version
 
         entries = read_atlas_db(atlas_db_path)
+        if curated_membership_path is not None:
+            entries, _membership_report = apply_membership(entries, read_membership(curated_membership_path))
         heritage_pairs = read_heritage_pairs(heritage_pairs_path)
         paronym_pairs = read_paronym_pairs(paronym_pairs_path)
         synonym_verdicts = read_synonym_verdicts(synonym_verdicts_path)
@@ -356,6 +361,7 @@ def publish_practice_deck(
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
     sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
+    curated_membership_path: Path | None = None,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
@@ -368,6 +374,7 @@ def publish_practice_deck(
         synonym_verdicts_path=synonym_verdicts_path,
         cloze_sources_path=cloze_sources_path,
         sentence_inventory_path=sentence_inventory_path,
+        curated_membership_path=curated_membership_path,
     )
     if deck_version != expected_version:
         raise PracticeDeckPublishError(
@@ -405,6 +412,7 @@ def main() -> int:
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
+    parser.add_argument("--curated-membership", type=Path)
     parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading/writing pointer")
@@ -417,6 +425,7 @@ def main() -> int:
         heritage_pairs_path=args.heritage_pairs,
         paronym_pairs_path=args.paronym_pairs,
         synonym_verdicts_path=args.synonym_verdicts,
+        curated_membership_path=args.curated_membership,
         cloze_sources_path=args.cloze_sources,
         sentence_inventory_path=args.sentence_inventory,
         release_tag=args.release_tag,

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "ea5ce97e64eab3e237b7c60309f959689ea9fe47c5f3789fff49b1a3d73f9be1",
+  "fingerprint": "0c09127315dce53aa386a2ab7a22cd5a4eda21c7721944bca33f3c7c2494d3a2",
   "inputs": {
     "lexicon_code": [
       {
@@ -61,6 +61,10 @@
       {
         "path": "scripts/lexicon/content_lexicon_reconciler.py",
         "sha256": "b2f1b2cab47fe23d34590355ba0c5c67a008bbb4e773852ce37c65aaf3d09a39"
+      },
+      {
+        "path": "scripts/lexicon/curated_membership.py",
+        "sha256": "a3f9dde7cb8792e0952701d301a0afa51a5a003fdff9767900be5928f9827916"
       },
       {
         "path": "scripts/lexicon/curated_ohoiko_ulp_repromote.py",
@@ -223,6 +227,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 54
+    "lexicon_code_files": 55
   }
 }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "0c09127315dce53aa386a2ab7a22cd5a4eda21c7721944bca33f3c7c2494d3a2",
+  "fingerprint": "1b4af7c9822020a9eeeb6794451f2a022644248b8f2f03ad2793a7be68b4df56",
   "inputs": {
     "lexicon_code": [
       {
@@ -64,7 +64,7 @@
       },
       {
         "path": "scripts/lexicon/curated_membership.py",
-        "sha256": "a3f9dde7cb8792e0952701d301a0afa51a5a003fdff9767900be5928f9827916"
+        "sha256": "45a81e21d503eeed19a770eb367dc794cac40f8dd60314ca51273b60a8b3f149"
       },
       {
         "path": "scripts/lexicon/curated_ohoiko_ulp_repromote.py",

--- a/site/src/data/lexicon-teacher-curated-membership.json
+++ b/site/src/data/lexicon-teacher-curated-membership.json
@@ -1,0 +1,27541 @@
+{
+  "schema": "curated-practice-membership-v1",
+  "schemaVersion": 1,
+  "members": [
+    {
+      "lemma": "абзац",
+      "slug": "абзац",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "абонемент",
+      "slug": "абонемент",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "абсолютно",
+      "slug": "абсолютно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "абсурд",
+      "slug": "абсурд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аварія",
+      "slug": "аварія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "австрієць",
+      "slug": "австрієць",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "автобус",
+      "slug": "автобус",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "автор",
+      "slug": "автор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "авітаміноз",
+      "slug": "авітаміноз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "агент",
+      "slug": "агент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "агресивний",
+      "slug": "агресивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "агресія",
+      "slug": "агресія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "агітація",
+      "slug": "агітація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "адаптація",
+      "slug": "адаптація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "адміністративний",
+      "slug": "адміністративний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "адреса",
+      "slug": "адреса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аеропорт",
+      "slug": "аеропорт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "азартний",
+      "slug": "азартний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "академія",
+      "slug": "академія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "акт",
+      "slug": "акт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "активний",
+      "slug": "активний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "активність",
+      "slug": "активність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "активізувати",
+      "slug": "активізувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "активіст",
+      "slug": "активіст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "акція",
+      "slug": "акція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "алгебра",
+      "slug": "алгебра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "алгоритм",
+      "slug": "алгоритм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "алергія",
+      "slug": "алергія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "алкоголь",
+      "slug": "алкоголь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "алкоголізм",
+      "slug": "алкоголізм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "амбітний",
+      "slug": "амбітний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аналіз",
+      "slug": "аналіз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аналітик",
+      "slug": "аналітик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "анархія",
+      "slug": "анархія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ангел",
+      "slug": "ангел",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "анекдот",
+      "slug": "анекдот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "антена",
+      "slug": "антена",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "античний",
+      "slug": "античний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "апетит",
+      "slug": "апетит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аргумент",
+      "slug": "аргумент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "арешт",
+      "slug": "арешт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "армія",
+      "slug": "армія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "архів",
+      "slug": "архів",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "архітектура",
+      "slug": "архітектура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "асоціюватися",
+      "slug": "асоціюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аспект",
+      "slug": "аспект",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аспірант",
+      "slug": "аспірант",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "астроном",
+      "slug": "астроном",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "асфальт",
+      "slug": "асфальт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "атака",
+      "slug": "атака",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "атмосфера",
+      "slug": "атмосфера",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "аякже",
+      "slug": "аякже",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бабуся",
+      "slug": "бабуся",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бавовняний",
+      "slug": "бавовняний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "багажник",
+      "slug": "багажник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "багатий",
+      "slug": "багатий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "багато",
+      "slug": "багато",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "багаторазовий",
+      "slug": "багаторазовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "багаторічний",
+      "slug": "багаторічний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бадьорий",
+      "slug": "бадьорий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бажаний",
+      "slug": "бажаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бажання",
+      "slug": "бажання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бажано",
+      "slug": "бажано",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бажати",
+      "slug": "бажати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "база",
+      "slug": "база",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бакалавр",
+      "slug": "бакалавр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "баланс",
+      "slug": "баланс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "балкон",
+      "slug": "балкон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "банан",
+      "slug": "банан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бандит",
+      "slug": "бандит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бандура",
+      "slug": "бандура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "банка",
+      "slug": "банка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "банкомат",
+      "slug": "банкомат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бар",
+      "slug": "бар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бар'єр",
+      "slug": "бар-єр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "басейн",
+      "slug": "басейн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "баскетбол",
+      "slug": "баскетбол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "батарея",
+      "slug": "батарея",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "батько",
+      "slug": "батько",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "батіг",
+      "slug": "батіг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бачити",
+      "slug": "бачити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бджола",
+      "slug": "бджола",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безглуздий",
+      "slug": "безглуздий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безкоштовний",
+      "slug": "безкоштовний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безлад",
+      "slug": "безлад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безліч",
+      "slug": "безліч",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безособовий",
+      "slug": "безособовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безпека",
+      "slug": "безпека",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безплатний",
+      "slug": "безплатний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "безпорадний",
+      "slug": "безпорадний",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "безпосередньо",
+      "slug": "безпосередньо",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "берег",
+      "slug": "берег",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "берегти",
+      "slug": "берегти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бережний",
+      "slug": "бережний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "березень",
+      "slug": "березень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "битва",
+      "slug": "битва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бити",
+      "slug": "бити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "битий",
+      "slug": "битий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "битися",
+      "slug": "битися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "благати",
+      "slug": "благати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "благодійний",
+      "slug": "благодійний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "благодійність",
+      "slug": "благодійність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "блакитний",
+      "slug": "блакитний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ближчий",
+      "slug": "ближчий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "близький",
+      "slug": "близький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "блискавка",
+      "slug": "блискавка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "блискітки",
+      "slug": "блискітки",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "блукати",
+      "slug": "блукати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "блювати",
+      "slug": "блювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "блідий",
+      "slug": "блідий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бог",
+      "slug": "бог",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "богиня",
+      "slug": "богиня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "божевільний",
+      "slug": "божевільний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бойовий",
+      "slug": "бойовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "болгарин",
+      "slug": "болгарин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "болісний",
+      "slug": "болісний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боліти",
+      "slug": "боліти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "борг",
+      "slug": "борг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "борець",
+      "slug": "борець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боротися",
+      "slug": "боротися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боротьба",
+      "slug": "боротьба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "борщ",
+      "slug": "борщ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "босоніж",
+      "slug": "босоніж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бот",
+      "slug": "бот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бочка",
+      "slug": "бочка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боярин",
+      "slug": "боярин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боятися",
+      "slug": "боятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "боєць",
+      "slug": "боєць",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брак",
+      "slug": "брак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бракувати",
+      "slug": "бракувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брат",
+      "slug": "брат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брати",
+      "slug": "брати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "братство",
+      "slug": "братство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брехати",
+      "slug": "брехати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брехня",
+      "slug": "брехня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брифінг",
+      "slug": "брифінг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брова",
+      "slug": "брова",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бродячий",
+      "slug": "бродячий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брошура",
+      "slug": "брошура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бруд",
+      "slug": "бруд",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "брудний",
+      "slug": "брудний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бувати",
+      "slug": "бувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будинок",
+      "slug": "будинок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будувати",
+      "slug": "будувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будь-хто",
+      "slug": "будь-хто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будь-який",
+      "slug": "будь-який",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будівля",
+      "slug": "будівля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "будівництво",
+      "slug": "будівництво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "буква",
+      "slug": "буква",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "булава",
+      "slug": "булава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "булочка",
+      "slug": "булочка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бульйон",
+      "slug": "бульйон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "буркотливий",
+      "slug": "буркотливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бурмотіти",
+      "slug": "бурмотіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бурхливий",
+      "slug": "бурхливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "буря",
+      "slug": "буря",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "бутерброд",
+      "slug": "бутерброд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бути",
+      "slug": "бути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "буханка",
+      "slug": "буханка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бухгалтер",
+      "slug": "бухгалтер",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бюджет",
+      "slug": "бюджет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бібліотека",
+      "slug": "бібліотека",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "біг",
+      "slug": "біг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бігати",
+      "slug": "бігати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бігти",
+      "slug": "бігти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "біда",
+      "slug": "біда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бідкатися",
+      "slug": "бідкатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бідний",
+      "slug": "бідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бізнес",
+      "slug": "бізнес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бій",
+      "slug": "бій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бійка",
+      "slug": "бійка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "бік",
+      "slug": "бік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "білий",
+      "slug": "білий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "білка",
+      "slug": "білка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "білок",
+      "slug": "білок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "білченя",
+      "slug": "білченя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "біль",
+      "slug": "біль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "більший",
+      "slug": "більший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "більшість",
+      "slug": "більшість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "біологічний",
+      "slug": "біологічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "біситися",
+      "slug": "біситися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "в'язниця",
+      "slug": "в-язниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "в'їхати",
+      "slug": "в-їхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вага",
+      "slug": "вага",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вагання",
+      "slug": "вагання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вагатися",
+      "slug": "вагатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вагітний",
+      "slug": "вагітний",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вагітність",
+      "slug": "вагітність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "важкий",
+      "slug": "важкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "важливий",
+      "slug": "важливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "важливість",
+      "slug": "важливість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "важчий",
+      "slug": "важчий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "важіль",
+      "slug": "важіль",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вазон",
+      "slug": "вазон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вакцина",
+      "slug": "вакцина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "валет",
+      "slug": "валет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "валитися",
+      "slug": "валитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "валюта",
+      "slug": "валюта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "валіза",
+      "slug": "валіза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ванна",
+      "slug": "ванна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вантажівка",
+      "slug": "вантажівка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "варений",
+      "slug": "варений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вареник",
+      "slug": "вареник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вартовий",
+      "slug": "вартовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "варяг",
+      "slug": "варяг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "варіант",
+      "slug": "варіант",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "варіація",
+      "slug": "варіація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ватага",
+      "slug": "ватага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ваш",
+      "slug": "ваш",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вбивати",
+      "slug": "вбивати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вбивство",
+      "slug": "вбивство",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вбивця",
+      "slug": "вбивця",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вбиральня",
+      "slug": "вбиральня",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вбити",
+      "slug": "вбити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вважати",
+      "slug": "вважати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вважатися",
+      "slug": "вважатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ввести",
+      "slug": "ввести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вводити",
+      "slug": "вводити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вглиб",
+      "slug": "вглиб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вгорі",
+      "slug": "вгорі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вдарити",
+      "slug": "вдарити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вдячний",
+      "slug": "вдячний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ведення",
+      "slug": "ведення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ведмідь",
+      "slug": "ведмідь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ведучий",
+      "slug": "ведучий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "везти",
+      "slug": "везти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "велетень",
+      "slug": "велетень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "великий",
+      "slug": "великий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "величезний",
+      "slug": "величезний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "величина",
+      "slug": "величина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "велосипед",
+      "slug": "велосипед",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вересень",
+      "slug": "вересень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "верства",
+      "slug": "верства",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "верхній",
+      "slug": "верхній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вершина",
+      "slug": "вершина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "веселий",
+      "slug": "веселий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "весна",
+      "slug": "весна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "весняний",
+      "slug": "весняний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "веснянки",
+      "slug": "веснянки",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вести",
+      "slug": "вести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "весільний",
+      "slug": "весільний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ветеран",
+      "slug": "ветеран",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вечеря",
+      "slug": "вечеря",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вечір",
+      "slug": "вечір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вечірка",
+      "slug": "вечірка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вживання",
+      "slug": "вживання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вживати",
+      "slug": "вживати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "взаємини",
+      "slug": "взаємини",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "взаємодія",
+      "slug": "взаємодія",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "взаємодіяти",
+      "slug": "взаємодіяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "взуватися",
+      "slug": "взуватися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "взутися",
+      "slug": "взутися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "взяти",
+      "slug": "взяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ви",
+      "slug": "ви",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вибачити",
+      "slug": "вибачити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вибирати",
+      "slug": "вибирати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виборчий",
+      "slug": "виборчий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вибрати",
+      "slug": "вибрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вибухати",
+      "slug": "вибухати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вибухнути",
+      "slug": "вибухнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вибір",
+      "slug": "вибір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виведення",
+      "slug": "виведення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вивести",
+      "slug": "вивести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виводити",
+      "slug": "виводити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вивчати",
+      "slug": "вивчати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вивчити",
+      "slug": "вивчити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вивіз",
+      "slug": "вивіз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вигляд",
+      "slug": "вигляд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виглядати",
+      "slug": "виглядати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виготовляти",
+      "slug": "виготовляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вигравати",
+      "slug": "вигравати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виграти",
+      "slug": "виграти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виграш",
+      "slug": "виграш",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вигук",
+      "slug": "вигук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вид",
+      "slug": "вид",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "видавати",
+      "slug": "видавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "видавець",
+      "slug": "видавець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "видалити",
+      "slug": "видалити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "видаляти",
+      "slug": "видаляти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "видатний",
+      "slug": "видатний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виделка",
+      "slug": "виделка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виділити",
+      "slug": "виділити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виділяти",
+      "slug": "виділяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виділятися",
+      "slug": "виділятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виживання",
+      "slug": "виживання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виживати",
+      "slug": "виживати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "визнаний",
+      "slug": "визнаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "визнати",
+      "slug": "визнати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "визначати",
+      "slug": "визначати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "визначити",
+      "slug": "визначити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вийти",
+      "slug": "вийти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "викидати",
+      "slug": "викидати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "викинути",
+      "slug": "викинути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "викладач",
+      "slug": "викладач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виклик",
+      "slug": "виклик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "викликати",
+      "slug": "викликати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виконати",
+      "slug": "виконати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виконувати",
+      "slug": "виконувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виконуватися",
+      "slug": "виконуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "використання",
+      "slug": "використання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "використати",
+      "slug": "використати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "використовувати",
+      "slug": "використовувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "використовуватися",
+      "slug": "використовуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "викрасти",
+      "slug": "викрасти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вилетіти",
+      "slug": "вилетіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вилупитися",
+      "slug": "вилупитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вилізти",
+      "slug": "вилізти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вилікувати",
+      "slug": "вилікувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимагати",
+      "slug": "вимагати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимикати",
+      "slug": "вимикати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимити",
+      "slug": "вимити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимкнути",
+      "slug": "вимкнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимова",
+      "slug": "вимова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимір",
+      "slug": "вимір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вимірювати",
+      "slug": "вимірювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "винахід",
+      "slug": "винахід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "винести",
+      "slug": "винести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виникати",
+      "slug": "виникати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виникнути",
+      "slug": "виникнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "винний",
+      "slug": "винний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вино",
+      "slug": "вино",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виносити",
+      "slug": "виносити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "винятковий",
+      "slug": "винятковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виняток",
+      "slug": "виняток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випадати",
+      "slug": "випадати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випадок",
+      "slug": "випадок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випасти",
+      "slug": "випасти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виписати",
+      "slug": "виписати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випити",
+      "slug": "випити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випробування",
+      "slug": "випробування",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випуск",
+      "slug": "випуск",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випускати",
+      "slug": "випускати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "випустити",
+      "slug": "випустити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "випічка",
+      "slug": "випічка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виражати",
+      "slug": "виражати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виражений",
+      "slug": "виражений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виробляти",
+      "slug": "виробляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виробник",
+      "slug": "виробник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирок",
+      "slug": "вирок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирости",
+      "slug": "вирости",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирубати",
+      "slug": "вирубати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вирушати",
+      "slug": "вирушати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирушити",
+      "slug": "вирушити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирішити",
+      "slug": "вирішити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вирішувати",
+      "slug": "вирішувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висипатися",
+      "slug": "висипатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висиплятися",
+      "slug": "висиплятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вислати",
+      "slug": "вислати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вислизнути",
+      "slug": "вислизнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висловити",
+      "slug": "висловити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висловлювати",
+      "slug": "висловлювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вислів",
+      "slug": "вислів",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виснажений",
+      "slug": "виснажений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виснажливий",
+      "slug": "виснажливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висновок",
+      "slug": "висновок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "високий",
+      "slug": "високий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висота",
+      "slug": "висота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виспатися",
+      "slug": "виспатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виставити",
+      "slug": "виставити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "виставка",
+      "slug": "виставка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виставляти",
+      "slug": "виставляти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вистачати",
+      "slug": "вистачати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висунути",
+      "slug": "висунути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "висушити",
+      "slug": "висушити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витерти",
+      "slug": "витерти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витирати",
+      "slug": "витирати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витрата",
+      "slug": "витрата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витрати",
+      "slug": "витрати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "витратити",
+      "slug": "витратити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витрачати",
+      "slug": "витрачати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "витримати",
+      "slug": "витримати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "витримувати",
+      "slug": "витримувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виховання",
+      "slug": "виховання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виходити",
+      "slug": "виходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вихід",
+      "slug": "вихід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вихідний",
+      "slug": "вихідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вичитати",
+      "slug": "вичитати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вичитувати",
+      "slug": "вичитувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вишиваний",
+      "slug": "вишиваний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вишиванка",
+      "slug": "вишиванка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вишитий",
+      "slug": "вишитий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вишкіл",
+      "slug": "вишкіл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вишуканий",
+      "slug": "вишуканий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вищий",
+      "slug": "вищий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виявити",
+      "slug": "виявити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виявитися",
+      "slug": "виявитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виявлятися",
+      "slug": "виявлятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виїжджати",
+      "slug": "виїжджати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "виїхати",
+      "slug": "виїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вказати",
+      "slug": "вказати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вказівка",
+      "slug": "вказівка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вкладка",
+      "slug": "вкладка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вкласти",
+      "slug": "вкласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "включати",
+      "slug": "включати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "включити",
+      "slug": "включити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вкрасти",
+      "slug": "вкрасти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вкусити",
+      "slug": "вкусити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "влада",
+      "slug": "влада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "владний",
+      "slug": "владний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "власний",
+      "slug": "власний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "власник",
+      "slug": "власник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "власниця",
+      "slug": "власниця",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "влаштовувати",
+      "slug": "влаштовувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "влаштувати",
+      "slug": "влаштувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "влучно",
+      "slug": "влучно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вмикати",
+      "slug": "вмикати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вміння",
+      "slug": "вміння",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "вміти",
+      "slug": "вміти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "внести",
+      "slug": "внести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "внизу",
+      "slug": "внизу",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "внук",
+      "slug": "внук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вовк",
+      "slug": "вовк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вовняний",
+      "slug": "вовняний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вогник",
+      "slug": "вогник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вогнище",
+      "slug": "вогнище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вогонь",
+      "slug": "вогонь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вода",
+      "slug": "вода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "водити",
+      "slug": "водити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "водій",
+      "slug": "водій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вокзал",
+      "slug": "вокзал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вологий",
+      "slug": "вологий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вологість",
+      "slug": "вологість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "володар",
+      "slug": "володар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "володіти",
+      "slug": "володіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "волонтер",
+      "slug": "волонтер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "волосся",
+      "slug": "волосся",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воля",
+      "slug": "воля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воліти",
+      "slug": "воліти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вона",
+      "slug": "вона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вони",
+      "slug": "вони",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ворог",
+      "slug": "ворог",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ворожий",
+      "slug": "ворожий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ворота",
+      "slug": "ворота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "восьмий",
+      "slug": "восьмий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "восьминіг",
+      "slug": "восьминіг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воювати",
+      "slug": "воювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воєвода",
+      "slug": "воєвода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воєнний",
+      "slug": "воєнний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "воїн",
+      "slug": "воїн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "впасти",
+      "slug": "впасти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "впевнений",
+      "slug": "впевнений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вплив",
+      "slug": "вплив",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "впливати",
+      "slug": "впливати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вплутувати",
+      "slug": "вплутувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "впоратися",
+      "slug": "впоратися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вправа",
+      "slug": "вправа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "впізнати",
+      "slug": "впізнати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вражати",
+      "slug": "вражати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "враження",
+      "slug": "враження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вручну",
+      "slug": "вручну",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "врятувати",
+      "slug": "врятувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "все",
+      "slug": "все",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "все-таки",
+      "slug": "все-таки",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "всесвіт",
+      "slug": "всесвіт",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "всесвітній",
+      "slug": "всесвітній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вставати",
+      "slug": "вставати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "встановити",
+      "slug": "встановити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "встановлений",
+      "slug": "встановлений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "встановлювати",
+      "slug": "встановлювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "встати",
+      "slug": "встати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "встигати",
+      "slug": "встигати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вступ",
+      "slug": "вступ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вступати",
+      "slug": "вступати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вступити",
+      "slug": "вступити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вступний",
+      "slug": "вступний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вся",
+      "slug": "вся",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "всякий",
+      "slug": "всякий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "всіляко",
+      "slug": "всіляко",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втекти",
+      "slug": "втекти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втома",
+      "slug": "втома",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втомити",
+      "slug": "втомити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втомитися",
+      "slug": "втомитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втомлений",
+      "slug": "втомлений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втрата",
+      "slug": "втрата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втратити",
+      "slug": "втратити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втрачати",
+      "slug": "втрачати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втретє",
+      "slug": "втретє",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втрутитися",
+      "slug": "втрутитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втручатися",
+      "slug": "втручатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втікати",
+      "slug": "втікати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втілити",
+      "slug": "втілити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "втім",
+      "slug": "втім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вуглевод",
+      "slug": "вуглевод",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вузол",
+      "slug": "вузол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вузький",
+      "slug": "вузький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вулик",
+      "slug": "вулик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вулиця",
+      "slug": "вулиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вус",
+      "slug": "вус",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вухо",
+      "slug": "вухо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчасний",
+      "slug": "вчасний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчений",
+      "slug": "вчений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчинок",
+      "slug": "вчинок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчитель",
+      "slug": "вчитель",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчителька",
+      "slug": "вчителька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчити",
+      "slug": "вчити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вчитися",
+      "slug": "вчитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вшанувати",
+      "slug": "вшанувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вщент",
+      "slug": "вщент",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "від'їхати",
+      "slug": "від-їхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відання",
+      "slug": "відання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відбиватися",
+      "slug": "відбиватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відбиток",
+      "slug": "відбиток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відбуватися",
+      "slug": "відбуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відвага",
+      "slug": "відвага",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відвести",
+      "slug": "відвести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відвідати",
+      "slug": "відвідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відвідувати",
+      "slug": "відвідувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відвідувач",
+      "slug": "відвідувач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відгук",
+      "slug": "відгук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "віддавати",
+      "slug": "віддавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "віддалено",
+      "slug": "віддалено",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "віддати",
+      "slug": "віддати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відділ",
+      "slug": "відділ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відділення",
+      "slug": "відділення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відзначати",
+      "slug": "відзначати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкладати",
+      "slug": "відкладати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкласти",
+      "slug": "відкласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкривати",
+      "slug": "відкривати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкриватися",
+      "slug": "відкриватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкрити",
+      "slug": "відкрити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкритий",
+      "slug": "відкритий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відкриття",
+      "slug": "відкриття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відлуння",
+      "slug": "відлуння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмова",
+      "slug": "відмова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмовитися",
+      "slug": "відмовитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмовлятися",
+      "slug": "відмовлятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відміна",
+      "slug": "відміна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмінити",
+      "slug": "відмінити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмінний",
+      "slug": "відмінний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмінність",
+      "slug": "відмінність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відмінок",
+      "slug": "відмінок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відновити",
+      "slug": "відновити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відновлений",
+      "slug": "відновлений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відновлювати",
+      "slug": "відновлювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відновлюватися",
+      "slug": "відновлюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відносини",
+      "slug": "відносини",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відокремлений",
+      "slug": "відокремлений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відомий",
+      "slug": "відомий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповідальний",
+      "slug": "відповідальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповідальність",
+      "slug": "відповідальність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповідати",
+      "slug": "відповідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповідач",
+      "slug": "відповідач",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповідь",
+      "slug": "відповідь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відповісти",
+      "slug": "відповісти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відпочивати",
+      "slug": "відпочивати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відпочинок",
+      "slug": "відпочинок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відпочити",
+      "slug": "відпочити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відправити",
+      "slug": "відправити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відпустити",
+      "slug": "відпустити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відпустка",
+      "slug": "відпустка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відреагувати",
+      "slug": "відреагувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відремонтувати",
+      "slug": "відремонтувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відро",
+      "slug": "відро",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відроджувати",
+      "slug": "відроджувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відрядження",
+      "slug": "відрядження",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відсвяткувати",
+      "slug": "відсвяткувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відсоток",
+      "slug": "відсоток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відстань",
+      "slug": "відстань",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відстоювати",
+      "slug": "відстоювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відсутність",
+      "slug": "відсутність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відсіч",
+      "slug": "відсіч",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відхилити",
+      "slug": "відхилити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відходити",
+      "slug": "відходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відчай",
+      "slug": "відчай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відчувати",
+      "slug": "відчувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відчути",
+      "slug": "відчути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відчуття",
+      "slug": "відчуття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відьма",
+      "slug": "відьма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відіграти",
+      "slug": "відіграти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "відійти",
+      "slug": "відійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "війна",
+      "slug": "війна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "військо",
+      "slug": "військо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "військовий",
+      "slug": "військовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вікно",
+      "slug": "вікно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вільний",
+      "slug": "вільний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вільно",
+      "slug": "вільно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вільха",
+      "slug": "вільха",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "віра",
+      "slug": "віра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вірити",
+      "slug": "вірити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вірус",
+      "slug": "вірус",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вірусний",
+      "slug": "вірусний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вірш",
+      "slug": "вірш",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вісім",
+      "slug": "вісім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вісімдесят",
+      "slug": "вісімдесят",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вісімнадцять",
+      "slug": "вісімнадцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вісімсот",
+      "slug": "вісімсот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітамін",
+      "slug": "вітамін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітамінний",
+      "slug": "вітамінний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітати",
+      "slug": "вітати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітатися",
+      "slug": "вітатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітер",
+      "slug": "вітер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітрина",
+      "slug": "вітрина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вітряний",
+      "slug": "вітряний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "вішати",
+      "slug": "вішати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гавкати",
+      "slug": "гавкати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гаджет",
+      "slug": "гаджет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гадка",
+      "slug": "гадка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "газета",
+      "slug": "газета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гай",
+      "slug": "гай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гак",
+      "slug": "гак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "галузь",
+      "slug": "галузь",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гальмувати",
+      "slug": "гальмувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гаманець",
+      "slug": "гаманець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гамбургер",
+      "slug": "гамбургер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гараж",
+      "slug": "гараж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гаразд",
+      "slug": "гаразд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гарбуз",
+      "slug": "гарбуз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гардероб",
+      "slug": "гардероб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гармата",
+      "slug": "гармата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гармидер",
+      "slug": "гармидер",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гармонія",
+      "slug": "гармонія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гарний",
+      "slug": "гарний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гей",
+      "slug": "гей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "геймер",
+      "slug": "геймер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гектар",
+      "slug": "гектар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "генерал",
+      "slug": "генерал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "геноцид",
+      "slug": "геноцид",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "географ",
+      "slug": "географ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "герб",
+      "slug": "герб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "герой",
+      "slug": "герой",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гетьман",
+      "slug": "гетьман",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гидливий",
+      "slug": "гидливий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глибина",
+      "slug": "глибина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глибокий",
+      "slug": "глибокий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глузд",
+      "slug": "глузд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глузувати",
+      "slug": "глузувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глухий",
+      "slug": "глухий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глюк",
+      "slug": "глюк",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "глядач",
+      "slug": "глядач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "глянути",
+      "slug": "глянути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гнилий",
+      "slug": "гнилий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гнити",
+      "slug": "гнити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гнучкий",
+      "slug": "гнучкий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гніздо",
+      "slug": "гніздо",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "говорити",
+      "slug": "говорити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "год",
+      "slug": "год",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "година",
+      "slug": "година",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "годинами",
+      "slug": "годинами",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "годинний",
+      "slug": "годинний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "годинник",
+      "slug": "годинник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "годувати",
+      "slug": "годувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голий",
+      "slug": "голий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голитися",
+      "slug": "голитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голка",
+      "slug": "голка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голова",
+      "slug": "голова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "головний",
+      "slug": "головний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "головоломка",
+      "slug": "головоломка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голодний",
+      "slug": "голодний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голос",
+      "slug": "голос",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голосний",
+      "slug": "голосний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голосувати",
+      "slug": "голосувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "голуб",
+      "slug": "голуб",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гоп",
+      "slug": "гоп",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гопак",
+      "slug": "гопак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гора",
+      "slug": "гора",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горб",
+      "slug": "горб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горище",
+      "slug": "горище",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горло",
+      "slug": "горло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гормон",
+      "slug": "гормон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "город",
+      "slug": "город",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горі",
+      "slug": "горі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горілка",
+      "slug": "горілка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горіти",
+      "slug": "горіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "горіх",
+      "slug": "горіх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "господар",
+      "slug": "господар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гострий",
+      "slug": "гострий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гострота",
+      "slug": "гострота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "готель",
+      "slug": "готель",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "готовий",
+      "slug": "готовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "готувати",
+      "slug": "готувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "готуватися",
+      "slug": "готуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "готівка",
+      "slug": "готівка",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "гра",
+      "slug": "гра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грабувати",
+      "slug": "грабувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гравюра",
+      "slug": "гравюра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "градус",
+      "slug": "градус",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грам",
+      "slug": "грам",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грати",
+      "slug": "грати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "графіка",
+      "slug": "графіка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "граціозний",
+      "slug": "граціозний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грек",
+      "slug": "грек",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грецький",
+      "slug": "грецький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гречка",
+      "slug": "гречка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гриб",
+      "slug": "гриб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "григоріанський",
+      "slug": "григоріанський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гризти",
+      "slug": "гризти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гризун",
+      "slug": "гризун",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "грип",
+      "slug": "грип",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гроза",
+      "slug": "гроза",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "громада",
+      "slug": "громада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "громадський",
+      "slug": "громадський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "громадянин",
+      "slug": "громадянин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "громіздкий",
+      "slug": "громіздкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гроно",
+      "slug": "гроно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грошовий",
+      "slug": "грошовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гроші",
+      "slug": "гроші",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грубий",
+      "slug": "грубий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "грудень",
+      "slug": "грудень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "груди",
+      "slug": "груди",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "група",
+      "slug": "група",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "груша",
+      "slug": "груша",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гріти",
+      "slug": "гріти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гріх",
+      "slug": "гріх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "губа",
+      "slug": "губа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "губний",
+      "slug": "губний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гугл",
+      "slug": "гугл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гуляти",
+      "slug": "гуляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гумка",
+      "slug": "гумка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гумор",
+      "slug": "гумор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гурт",
+      "slug": "гурт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гуртожиток",
+      "slug": "гуртожиток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "густий",
+      "slug": "густий",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "гучний",
+      "slug": "гучний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гігієна",
+      "slug": "гігієна",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гідність",
+      "slug": "гідність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гілка",
+      "slug": "гілка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гілочка",
+      "slug": "гілочка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гіркий",
+      "slug": "гіркий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гірчиця",
+      "slug": "гірчиця",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "гірший",
+      "slug": "гірший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "гітара",
+      "slug": "гітара",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "давати",
+      "slug": "давати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "давній",
+      "slug": "давній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "далекосяжний",
+      "slug": "далекосяжний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "далина",
+      "slug": "далина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "даний",
+      "slug": "даний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дар",
+      "slug": "дар",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дата",
+      "slug": "дата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дати",
+      "slug": "дати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дбати",
+      "slug": "дбати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "двадцять",
+      "slug": "двадцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дванадцятий",
+      "slug": "дванадцятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "двері",
+      "slug": "двері",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "двійнята",
+      "slug": "двійнята",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "двір",
+      "slug": "двір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "двісті",
+      "slug": "двісті",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дев'ятий",
+      "slug": "дев-ятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дев'ять",
+      "slug": "дев-ять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дедалі",
+      "slug": "дедалі",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дедлайн",
+      "slug": "дедлайн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "декілька",
+      "slug": "декілька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "демократія",
+      "slug": "демократія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "демон",
+      "slug": "демон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "денний",
+      "slug": "денний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "день",
+      "slug": "день",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "депресія",
+      "slug": "депресія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "депутат",
+      "slug": "депутат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дерево",
+      "slug": "дерево",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "держава",
+      "slug": "держава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "державний",
+      "slug": "державний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дерти",
+      "slug": "дерти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "десерт",
+      "slug": "десерт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "десятий",
+      "slug": "десятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "десять",
+      "slug": "десять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "деталь",
+      "slug": "деталь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "детектив",
+      "slug": "детектив",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дефіцит",
+      "slug": "дефіцит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дехто",
+      "slug": "дехто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дешевий",
+      "slug": "дешевий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "деякий",
+      "slug": "деякий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "джерело",
+      "slug": "джерело",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "джунглі",
+      "slug": "джунглі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дзвонити",
+      "slug": "дзвонити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дзеркало",
+      "slug": "дзеркало",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дзижчати",
+      "slug": "дзижчати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дивак",
+      "slug": "дивак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "диван",
+      "slug": "диван",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дивитися",
+      "slug": "дивитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дивний",
+      "slug": "дивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "диво",
+      "slug": "диво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дивувати",
+      "slug": "дивувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дивуватися",
+      "slug": "дивуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дизайнер",
+      "slug": "дизайнер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дикий",
+      "slug": "дикий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "динамічний",
+      "slug": "динамічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "династія",
+      "slug": "династія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "динозавр",
+      "slug": "динозавр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "диплом",
+      "slug": "диплом",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дипломат",
+      "slug": "дипломат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "диск",
+      "slug": "диск",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дискусія",
+      "slug": "дискусія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дисципліна",
+      "slug": "дисципліна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дитбудинок",
+      "slug": "дитбудинок",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "дитина",
+      "slug": "дитина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дитинство",
+      "slug": "дитинство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дитятко",
+      "slug": "дитятко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дитячий",
+      "slug": "дитячий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дихальний",
+      "slug": "дихальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дихати",
+      "slug": "дихати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дно",
+      "slug": "дно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доба",
+      "slug": "доба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "добрий",
+      "slug": "добрий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "добробут",
+      "slug": "добробут",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довгий",
+      "slug": "довгий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довгостроковий",
+      "slug": "довгостроковий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довести",
+      "slug": "довести",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довжина",
+      "slug": "довжина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доводити",
+      "slug": "доводити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довший",
+      "slug": "довший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довіра",
+      "slug": "довіра",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довірити",
+      "slug": "довірити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довіряти",
+      "slug": "довіряти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "довічний",
+      "slug": "довічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "догляд",
+      "slug": "догляд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доглядати",
+      "slug": "доглядати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доглянути",
+      "slug": "доглянути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "договір",
+      "slug": "договір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "додавання",
+      "slug": "додавання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "додавати",
+      "slug": "додавати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "додати",
+      "slug": "додати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "додатковий",
+      "slug": "додатковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "додаток",
+      "slug": "додаток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дозволити",
+      "slug": "дозволити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дозволяти",
+      "slug": "дозволяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дозвіл",
+      "slug": "дозвіл",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дозвілля",
+      "slug": "дозвілля",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доказ",
+      "slug": "доказ",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "документ",
+      "slug": "документ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "долар",
+      "slug": "долар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "долати",
+      "slug": "долати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "долина",
+      "slug": "долина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доля",
+      "slug": "доля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "домашній",
+      "slug": "домашній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "домовитися",
+      "slug": "домовитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "домовленість",
+      "slug": "домовленість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "домовлятися",
+      "slug": "домовлятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "домівка",
+      "slug": "домівка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дон",
+      "slug": "дон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "донатити",
+      "slug": "донатити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "донька",
+      "slug": "донька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допис",
+      "slug": "допис",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допити",
+      "slug": "допити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допитливий",
+      "slug": "допитливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допомагати",
+      "slug": "допомагати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допомога",
+      "slug": "допомога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допомогти",
+      "slug": "допомогти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допуст",
+      "slug": "допуст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "допустити",
+      "slug": "допустити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дорога",
+      "slug": "дорога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дорогий",
+      "slug": "дорогий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дорожній",
+      "slug": "дорожній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дорожчий",
+      "slug": "дорожчий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дорослий",
+      "slug": "дорослий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досвід",
+      "slug": "досвід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дослідження",
+      "slug": "дослідження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досліджувати",
+      "slug": "досліджувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дослідник",
+      "slug": "дослідник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "достатній",
+      "slug": "достатній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "достаток",
+      "slug": "достаток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доступ",
+      "slug": "доступ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доступний",
+      "slug": "доступний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досягати",
+      "slug": "досягати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досягнення",
+      "slug": "досягнення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досягнути",
+      "slug": "досягнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "досягти",
+      "slug": "досягти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дотик",
+      "slug": "дотик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дотичний",
+      "slug": "дотичний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дотла",
+      "slug": "дотла",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "доторкнутися",
+      "slug": "доторкнутися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "дотримуватися",
+      "slug": "дотримуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дофамін",
+      "slug": "дофамін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "доходити",
+      "slug": "доходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дохід",
+      "slug": "дохід",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дошка",
+      "slug": "дошка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дощ",
+      "slug": "дощ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дощити",
+      "slug": "дощити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дощовик",
+      "slug": "дощовик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "драбина",
+      "slug": "драбина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "драма",
+      "slug": "драма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дратувати",
+      "slug": "дратувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дробовий",
+      "slug": "дробовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дрова",
+      "slug": "дрова",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дрон",
+      "slug": "дрон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "друг",
+      "slug": "друг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "другий",
+      "slug": "другий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дружина",
+      "slug": "дружина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дрібний",
+      "slug": "дрібний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дрімати",
+      "slug": "дрімати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дуб",
+      "slug": "дуб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дума",
+      "slug": "дума",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "думати",
+      "slug": "думати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "думка",
+      "slug": "думка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дурень",
+      "slug": "дурень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дурний",
+      "slug": "дурний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дурниця",
+      "slug": "дурниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "душа",
+      "slug": "душа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дьоготь",
+      "slug": "дьоготь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дядько",
+      "slug": "дядько",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дякувати",
+      "slug": "дякувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діабет",
+      "slug": "діабет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діагноз",
+      "slug": "діагноз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діаметр",
+      "slug": "діаметр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діарея",
+      "slug": "діарея",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дівчатко",
+      "slug": "дівчатко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дівчина",
+      "slug": "дівчина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дівчинка",
+      "slug": "дівчинка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дідух",
+      "slug": "дідух",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дізнатися",
+      "slug": "дізнатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дійти",
+      "slug": "дійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ділення",
+      "slug": "ділення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ділити",
+      "slug": "ділити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ділитися",
+      "slug": "ділитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діло",
+      "slug": "діло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діловий",
+      "slug": "діловий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дільник",
+      "slug": "дільник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дільниця",
+      "slug": "дільниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ділянка",
+      "slug": "ділянка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дім",
+      "slug": "дім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діставати",
+      "slug": "діставати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "діставатися",
+      "slug": "діставатися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "дістати",
+      "slug": "дістати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дістатися",
+      "slug": "дістатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дія",
+      "slug": "дія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діяльність",
+      "slug": "діяльність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діяти",
+      "slug": "діяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "діяч",
+      "slug": "діяч",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дієслово",
+      "slug": "дієслово",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "дієта",
+      "slug": "дієта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ейфорія",
+      "slug": "ейфорія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "екзамен",
+      "slug": "екзамен",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "екологічний",
+      "slug": "екологічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "екологія",
+      "slug": "екологія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "економити",
+      "slug": "економити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "екран",
+      "slug": "екран",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "екскурсія",
+      "slug": "екскурсія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "експеримент",
+      "slug": "експеримент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "експерт",
+      "slug": "експерт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "елемент",
+      "slug": "елемент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "еліта",
+      "slug": "еліта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "емоційний",
+      "slug": "емоційний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "емоційність",
+      "slug": "емоційність",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "емоція",
+      "slug": "емоція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "енергія",
+      "slug": "енергія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "епідемічний",
+      "slug": "епідемічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "епідемія",
+      "slug": "епідемія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ера",
+      "slug": "ера",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ерудиція",
+      "slug": "ерудиція",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "естафета",
+      "slug": "естафета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "етап",
+      "slug": "етап",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "етер",
+      "slug": "етер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ефект",
+      "slug": "ефект",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ефективний",
+      "slug": "ефективний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ешелон",
+      "slug": "ешелон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жаба",
+      "slug": "жаба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жайворонок",
+      "slug": "жайворонок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жалюгідний",
+      "slug": "жалюгідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жарт",
+      "slug": "жарт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жах",
+      "slug": "жах",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жахливий",
+      "slug": "жахливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жвавий",
+      "slug": "жвавий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жебракувати",
+      "slug": "жебракувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жертва",
+      "slug": "жертва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жертвувати",
+      "slug": "жертвувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "живий",
+      "slug": "живий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "живлення",
+      "slug": "живлення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "живіт",
+      "slug": "живіт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жила",
+      "slug": "жила",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жир",
+      "slug": "жир",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жирний",
+      "slug": "жирний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жити",
+      "slug": "жити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "життя",
+      "slug": "життя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "життєвий",
+      "slug": "життєвий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "життєпис",
+      "slug": "життєпис",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жовтень",
+      "slug": "жовтень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жовтий",
+      "slug": "жовтий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жовток",
+      "slug": "жовток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жодний",
+      "slug": "жодний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жорстко",
+      "slug": "жорстко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жорстоко",
+      "slug": "жорстоко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жувати",
+      "slug": "жувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жук",
+      "slug": "жук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "журнал",
+      "slug": "журнал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "журналіст",
+      "slug": "журналіст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жінка",
+      "slug": "жінка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "жіночий",
+      "slug": "жіночий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "з'явитися",
+      "slug": "з-явитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "з'являтися",
+      "slug": "з-являтися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "з'ясувальний",
+      "slug": "з-ясувальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "з'ясувати",
+      "slug": "з-ясувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "з'їсти",
+      "slug": "з-їсти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забезпечений",
+      "slug": "забезпечений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забезпечення",
+      "slug": "забезпечення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забезпечити",
+      "slug": "забезпечити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забирати",
+      "slug": "забирати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забити",
+      "slug": "забити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забобон",
+      "slug": "забобон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заборонити",
+      "slug": "заборонити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забрати",
+      "slug": "забрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забронювати",
+      "slug": "забронювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забувати",
+      "slug": "забувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "забути",
+      "slug": "забути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завадити",
+      "slug": "завадити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заважати",
+      "slug": "заважати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завантажити",
+      "slug": "завантажити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "завантажувати",
+      "slug": "завантажувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "завдання",
+      "slug": "завдання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завершити",
+      "slug": "завершити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завестися",
+      "slug": "завестися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зависати",
+      "slug": "зависати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зависнути",
+      "slug": "зависнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заводитися",
+      "slug": "заводитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завоювати",
+      "slug": "завоювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завчасно",
+      "slug": "завчасно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "завіса",
+      "slug": "завіса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загадка",
+      "slug": "загадка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загадковий",
+      "slug": "загадковий",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "загальмувати",
+      "slug": "загальмувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загальний",
+      "slug": "загальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загартовуватися",
+      "slug": "загартовуватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загиблий",
+      "slug": "загиблий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загинути",
+      "slug": "загинути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загострення",
+      "slug": "загострення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загрожувати",
+      "slug": "загрожувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загроза",
+      "slug": "загроза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загубити",
+      "slug": "загубити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загубитися",
+      "slug": "загубитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загублений",
+      "slug": "загублений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "загін",
+      "slug": "загін",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задача",
+      "slug": "задача",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задзвонити",
+      "slug": "задзвонити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задній",
+      "slug": "задній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задоволений",
+      "slug": "задоволений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задоволення",
+      "slug": "задоволення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "задумати",
+      "slug": "задумати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зазнати",
+      "slug": "зазнати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зазначати",
+      "slug": "зазначати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зазначити",
+      "slug": "зазначити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зайвий",
+      "slug": "зайвий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "займати",
+      "slug": "займати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "займатися",
+      "slug": "займатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "займенник",
+      "slug": "займенник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зайняти",
+      "slug": "зайняти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зайнятий",
+      "slug": "зайнятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зайти",
+      "slug": "зайти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закинути",
+      "slug": "закинути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заклад",
+      "slug": "заклад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закласти",
+      "slug": "закласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заклик",
+      "slug": "заклик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заколот",
+      "slug": "заколот",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закон",
+      "slug": "закон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "законодавство",
+      "slug": "законодавство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закономірність",
+      "slug": "закономірність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закордонний",
+      "slug": "закордонний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закрити",
+      "slug": "закрити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закритий",
+      "slug": "закритий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закричати",
+      "slug": "закричати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закінчити",
+      "slug": "закінчити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "закінчувати",
+      "slug": "закінчувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "закінчуватися",
+      "slug": "закінчуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залежати",
+      "slug": "залежати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залежність",
+      "slug": "залежність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залишати",
+      "slug": "залишати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залишатися",
+      "slug": "залишатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залишити",
+      "slug": "залишити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залишитися",
+      "slug": "залишитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залишок",
+      "slug": "залишок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залоза",
+      "slug": "залоза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залучати",
+      "slug": "залучати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залучити",
+      "slug": "залучити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залізний",
+      "slug": "залізний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "залізо",
+      "slug": "залізо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замерзнути",
+      "slug": "замерзнути",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "замикати",
+      "slug": "замикати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замкнений",
+      "slug": "замкнений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замкнути",
+      "slug": "замкнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замкнутий",
+      "slug": "замкнутий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замовити",
+      "slug": "замовити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замовкати",
+      "slug": "замовкати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "замовкнути",
+      "slug": "замовкнути",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "замовляти",
+      "slug": "замовляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заможний",
+      "slug": "заможний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замок",
+      "slug": "замок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заміна",
+      "slug": "заміна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замінити",
+      "slug": "замінити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "замісити",
+      "slug": "замісити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "занести",
+      "slug": "занести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заносити",
+      "slug": "заносити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заняття",
+      "slug": "заняття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заохотити",
+      "slug": "заохотити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заохочувати",
+      "slug": "заохочувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заощаджувати",
+      "slug": "заощаджувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запалити",
+      "slug": "запалити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запальничка",
+      "slug": "запальничка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запалювати",
+      "slug": "запалювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запам'ятати",
+      "slug": "запам-ятати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запанувати",
+      "slug": "запанувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "заперечення",
+      "slug": "заперечення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заперечити",
+      "slug": "заперечити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "заперечувати",
+      "slug": "заперечувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запечений",
+      "slug": "запечений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запис",
+      "slug": "запис",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "записати",
+      "slug": "записати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "записка",
+      "slug": "записка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "записувати",
+      "slug": "записувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запит",
+      "slug": "запит",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запитання",
+      "slug": "запитання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запитати",
+      "slug": "запитати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запитувати",
+      "slug": "запитувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запланувати",
+      "slug": "запланувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заплатити",
+      "slug": "заплатити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заплутаний",
+      "slug": "заплутаний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заплутатися",
+      "slug": "заплутатися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "запліснявілий",
+      "slug": "запліснявілий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запобігати",
+      "slug": "запобігати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запобігти",
+      "slug": "запобігти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "заповнити",
+      "slug": "заповнити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запроваджувати",
+      "slug": "запроваджувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запровадити",
+      "slug": "запровадити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запропонувати",
+      "slug": "запропонувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запросити",
+      "slug": "запросити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запустити",
+      "slug": "запустити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запізнитися",
+      "slug": "запізнитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "запізнюватися",
+      "slug": "запізнюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заражатися",
+      "slug": "заражатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заразитися",
+      "slug": "заразитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зарити",
+      "slug": "зарити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зарплата",
+      "slug": "зарплата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засвоювати",
+      "slug": "засвоювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засвоюватися",
+      "slug": "засвоюватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засвоєння",
+      "slug": "засвоєння",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "засвітити",
+      "slug": "засвітити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "засинати",
+      "slug": "засинати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заслуга",
+      "slug": "заслуга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засмага",
+      "slug": "засмага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засмагати",
+      "slug": "засмагати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заснути",
+      "slug": "заснути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заспокоюватися",
+      "slug": "заспокоюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заспокоїтися",
+      "slug": "заспокоїтися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заспокійливий",
+      "slug": "заспокійливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застава",
+      "slug": "застава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застати",
+      "slug": "застати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застосовувати",
+      "slug": "застосовувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застосунок",
+      "slug": "застосунок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застрягати",
+      "slug": "застрягати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застрягнути",
+      "slug": "застрягнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застуда",
+      "slug": "застуда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "застій",
+      "slug": "застій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засуджувати",
+      "slug": "засуджувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "засудити",
+      "slug": "засудити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "засяяти",
+      "slug": "засяяти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "засіб",
+      "slug": "засіб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "затамувати",
+      "slug": "затамувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зателефонувати",
+      "slug": "зателефонувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "затишний",
+      "slug": "затишний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "затримати",
+      "slug": "затримати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "затримка",
+      "slug": "затримка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "затримувати",
+      "slug": "затримувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "затягувати",
+      "slug": "затягувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зафіксувати",
+      "slug": "зафіксувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захаращений",
+      "slug": "захаращений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захворювання",
+      "slug": "захворювання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захворюваність",
+      "slug": "захворюваність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захворіти",
+      "slug": "захворіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захисний",
+      "slug": "захисний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захисник",
+      "slug": "захисник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захист",
+      "slug": "захист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захистити",
+      "slug": "захистити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захищати",
+      "slug": "захищати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заховати",
+      "slug": "заховати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заходити",
+      "slug": "заходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захопити",
+      "slug": "захопити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захопитися",
+      "slug": "захопитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захоплювати",
+      "slug": "захоплювати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "захоплюватися",
+      "slug": "захоплюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захотіти",
+      "slug": "захотіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "захід",
+      "slug": "захід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "західний",
+      "slug": "західний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зачекати",
+      "slug": "зачекати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зачіпати",
+      "slug": "зачіпати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заява",
+      "slug": "заява",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заявка",
+      "slug": "заявка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заїжджати",
+      "slug": "заїжджати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "заїхати",
+      "slug": "заїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збалансований",
+      "slug": "збалансований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зберегти",
+      "slug": "зберегти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збереження",
+      "slug": "збереження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зберігати",
+      "slug": "зберігати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зберігатися",
+      "slug": "зберігатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збивати",
+      "slug": "збивати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збирати",
+      "slug": "збирати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збиратися",
+      "slug": "збиратися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збити",
+      "slug": "збити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збиток",
+      "slug": "збиток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збрехати",
+      "slug": "збрехати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зброя",
+      "slug": "зброя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збудований",
+      "slug": "збудований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збій",
+      "slug": "збій",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збільшення",
+      "slug": "збільшення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збільшувати",
+      "slug": "збільшувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "збірка",
+      "slug": "збірка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зважати",
+      "slug": "зважати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зважити",
+      "slug": "зважити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "званий",
+      "slug": "званий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звати",
+      "slug": "звати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звернути",
+      "slug": "звернути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звернутися",
+      "slug": "звернутися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звертати",
+      "slug": "звертати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звести",
+      "slug": "звести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звинуватити",
+      "slug": "звинуватити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звинувачувати",
+      "slug": "звинувачувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звичай",
+      "slug": "звичай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звичайний",
+      "slug": "звичайний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звичка",
+      "slug": "звичка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зводити",
+      "slug": "зводити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зволожити",
+      "slug": "зволожити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зволожувати",
+      "slug": "зволожувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зволікати",
+      "slug": "зволікати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зворотний",
+      "slug": "зворотний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звук",
+      "slug": "звук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звучати",
+      "slug": "звучати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звільнити",
+      "slug": "звільнити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звільнитися",
+      "slug": "звільнитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звільняти",
+      "slug": "звільняти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "звільнятися",
+      "slug": "звільнятися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "звістка",
+      "slug": "звістка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "звіт",
+      "slug": "звіт",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згадати",
+      "slug": "згадати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згадка",
+      "slug": "згадка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згадувати",
+      "slug": "згадувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згода",
+      "slug": "згода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згодний",
+      "slug": "згодний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згодом",
+      "slug": "згодом",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "згоріти",
+      "slug": "згоріти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здаватися",
+      "slug": "здаватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здавна",
+      "slug": "здавна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здатися",
+      "slug": "здатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здатний",
+      "slug": "здатний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здатність",
+      "slug": "здатність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здерти",
+      "slug": "здерти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здивований",
+      "slug": "здивований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здивувати",
+      "slug": "здивувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здобути",
+      "slug": "здобути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здогадатися",
+      "slug": "здогадатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здоров'я",
+      "slug": "здоров-я",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здоровий",
+      "slug": "здоровий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здібність",
+      "slug": "здібність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "здійснювати",
+      "slug": "здійснювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зелений",
+      "slug": "зелений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зеленіти",
+      "slug": "зеленіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "землетрус",
+      "slug": "землетрус",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "земля",
+      "slug": "земля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "земний",
+      "slug": "земний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зерно",
+      "slug": "зерно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зима",
+      "slug": "зима",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зимовий",
+      "slug": "зимовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зламаний",
+      "slug": "зламаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зламати",
+      "slug": "зламати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злива",
+      "slug": "злива",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злий",
+      "slug": "злий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зловити",
+      "slug": "зловити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злодій",
+      "slug": "злодій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злочин",
+      "slug": "злочин",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злочинець",
+      "slug": "злочинець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злочинність",
+      "slug": "злочинність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злякатися",
+      "slug": "злякатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "злість",
+      "slug": "злість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змагання",
+      "slug": "змагання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зменшити",
+      "slug": "зменшити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зменшувати",
+      "slug": "зменшувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зменшуватися",
+      "slug": "зменшуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змога",
+      "slug": "змога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змогти",
+      "slug": "змогти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змусити",
+      "slug": "змусити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змушений",
+      "slug": "змушений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ЗМІ",
+      "slug": "змі",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зміна",
+      "slug": "зміна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змінити",
+      "slug": "змінити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змінитися",
+      "slug": "змінитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змінювати",
+      "slug": "змінювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "змінюватися",
+      "slug": "змінюватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зміст",
+      "slug": "зміст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знадобитися",
+      "slug": "знадобитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знайомий",
+      "slug": "знайомий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знайомство",
+      "slug": "знайомство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знайти",
+      "slug": "знайти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знак",
+      "slug": "знак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знаменитість",
+      "slug": "знаменитість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знання",
+      "slug": "знання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знати",
+      "slug": "знати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знахар",
+      "slug": "знахар",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знаходити",
+      "slug": "знаходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знаходитися",
+      "slug": "знаходитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знахідний",
+      "slug": "знахідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "значення",
+      "slug": "значення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "значити",
+      "slug": "значити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "значний",
+      "slug": "значний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зневага",
+      "slug": "зневага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зневажати",
+      "slug": "зневажати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зневоднення",
+      "slug": "зневоднення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знепритомніти",
+      "slug": "знепритомніти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знецінення",
+      "slug": "знецінення",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зниження",
+      "slug": "зниження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знижка",
+      "slug": "знижка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знижувати",
+      "slug": "знижувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зникати",
+      "slug": "зникати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зникнути",
+      "slug": "зникнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знищити",
+      "slug": "знищити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зносити",
+      "slug": "зносити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знудити",
+      "slug": "знудити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знущатися",
+      "slug": "знущатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зняти",
+      "slug": "зняти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "знімати",
+      "slug": "знімати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зокрема",
+      "slug": "зокрема",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "золотий",
+      "slug": "золотий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зомліти",
+      "slug": "зомліти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зона",
+      "slug": "зона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зоряний",
+      "slug": "зоряний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зосереджуватися",
+      "slug": "зосереджуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зосередитися",
+      "slug": "зосередитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зошит",
+      "slug": "зошит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрада",
+      "slug": "зрада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зраджувати",
+      "slug": "зраджувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "зрадити",
+      "slug": "зрадити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрадник",
+      "slug": "зрадник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрештою",
+      "slug": "зрештою",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрив",
+      "slug": "зрив",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зробити",
+      "slug": "зробити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрозуміти",
+      "slug": "зрозуміти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зростати",
+      "slug": "зростати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зруйнований",
+      "slug": "зруйнований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зручний",
+      "slug": "зручний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зрілість",
+      "slug": "зрілість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зріст",
+      "slug": "зріст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зріти",
+      "slug": "зріти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зуб",
+      "slug": "зуб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зубний",
+      "slug": "зубний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зуміти",
+      "slug": "зуміти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зупинити",
+      "slug": "зупинити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зупинитися",
+      "slug": "зупинитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зупинка",
+      "slug": "зупинка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зупинятися",
+      "slug": "зупинятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зусилля",
+      "slug": "зусилля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зустріти",
+      "slug": "зустріти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зустрітися",
+      "slug": "зустрітися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зустріч",
+      "slug": "зустріч",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зустрічати",
+      "slug": "зустрічати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зустрічатися",
+      "slug": "зустрічатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зухвалий",
+      "slug": "зухвалий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зібрати",
+      "slug": "зібрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зіграти",
+      "slug": "зіграти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зійти",
+      "slug": "зійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зіпсований",
+      "slug": "зіпсований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зіпсувати",
+      "slug": "зіпсувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зіпсуватися",
+      "slug": "зіпсуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зірватися",
+      "slug": "зірватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "зірка",
+      "slug": "зірка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ймовірність",
+      "slug": "ймовірність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "йти",
+      "slug": "йти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кабан",
+      "slug": "кабан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кабачок",
+      "slug": "кабачок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каблук",
+      "slug": "каблук",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "кабінет",
+      "slug": "кабінет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кав'ярня",
+      "slug": "кав-ярня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кава",
+      "slug": "кава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "казати",
+      "slug": "казати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "казка",
+      "slug": "казка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "календар",
+      "slug": "календар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "календарний",
+      "slug": "календарний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "калорія",
+      "slug": "калорія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "калькувати",
+      "slug": "калькувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "калюжа",
+      "slug": "калюжа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каліграфія",
+      "slug": "каліграфія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "камера",
+      "slug": "камера",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кампанія",
+      "slug": "кампанія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "камін",
+      "slug": "камін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "камінь",
+      "slug": "камінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кандидат",
+      "slug": "кандидат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "капець",
+      "slug": "капець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "капуста",
+      "slug": "капуста",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "капітан",
+      "slug": "капітан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кара",
+      "slug": "кара",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "карамель",
+      "slug": "карамель",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "карантин",
+      "slug": "карантин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "карати",
+      "slug": "карати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "карта",
+      "slug": "карта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "картина",
+      "slug": "картина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "картка",
+      "slug": "картка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "картопля",
+      "slug": "картопля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "карієс",
+      "slug": "карієс",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каса",
+      "slug": "каса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "касирка",
+      "slug": "касирка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каструля",
+      "slug": "каструля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кат",
+      "slug": "кат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каталог",
+      "slug": "каталог",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кататися",
+      "slug": "кататися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "категорія",
+      "slug": "категорія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "католик",
+      "slug": "католик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "качка",
+      "slug": "качка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кашляти",
+      "slug": "кашляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "каштан",
+      "slug": "каштан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квартал",
+      "slug": "квартал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квартира",
+      "slug": "квартира",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квашений",
+      "slug": "квашений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квиток",
+      "slug": "квиток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квітень",
+      "slug": "квітень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квіти",
+      "slug": "квіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квітка",
+      "slug": "квітка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "квітник",
+      "slug": "квітник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кепський",
+      "slug": "кепський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кермо",
+      "slug": "кермо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "керувати",
+      "slug": "керувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "керівник",
+      "slug": "керівник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "керівництво",
+      "slug": "керівництво",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кивати",
+      "slug": "кивати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кивнути",
+      "slug": "кивнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кидати",
+      "slug": "кидати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кий",
+      "slug": "кий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "килим",
+      "slug": "килим",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кинути",
+      "slug": "кинути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кипіти",
+      "slug": "кипіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кисломолочний",
+      "slug": "кисломолочний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "киця",
+      "slug": "киця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кишеньковий",
+      "slug": "кишеньковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кишеня",
+      "slug": "кишеня",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кишківник",
+      "slug": "кишківник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "київський",
+      "slug": "київський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клавіатура",
+      "slug": "клавіатура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клас",
+      "slug": "клас",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "класти",
+      "slug": "класти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клацати",
+      "slug": "клацати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клеїти",
+      "slug": "клеїти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "кликати",
+      "slug": "кликати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кличний",
+      "slug": "кличний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клуб",
+      "slug": "клуб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клумба",
+      "slug": "клумба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ключ",
+      "slug": "ключ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ключовий",
+      "slug": "ключовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клястися",
+      "slug": "клястися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "клятий",
+      "slug": "клятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клімат",
+      "slug": "клімат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клітина",
+      "slug": "клітина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клітка",
+      "slug": "клітка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клітковина",
+      "slug": "клітковина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кліщ",
+      "slug": "кліщ",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "клієнт",
+      "slug": "клієнт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "книга",
+      "slug": "книга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "книголюб",
+      "slug": "книголюб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "книжка",
+      "slug": "книжка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "книжковий",
+      "slug": "книжковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "книжний",
+      "slug": "книжний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кнопка",
+      "slug": "кнопка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "князь",
+      "slug": "князь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коала",
+      "slug": "коала",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ковдра",
+      "slug": "ковдра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ковзанка",
+      "slug": "ковзанка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ковтати",
+      "slug": "ковтати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "когнітивний",
+      "slug": "когнітивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кодекс",
+      "slug": "кодекс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кожний",
+      "slug": "кожний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коза",
+      "slug": "коза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "козак",
+      "slug": "козак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "козаків",
+      "slug": "козаків",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "козацтво",
+      "slug": "козацтво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "козацький",
+      "slug": "козацький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коктейль",
+      "slug": "коктейль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колега",
+      "slug": "колега",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колегіум",
+      "slug": "колегіум",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колегія",
+      "slug": "колегія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колесо",
+      "slug": "колесо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коли",
+      "slug": "коли",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колишній",
+      "slug": "колишній",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колода",
+      "slug": "колода",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "колокація",
+      "slug": "колокація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колосальний",
+      "slug": "колосальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кольоровий",
+      "slug": "кольоровий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коліно",
+      "slug": "коліно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "колір",
+      "slug": "колір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кома",
+      "slug": "кома",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "команда",
+      "slug": "команда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "командний",
+      "slug": "командний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "комар",
+      "slug": "комар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "комаха",
+      "slug": "комаха",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "комбінувати",
+      "slug": "комбінувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коментар",
+      "slug": "коментар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "комора",
+      "slug": "комора",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "комп'ютер",
+      "slug": "комп-ютер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "компакт-диск",
+      "slug": "компакт-диск",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "компанія",
+      "slug": "компанія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конкретний",
+      "slug": "конкретний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конкурент",
+      "slug": "конкурент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "консерва",
+      "slug": "консерва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конструкція",
+      "slug": "конструкція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "контакт",
+      "slug": "контакт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "контекст",
+      "slug": "контекст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "контракт",
+      "slug": "контракт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "контроль",
+      "slug": "контроль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "контролювати",
+      "slug": "контролювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конференція",
+      "slug": "конференція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конфлікт",
+      "slug": "конфлікт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "конфорка",
+      "slug": "конфорка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "концентрація",
+      "slug": "концентрація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "концентруватися",
+      "slug": "концентруватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "концерт",
+      "slug": "концерт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "копалина",
+      "slug": "копалина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "копчений",
+      "slug": "копчений",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "копійка",
+      "slug": "копійка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корабель",
+      "slug": "корабель",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кордон",
+      "slug": "кордон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корисний",
+      "slug": "корисний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "користуватися",
+      "slug": "користуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "користувач",
+      "slug": "користувач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кориця",
+      "slug": "кориця",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корм",
+      "slug": "корм",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "коробка",
+      "slug": "коробка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корова",
+      "slug": "корова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "король",
+      "slug": "король",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корона",
+      "slug": "корона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "короткий",
+      "slug": "короткий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "короткочасний",
+      "slug": "короткочасний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корт",
+      "slug": "корт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "корінь",
+      "slug": "корінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коса",
+      "slug": "коса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "косметолог",
+      "slug": "косметолог",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "космос",
+      "slug": "космос",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "котельня",
+      "slug": "котельня",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "котик",
+      "slug": "котик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "котитися",
+      "slug": "котитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "котлета",
+      "slug": "котлета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кофеїн",
+      "slug": "кофеїн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кохання",
+      "slug": "кохання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кохати",
+      "slug": "кохати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кошеня",
+      "slug": "кошеня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кошик",
+      "slug": "кошик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кошмар",
+      "slug": "кошмар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кошовий",
+      "slug": "кошовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кошт",
+      "slug": "кошт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "коштувати",
+      "slug": "коштувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крадій",
+      "slug": "крадій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кран",
+      "slug": "кран",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крапка",
+      "slug": "крапка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "красивий",
+      "slug": "красивий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "красти",
+      "slug": "красти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кращий",
+      "slug": "кращий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "краєвид",
+      "slug": "краєвид",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "країна",
+      "slug": "країна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "креветка",
+      "slug": "креветка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крем",
+      "slug": "крем",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "криза",
+      "slug": "криза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крик",
+      "slug": "крик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крило",
+      "slug": "крило",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крити",
+      "slug": "крити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "критик",
+      "slug": "критик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "критичний",
+      "slug": "критичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кричати",
+      "slug": "кричати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кров",
+      "slug": "кров",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крок",
+      "slug": "крок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кролик",
+      "slug": "кролик",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кросівка",
+      "slug": "кросівка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "круглий",
+      "slug": "круглий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кругом",
+      "slug": "кругом",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "крупа",
+      "slug": "крупа",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крутий",
+      "slug": "крутий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крутити",
+      "slug": "крутити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "крісло",
+      "slug": "крісло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кубічний",
+      "slug": "кубічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "культура",
+      "slug": "культура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "культурний",
+      "slug": "культурний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кулінарний",
+      "slug": "кулінарний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купа",
+      "slug": "купа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купатися",
+      "slug": "купатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купець",
+      "slug": "купець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купити",
+      "slug": "купити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купол",
+      "slug": "купол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "купувати",
+      "slug": "купувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кур'єр",
+      "slug": "кур-єр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "куратор",
+      "slug": "куратор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "курс",
+      "slug": "курс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "куртка",
+      "slug": "куртка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "курча",
+      "slug": "курча",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "курятина",
+      "slug": "курятина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "курячий",
+      "slug": "курячий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "куріння",
+      "slug": "куріння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "курінь",
+      "slug": "курінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "куток",
+      "slug": "куток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "куточок",
+      "slug": "куточок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кутя",
+      "slug": "кутя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кухня",
+      "slug": "кухня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кухонний",
+      "slug": "кухонний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кущ",
+      "slug": "кущ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кшталт",
+      "slug": "кшталт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кіл",
+      "slug": "кіл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кілограм",
+      "slug": "кілограм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кілометр",
+      "slug": "кілометр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кілька",
+      "slug": "кілька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кількісний",
+      "slug": "кількісний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кількість",
+      "slug": "кількість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кільце",
+      "slug": "кільце",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кімната",
+      "slug": "кімната",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кінець",
+      "slug": "кінець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кінотеатр",
+      "slug": "кінотеатр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кінь",
+      "slug": "кінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кістка",
+      "slug": "кістка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кіт",
+      "slug": "кіт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "кішка",
+      "slug": "кішка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лава",
+      "slug": "лава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лавка",
+      "slug": "лавка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лад",
+      "slug": "лад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ладан",
+      "slug": "ладан",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лазанья",
+      "slug": "лазанья",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лактоза",
+      "slug": "лактоза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ламати",
+      "slug": "ламати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лампочка",
+      "slug": "лампочка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лапа",
+      "slug": "лапа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ласка",
+      "slug": "ласка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ластовиння",
+      "slug": "ластовиння",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "лев",
+      "slug": "лев",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "легенда",
+      "slug": "легенда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "легкий",
+      "slug": "легкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лежати",
+      "slug": "лежати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лексика",
+      "slug": "лексика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лекція",
+      "slug": "лекція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лелека",
+      "slug": "лелека",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "летіти",
+      "slug": "летіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лимон",
+      "slug": "лимон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "линяти",
+      "slug": "линяти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "липень",
+      "slug": "липень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "липкий",
+      "slug": "липкий",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "лисиця",
+      "slug": "лисиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лист",
+      "slug": "лист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "листопад",
+      "slug": "листопад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лити",
+      "slug": "лити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лихоманка",
+      "slug": "лихоманка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лицар",
+      "slug": "лицар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лице",
+      "slug": "лице",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лоб",
+      "slug": "лоб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "логіка",
+      "slug": "логіка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "логічний",
+      "slug": "логічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ложка",
+      "slug": "ложка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лотерея",
+      "slug": "лотерея",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лоток",
+      "slug": "лоток",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "лука",
+      "slug": "лука",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лунати",
+      "slug": "лунати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "львівський",
+      "slug": "львівський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "льодовий",
+      "slug": "льодовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "льодяник",
+      "slug": "льодяник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "любити",
+      "slug": "любити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "люблячий",
+      "slug": "люблячий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "любов",
+      "slug": "любов",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "людина",
+      "slug": "людина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "людство",
+      "slug": "людство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "людський",
+      "slug": "людський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "людяний",
+      "slug": "людяний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "люлька",
+      "slug": "люлька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лютий",
+      "slug": "лютий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лягати",
+      "slug": "лягати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лякати",
+      "slug": "лякати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лячно",
+      "slug": "лячно",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лід",
+      "slug": "лід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лідер",
+      "slug": "лідер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ліжко",
+      "slug": "ліжко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лікар",
+      "slug": "лікар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лікарня",
+      "slug": "лікарня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лікарняний",
+      "slug": "лікарняний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ліки",
+      "slug": "ліки",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лікування",
+      "slug": "лікування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лікувати",
+      "slug": "лікувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лінгвіст",
+      "slug": "лінгвіст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лінивий",
+      "slug": "лінивий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "лінія",
+      "slug": "лінія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ліпити",
+      "slug": "ліпити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ліс",
+      "slug": "ліс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літ",
+      "slug": "літ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літак",
+      "slug": "літак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літати",
+      "slug": "літати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літера",
+      "slug": "літера",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літній",
+      "slug": "літній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "літр",
+      "slug": "літр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ліфт",
+      "slug": "ліфт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "м'яз",
+      "slug": "м-яз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "м'який",
+      "slug": "м-який",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "м'ясо",
+      "slug": "м-ясо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "м'яч",
+      "slug": "м-яч",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мавпа",
+      "slug": "мавпа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "магазин",
+      "slug": "магазин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "магнат",
+      "slug": "магнат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "магістратура",
+      "slug": "магістратура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "магічний",
+      "slug": "магічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "магія",
+      "slug": "магія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маз",
+      "slug": "маз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мазепа",
+      "slug": "мазепа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "майбутній",
+      "slug": "майбутній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "майданчик",
+      "slug": "майданчик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "майстер",
+      "slug": "майстер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "майстерня",
+      "slug": "майстерня",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "майя",
+      "slug": "майя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "макарони",
+      "slug": "макарони",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "Максим",
+      "slug": "максим",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маленький",
+      "slug": "маленький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "малеча",
+      "slug": "малеча",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "малий",
+      "slug": "малий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "малювати",
+      "slug": "малювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "малюк",
+      "slug": "малюк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маля",
+      "slug": "маля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мама",
+      "slug": "мама",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мамин",
+      "slug": "мамин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мандрівник",
+      "slug": "мандрівник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мапа",
+      "slug": "мапа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "марафон",
+      "slug": "марафон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маркетинг",
+      "slug": "маркетинг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мартин",
+      "slug": "мартин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маса",
+      "slug": "маса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "масло",
+      "slug": "масло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "масовий",
+      "slug": "масовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "масштаб",
+      "slug": "масштаб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "математик",
+      "slug": "математик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "матеріал",
+      "slug": "матеріал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мати",
+      "slug": "мати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "матрац",
+      "slug": "матрац",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "матюкатися",
+      "slug": "матюкатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "машина",
+      "slug": "машина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "маєток",
+      "slug": "маєток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "меблі",
+      "slug": "меблі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мед",
+      "slug": "мед",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "медитація",
+      "slug": "медитація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "медицина",
+      "slug": "медицина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "медичний",
+      "slug": "медичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "медовий",
+      "slug": "медовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "межа",
+      "slug": "межа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мелатонін",
+      "slug": "мелатонін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "менеджер",
+      "slug": "менеджер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "менеджмент",
+      "slug": "менеджмент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "менший",
+      "slug": "менший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "меншість",
+      "slug": "меншість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мер",
+      "slug": "мер",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мережа",
+      "slug": "мережа",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мерзнути",
+      "slug": "мерзнути",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "мертвий",
+      "slug": "мертвий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мета",
+      "slug": "мета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "метаболізм",
+      "slug": "метаболізм",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "метод",
+      "slug": "метод",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "метр",
+      "slug": "метр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "механізм",
+      "slug": "механізм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мешканець",
+      "slug": "мешканець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ми",
+      "slug": "ми",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "милий",
+      "slug": "милий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мило",
+      "slug": "мило",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "минати",
+      "slug": "минати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "минулий",
+      "slug": "минулий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "минути",
+      "slug": "минути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мирний",
+      "slug": "мирний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "миска",
+      "slug": "миска",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мислення",
+      "slug": "мислення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мисливець",
+      "slug": "мисливець",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "мистецтво",
+      "slug": "мистецтво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мити",
+      "slug": "мити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "миша",
+      "slug": "миша",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мишка",
+      "slug": "мишка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "млинець",
+      "slug": "млинець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "млявий",
+      "slug": "млявий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "множина",
+      "slug": "множина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мобілка",
+      "slug": "мобілка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мова",
+      "slug": "мова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мовчати",
+      "slug": "мовчати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "могти",
+      "slug": "могти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "можливий",
+      "slug": "можливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "можливість",
+      "slug": "можливість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мозок",
+      "slug": "мозок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мозоль",
+      "slug": "мозоль",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "мокрий",
+      "slug": "мокрий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "молитва",
+      "slug": "молитва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "молитися",
+      "slug": "молитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "молодий",
+      "slug": "молодий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "молодість",
+      "slug": "молодість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "молоко",
+      "slug": "молоко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "момент",
+      "slug": "момент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "монах",
+      "slug": "монах",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "монета",
+      "slug": "монета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "монумент",
+      "slug": "монумент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "море",
+      "slug": "море",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "морква",
+      "slug": "морква",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мороз",
+      "slug": "мороз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "морозиво",
+      "slug": "морозиво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "морозилка",
+      "slug": "морозилка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "морський",
+      "slug": "морський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "морщити",
+      "slug": "морщити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "москаль",
+      "slug": "москаль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мотивація",
+      "slug": "мотивація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мотивувати",
+      "slug": "мотивувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мотоцикл",
+      "slug": "мотоцикл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мощі",
+      "slug": "мощі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мрія",
+      "slug": "мрія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мріяти",
+      "slug": "мріяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мудрість",
+      "slug": "мудрість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мужній",
+      "slug": "мужній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мужність",
+      "slug": "мужність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "музей",
+      "slug": "музей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "музика",
+      "slug": "музика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "музикант",
+      "slug": "музикант",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "музичний",
+      "slug": "музичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мусити",
+      "slug": "мусити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "муха",
+      "slug": "муха",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мушля",
+      "slug": "мушля",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мігрень",
+      "slug": "мігрень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мій",
+      "slug": "мій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мікробіом",
+      "slug": "мікробіом",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мікрофлора",
+      "slug": "мікрофлора",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мікрофон",
+      "slug": "мікрофон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мікрохвильова піч",
+      "slug": "мікрохвильова-піч",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "мікрохвильовка",
+      "slug": "мікрохвильовка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міксер",
+      "slug": "міксер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мілина",
+      "slug": "мілина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мілкий",
+      "slug": "мілкий",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "мільйон",
+      "slug": "мільйон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мільярд",
+      "slug": "мільярд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мінерал",
+      "slug": "мінерал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мінус",
+      "slug": "мінус",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міняти",
+      "slug": "міняти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мінімум",
+      "slug": "мінімум",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міністерство",
+      "slug": "міністерство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міністр",
+      "slug": "міністр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міра",
+      "slug": "міра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міст",
+      "slug": "міст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "містити",
+      "slug": "містити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місто",
+      "slug": "місто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місце",
+      "slug": "місце",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місцевий",
+      "slug": "місцевий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місцевість",
+      "slug": "місцевість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міський",
+      "slug": "міський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місяць",
+      "slug": "місяць",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "місія",
+      "slug": "місія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міф",
+      "slug": "міф",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "міцний",
+      "slug": "міцний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "мішок",
+      "slug": "мішок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набережна",
+      "slug": "набережна",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "набирати",
+      "slug": "набирати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набити",
+      "slug": "набити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наближатися",
+      "slug": "наближатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наближений",
+      "slug": "наближений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наближення",
+      "slug": "наближення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наблизитися",
+      "slug": "наблизитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набрати",
+      "slug": "набрати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набридати",
+      "slug": "набридати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набриднути",
+      "slug": "набриднути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набувати",
+      "slug": "набувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "набір",
+      "slug": "набір",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навантаження",
+      "slug": "навантаження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навести",
+      "slug": "навести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навичка",
+      "slug": "навичка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навколишній",
+      "slug": "навколишній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навушники",
+      "slug": "навушники",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "навчати",
+      "slug": "навчати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навчатися",
+      "slug": "навчатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навчити",
+      "slug": "навчити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "навчитися",
+      "slug": "навчитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нагадувати",
+      "slug": "нагадувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нагляд",
+      "slug": "нагляд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нагода",
+      "slug": "нагода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нагодувати",
+      "slug": "нагодувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наголошувати",
+      "slug": "наголошувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надавати",
+      "slug": "надавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надалі",
+      "slug": "надалі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надихати",
+      "slug": "надихати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надихнути",
+      "slug": "надихнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надлишок",
+      "slug": "надлишок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надмірний",
+      "slug": "надмірний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надолужити",
+      "slug": "надолужити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надскладний",
+      "slug": "надскладний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надувний",
+      "slug": "надувний",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "надійний",
+      "slug": "надійний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надійти",
+      "slug": "надійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "надіслати",
+      "slug": "надіслати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "Надія",
+      "slug": "надія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "назва",
+      "slug": "назва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "названий",
+      "slug": "названий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "назвати",
+      "slug": "назвати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "називати",
+      "slug": "називати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "називний",
+      "slug": "називний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "най",
+      "slug": "най",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найбільший",
+      "slug": "найбільший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найважливіший",
+      "slug": "найважливіший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найвищий",
+      "slug": "найвищий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найгірший",
+      "slug": "найгірший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найдальший",
+      "slug": "найдальший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найкращий",
+      "slug": "найкращий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наймати",
+      "slug": "наймати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найменший",
+      "slug": "найменший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найняти",
+      "slug": "найняти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "найсильніший",
+      "slug": "найсильніший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наказ",
+      "slug": "наказ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "накричати",
+      "slug": "накричати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "налаштувати",
+      "slug": "налаштувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "належати",
+      "slug": "належати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "належний",
+      "slug": "належний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наляканий",
+      "slug": "наляканий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "налякати",
+      "slug": "налякати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "налякатися",
+      "slug": "налякатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "налічувати",
+      "slug": "налічувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "намагатися",
+      "slug": "намагатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "намалювати",
+      "slug": "намалювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "намочити",
+      "slug": "намочити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наочний",
+      "slug": "наочний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напад",
+      "slug": "напад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нападати",
+      "slug": "нападати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нападник",
+      "slug": "нападник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напасти",
+      "slug": "напасти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напередодні",
+      "slug": "напередодні",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напис",
+      "slug": "напис",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "написаний",
+      "slug": "написаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "написати",
+      "slug": "написати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напитися",
+      "slug": "напитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наповнений",
+      "slug": "наповнений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "направлення",
+      "slug": "направлення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напруга",
+      "slug": "напруга",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напружений",
+      "slug": "напружений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "напій",
+      "slug": "напій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нарада",
+      "slug": "нарада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наразі",
+      "slug": "наразі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наркоманія",
+      "slug": "наркоманія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наркотик",
+      "slug": "наркотик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народ",
+      "slug": "народ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народження",
+      "slug": "народження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народжуватися",
+      "slug": "народжуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народити",
+      "slug": "народити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народитися",
+      "slug": "народитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "народний",
+      "slug": "народний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "населений",
+      "slug": "населений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "населення",
+      "slug": "населення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "насильство",
+      "slug": "насильство",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "насипати",
+      "slug": "насипати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наслідок",
+      "slug": "наслідок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наслідувати",
+      "slug": "наслідувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "насмішити",
+      "slug": "насмішити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "насолода",
+      "slug": "насолода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "насолоджуватися",
+      "slug": "насолоджуватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "насолодитися",
+      "slug": "насолодитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "настання",
+      "slug": "настання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "настати",
+      "slug": "настати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "настрій",
+      "slug": "настрій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наступ",
+      "slug": "наступ",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наступний",
+      "slug": "наступний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "натовп",
+      "slug": "натовп",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "натуральний",
+      "slug": "натуральний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "натяк",
+      "slug": "натяк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "натякати",
+      "slug": "натякати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наука",
+      "slug": "наука",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "науковець",
+      "slug": "науковець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "науковий",
+      "slug": "науковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нахабний",
+      "slug": "нахабний",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "нахабність",
+      "slug": "нахабність",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "нахилитися",
+      "slug": "нахилитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нацист",
+      "slug": "нацист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "національний",
+      "slug": "національний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "національність",
+      "slug": "національність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "начальник",
+      "slug": "начальник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "начинка",
+      "slug": "начинка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наш",
+      "slug": "наш",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нащадок",
+      "slug": "нащадок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наявний",
+      "slug": "наявний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наявність",
+      "slug": "наявність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наївний",
+      "slug": "наївний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "наїстися",
+      "slug": "наїстися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "небезпека",
+      "slug": "небезпека",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "небезпечний",
+      "slug": "небезпечний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "небесний",
+      "slug": "небесний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "небо",
+      "slug": "небо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "небокрай",
+      "slug": "небокрай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невдалий",
+      "slug": "невдалий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невдаха",
+      "slug": "невдаха",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невдача",
+      "slug": "невдача",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невдовзі",
+      "slug": "невдовзі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невеликий",
+      "slug": "невеликий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невизначений",
+      "slug": "невизначений",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "невідомий",
+      "slug": "невідомий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "невідомо",
+      "slug": "невідомо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "негайний",
+      "slug": "негайний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "негайно",
+      "slug": "негайно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "негативний",
+      "slug": "негативний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "недовіра",
+      "slug": "недовіра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "недостатній",
+      "slug": "недостатній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нежить",
+      "slug": "нежить",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незавершений",
+      "slug": "незавершений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незадовільний",
+      "slug": "незадовільний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незаперечний",
+      "slug": "незаперечний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незграбний",
+      "slug": "незграбний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незліченний",
+      "slug": "незліченний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незнайомець",
+      "slug": "незнайомець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "незначний",
+      "slug": "незначний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неймовірний",
+      "slug": "неймовірний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нейромедіатор",
+      "slug": "нейромедіатор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нейтральний",
+      "slug": "нейтральний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "немовля",
+      "slug": "немовля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неможливий",
+      "slug": "неможливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ненавидіти",
+      "slug": "ненавидіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ненадійний",
+      "slug": "ненадійний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "необхідний",
+      "slug": "необхідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неоплачений",
+      "slug": "неоплачений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неперевершений",
+      "slug": "неперевершений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непередбачуваний",
+      "slug": "непередбачуваний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неповага",
+      "slug": "неповага",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неповнолітній",
+      "slug": "неповнолітній",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неповторний",
+      "slug": "неповторний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непокоїти",
+      "slug": "непокоїти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непорозуміння",
+      "slug": "непорозуміння",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непотрібний",
+      "slug": "непотрібний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непохитний",
+      "slug": "непохитний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неправильний",
+      "slug": "неправильний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неприємність",
+      "slug": "неприємність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "непрямий",
+      "slug": "непрямий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нервовий",
+      "slug": "нервовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нервувати",
+      "slug": "нервувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нерідко",
+      "slug": "нерідко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нескінченний",
+      "slug": "нескінченний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нескінченність",
+      "slug": "нескінченність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "несправедливість",
+      "slug": "несправедливість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нестача",
+      "slug": "нестача",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нестерпний",
+      "slug": "нестерпний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нести",
+      "slug": "нести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нестримний",
+      "slug": "нестримний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нехтувати",
+      "slug": "нехтувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нечіткий",
+      "slug": "нечіткий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нещасний",
+      "slug": "нещасний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "неістота",
+      "slug": "неістота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нижчий",
+      "slug": "нижчий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "низ",
+      "slug": "низ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "низка",
+      "slug": "низка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "низький",
+      "slug": "низький",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нинішній",
+      "slug": "нинішній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нирка",
+      "slug": "нирка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нити",
+      "slug": "нити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нитка",
+      "slug": "нитка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "новий",
+      "slug": "новий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "новина",
+      "slug": "новина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "новонароджений",
+      "slug": "новонароджений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "новорічний",
+      "slug": "новорічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "новітній",
+      "slug": "новітній",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нога",
+      "slug": "нога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "номер",
+      "slug": "номер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "норма",
+      "slug": "норма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нормалізація",
+      "slug": "нормалізація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "носити",
+      "slug": "носити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "носій",
+      "slug": "носій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нудити",
+      "slug": "нудити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нудний",
+      "slug": "нудний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нуль",
+      "slug": "нуль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "няня",
+      "slug": "няня",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "ніготь",
+      "slug": "ніготь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ніж",
+      "slug": "ніж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ніжка",
+      "slug": "ніжка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "німець",
+      "slug": "німець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "німецький",
+      "slug": "німецький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "німий",
+      "slug": "німий",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "ніс",
+      "slug": "ніс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нісенітниця",
+      "slug": "нісенітниця",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "нічний",
+      "slug": "нічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ніякий",
+      "slug": "ніякий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "об'єднувати",
+      "slug": "об-єднувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обганяти",
+      "slug": "обганяти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обговорити",
+      "slug": "обговорити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обговорювати",
+      "slug": "обговорювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обдурити",
+      "slug": "обдурити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обдурювати",
+      "slug": "обдурювати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обережний",
+      "slug": "обережний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обзивати",
+      "slug": "обзивати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обирати",
+      "slug": "обирати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обладнання",
+      "slug": "обладнання",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "область",
+      "slug": "область",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "облаштовуватися",
+      "slug": "облаштовуватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "облаштуватися",
+      "slug": "облаштуватися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обличчя",
+      "slug": "обличчя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "облога",
+      "slug": "облога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обманювати",
+      "slug": "обманювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обмежений",
+      "slug": "обмежений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обмежити",
+      "slug": "обмежити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обмін",
+      "slug": "обмін",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обов'язковий",
+      "slug": "обов-язковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обов'язок",
+      "slug": "обов-язок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обожнювати",
+      "slug": "обожнювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оболонка",
+      "slug": "оболонка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оборона",
+      "slug": "оборона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ображати",
+      "slug": "ображати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "образ",
+      "slug": "образ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "образити",
+      "slug": "образити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обраний",
+      "slug": "обраний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обрати",
+      "slug": "обрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обробити",
+      "slug": "обробити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обробка",
+      "slug": "обробка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обставина",
+      "slug": "обставина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обставини",
+      "slug": "обставини",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обставинний",
+      "slug": "обставинний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обсяг",
+      "slug": "обсяг",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обхитрити",
+      "slug": "обхитрити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обходити",
+      "slug": "обходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обходитися",
+      "slug": "обходитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обігнати",
+      "slug": "обігнати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обігрівач",
+      "slug": "обігрівач",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "обід",
+      "slug": "обід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обідній",
+      "slug": "обідній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обізвати",
+      "slug": "обізвати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обіймати",
+      "slug": "обіймати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обійняти",
+      "slug": "обійняти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обійти",
+      "slug": "обійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обійтися",
+      "slug": "обійтися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обіцянка",
+      "slug": "обіцянка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "обіцяти",
+      "slug": "обіцяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "овоч",
+      "slug": "овоч",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "огида",
+      "slug": "огида",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "огидний",
+      "slug": "огидний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "огидно",
+      "slug": "огидно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "оголосити",
+      "slug": "оголосити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оголошення",
+      "slug": "оголошення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оголошувати",
+      "slug": "оголошувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "огірок",
+      "slug": "огірок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "один",
+      "slug": "один",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одинадцятий",
+      "slug": "одинадцятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одиниця",
+      "slug": "одиниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "однина",
+      "slug": "однина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "однокласник",
+      "slug": "однокласник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одноразовий",
+      "slug": "одноразовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "односпрямований",
+      "slug": "односпрямований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одружитися",
+      "slug": "одружитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одужувати",
+      "slug": "одужувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одяг",
+      "slug": "одяг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одягати",
+      "slug": "одягати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "одягнути",
+      "slug": "одягнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ожиріння",
+      "slug": "ожиріння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "озеро",
+      "slug": "озеро",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "озерце",
+      "slug": "озерце",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ознака",
+      "slug": "ознака",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "означальний",
+      "slug": "означальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "означати",
+      "slug": "означати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "океан",
+      "slug": "океан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "око",
+      "slug": "око",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "окремий",
+      "slug": "окремий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "окупація",
+      "slug": "окупація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "олень",
+      "slug": "олень",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оленя",
+      "slug": "оленя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "олія",
+      "slug": "олія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "омріяний",
+      "slug": "омріяний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "операція",
+      "slug": "операція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оперний",
+      "slug": "оперний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опинитися",
+      "slug": "опинитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "описати",
+      "slug": "описати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "описувати",
+      "slug": "описувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оплата",
+      "slug": "оплата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оповідання",
+      "slug": "оповідання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опозиція",
+      "slug": "опозиція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опонент",
+      "slug": "опонент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опосередковано",
+      "slug": "опосередковано",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "опублікувати",
+      "slug": "опублікувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опуститися",
+      "slug": "опуститися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опік",
+      "slug": "опік",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опікун",
+      "slug": "опікун",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "опір",
+      "slug": "опір",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "орган",
+      "slug": "орган",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "організація",
+      "slug": "організація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "організм",
+      "slug": "організм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "організований",
+      "slug": "організований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "організувати",
+      "slug": "організувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оренда",
+      "slug": "оренда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "орендар",
+      "slug": "орендар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "орендодавець",
+      "slug": "орендодавець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "орендувати",
+      "slug": "орендувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "орудний",
+      "slug": "орудний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "освіта",
+      "slug": "освіта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "освітній",
+      "slug": "освітній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "освічений",
+      "slug": "освічений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оселя",
+      "slug": "оселя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "осередок",
+      "slug": "осередок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ослаблювати",
+      "slug": "ослаблювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "основа",
+      "slug": "основа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "основний",
+      "slug": "основний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "особа",
+      "slug": "особа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "особистий",
+      "slug": "особистий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "особливий",
+      "slug": "особливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "особливість",
+      "slug": "особливість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "останній",
+      "slug": "останній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "остогиднути",
+      "slug": "остогиднути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "острів",
+      "slug": "острів",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "осінній",
+      "slug": "осінній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "осінь",
+      "slug": "осінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "отаман",
+      "slug": "отаман",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оточити",
+      "slug": "оточити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "отримати",
+      "slug": "отримати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "отримувати",
+      "slug": "отримувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "отруєння",
+      "slug": "отруєння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "отруїти",
+      "slug": "отруїти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "офіс",
+      "slug": "офіс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "офіціант",
+      "slug": "офіціант",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "офіціантка",
+      "slug": "офіціантка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "офіційний",
+      "slug": "офіційний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "офіційно",
+      "slug": "офіційно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "охайний",
+      "slug": "охайний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "охолоджувати",
+      "slug": "охолоджувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "охолодити",
+      "slug": "охолодити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "охопити",
+      "slug": "охопити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "охорона",
+      "slug": "охорона",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "охоронець",
+      "slug": "охоронець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оцінити",
+      "slug": "оцінити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оцінка",
+      "slug": "оцінка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оцінювати",
+      "slug": "оцінювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очевидний",
+      "slug": "очевидний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очистити",
+      "slug": "очистити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очко",
+      "slug": "очко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очолити",
+      "slug": "очолити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очікування",
+      "slug": "очікування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "очікувати",
+      "slug": "очікувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "оштрафувати",
+      "slug": "оштрафувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "п'яний",
+      "slug": "п-яний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "п'ятий",
+      "slug": "п-ятий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "п'ятниця",
+      "slug": "п-ятниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "п'ятсот",
+      "slug": "п-ятсот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "п'ять",
+      "slug": "п-ять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "павук",
+      "slug": "павук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "падати",
+      "slug": "падати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "падіння",
+      "slug": "падіння",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "пакет",
+      "slug": "пакет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пакувати",
+      "slug": "пакувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "палац",
+      "slug": "палац",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "палець",
+      "slug": "палець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "палити",
+      "slug": "палити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "палиця",
+      "slug": "палиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пам'ятати",
+      "slug": "пам-ятати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пам'ятка",
+      "slug": "пам-ятка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пам'ятник",
+      "slug": "пам-ятник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пам'ять",
+      "slug": "пам-ять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "памперс",
+      "slug": "памперс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пан",
+      "slug": "пан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "панування",
+      "slug": "панування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "панувати",
+      "slug": "панувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "панянка",
+      "slug": "панянка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "паніка",
+      "slug": "паніка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "панікувати",
+      "slug": "панікувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "папуга",
+      "slug": "папуга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "папір",
+      "slug": "папір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "паралельний",
+      "slug": "паралельний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "парасолька",
+      "slug": "парасолька",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "парк",
+      "slug": "парк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "паровоз",
+      "slug": "паровоз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "партнер",
+      "slug": "партнер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "партія",
+      "slug": "партія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пасажир",
+      "slug": "пасажир",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пасивний",
+      "slug": "пасивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "паспорт",
+      "slug": "паспорт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "паста",
+      "slug": "паста",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пастка",
+      "slug": "пастка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пастух",
+      "slug": "пастух",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пасіка",
+      "slug": "пасіка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "патріот",
+      "slug": "патріот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пауза",
+      "slug": "пауза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пахнути",
+      "slug": "пахнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пацієнт",
+      "slug": "пацієнт",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "певний",
+      "slug": "певний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "педаль",
+      "slug": "педаль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "педіатр",
+      "slug": "педіатр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пекарня",
+      "slug": "пекарня",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пекельний",
+      "slug": "пекельний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пекло",
+      "slug": "пекло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пенсія",
+      "slug": "пенсія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перебрати",
+      "slug": "перебрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перебувати",
+      "slug": "перебувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перебудувати",
+      "slug": "перебудувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перебіг",
+      "slug": "перебіг",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перебільшення",
+      "slug": "перебільшення",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "перевага",
+      "slug": "перевага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переважати",
+      "slug": "переважати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевезти",
+      "slug": "перевезти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевищувати",
+      "slug": "перевищувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевтома",
+      "slug": "перевтома",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевірити",
+      "slug": "перевірити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевірка",
+      "slug": "перевірка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перевіряти",
+      "slug": "перевіряти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перегнати",
+      "slug": "перегнати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переговори",
+      "slug": "переговори",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передавати",
+      "slug": "передавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передаватися",
+      "slug": "передаватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передати",
+      "slug": "передати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передача",
+      "slug": "передача",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передбачити",
+      "slug": "передбачити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передній",
+      "slug": "передній",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "передплата",
+      "slug": "передплата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передсвятковий",
+      "slug": "передсвятковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передувати",
+      "slug": "передувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "передчуття",
+      "slug": "передчуття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пережити",
+      "slug": "пережити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перезавантажити",
+      "slug": "перезавантажити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перезавантажувати",
+      "slug": "перезавантажувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "переймати",
+      "slug": "переймати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перейматися",
+      "slug": "перейматися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перейменувати",
+      "slug": "перейменувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перейняти",
+      "slug": "перейняти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перейти",
+      "slug": "перейти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перекладати",
+      "slug": "перекладати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перекладач",
+      "slug": "перекладач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перекласти",
+      "slug": "перекласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переконаний",
+      "slug": "переконаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переконання",
+      "slug": "переконання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переконати",
+      "slug": "переконати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переконатися",
+      "slug": "переконатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переконливий",
+      "slug": "переконливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перекусити",
+      "slug": "перекусити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перекушувати",
+      "slug": "перекушувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "перелом",
+      "slug": "перелом",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перемовини",
+      "slug": "перемовини",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перемога",
+      "slug": "перемога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перемогти",
+      "slug": "перемогти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перепис",
+      "slug": "перепис",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переписати",
+      "slug": "переписати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переплутати",
+      "slug": "переплутати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переповнений",
+      "slug": "переповнений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перепустка",
+      "slug": "перепустка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перерва",
+      "slug": "перерва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перервати",
+      "slug": "перервати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переривати",
+      "slug": "переривати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перерости",
+      "slug": "перерости",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переселенець",
+      "slug": "переселенець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переставати",
+      "slug": "переставати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перестати",
+      "slug": "перестати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перетворити",
+      "slug": "перетворити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перетин",
+      "slug": "перетин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перефразувати",
+      "slug": "перефразувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переходити",
+      "slug": "переходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перехід",
+      "slug": "перехід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перець",
+      "slug": "перець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перешкода",
+      "slug": "перешкода",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переїжджати",
+      "slug": "переїжджати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переїзд",
+      "slug": "переїзд",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "переїхати",
+      "slug": "переїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "периметр",
+      "slug": "периметр",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "персик",
+      "slug": "персик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "персонаж",
+      "slug": "персонаж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перспектива",
+      "slug": "перспектива",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перстень",
+      "slug": "перстень",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перун",
+      "slug": "перун",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перше",
+      "slug": "перше",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "перший",
+      "slug": "перший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "період",
+      "slug": "період",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пес",
+      "slug": "пес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "печиво",
+      "slug": "печиво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "печінка",
+      "slug": "печінка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пиво",
+      "slug": "пиво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пил",
+      "slug": "пил",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "пилок",
+      "slug": "пилок",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "пиріг",
+      "slug": "пиріг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "писар",
+      "slug": "писар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "писати",
+      "slug": "писати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "питання",
+      "slug": "питання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "питати",
+      "slug": "питати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пити",
+      "slug": "пити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пишатися",
+      "slug": "пишатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плавання",
+      "slug": "плавання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плавати",
+      "slug": "плавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плакати",
+      "slug": "плакати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "план",
+      "slug": "план",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "планета",
+      "slug": "планета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "планувати",
+      "slug": "планувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пласт",
+      "slug": "пласт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пластир",
+      "slug": "пластир",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плата",
+      "slug": "плата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "платити",
+      "slug": "платити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "платіж",
+      "slug": "платіж",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "племінник",
+      "slug": "племінник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пливти",
+      "slug": "пливти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плита",
+      "slug": "плита",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плоский",
+      "slug": "плоский",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "площа",
+      "slug": "площа",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плюватися",
+      "slug": "плюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пляж",
+      "slug": "пляж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пляма",
+      "slug": "пляма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пляшка",
+      "slug": "пляшка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пліснява",
+      "slug": "пліснява",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "плітка",
+      "slug": "плітка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побажання",
+      "slug": "побажання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побачення",
+      "slug": "побачення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побачити",
+      "slug": "побачити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побиття",
+      "slug": "побиття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побороти",
+      "slug": "побороти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побувати",
+      "slug": "побувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побудувати",
+      "slug": "побудувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побут",
+      "slug": "побут",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побутувати",
+      "slug": "побутувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "побігти",
+      "slug": "побігти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пов'язаний",
+      "slug": "пов-язаний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пов'язати",
+      "slug": "пов-язати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пов'язувати",
+      "slug": "пов-язувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повага",
+      "slug": "повага",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поважати",
+      "slug": "поважати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поведінка",
+      "slug": "поведінка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повезти",
+      "slug": "повезти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повернути",
+      "slug": "повернути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повернутися",
+      "slug": "повернутися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повертати",
+      "slug": "повертати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повертатися",
+      "slug": "повертатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поверхневий",
+      "slug": "поверхневий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повести",
+      "slug": "повести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повний",
+      "slug": "повний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повноліття",
+      "slug": "повноліття",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повноцінний",
+      "slug": "повноцінний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поводитися",
+      "slug": "поводитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повстанець",
+      "slug": "повстанець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повстання",
+      "slug": "повстання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повсюдний",
+      "slug": "повсюдний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повсякденний",
+      "slug": "повсякденний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повторюваний",
+      "slug": "повторюваний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повторювати",
+      "slug": "повторювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повідомити",
+      "slug": "повідомити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повідомлення",
+      "slug": "повідомлення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повідомляти",
+      "slug": "повідомляти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повірити",
+      "slug": "повірити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повісити",
+      "slug": "повісити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "повітря",
+      "slug": "повітря",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поганий",
+      "slug": "поганий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погляд",
+      "slug": "погляд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поговорити",
+      "slug": "поговорити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погода",
+      "slug": "погода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погоджуватися",
+      "slug": "погоджуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погодитися",
+      "slug": "погодитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поголитися",
+      "slug": "поголитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пограбувати",
+      "slug": "пограбувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погіршення",
+      "slug": "погіршення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погіршитися",
+      "slug": "погіршитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "погіршуватися",
+      "slug": "погіршуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подавати",
+      "slug": "подавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подаватися",
+      "slug": "подаватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подарувати",
+      "slug": "подарувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подарунок",
+      "slug": "подарунок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подати",
+      "slug": "подати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "податок",
+      "slug": "податок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подвиг",
+      "slug": "подвиг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подвір'я",
+      "slug": "подвір-я",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подзвонити",
+      "slug": "подзвонити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подивитися",
+      "slug": "подивитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подобатися",
+      "slug": "подобатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подолати",
+      "slug": "подолати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подорож",
+      "slug": "подорож",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подорожувати",
+      "slug": "подорожувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подразнений",
+      "slug": "подразнений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подруга",
+      "slug": "подруга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подумати",
+      "slug": "подумати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подібний",
+      "slug": "подібний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поділити",
+      "slug": "поділити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поділитися",
+      "slug": "поділитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "подія",
+      "slug": "подія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поет",
+      "slug": "поет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пожежник",
+      "slug": "пожежник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пожертвувати",
+      "slug": "пожертвувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поживний",
+      "slug": "поживний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поза",
+      "slug": "поза",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "позбуватися",
+      "slug": "позбуватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позбутися",
+      "slug": "позбутися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позивач",
+      "slug": "позивач",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "позивний",
+      "slug": "позивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позика",
+      "slug": "позика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позиція",
+      "slug": "позиція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "познайомитися",
+      "slug": "познайомитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позначати",
+      "slug": "позначати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позіхати",
+      "slug": "позіхати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "позіхнути",
+      "slug": "позіхнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "показ",
+      "slug": "показ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "показати",
+      "slug": "показати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "показник",
+      "slug": "показник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "показувати",
+      "slug": "показувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покарання",
+      "slug": "покарання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покарати",
+      "slug": "покарати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покладатися",
+      "slug": "покладатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покласти",
+      "slug": "покласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поклястися",
+      "slug": "поклястися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "покоління",
+      "slug": "покоління",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покращити",
+      "slug": "покращити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покращувати",
+      "slug": "покращувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покрив",
+      "slug": "покрив",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покрити",
+      "slug": "покрити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покупець",
+      "slug": "покупець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покупка",
+      "slug": "покупка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "покійний",
+      "slug": "покійний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поламати",
+      "slug": "поламати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поле",
+      "slug": "поле",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полегшувати",
+      "slug": "полегшувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полетіти",
+      "slug": "полетіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полиця",
+      "slug": "полиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полк",
+      "slug": "полк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "половина",
+      "slug": "половина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полон",
+      "slug": "полон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полонений",
+      "slug": "полонений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полуниця",
+      "slug": "полуниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полюбити",
+      "slug": "полюбити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полювати",
+      "slug": "полювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полягати",
+      "slug": "полягати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полягти",
+      "slug": "полягти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "поляк",
+      "slug": "поляк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полігон",
+      "slug": "полігон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "полізти",
+      "slug": "полізти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "політик",
+      "slug": "політик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "політика",
+      "slug": "політика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поліція",
+      "slug": "поліція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "померлий",
+      "slug": "померлий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "померти",
+      "slug": "померти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помилка",
+      "slug": "помилка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помити",
+      "slug": "помити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помідор",
+      "slug": "помідор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поміститися",
+      "slug": "поміститися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помітити",
+      "slug": "помітити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помітний",
+      "slug": "помітний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помічати",
+      "slug": "помічати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помічник",
+      "slug": "помічник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "помішати",
+      "slug": "помішати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "помішувати",
+      "slug": "помішувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "поміщатися",
+      "slug": "поміщатися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "понеділок",
+      "slug": "понеділок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "понести",
+      "slug": "понести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "понизити",
+      "slug": "понизити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поносити",
+      "slug": "поносити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пообідати",
+      "slug": "пообідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пообіцяти",
+      "slug": "пообіцяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поперед",
+      "slug": "поперед",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "попередження",
+      "slug": "попередження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "попередити",
+      "slug": "попередити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "попередній",
+      "slug": "попередній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "попит",
+      "slug": "попит",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "попросити",
+      "slug": "попросити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "популярний",
+      "slug": "популярний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пора",
+      "slug": "пора",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порада",
+      "slug": "порада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порадити",
+      "slug": "порадити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поразка",
+      "slug": "поразка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поранений",
+      "slug": "поранений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поранити",
+      "slug": "поранити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порвати",
+      "slug": "порвати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порода",
+      "slug": "порода",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порожнеча",
+      "slug": "порожнеча",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порожній",
+      "slug": "порожній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порожніти",
+      "slug": "порожніти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "порох",
+      "slug": "порох",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порт",
+      "slug": "порт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "портрет",
+      "slug": "портрет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порухати",
+      "slug": "порухати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "порушення",
+      "slug": "порушення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порушити",
+      "slug": "порушити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порушувати",
+      "slug": "порушувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порція",
+      "slug": "порція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порядок",
+      "slug": "порядок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порівняльний",
+      "slug": "порівняльний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поріг",
+      "slug": "поріг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "порічка",
+      "slug": "порічка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посада",
+      "slug": "посада",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посилити",
+      "slug": "посилити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посилка",
+      "slug": "посилка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поскаржитися",
+      "slug": "поскаржитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "послуга",
+      "slug": "послуга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "послухати",
+      "slug": "послухати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "послідовність",
+      "slug": "послідовність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посмішка",
+      "slug": "посмішка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посол",
+      "slug": "посол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посольство",
+      "slug": "посольство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поспіль",
+      "slug": "поспіль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поспішати",
+      "slug": "поспішати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поспішити",
+      "slug": "поспішити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поставити",
+      "slug": "поставити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постаратися",
+      "slug": "постаратися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постать",
+      "slug": "постать",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постити",
+      "slug": "постити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постувати",
+      "slug": "постувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постукати",
+      "slug": "постукати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поступ",
+      "slug": "поступ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поступовий",
+      "slug": "поступовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "постійний",
+      "slug": "постійний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посуд",
+      "slug": "посуд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посудомийка",
+      "slug": "посудомийка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посібник",
+      "slug": "посібник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "посів",
+      "slug": "посів",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потворний",
+      "slug": "потворний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потенційний",
+      "slug": "потенційний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поточний",
+      "slug": "поточний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потрапити",
+      "slug": "потрапити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потреба",
+      "slug": "потреба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потребувати",
+      "slug": "потребувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потрібний",
+      "slug": "потрібний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потужний",
+      "slug": "потужний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потяг",
+      "slug": "потяг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "потіти",
+      "slug": "потіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похапцем",
+      "slug": "похапцем",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похвалити",
+      "slug": "похвалити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похилити",
+      "slug": "похилити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похитати",
+      "slug": "похитати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похмурий",
+      "slug": "похмурий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поховати",
+      "slug": "поховати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "походження",
+      "slug": "походження",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похорон",
+      "slug": "похорон",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "похід",
+      "slug": "похід",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "почати",
+      "slug": "почати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "початися",
+      "slug": "початися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "початок",
+      "slug": "початок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "починати",
+      "slug": "починати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "починатися",
+      "slug": "починатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "почистити",
+      "slug": "почистити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "почувати",
+      "slug": "почувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "почуватися",
+      "slug": "почуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "почути",
+      "slug": "почути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поширитися",
+      "slug": "поширитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поширювати",
+      "slug": "поширювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поширюватися",
+      "slug": "поширюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пошкодження",
+      "slug": "пошкодження",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пошта",
+      "slug": "пошта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поштовх",
+      "slug": "поштовх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пошук",
+      "slug": "пошук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пояснити",
+      "slug": "пояснити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пояснювати",
+      "slug": "пояснювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поєднуватися",
+      "slug": "поєднуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поїзд",
+      "slug": "поїзд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поїздка",
+      "slug": "поїздка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "поїхати",
+      "slug": "поїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "правда",
+      "slug": "правда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "правдиво",
+      "slug": "правдиво",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "правило",
+      "slug": "правило",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "правильний",
+      "slug": "правильний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "православний",
+      "slug": "православний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прагнути",
+      "slug": "прагнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "практика",
+      "slug": "практика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "практикувати",
+      "slug": "практикувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прапор",
+      "slug": "прапор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "праска",
+      "slug": "праска",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "працьовитий",
+      "slug": "працьовитий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "працювати",
+      "slug": "працювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "праця",
+      "slug": "праця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "працівник",
+      "slug": "працівник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пращур",
+      "slug": "пращур",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "предмет",
+      "slug": "предмет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "представити",
+      "slug": "представити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "представник",
+      "slug": "представник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "премія",
+      "slug": "премія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "препарат",
+      "slug": "препарат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "престол",
+      "slug": "престол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "претензія",
+      "slug": "претензія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибирання",
+      "slug": "прибирання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибирати",
+      "slug": "прибирати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибрати",
+      "slug": "прибрати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибулець",
+      "slug": "прибулець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибути",
+      "slug": "прибути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прибігти",
+      "slug": "прибігти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приватність",
+      "slug": "приватність",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "привернути",
+      "slug": "привернути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "привести",
+      "slug": "привести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "привид",
+      "slug": "привид",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "привілей",
+      "slug": "привілей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пригадати",
+      "slug": "пригадати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пригода",
+      "slug": "пригода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приголомшений",
+      "slug": "приголомшений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приголомшливий",
+      "slug": "приголомшливий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приголосний",
+      "slug": "приголосний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пригоріти",
+      "slug": "пригоріти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приготування",
+      "slug": "приготування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приготувати",
+      "slug": "приготувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "придумати",
+      "slug": "придумати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приділити",
+      "slug": "приділити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приділяти",
+      "slug": "приділяти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приз",
+      "slug": "приз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "призвести",
+      "slug": "призвести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "призводити",
+      "slug": "призводити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приймати",
+      "slug": "приймати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прийменник",
+      "slug": "прийменник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прийняти",
+      "slug": "прийняти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прийти",
+      "slug": "прийти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прийтися",
+      "slug": "прийтися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приклад",
+      "slug": "приклад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приклеїти",
+      "slug": "приклеїти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикметник",
+      "slug": "прикметник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикраса",
+      "slug": "прикраса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикрасити",
+      "slug": "прикрасити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикрашати",
+      "slug": "прикрашати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикро",
+      "slug": "прикро",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикріпити",
+      "slug": "прикріпити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикріплений",
+      "slug": "прикріплений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прикріпляти",
+      "slug": "прикріпляти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "прилетіти",
+      "slug": "прилетіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "примхливий",
+      "slug": "примхливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приміщення",
+      "slug": "приміщення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "принести",
+      "slug": "принести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "принишкнути",
+      "slug": "принишкнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приносити",
+      "slug": "приносити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "принцеса",
+      "slug": "принцеса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "принцип",
+      "slug": "принцип",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "припинити",
+      "slug": "припинити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "припускати",
+      "slug": "припускати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "припустити",
+      "slug": "припустити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приречений",
+      "slug": "приречений",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "природа",
+      "slug": "природа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "природний",
+      "slug": "природний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присвятити",
+      "slug": "присвятити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присвячений",
+      "slug": "присвячений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прислівник",
+      "slug": "прислівник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присудок",
+      "slug": "присудок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присяга",
+      "slug": "присяга",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присягатися",
+      "slug": "присягатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "присягнутися",
+      "slug": "присягнутися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "притулок",
+      "slug": "притулок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "притча",
+      "slug": "притча",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прихильник",
+      "slug": "прихильник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прихисток",
+      "slug": "прихисток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приховати",
+      "slug": "приховати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приходити",
+      "slug": "приходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "причина",
+      "slug": "причина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прищ",
+      "slug": "прищ",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приєднаний",
+      "slug": "приєднаний",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "приєднатися",
+      "slug": "приєднатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приємний",
+      "slug": "приємний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приємність",
+      "slug": "приємність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приїжджати",
+      "slug": "приїжджати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "приїхати",
+      "slug": "приїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проблема",
+      "slug": "проблема",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пробувати",
+      "slug": "пробувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пробурмотіти",
+      "slug": "пробурмотіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провал",
+      "slug": "провал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проваритися",
+      "slug": "проваритися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проведення",
+      "slug": "проведення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провести",
+      "slug": "провести",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провина",
+      "slug": "провина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провисання",
+      "slug": "провисання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проводити",
+      "slug": "проводити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проводитися",
+      "slug": "проводитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провчити",
+      "slug": "провчити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "провітрювати",
+      "slug": "провітрювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прогалина",
+      "slug": "прогалина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прогноз",
+      "slug": "прогноз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проголосувати",
+      "slug": "проголосувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "програма",
+      "slug": "програма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "програти",
+      "slug": "програти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прогрес",
+      "slug": "прогрес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прогулянка",
+      "slug": "прогулянка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продавати",
+      "slug": "продавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продаватися",
+      "slug": "продаватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продаж",
+      "slug": "продаж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продати",
+      "slug": "продати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продовжити",
+      "slug": "продовжити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продовжувати",
+      "slug": "продовжувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продукт",
+      "slug": "продукт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продуктивний",
+      "slug": "продуктивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "продуктивність",
+      "slug": "продуктивність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пройти",
+      "slug": "пройти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пройтися",
+      "slug": "пройтися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прокачувати",
+      "slug": "прокачувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прокидатися",
+      "slug": "прокидатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прокинутися",
+      "slug": "прокинутися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проломити",
+      "slug": "проломити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "промова",
+      "slug": "промова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "промокнути",
+      "slug": "промокнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "промінь",
+      "slug": "промінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проникати",
+      "slug": "проникати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пронос",
+      "slug": "пронос",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "пропозиція",
+      "slug": "пропозиція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пропонувати",
+      "slug": "пропонувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пропуск",
+      "slug": "пропуск",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пропускати",
+      "slug": "пропускати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пропустити",
+      "slug": "пропустити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прорив",
+      "slug": "прорив",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "просити",
+      "slug": "просити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "простий",
+      "slug": "простий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "просторий",
+      "slug": "просторий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проти",
+      "slug": "проти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "протилежний",
+      "slug": "протилежний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "протиставний",
+      "slug": "протиставний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "протяг",
+      "slug": "протяг",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "протягом",
+      "slug": "протягом",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "професор",
+      "slug": "професор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "професійний",
+      "slug": "професійний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "профілактика",
+      "slug": "профілактика",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прохання",
+      "slug": "прохання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проходити",
+      "slug": "проходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "процедура",
+      "slug": "процедура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "процес",
+      "slug": "процес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "процесор",
+      "slug": "процесор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прочитати",
+      "slug": "прочитати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прочитувати",
+      "slug": "прочитувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прошепотіти",
+      "slug": "прошепотіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прощальний",
+      "slug": "прощальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проявитися",
+      "slug": "проявитися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проявлятися",
+      "slug": "проявлятися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проєкт",
+      "slug": "проєкт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проігнорувати",
+      "slug": "проігнорувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проіснувати",
+      "slug": "проіснувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проїжджати",
+      "slug": "проїжджати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "проїхати",
+      "slug": "проїхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пряжа",
+      "slug": "пряжа",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пряний",
+      "slug": "пряний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "прізвище",
+      "slug": "прізвище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пріоритет",
+      "slug": "пріоритет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "псевдонім",
+      "slug": "псевдонім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "психолог",
+      "slug": "психолог",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "психологічний",
+      "slug": "психологічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "психологія",
+      "slug": "психологія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "психічний",
+      "slug": "психічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "птах",
+      "slug": "птах",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пташка",
+      "slug": "пташка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "публікувати",
+      "slug": "публікувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пустий",
+      "slug": "пустий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пустити",
+      "slug": "пустити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "путін",
+      "slug": "путін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пухир",
+      "slug": "пухир",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пухнастий",
+      "slug": "пухнастий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пшениця",
+      "slug": "пшениця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "південний",
+      "slug": "південний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "південь",
+      "slug": "південь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "півень",
+      "slug": "півень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "північний",
+      "slug": "північний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "під'їзд",
+      "slug": "під-їзд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підвищити",
+      "slug": "підвищити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підвищувати",
+      "slug": "підвищувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підготовка",
+      "slug": "підготовка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підготувати",
+      "slug": "підготувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підготуватися",
+      "slug": "підготуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підкова",
+      "slug": "підкова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підкреслити",
+      "slug": "підкреслити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підкреслювати",
+      "slug": "підкреслювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підкупити",
+      "slug": "підкупити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підкупляти",
+      "slug": "підкупляти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "підлабузник",
+      "slug": "підлабузник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підлога",
+      "slug": "підлога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підлітковий",
+      "slug": "підлітковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підліток",
+      "slug": "підліток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підмет",
+      "slug": "підмет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піднебіння",
+      "slug": "піднебіння",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підняти",
+      "slug": "підняти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піднятися",
+      "slug": "піднятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піднімати",
+      "slug": "піднімати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підозра",
+      "slug": "підозра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підозрюваний",
+      "slug": "підозрюваний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підозрілий",
+      "slug": "підозрілий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підозріло",
+      "slug": "підозріло",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "підошва",
+      "slug": "підошва",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підпис",
+      "slug": "підпис",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підписаний",
+      "slug": "підписаний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підписати",
+      "slug": "підписати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підписка",
+      "slug": "підписка",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "підписувати",
+      "slug": "підписувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підприємець",
+      "slug": "підприємець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підробка",
+      "slug": "підробка",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "підручник",
+      "slug": "підручник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підрядний",
+      "slug": "підрядний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підрядність",
+      "slug": "підрядність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підстава",
+      "slug": "підстава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підсумок",
+      "slug": "підсумок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підтримати",
+      "slug": "підтримати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підтримка",
+      "slug": "підтримка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підтримувати",
+      "slug": "підтримувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підходити",
+      "slug": "підходити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підібрати",
+      "slug": "підібрати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "підійти",
+      "slug": "підійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пізній",
+      "slug": "пізній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пік",
+      "slug": "пік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пільга",
+      "slug": "пільга",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пінгвін",
+      "slug": "пінгвін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пісний",
+      "slug": "пісний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пісня",
+      "slug": "пісня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пісок",
+      "slug": "пісок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піт",
+      "slug": "піт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піти",
+      "slug": "піти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пітніти",
+      "slug": "пітніти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піхота",
+      "slug": "піхота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "піца",
+      "slug": "піца",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "пішохід",
+      "slug": "пішохід",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "равлик",
+      "slug": "равлик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "радити",
+      "slug": "радити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "радник",
+      "slug": "радник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "радянський",
+      "slug": "радянський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "радісний",
+      "slug": "радісний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "радість",
+      "slug": "радість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "раз",
+      "slug": "раз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "район",
+      "slug": "район",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рак",
+      "slug": "рак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ракета",
+      "slug": "ракета",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рамка",
+      "slug": "рамка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рана",
+      "slug": "рана",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ранковий",
+      "slug": "ранковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рання",
+      "slug": "рання",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ранній",
+      "slug": "ранній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "раптовий",
+      "slug": "раптовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рахувати",
+      "slug": "рахувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "раціон",
+      "slug": "раціон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рвати",
+      "slug": "рвати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "реагувати",
+      "slug": "реагувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "реальний",
+      "slug": "реальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ребро",
+      "slug": "ребро",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ревний",
+      "slug": "ревний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "регулярний",
+      "slug": "регулярний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "регіон",
+      "slug": "регіон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "регіональний",
+      "slug": "регіональний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "режим",
+      "slug": "режим",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "резолюція",
+      "slug": "резолюція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "результат",
+      "slug": "результат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рейка",
+      "slug": "рейка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "реклама",
+      "slug": "реклама",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рекламація",
+      "slug": "рекламація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рекомендація",
+      "slug": "рекомендація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рекомендувати",
+      "slug": "рекомендувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "релігія",
+      "slug": "релігія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ремонт",
+      "slug": "ремонт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ремонтувати",
+      "slug": "ремонтувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рентген",
+      "slug": "рентген",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ресторан",
+      "slug": "ресторан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ресурс",
+      "slug": "ресурс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ретельний",
+      "slug": "ретельний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ретельно",
+      "slug": "ретельно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "реформа",
+      "slug": "реформа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рецепт",
+      "slug": "рецепт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "речення",
+      "slug": "речення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "речовина",
+      "slug": "речовина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "решта",
+      "slug": "решта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "реєстрація",
+      "slug": "реєстрація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "риба",
+      "slug": "риба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ризик",
+      "slug": "ризик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "риса",
+      "slug": "риса",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рити",
+      "slug": "рити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ритм",
+      "slug": "ритм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "риторика",
+      "slug": "риторика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "робити",
+      "slug": "робити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "робота",
+      "slug": "робота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "робочий",
+      "slug": "робочий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "робітник",
+      "slug": "робітник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рогівка",
+      "slug": "рогівка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "родина",
+      "slug": "родина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "родинний",
+      "slug": "родинний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "родич",
+      "slug": "родич",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "родовий",
+      "slug": "родовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рожевий",
+      "slug": "рожевий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розбиратися",
+      "slug": "розбиратися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розбити",
+      "slug": "розбити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розбитий",
+      "slug": "розбитий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розбудити",
+      "slug": "розбудити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розв'язати",
+      "slug": "розв-язати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розважатися",
+      "slug": "розважатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розвивати",
+      "slug": "розвивати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розвиток",
+      "slug": "розвиток",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розвідка",
+      "slug": "розвідка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розглядатися",
+      "slug": "розглядатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розгорнути",
+      "slug": "розгорнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "роздратований",
+      "slug": "роздратований",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розетка",
+      "slug": "розетка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "роззуватися",
+      "slug": "роззуватися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "роззутися",
+      "slug": "роззутися",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розказати",
+      "slug": "розказати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розказувати",
+      "slug": "розказувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розклад",
+      "slug": "розклад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розкіш",
+      "slug": "розкіш",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розкішний",
+      "slug": "розкішний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розлад",
+      "slug": "розлад",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розливати",
+      "slug": "розливати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розлити",
+      "slug": "розлити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розлючений",
+      "slug": "розлючений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розмова",
+      "slug": "розмова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розмовляти",
+      "slug": "розмовляти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розмовний",
+      "slug": "розмовний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розмір",
+      "slug": "розмір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розпач",
+      "slug": "розпач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розповсюдитися",
+      "slug": "розповсюдитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розповідати",
+      "slug": "розповідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розповісти",
+      "slug": "розповісти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розпродаж",
+      "slug": "розпродаж",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розрахунок",
+      "slug": "розрахунок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розробити",
+      "slug": "розробити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розробляти",
+      "slug": "розробляти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розробник",
+      "slug": "розробник",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розсада",
+      "slug": "розсада",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розслаблятися",
+      "slug": "розслаблятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розслідування",
+      "slug": "розслідування",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розтанути",
+      "slug": "розтанути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розташований",
+      "slug": "розташований",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розум",
+      "slug": "розум",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розумний",
+      "slug": "розумний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розуміння",
+      "slug": "розуміння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розуміти",
+      "slug": "розуміти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розчарувати",
+      "slug": "розчарувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розчухати",
+      "slug": "розчухати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "розширити",
+      "slug": "розширити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розширювати",
+      "slug": "розширювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розібратися",
+      "slug": "розібратися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "розірвати",
+      "slug": "розірвати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "роль",
+      "slug": "роль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рослина",
+      "slug": "рослина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рости",
+      "slug": "рости",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "росія",
+      "slug": "росія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рубати",
+      "slug": "рубати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рубіж",
+      "slug": "рубіж",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рудий",
+      "slug": "рудий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рука",
+      "slug": "рука",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рукав",
+      "slug": "рукав",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "руський",
+      "slug": "руський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рутина",
+      "slug": "рутина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рух",
+      "slug": "рух",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рухати",
+      "slug": "рухати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "рухатися",
+      "slug": "рухатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рученя",
+      "slug": "рученя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ручний",
+      "slug": "ручний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "руїна",
+      "slug": "руїна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рюкзак",
+      "slug": "рюкзак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ряд",
+      "slug": "ряд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рядок",
+      "slug": "рядок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рівень",
+      "slug": "рівень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рівний",
+      "slug": "рівний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рівноправний",
+      "slug": "рівноправний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рівність",
+      "slug": "рівність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ріг",
+      "slug": "ріг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рід",
+      "slug": "рід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рідина",
+      "slug": "рідина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рідкий",
+      "slug": "рідкий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рідний",
+      "slug": "рідний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "Різдво",
+      "slug": "різдво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "різдвяний",
+      "slug": "різдвяний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "різкий",
+      "slug": "різкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "різний",
+      "slug": "різний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "різниця",
+      "slug": "різниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рік",
+      "slug": "рік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "річ",
+      "slug": "річ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "річка",
+      "slug": "річка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "річний",
+      "slug": "річний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "річниця",
+      "slug": "річниця",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рішення",
+      "slug": "рішення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рішучий",
+      "slug": "рішучий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "рішучість",
+      "slug": "рішучість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сад",
+      "slug": "сад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "садівництво",
+      "slug": "садівництво",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сало",
+      "slug": "сало",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "самолікування",
+      "slug": "самолікування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "самонавіювання",
+      "slug": "самонавіювання",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "самооцінка",
+      "slug": "самооцінка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "саморобний",
+      "slug": "саморобний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "самостійний",
+      "slug": "самостійний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "самотній",
+      "slug": "самотній",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сантиметр",
+      "slug": "сантиметр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "санчата",
+      "slug": "санчата",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сарай",
+      "slug": "сарай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сваритися",
+      "slug": "сваритися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сварка",
+      "slug": "сварка",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свекор",
+      "slug": "свекор",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "свекруха",
+      "slug": "свекруха",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свербіж",
+      "slug": "свербіж",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "светр",
+      "slug": "светр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свинина",
+      "slug": "свинина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свобода",
+      "slug": "свобода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "святий",
+      "slug": "святий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "святковий",
+      "slug": "святковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "святкувати",
+      "slug": "святкувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свято",
+      "slug": "свято",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свідок",
+      "slug": "свідок",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свідомий",
+      "slug": "свідомий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свідчити",
+      "slug": "свідчити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свіжий",
+      "slug": "свіжий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свій",
+      "slug": "свій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світанок",
+      "slug": "світанок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світати",
+      "slug": "світати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світити",
+      "slug": "світити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світло",
+      "slug": "світло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світловий",
+      "slug": "світловий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "світовий",
+      "slug": "світовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "свічка",
+      "slug": "свічка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сезон",
+      "slug": "сезон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сезонний",
+      "slug": "сезонний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сейм",
+      "slug": "сейм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "секрет",
+      "slug": "секрет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сектор",
+      "slug": "сектор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "секунда",
+      "slug": "секунда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "селище",
+      "slug": "селище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "село",
+      "slug": "село",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "селянин",
+      "slug": "селянин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сенс",
+      "slug": "сенс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сервер",
+      "slug": "сервер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серветка",
+      "slug": "серветка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сервіз",
+      "slug": "сервіз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сердитися",
+      "slug": "сердитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "середина",
+      "slug": "середина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "середньостатистичний",
+      "slug": "середньостатистичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "середній",
+      "slug": "середній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "середовище",
+      "slug": "середовище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серйозний",
+      "slug": "серйозний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серотонін",
+      "slug": "серотонін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серпень",
+      "slug": "серпень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серце",
+      "slug": "серце",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "серіал",
+      "slug": "серіал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сестра",
+      "slug": "сестра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сеча",
+      "slug": "сеча",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сигнал",
+      "slug": "сигнал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сидіти",
+      "slug": "сидіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сила",
+      "slug": "сила",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сильний",
+      "slug": "сильний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "символ",
+      "slug": "символ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "символіка",
+      "slug": "символіка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "символічний",
+      "slug": "символічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "симптом",
+      "slug": "симптом",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "син",
+      "slug": "син",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "синонім",
+      "slug": "синонім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "синтез",
+      "slug": "синтез",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "синтезувати",
+      "slug": "синтезувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "синяк",
+      "slug": "синяк",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "синій",
+      "slug": "синій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сирий",
+      "slug": "сирий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сирник",
+      "slug": "сирник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сироп",
+      "slug": "сироп",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сирота",
+      "slug": "сирота",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сиротинець",
+      "slug": "сиротинець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "система",
+      "slug": "система",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ситуація",
+      "slug": "ситуація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сич",
+      "slug": "сич",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скажений",
+      "slug": "скажений",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сказ",
+      "slug": "сказ",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сказати",
+      "slug": "сказати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скандал",
+      "slug": "скандал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скарб",
+      "slug": "скарб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скарга",
+      "slug": "скарга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скаржитися",
+      "slug": "скаржитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скасовувати",
+      "slug": "скасовувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скасувати",
+      "slug": "скасувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скатертина",
+      "slug": "скатертина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "склад",
+      "slug": "склад",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "складатися",
+      "slug": "складатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "складений",
+      "slug": "складений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "складний",
+      "slug": "складний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "складнопідрядний",
+      "slug": "складнопідрядний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "складносурядний",
+      "slug": "складносурядний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скласти",
+      "slug": "скласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скло",
+      "slug": "скло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скляний",
+      "slug": "скляний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "склянка",
+      "slug": "склянка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скрипка",
+      "slug": "скрипка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скромно",
+      "slug": "скромно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скульптура",
+      "slug": "скульптура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "скупий",
+      "slug": "скупий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слабкий",
+      "slug": "слабкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слабкість",
+      "slug": "слабкість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слава",
+      "slug": "слава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слизький",
+      "slug": "слизький",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "словесно",
+      "slug": "словесно",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слово",
+      "slug": "слово",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "словосполучення",
+      "slug": "словосполучення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "служба",
+      "slug": "служба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "службовий",
+      "slug": "службовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "служити",
+      "slug": "служити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слух",
+      "slug": "слух",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "слухати",
+      "slug": "слухати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сльоза",
+      "slug": "сльоза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слід",
+      "slug": "слід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "слідкувати",
+      "slug": "слідкувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сліпий",
+      "slug": "сліпий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смажити",
+      "slug": "смажити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смак",
+      "slug": "смак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смалець",
+      "slug": "смалець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смартфон",
+      "slug": "смартфон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смачний",
+      "slug": "смачний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смердючий",
+      "slug": "смердючий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смерть",
+      "slug": "смерть",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сметана",
+      "slug": "сметана",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смородина",
+      "slug": "смородина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смуга",
+      "slug": "смуга",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сміти",
+      "slug": "сміти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смітити",
+      "slug": "смітити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смітник",
+      "slug": "смітник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сміття",
+      "slug": "сміття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сміх",
+      "slug": "сміх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смішний",
+      "slug": "смішний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "смішно",
+      "slug": "смішно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сміятися",
+      "slug": "сміятися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "снайпер",
+      "slug": "снайпер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сніг",
+      "slug": "сніг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сніданок",
+      "slug": "сніданок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "снідати",
+      "slug": "снідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сніжити",
+      "slug": "сніжити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "собака",
+      "slug": "собака",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сова",
+      "slug": "сова",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "солдат",
+      "slug": "солдат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "соловей",
+      "slug": "соловей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "солодкий",
+      "slug": "солодкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "солодощі",
+      "slug": "солодощі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "солома",
+      "slug": "солома",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сон",
+      "slug": "сон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сонливість",
+      "slug": "сонливість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сонний",
+      "slug": "сонний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сонце",
+      "slug": "сонце",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сонячний",
+      "slug": "сонячний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сором",
+      "slug": "сором",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "соромитися",
+      "slug": "соромитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сорочка",
+      "slug": "сорочка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сосиска",
+      "slug": "сосиска",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сотий",
+      "slug": "сотий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сотник",
+      "slug": "сотник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сотня",
+      "slug": "сотня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сохнути",
+      "slug": "сохнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "соціальний",
+      "slug": "соціальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "союз",
+      "slug": "союз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "союзник",
+      "slug": "союзник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спадкоємець",
+      "slug": "спадкоємець",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спадщина",
+      "slug": "спадщина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спакувати",
+      "slug": "спакувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спалах",
+      "slug": "спалах",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спалахнути",
+      "slug": "спалахнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спалити",
+      "slug": "спалити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спальня",
+      "slug": "спальня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спати",
+      "slug": "спати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спека",
+      "slug": "спека",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спеціальний",
+      "slug": "спеціальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спеціаліст",
+      "slug": "спеціаліст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спина",
+      "slug": "спина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спинити",
+      "slug": "спинити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "список",
+      "slug": "список",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сповнений",
+      "slug": "сповнений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сповільнюватися",
+      "slug": "сповільнюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сповіщення",
+      "slug": "сповіщення",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "спогад",
+      "slug": "спогад",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сподобатися",
+      "slug": "сподобатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сподіватися",
+      "slug": "сподіватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "споживати",
+      "slug": "споживати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спокій",
+      "slug": "спокій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спокійний",
+      "slug": "спокійний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сполучний",
+      "slug": "сполучний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сполучник",
+      "slug": "сполучник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спонтанний",
+      "slug": "спонтанний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спорожніти",
+      "slug": "спорожніти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спорт",
+      "slug": "спорт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спортзал",
+      "slug": "спортзал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спортивний",
+      "slug": "спортивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спорядження",
+      "slug": "спорядження",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "споріднений",
+      "slug": "споріднений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спостерігати",
+      "slug": "спостерігати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спостерігатися",
+      "slug": "спостерігатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спосіб",
+      "slug": "спосіб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спотворювати",
+      "slug": "спотворювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "справа",
+      "slug": "справа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "справедливий",
+      "slug": "справедливий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "справедливо",
+      "slug": "справедливо",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "справедливість",
+      "slug": "справедливість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "справжній",
+      "slug": "справжній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спрага",
+      "slug": "спрага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сприймати",
+      "slug": "сприймати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спричинити",
+      "slug": "спричинити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сприяти",
+      "slug": "сприяти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спроба",
+      "slug": "спроба",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спробувати",
+      "slug": "спробувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співак",
+      "slug": "співак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співати",
+      "slug": "співати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співбесіда",
+      "slug": "співбесіда",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співпраця",
+      "slug": "співпраця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співробітник",
+      "slug": "співробітник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співрозмовник",
+      "slug": "співрозмовник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "співчувати",
+      "slug": "співчувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спідниця",
+      "slug": "спідниця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спізнитися",
+      "slug": "спізнитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спікер",
+      "slug": "спікер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спілкування",
+      "slug": "спілкування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спілкуватися",
+      "slug": "спілкуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спільний",
+      "slug": "спільний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спільник",
+      "slug": "спільник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спільно",
+      "slug": "спільно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спільнота",
+      "slug": "спільнота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спіраль",
+      "slug": "спіраль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спітніти",
+      "slug": "спітніти",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "спішити",
+      "slug": "спішити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "срібний",
+      "slug": "срібний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ставати",
+      "slug": "ставати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ставатися",
+      "slug": "ставатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ставити",
+      "slug": "ставити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ставлення",
+      "slug": "ставлення",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стадіон",
+      "slug": "стадіон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стаж",
+      "slug": "стаж",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "стажування",
+      "slug": "стажування",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "стайня",
+      "slug": "стайня",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стан",
+      "slug": "стан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стандарт",
+      "slug": "стандарт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "становити",
+      "slug": "становити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "становище",
+      "slug": "становище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "станція",
+      "slug": "станція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "старатися",
+      "slug": "старатися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "старий",
+      "slug": "старий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "старший",
+      "slug": "старший",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "старіти",
+      "slug": "старіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "статистика",
+      "slug": "статистика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "статися",
+      "slug": "статися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "статок",
+      "slug": "статок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стаття",
+      "slug": "стаття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стать",
+      "slug": "стать",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стверджувати",
+      "slug": "стверджувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ствердити",
+      "slug": "ствердити",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "створити",
+      "slug": "створити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "створювати",
+      "slug": "створювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "створюватися",
+      "slug": "створюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стебло",
+      "slug": "стебло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стегно",
+      "slug": "стегно",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стежити",
+      "slug": "стежити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стежка",
+      "slug": "стежка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "степ",
+      "slug": "степ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стиль",
+      "slug": "стиль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стимулювати",
+      "slug": "стимулювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стипендія",
+      "slug": "стипендія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стирати",
+      "slug": "стирати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сто",
+      "slug": "сто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "століття",
+      "slug": "століття",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стоматолог",
+      "slug": "стоматолог",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сторона",
+      "slug": "сторона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сторінка",
+      "slug": "сторінка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стосунок",
+      "slug": "стосунок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стояти",
+      "slug": "стояти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "страва",
+      "slug": "страва",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "страта",
+      "slug": "страта",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стратег",
+      "slug": "стратег",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стратегічний",
+      "slug": "стратегічний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стратити",
+      "slug": "стратити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "страх",
+      "slug": "страх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "страховка",
+      "slug": "страховка",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "страхування",
+      "slug": "страхування",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "страшний",
+      "slug": "страшний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стрес",
+      "slug": "стрес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стресовий",
+      "slug": "стресовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стрибати",
+      "slug": "стрибати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стрибнути",
+      "slug": "стрибнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "строгий",
+      "slug": "строгий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "строк",
+      "slug": "строк",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "структура",
+      "slug": "структура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "структурний",
+      "slug": "структурний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "струм",
+      "slug": "струм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "струс",
+      "slug": "струс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стріла",
+      "slug": "стріла",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стрілець",
+      "slug": "стрілець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стрічка",
+      "slug": "стрічка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "студент",
+      "slug": "студент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "студентка",
+      "slug": "студентка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "студія",
+      "slug": "студія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стукати",
+      "slug": "стукати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стукіт",
+      "slug": "стукіт",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ступінь",
+      "slug": "ступінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стіл",
+      "slug": "стіл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стілець",
+      "slug": "стілець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "стіна",
+      "slug": "стіна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "субординація",
+      "slug": "субординація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "субота",
+      "slug": "субота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суворий",
+      "slug": "суворий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суд",
+      "slug": "суд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суддя",
+      "slug": "суддя",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сукня",
+      "slug": "сукня",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "султан",
+      "slug": "султан",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сумка",
+      "slug": "сумка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сумний",
+      "slug": "сумний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сумнів",
+      "slug": "сумнів",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сумніватися",
+      "slug": "сумніватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суп",
+      "slug": "суп",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суперечка",
+      "slug": "суперечка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суперечливий",
+      "slug": "суперечливий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "супермаркет",
+      "slug": "супермаркет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суперник",
+      "slug": "суперник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "супроводжувати",
+      "slug": "супроводжувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "супроводити",
+      "slug": "супроводити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "супровід",
+      "slug": "супровід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "супутник",
+      "slug": "супутник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сурядний",
+      "slug": "сурядний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сурядність",
+      "slug": "сурядність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "суспільство",
+      "slug": "суспільство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сусідка",
+      "slug": "сусідка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сусідній",
+      "slug": "сусідній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сухий",
+      "slug": "сухий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сухожилля",
+      "slug": "сухожилля",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сучасний",
+      "slug": "сучасний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сфера",
+      "slug": "сфера",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сфотографуватися",
+      "slug": "сфотографуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "схил",
+      "slug": "схил",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "схильність",
+      "slug": "схильність",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сховати",
+      "slug": "сховати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сходити",
+      "slug": "сходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "схожий",
+      "slug": "схожий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "схід",
+      "slug": "схід",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "східний",
+      "slug": "східний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сцена",
+      "slug": "сцена",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сьомий",
+      "slug": "сьомий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сюжет",
+      "slug": "сюжет",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сяяти",
+      "slug": "сяяти",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "сідати",
+      "slug": "сідати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сік",
+      "slug": "сік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сіль",
+      "slug": "сіль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сім",
+      "slug": "сім",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сім'я",
+      "slug": "сім-я",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сімейний",
+      "slug": "сімейний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сімсот",
+      "slug": "сімсот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сіно",
+      "slug": "сіно",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сірий",
+      "slug": "сірий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сісти",
+      "slug": "сісти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "сітка",
+      "slug": "сітка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "січень",
+      "slug": "січень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "січовий",
+      "slug": "січовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "таблетка",
+      "slug": "таблетка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "таблиця",
+      "slug": "таблиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "табір",
+      "slug": "табір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "такий",
+      "slug": "такий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тактика",
+      "slug": "тактика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "талановитий",
+      "slug": "талановитий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "талант",
+      "slug": "талант",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "танець",
+      "slug": "танець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "танцювати",
+      "slug": "танцювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тарган",
+      "slug": "тарган",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тарілка",
+      "slug": "тарілка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "татарин",
+      "slug": "татарин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тато",
+      "slug": "тато",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "таємний",
+      "slug": "таємний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "таємничий",
+      "slug": "таємничий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "таємно",
+      "slug": "таємно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "тварина",
+      "slug": "тварина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "твердження",
+      "slug": "твердження",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "твердий",
+      "slug": "твердий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "творення",
+      "slug": "творення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "творчість",
+      "slug": "творчість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "твій",
+      "slug": "твій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "твір",
+      "slug": "твір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "текст",
+      "slug": "текст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "текти",
+      "slug": "текти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "телевізор",
+      "slug": "телевізор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "телефон",
+      "slug": "телефон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "телятина",
+      "slug": "телятина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тема",
+      "slug": "тема",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "темний",
+      "slug": "темний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "температура",
+      "slug": "температура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "темрява",
+      "slug": "темрява",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "теорія",
+      "slug": "теорія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "теплий",
+      "slug": "теплий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "терапевт",
+      "slug": "терапевт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "територія",
+      "slug": "територія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "термін",
+      "slug": "термін",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "термінал",
+      "slug": "термінал",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "терплячий",
+      "slug": "терплячий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "терпіння",
+      "slug": "терпіння",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "тесла",
+      "slug": "тесла",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тесть",
+      "slug": "тесть",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тетеря",
+      "slug": "тетеря",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "теща",
+      "slug": "теща",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ти",
+      "slug": "ти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тиждень",
+      "slug": "тиждень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тил",
+      "slug": "тил",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "тип",
+      "slug": "тип",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тиск",
+      "slug": "тиск",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тисяча",
+      "slug": "тисяча",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "титул",
+      "slug": "титул",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тихий",
+      "slug": "тихий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тиша",
+      "slug": "тиша",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тканина",
+      "slug": "тканина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "товар",
+      "slug": "товар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "товктися",
+      "slug": "товктися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "товстий",
+      "slug": "товстий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "того",
+      "slug": "того",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "той",
+      "slug": "той",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "токсин",
+      "slug": "токсин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "том",
+      "slug": "том",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тонкий",
+      "slug": "тонкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тонна",
+      "slug": "тонна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торба",
+      "slug": "торба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торговий",
+      "slug": "торговий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торкатися",
+      "slug": "торкатися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торкнутися",
+      "slug": "торкнутися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торт",
+      "slug": "торт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "торік",
+      "slug": "торік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "точний",
+      "slug": "точний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тощо",
+      "slug": "тощо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "трава",
+      "slug": "трава",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "травень",
+      "slug": "травень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "травлення",
+      "slug": "травлення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "травма",
+      "slug": "травма",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "травний",
+      "slug": "травний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "трагедія",
+      "slug": "трагедія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "традиція",
+      "slug": "традиція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "трактор",
+      "slug": "трактор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "транспорт",
+      "slug": "транспорт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "траплятися",
+      "slug": "траплятися",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тренажерний",
+      "slug": "тренажерний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тренер",
+      "slug": "тренер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тренування",
+      "slug": "тренування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тренувати",
+      "slug": "тренувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тренуватися",
+      "slug": "тренуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "третина",
+      "slug": "третина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "третій",
+      "slug": "третій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тривалий",
+      "slug": "тривалий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тривалість",
+      "slug": "тривалість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тривати",
+      "slug": "тривати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тривога",
+      "slug": "тривога",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тридцять",
+      "slug": "тридцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тримати",
+      "slug": "тримати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тринадцять",
+      "slug": "тринадцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "триста",
+      "slug": "триста",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тротуар",
+      "slug": "тротуар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "троянда",
+      "slug": "троянда",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "труднощі",
+      "slug": "труднощі",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "трясти",
+      "slug": "трясти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "трійка",
+      "slug": "трійка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тріщина",
+      "slug": "тріщина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "туалет",
+      "slug": "туалет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "туга",
+      "slug": "туга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "туз",
+      "slug": "туз",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "туман",
+      "slug": "туман",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "турбувати",
+      "slug": "турбувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "турбуватися",
+      "slug": "турбуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "турецький",
+      "slug": "турецький",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "турист",
+      "slug": "турист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "турок",
+      "slug": "турок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тютюн",
+      "slug": "тютюн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тягати",
+      "slug": "тягати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тяжкий",
+      "slug": "тяжкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тікати",
+      "slug": "тікати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тіло",
+      "slug": "тіло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тінь",
+      "slug": "тінь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "тітка",
+      "slug": "тітка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "увага",
+      "slug": "увага",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "увесь",
+      "slug": "увесь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "увійти",
+      "slug": "увійти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "увімкнути",
+      "slug": "увімкнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "угода",
+      "slug": "угода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "угіддя",
+      "slug": "угіддя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "удавати",
+      "slug": "удавати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "удар",
+      "slug": "удар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ударити",
+      "slug": "ударити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "удача",
+      "slug": "удача",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "укласти",
+      "slug": "укласти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "Україна",
+      "slug": "україна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "українець",
+      "slug": "українець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "український",
+      "slug": "український",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "улюбленець",
+      "slug": "улюбленець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "улюблений",
+      "slug": "улюблений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "умова",
+      "slug": "умова",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "умовний",
+      "slug": "умовний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уміння",
+      "slug": "уміння",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уникати",
+      "slug": "уникати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уникнути",
+      "slug": "уникнути",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "університет",
+      "slug": "університет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уособлювати",
+      "slug": "уособлювати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "упасти",
+      "slug": "упасти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "урожай",
+      "slug": "урожай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "урок",
+      "slug": "урок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "урочистий",
+      "slug": "урочистий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "урочистість",
+      "slug": "урочистість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уряд",
+      "slug": "уряд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "усвідомлювати",
+      "slug": "усвідомлювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ускладнення",
+      "slug": "ускладнення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ускладнити",
+      "slug": "ускладнити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "усний",
+      "slug": "усний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "успіх",
+      "slug": "успіх",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "успішний",
+      "slug": "успішний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "утворити",
+      "slug": "утворити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уточнювати",
+      "slug": "уточнювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ухвалити",
+      "slug": "ухвалити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "учасник",
+      "slug": "учасник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "участь",
+      "slug": "участь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "учениця",
+      "slug": "учениця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "учень",
+      "slug": "учень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "учитель",
+      "slug": "учитель",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "учити",
+      "slug": "учити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уява",
+      "slug": "уява",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "уявити",
+      "slug": "уявити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "файл",
+      "slug": "файл",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "факт",
+      "slug": "факт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фактор",
+      "slug": "фактор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фантастичний",
+      "slug": "фантастичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фарба",
+      "slug": "фарба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фахівець",
+      "slug": "фахівець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фашист",
+      "slug": "фашист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фейсбук",
+      "slug": "фейсбук",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ферма",
+      "slug": "ферма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фермент",
+      "slug": "фермент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фермер",
+      "slug": "фермер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фестиваль",
+      "slug": "фестиваль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "флот",
+      "slug": "флот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фольга",
+      "slug": "фольга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фон",
+      "slug": "фон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фонд",
+      "slug": "фонд",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фоновий",
+      "slug": "фоновий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "форма",
+      "slug": "форма",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "формуватися",
+      "slug": "формуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "формула",
+      "slug": "формула",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "форпост",
+      "slug": "форпост",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фортеця",
+      "slug": "фортеця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "форум",
+      "slug": "форум",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фотографія",
+      "slug": "фотографія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фрагмент",
+      "slug": "фрагмент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фраза",
+      "slug": "фраза",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "францій",
+      "slug": "францій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фрукт",
+      "slug": "фрукт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фруктовий",
+      "slug": "фруктовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "функціонувати",
+      "slug": "функціонувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "функція",
+      "slug": "функція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "футболка",
+      "slug": "футболка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "футбольний",
+      "slug": "футбольний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "футляр",
+      "slug": "футляр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фігура",
+      "slug": "фігура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фізика",
+      "slug": "фізика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фізичний",
+      "slug": "фізичний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фільм",
+      "slug": "фільм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фінанси",
+      "slug": "фінанси",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "фітнес",
+      "slug": "фітнес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хазяїн",
+      "slug": "хазяїн",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ханство",
+      "slug": "ханство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хаос",
+      "slug": "хаос",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "характер",
+      "slug": "характер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "характеристика",
+      "slug": "характеристика",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "характерний",
+      "slug": "характерний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "харчовий",
+      "slug": "харчовий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "харчування",
+      "slug": "харчування",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "харчуватися",
+      "slug": "харчуватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хата",
+      "slug": "хата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хатинка",
+      "slug": "хатинка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хвалити",
+      "slug": "хвалити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хвилина",
+      "slug": "хвилина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хвилюватися",
+      "slug": "хвилюватися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хворий",
+      "slug": "хворий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хвороба",
+      "slug": "хвороба",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хворіти",
+      "slug": "хворіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хвіст",
+      "slug": "хвіст",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хибний",
+      "slug": "хибний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хлопець",
+      "slug": "хлопець",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хлопчик",
+      "slug": "хлопчик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хліб",
+      "slug": "хліб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хлів",
+      "slug": "хлів",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хмара",
+      "slug": "хмара",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ховати",
+      "slug": "ховати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ходити",
+      "slug": "ходити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ходьба",
+      "slug": "ходьба",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "холод",
+      "slug": "холод",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "холодильник",
+      "slug": "холодильник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "холодний",
+      "slug": "холодний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хороший",
+      "slug": "хороший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хортиця",
+      "slug": "хортиця",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хотіти",
+      "slug": "хотіти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "храм",
+      "slug": "храм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хрест",
+      "slug": "хрест",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хто",
+      "slug": "хто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хтось",
+      "slug": "хтось",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "худий",
+      "slug": "худий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "худоба",
+      "slug": "худоба",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хутір",
+      "slug": "хутір",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "хірург",
+      "slug": "хірург",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цар",
+      "slug": "цар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "царство",
+      "slug": "царство",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цвинтар",
+      "slug": "цвинтар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цвісти",
+      "slug": "цвісти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цегла",
+      "slug": "цегла",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цей",
+      "slug": "цей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "центр",
+      "slug": "центр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "центральний",
+      "slug": "центральний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "церква",
+      "slug": "церква",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цибуля",
+      "slug": "цибуля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цивільний",
+      "slug": "цивільний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "циган",
+      "slug": "циган",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цигарка",
+      "slug": "цигарка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цимбали",
+      "slug": "цимбали",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "циркулювати",
+      "slug": "циркулювати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цитата",
+      "slug": "цитата",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цифра",
+      "slug": "цифра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цифровий",
+      "slug": "цифровий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цукор",
+      "slug": "цукор",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цуценя",
+      "slug": "цуценя",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цуцик",
+      "slug": "цуцик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цікавий",
+      "slug": "цікавий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цікавитися",
+      "slug": "цікавитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цікавіший",
+      "slug": "цікавіший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цілий",
+      "slug": "цілий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цілодобово",
+      "slug": "цілодобово",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "ціль",
+      "slug": "ціль",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ціна",
+      "slug": "ціна",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цінний",
+      "slug": "цінний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цінник",
+      "slug": "цінник",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "цінність",
+      "slug": "цінність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чай",
+      "slug": "чай",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чайний",
+      "slug": "чайний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чайові",
+      "slug": "чайові",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чаклун",
+      "slug": "чаклун",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чапля",
+      "slug": "чапля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "час",
+      "slug": "час",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "часник",
+      "slug": "часник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "часопис",
+      "slug": "часопис",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "частий",
+      "slug": "частий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "частина",
+      "slug": "частина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "частка",
+      "slug": "частка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "частота",
+      "slug": "частота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "частувати",
+      "slug": "частувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чаша",
+      "slug": "чаша",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чашка",
+      "slug": "чашка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чверть",
+      "slug": "чверть",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чекати",
+      "slug": "чекати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чемний",
+      "slug": "чемний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чемпіон",
+      "slug": "чемпіон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чемпіонат",
+      "slug": "чемпіонат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "червень",
+      "slug": "червень",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "червоний",
+      "slug": "червоний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "черга",
+      "slug": "черга",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "черговий",
+      "slug": "черговий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "черепаха",
+      "slug": "черепаха",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "четвертий",
+      "slug": "четвертий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чий",
+      "slug": "чий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чийсь",
+      "slug": "чийсь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чим",
+      "slug": "чим",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чин",
+      "slug": "чин",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чинити",
+      "slug": "чинити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чинник",
+      "slug": "чинник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "число",
+      "slug": "число",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "числівник",
+      "slug": "числівник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чистити",
+      "slug": "чистити",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чисто",
+      "slug": "чисто",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "читати",
+      "slug": "читати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "читач",
+      "slug": "читач",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "член",
+      "slug": "член",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чобіт",
+      "slug": "чобіт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чого",
+      "slug": "чого",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чоло",
+      "slug": "чоло",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чоловік",
+      "slug": "чоловік",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чоловічий",
+      "slug": "чоловічий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чорний",
+      "slug": "чорний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чорніти",
+      "slug": "чорніти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чотири",
+      "slug": "чотири",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чотирнадцять",
+      "slug": "чотирнадцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чудо",
+      "slug": "чудо",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чуйність",
+      "slug": "чуйність",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чути",
+      "slug": "чути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чутливий",
+      "slug": "чутливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "чухати",
+      "slug": "чухати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шаблон",
+      "slug": "шаблон",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шабля",
+      "slug": "шабля",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шалений",
+      "slug": "шалений",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шановний",
+      "slug": "шановний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шанс",
+      "slug": "шанс",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шанувальник",
+      "slug": "шанувальник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шапка",
+      "slug": "шапка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шар",
+      "slug": "шар",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шафа",
+      "slug": "шафа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шафка",
+      "slug": "шафка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шаховий",
+      "slug": "шаховий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шахрайство",
+      "slug": "шахрайство",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "швабра",
+      "slug": "швабра",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "швидкий",
+      "slug": "швидкий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шедевр",
+      "slug": "шедевр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шина",
+      "slug": "шина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шиплячий",
+      "slug": "шиплячий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ширина",
+      "slug": "ширина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ширитися",
+      "slug": "ширитися",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "широкий",
+      "slug": "широкий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкаралупа",
+      "slug": "шкаралупа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкарпетка",
+      "slug": "шкарпетка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкварка",
+      "slug": "шкварка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкодити",
+      "slug": "шкодити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "школа",
+      "slug": "школа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "школяр",
+      "slug": "школяр",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкура",
+      "slug": "шкура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкідливий",
+      "slug": "шкідливий",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкідливість",
+      "slug": "шкідливість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкіра",
+      "slug": "шкіра",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шкірний",
+      "slug": "шкірний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шланг",
+      "slug": "шланг",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шлунок",
+      "slug": "шлунок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шлюб",
+      "slug": "шлюб",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шлях",
+      "slug": "шлях",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шнурок",
+      "slug": "шнурок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шок",
+      "slug": "шок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шоколад",
+      "slug": "шоколад",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шоколадний",
+      "slug": "шоколадний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шолом",
+      "slug": "шолом",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шостий",
+      "slug": "шостий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шпигун",
+      "slug": "шпигун",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штани",
+      "slug": "штани",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штат",
+      "slug": "штат",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штовхнути",
+      "slug": "штовхнути",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штора",
+      "slug": "штора",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штраф",
+      "slug": "штраф",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штрафувати",
+      "slug": "штрафувати",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "штурм",
+      "slug": "штурм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "штучний",
+      "slug": "штучний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шукати",
+      "slug": "шукати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шум",
+      "slug": "шум",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шумний",
+      "slug": "шумний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шуміти",
+      "slug": "шуміти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шістдесят",
+      "slug": "шістдесят",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шістка",
+      "slug": "шістка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шістнадцять",
+      "slug": "шістнадцять",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шістсот",
+      "slug": "шістсот",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "шість",
+      "slug": "шість",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щасливий",
+      "slug": "щасливий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щасливої дороги",
+      "slug": "щасливої-дороги",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "щастити",
+      "slug": "щастити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щеплення",
+      "slug": "щеплення",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щиколотка",
+      "slug": "щиколотка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щирий",
+      "slug": "щирий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щит",
+      "slug": "щит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "що",
+      "slug": "що",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щоденний",
+      "slug": "щоденний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щоденник",
+      "slug": "щоденник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щось",
+      "slug": "щось",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "щілина",
+      "slug": "щілина",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "юліанський",
+      "slug": "юліанський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "юрист",
+      "slug": "юрист",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яблуко",
+      "slug": "яблуко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яблучко",
+      "slug": "яблучко",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яблучний",
+      "slug": "яблучний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "явище",
+      "slug": "явище",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "явно",
+      "slug": "явно",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "ягода",
+      "slug": "ягода",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ядерний",
+      "slug": "ядерний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ядро",
+      "slug": "ядро",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "язик",
+      "slug": "язик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яйце",
+      "slug": "яйце",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "як",
+      "slug": "як",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "який",
+      "slug": "який",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "якийсь",
+      "slug": "якийсь",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "якомога",
+      "slug": "якомога",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "якісний",
+      "slug": "якісний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "якість",
+      "slug": "якість",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ялинка",
+      "slug": "ялинка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ялинковий",
+      "slug": "ялинковий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яловичина",
+      "slug": "яловичина",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "яма",
+      "slug": "яма",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "янгол",
+      "slug": "янгол",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "янголятко",
+      "slug": "янголятко",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єврей",
+      "slug": "єврей",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "європейський",
+      "slug": "європейський",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єдиний",
+      "slug": "єдиний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єднальний",
+      "slug": "єднальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єдність",
+      "slug": "єдність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єнот",
+      "slug": "єнот",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "єпископ",
+      "slug": "єпископ",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ігнорувати",
+      "slug": "ігнорувати",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "іграшка",
+      "slug": "іграшка",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ігровий",
+      "slug": "ігровий",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ідеальний",
+      "slug": "ідеальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ідентичність",
+      "slug": "ідентичність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ідея",
+      "slug": "ідея",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ікона",
+      "slug": "ікона",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ім'я",
+      "slug": "ім-я",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "імбирний",
+      "slug": "імбирний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "іменник",
+      "slug": "іменник",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "імперія",
+      "slug": "імперія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "імунний",
+      "slug": "імунний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "імунітет",
+      "slug": "імунітет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інверсія",
+      "slug": "інверсія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інвестиція",
+      "slug": "інвестиція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інгредієнт",
+      "slug": "інгредієнт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "індій",
+      "slug": "індій",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інженер",
+      "slug": "інженер",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інстаграм",
+      "slug": "інстаграм",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інститут",
+      "slug": "інститут",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інструкція",
+      "slug": "інструкція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інструмент",
+      "slug": "інструмент",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інсульт",
+      "slug": "інсульт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтелект",
+      "slug": "інтелект",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтелектуальний",
+      "slug": "інтелектуальний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтенсивний",
+      "slug": "інтенсивний",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтенсивність",
+      "slug": "інтенсивність",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтерес",
+      "slug": "інтерес",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інтернет",
+      "slug": "інтернет",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інфаркт",
+      "slug": "інфаркт",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інфекція",
+      "slug": "інфекція",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інформація",
+      "slug": "інформація",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інфраструктура",
+      "slug": "інфраструктура",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "інший",
+      "slug": "інший",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "іронічність",
+      "slug": "іронічність",
+      "sources": [
+        "homework"
+      ]
+    },
+    {
+      "lemma": "іронія",
+      "slug": "іронія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "існувати",
+      "slug": "існувати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "іспит",
+      "slug": "іспит",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "історик",
+      "slug": "історик",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "історія",
+      "slug": "історія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "істота",
+      "slug": "істота",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "іти",
+      "slug": "іти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ієрархія",
+      "slug": "ієрархія",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їжа",
+      "slug": "їжа",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їжак",
+      "slug": "їжак",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їздити",
+      "slug": "їздити",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їсти",
+      "slug": "їсти",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їстівний",
+      "slug": "їстівний",
+      "sources": [
+        "homework",
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їхати",
+      "slug": "їхати",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "їхній",
+      "slug": "їхній",
+      "sources": [
+        "teacher_inventory"
+      ]
+    },
+    {
+      "lemma": "ґанок",
+      "slug": "ґанок",
+      "sources": [
+        "teacher_inventory"
+      ]
+    }
+  ]
+}

--- a/tests/test_curated_membership.py
+++ b/tests/test_curated_membership.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.generate_practice_deck import BuildConfig, JsonVesumVerifier, _select_practice_lexemes
+from scripts.audit.lexeme_filter import is_practice_eligible, practice_ineligibility_reason
+from scripts.audit.measure_curated_membership import measure_membership
+from scripts.lexicon.curated_membership import apply_membership, build_membership, read_membership
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    homework = tmp_path / "homework.jsonl"
+    homework.write_text(
+        json.dumps(
+            {
+                "seedRow": 1,
+                "lemma": "слово",
+                "gloss": "word",
+                "sentenceStatus": "has_candidates",
+                "admission": {"practice": True, "mode": "local_practice_private_teacher"},
+                "vesumAttestation": {"attested": True},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    teacher = tmp_path / "teacher.json"
+    _write_json(
+        teacher,
+        {
+            "cloze": [
+                {"lemmaId": "слово", "sentence": "Never read this."},
+                {"lemmaId": "книга", "options": [{"label": "Never read this either."}]},
+                {"lemmaId": "(чайний) сервіз", "lemma": "сервіз"},
+            ]
+        },
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_json(
+        manifest,
+        {
+            "entries": [
+                {"lemma": "слово", "url_slug": "слово", "gloss": "word", "cefr": "A1"},
+                {"lemma": "книга", "url_slug": "книга", "gloss": "book", "cefr": "A1"},
+                {"lemma": "сервіз", "url_slug": "сервіз", "gloss": "service", "cefr": "A2"},
+            ]
+        },
+    )
+    return homework, teacher, manifest
+
+
+def test_build_membership_uses_only_exact_inventory_keys_and_no_teacher_prose(tmp_path: Path) -> None:
+    homework, teacher, manifest = _inputs(tmp_path)
+
+    payload, report = build_membership(
+        homework_seed_path=homework,
+        teacher_inventory_path=teacher,
+        manifest_path=manifest,
+    )
+
+    assert [member["slug"] for member in payload["members"]] == ["книга", "слово"]
+    assert report["teacher_inventory"]["unique_keys"] == 3
+    assert report["teacher_inventory"]["resolved_keys"] == 2
+    assert "Never read this" not in json.dumps(payload, ensure_ascii=False)
+
+
+def test_apply_membership_unlocks_practice_but_not_cloze() -> None:
+    entries = [
+        {
+            "lemma": "слово",
+            "url_slug": "слово",
+            "gloss": "word",
+            "cefr": "A1",
+            "primary_source": "source_inventory_grow",
+            "surface_admission": {"cloze": False},
+        }
+    ]
+
+    merged, report = apply_membership(
+        entries,
+        [{"lemma": "слово", "slug": "слово", "sources": ["homework"]}],
+    )
+
+    assert report == {"members": 1, "resolved": 1}
+    assert merged[0]["curated_membership"] is True
+    assert merged[0]["surface_admission"] == {"cloze": False, "practice": True}
+    assert is_practice_eligible(merged[0]) is True
+    assert practice_ineligibility_reason(merged[0]) is None
+
+
+def test_apply_membership_rejects_missing_atlas_route() -> None:
+    with pytest.raises(ValueError, match="unresolved Atlas route"):
+        apply_membership([], [{"lemma": "слово", "slug": "слово", "sources": ["homework"]}])
+
+
+def test_membership_entries_are_selected_before_the_general_practice_pool() -> None:
+    entries = [
+        {
+            "lemma": "книга",
+            "url_slug": "книга",
+            "gloss": "book",
+            "cefr": "A1",
+            "primary_source": "source_inventory_grow",
+            "surface_admission": {"cloze": False},
+        },
+        {
+            "lemma": "школа",
+            "url_slug": "школа",
+            "gloss": "school",
+            "cefr": "A1",
+            "course_usage": [{"module": "fixture"}],
+        },
+    ]
+    merged, _report = apply_membership(
+        entries,
+        [{"lemma": "книга", "slug": "книга", "sources": ["teacher_inventory"]}],
+    )
+
+    selected, _lexemes, _by_plain_lemma, _by_id = _select_practice_lexemes(
+        merged,
+        JsonVesumVerifier.from_path(Path("tests/fixtures/lexicon-practice-vesum.json")),
+        BuildConfig(target=1, source_label="fixture"),
+    )
+
+    assert [entry["url_slug"] for entry, _lexeme in selected] == ["книга"]
+
+
+def test_measurement_reports_union_floor_and_recognition_modes(tmp_path: Path) -> None:
+    homework, teacher, manifest = _inputs(tmp_path)
+    membership_payload, _report = build_membership(
+        homework_seed_path=homework,
+        teacher_inventory_path=teacher,
+        manifest_path=manifest,
+    )
+    membership = tmp_path / "membership.json"
+    _write_json(membership, membership_payload)
+    practice_dir = tmp_path / "practice"
+    practice_dir.mkdir()
+    _write_json(
+        practice_dir / "practice-index.A1.json",
+        {
+            "items": [
+                {"lemmaId": "слово", "cefr": "A1", "modes": ["flashcards", "matching", "choice"]},
+                {"lemmaId": "книга", "cefr": "A1", "modes": ["flashcards", "matching"]},
+            ]
+        },
+    )
+
+    measured = measure_membership(
+        homework_seed_path=homework,
+        teacher_inventory_path=teacher,
+        manifest_path=manifest,
+        membership_path=membership,
+        practice_dir=practice_dir,
+    )
+
+    assert read_membership(membership)[0]["slug"] == "книга"
+    assert measured["homework"]["missing_from_curated_keys"] == 0
+    assert measured["homework"]["missing_from_practice_indexes"] == 0
+    assert measured["teacher_inventory"] == {
+        "cards": 3,
+        "unique_keys": 3,
+        "resolved_membership_routes": 2,
+    }
+    assert measured["recognition_mode_eligibility"]["A1"] == {
+        "lexemes": 2,
+        "flashcards": 2,
+        "matching": 2,
+        "choice": 1,
+    }


### PR DESCRIPTION
Closes #6259
Refs #6132
Refs #4387

## What changed

- Adds a lemma-only Curated Practice membership overlay that is the resolved A union B, without reading teacher sentence bodies or options into the practice generator.
- Gives exact, resolved union routes priority in practice selection, unlocking non-sentence modes while preserving the existing cloze rights/admission gate.
- Adds a deterministic builder, membership measurement command, Make target, and publish fingerprint plumbing.

## Evidence (cwd: dispatch worktree)

| Check | Command and raw result |
| --- | --- |
| A source and Curated keys | `.venv/bin/python -m scripts.audit.measure_curated_membership ...` -> 1,019 unique homework lemmas; 740 public-route rows; `missing_from_curated_keys: 0`. |
| A practice coverage | Same measurement -> 696 policy-eligible routes; `missing_from_practice_indexes: 0`. Policy residuals: 290 local-only/no public route, 1 missing public route, 6 VESUM no-document-hit, plus 38 existing Atlas entries excluded by normal card policy (27 missing gloss, 10 no curriculum anchor, 1 form-of). |
| B retained | Builder -> `teacher_keys=5093`; measurement -> 5,093 cards / 5,093 unique keys. The overlay resolves 3,689 exact Atlas routes without using legacy last-token fallback. |
| Union and modes | Builder -> `routes=3852`; generated candidate indexes report all flashcard counts A1=1467, A2=1490, B1=1664, B2=952, C1=427; matching/choice counts are reported by the measurement command. |
| Candidate deck | `generate_practice_deck.py --curated-membership ... --vesum-db ... --out-dir batch_state/...` + `publish.py --dry-run` -> `atlas-practice-v1-8311bd63b7832818`, 45 shards. No release asset was uploaded. |
| Validation | 146 focused tests passed; Ruff clean; candidate static-assets validation passed. Staged OPSEC: `Checking 8 files ... PASS`. |

Cloze remains a separate sentence/rights layer under #6188; this PR does not claim cloze completion. The release upload and pointer mutation are deliberately not performed because public release is out of scope; the driver owns review and merge.