### PR TITLE
feat(foundry): add Lapa and lang-uk adoption kit

### DIFF
--- a/data/projects/open_model_data/integrations/upstream-locks.json
+++ b/data/projects/open_model_data/integrations/upstream-locks.json
@@ -1,0 +1,15 @@
+{
+  "lang_uk_leaderboard": {
+    "commit": "bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f",
+    "repository": "https://github.com/lang-uk/ukrainian-llm-leaderboard",
+    "result_dataset_revision": "3da506fe31f69d7e88754a665d1de01d774913a2",
+    "target_contract": "results_<created_at>.json plus Foundry evidence sidecar"
+  },
+  "lapa": {
+    "commit": "7e695c2bb9deaa214421a657ae23c85968947305",
+    "license": "MIT",
+    "repository": "https://github.com/UNLP-AI/lapa",
+    "target_path": "training/lapa-12b-pt-template.yml"
+  },
+  "schema_version": "foundry_upstream_integration_locks.v1"
+}

--- a/docs/projects/ukrainian-data-foundry-adoption/README.md
+++ b/docs/projects/ukrainian-data-foundry-adoption/README.md
@@ -1,0 +1,106 @@
+# Ukrainian Data Foundry adoption kit
+
+This kit turns the shipped Foundry and open-weight evaluation artifacts into a
+small local trial and concrete Lapa or lang-uk handoff packages. It needs no
+API key and performs no download, training, optimizer run, weight-adapter
+creation, upload, or external submission.
+
+## Install without an API
+
+Use Python 3.12.8 and the repository's pinned dependency file:
+
+```bash
+git clone https://github.com/learn-ukrainian/learn-ukrainian.github.io.git
+cd learn-ukrainian.github.io
+pyenv local 3.12.8
+pyenv exec python -m venv .venv
+.venv/bin/python -m pip install -r requirements.lock
+```
+
+No provider credential is read. The commands below operate on local JSON or
+JSONL only. Teams that already have the repository environment can start with
+the trial.
+
+## Ten-minute consumer-owned trial
+
+The default input is the eight-row, project-authored MIT example. Replace it
+with a consumer-owned JSONL that satisfies the portable corpus schema when
+ready.
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.adoption_cli trial \
+  --output batch_state/foundry-adoption-trial
+```
+
+The output contains verified deterministic Foundry views, tokenizer/cost and
+recipe receipts, and a source-only 4,000-case evaluation request packet. It
+does not invoke a model. Score saved local-model output with the evaluation
+command documented in the
+[evaluation guide](../ua-open-weight-eval/README.md).
+
+## Lapa data adapter
+
+The pinned integration target is Lapa commit
+`7e695c2bb9deaa214421a657ae23c85968947305`, file
+`training/lapa-12b-pt-template.yml`. Generate the handoff:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.adoption_cli lapa \
+  --foundry-run batch_state/foundry-adoption-trial/foundry \
+  --output batch_state/lapa-foundry-handoff
+```
+
+`foundry-pretraining.jsonl` uses Lapa's one-field `{"text": ...}` continued
+pretraining shape. The adapter accepts only the verified faithful-source view,
+requires an empty mask list, and emits separate lineage. It never flattens a
+masked modern-learning row, exports a benchmark case, or creates a LoRA or
+other weight adapter. The receipt pins the upstream commit and intended YAML
+target, so a Lapa maintainer can add the generated file to that template with
+reviewable provenance instead of receiving an empty outreach request.
+
+## lang-uk result adapter
+
+The pinned target is the Ukrainian LLM leaderboard commit
+`bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f`, with result-dataset revision
+`3da506fe31f69d7e88754a665d1de01d774913a2`. Start with a saved lm-eval-shaped
+file containing `config_general.model_name` and numeric metrics under
+`results`, plus a complete Foundry broad-evaluation report:
+
+```bash
+.venv/bin/python -m scripts.projects.open_model_data.adoption_cli lang-uk \
+  --results batch_state/results_2026-08-02T00-00-00.json \
+  --broad-report batch_state/ua-open-weight-eval/report.json \
+  --foundry-run batch_state/foundry-adoption-trial/foundry \
+  --output batch_state/lang-uk-foundry-handoff
+```
+
+The standard result file is copied byte-for-byte. Its adjacent Foundry sidecar
+binds the model name, result hash, Foundry run, broad-suite release and case
+hashes, all fourteen tracks, and the pinned upstream revisions. Packaging does
+not submit anything; maintainers receive a complete artifact pair they can
+review and upload through their normal process.
+
+## Українською
+
+Цей комплект перетворює перевірені результати Foundry на малий локальний
+дослід і конкретні пакети для Lapa та lang-uk. Ключі API не потрібні. Команди
+не завантажують моделі, не навчають їх, не запускають оптимізатор, не створюють
+вагові адаптери й нічого не публікують.
+
+Команда `trial` готує представлення Foundry та пакет оцінювання без правильних
+відповідей. Команда `lapa` бере лише незамасковані рядки вірного відтворення
+джерела й додає окрему історію походження. Команда `lang-uk` перевіряє
+збережені числові результати та додає супровідний файл із хешами Foundry й
+окремими результатами всіх чотирнадцяти напрямів. Єдиного бала «якості
+української» пакет не створює.
+
+## Submission checklist
+
+- Re-run Foundry `verify` and open-weight-evaluation `verify`.
+- Keep the upstream commit and result-dataset revision from
+  `upstream-locks.json` in the proposed change.
+- Attach the generated receipt and lineage/sidecar; do not attach evaluation
+  text to a training-data change.
+- Report every broad-evaluation track separately, including preservation and
+  unresolved cases.
+- Let the upstream maintainer perform the actual submission or merge.

