### PR TITLE
feat(context): reconcile ACP receipts into Entire

### DIFF
--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -17,10 +17,15 @@ effort: low
 
 # Entire context recall (public, body-free)
 
-**Automatic intake:** On any non-trivial task, run `status` + `search` (and
-`record-use` when locators inform the plan) **before** prioritization or
-dispatch. Do not wait for the operator to say “use Entire.” Skip only for pure
-one-line questions or when the module is missing/disabled (note that once).
+**Automatic intake:** On any non-trivial task, the accountable root runs
+`status` + `search` once **before** prioritization or dispatch. If the results
+matter, the root creates at most one verified `handoff` capsule (at most five
+cards and 8 KiB) and gives that same capsule to every participant that needs
+it. Children consume the capsule; they do not repeat a fleet-wide search merely
+because they use a different provider. Run `record-use` only when verified
+locators materially informed the work. Do not wait for the operator to say
+“use Entire.” Skip only for pure one-line questions or when the module is
+missing/disabled (note that once).
 
 This skill is the canonical agent-facing contract for the public context layer.
 It runs one provider-neutral CLI — `python -m scripts.entire_context` — over the
@@ -35,6 +40,11 @@ it never mutates them.
   `content_included: false`). Never request, emit, or persist transcripts,
   prompts, responses, subjects, artifacts, raw captures, secrets, or
   AI-generated summaries.
+- **Automatic context stays body-free.** Never place raw prompts, transcripts,
+  responses, session bodies, generated recaps, or generated summaries in an
+  intake prompt or distributed capsule. Human investigation with optional
+  Entire product tools remains private and manual; its output is not promoted
+  automatically.
 - **No Entire dependency.** Entire CLI 0.8.42 stays pinned, optional, and
   non-load-bearing. This workflow makes **zero** Entire CLI invocations and
   zero network calls. Do not run `entire` login, search, checkpoint, attach,
@@ -132,28 +142,41 @@ and `handoff` for a bounded capsule. Use the `.venv/bin/python` commands above;
 they are the canonical recall path.
 
 Native `entire blame --json` is allowed only for local attribution. Prompt-
