### PR TITLE
fix(bridge): use sealed worktree cwd for review-pr ACP invoke

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -329,7 +329,7 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     result = invoke_inter_agent(
                         participant,
                         sealed_prompt,
-                        cwd=Path(REPO_ROOT),
+                        cwd=checkout.path,
                         task_id=task_id,
                         correlation_id=formal_job.review_id,
                         idempotency_key=authority_key,


### PR DESCRIPTION
## Summary
- `handle_review_pr` in `scripts/ai_agent_bridge/_review_pr.py` was passing `cwd=Path(REPO_ROOT)` (the primary checkout) into `invoke_inter_agent`, but ACPX shadow adapters call `_require_non_primary_worktree` and refuse to spawn against the protected primary checkout (`AcpxGlmShadowAdapter: refusing to spawn against the protected primary checkout`).
- Regression introduced with ACP authority canonicalization (#6195, `014dd0d9f7`).
- Fix: use `checkout.path` (the provisioned sealed `ProvisionedReviewWorktree` snapshot), matching the pattern `_claude.py` already uses for its review invocation (`cwd=checkout.path if checkout is not None else REPO_ROOT`).
- Evidence root / reject roots were already scoped to `checkout.path` and are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/ai_agent_bridge/ -q` — 266 passed
- [x] `.venv/bin/ruff check scripts/ai_agent_bridge/_review_pr.py` — clean
- [x] `python -m scripts.ai_agent_bridge review-pr 6265 --reviewer glm --dry-run` — still emits prompt correctly

Note: this PR's own cross-family review may hit the same class of bug if CF review can't run against a checkout still missing this fix — if so, leave merge to the driver/operator once independently confirmed green.

X-Agent: claude/6266-review-pr-cwd