--- a/scripts/projects/open_model_data/adoption_cli.py
+++ b/scripts/projects/open_model_data/adoption_cli.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Package Foundry outputs for a local trial, Lapa, or lang-uk.
+
+This adapter never downloads a model, runs training, creates a weight adapter,
+or contacts an external service. It transforms already verified artifacts and
+records exact upstream and input revisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.projects.open_model_data import foundry_cli
+from scripts.projects.ua_open_weight_eval import suite_cli
+
+LOCKS_PATH = ROOT / "data/projects/open_model_data/integrations/upstream-locks.json"
+EXAMPLE_PATH = ROOT / "data/projects/open_model_data/examples/portable-corpus-v1.jsonl"
+EXAMPLE_COST_PATH = ROOT / "data/projects/open_model_data/examples/portable-cost-v1.json"
+
+
+class AdoptionError(ValueError):
+    """An adoption input violates a pinned integration contract."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AdoptionError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AdoptionError(f"expected JSON object: {path}")
+    return value
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise AdoptionError(f"cannot read JSONL {path}: {exc}") from exc
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise AdoptionError(f"invalid JSONL {path}:{line_number}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise AdoptionError(f"expected object at {path}:{line_number}")
+        rows.append(row)
+    if not rows:
+        raise AdoptionError(f"empty JSONL: {path}")
+    return rows
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.write_text("".join(_canonical_json(dict(row)) + "\n" for row in rows), encoding="utf-8")
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AdoptionError(message)
+
+
+def _atomic_output(output_dir: Path, builder: Any) -> dict[str, Any]:
+    _require(not output_dir.exists(), f"refusing to replace output directory: {output_dir}")
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output_dir.name}-", dir=output_dir.parent))
+    try:
+        result = builder(staging)
+        staging.replace(output_dir)
+        return result
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def trial(*, input_path: Path, output_dir: Path, max_records: int) -> dict[str, Any]:
+    """Run the small no-model Foundry trial and prepare evaluation requests."""
+
+    def build(staging: Path) -> dict[str, Any]:
+        foundry = foundry_cli.prepare(
+            input_path=input_path,
+            output_dir=staging / "foundry",
+            max_records=max_records,
+            evaluation_artifacts=(),
+            tokenizer_path=None,
+            tokenizer_identifier=None,
+            tokenizer_revision=None,
+            cost_path=EXAMPLE_COST_PATH if input_path.resolve() == EXAMPLE_PATH.resolve() else None,
+        )
+        verification = foundry_cli.verify(foundry.output_dir)
+        request_path = staging / "ua-open-weight-eval-requests.jsonl"
+        requests = suite_cli.prepare_requests(request_path)
+        receipt = {
+            "schema_version": "foundry_adoption_trial_receipt.v1",
+            "input_sha256": _sha256_file(input_path),
+            "foundry_receipt_sha256": _sha256_file(foundry.output_dir / "run-receipt.json"),
+            "evaluation_requests_sha256": requests["sha256"],
+            "records": foundry.receipt["input"]["records"],
+            "evaluation_requests": requests["requests"],
+            "verification": verification["status"],
+            "network_or_api_used": False,
+            "model_or_training_run": False,
+        }
+        _write_json(staging / "trial-receipt.json", receipt)
+        return receipt
+
+    return _atomic_output(output_dir, build)
+
+
+def export_lapa(*, foundry_run: Path, output_dir: Path) -> dict[str, Any]:
+    """Export only verified, unmasked faithful rows to Lapa's JSONL text shape."""
+    verification = foundry_cli.verify(foundry_run)
+    rows = _read_jsonl(foundry_run / "faithful-source.jsonl")
+    locks = _read_json(LOCKS_PATH)
+
+    def build(staging: Path) -> dict[str, Any]:
+        output_rows: list[dict[str, str]] = []
+        lineage: list[dict[str, str]] = []
+        for row in rows:
+            _require(row.get("schema_version") == "foundry_faithful_source_view_v1", "not a faithful Foundry view")
+            _require(row.get("character_mask_spans") == [], "masked or rewritten row cannot enter Lapa pretraining export")
+            text = row.get("text")
+            _require(isinstance(text, str) and text, "empty Lapa text row")
+            _require(foundry_cli.sha256_text(text) == row.get("text_sha256"), "Foundry text hash mismatch")
+            output_rows.append({"text": text})
+            lineage.append(
+                {
+                    "record_id": str(row["record_id"]),
+                    "text_sha256": str(row["text_sha256"]),
+                    "source_record_id": str(row["lineage"]["source_record_id"]),
+                }
+            )
+        dataset_path = staging / "foundry-pretraining.jsonl"
+        _write_jsonl(dataset_path, output_rows)
+        _write_jsonl(staging / "foundry-pretraining.lineage.jsonl", lineage)
+        receipt = {
+            "schema_version": "foundry_lapa_integration_receipt.v1",
+            "upstream": locks["lapa"],
+            "target_format": {"media_type": "application/jsonl", "fields": ["text"]},
+            "source_foundry_run_receipt_sha256": _sha256_file(foundry_run / "run-receipt.json"),
+            "source_verification": verification["status"],
+            "rows": len(output_rows),
+            "dataset_sha256": _sha256_file(dataset_path),
+            "lineage_sha256": _sha256_file(staging / "foundry-pretraining.lineage.jsonl"),
+            "masked_rows_exported": 0,
+            "evaluation_rows_exported": 0,
+            "training_or_weight_adapter_created": False,
+        }
+        _write_json(staging / "lapa-integration-receipt.json", receipt)
+        return receipt
+
+    return _atomic_output(output_dir, build)
+
+
+def _validate_lang_uk_results(results: Mapping[str, Any]) -> str:
+    general = results.get("config_general")
+    metrics = results.get("results")
+    _require(isinstance(general, dict) and isinstance(general.get("model_name"), str), "missing lang-uk model_name")
+    _require(isinstance(metrics, dict) and metrics, "missing lang-uk results")
+    for task_name, task_metrics in metrics.items():
+        _require(isinstance(task_name, str) and isinstance(task_metrics, dict), "invalid lang-uk task")
+        for metric_name, value in task_metrics.items():
+            if metric_name == "qg_meta":
+                _require(isinstance(value, dict), "qg_meta must be an object")
+                continue
+            _require(isinstance(value, int | float) and not isinstance(value, bool), "lang-uk metric must be numeric")
+    return general["model_name"]
+
+
+def package_lang_uk(
+    *,
+    results_path: Path,
+    broad_report_path: Path,
+    foundry_run: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Copy validated lang-uk results and add reproducibility evidence."""
+    _require(
+        results_path.name.startswith("results_") and results_path.suffix == ".json",
+        "lang-uk result filename must match results_*.json",
+    )
+    results = _read_json(results_path)
+    model_name = _validate_lang_uk_results(results)
+    broad_report = _read_json(broad_report_path)
+    _require(broad_report.get("schema_version") == suite_cli.REPORT_SCHEMA, "wrong broad evaluation report schema")
+    scoring = broad_report.get("scoring")
+    _require(isinstance(scoring, dict) and scoring.get("global_quality_score") is None, "broad report has a global score")
+    _require(scoring.get("closed_model_judge_used") is False, "closed model judge report rejected")
+    _require(set(broad_report.get("tracks", {})) == set(suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"]), "broad report track set drift")
+    _require(
+        broad_report.get("cases_sha256") == suite_cli.sha256_file(suite_cli.CASES_PATH),
+        "broad report is not bound to the current frozen case file",
+    )
+    verification = foundry_cli.verify(foundry_run)
+    locks = _read_json(LOCKS_PATH)
+
+    def build(staging: Path) -> dict[str, Any]:
+        copied_results = staging / results_path.name
+        shutil.copyfile(results_path, copied_results)
+        sidecar = {
+            "schema_version": "foundry_lang_uk_evidence_sidecar.v1",
+            "model_name": model_name,
+            "upstream": locks["lang_uk_leaderboard"],
+            "lang_uk_results": {
+                "file": copied_results.name,
+                "sha256": _sha256_file(copied_results),
+            },
+            "foundry": {
+                "run_receipt_sha256": _sha256_file(foundry_run / "run-receipt.json"),
+                "verification": verification["status"],
+            },
+            "broad_evaluation": {
+                "release_id": broad_report["release_id"],
+                "report_sha256": _sha256_file(broad_report_path),
+                "cases_sha256": broad_report["cases_sha256"],
+                "tracks": sorted(broad_report["tracks"]),
+                "global_score": None,
+            },
+            "closed_api_or_judge_used": False,
+            "external_submission_performed": False,
+        }
+        _write_json(staging / f"{results_path.stem}.foundry.json", sidecar)
+        return sidecar
+
+    return _atomic_output(output_dir, build)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, prog="ukrainian-data-foundry-adoption")
+    commands = parser.add_subparsers(dest="command", required=True)
+    trial_parser = commands.add_parser("trial", help="run the ten-minute, no-model trial")
+    trial_parser.add_argument("--input", type=Path, default=EXAMPLE_PATH)
+    trial_parser.add_argument("--output", type=Path, required=True)
+    trial_parser.add_argument("--max-records", type=int, default=100)
+    lapa = commands.add_parser("lapa", help="export faithful unmasked JSONL for pinned Lapa")
+    lapa.add_argument("--foundry-run", type=Path, required=True)
+    lapa.add_argument("--output", type=Path, required=True)
+    lang_uk = commands.add_parser("lang-uk", help="package saved lang-uk and broad-eval results")
+    lang_uk.add_argument("--results", type=Path, required=True)
+    lang_uk.add_argument("--broad-report", type=Path, required=True)
+    lang_uk.add_argument("--foundry-run", type=Path, required=True)
+    lang_uk.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "trial":
+            result = trial(input_path=args.input, output_dir=args.output, max_records=args.max_records)
+        elif args.command == "lapa":
+            result = export_lapa(foundry_run=args.foundry_run, output_dir=args.output)
+        else:
+            result = package_lang_uk(
+                results_path=args.results,
+                broad_report_path=args.broad_report,
+                foundry_run=args.foundry_run,
+                output_dir=args.output,
+            )
+    except (AdoptionError, OSError, foundry_cli.FoundryError, suite_cli.SuiteError) as exc:
+        print(f"foundry-adoption: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_open_model_adoption_cli.py
+++ b/tests/test_open_model_adoption_cli.py
@@ -1,0 +1,124 @@
+"""End-to-end contract tests for Foundry adoption adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import adoption_cli
+from scripts.projects.ua_open_weight_eval import suite_cli
+
+
+def _json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+@pytest.fixture(scope="module")
+def trial_run(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    output = tmp_path_factory.mktemp("foundry-adoption") / "trial"
+    receipt = adoption_cli.trial(
+        input_path=adoption_cli.EXAMPLE_PATH,
+        output_dir=output,
+        max_records=100,
+    )
+    assert receipt["verification"] == "passed"
+    return output
+
+
+def test_trial_is_no_api_reproducible_and_small(trial_run: Path) -> None:
+    receipt = _json(trial_run / "trial-receipt.json")
+    assert receipt["records"] == 8
+    assert receipt["evaluation_requests"] == 4000
+    assert receipt["network_or_api_used"] is False
+    assert receipt["model_or_training_run"] is False
+    assert (trial_run / "foundry/run-receipt.json").is_file()
+    assert (trial_run / "ua-open-weight-eval-requests.jsonl").is_file()
+
+
+def test_lapa_adapter_emits_only_unmasked_text_and_lineage(trial_run: Path, tmp_path: Path) -> None:
+    output = tmp_path / "lapa"
+    receipt = adoption_cli.export_lapa(foundry_run=trial_run / "foundry", output_dir=output)
+    rows = _jsonl(output / "foundry-pretraining.jsonl")
+    lineage = _jsonl(output / "foundry-pretraining.lineage.jsonl")
+    assert receipt["rows"] == 7
+    assert len(rows) == len(lineage) == 7
+    assert all(set(row) == {"text"} and row["text"] for row in rows)
+    assert receipt["masked_rows_exported"] == 0
+    assert receipt["evaluation_rows_exported"] == 0
+    assert receipt["training_or_weight_adapter_created"] is False
+    assert receipt["upstream"]["commit"] == "7e695c2bb9deaa214421a657ae23c85968947305"
+
+
+def test_lang_uk_adapter_validates_saved_results_and_broad_tracks(trial_run: Path, tmp_path: Path) -> None:
+    cases = suite_cli.read_jsonl(suite_cli.CASES_PATH)
+    responses_path = tmp_path / "responses.jsonl"
+    response_rows = [
+        {
+            "item_id": case["case_id"],
+            "action": case["expected"]["action"],
+            "output_text": case["expected"]["accepted_texts"][0],
+        }
+        for case in cases
+    ]
+    responses_path.write_text(suite_cli.encode_jsonl(response_rows), encoding="utf-8")
+    broad_report_path = tmp_path / "broad-report.json"
+    suite_cli.score_saved(responses_path, broad_report_path)
+    results_path = tmp_path / "results_2026-08-02T00-00-00.json"
+    results_path.write_text(
+        json.dumps(
+            {
+                "config_general": {"model_name": "local/open-weight-fixture"},
+                "results": {"example_task": {"acc": 0.5, "qg_meta": {"seed": 42}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "lang-uk"
+    sidecar = adoption_cli.package_lang_uk(
+        results_path=results_path,
+        broad_report_path=broad_report_path,
+        foundry_run=trial_run / "foundry",
+        output_dir=output,
+    )
+    assert (output / results_path.name).read_bytes() == results_path.read_bytes()
+    assert sidecar["model_name"] == "local/open-weight-fixture"
+    assert sidecar["broad_evaluation"]["tracks"] == sorted(
+        suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"]
+    )
+    assert sidecar["broad_evaluation"]["global_score"] is None
+    assert sidecar["closed_api_or_judge_used"] is False
+    assert sidecar["external_submission_performed"] is False
+    assert sidecar["upstream"]["commit"] == "bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f"
+
+
+def test_lang_uk_adapter_rejects_non_numeric_metrics(tmp_path: Path) -> None:
+    with pytest.raises(adoption_cli.AdoptionError, match="numeric"):
+        adoption_cli._validate_lang_uk_results(
+            {
+                "config_general": {"model_name": "fixture"},
+                "results": {"task": {"acc": "not-a-number"}},
+            }
+        )
+
+
+def test_lang_uk_adapter_requires_upstream_result_filename(tmp_path: Path) -> None:
+    with pytest.raises(adoption_cli.AdoptionError, match="results_\\*\\.json"):
+        adoption_cli.package_lang_uk(
+            results_path=tmp_path / "scores.json",
+            broad_report_path=tmp_path / "report.json",
+            foundry_run=tmp_path / "foundry",
+            output_dir=tmp_path / "output",
+        )
+
+
+def test_public_parser_exposes_all_three_adoption_flows() -> None:
+    help_text = adoption_cli.build_parser().format_help()
+    assert "trial" in help_text
+    assert "lapa" in help_text
+    assert "lang-uk" in help_text

--- a/tests/test_open_model_adoption_cli.py
+++ b/tests/test_open_model_adoption_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,63 @@ def trial_run(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return output
 
 
+@pytest.fixture(scope="module")
+def broad_report_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    output = tmp_path_factory.mktemp("foundry-adoption-report")
+    responses_path = output / "responses.jsonl"
+    response_rows = [
+        {
+            "item_id": case["case_id"],
+            "action": case["expected"]["action"],
+            "output_text": case["expected"]["accepted_texts"][0],
+        }
+        for case in suite_cli.read_jsonl(suite_cli.CASES_PATH)
+    ]
+    responses_path.write_text(suite_cli.encode_jsonl(response_rows), encoding="utf-8")
+    report_path = output / "broad-report.json"
+    suite_cli.score_saved(responses_path, report_path)
+    return report_path
+
+
+def _write_lang_uk_results(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "config_general": {"model_name": "local/open-weight-fixture"},
+                "results": {"example_task": {"acc": 0.5, "qg_meta": {"seed": 42}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _tampered_foundry_run(trial_run: Path, destination: Path, mutation: str) -> Path:
+    foundry_run = destination / "foundry"
+    shutil.copytree(trial_run / "foundry", foundry_run)
+    faithful_path = foundry_run / "faithful-source.jsonl"
+    rows = _jsonl(faithful_path)
+    if mutation == "wrong_schema":
+        rows[0]["schema_version"] = "not_a_faithful_view"
+    elif mutation == "masked":
+        rows[0]["character_mask_spans"] = [{"start": 0, "end": 1}]
+    elif mutation == "text_hash":
+        rows[0]["text"] += " tampered"
+    else:  # pragma: no cover - protects the test helper itself
+        raise AssertionError(f"unknown mutation: {mutation}")
+    faithful_path.write_text(suite_cli.encode_jsonl(rows), encoding="utf-8")
+
+    receipt_path = foundry_run / "run-receipt.json"
+    receipt = _json(receipt_path)
+    artifact = receipt["reproduction"]["artifacts"]["faithful_source"]
+    artifact["bytes"] = faithful_path.stat().st_size
+    artifact["sha256"] = adoption_cli._sha256_file(faithful_path)
+    receipt_path.write_text(
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return foundry_run
+
+
 def test_trial_is_no_api_reproducible_and_small(trial_run: Path) -> None:
     receipt = _json(trial_run / "trial-receipt.json")
     assert receipt["records"] == 8
@@ -55,30 +113,32 @@ def test_lapa_adapter_emits_only_unmasked_text_and_lineage(trial_run: Path, tmp_
     assert receipt["upstream"]["commit"] == "7e695c2bb9deaa214421a657ae23c85968947305"
 
 
-def test_lang_uk_adapter_validates_saved_results_and_broad_tracks(trial_run: Path, tmp_path: Path) -> None:
-    cases = suite_cli.read_jsonl(suite_cli.CASES_PATH)
-    responses_path = tmp_path / "responses.jsonl"
-    response_rows = [
-        {
-            "item_id": case["case_id"],
-            "action": case["expected"]["action"],
-            "output_text": case["expected"]["accepted_texts"][0],
-        }
-        for case in cases
-    ]
-    responses_path.write_text(suite_cli.encode_jsonl(response_rows), encoding="utf-8")
-    broad_report_path = tmp_path / "broad-report.json"
-    suite_cli.score_saved(responses_path, broad_report_path)
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("wrong_schema", "not a faithful Foundry view"),
+        ("masked", "masked or rewritten row"),
+        ("text_hash", "Foundry text hash mismatch"),
+    ],
+)
+def test_lapa_adapter_rejects_ineligible_rows(
+    trial_run: Path,
+    tmp_path: Path,
+    mutation: str,
+    message: str,
+) -> None:
+    foundry_run = _tampered_foundry_run(trial_run, tmp_path, mutation)
+    with pytest.raises(adoption_cli.AdoptionError, match=message):
+        adoption_cli.export_lapa(foundry_run=foundry_run, output_dir=tmp_path / "lapa")
+
+
+def test_lang_uk_adapter_validates_saved_results_and_broad_tracks(
+    trial_run: Path,
+    broad_report_path: Path,
+    tmp_path: Path,
+) -> None:
     results_path = tmp_path / "results_2026-08-02T00-00-00.json"
-    results_path.write_text(
-        json.dumps(
-            {
-                "config_general": {"model_name": "local/open-weight-fixture"},
-                "results": {"example_task": {"acc": 0.5, "qg_meta": {"seed": 42}}},
-            }
-        ),
-        encoding="utf-8",
-    )
+    _write_lang_uk_results(results_path)
     output = tmp_path / "lang-uk"
     sidecar = adoption_cli.package_lang_uk(
         results_path=results_path,
@@ -95,6 +155,50 @@ def test_lang_uk_adapter_validates_saved_results_and_broad_tracks(trial_run: Pat
     assert sidecar["closed_api_or_judge_used"] is False
     assert sidecar["external_submission_performed"] is False
     assert sidecar["upstream"]["commit"] == "bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("wrong_schema", "wrong broad evaluation report schema"),
+        ("global_score", "broad report has a global score"),
+        ("closed_judge", "closed model judge report rejected"),
+        ("dropped_track", "broad report track set drift"),
+        ("cases_hash", "not bound to the current frozen case file"),
+    ],
+)
+def test_lang_uk_adapter_rejects_unbound_broad_reports(
+    trial_run: Path,
+    broad_report_path: Path,
+    tmp_path: Path,
+    mutation: str,
+    message: str,
+) -> None:
+    report = _json(broad_report_path)
+    if mutation == "wrong_schema":
+        report["schema_version"] = "wrong_report_schema"
+    elif mutation == "global_score":
+        report["scoring"]["global_quality_score"] = 0.5
+    elif mutation == "closed_judge":
+        report["scoring"]["closed_model_judge_used"] = True
+    elif mutation == "dropped_track":
+        report["tracks"].pop(next(iter(report["tracks"])))
+    elif mutation == "cases_hash":
+        report["cases_sha256"] = "0" * 64
+    else:  # pragma: no cover - protects the test helper itself
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    tampered_report = tmp_path / "broad-report.json"
+    tampered_report.write_text(json.dumps(report), encoding="utf-8")
+    results_path = tmp_path / "results_2026-08-02T00-00-00.json"
+    _write_lang_uk_results(results_path)
+    with pytest.raises(adoption_cli.AdoptionError, match=message):
+        adoption_cli.package_lang_uk(
+            results_path=results_path,
+            broad_report_path=tampered_report,
+            foundry_run=trial_run / "foundry",
+            output_dir=tmp_path / "lang-uk",
+        )
 
 
 def test_lang_uk_adapter_rejects_non_numeric_metrics(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a zero-API ten-minute Foundry trial that emits verified views plus the 4,000-case source-only request packet
- add a pinned Lapa data adapter that exports only verified unmasked faithful rows as `{text}` JSONL with separate lineage and no benchmark rows
- add a pinned lang-uk adapter that validates lm-eval-shaped saved results, requires the current broad per-track report, copies results byte-for-byte, and emits a reproducibility sidecar
- pin exact Lapa and lang-uk upstream commits/result revision and provide Ukrainian/English handoff documentation
- perform no model download, training, optimizer execution, weight adapter creation, upload, outreach, or external submission

## Verification
- 19 end-to-end tests passed
- literal trial emitted 8 verified input records, 4,000 requests, and 7 Lapa rows with zero masked/evaluation rows
- Ruff, Markdownlint, OPSEC, trailer, and diff checks passed
- 4 changed files

Completes the adoption package for #6164.

## Issue linkage

Closes #6164.