-bearing `entire why`, cloud `entire search`, generated recap, investigate
-findings, and Entire review are optional manual tools. They never automatically
-enter a canonical capsule. Entire review is supplemental and never satisfies
-the Fleet formal-review gate.
+bearing `entire why`, logged-in cloud search, generated recap, investigate
+findings, session handoff, and Entire review are optional **human/operator
+investigation tools**. They may help a person search past agent work, recap a
+private session, explain why code exists, investigate a change, or prepare a
+private handoff. Their output never automatically enters a canonical capsule,
+changes fleet state, or proves review. Entire review is supplemental and never
+satisfies the sealed Fleet formal-review gate.
+
+Current official product references:
+
+- [Entire Skills](https://docs.entire.io/learn/skills)
+- [Review and recap agent work](https://docs.entire.io/learn/review-and-recap-agent-work)
+- [Search past agent work](https://docs.entire.io/learn/search-past-agent-work)
+- [Investigate why code exists](https://docs.entire.io/learn/investigate-why-code-exists)
 
 ## How to consume results
 
-1. Prefer exact identifiers when you have them (commit SHA, conversation ID,
+1. The accountable root owns recall for the task: run one status/search intake,
+   select only materially relevant verified cards, create no more than one
+   bounded capsule, and distribute it to the relevant participants.
+2. Prefer exact identifiers when you have them (commit SHA, conversation ID,
    locator ID) — exact canonical ID or SHA matches rank first.
-2. Treat every card as a **locator**: read the canonical source itself
+3. Treat every card as a **locator**: read the canonical source itself
    (`git show`, the ACP receipt, the GitHub issue) before relying on details.
    The card's `canonical_digest` proves the locator matches the canonical
    evidence at recall time.
-3. Check `omitted` before concluding absence: an omitted card names the
+4. Check `omitted` before concluding absence: an omitted card names the
    locator and a machine reason (`source_missing`, `digest_mismatch`,
    `partial_terminal`, `tombstoned`, `unsupported_kind`, `capsule_budget`).
-4. A handoff capsule with `"complete": false` intentionally dropped items to
+5. A handoff capsule with `"complete": false` intentionally dropped items to
    stay within the item/byte caps; it is still valid JSON and safe to pass on.
-5. Ranking is deterministic and Unicode-casefold based with `locator_id` as
+6. Ranking is deterministic and Unicode-casefold based with `locator_id` as
    the final tie-break, so identical fixtures give identical results to every
    harness.
-6. Search delivery is not evidence of use. When verified cards materially
+7. Search delivery is not evidence of use. When verified cards materially
    informed intake, architecture, implementation, explanation, review, or
    handoff, run `record-use` with the exact task, harness, purpose, and locator
    IDs. The body-free idempotent receipt is the only basis for Monitor's
@@ -167,6 +190,10 @@ the Fleet formal-review gate.
   integration.
 - Codex CLI and Codex Desktop first use the installed native `codex`
   integration and the same project hooks. Do not invent a `codex-gui` agent.
+- Claude models hosted by Claude Code use `claude-code`; any supported model
+  hosted by OpenCode uses `opencode`. Grok and AGY follow the integration of
+  the harness that actually launches them. A provider/model label does not
+  identify a capture integration.
 - Add an external `entire-agent-<harness>` adapter only after a source-blind
   canary proves that the actual unsupported harness has no native capture
   path. A model name alone is never evidence that an adapter is required.

--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -41,6 +41,23 @@ button, input, select { font: inherit; }
 .filter-strip { background: var(--bg2); border: 1px solid var(--border); display: grid; gap: 10px; grid-template-columns: 1.2fr repeat(5, minmax(110px, 1fr)) auto; margin: 22px 0 18px; padding: 12px; }
 .field { display: grid; gap: 4px; min-width: 0; }.field label { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }.field input, .field select { border: 1px solid var(--border); border-radius: 3px; min-width: 0; padding: 7px 8px; }
 .filter-note { align-self: end; color: var(--text3); font-size: 11px; line-height: 1.35; max-width: 170px; padding-bottom: 5px; }
+.context-grid { display: grid; gap: 16px; grid-template-columns: minmax(300px, .72fr) minmax(0, 1.28fr); margin: 0 0 18px; }
+.health-grid { display: grid; gap: 1px; grid-template-columns: repeat(2, minmax(0, 1fr)); background: var(--border); }
+.health-item { background: var(--bg2); min-width: 0; padding: 12px 14px; }
+.health-item strong { display: block; font-family: Charter, Georgia, serif; font-size: 21px; overflow-wrap: anywhere; }
+.health-item span { color: var(--text3); display: block; font-size: 10px; font-weight: 800; letter-spacing: .07em; margin-top: 5px; text-transform: uppercase; }
+.context-section { border-top: 1px solid var(--border); padding: 13px 16px 3px; }
+.context-section:first-child { border-top: 0; }
+.context-section h4 { font-family: Charter, Georgia, serif; font-size: 15px; margin: 0 0 9px; }
+.context-cards { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 12px; }
+.context-card { border: 1px solid var(--border); min-width: 0; padding: 11px; }
+.context-card-head { align-items: center; display: flex; flex-wrap: wrap; gap: 7px; justify-content: space-between; }
+.context-card strong, .context-card .mono { overflow-wrap: anywhere; word-break: break-word; }
+.context-facts { color: var(--text2); display: grid; font-size: 11px; gap: 5px; line-height: 1.4; margin-top: 8px; }
+.context-actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 9px; }
+.context-actions a { border: 1px solid var(--border); border-radius: 3px; color: var(--accent); font-size: 11px; font-weight: 700; padding: 5px 7px; text-decoration: none; }
+.context-actions a:hover, .context-actions a:focus-visible { border-color: var(--accent); text-decoration: underline; }
+.context-failure { background: rgba(156, 40, 40, .08); border-left: 3px solid var(--red); color: var(--red); font-size: 12px; line-height: 1.45; margin: 0 16px 14px; padding: 9px 10px; }
 .operations-grid { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0 0 18px; }
 .legacy-diagnostics { background: rgba(168, 132, 43, .06); border: 1px solid var(--border); margin: 0 0 18px; }
 .legacy-diagnostics summary { cursor: pointer; font-family: Charter, Georgia, serif; font-size: 18px; font-weight: 700; padding: 13px 16px; }
@@ -57,8 +74,8 @@ button, input, select { font: inherit; }
 .table-wrap { max-height: 360px; overflow: auto; }.table { border-collapse: collapse; font-size: 12px; width: 100%; }.table th { background: var(--bg2); border-bottom: 1px solid var(--border); color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; padding: 8px 10px; position: sticky; text-align: left; text-transform: uppercase; top: 0; }.table td { border-bottom: 1px solid rgba(212, 205, 184, .68); max-width: 230px; padding: 9px 10px; vertical-align: top; }.table tr:last-child td { border-bottom: 0; }.table tr:hover td { background: rgba(122, 28, 32, .035); }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 11px; overflow-wrap: anywhere; }.preview { color: var(--text2); line-height: 1.35; }.muted { color: var(--text3); }.empty { color: var(--text3); font-size: 13px; line-height: 1.5; padding: 22px 16px; }.pill { border: 1px solid var(--border); border-radius: 999px; color: var(--text2); display: inline-block; font-size: 10px; font-weight: 750; padding: 2px 6px; white-space: nowrap; }.pill.complete, .pill.live { background: rgba(61, 107, 74, .12); border-color: rgba(61, 107, 74, .3); color: var(--green); }.pill.running, .pill.queued { background: rgba(42, 86, 128, .11); border-color: rgba(42, 86, 128, .28); color: var(--blue); }.pill.failed, .pill.dead_lettered { background: rgba(156, 40, 40, .11); border-color: rgba(156, 40, 40, .3); color: var(--red); }.pill.incomplete, .pill.expired, .pill.partial { background: rgba(168, 132, 43, .12); border-color: rgba(168, 132, 43, .3); color: var(--yellow); }
 .footnote { color: var(--text3); font-size: 11px; line-height: 1.5; margin: 22px 0 0; }.footnote strong { color: var(--text2); }.error { background: rgba(156, 40, 40, .08); border-left: 3px solid var(--red); color: var(--red); font-size: 13px; margin-bottom: 16px; padding: 10px 12px; }.hidden { display: none; }
-@media (max-width: 1120px) { .summary { grid-template-columns: repeat(3, 1fr); }.operations-grid, .grid { grid-template-columns: 1fr; }.filter-strip { grid-template-columns: repeat(3, minmax(0, 1fr)); }.filter-note { grid-column: 1 / -1; max-width: none; } }
-@media (max-width: 720px) { .topbar { align-items: flex-start; flex-wrap: wrap; }.brand { min-width: 0; }.hero { grid-template-columns: 1fr; }.summary { grid-template-columns: repeat(2, 1fr); }.filter-strip { grid-template-columns: 1fr 1fr; }.table-wrap { max-height: none; }.wrap { padding: 20px 14px 48px; } }
+@media (max-width: 1120px) { .summary { grid-template-columns: repeat(3, 1fr); }.operations-grid, .grid, .context-grid { grid-template-columns: 1fr; }.filter-strip { grid-template-columns: repeat(3, minmax(0, 1fr)); }.filter-note { grid-column: 1 / -1; max-width: none; } }
+@media (max-width: 720px) { .topbar { align-items: flex-start; flex-wrap: wrap; }.brand { min-width: 0; }.hero { grid-template-columns: 1fr; }.summary { grid-template-columns: repeat(2, 1fr); }.filter-strip, .context-cards { grid-template-columns: 1fr; }.health-grid { grid-template-columns: 1fr 1fr; }.table-wrap { max-height: none; }.wrap { padding: 20px 14px 48px; } }
 @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; transition: none !important; } }
 </style>
 </head>
@@ -112,6 +129,17 @@ button, input, select { font: inherit; }
     <div class="field"><label for="filter-pr">PR</label><input id="filter-pr" inputmode="numeric" placeholder="6159" oninput="queueRefresh()"></div>
     <div class="field"><label for="filter-conversation">Conversation</label><input id="filter-conversation" placeholder="opaque ID" oninput="queueRefresh()"></div>
     <div class="filter-note">Filters narrow current authority evidence only. Historical compatibility diagnostics remain unfiltered.</div>
+  </section>
+
+  <section class="context-grid" aria-label="Entire context observability">
+    <article class="panel ledger cyan" aria-labelledby="context-health-heading">
+      <div class="panel-head"><h3 id="context-health-heading">Context projection</h3><p>Local · body-free · non-authoritative</p></div>
+      <div id="context-health-content" class="empty" aria-live="polite">Loading projection health…</div>
+    </article>
+    <article class="panel ledger purple" aria-labelledby="context-used-heading">
+      <div class="panel-head"><h3 id="context-used-heading">Context used</h3><p>Reverified locators for the selected ACP conversation</p></div>
+      <div id="context-used-content" class="empty" aria-live="polite">Select an exact conversation ID to inspect verified context.</div>
+    </article>
   </section>
 
   <details class="legacy-diagnostics">
@@ -202,6 +230,28 @@ function table(headers, rows, empty) {
   return `<div class="table-wrap"><table class="table"><thead><tr>${headers.map(header => `<th>${escapeHtml(header)}</th>`).join('')}</tr></thead><tbody>${rows.join('')}</tbody></table></div>`;
 }
 
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function listValue(value) {
+  return Array.isArray(value) ? value.filter(item => item && typeof item === 'object') : [];
+}
+
+function allowlistedSafeUrl(value) {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    const parsed = new URL(value, location.origin);
+    if (parsed.origin !== location.origin || parsed.pathname !== '/acp.html') return null;
+    const keys = [...parsed.searchParams.keys()];
+    const conversation = parsed.searchParams.get('conversation');
+    if (keys.length !== 1 || keys[0] !== 'conversation' || !/^conversation_[0-9a-f]{32}$/.test(conversation || '')) return null;
+    return `${parsed.pathname}?conversation=${encodeURIComponent(conversation)}`;
+  } catch {
+    return null;
+  }
+}
+
 function filters() {
   const value = id => document.getElementById(id).value.trim();
   return {
@@ -268,6 +318,147 @@ function renderOverview(data) {
   document.getElementById('legacy-requests-note').textContent = `${short(legacy.total, '0')} legacy request rows remain readable for compatibility and are excluded from current authority health.`;
 }
 
+function renderContextHealth(status) {
+  const target = document.getElementById('context-health-content');
+  const recall = objectValue(status.recall);
+  const projection = objectValue(recall.projection);
+  if (projection.available !== true) {
+    const reason = short(projection.reason || recall.reason, 'projection unavailable').replaceAll('_', ' ');
+    target.innerHTML = `<div class="context-failure">Projection unavailable · ${escapeHtml(reason)}. Canonical ACP and Fleet evidence remain authoritative.</div>`;
+    return;
+  }
+  const counts = objectValue(projection.counts);
+  const health = objectValue(projection.projection_health);
+  const acp = objectValue(health.acp);
+  const use = objectValue(status.use);
+  const consumers = Object.entries(objectValue(use.by_consumer));
+  const consumerCopy = consumers.length
+    ? consumers.map(([consumer, count]) => `${escapeHtml(consumer)} ${escapeHtml(short(count, '0'))}`).join(' · ')
+    : 'No proven use receipts';
+  const lag = acp.lag_seconds == null ? 'Not reported' : `${escapeHtml(short(acp.lag_seconds, '0'))}s`;
+  const reconciliation = acp.last_reconciliation_at
+    ? formatTime(acp.last_reconciliation_at)
+    : 'Not reported';
+  target.innerHTML = `
+    <div class="health-grid">
+      <div class="health-item"><strong>${escapeHtml(short(counts.promoted, '0'))}</strong><span>Verified locators</span></div>
+      <div class="health-item"><strong>${escapeHtml(short(health.pending ?? counts.pending, '0'))}</strong><span>Pending claims</span></div>
+      <div class="health-item"><strong>${escapeHtml(short(health.tombstoned ?? counts.tombstoned, '0'))}</strong><span>Tombstoned</span></div>
+      <div class="health-item"><strong>${escapeHtml(short(health.dangling, 'Not reported'))}</strong><span>Dangling locators</span></div>
+      <div class="health-item"><strong>${lag}</strong><span>Projection lag</span></div>
+      <div class="health-item"><strong>${escapeHtml(short(acp.retries, 'Not reported'))}</strong><span>ACP retries</span></div>
+    </div>
+    <div class="context-section"><h4>Reconciliation</h4><div class="context-facts"><span>Last reconciliation: ${escapeHtml(reconciliation)}</span><span>Last projected event: ${escapeHtml(formatTime(projection.last_event_at))}</span><span>Failures: ${escapeHtml(short(acp.failures, 'Not reported'))}</span></div></div>
+    <div class="context-section"><h4>Proven use by consumer</h4><div class="context-facts"><span>${consumerCopy}</span><span>${escapeHtml(short(use.receipts, '0'))} body-free use receipts · last ${escapeHtml(formatTime(use.last_use_at))}</span><span>Initiating orchestrator is shown only when a canonical source explicitly supplies it; it is never inferred here.</span></div></div>`;
+}
+
+function contextSourceLabel(kind) {
+  const labels = {
+    acp_conversation: 'ACP discussion', fleet_receipt: 'Fleet receipt', formal_review: 'Formal review',
+    git_commit: 'Git commit', github_issue: 'GitHub issue', github_pr: 'GitHub pull request',
+    monitor_run: 'Monitor run', rollover: 'Rollover checkpoint',
+  };
+  return labels[kind] || short(kind, 'Unknown source').replaceAll('_', ' ');
+}
+
+function sourceEventTime(card) {
+  const excerpt = objectValue(card.excerpt);
+  const facets = objectValue(card.facets);
+  return excerpt.updated_at || excerpt.commit_ts || excerpt.published_at || facets.event_ts || null;
+}
+
+function authoritativeOrchestrator(card) {
+  const excerpt = objectValue(card.excerpt);
+  return excerpt.initiating_orchestrator_authoritative === true && typeof excerpt.initiating_orchestrator === 'string'
+    ? excerpt.initiating_orchestrator
+    : null;
+}
+
+function contextCard(card) {
+  const kind = short(card.kind, 'unknown');
+  const excerpt = objectValue(card.excerpt);
+  const facets = objectValue(card.facets);
+  const checkpointId = typeof card.entire_checkpoint_id === 'string' ? card.entire_checkpoint_id : null;
+  const gitSha = typeof card.git_sha === 'string' ? card.git_sha : null;
+  const sourceState = excerpt.state || facets.state || 'verified';
+  const eventTime = sourceEventTime(card);
+  const orchestrator = authoritativeOrchestrator(card);
+  const actions = [];
+  if (kind === 'acp_conversation' && /^conversation_[0-9a-f]{32}$/.test(String(card.canonical_id || ''))) {
+    const href = allowlistedSafeUrl(`/acp.html?conversation=${encodeURIComponent(card.canonical_id)}`);
+    if (href) actions.push(`<a href="${escapeHtml(href)}">Open authoritative ACP conversation</a>`);
+  }
+  return `<article class="context-card">
+    <div class="context-card-head"><strong>${escapeHtml(contextSourceLabel(kind))}</strong>${pill(sourceState)}</div>
+    <div class="context-facts">
+      <span class="mono">Source ID · ${escapeHtml(short(card.canonical_id))}</span>
+      <span>Verification · reverified from the canonical local source on this refresh${eventTime ? ` · source updated ${escapeHtml(formatTime(eventTime))}` : ''}</span>
+      <span class="mono">Receipt / locator · ${escapeHtml(short(card.locator_id))}</span>
+      ${gitSha ? `<span class="mono">Commit · ${escapeHtml(gitSha)}</span>` : ''}
+      ${checkpointId ? `<span class="mono">Entire checkpoint · ${escapeHtml(checkpointId)} · navigation unavailable (no allowlisted local route)</span>` : ''}
+      ${orchestrator ? `<span>Initiating orchestrator · ${escapeHtml(orchestrator)}</span>` : ''}
+    </div>
+    ${actions.length ? `<div class="context-actions">${actions.join('')}</div>` : ''}
+  </article>`;
+}
+
+function renderConversationContext(conversationId, payload, relatedPayload) {
+  const target = document.getElementById('context-used-content');
+  if (!conversationId) {
+    target.innerHTML = '<div class="empty">Select an exact conversation ID to inspect verified context. No prompt or transcript body is queried by this panel.</div>';
+    return;
+  }
+  if (payload.available !== true) {
+    const reason = short(payload.reason, 'projection unavailable').replaceAll('_', ' ');
+    target.innerHTML = `<div class="context-failure">Context projection failure · ${escapeHtml(reason)}. The ACP receipt remains authoritative.</div>`;
+    return;
+  }
+  const direct = listValue(payload.results);
+  const exact = direct.find(card => card.kind === 'acp_conversation' && card.canonical_id === conversationId);
+  const omissions = [...listValue(payload.omitted), ...listValue(relatedPayload.omitted)];
+  if (!exact) {
+    const sourceMissing = omissions.some(item => item.reason === 'source_missing');
+    const malformed = omissions.some(item => item.reason === 'resolution_error' || item.reason === 'digest_mismatch');
+    const reason = sourceMissing ? 'source_missing' : malformed ? 'verification_failed' : 'not_projected';
+    target.innerHTML = `<div class="context-failure">No verified locator is available for this ACP conversation · ${escapeHtml(reason.replaceAll('_', ' '))}. Search never falls back to an unverified or tombstoned claim.</div>`;
+    return;
+  }
+  const byLocator = new Map();
+  for (const card of [...direct, ...listValue(relatedPayload.results)]) {
+    if (typeof card.locator_id === 'string') byLocator.set(card.locator_id, card);
+  }
+  const related = [...byLocator.values()].filter(card => card.locator_id !== exact.locator_id);
+  const omissionCopy = omissions.length
+    ? `<div class="context-failure">${escapeHtml(short(omissions.length))} related locator${omissions.length === 1 ? '' : 's'} omitted after re-verification · ${escapeHtml([...new Set(omissions.map(item => short(item.reason, 'verification failed').replaceAll('_', ' ')))].join(' · '))}</div>`
+    : '';
+  target.innerHTML = `
+    <div class="context-section"><h4>Selected conversation</h4><div class="context-cards">${contextCard(exact)}</div></div>
+    <div class="context-section"><h4>Related verified discussions, commits, and checkpoints</h4>${related.length ? `<div class="context-cards">${related.map(contextCard).join('')}</div>` : '<div class="empty">No additional promoted source shares this conversation\'s verified commit correlation.</div>'}</div>
+    ${omissionCopy}`;
+}
+
+async function refreshConversationContext(contextStatus) {
+  renderContextHealth(contextStatus);
+  const conversationId = filters().conversation;
+  if (!conversationId) {
+    renderConversationContext('', {}, {});
+    return;
+  }
+  try {
+    const params = new URLSearchParams({ q: conversationId, limit: '10' });
+    const payload = await fetchJson(`/api/ops/entire-context/search?${params}`);
+    const exact = listValue(payload.results).find(card => card.kind === 'acp_conversation' && card.canonical_id === conversationId);
+    let relatedPayload = { results: [], omitted: [] };
+    if (exact && typeof exact.git_sha === 'string') {
+      const related = new URLSearchParams({ q: exact.git_sha, limit: '10' });
+      relatedPayload = await fetchJson(`/api/ops/entire-context/search?${related}`);
+    }
+    renderConversationContext(conversationId, payload, relatedPayload);
+  } catch {
+    renderConversationContext(conversationId, { available: false, reason: 'projection_request_failed' }, {});
+  }
+}
+
 function renderOperations(data) {
   const broker = data.broker || {};
   const processValue = broker.live_process_count == null ? 'Unavailable' : short(broker.live_process_count, '0');
@@ -308,7 +499,15 @@ function renderReviews(data) {
 }
 
 function renderAcp(data) {
-  const rows = (data.conversations || []).map(item => `<tr><td class="mono">${escapeHtml(item.conversation_id)}</td><td>${pill(item.classification)}</td><td>${escapeHtml((item.participants || []).join(' / ') || '—')}</td><td>${escapeHtml(item.rounds_completed)}/${escapeHtml(item.rounds_requested)}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`);
+  const rows = (data.conversations || []).map(item => {
+    const conversationId = short(item.conversation_id, '');
+    const selected = `/fleet.html?conversation=${encodeURIComponent(conversationId)}`;
+    const authoritative = allowlistedSafeUrl(`/acp.html?conversation=${encodeURIComponent(conversationId)}`);
+    const links = authoritative
+      ? `<a href="${escapeHtml(selected)}">Inspect context</a><br><a href="${escapeHtml(authoritative)}">Open conversation</a>`
+      : `<a href="${escapeHtml(selected)}">Inspect context</a>`;
+    return `<tr><td class="mono">${escapeHtml(conversationId)}<br><span class="context-actions">${links}</span></td><td>${pill(item.classification)}</td><td>${escapeHtml((item.participants || []).join(' / ') || '—')}</td><td>${escapeHtml(item.rounds_completed)}/${escapeHtml(item.rounds_requested)}</td><td>${escapeHtml(formatTime(item.updated_at))}</td></tr>`;
+  });
   document.getElementById('acp-content').innerHTML = table(['Conversation', 'State', 'Participants', 'Rounds', 'Updated'], rows, 'No ACP conversations match the current observer filters.');
 }
 
@@ -331,7 +530,11 @@ async function refreshFleet() {
   setError('');
   try {
     const common = ['state', 'agent', 'source', 'conversation'];
-    const [health, overview, operations, requests, authorityJobs, reviews, acp, deadLetters, activity, messages] = await Promise.all([
+    const contextStatusRequest = fetchJson('/api/ops/entire-context/status').catch(() => ({
+      recall: { available: false, reason: 'projection_request_failed', projection: { available: false, reason: 'projection_request_failed' } },
+      use: {},
+    }));
+    const [health, overview, operations, requests, authorityJobs, reviews, acp, deadLetters, activity, messages, contextStatus] = await Promise.all([
       fetchJson('/api/fleet/health'), fetchJson('/api/fleet/overview'), fetchJson('/api/fleet/operations'),
       fetchJson(query('/api/fleet/authority/jobs', ['state', 'agent', 'source', 'conversation'], { kind: 'request' })),
       fetchJson(query('/api/fleet/authority/jobs', ['kind', 'state', 'agent', 'source', 'pr', 'conversation'])),
@@ -340,9 +543,11 @@ async function refreshFleet() {
       fetchJson(query('/api/fleet/dead-letters', ['state', 'agent', 'source'])),
       fetchJson(query('/api/fleet/activity', ['state', 'agent', 'source'])),
       fetchJson(query('/api/fleet/messages', ['kind', ...common])),
+      contextStatusRequest,
     ]);
     renderHealth(health); renderOverview(overview); renderOperations(operations); renderRequests(requests); renderAuthorityJobs(authorityJobs); renderReviews(reviews);
     renderAcp(acp); renderDeadLetters(deadLetters); renderActivity(activity); renderMessages(messages);
+    await refreshConversationContext(contextStatus);
   } catch (error) {
     setError(`Observer data could not be read: ${error.message}`);
   }

--- a/docs/architecture/adr/adr-018-entire-acp-context-layer.md
+++ b/docs/architecture/adr/adr-018-entire-acp-context-layer.md
@@ -7,6 +7,7 @@
 **Related**: [#4707](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4707),
 [#5880](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5880),
 [#6162](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162),
+[#6183](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6183),
 [architecture research and advisor receipt](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162#issuecomment-5150430545),
 [rollout plan](../../plans/2026-08-01-entire-acp-context-layer-rollout.md)
 
@@ -43,6 +44,13 @@ content. An LLM may use an Entire search result only as a locator; before any
 context is injected, the locator is resolved against the authoritative local
 system and its digest is verified.
 
+The public agent workflow is deliberately stricter than the optional product
+experience described in Entire's documentation. It uses the repository's
+local, body-free projection and makes no cloud Entire call. Human operators may
+privately use Entire search, recap/review, why/blame/investigate, and session
+handoff for investigation, but those bodies and generated findings do not enter
+automatic agent context or become fleet evidence.
+
 ### Authority boundary
 
 | Concern | Authority | Entire's permitted role |
@@ -53,22 +61,23 @@ system and its digest is verified.
 | Stream ownership and fencing | Session streams | Record a non-secret locator; never grant, renew, close, or reroute a lease. |
 | Cross-session continuity | Rollover receipts and hydration capsules | Rank possible history; canonical receipts still perform hydration. |
 | Formal review | Sealed cross-family review receipt | Supply context to a reviewer; never approve or satisfy the gate. |
-| Session/checkpoint history | Entire private checkpoint store | Index only sessions that pass the body-free storage gate and relate them to commits. |
+| Session/checkpoint history | Host-harness session record; Git commit for code | Optionally index a private checkpoint locator; never hydrate session bodies automatically. |
 
 ### Active retrieval, not passive capture
 
-Entire does not give an LLM memory merely because hooks captured a session. A
-repository-owned `entire-context` workflow will make the memory active:
+Entire does not give an LLM memory merely because hooks captured a session. The
+implemented repository-owned `entire-context` workflow makes verified local
+history available without automating Entire's cloud CLI:
 
-1. Consult `entire agent-help --json` so command selection matches installed
-   CLI 0.8.42.
-2. Search with a bounded query and request machine-readable metadata only.
-3. Resolve the selected checkpoint or commit through a project-owned context
+1. The accountable root checks projection `status` and performs one bounded
+   local `search` before prioritization or dispatch.
+2. Resolve each selected locator through a project-owned context
    link into GitHub, Fleet/ACP, Monitor, review, or rollover evidence.
-4. Verify the canonical identifier and digest. Missing or mismatched evidence
+3. Verify the canonical identifier and digest. Missing or mismatched evidence
    is dropped and reported; it is never injected.
-5. Build a size-bounded hydration capsule from canonical local evidence.
-6. Record which locator IDs the task consumed so later audits can distinguish
+4. Build at most one capsule of no more than five cards and 8 KiB, then give
+   the same capsule to the relevant participants.
+5. Record which locator IDs materially informed the task so later audits can distinguish
    capture from actual use.
 
 This path is available to any seat, including Kimi and GLM. A non-native seat
@@ -106,18 +115,19 @@ and the phase is recorded as blocked by the pinned product capability.
 
 ### Searchable corpus
 
-The smallest useful corpus is headers-only and mechanically extracted:
+The automatic corpus is body-free and mechanically extracted:
 
-- opaque IDs, timestamps, source kind, repository, commit SHA, actor/model,
-  stream epic, track, state, labels, and touched paths;
-- an already-public GitHub issue or PR title; or
-- the heading and immutable Git SHA of an operator-approved ADR or runbook.
+- opaque IDs, timestamps, source kind, canonical namespace and identifier,
+  canonical digest, repository, commit SHA, actor/model/harness, state, and
+  touched paths where the typed resolver admits them; and
+- allowlisted non-body routing metadata from verified ACP, rollover, GitHub,
+  formal-review, Fleet-receipt, and Monitor-run sources.
 
-The bridge does not compose intent, outcome, rationale, or summaries. Private
-ACP prompts and subjects are not promoted into search fields. Richer reusable
-memory is a separate, later tier consisting only of human-approved ADRs,
-runbooks, decision records, and skills. Entire ranks their locators; the agent
-reads their canonical repository versions.
+The bridge does not compose intent, outcome, rationale, titles, headings, or
+summaries. Prompts, transcripts, responses, session bodies, ACP subjects, and
+generated recaps remain outside automatic context. Richer reusable memory is a
+deferred tier consisting only of approved canonical repository artifacts; it
+does not authorize automatic body ingestion.
 
 ### Failure and privacy rules
 
@@ -131,8 +141,9 @@ reads their canonical repository versions.
   checkpoint destination.
 - `checkpoint explain --full`, `--raw-transcript`, `--transcript`, generated
   explanations, and Entire Dispatch are prohibited in automated integration.
-- Semantic search and recap remain disabled until their login, cloud egress,
-  retention, and returned-field behavior pass explicit canaries.
+- Logged-in semantic search, recap, review, why/blame/investigate, and session
+  handoff remain manual operator tools. Their bodies and generated output are
+  excluded from the public automated workflow.
 - Entire's own review or investigate workflows may assist discussion, but they
   never satisfy the repository formal-review gate.
 
@@ -194,6 +205,24 @@ plugin could technically be written.
   contract is proved.
 - CLI upgrades require a new compatibility review; this decision does not
   authorize moving beyond 0.8.42.
+
+### Implemented slice (2026-08-02)
+
+The current repository implements the local, non-authoritative slice rather
+than the original cloud-search sketch:
+
+| Evidence | Current disposition |
+| --- | --- |
+| `scripts/entire_context/` | Local projection, typed verification, bounded search/explain/handoff, use receipts, and explicit sanitized provider-status refresh. |
+| `scripts/api/entire_context_router.py` | Read-only Monitor status and search at `/api/ops/entire-context/status` and `/api/ops/entire-context/search`; no synchronous Entire call. |
+| `tests/test_entire_context.py`, `tests/test_entire_context_recall.py`, `tests/test_entire_context_live.py` | Schema/lifecycle, fail-closed resolution, body-leakage, recall-budget, provider-cache, and live-router coverage. |
+| `tests/test_entire_native_onboarding.py` | Composed fail-open capture hooks for the host harnesses `codex`, `claude-code`, and `opencode`, with private routing checks. |
+| `scripts/entire/external_agents/entire-agent-kimi/` | Explicit standalone Kimi Code adapter; hosted Kimi/GLM continue to use their host integration. |
+
+This evidence does not prove cloud semantic-search privacy, generated recap
+safety, arbitrary metadata-card ingestion, or a need for an ACP plugin. Those
+capabilities remain outside automatic recall and do not change the authority
+table.
 
 ## Verification
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -24,6 +24,7 @@
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution | Worktree writes only; not durable fleet authority |
 | **Fleet-comms + file handoffs** | Durable coordination | **File dual-write remains authoritative in every current plane mode** — query `plane-status`, never hard-code live mode |
 | **ACPX** | Explicit fixed Codex↔Grok panel for one consequential read-only design/risk comparison (default-off/shadow) | Sole surface `acp-discuss`; no automatic launcher/delegate use, queue, retry, formal review, or authority |
+| **Entire context recall** | Optional body-free historical discovery and provenance | Local verified locator cards only; never coordination, source authority, rollover, Monitor, or formal review |
 | **Buzz** | **Deferred** | Relay-as-authority conflicts with the current model — out of scope |
 
 **Discussion is not formal review.** Design panels and same-family helpers do not
@@ -582,6 +583,33 @@ The bridge runs a citation-provenance check on every channel post and reply befo
 **Implementation:** `scripts/ai_agent_bridge/_citation_check.py` (detection + verification + annotation). Hook lives in `_channels.py:post()` — controlled by `verify_citations: bool = True` keyword. System/audit kinds (anything other than `post`/`reply`) skip verification automatically.
 
 **Graceful degradation:** the verifier soft-skips if `data/sources.db` is missing (worktree without the data dir, fresh checkout, CI minimal env). Soft-skips never produce flags — they're recorded internally as "verifier unavailable" so a deployment problem cannot manufacture false positives.
+
+---
+
+## Provider-neutral historical recall
+
+At intake for a non-trivial task, the accountable root uses the public
+[`entire-context` skill](../../agents_extensions/shared/skills/entire-context/SKILL.md).
+The root runs local `status` and one bounded `search` before prioritization or
+dispatch. If verified locators materially help, it creates at most one
+five-card/8-KiB capsule and includes that same capsule in the relevant Codex,
+Claude/OpenCode, Kimi, GLM, Grok, or AGY participant briefs. A child does not
+repeat the broad search simply because it uses another provider.
+
+This is context distribution, not a new fleet plane. ACP still owns live
+discussion and terminal receipts; Git/GitHub own code history and disposition;
+Fleet/file handoffs own coordination; Monitor owns runtime state; rollover owns
+cross-session continuity; and sealed Fleet review owns the formal review gate.
+Search delivery is not proof of use. The root records `record-use` only after a
+verified locator materially informed planning, implementation, explanation,
+review, or handoff.
+
+Entire capture follows the host harness (`codex`, `claude-code`, `opencode`, or
+an explicitly proved external harness adapter), never a model label. The
+canonical seat-by-seat capture and recall matrix is in
+[`agent-seat-onboarding.md`](../runbooks/agent-seat-onboarding.md#entire-recall-onboarding-matrix).
+Raw prompts, transcripts, responses, session bodies, generated recaps, and
+generated summaries never enter automatic context.
 
 ---
 

--- a/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
+++ b/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
@@ -1,22 +1,24 @@
 # Entire 0.8.42 context-layer and ACP integration rollout
 
-**Status:** Plan of record for staged implementation
+**Status:** Plan of record; local body-free context links and recall implemented,
+remaining product/cloud capabilities deferred
 **Owner:** Infra harness stream, #4707
-**Tracking:** [#6162](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162)
+**Tracking:** [#6162](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162),
+[#6183](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6183)
 **Decision:** [ADR-018](../architecture/adr/adr-018-entire-acp-context-layer.md)
 **Version boundary:** stable Entire CLI 0.8.42 only
 
 ## Outcome
 
-Entire will be used for more than recovery, but it will not become another
-controller. Its useful job is to help an agent find prior work across sessions
-and commits, connect that history to ACP/Fleet/Monitor receipts, and then load a
-small amount of verified canonical context into the current task.
+Entire may be used for more than recovery, but it will not become another
+controller. The implemented project path helps an agent find prior work in a
+local body-free projection, connect that history to ACP/Fleet/Monitor receipts,
+and load a small amount of verified canonical context into the current task.
 
 The rollout has four product outcomes:
 
-1. **Active recall:** an LLM can search prior checkpoints before or during work
-   and receive a bounded, cited hydration capsule.
+1. **Active recall:** an accountable root can search verified local locator
+   cards before work and distribute one bounded, cited hydration capsule.
 2. **Intent and provenance:** a reviewer can move from a commit or code line to
    its Entire checkpoint and then to the exact issue, ACP discussion, review,
    or rollover receipt.
@@ -29,46 +31,30 @@ Recovery remains a supported fallback, not the definition of the product.
 
 ## What the official guidance changes
 
-Entire's own guidance describes an agent-facing context layer rather than only
-a journal:
+Entire's current guidance describes agent-facing workflows rather than only a
+journal:
 
-- [Entire Skills](https://docs.entire.io/guides/skills/overview) define
-  workflows for explain, recall, replay, review, search, session handoff,
-  session-to-skill, teach, and what-happened.
-- [Search from an agent](https://docs.entire.io/guides/search/semantic-search/search-from-your-agent)
-  is intended to run before or during code changes, not only after a failure.
-- [Agent hooks](https://entire.io/blog/agent-hooks-the-integration-layer-between-entire-cli-and-your-agent)
-  normalize session and turn lifecycle events and are designed to be
-  idempotent and fail-open.
-- [External agent plugins](https://entire.io/blog/bring-your-own-agents-to-entire)
-  let a stateless executable translate another agent's events and transcripts
-  into Entire's common lifecycle.
-- [Recap and review](https://entire.io/blog/new-cli-commands-recap-review-labs)
-  expose team/session/token/tool/skill activity and checkpoint-informed review.
-- [Agent-help](https://entire.io/blog/introducing-entire-agent-help) makes the
-  installed CLI, rather than current web documentation, the command source of
-  truth.
-- [Ref-based storage](https://entire.io/blog/introducing-ref-based-checkpoint-storage)
-  is available in 0.8.42 and avoids shared-branch contention, but it is an
-  opt-in backend that still requires project-specific routing proof.
-- [Security guidance](https://docs.entire.io/security) says redaction is
-  best-effort, checkpoint metadata can live in another private repository,
-  commit trailers are permanent, and local shadow refs can hold raw source
-  snapshots.
-- [The CLI architecture](https://entire.io/blog/the-entire-cli-how-it-works-and-where-its-headed)
-  treats checkpoint IDs as Git-linked semantic identifiers that survive common
-  history rewrites.
+- [Entire Skills](https://docs.entire.io/learn/skills) groups the product's
+  search, explanation, investigation, review/recap, and handoff workflows.
+- [Search past agent work](https://docs.entire.io/learn/search-past-agent-work)
+  describes logged-in semantic search across prior work.
+- [Review and recap agent work](https://docs.entire.io/learn/review-and-recap-agent-work)
+  describes generated review and recap workflows.
+- [Investigate why code exists](https://docs.entire.io/learn/investigate-why-code-exists)
+  describes explain/why/blame/investigate-style provenance work.
 
-These sources establish the opportunity and the risk. They do not prove that
-every current documentation feature exists safely under the pinned 0.8.42
-binary, so installed help and disposable canaries remain decisive.
+These sources establish useful private investigation workflows. They do not
+authorize project automation to send prompts, transcripts, responses, session
+bodies, or generated summaries to an agent. The public workflow therefore
+remains stricter, local, body-free, and independent of logged-in cloud search.
 
 ## Installed 0.8.42 capability matrix
 
 The following table distinguishes observed command surfaces from authorized
-use. `entire agent-help --json` in this checkout reports 0.8.42 and the public
-repository identity derived from `origin`; `entire status` reports that this
-public checkout is not enabled.
+use. The repository pins the private checkpoint destination, disables Entire
+telemetry, and composes fail-open hooks for supported host harnesses. Runtime
+availability still requires an explicit probe; configuration is not a health
+claim.
 
 | Capability | 0.8.42 evidence | Rollout disposition |
 | --- | --- | --- |
@@ -84,8 +70,11 @@ public checkout is not enabled.
 | Dispatch | `dispatch --local` or server summary | Prohibited because project policy forbids AI-generated session summaries. |
 | Generated explanation | `checkpoint explain --generate` | Prohibited for the same reason. |
 | Labs review/investigate/import/why/blame/experts | Listed by `entire labs`; explicitly experimental | Advisory canaries only; never authoritative. |
-| External-agent plugin | Official protocol; no project implementation | Deferred until the receipt-based join proves a missing capability. |
+| External-agent plugin | Standalone Kimi Code adapter implemented; no ACP-wide plugin | Use only for the actual standalone `kimi` harness; the general ACP plugin remains deferred. |
 | Agent Skills | Official cross-agent workflows | Pin and review only the required workflows; wrap them in project policy. |
+| Local context-link recall | `scripts/entire_context/`; tests for search, explain, handoff, typed resolvers, and use receipts | Implemented public path; body-free, bounded, local, and non-authoritative. |
+| Monitor projection | Read-only `/api/ops/entire-context/status` and `/api/ops/entire-context/search` | Implemented; no synchronous Entire call. |
+| Host-harness capture | Composed `codex`, `claude-code`, and `opencode` hooks; standalone Kimi adapter | Implemented where installed; follows the harness, not the model label, and remains separate from recall. |
 
 ## System roles
 
@@ -93,23 +82,27 @@ public checkout is not enabled.
 flowchart LR
     Agent["Codex, Claude, Kimi, GLM, or another seat"]
     Skill["Project entire-context workflow"]
-    Entire["Entire 0.8.42 private checkpoint index"]
+    Projection["Local body-free context-link projection"]
+    Entire["Optional private Entire product tools"]
     Resolver["Context-link resolver and digest gate"]
     Canonical["GitHub · Fleet/ACP · Monitor · rollover · formal review"]
     Capsule["Bounded hydration capsule with citations"]
 
     Agent -->|"bounded query"| Skill
-    Skill -->|"metadata-only search"| Entire
-    Entire -->|"checkpoint/commit locators"| Skill
+    Skill -->|"bounded local search"| Projection
+    Projection -->|"verified locator candidates"| Skill
     Skill --> Resolver
     Resolver -->|"fetch exact evidence"| Canonical
     Canonical -->|"canonical bytes + digest"| Resolver
     Resolver -->|"verified excerpts only"| Capsule
     Capsule --> Agent
+    Entire -.->|"manual operator investigation only"| Agent
 ```
 
-Entire ranks possible history. The resolver decides whether a result is safe
-and true. Canonical systems provide every byte that enters the LLM's context.
+The local projection ranks possible history. The resolver decides whether a
+result is safe and true. Canonical systems provide every byte that enters the
+LLM's automatic context. Optional Entire product output stays outside that
+automatic path.
 
 ## Search corpus and context-link contract
 
@@ -119,14 +112,13 @@ The initial index uses only fields copied mechanically from canonical records:
 
 - checkpoint ID, commit SHA, source kind, canonical ID, timestamp;
 - public repository, stream epic, track, state, labels, touched paths;
-- model, harness, participant names, token-count bucket;
-- an already-public GitHub issue/PR title; and
-- exact approved document path, heading, and Git SHA.
+- allowlisted model/harness and non-body routing fields exposed by typed
+  canonical resolvers.
 
-No bridge component writes an `intent`, `outcome`, `rationale`, `summary`, or
-other synthesized field. A private ACP subject is not treated as a public
-title. Each search field must name the canonical field from which it was
-copied.
+No bridge component writes an `intent`, `outcome`, `rationale`, title, heading,
+`summary`, or other synthesized field. Prompts, transcripts, responses,
+session bodies, and private ACP subjects are excluded. Each search field must
+name the canonical field from which it was copied.
 
 The project does not assume that Entire 0.8.42 can ingest arbitrary typed
 metadata cards. The baseline join works from supported Entire checkpoint and
@@ -170,6 +162,24 @@ The projection is disposable and rebuildable from canonical receipts.
 
 ## Staged rollout
 
+Implementation status as of 2026-08-02:
+
+| Phase | Evidence-backed status |
+| --- | --- |
+| Phase 0 | Private routing, fail-open host hooks, and no-public-ref configuration have automated coverage; the broader remote leakage and outage canary set below remains a gate, not a completed claim. |
+| Phase 1 | The `#6174` local context-link schema, append-only projection, typed resolvers, ACP reconciliation, and read-only Monitor surface are implemented. |
+| Phase 2 | The `#6183` local `status`, `search`, `explain-change`, `handoff`, and `record-use` path is implemented with hard body/result/budget limits. Cloud semantic search is not automated. |
+| Phase 3 | Body-free use receipts are implemented; curated body admission and product analytics remain deferred. |
+| Phase 4 | ACP plugin remains deferred; current ACP terminal receipts already project into the local context index. |
+
+The implemented provider-neutral intake contract is one root `status` +
+`search`, at most one verified five-card/8-KiB capsule distributed to relevant
+participants, and `record-use` only when verified locators materially informed
+the task. Participants do not repeat broad recall by model. Capture attaches to
+the host harness (`codex`, `claude-code`, `opencode`, or an explicitly proved
+external harness adapter), not to Codex, Claude, Kimi, GLM, Grok, or AGY model
+labels.
+
 ### Phase 0 — containment and capability proof
 
 No product checkout is enabled during this phase.
@@ -201,12 +211,13 @@ Any private-routing or leakage failure stops the program.
 
 ### Phase 1 — supported checkpoints and canonical joins
 
-Capture only supported accountable Codex/Claude integration sessions. Do not
-attempt native Kimi/GLM capture yet. This phase begins only if the Phase 0
-remote inspection proves that the chosen 0.8.42 path stores no forbidden
-transcript or prompt bodies. If native capture cannot satisfy that rule, hooks
-remain disabled and the capability is recorded as blocked; the project does
-not weaken the privacy contract or manufacture synthetic sessions.
+Capture follows supported host-harness integrations, not model labels. Codex
+CLI/Desktop use `codex`; Claude Code-hosted models use `claude-code`; OpenCode-
+hosted models use `opencode`; and the explicit standalone Kimi Code adapter is
+only for the actual `kimi` harness. This phase proceeds only where private-
+route and content canaries satisfy the boundary. A failed canary disables that
+capture route; the project does not weaken the privacy contract or manufacture
+synthetic sessions.
 
 Deliverables:
 
@@ -241,11 +252,9 @@ Initial workflows:
 - `review-with-intent`: supply verified context to the reviewer without
   changing the formal-review gate.
 
-Search is enabled only after a separate egress decision establishes what is
-sent to Entire, where it is retained, and which returned fields are admitted.
-If cloud search is not approved, the workflow still supports known-ID
-explanation and project-local cross-link lookup; it does not pretend to provide
-semantic search.
+Local body-free search is implemented. Logged-in cloud Entire search remains a
+manual operator investigation tool and is never invoked by the public skill.
+Its results do not enter automatic capsules.
 
 Exit gate:
 
@@ -359,9 +368,12 @@ review of the finished documentation remains a separate gate.
 ## Ordered implementation issues
 
 1. Phase 0 destination, leakage, and exact-version canary harness.
-2. Phase 1 context-link schema, outbox lifecycle, and Monitor projection.
-3. Phase 2 reviewed `entire-context` workflow and egress decision.
-4. Phase 3 curated workflow-source admission and utility evaluation.
+2. Phase 1 context-link schema, outbox lifecycle, and Monitor projection
+   (implemented local slice; continue verification/operations hardening).
+3. Phase 2 provider-neutral `entire-context` onboarding and judged local recall
+   evaluation (core workflow implemented under #6183).
+4. Phase 3 curated workflow-source admission and utility evaluation, only
+   after a separately approved body policy.
 5. Phase 4 ACP plugin only if evidence proves a residual need.
 
 These issues may run only after dependency and ownership checks. They do not

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -29,6 +29,8 @@ caps or live modes.
    [`docs/SCRIPTS.md`](../SCRIPTS.md).
 6. Cooperation detail (deliberation, Green Team, V2):
    [`docs/best-practices/agent-cooperation.md`](../best-practices/agent-cooperation.md).
+7. Provider-neutral historical recall:
+   [`entire-context`](../../agents_extensions/shared/skills/entire-context/SKILL.md).
 
 ---
 
@@ -40,7 +42,53 @@ caps or live modes.
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution in a worktree | Durable fleet authority or formal CF |
 | **Fleet-comms + file handoffs** | Durable coordination and authority today; **file dual-write remains authoritative in every current plane mode** | Competing message buses; silent plane/retention/eligibility flips |
 | **ACPX** | Routine first-choice structured transport for eligible two-seat read-only communication; fleet launchers make `discuss` select it automatically for Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek; not a coordination plane | Persistent sessions, backlog, auto-retries, unrestricted chat, plane flips, review eligibility |
+| **Entire context recall** | Optional, body-free historical discovery and provenance through verified local locator cards | Task state, live discussion, terminal receipts, source code authority, rollover, Monitor state, or formal review |
 | **Buzz** | **Explicitly deferred** | Anything in this rollout — relay-as-authority conflicts with the current authority model |
+
+### Entire recall onboarding matrix
+
+Capture belongs to the **host harness**, not to a model label. The same model
+may therefore use a different capture integration when it runs under a
+different host. Capture is also separate from recall: every listed seat can
+consume the same project-generated body-free capsule even when that seat has no
+native Entire capture path.
+
+| Seat or model | Host-harness capture route | Cold-start recall behavior |
+| --- | --- | --- |
+| Codex CLI or Desktop | Installed `codex` integration and shared project hooks | The accountable root runs local `status` + `search` once; Codex consumes the root's verified capsule. |
+| Claude in Claude Code | Installed `claude-code` integration | Same shared-capsule contract; no Claude-specific search or authority. |
+| Any supported model in OpenCode, including Claude or GLM | Installed `opencode` integration | Same shared-capsule contract; the model name does not select capture. |
+| Kimi in Claude Code or OpenCode | The active host's `claude-code` or `opencode` integration | Same shared-capsule contract; do not install a Kimi adapter for a hosted Kimi model. |
+| Standalone Kimi Code | Project `entire-agent-kimi` adapter only when explicitly installed for the actual standalone `kimi` harness | Same shared-capsule contract; adapter capture never replaces local verified recall. |
+| GLM outside a proved native host | No model-named integration is inferred | Consume the root's capsule; add no adapter without a source-blind unsupported-harness canary. |
+| Grok | Integration of the harness that actually launches Grok; none is inferred from `grok` alone | Consume the root's capsule; ACP remains live discussion and terminal receipts. |
+| AGY / Gemini | Integration of the harness that actually launches AGY; none is inferred from `agy` or a Gemini model label | Consume the root's capsule; the AGY bridge remains execution/discussion transport. |
+
+For each non-trivial task, the accountable root performs this contract:
+
+1. Run `.venv/bin/python -m scripts.entire_context status` and one bounded
+   `search --query "<task keywords>"` before prioritization or dispatch.
+2. Resolve any useful locator against its canonical local source. If results
+   materially help, create at most one `handoff` capsule (five cards, 8 KiB)
+   and give that same capsule to the participants that need it.
+3. Keep raw prompts, transcripts, responses, session bodies, generated recaps,
+   and generated summaries out of automatic context. Do not run cloud Entire
+   commands from the public skill.
+4. Run `record-use` only for locators that were verified and materially
+   informed the task. Search delivery alone is not use.
+5. Continue normally when recall is unavailable. Git/GitHub remain
+   authoritative for code; Fleet/file handoffs for coordination; ACP for live
+   discussion and terminal receipts; Monitor for runtime state; rollover for
+   continuity; sealed Fleet review for the formal review gate.
+
+The operator may privately use Entire's product workflows for
+[skills](https://docs.entire.io/learn/skills),
+[search](https://docs.entire.io/learn/search-past-agent-work),
+[review and recap](https://docs.entire.io/learn/review-and-recap-agent-work), or
+[why/blame/investigation and session handoff](https://docs.entire.io/learn/investigate-why-code-exists).
+These are investigation aids, not fleet evidence. Their prompts, results,
+transcripts, generated explanations, and summaries are not admitted to the
+automatic capsule and do not change task, review, or merge disposition.
 
 ### Human overview pages
 

--- a/scripts/agent_runtime/acpx_discuss.py
+++ b/scripts/agent_runtime/acpx_discuss.py
@@ -1247,11 +1247,16 @@ def run_discussion(**kwargs: Any) -> dict[str, Any]:
             # best-effort and cannot change the discussion result.
             from scripts.entire_context.reconcile import project_terminal_acp_receipt
 
-            project_terminal_acp_receipt(
+            projection = project_terminal_acp_receipt(
                 conversation_id=str(result["conversation_id"]),
                 acp_root=root,
                 repo_root=Path(kwargs["cwd"]),
             )
+            if projection.get("outcome") not in {"promoted", "already_promoted"}:
+                logger.warning(
+                    "optional ACP context projection skipped: %s",
+                    projection.get("reason") or projection.get("outcome") or "unknown",
+                )
         except Exception as exc:
             logger.warning(
                 "optional ACP context projection failed: %s", type(exc).__name__

--- a/scripts/api/entire_context_router.py
+++ b/scripts/api/entire_context_router.py
@@ -25,6 +25,17 @@ from .repository_authority import preparation_data_root
 
 router = APIRouter(tags=["entire-context"])
 
+_PROJECTION_COUNT_STATES = ("pending", "promoted", "tombstoned")
+_ACP_HEALTH_NUMBER_FIELDS = ("attempts", "failures", "lag_seconds", "retries")
+_ACP_HEALTH_TEXT_FIELDS = (
+    "last_attempt_at",
+    "last_failure_at",
+    "last_failure_reason",
+    "last_reconciliation_at",
+    "last_success_at",
+    "source_latest_at",
+)
+
 
 def _repo_root() -> Path:
     return preparation_data_root(
@@ -37,6 +48,110 @@ def _rollover_root(root: Path) -> Path:
     """Resolve the existing shared rollover registry, with an explicit service override."""
     configured = os.environ.get("ENTIRE_CONTEXT_ROLLOVER_ROOT")
     return Path(configured) if configured else shared_repository_root(root)
+
+
+def _safe_count(value: Any) -> int:
+    """Normalize one aggregate count without letting malformed telemetry fail a GET."""
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _optional_count(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        count = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return count if count >= 0 else None
+
+
+def _safe_text(value: Any) -> str | None:
+    """Return one bounded machine field; omit bodies and path-like values."""
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > 256:
+        return None
+    if value.startswith(("/", "~")) or "\\" in value:
+        return None
+    return value
+
+
+def _safe_count_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, int] = {}
+    for key, raw_count in value.items():
+        safe_key = _safe_text(key)
+        safe_count = _optional_count(raw_count)
+        if safe_key is not None and safe_count is not None:
+            result[safe_key] = safe_count
+    return dict(sorted(result.items()))
+
+
+def _public_projection_health(value: Any) -> dict[str, Any]:
+    """Project the stable reliability contract without forwarding unknown fields."""
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, Any] = {}
+    for field in ("pending", "tombstoned", "dangling"):
+        safe_count = _optional_count(value.get(field))
+        if safe_count is not None:
+            result[field] = safe_count
+    result["tombstones_by_reason"] = _safe_count_map(value.get("tombstones_by_reason"))
+    raw_acp = value.get("acp")
+    if not isinstance(raw_acp, dict):
+        return result
+    acp: dict[str, Any] = {}
+    for field in _ACP_HEALTH_NUMBER_FIELDS:
+        if field == "lag_seconds" and raw_acp.get(field) is None:
+            acp[field] = None
+        else:
+            safe_count = _optional_count(raw_acp.get(field))
+            if safe_count is not None:
+                acp[field] = safe_count
+    for field in _ACP_HEALTH_TEXT_FIELDS:
+        acp[field] = _safe_text(raw_acp.get(field))
+    raw_last = raw_acp.get("last_reconciliation")
+    if isinstance(raw_last, dict):
+        acp["last_reconciliation"] = {
+            "examined": _safe_count(raw_last.get("examined")),
+            "changed": _safe_count(raw_last.get("changed")),
+            "skipped": _safe_count(raw_last.get("skipped")),
+            "truncated": raw_last.get("truncated") is True,
+            "limit": _safe_count(raw_last.get("limit")),
+        }
+    result["acp"] = acp
+    return result
+
+
+def _public_projection_status(projection: dict[str, Any]) -> dict[str, Any]:
+    """Expose only body-free, non-path projection health fields to Monitor."""
+    if projection.get("available") is not True:
+        return {
+            "available": False,
+            "reason": _safe_text(projection.get("reason")) or "projection_unavailable",
+        }
+    raw_counts = projection.get("counts")
+    counts = raw_counts if isinstance(raw_counts, dict) else {}
+    public: dict[str, Any] = {
+        "available": True,
+        "schema_version": _safe_count(projection.get("schema_version")),
+        "counts": {
+            state: _safe_count(counts.get(state, 0)) for state in _PROJECTION_COUNT_STATES
+        },
+        "events": _safe_count(projection.get("events")),
+        "last_event_at": _safe_text(projection.get("last_event_at")),
+        "use_receipts": _safe_count(projection.get("use_receipts")),
+        "last_use_at": _safe_text(projection.get("last_use_at")),
+        "uses_by_consumer": _safe_count_map(projection.get("uses_by_consumer")),
+    }
+    projection_health = _public_projection_health(projection.get("projection_health"))
+    if projection_health:
+        public["projection_health"] = projection_health
+    return public
 
 
 def _projection_status(root: Path) -> dict[str, Any]:
@@ -54,34 +169,52 @@ def _projection_status(root: Path) -> dict[str, Any]:
 def entire_context_status() -> dict[str, Any]:
     """Truthfully distinguish capture, recall availability, and proven use."""
     root = _repo_root()
-    projection = _projection_status(root)
+    projection = _public_projection_status(_projection_status(root))
     provider = load_provider_status(root)
     counts = projection.get("counts", {}) if projection.get("available") else {}
-    installed_agents = provider.get("installed_agents", []) if provider.get("available") else []
+    installed_agents = (
+        provider.get("installed_agents", [])
+        if isinstance(provider, dict) and provider.get("available") is True
+        else []
+    )
+    if not isinstance(installed_agents, list):
+        installed_agents = []
+    installed_agents = [
+        agent for agent in (_safe_text(value) for value in installed_agents) if agent is not None
+    ]
+    promoted_links = _safe_count(counts.get("promoted"))
+    use_receipts = _safe_count(projection.get("use_receipts"))
     return {
         "schema": "entire-context-monitor.v1",
         "body_free": True,
         "authoritative": False,
         "capture": {
-            "configured": provider.get("enabled") is True,
+            "configured": isinstance(provider, dict) and provider.get("enabled") is True,
             "installed_agents": installed_agents,
             "native_agent_installed": bool(installed_agents),
-            "provider_status_available": provider.get("available") is True,
+            "provider_status_available": isinstance(provider, dict)
+            and provider.get("available") is True,
         },
         "recall": {
             "available": projection.get("available") is True
-            and int(counts.get("promoted", 0)) > 0,
-            "promoted_links": int(counts.get("promoted", 0)),
+            and promoted_links > 0,
+            "reason": projection.get("reason"),
+            "promoted_links": promoted_links,
             "projection": projection,
         },
         "use": {
             "proven": projection.get("available") is True
-            and int(projection.get("use_receipts", 0)) > 0,
-            "receipts": int(projection.get("use_receipts", 0)),
+            and use_receipts > 0,
+            "receipts": use_receipts,
             "last_use_at": projection.get("last_use_at"),
-            "by_consumer": projection.get("uses_by_consumer", {}),
+            "by_consumer": _safe_count_map(projection.get("uses_by_consumer")),
         },
-        "provider": provider,
+        "provider": {
+            "available": isinstance(provider, dict) and provider.get("available") is True,
+            "enabled": isinstance(provider, dict) and provider.get("enabled") is True,
+            "stale": isinstance(provider, dict) and provider.get("stale") is True,
+            "version": _safe_text(provider.get("version")) if isinstance(provider, dict) else None,
+        },
     }
 
 

--- a/scripts/entire_context/cli.py
+++ b/scripts/entire_context/cli.py
@@ -34,7 +34,7 @@ from .model import (
     canonical_json,
     validate_identity,
 )
-from .paths import projection_path
+from .paths import ENV_ACP_ROOT, acp_root, projection_path
 from .provider import refresh_provider_status
 from .recall import (
     MAX_RESULTS,
@@ -68,7 +68,6 @@ EXIT_NOT_FOUND = 1
 EXIT_REFUSED = 2
 
 ENV_DISABLED = "ENTIRE_CONTEXT_DISABLED"
-ENV_ACP_ROOT = "ENTIRE_CONTEXT_ACP_ROOT"
 ENV_ROLLOVER_ROOT = "ENTIRE_CONTEXT_ROLLOVER_ROOT"
 ENV_FLEET_ROOT = "ENTIRE_CONTEXT_FLEET_ROOT"
 ENV_MONITOR_ROOT = "ENTIRE_CONTEXT_MONITOR_ROOT"
@@ -228,12 +227,8 @@ def _resolve_repo(args: argparse.Namespace) -> Path:
     return Path(getattr(args, "repo", None) or Path.cwd())
 
 
-def _resolve_acp_root(args: argparse.Namespace) -> Path | None:
-    explicit = getattr(args, "acp_root", None)
-    if explicit:
-        return Path(explicit)
-    env = os.environ.get(ENV_ACP_ROOT)
-    return Path(env) if env else None
+def _resolve_acp_root(args: argparse.Namespace) -> Path:
+    return acp_root(_resolve_repo(args), getattr(args, "acp_root", None))
 
 
 def _resolve_rollover_root(args: argparse.Namespace) -> Path | None:
@@ -318,8 +313,6 @@ def cmd_bootstrap_acp(args: argparse.Namespace) -> int:
     if _disabled():
         return _refused("projection_disabled")
     acp_root = _resolve_acp_root(args)
-    if acp_root is None:
-        return _refused("source_missing")
     try:
         resolution = resolve_acp_conversation(args.conversation_id, acp_root=acp_root, git_sha=args.git_sha)
     except ResolutionError as exc:
@@ -594,8 +587,6 @@ def cmd_record_use(args: argparse.Namespace) -> int:
 def cmd_reconcile_acp(args: argparse.Namespace) -> int:
     """Recover complete ACP terminal receipts missed by the live callback."""
     acp_root = _resolve_acp_root(args)
-    if acp_root is None:
-        return _refused("source_missing")
     payload = reconcile_terminal_acp_receipts(
         acp_root=acp_root,
         repo_root=_resolve_repo(args),
@@ -672,7 +663,7 @@ def build_parser() -> argparse.ArgumentParser:
         command.add_argument(
             "--acp-root",
             default=None,
-            help=f"ACP receipt plane root (default: {ENV_ACP_ROOT}); required to verify ACP links",
+            help=f"ACP receipt plane root (default: {ENV_ACP_ROOT}, then canonical Fleet root)",
         )
         command.add_argument(
             "--rollover-root",
@@ -736,7 +727,7 @@ def build_parser() -> argparse.ArgumentParser:
     bootstrap_acp.add_argument(
         "--acp-root",
         default=None,
-        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT})",
+        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT}, then canonical Fleet root)",
     )
     bootstrap_acp.set_defaults(func=cmd_bootstrap_acp)
 
@@ -886,7 +877,7 @@ def build_parser() -> argparse.ArgumentParser:
     reconcile_acp.add_argument(
         "--acp-root",
         default=None,
-        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT})",
+        help=f"ACP receipt plane root (default: {ENV_ACP_ROOT}, then canonical Fleet root)",
     )
     reconcile_acp.add_argument("--repo", default=None, help="Repository/worktree used to resolve shared state")
     reconcile_acp.add_argument("--actor", default="acp-reconcile", help="Body-free actor identity")

--- a/scripts/entire_context/paths.py
+++ b/scripts/entire_context/paths.py
@@ -6,10 +6,13 @@ import os
 import subprocess
 from pathlib import Path
 
+from scripts.fleet_comms.paths import default_plane_root
+
 DEFAULT_STATE_RELATIVE = Path("batch_state") / "entire-context" / "v1"
 DEFAULT_DB_NAME = "context-links.sqlite3"
 DEFAULT_PROVIDER_STATUS_NAME = "provider-status.json"
 ENV_DB = "ENTIRE_CONTEXT_DB"
+ENV_ACP_ROOT = "ENTIRE_CONTEXT_ACP_ROOT"
 
 
 def shared_repository_root(cwd: Path | str) -> Path:
@@ -54,6 +57,21 @@ def projection_path(cwd: Path | str, explicit: Path | str | None = None) -> Path
     if configured:
         return Path(configured).expanduser().resolve()
     return state_directory(cwd) / DEFAULT_DB_NAME
+
+
+def acp_root(cwd: Path | str, explicit: Path | str | None = None) -> Path:
+    """Resolve the shared canonical ACP plane used by Fleet services.
+
+    Caller-supplied and Entire-specific overrides win.  The default delegates
+    to Fleet Comms' canonical resolver so the CLI, API, primary checkout, and
+    linked worktrees cannot drift onto different receipt databases.
+    """
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+    configured = os.environ.get(ENV_ACP_ROOT)
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return default_plane_root(repo_root=Path(cwd))
 
 
 def provider_status_path(cwd: Path | str) -> Path:

--- a/scripts/entire_context/reconcile.py
+++ b/scripts/entire_context/reconcile.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from .model import LinkKind, SchemaError, isoformat_z, parse_timestamp, utc_now
 from .paths import projection_path
 from .resolvers import ResolutionError, resolve_acp_conversation
 from .store import AdmitOutcome, ContextLinkStore
@@ -40,37 +42,182 @@ def project_terminal_acp_receipt(
     """Project one exact terminal receipt idempotently after ACP completion."""
     if _disabled():
         return {"outcome": "skipped", "reason": "projection_disabled"}
+    store = ContextLinkStore(projection_path(repo_root, db_path))
     try:
         resolution = resolve_acp_conversation(
             conversation_id,
             acp_root=Path(acp_root),
         )
-        result = ContextLinkStore(
-            projection_path(repo_root, db_path)
-        ).admit(resolution.link, resolution.verification, actor=actor)
     except ResolutionError as exc:
+        _tombstone_exact(store, conversation_id, reason=exc.reason, actor=actor)
+        _record_sync(
+            store,
+            operation="live",
+            outcome="failed",
+            reason=exc.reason,
+            examined=1,
+            skipped=1,
+        )
         return {"outcome": "skipped", "reason": exc.reason}
+    try:
+        result = store.admit(resolution.link, resolution.verification, actor=actor)
+        successful = result.outcome in {
+            AdmitOutcome.PROMOTED,
+            AdmitOutcome.ALREADY_PROMOTED,
+        }
+        tombstoned = (
+            _tombstone_exact(
+                store,
+                conversation_id,
+                reason="digest_mismatch",
+                actor=actor,
+                keep_locator=resolution.link.locator_id,
+            )
+            if successful
+            else 0
+        )
+        _record_sync(
+            store,
+            operation="live",
+            outcome="succeeded" if successful else "failed",
+            reason="" if successful else (result.reason or result.outcome.value),
+            source_latest_at=str(resolution.link.facets.get("event_ts") or "") or None,
+            examined=1,
+            changed=int(result.outcome is AdmitOutcome.PROMOTED) + tombstoned,
+        )
     except (OSError, sqlite3.Error, KeyError, TypeError, ValueError):
         return {"outcome": "skipped", "reason": "projection_unavailable"}
-    return result.to_dict()
+    return {**result.to_dict(), "tombstoned": tombstoned}
 
 
-def _terminal_complete_ids(acp_root: Path, *, limit: int) -> list[str]:
+def _terminal_complete_ids(
+    acp_root: Path,
+    *,
+    limit: int,
+    attempt: int = 0,
+) -> tuple[list[str], bool, str | None]:
     db_path = Path(acp_root).expanduser().resolve() / "comms.sqlite3"
     if not db_path.is_file():
-        return []
+        raise ResolutionError("source_missing")
     capped = max(0, min(int(limit), MAX_RECONCILE_ROWS))
     with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:
-        rows = connection.execute(
-            "SELECT event.conversation_id FROM acp_conversation_events AS event"
+        where_latest_complete = (
+            " FROM acp_conversation_events AS event"
             " WHERE event.sequence = ("
             "SELECT MAX(latest.sequence) FROM acp_conversation_events AS latest"
             " WHERE latest.conversation_id = event.conversation_id"
             ") AND event.state = 'COMPLETE'"
-            " ORDER BY event.conversation_id LIMIT ?",
-            (capped,),
-        ).fetchall()
-    return [str(row[0]) for row in rows]
+        )
+        total = int(connection.execute("SELECT COUNT(*)" + where_latest_complete).fetchone()[0])
+        visible: list[tuple[Any, ...]] = []
+        if capped and total:
+            offset = (max(0, int(attempt)) * capped) % total
+            visible = connection.execute(
+                "SELECT event.conversation_id, event.created_at"
+                + where_latest_complete
+                + " ORDER BY event.conversation_id LIMIT ? OFFSET ?",
+                (capped, offset),
+            ).fetchall()
+            if len(visible) < min(capped, total):
+                visible.extend(
+                    connection.execute(
+                        "SELECT event.conversation_id, event.created_at"
+                        + where_latest_complete
+                        + " ORDER BY event.conversation_id LIMIT ?",
+                        (min(capped, total) - len(visible),),
+                    ).fetchall()
+                )
+    timestamps: list[datetime] = []
+    for row in visible:
+        try:
+            timestamps.append(parse_timestamp(str(row[1])))
+        except (SchemaError, TypeError, ValueError):
+            continue
+    source_latest_at = isoformat_z(max(timestamps)) if timestamps else None
+    return [str(row[0]) for row in visible], total > capped, source_latest_at
+
+
+def _fair_window(
+    source_ids: list[str],
+    projected_ids: list[str],
+    *,
+    limit: int,
+    attempt: int,
+) -> list[str]:
+    """Interleave rotating source/projection pages without starving either."""
+    if limit <= 0:
+        return []
+    lanes = (source_ids, projected_ids) if attempt % 2 == 0 else (projected_ids, source_ids)
+    selected: list[str] = []
+    seen: set[str] = set()
+    for index in range(max(map(len, lanes), default=0)):
+        for lane in lanes:
+            if index >= len(lane) or lane[index] in seen:
+                continue
+            seen.add(lane[index])
+            selected.append(lane[index])
+            if len(selected) == limit:
+                return selected
+    return selected
+
+
+def _tombstone_exact(
+    store: ContextLinkStore,
+    conversation_id: str,
+    *,
+    reason: str,
+    actor: str,
+    keep_locator: str | None = None,
+) -> int:
+    """Tombstone stale locators for one canonical ACP identity."""
+    try:
+        links, _truncated = store.promoted_for_canonical(
+            LinkKind.ACP_CONVERSATION,
+            conversation_id,
+        )
+    except sqlite3.Error:
+        return 0
+    changed = 0
+    for link in links:
+        locator_id = str(link["locator_id"])
+        if locator_id == keep_locator:
+            continue
+        changed += int(store.tombstone(locator_id, reason=reason, actor=actor))
+    return changed
+
+
+def _record_sync(
+    store: ContextLinkStore,
+    *,
+    operation: str,
+    outcome: str,
+    reason: str = "",
+    source_latest_at: str | None = None,
+    examined: int = 0,
+    changed: int = 0,
+    skipped: int = 0,
+    truncated: bool = False,
+    limit: int = 0,
+    dangling: int = 0,
+) -> None:
+    """Best-effort observability; telemetry never changes projection results."""
+    try:
+        store.record_projection_sync(
+            source_kind=LinkKind.ACP_CONVERSATION,
+            operation=operation,
+            outcome=outcome,
+            reason=reason,
+            source_latest_at=source_latest_at,
+            examined=examined,
+            changed=changed,
+            skipped=skipped,
+            truncated=truncated,
+            limit=limit,
+            dangling=dangling,
+            now=utc_now(),
+        )
+    except (OSError, sqlite3.Error, SchemaError, KeyError, TypeError, ValueError):
+        return
 
 
 def reconcile_terminal_acp_receipts(
@@ -84,32 +231,109 @@ def reconcile_terminal_acp_receipts(
     """Recover any terminal ACP receipts missed by the post-commit callback."""
     if _disabled():
         return {"outcome": "skipped", "reason": "projection_disabled"}
+    capped = max(0, min(int(limit), MAX_RECONCILE_ROWS))
+    store = ContextLinkStore(projection_path(repo_root, db_path))
+    prior_attempts = 0
+    if store.db_path.is_file():
+        try:
+            prior_attempts = int(store.status()["projection_health"]["acp"]["attempts"])
+        except (sqlite3.Error, KeyError, TypeError, ValueError):
+            return {"outcome": "skipped", "reason": "projection_unavailable"}
+    page_attempt = prior_attempts if capped > 1 else prior_attempts // 2
     try:
-        conversation_ids = _terminal_complete_ids(acp_root, limit=limit)
+        complete_ids, source_truncated, source_latest_at = _terminal_complete_ids(
+            acp_root,
+            limit=capped,
+            attempt=page_attempt,
+        )
+    except ResolutionError as exc:
+        if store.db_path.is_file():
+            _record_sync(store, operation="reconcile", outcome="failed", reason=exc.reason, limit=capped)
+        return {"outcome": "skipped", "reason": exc.reason}
     except sqlite3.Error:
+        if store.db_path.is_file():
+            _record_sync(store, operation="reconcile", outcome="failed", reason="source_unreadable", limit=capped)
         return {"outcome": "skipped", "reason": "source_unreadable"}
+    try:
+        existing, projection_truncated = (
+            store.promoted_for_kind(
+                LinkKind.ACP_CONVERSATION,
+                limit=capped,
+                attempt=page_attempt,
+            )
+            if store.db_path.is_file()
+            else ([], False)
+        )
+    except (sqlite3.Error, KeyError, TypeError, ValueError):
+        return {"outcome": "skipped", "reason": "projection_unavailable"}
+    existing_by_id: dict[str, list[dict[str, Any]]] = {}
+    for link in existing:
+        existing_by_id.setdefault(str(link["canonical_id"]), []).append(link)
+    projected_ids = sorted(existing_by_id)
+    conversation_ids = _fair_window(
+        complete_ids,
+        projected_ids,
+        limit=capped,
+        attempt=prior_attempts,
+    )
+    truncated = source_truncated or projection_truncated or (
+        len(set(complete_ids) | set(projected_ids)) > capped
+    )
     counts = {
         AdmitOutcome.PROMOTED.value: 0,
         AdmitOutcome.ALREADY_PROMOTED.value: 0,
+        "tombstoned": 0,
         "skipped": 0,
     }
     reasons: dict[str, int] = {}
     for conversation_id in conversation_ids:
-        result = project_terminal_acp_receipt(
-            conversation_id=conversation_id,
-            acp_root=acp_root,
-            repo_root=repo_root,
-            db_path=db_path,
-            actor=actor,
-        )
-        outcome = str(result["outcome"])
-        counts[outcome] = counts.get(outcome, 0) + 1
-        reason = str(result.get("reason") or "")
-        if reason:
-            reasons[reason] = reasons.get(reason, 0) + 1
+        try:
+            resolution = resolve_acp_conversation(conversation_id, acp_root=Path(acp_root))
+        except ResolutionError as exc:
+            changed = _tombstone_exact(store, conversation_id, reason=exc.reason, actor=actor)
+            counts["tombstoned"] += changed
+            if not changed:
+                counts["skipped"] += 1
+            reasons[exc.reason] = reasons.get(exc.reason, 0) + 1
+            continue
+        try:
+            admitted = store.admit(resolution.link, resolution.verification, actor=actor)
+            counts[admitted.outcome.value] = counts.get(admitted.outcome.value, 0) + 1
+            stale = _tombstone_exact(
+                store,
+                conversation_id,
+                reason="digest_mismatch",
+                actor=actor,
+                keep_locator=resolution.link.locator_id,
+            )
+            counts["tombstoned"] += stale
+            if stale:
+                reasons["digest_mismatch"] = reasons.get("digest_mismatch", 0) + stale
+        except (OSError, sqlite3.Error, SchemaError, KeyError, TypeError, ValueError):
+            counts["skipped"] += 1
+            reasons["projection_unavailable"] = reasons.get("projection_unavailable", 0) + 1
+    changed = counts[AdmitOutcome.PROMOTED.value] + counts["tombstoned"]
+    dangling = reasons.get("projection_unavailable", 0)
+    _record_sync(
+        store,
+        operation="reconcile",
+        outcome="succeeded",
+        source_latest_at=source_latest_at,
+        examined=len(conversation_ids),
+        changed=changed,
+        skipped=counts["skipped"],
+        truncated=truncated,
+        limit=capped,
+        dangling=dangling,
+    )
+    lag_seconds = 0 if source_latest_at is not None and not truncated and dangling == 0 else None
     return {
         "outcome": "reconciled",
         "examined": len(conversation_ids),
         "counts": counts,
         "reasons": dict(sorted(reasons.items())),
+        "truncated": truncated,
+        "limit": capped,
+        "source_latest_at": source_latest_at,
+        "lag_seconds": lag_seconds,
     }

--- a/scripts/entire_context/store.py
+++ b/scripts/entire_context/store.py
@@ -26,6 +26,7 @@ from .model import (
     LOCATOR_ID_RE,
     SCHEMA_VERSION,
     ContextLink,
+    LinkKind,
     SchemaError,
     VerificationEvidence,
     VerificationStatus,
@@ -76,6 +77,26 @@ CREATE TABLE IF NOT EXISTS use_receipts (
 );
 CREATE INDEX IF NOT EXISTS idx_use_receipts_recorded_at
     ON use_receipts(recorded_at, receipt_id);
+CREATE TABLE IF NOT EXISTS projection_sync_state (
+    source_kind TEXT PRIMARY KEY,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    failures INTEGER NOT NULL DEFAULT 0,
+    retries INTEGER NOT NULL DEFAULT 0,
+    last_outcome TEXT NOT NULL DEFAULT '',
+    last_attempt_at TEXT,
+    last_success_at TEXT,
+    last_failure_at TEXT,
+    last_failure_reason TEXT,
+    last_reconciliation_at TEXT,
+    source_latest_at TEXT,
+    lag_seconds INTEGER,
+    last_examined INTEGER NOT NULL DEFAULT 0,
+    last_changed INTEGER NOT NULL DEFAULT 0,
+    last_skipped INTEGER NOT NULL DEFAULT 0,
+    last_truncated INTEGER NOT NULL DEFAULT 0,
+    last_limit INTEGER NOT NULL DEFAULT 0,
+    dangling INTEGER NOT NULL DEFAULT 0
+);
 """
 
 
@@ -329,6 +350,40 @@ class ContextLinkStore:
             return "verification_stale"
         return None
 
+    def tombstone(
+        self,
+        locator_id: str,
+        *,
+        reason: str,
+        actor: str,
+        now: datetime | None = None,
+    ) -> bool:
+        """Converge one projected locator to a terminal body-free tombstone.
+
+        Returns ``True`` only when this call applied the transition. Missing
+        and already-tombstoned locators are idempotent no-ops.
+        """
+        if LOCATOR_ID_RE.fullmatch(locator_id) is None:
+            raise SchemaError("locator_id is invalid")
+        validate_identity(reason, field_name="reason")
+        validate_identity(actor, field_name="actor")
+        timestamp = isoformat_z(now or utc_now())
+        with self._transaction() as connection:
+            state = self._current_state(connection, locator_id)
+            if state is None or state == "tombstoned":
+                return False
+            connection.execute(
+                "INSERT INTO link_events(locator_id, event_type, payload_json, reason, actor, recorded_at)"
+                " VALUES (?, 'tombstoned', '{}', ?, ?, ?)",
+                (locator_id, reason, actor, timestamp),
+            )
+            connection.execute(
+                "UPDATE context_links SET state = 'tombstoned', tombstone_reason = ?"
+                " WHERE locator_id = ?",
+                (reason, locator_id),
+            )
+        return True
+
     # ── reads ────────────────────────────────────────────────────────────────
 
     @staticmethod
@@ -407,9 +462,66 @@ class ContextLinkStore:
                 "SELECT consumer, COUNT(*) AS n FROM use_receipts"
                 " GROUP BY consumer ORDER BY consumer"
             ).fetchall()
+            tombstone_reasons = connection.execute(
+                "SELECT tombstone_reason, COUNT(*) AS n FROM context_links"
+                " WHERE state = 'tombstoned' GROUP BY tombstone_reason"
+                " ORDER BY tombstone_reason"
+            ).fetchall()
+            sync_table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table'"
+                " AND name = 'projection_sync_state'"
+            ).fetchone()
+            acp_sync = None
+            if sync_table is not None:
+                acp_sync = connection.execute(
+                    "SELECT * FROM projection_sync_state WHERE source_kind = ?",
+                    (LinkKind.ACP_CONVERSATION.value,),
+                ).fetchone()
+        count_map = {str(row["state"]): int(row["n"]) for row in counts}
+        acp_health = {
+            "attempts": 0,
+            "failures": 0,
+            "retries": 0,
+            "last_attempt_at": None,
+            "last_success_at": None,
+            "last_failure_at": None,
+            "last_failure_reason": None,
+            "last_reconciliation_at": None,
+            "source_latest_at": None,
+            "lag_seconds": None,
+            "last_reconciliation": {
+                "examined": 0,
+                "changed": 0,
+                "skipped": 0,
+                "truncated": False,
+                "limit": 0,
+            },
+        }
+        dangling = 0
+        if acp_sync is not None:
+            dangling = int(acp_sync["dangling"])
+            acp_health = {
+                "attempts": int(acp_sync["attempts"]),
+                "failures": int(acp_sync["failures"]),
+                "retries": int(acp_sync["retries"]),
+                "last_attempt_at": acp_sync["last_attempt_at"],
+                "last_success_at": acp_sync["last_success_at"],
+                "last_failure_at": acp_sync["last_failure_at"],
+                "last_failure_reason": acp_sync["last_failure_reason"],
+                "last_reconciliation_at": acp_sync["last_reconciliation_at"],
+                "source_latest_at": acp_sync["source_latest_at"],
+                "lag_seconds": acp_sync["lag_seconds"],
+                "last_reconciliation": {
+                    "examined": int(acp_sync["last_examined"]),
+                    "changed": int(acp_sync["last_changed"]),
+                    "skipped": int(acp_sync["last_skipped"]),
+                    "truncated": bool(acp_sync["last_truncated"]),
+                    "limit": int(acp_sync["last_limit"]),
+                },
+            }
         return {
             "schema_version": SCHEMA_VERSION,
-            "counts": {str(row["state"]): int(row["n"]) for row in counts},
+            "counts": count_map,
             "events": int(events["n"]) if events else 0,
             "last_event_at": events["last_at"] if events else None,
             "use_receipts": int(uses["n"]) if uses else 0,
@@ -417,6 +529,186 @@ class ContextLinkStore:
             "uses_by_consumer": {
                 str(row["consumer"]): int(row["n"]) for row in use_consumers
             },
+            "projection_health": {
+                "pending": count_map.get("pending", 0),
+                "tombstoned": count_map.get("tombstoned", 0),
+                "dangling": dangling,
+                "tombstones_by_reason": {
+                    str(row["tombstone_reason"]): int(row["n"])
+                    for row in tombstone_reasons
+                    if row["tombstone_reason"]
+                },
+                "acp": acp_health,
+            },
+        }
+
+    def promoted_for_kind(
+        self,
+        kind: LinkKind,
+        *,
+        limit: int,
+        attempt: int = 0,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Return a bounded deterministic page that rotates across retries."""
+        if not isinstance(kind, LinkKind):
+            raise SchemaError("kind must be an allowlisted LinkKind")
+        capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
+        with self._connect(write=False) as connection:
+            total = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM context_links WHERE state = 'promoted' AND kind = ?",
+                    (kind.value,),
+                ).fetchone()[0]
+            )
+            rows: list[sqlite3.Row] = []
+            if capped and total:
+                offset = (max(0, int(attempt)) * capped) % total
+                rows = connection.execute(
+                    "SELECT * FROM context_links WHERE state = 'promoted' AND kind = ?"
+                    " ORDER BY canonical_id, locator_id LIMIT ? OFFSET ?",
+                    (kind.value, capped, offset),
+                ).fetchall()
+                if len(rows) < min(capped, total):
+                    rows.extend(
+                        connection.execute(
+                            "SELECT * FROM context_links WHERE state = 'promoted' AND kind = ?"
+                            " ORDER BY canonical_id, locator_id LIMIT ?",
+                            (kind.value, min(capped, total) - len(rows)),
+                        ).fetchall()
+                    )
+        return [self._row_to_link_dict(row) for row in rows], total > capped
+
+    def promoted_for_canonical(
+        self,
+        kind: LinkKind,
+        canonical_id: str,
+        *,
+        limit: int = MAX_RELATED_SCAN_ROWS,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Return bounded promoted locators for one exact canonical identity."""
+        if not isinstance(kind, LinkKind):
+            raise SchemaError("kind must be an allowlisted LinkKind")
+        capped = max(0, min(int(limit), MAX_RELATED_SCAN_ROWS))
+        with self._connect(write=False) as connection:
+            rows = connection.execute(
+                "SELECT * FROM context_links WHERE state = 'promoted' AND kind = ?"
+                " AND canonical_id = ? ORDER BY locator_id LIMIT ?",
+                (kind.value, canonical_id, capped + 1),
+            ).fetchall()
+        return [self._row_to_link_dict(row) for row in rows[:capped]], len(rows) > capped
+
+    def record_projection_sync(
+        self,
+        *,
+        source_kind: LinkKind,
+        operation: str,
+        outcome: str,
+        reason: str = "",
+        source_latest_at: str | None = None,
+        examined: int = 0,
+        changed: int = 0,
+        skipped: int = 0,
+        truncated: bool = False,
+        limit: int = 0,
+        dangling: int = 0,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Persist bounded body-free sync health in this disposable projection."""
+        if not isinstance(source_kind, LinkKind):
+            raise SchemaError("source_kind must be an allowlisted LinkKind")
+        if operation not in {"live", "reconcile"}:
+            raise SchemaError("operation must be live or reconcile")
+        if outcome not in {"succeeded", "failed"}:
+            raise SchemaError("outcome must be succeeded or failed")
+        if reason:
+            validate_identity(reason, field_name="reason")
+        values = (examined, changed, skipped, limit, dangling)
+        if any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in values):
+            raise SchemaError("projection sync counts must be non-negative integers")
+        if limit > MAX_RELATED_SCAN_ROWS:
+            raise SchemaError("projection sync limit exceeds the bounded maximum")
+        timestamp = isoformat_z(now or utc_now())
+        normalized_source_at = None
+        lag_seconds = None
+        if source_latest_at is not None:
+            normalized_source_at = isoformat_z(parse_timestamp(source_latest_at))
+            # This metric is projection backlog lag, not source age. A
+            # successful non-truncated pass with no dangling records proves
+            # catch-up; otherwise lag is unknown rather than misleading.
+            lag_seconds = 0 if outcome == "succeeded" and not truncated and dangling == 0 else None
+        with self._transaction() as connection:
+            prior = connection.execute(
+                "SELECT * FROM projection_sync_state WHERE source_kind = ?",
+                (source_kind.value,),
+            ).fetchone()
+            attempts = (int(prior["attempts"]) if prior is not None else 0) + 1
+            failures = (int(prior["failures"]) if prior is not None else 0) + (
+                1 if outcome == "failed" else 0
+            )
+            retries = (int(prior["retries"]) if prior is not None else 0) + (
+                1 if prior is not None and prior["last_outcome"] == "failed" else 0
+            )
+            last_success_at = (
+                timestamp if outcome == "succeeded" else (prior["last_success_at"] if prior is not None else None)
+            )
+            last_failure_at = (
+                timestamp if outcome == "failed" else (prior["last_failure_at"] if prior is not None else None)
+            )
+            last_failure_reason = (
+                reason if outcome == "failed" else (prior["last_failure_reason"] if prior is not None else None)
+            )
+            reconciliation_at = (
+                timestamp
+                if operation == "reconcile"
+                else (prior["last_reconciliation_at"] if prior is not None else None)
+            )
+            reconciliation_values = (
+                (examined, changed, skipped, int(truncated), limit)
+                if operation == "reconcile"
+                else (
+                    (
+                        int(prior["last_examined"]),
+                        int(prior["last_changed"]),
+                        int(prior["last_skipped"]),
+                        int(prior["last_truncated"]),
+                        int(prior["last_limit"]),
+                    )
+                    if prior is not None
+                    else (0, 0, 0, 0, 0)
+                )
+            )
+            connection.execute(
+                "INSERT OR REPLACE INTO projection_sync_state("
+                "source_kind, attempts, failures, retries, last_outcome, last_attempt_at,"
+                "last_success_at, last_failure_at, last_failure_reason, last_reconciliation_at,"
+                "source_latest_at, lag_seconds, last_examined, last_changed, last_skipped,"
+                "last_truncated, last_limit, dangling) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    source_kind.value,
+                    attempts,
+                    failures,
+                    retries,
+                    outcome,
+                    timestamp,
+                    last_success_at,
+                    last_failure_at,
+                    last_failure_reason,
+                    reconciliation_at,
+                    normalized_source_at
+                    if normalized_source_at is not None
+                    else (prior["source_latest_at"] if prior is not None else None),
+                    lag_seconds
+                    if source_latest_at is not None
+                    else (prior["lag_seconds"] if prior is not None else None),
+                    *reconciliation_values,
+                    dangling,
+                ),
+            )
+        return {
+            "attempts": attempts,
+            "failures": failures,
+            "retries": retries,
+            "last_attempt_at": timestamp,
         }
 
     def record_use(

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -1216,3 +1216,40 @@ def test_racing_reservations_never_expose_a_conversation_without_created_event(t
         ).fetchone()[0] == 1
     finally:
         conn.close()
+
+
+def test_optional_projection_failure_never_changes_complete_discussion_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from scripts.entire_context import reconcile
+
+    expected = {
+        "conversation_id": "conversation_" + "a" * 32,
+        "state": "COMPLETE",
+        "classification": "complete",
+    }
+
+    class FakeController:
+        def __init__(self, *, root: Path):
+            self.root = root
+
+        def run(self, **kwargs):
+            del kwargs
+            return dict(expected)
+
+        def close(self):
+            return None
+
+    def fail_projection(**kwargs):
+        del kwargs
+        raise sqlite3.DatabaseError("projection-only failure")
+
+    monkeypatch.setattr(acpx_discuss, "AcpxDiscussionController", FakeController)
+    monkeypatch.setattr(reconcile, "project_terminal_acp_receipt", fail_projection)
+
+    result = acpx_discuss.run_discussion(cwd=tmp_path)
+
+    assert result == expected
+    assert "optional ACP context projection failed: DatabaseError" in caplog.text

--- a/tests/test_entire_context_live.py
+++ b/tests/test_entire_context_live.py
@@ -228,6 +228,101 @@ def test_monitor_status_distinguishes_capture_recall_and_use(
     assert "projection_path" not in response.text
 
 
+def test_monitor_status_allowlists_reconciliation_health_and_malformed_aggregates(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(entire_context_router, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        entire_context_router,
+        "_projection_status",
+        lambda _root: {
+            "available": True,
+            "schema_version": 1,
+            "counts": {"promoted": "4", "pending": True, "tombstoned": None},
+            "events": "8",
+            "last_event_at": "2026-08-02T12:00:00Z",
+            "use_receipts": "2",
+            "last_use_at": "2026-08-02T12:01:00Z",
+            "uses_by_consumer": {"codex": "2", "broken": object()},
+            "projection_path": "/private/worktree/context.sqlite3",
+            "prompt": "must never cross the API boundary",
+            "projection_health": {
+                "pending": 1,
+                "tombstoned": 2,
+                "dangling": 3,
+                "tombstones_by_reason": {"source_missing": 2},
+                "acp": {
+                    "attempts": 5,
+                    "failures": 1,
+                    "retries": 2,
+                    "last_attempt_at": "2026-08-02T12:00:00Z",
+                    "last_success_at": "2026-08-02T11:59:00Z",
+                    "last_failure_at": "2026-08-02T11:58:00Z",
+                    "last_failure_reason": "source_missing",
+                    "last_reconciliation_at": "2026-08-02T12:00:00Z",
+                    "source_latest_at": "2026-08-02T11:59:55Z",
+                    "lag_seconds": 5,
+                    "last_reconciliation": {
+                        "examined": 7,
+                        "changed": 1,
+                        "skipped": 6,
+                        "truncated": False,
+                        "limit": 500,
+                        "local_path": "/forbidden",
+                    },
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        entire_context_router,
+        "load_provider_status",
+        lambda _root: {
+            "available": True,
+            "enabled": True,
+            "installed_agents": "malformed",
+            "prompt": "forbidden",
+        },
+    )
+
+    response = TestClient(app).get("/api/ops/entire-context/status")
+    payload = response.json()
+    projection = payload["recall"]["projection"]
+
+    assert response.status_code == 200
+    assert payload["capture"]["installed_agents"] == []
+    assert payload["recall"]["promoted_links"] == 4
+    assert payload["use"]["by_consumer"] == {"codex": 2}
+    assert projection["counts"] == {"pending": 0, "promoted": 4, "tombstoned": 0}
+    assert projection["projection_health"] == {
+        "pending": 1,
+        "tombstoned": 2,
+        "dangling": 3,
+        "tombstones_by_reason": {"source_missing": 2},
+        "acp": {
+            "attempts": 5,
+            "failures": 1,
+            "lag_seconds": 5,
+            "retries": 2,
+            "last_attempt_at": "2026-08-02T12:00:00Z",
+            "last_failure_at": "2026-08-02T11:58:00Z",
+            "last_failure_reason": "source_missing",
+            "last_reconciliation_at": "2026-08-02T12:00:00Z",
+            "last_success_at": "2026-08-02T11:59:00Z",
+            "source_latest_at": "2026-08-02T11:59:55Z",
+            "last_reconciliation": {
+                "examined": 7,
+                "changed": 1,
+                "skipped": 6,
+                "truncated": False,
+                "limit": 500,
+            },
+        },
+    }
+    assert "/private/" not in response.text
+    assert "prompt" not in response.text
+
+
 def test_monitor_search_reverifies_typed_issue_from_shared_local_cache(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -23,10 +23,12 @@ import os
 import sqlite3
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from scripts.entire_context import cli, recall
+from scripts.entire_context import reconcile as reconcile_module
 from scripts.entire_context.model import (
     ContextLink,
     LinkKind,
@@ -36,11 +38,16 @@ from scripts.entire_context.model import (
     isoformat_z,
     utc_now,
 )
+from scripts.entire_context.paths import ENV_ACP_ROOT, acp_root
 from scripts.entire_context.recall import (
     MAX_CAPSULE_BYTES,
     MAX_HANDOFF_ITEMS,
     MAX_SEARCH_OMISSIONS,
     rank_candidate,
+)
+from scripts.entire_context.reconcile import (
+    project_terminal_acp_receipt,
+    reconcile_terminal_acp_receipts,
 )
 from scripts.entire_context.resolvers import (
     REASON_DIGEST_MISMATCH,
@@ -64,7 +71,7 @@ from scripts.entire_context.resolvers import (
     rollover_projection,
     rollover_projection_digest,
 )
-from scripts.entire_context.store import AdmitOutcome, ContextLinkStore
+from scripts.entire_context.store import AdmitOutcome, AdmitResult, ContextLinkStore
 from scripts.orchestration import task_identity
 from scripts.orchestration.task_family import rollover, rollover_registry
 
@@ -386,6 +393,53 @@ def test_git_bootstrap_then_search_recall(
     assert_body_free(out)
 
 
+def test_acp_root_reuses_canonical_fleet_resolution_and_override_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = make_git_repo(tmp_path, name="primary")
+    commit_files(primary, {"tracked.txt": "one\n"}, "primary")
+    worktree = primary / ".worktrees" / "dispatch" / "codex" / "root-proof"
+    git(primary, "worktree", "add", "-q", "-b", "root-proof", str(worktree))
+    expected = primary / "batch_state" / "fleet-comms" / "v1"
+
+    monkeypatch.delenv(ENV_ACP_ROOT, raising=False)
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    assert acp_root(primary) == expected
+    assert acp_root(worktree) == expected
+
+    entire_override = tmp_path / "entire-override"
+    explicit_override = tmp_path / "explicit-override"
+    monkeypatch.setenv(ENV_ACP_ROOT, str(entire_override))
+    assert acp_root(worktree) == entire_override
+    assert acp_root(worktree, explicit_override) == explicit_override
+
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.delenv(ENV_ACP_ROOT)
+    assert acp_root(isolated) == isolated / "batch_state" / "fleet-comms" / "v1"
+
+
+def test_cli_automatically_uses_service_acp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    plane = make_acp_plane(tmp_path)
+    db = tmp_path / "projection.sqlite3"
+    monkeypatch.delenv(ENV_ACP_ROOT, raising=False)
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(plane))
+
+    code, out = run_cli(capsys, "bootstrap-acp", CONV_ID, "--db", str(db))
+    assert code == 0
+    assert json.loads(out)["outcome"] == "promoted"
+    code, out = run_cli(capsys, "search", "--query", CONV_ID, "--db", str(db))
+    assert code == 0
+    payload = json.loads(out)
+    assert [item["canonical_id"] for item in payload["results"]] == [CONV_ID]
+    assert payload["omitted"] == []
+
+
 def test_git_projection_supports_merge_parents_and_rejects_tree(tmp_path: Path) -> None:
     repo = make_git_repo(tmp_path)
     base = commit_files(repo, {"base.txt": "base\n"}, "base")
@@ -456,6 +510,247 @@ def test_acp_bootstrap_then_recall(tmp_path: Path, capsys: pytest.CaptureFixture
     assert code == 0
     assert [c["canonical_id"] for c in json.loads(out)["results"]] == [CONV_ID]
     assert_body_free(out)
+
+
+def test_acp_reconciliation_is_bounded_idempotent_and_converges_stale_links(
+    tmp_path: Path,
+) -> None:
+    plane = make_acp_plane(tmp_path)
+    db = tmp_path / "projection.sqlite3"
+
+    first = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    replay = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    assert first["counts"]["promoted"] == 1
+    assert first["lag_seconds"] == 0
+    assert replay["counts"]["already_promoted"] == 1
+    old_locator = ContextLinkStore(db).candidates()[0]["locator_id"]
+
+    append_acp_state_event(plane)
+    refreshed = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    assert refreshed["counts"]["promoted"] == 1
+    assert refreshed["counts"]["tombstoned"] == 1
+    store = ContextLinkStore(db)
+    promoted = store.candidates()
+    assert len(promoted) == 1
+    assert promoted[0]["locator_id"] != old_locator
+    assert store.explain(old_locator)["tombstone_reason"] == "digest_mismatch"
+
+    with sqlite3.connect(plane / "comms.sqlite3") as connection:
+        _insert_acp_event(
+            connection,
+            CONV_ID,
+            6,
+            "STATE",
+            state="PARTIAL_COMPLETE",
+            created_at="2026-08-01T10:06:00Z",
+        )
+    partial = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    assert partial["counts"]["tombstoned"] == 1
+    assert partial["reasons"] == {"partial_terminal": 1}
+    assert store.candidates() == []
+    health = store.status()["projection_health"]
+    assert health["dangling"] == 0
+    assert health["tombstones_by_reason"] == {"digest_mismatch": 1, "partial_terminal": 1}
+    assert health["acp"]["attempts"] == 4
+    assert health["acp"]["last_reconciliation"]["examined"] == 1
+
+
+def test_acp_reconciliation_tombstones_removed_source_and_fails_closed_on_bad_db(
+    tmp_path: Path,
+) -> None:
+    plane = make_acp_plane(tmp_path)
+    db = tmp_path / "projection.sqlite3"
+    reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    locator_id = ContextLinkStore(db).candidates()[0]["locator_id"]
+    with sqlite3.connect(plane / "comms.sqlite3") as connection:
+        connection.execute("DELETE FROM acp_conversation_events WHERE conversation_id = ?", (CONV_ID,))
+        connection.execute("DELETE FROM acp_conversations WHERE conversation_id = ?", (CONV_ID,))
+
+    removed = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    assert removed["counts"]["tombstoned"] == 1
+    assert removed["reasons"] == {"source_missing": 1}
+    assert ContextLinkStore(db).explain(locator_id)["state"] == "tombstoned"
+
+    missing = reconcile_terminal_acp_receipts(
+        acp_root=tmp_path / "missing-plane",
+        repo_root=tmp_path,
+        db_path=db,
+    )
+    assert missing == {"outcome": "skipped", "reason": "source_missing"}
+    malformed_root = tmp_path / "malformed-plane"
+    malformed_root.mkdir()
+    (malformed_root / "comms.sqlite3").write_bytes(b"not sqlite")
+    malformed = reconcile_terminal_acp_receipts(
+        acp_root=malformed_root,
+        repo_root=tmp_path,
+        db_path=db,
+    )
+    assert malformed == {"outcome": "skipped", "reason": "source_unreadable"}
+
+
+def test_acp_reconciliation_reports_zero_limit_without_work(tmp_path: Path) -> None:
+    plane = make_acp_plane(tmp_path)
+    result = reconcile_terminal_acp_receipts(
+        acp_root=plane,
+        repo_root=tmp_path,
+        db_path=tmp_path / "projection.sqlite3",
+        limit=0,
+    )
+    assert result["examined"] == 0
+    assert result["limit"] == 0
+    assert result["truncated"] is True
+    assert result["counts"]["promoted"] == 0
+
+
+def test_acp_reconciliation_rotates_bounded_windows_until_all_ids_converge(
+    tmp_path: Path,
+) -> None:
+    plane = make_acp_plane(tmp_path)
+    with sqlite3.connect(plane / "comms.sqlite3") as connection:
+        for suffix in ("2", "3"):
+            conversation_id = "conversation_" + suffix * 32
+            connection.execute(
+                "INSERT INTO acp_conversations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    conversation_id,
+                    "task-digest",
+                    "correlation-digest",
+                    f"idem-{suffix}",
+                    1,
+                    json.dumps(["claude", "kimi"]),
+                    "2026-08-01T10:00:00Z",
+                    "2026-08-01T11:00:00Z",
+                    10_000,
+                    1_024,
+                ),
+            )
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                1,
+                "CALL_TERMINAL",
+                sender="claude",
+                round_no=1,
+                outcome="ok",
+                created_at="2026-08-01T10:00:01Z",
+            )
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                2,
+                "CALL_TERMINAL",
+                sender="kimi",
+                round_no=1,
+                outcome="ok",
+                created_at="2026-08-01T10:00:02Z",
+            )
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                3,
+                "SYNTHESIS_TERMINAL",
+                outcome="ok",
+                created_at="2026-08-01T10:00:03Z",
+            )
+            _insert_acp_event(
+                connection,
+                conversation_id,
+                4,
+                "STATE",
+                state="COMPLETE",
+                duration_ms=25,
+                token_count=150,
+                created_at="2026-08-01T10:00:04Z",
+            )
+    db = tmp_path / "projection.sqlite3"
+    results = [
+        reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db, limit=1)
+        for _ in range(5)
+    ]
+    assert all(result["examined"] == 1 and result["truncated"] is True for result in results)
+    assert len(ContextLinkStore(db).candidates()) == 3
+
+
+def test_acp_reconciliation_pages_beyond_max_without_starvation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plane = tmp_path / "large-plane"
+    plane.mkdir()
+    conversation_ids = [f"conversation_{index:032x}" for index in range(501)]
+    with sqlite3.connect(plane / "comms.sqlite3") as connection:
+        connection.execute(
+            "CREATE TABLE acp_conversation_events("
+            "conversation_id TEXT, sequence INTEGER, state TEXT, created_at TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO acp_conversation_events VALUES (?, 1, 'COMPLETE', ?)",
+            [(conversation_id, "2026-08-01T10:00:04Z") for conversation_id in conversation_ids],
+        )
+
+    def resolve(conversation_id: str, *, acp_root: Path):
+        del acp_root
+        digest = "sha256:" + hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()
+        link = ContextLink(
+            kind=LinkKind.ACP_CONVERSATION,
+            canonical_namespace="acp:conversations",
+            canonical_id=conversation_id,
+            canonical_digest=digest,
+            facets={
+                "source_kind": "acp_conversation",
+                "state": "COMPLETE",
+                "event_ts": "2026-08-01T10:00:04Z",
+            },
+        )
+        verification = VerificationEvidence(
+            verifier="acp-receipt",
+            canonical_digest=digest,
+            status=VerificationStatus.VERIFIED,
+            evidence_locator=f"acp:conversation/{conversation_id}",
+            checked_at=isoformat_z(utc_now()),
+        )
+        return SimpleNamespace(link=link, verification=verification)
+
+    monkeypatch.setattr(reconcile_module, "resolve_acp_conversation", resolve)
+    db = tmp_path / "projection.sqlite3"
+    first = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+    second = reconcile_terminal_acp_receipts(acp_root=plane, repo_root=tmp_path, db_path=db)
+
+    assert first["examined"] == 500 and first["truncated"] is True
+    assert second["examined"] == 500 and second["truncated"] is True
+    assert first["lag_seconds"] is None and second["lag_seconds"] is None
+    with sqlite3.connect(db) as connection:
+        promoted_count = connection.execute(
+            "SELECT COUNT(*) FROM context_links WHERE state = 'promoted'"
+        ).fetchone()[0]
+    assert promoted_count == 501
+
+
+def test_live_projection_refusal_is_observed_as_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plane = make_acp_plane(tmp_path)
+    db = tmp_path / "projection.sqlite3"
+    original = ContextLinkStore.admit
+
+    def refuse(self, link, verification, *, actor="unknown", now=None):
+        del self, verification, actor, now
+        return AdmitResult(link.locator_id, AdmitOutcome.REFUSED, "verification_stale", "tombstoned")
+
+    monkeypatch.setattr(ContextLinkStore, "admit", refuse)
+    result = project_terminal_acp_receipt(
+        conversation_id=CONV_ID,
+        acp_root=plane,
+        repo_root=tmp_path,
+        db_path=db,
+    )
+    monkeypatch.setattr(ContextLinkStore, "admit", original)
+    assert result["outcome"] == "refused"
+    health = ContextLinkStore(db).status()["projection_health"]["acp"]
+    assert health["attempts"] == 1
+    assert health["failures"] == 1
+    assert health["last_failure_reason"] == "verification_stale"
 
 
 # ── provider neutrality ──────────────────────────────────────────────────────

--- a/tests/test_fleet_dashboard_contract.py
+++ b/tests/test_fleet_dashboard_contract.py
@@ -53,6 +53,29 @@ def test_fleet_page_is_a_read_only_consolidated_observer() -> None:
     assert "['conversation', 'filter-conversation']" in html
 
 
+def test_fleet_page_exposes_body_free_context_and_safe_acp_navigation() -> None:
+    html = (DASHBOARDS / "fleet.html").read_text(encoding="utf-8")
+
+    assert "Context projection" in html
+    assert "Context used" in html
+    assert "Related verified discussions, commits, and checkpoints" in html
+    assert "/api/ops/entire-context/status" in html
+    assert "/api/ops/entire-context/search" in html
+    assert "projection_health" in html
+    assert "uses_by_consumer" not in html  # Browser consumes the public `use.by_consumer` view.
+    assert "allowlistedSafeUrl" in html
+    assert "parsed.origin !== location.origin" in html
+    assert "parsed.pathname !== '/acp.html'" in html
+    assert "Open authoritative ACP conversation" in html
+    assert "navigation unavailable (no allowlisted local route)" in html
+    assert "source_missing" in html
+    assert "projection_request_failed" in html
+    assert "No prompt or transcript body is queried by this panel" in html
+    assert "initiating_orchestrator_authoritative === true" in html
+    assert "method: 'POST'" not in html
+    assert 'method: "POST"' not in html
+
+
 def test_fleet_routes_are_registered_get_only_and_contracted() -> None:
     observer_app = FastAPI()
     observer_app.include_router(fleet_router, prefix="/api/fleet")


### PR DESCRIPTION
## Summary

- reconcile terminal ACP receipts into the body-free Entire projection through an idempotent, fail-open live callback and bounded repair path
- expose sanitized projection health and verified context-use evidence in the Monitor API and Fleet Observer UI
- make ACP root discovery canonical across the primary checkout and linked worktrees
- document the approved ACP × Entire authority boundary, host/harness onboarding, and deferred capabilities

## Why

ACP owns live discussions and their terminal receipts, while Entire is an optional non-authoritative historical discovery layer. The previous integration required manual ACP root configuration and lacked bounded reconciliation, projection health, and a user-visible correlation surface. This change composes the systems only through verified body-free locators; Git and GitHub remain change authority and the sealed Fleet formal-review path remains untouched.

## Validation

- `253 passed` across Entire projection/recall/live, native onboarding, ACP discussion, Monitor API, and Fleet Observer tests
- Ruff, Python byte-compilation, extracted dashboard JavaScript syntax, Markdown lint, `git diff --check`, agent-trailer lint, and OPSEC lint pass
- fresh two-round ACP discussion: `conversation_ef2133b017794e15ad8eb8ec229a90a8` (Codex + Grok, 2/2 successful, 52.282 s)
- exact idempotent replay: duplicate suppressed in 0.27 s; canonical `acp-verify --require-replay` passed every check
- Entire discovery: `clink_71f4ab646e9edd67e008204b32e0f3240467e18fd3cb5f4744c59f6ae992c38a` resolved in 0.28 s from both the implementation worktree and a separate detached linked worktree without a manual root
- in-app browser proof: desktop and 390 px layouts rendered the fresh verified context card, same-origin ACP link, zero horizontal overflow, and zero console errors
- legitimate planning-use receipt: `ecuse_2160c131473d2e535b0a4dc0ca22ce08143563cd9ab0742127fc8c8e739f8f4e`

Closes #6183
Stream epic: #4707
