### PR TITLE
feat(foundry): prepare UA open-weight evaluation release

### DIFF
--- a/data/projects/open_model_data/integrations/upstream-locks.json
+++ b/data/projects/open_model_data/integrations/upstream-locks.json
@@ -2,13 +2,13 @@
   "lang_uk_leaderboard": {
     "commit": "bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f",
     "repository": "https://github.com/lang-uk/ukrainian-llm-leaderboard",
-    "result_dataset_revision": "3da506fe31f69d7e88754a665d1de01d774913a2",
-    "target_contract": "results_<created_at>.json plus Foundry evidence sidecar"
+    "result_dataset_revision": "3da506d82b7f960275ed90716da8a8c5c6299f42",
+    "target_contract": "aggregated/results_<created_at>.json plus adjacent Foundry evidence sidecar"
   },
   "lapa": {
     "commit": "7e695c2bb9deaa214421a657ae23c85968947305",
     "license": "MIT",
-    "repository": "https://github.com/UNLP-AI/lapa",
+    "repository": "https://github.com/lapa-llm/lapa-llm",
     "target_path": "training/lapa-12b-pt-template.yml"
   },
   "schema_version": "foundry_upstream_integration_locks.v1"

--- a/data/projects/ua_open_weight_eval/v0.1.0/release_receipt.json
+++ b/data/projects/ua_open_weight_eval/v0.1.0/release_receipt.json
@@ -6,7 +6,7 @@
     "foundry_firewall": "a1c2f3693a8672f7ab1d8e745fafd75c5c45eab2ba2bcd5e17d9ac4739635aee",
     "local_run_config_example": "0e3fc35c1e8631b6aba1258141ac7d3d33726493481ca783deec15f474a5fa55",
     "saved_response_schema": "652e2ce89d170d5011a4fcfdf4fdd02fe7e1728d19c6b8a7479e38fc58b4cdb2",
-    "suite_cli": "401cbe4bd416d38b0ce9aad6391b96beca30e1fce3c4c3f6275afd3c9d40a048"
+    "suite_cli": "476cd3ab1872acf0ab9c96ed995f8b54b78fbef54a60f0498a3244b9a1f5095c"
   },
   "counts": {
     "by_category": {

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -9,7 +9,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Last refreshed** | 2026-08-02 (corpus verdict CONTINUE; #6171 is the sole required Foundry lane; the project stops before model download, rental, or training) |
+| **Last refreshed** | 2026-08-02 (Foundry implementation complete; release and external validation tracked separately in #6273; training remains prohibited) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Help people and AI produce measurably better, authentically Ukrainian language through decolonized learning products and reusable, evidence-backed open-model infrastructure. Quality non-negotiable. |
@@ -65,7 +65,7 @@ is the single source of truth for membership (auditor:
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
-| open-model-data | #6164 (successor to closed #6056) | Ukrainian Data Foundry Phase 2–4: apply the [CONTINUE corpus-usability decision](research/UKRAINIAN_CORPUS_TRAINING_USABILITY_DECISION.md), separate downstream model-learning eligibility from raw-source/publication permissions, detect contextual Ukrainian language-contact failures, produce evidence-backed silver with optional human-gold upgrades, export model-ready views, and ship a corpus-portable clean-Ukrainian tool, consumer training recipe, and reproducible no-training release candidate; project-funded or project-operated model training is out of scope |
+| open-model-data | closed #6164 (successor to closed #6056); active child #6273 | The Foundry implementation, portable tool, model-ready exports, open-weight evaluation suite, and adoption adapters are shipped. #6273 owns rights-complete publication, one reproducible real-model evaluation, concrete upstream submissions, and an external run receipt. Training remains out of scope. |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -97,7 +97,7 @@ epic-board state and bind only once that stream's driver (State: the operator) c
 | --- | --- | --- | --- |
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
 | eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
-| open-model-data | ACTIVE | Execute #6171: package the production detector/evidence/views as a corpus-portable clean-Ukrainian tool, ship the model-neutral consumer training recipe and validated cost formula, and reproduce the no-training release candidate in a clean environment. Closed #6170 is historical and not planned; it is not a next step. | A stranger can run the admitted-source, contextual interference/calque/grammar/morphology, protected-variation, silver-evidence, disjoint-view, tokenizer, recipe, cost, and evaluation-firewall path on a bounded consumer-owned corpus; committed receipts prove the clean run and limitations. The project stops before an optimizer, accelerator rental, model-weight download, adapter, or model upload. Publication remains operator-gated. |
+| open-model-data | ACTIVE | Execute #6273: publish the rights-complete UA Open-Weight Eval v0.1.0 package, run one approved or already-local open-weight model across the frozen 4,000 cases, prepare concrete Lapa/lang-uk submissions, and obtain independent external execution evidence. #6171 and #6164 remain completed implementation history. | The GitHub release and exact hashes are public; the Hugging Face package is published after approval or has an exact approval blocker; fourteen-track real-model results are reproducible; and an independently produced run receipt exists before adoption is claimed. No training, global quality score, or evaluation-to-learning leakage occurs. |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |

--- a/docs/projects/ua-open-weight-eval/CONTAMINATION_POLICY.md
+++ b/docs/projects/ua-open-weight-eval/CONTAMINATION_POLICY.md
@@ -1,0 +1,33 @@
+# Contamination policy
+
+UA Open-Weight Evaluation 0.1.0 is evaluation-only. Every frozen case has
+`foundry_learning_eligible: false`; no case, accepted answer, edit, duplicate,
+near-duplicate, transformation, or derived rule may enter a Foundry training,
+correction, preference, quality-filter, tokenizer-training, or product-learning
+view.
+
+## Mechanical boundary
+
+- `prepare` emits only source text, item identifiers, and hashes. It emits no
+  expected action, accepted text, edit, or evidence grade.
+- `score` joins gold only after a complete saved-output file exists.
+- The Foundry exclusion registry loads all 4,000 cases and rejects exact and
+  near-duplicate learning candidates.
+- The UA Eval 0.1.1 anchor remains byte-frozen. The parked v0.2 pending-review
+  packet is not part of this release.
+- Context wrapping expands controlled situations; it does not add independent
+  linguistic judgments.
+
+## Model disclosures
+
+A published run must name the suite release hash, model and tokenizer revision,
+model-content hash, decoding settings, request and response hashes, and local
+run receipt. Authors should disclose known or suspected benchmark exposure.
+Public availability means contamination cannot be ruled out for pretrained
+models.
+
+## Reporting boundary
+
+Report all fourteen tracks separately. Do not collapse the result into a global
+Ukrainian-quality score. Read correction results together with correct-control,
+protected-text overcorrection, and unresolved-case abstention behavior.

--- a/docs/projects/ua-open-weight-eval/DATA_CARD.md
+++ b/docs/projects/ua-open-weight-eval/DATA_CARD.md
@@ -11,7 +11,9 @@ single measure of Ukrainian quality.
 
 The immutable UA Eval 0.1.1 held-out manifest is the human-gold anchor. Its
 error sources and accepted corrections yield 1,000 error cases and 1,000
-correct controls through deterministic, hash-recorded context wrapping.
+correct controls through deterministic, hash-recorded context wrapping. This
+means the suite contains 1,000 independent human-gold anchor judgments, not
+4,000 independent human judgments.
 
 The protected and unresolved halves derive from project regression evidence
 and project-authored controlled seeds. Each row says `source_backed_silver`,
@@ -21,6 +23,19 @@ independent linguistic examples.
 
 The parked v0.2 review packet remains frozen evidence only. Its cases are not
 silently promoted to gold.
+
+## Licensing and attribution
+
+Rows whose identifiers start with `uaw-011-` are UA-GEC derivatives under CC
+BY 4.0. Rows whose identifiers start with `uaw-silver-` are project-authored
+under MIT. The exact transformations, citation, pinned revisions, exclusions,
+and file-level dispositions are recorded in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and in the generated
+`PUBLICATION_MANIFEST.json`.
+
+No VESUM dictionary byte or derived evidence artifact, private corpus byte,
+provider raw output, model weight, or pending v0.2 review item is included in
+the publication package.
 
 ## Risks and limitations
 
@@ -32,6 +47,8 @@ silently promoted to gold.
   accepted set.
 - Correct abstention protects ambiguity but does not resolve it.
 - A model may have encountered public benchmark text during pretraining.
+- The source-backed and controlled silver cases are evidence-graded stress
+  tests, not qualified-human acceptance or a replacement for new human gold.
 
 Publish the full per-track report, release hash, model and tokenizer revision,
 decoding settings, and local-run receipt. Do not report a derived global score.
@@ -43,3 +60,6 @@ registry loads the complete case file by default and applies exact and
 near-duplicate filtering before emitting learning views. Evaluation requests
 contain sources only; gold fields are joined only by the deterministic scorer
 after model output has been saved.
+
+The full mechanical boundary and run-disclosure requirements are in
+[CONTAMINATION_POLICY.md](CONTAMINATION_POLICY.md).

--- a/docs/projects/ua-open-weight-eval/HUGGING_FACE_README.md
+++ b/docs/projects/ua-open-weight-eval/HUGGING_FACE_README.md
@@ -1,0 +1,131 @@
+---
+annotations_creators:
+  - expert-generated
+  - other
+configs:
+  - config_name: default
+    data_files:
+      - path: cases.jsonl
+        split: test
+language:
+  - uk
+language_creators:
+  - found
+  - expert-generated
+license:
+  - cc-by-4.0
+  - mit
+multilinguality:
+  - monolingual
+pretty_name: Ukrainian Open-Weight Evaluation 0.1.0
+size_categories:
+  - 1K<n<10K
+source_datasets:
+  - extended
+tags:
+  - evaluation
+  - open-weight
+  - text
+  - ukrainian
+task_categories:
+  - text-generation
+  - text-classification
+---
+
+# Ukrainian Open-Weight Evaluation 0.1.0
+
+A frozen, 4,000-case Ukrainian correction-and-preservation evaluation for local
+open-weight models. It reports fourteen tracks separately, uses deterministic
+saved-output scoring, and has no global Ukrainian-quality score or model judge.
+
+The dataset has mixed row-level licensing: 2,000 UA-GEC-derived rows are CC BY
+4.0, and 2,000 project-authored silver or unresolved rows are MIT. Read
+`THIRD_PARTY_NOTICES.md` and the generated `PUBLICATION_MANIFEST.json` before
+reuse.
+
+## What the 4,000 cases mean
+
+- 1,000 error cases derive from the immutable UA Eval 0.1.1 human-gold anchor.
+- 1,000 correct controls derive from accepted human-gold targets.
+- 1,000 protected cases and 1,000 unresolved cases derive from 28
+  project-authored source-backed or controlled silver seeds.
+- Deterministic context wrapping creates controlled cases, not 4,000
+  independent linguistic judgments. The release claims 1,000 independent
+  human-gold anchor judgments.
+
+Evidence grades are embedded per row: `human_gold`,
+`human_gold_derived_control`, `source_backed_silver`, `controlled_silver`, or
+`unresolved`.
+
+## English quickstart
+
+Load the evaluation split without treating it as training data:
+
+```python
+from datasets import load_dataset
+
+cases = load_dataset("OWNER/ua-open-weight-eval", split="test")
+```
+
+For the verified offline runner and scorer, clone the exact GitHub tag:
+
+```bash
+git clone --branch ua-open-weight-eval-v0.1.0 \
+  https://github.com/learn-ukrainian/learn-ukrainian.github.io.git
+cd learn-ukrainian.github.io
+pyenv local 3.12.8
+pyenv exec python -m venv .venv
+.venv/bin/python -m pip install -e .
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli verify
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli prepare \
+  --output batch_state/ua-open-weight-eval/requests.jsonl
+```
+
+Run the source-only requests with a model already present on your machine, save
+one object per case using `saved_response.schema.json`, then score. Request IDs
+are opaque and do not expose internal category labels:
+
+```bash
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli score \
+  --responses batch_state/ua-open-weight-eval/responses.jsonl \
+  --output batch_state/ua-open-weight-eval/report.json
+```
+
+Use `local_run_config.example.json`, `validate-run-config`, and `run-local` to
+create an offline local-run receipt. The command refuses network providers and
+does not download weights. The standalone `run_mlx_model.py` is a resumable MLX
+runner for a model that is already present locally; install and select the
+open-weight runtime separately under its own terms.
+
+## Коротка інструкція українською
+
+Це набір лише для оцінювання. Не додавайте приклади, відповіді, виправлення чи
+похідні правила до навчальних даних.
+
+```bash
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli verify
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli prepare \
+  --output batch_state/ua-open-weight-eval/requests.jsonl
+```
+
+Запустіть пакет запитів уже наявною локальною моделлю, збережіть відповіді за
+схемою `saved_response.schema.json`, а потім виконайте команду `score`.
+Публікуйте результати окремо за всіма чотирнадцятьма напрямами разом із хешем
+випуску, точною версією моделі й токенізатора, параметрами декодування та
+локальною квитанцією запуску.
+
+## Tracks and limitations
+
+The tracks are grammar, morphology, calques, Russian interference, quoted
+Russian, surzhyk, historical or archaic language, regional or dialectal
+language, register, OCR, proper names, ambiguity, overcorrection, and protected
+text.
+
+Exact-match scoring misses valid alternatives outside the accepted set.
+Silver cases reflect project-authored assumptions and limited lexical
+diversity. Public benchmark exposure may contaminate pretrained models. A good
+result on these tracks is not a claim of broad Ukrainian fluency.
+
+See `DATA_CARD.md`, `CONTAMINATION_POLICY.md`, `THIRD_PARTY_NOTICES.md`,
+`PUBLICATION_MANIFEST.json`, and `SHA256SUMS` for the complete evidence and
+rights boundary.

--- a/docs/projects/ua-open-weight-eval/README.md
+++ b/docs/projects/ua-open-weight-eval/README.md
@@ -5,6 +5,15 @@ This is a broad, deterministic companion to the immutable human-gold
 that release, and it does not resume the parked human-review-dependent v0.2
 proposal. It needs no paid annotator, closed API, or model judge.
 
+## Release and adoption status
+
+The repository implementation shipped in PR #6268. The public package uses the
+non-colliding tag `ua-open-weight-eval-v0.1.0`; its generated
+`PUBLICATION_MANIFEST.json` and `SHA256SUMS` define the canonical released
+bytes. GitHub and Hugging Face publication, real-model results, and external
+adoption are separate facts tracked in issue #6273. An adapter or local fixture
+does not demonstrate adoption.
+
 ## What ships
 
 The release contains 4,000 evaluation-only cases, balanced equally across
@@ -17,12 +26,18 @@ one or more named tracks:
   dialectal language;
 - register, OCR, proper names, ambiguity, overcorrection, and protected text.
 
-The 1,000 error cases retain UA Eval 0.1.1 human gold. Correct controls are
-deterministic derivatives of accepted human-gold targets. Protected and
-unresolved tracks use visibly labelled source-backed or controlled silver
-seeds. Context wrappers increase coverage, not lexical diversity; the receipt
-reports evidence grades so consumers cannot mistake those cases for new human
-annotations.
+The 1,000 error cases retain UA Eval 0.1.1 human gold. The 1,000 correct
+controls are deterministic derivatives of accepted human-gold targets.
+Protected and unresolved tracks use visibly labelled source-backed or
+controlled silver seeds. Context wrappers increase controlled coverage, not
+lexical diversity: the 4,000 cases are not 4,000 independent linguistic
+judgments. The release claims 1,000 independent human-gold anchors and reports
+every other evidence grade explicitly.
+
+The byte-level licensing and attribution boundary is in
+[Third-party notices](THIRD_PARTY_NOTICES.md). The separate
+[contamination policy](CONTAMINATION_POLICY.md) forbids evaluation cases and
+derivatives from every Foundry learning view.
 
 ## Ten-minute, zero-API trial
 
@@ -35,7 +50,8 @@ The commands below only build files. They never download or invoke a model.
 ```
 
 Run that source-only request packet with a model already present on your own
-machine. Save one JSON object per case using
+machine. Request identifiers are opaque sequence IDs; internal case IDs and
+their category labels are not exposed. Save one JSON object per case using
 `saved_response.schema.json`. Then score it without a judge:
 
 ```bash
@@ -59,6 +75,27 @@ score is deliberately `null`; comparing models requires examining the track
 and category profile. In particular, correction accuracy must be read beside
 correct-control and protected-text overcorrection rates.
 
+## Build the publication package
+
+From the exact reviewed release head, stage the GitHub/Hugging Face payload and
+deterministic archive:
+
+```bash
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli \
+  package-publication \
+  --source-revision FULL_40_CHARACTER_GIT_SHA \
+  --output batch_state/ua-open-weight-eval-publication \
+  --archive batch_state/ua-open-weight-eval-v0.1.0.zip
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.suite_cli \
+  verify-publication-package \
+  --package batch_state/ua-open-weight-eval-publication
+```
+
+The command rejects missing or extra files and includes no model weights,
+provider output, private corpus, VESUM data, literary/textbook corpus content,
+or pending v0.2 material. The staged directory is the complete Hugging Face
+dataset-repository payload; upload remains an explicit operator approval gate.
+
 ## Українською
 
 Це широке детерміноване доповнення до незмінного набору з людською золотою
@@ -70,9 +107,13 @@ correct-control and protected-text overcorrection rates.
 правильних контрольних, захищених і нерозв'язаних. Для кожного прикладу
 збережено джерело, рівень доказовості та хеш. Результати подаються окремо за
 всіма чотирнадцятьма напрямами; єдиного оманливого показника «якості
-української» немає.
+української» немає. Ці 4 000 прикладів не є 4 000 незалежних мовних суджень:
+людською золотою основою є 1 000 помилкових прикладів, а решта містить
+детерміновані контрольні похідні та явно позначені срібні або нерозв'язані
+дані.
 
-Команда `prepare` створює пакет без правильних відповідей. Модель працює з ним
+Команда `prepare` створює пакет без правильних відповідей і використовує
+непрозорі послідовні ідентифікатори без міток категорій. Модель працює з ним
 локально, а команда `score` детерміновано оцінює збережені відповіді. Набір і
 його похідні заборонено додавати до навчальних представлень Foundry.
 

--- a/docs/projects/ua-open-weight-eval/THIRD_PARTY_NOTICES.md
+++ b/docs/projects/ua-open-weight-eval/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,86 @@
+# Third-party notices and publication disposition
+
+This notice covers the public payload for UA Open-Weight Evaluation 0.1.0.
+It records the project's publication classification; it is not legal advice.
+`PUBLICATION_MANIFEST.json` and `SHA256SUMS` bind the notice to the exact
+published bytes.
+
+## File-level disposition
+
+| Published file | Disposition |
+| --- | --- |
+| `cases.jsonl` | Mixed, row-scoped data terms described below |
+| `controlled_seeds.jsonl` | Project-authored data under MIT |
+| JSON configuration, schema, and receipts | Project-authored metadata under MIT |
+| README, data card, contamination policy, and this notice | Project-authored documentation under MIT |
+| `LICENSE-MIT.txt` | Verbatim repository MIT license |
+| `PUBLICATION_MANIFEST.json` and `SHA256SUMS` | Generated project metadata under MIT |
+
+No model weights, adapters, provider raw output, failed-attempt logs, private
+corpus bytes, Google Drive content, non-redistributable literary or textbook
+content, VESUM dictionary data, VESUM-derived evidence artifacts, or UA Eval
+v0.2 pending-review material is included.
+
+## UA-GEC 2.0 — rows with prefix `uaw-011-`
+
+The 1,000 error rows and 1,000 correct-control rows derive from:
+
+- **Work:** UA-GEC, Ukrainian Grammatical Error Corpus, version 2.0
+- **Creators/citation:** Syvokon, Nahorna, Kuchmiichuk, and Osidach,
+  *UA-GEC*, UNLP 2023
+- **Source:** [grammarly/ua-gec](https://github.com/grammarly/ua-gec)
+- **Pinned revision:**
+  [`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`](https://github.com/grammarly/ua-gec/tree/4757f72f192c4a41e4c8fb1d9690a948f87cf6d6)
+- **License:** [Creative Commons Attribution 4.0 International
+  (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Pinned license evidence:**
+  [upstream `LICENSE`](https://github.com/grammarly/ua-gec/blob/4757f72f192c4a41e4c8fb1d9690a948f87cf6d6/LICENSE)
+
+Changes made by this project:
+
+- selected the frozen UA Eval 0.1.1 held-out anchor and retained its accepted
+  correction references;
+- created deterministic context-wrapped error rows;
+- created deterministic correct controls from accepted targets;
+- added case identifiers, evidence grades, track labels, hashes, expected
+  actions, and evaluation-only handling metadata; and
+- repeated anchor judgments under controlled wrappers. These transformations
+  create 2,000 cases, not 2,000 independent human judgments.
+
+No endorsement by the UA-GEC creators or Grammarly is implied. Reusers must
+retain this attribution, link the CC BY 4.0 license, and identify their own
+changes.
+
+## Project-authored silver — rows with prefix `uaw-silver-`
+
+The 1,000 protected and 1,000 unresolved rows are deterministic wrappers around
+28 project-authored controlled or source-backed test seeds. They are published
+under the repository MIT license. Their evidence grades are silver or
+unresolved; none is human gold or native-speaker acceptance.
+
+Some seed locators name project tests that used VESUM, SUM, heritage sources,
+Russian morphology, or other evidence to exercise routing behavior. The public
+payload includes the project-authored test text and locator string only. It
+does not copy those dictionaries, source entries, lookup results, or derived
+evidence artifacts.
+
+## dict_uk / VESUM v6.8.0 — verification source excluded from payload
+
+The Foundry tests referenced by some silver rows used:
+
+- **Work:** `dict_uk` / VESUM morphological dictionary, release `v6.8.0`
+- **Source:** [brown-uk/dict_uk](https://github.com/brown-uk/dict_uk)
+- **Pinned revision:**
+  [`bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824`](https://github.com/brown-uk/dict_uk/tree/bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824)
+- **License:** [Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+  International](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+
+No VESUM dictionary byte or VESUM-derived evidence artifact is part of this
+publication payload. Consumers who independently use VESUM must comply with
+its license.
+
+## Repository software
+
+The extractor, scorer, validators, and offline runner in the tagged source
+repository are covered by the repository's [MIT license](../../../LICENSE).
+That license does not replace the CC BY 4.0 terms for UA-GEC-derived rows.

--- a/docs/projects/ukrainian-data-foundry-adoption/README.md
+++ b/docs/projects/ukrainian-data-foundry-adoption/README.md
@@ -42,7 +42,9 @@ command documented in the
 
 The pinned integration target is Lapa commit
 `7e695c2bb9deaa214421a657ae23c85968947305`, file
-`training/lapa-12b-pt-template.yml`. Generate the handoff:
+`training/lapa-12b-pt-template.yml`, in
+[`lapa-llm/lapa-llm`](https://github.com/lapa-llm/lapa-llm). Generate the
+handoff:
 
 ```bash
 .venv/bin/python -m scripts.projects.open_model_data.adoption_cli lapa \
@@ -62,9 +64,12 @@ reviewable provenance instead of receiving an empty outreach request.
 
 The pinned target is the Ukrainian LLM leaderboard commit
 `bd3d8431e97b3ff86e4f25381ac6b5ecccadad5f`, with result-dataset revision
-`3da506fe31f69d7e88754a665d1de01d774913a2`. Start with a saved lm-eval-shaped
-file containing `config_general.model_name` and numeric metrics under
-`results`, plus a complete Foundry broad-evaluation report:
+`3da506d82b7f960275ed90716da8a8c5c6299f42`. Start with an authentic saved
+lm-eval result containing top-level `model_name`, a per-task `n-shot` mapping,
+and task dictionaries under `results`. Each task may carry its string `alias`
+but must include numeric metrics. Use the upstream filename and destination
+`aggregated/results_<created_at>.json`, plus a complete Foundry broad-evaluation
+report:
 
 ```bash
 .venv/bin/python -m scripts.projects.open_model_data.adoption_cli lang-uk \
@@ -74,7 +79,8 @@ file containing `config_general.model_name` and numeric metrics under
   --output batch_state/lang-uk-foundry-handoff
 ```
 
-The standard result file is copied byte-for-byte. Its adjacent Foundry sidecar
+The standard result file is copied byte-for-byte. Its adjacent, non-consumed
+Foundry sidecar
 binds the model name, result hash, Foundry run, broad-suite release and case
 hashes, all fourteen tracks, and the pinned upstream revisions. Packaging does
 not submit anything; maintainers receive a complete artifact pair they can

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -12,13 +12,17 @@
 > labour from the critical path. On 2026-08-02, the operator directed the
 > Foundry to ship the clean-Ukrainian preparation tool and consumer training
 > recipe without project-funded or project-operated model training. Training
-> belongs to downstream teams that choose to use the released artifacts.
+> belongs to downstream teams that choose to use the released artifacts. The
+> operator separately authorized release and external-validation work under
+> #6273 on 2026-08-02, with just-in-time approval gates for account use,
+> uploads, external submissions, model downloads, and compute or storage cost.
 > **Recorded:** 2026-07-30; Foundry direction and existing-asset baseline
 > refreshed 2026-08-02
 > **Applies to:** Ukrainian model evaluation, dataset work, training-data
 > preparation, and UNLP ecosystem monitoring
-> **Does not authorize:** model training, dataset publication, or mixing
-> evaluation gold into training data
+> **Does not authorize:** model training or mixing evaluation gold into
+> training data; Hugging Face publication and external submissions retain the
+> explicit approval gates in #6273
 
 ## North star
 
@@ -42,11 +46,12 @@ Curated data, provenance, evaluation, and tooling transfer to every new model
 generation.
 
 This direction prioritizes transferable data, grammar, lexical naturalness,
-and evidence over owning or producing model weights. Project completion stops
-before model download, accelerator rental, optimizer execution, adapter
-production, or weight upload. A downstream team may independently use the
-Foundry recipe and report results, but that is consumer validation rather than
-a Foundry execution lane. The accepted boundary between public evaluation gold,
+and evidence over owning or producing model weights. Foundry implementation
+completion stops before model download, accelerator rental, optimizer
+execution, adapter production, or weight upload. The separate release-and-
+validation issue #6273 may run evaluation only with an already-local model, or
+after explicit approval for a model download and bounded compute. It does not
+authorize training. The accepted boundary between public evaluation gold,
 private product data, and training data remains intact.
 
 ## Solo-operator execution model
@@ -85,16 +90,21 @@ the Foundry release.
 
 ## GitHub execution homes
 
-- [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
-  owns Foundry Phase 2–4: real corpus admission, production contextual
+- Closed [#6164](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6164)
+  owns the completed Foundry Phase 2–4 implementation: real corpus admission, production contextual
   language-contact detection, evidence-backed silver with an optional
   qualified-human upgrade, real model-ready exports, a model-neutral clean-
   Ukrainian tool, reproducible consumer training recipe, and no-training
-  release candidate. Project-operated open-weight treatment is out of scope.
+  release candidate. It closed after PRs #6266, #6268, and #6271.
   Closed
   [#6056](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6056)
   owns the completed interfaces, profiler, exporters, recipes, and synthetic
   reference build on which this production program depends.
+- [#6273](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6273)
+  is the active post-completion release and external-validation child of #6164.
+  It owns rights-complete publication, a real fourteen-track open-weight result,
+  concrete Lapa and lang-uk submissions after approval, and the external run
+  receipt required before an adoption claim.
 - [#6057](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6057)
   is closed as not planned under the solo-operator model while preserving the
   completed v0.2 error analysis and frozen design. Its reviewer-intensive
@@ -298,42 +308,39 @@ later decisions. The project verdict is **CONTINUE**.
   reconstructing original-source evidence; it is not provenance authority or a
   candidate training collection.
 
-### Completed foundations and sole remaining lane
+### Completed Foundry implementation and release-validation lane
 
 The production corpus audit, admission baseline, full-corpus detector,
 evidence-grade silver/protection factory, separate model views, tokenizer
-diagnostics, and reference build are complete under #6166–#6169. PR #6248
-supplies the later corpus-usability decision that defines #6171's remaining
-capability-separation work. Together they establish that the project has the
-source material and component interfaces needed to finish the Foundry.
+diagnostics, and reference build completed under #6166–#6169. PR #6248 supplied
+the corpus-usability decision. #6171 and PR #6266 then completed capability-
+specific admission, restored locators, the consumer JSONL and public CLI,
+contextual non-erasure routes, evidence surfaces, disjoint views, receipts, and
+clean reproduction. PR #6268 added the frozen 4,000-case, fourteen-track open-
+weight evaluation; PR #6271 added the Lapa and lang-uk adapters.
 
-Issue #6171 is the sole remaining Foundry execution lane. It must, in order:
+Issue #6273 is the separate release-and-validation lane. It must:
 
-1. separate downstream local-learning eligibility from raw-source
-   redistribution, dataset publication, and model publication in the executable
-   admission contract, while restoring retained source locators;
-2. expose one bounded consumer-owned JSONL input and one documented public CLI
-   over admission, contextual language contact, evidence, model views,
-   tokenizer diagnostics, cost calculation, and the evaluation firewall;
-3. preserve original text and the Russian-quotation, modern-interference,
-   phonetic-Russian, mixed, historical, regional, dialectal, protected, OCR,
-   other-language, and unresolved routes;
-4. expose the calque, grammar/government, morphology/OOV, VESUM, R2U, ULIF, and
-   heritage evidence surfaces without promoting any one source to an automatic
-   verdict;
-5. emit deterministic faithful-source, modern-learning, silver correction,
-   preference, filter, evaluation, tokenizer, recipe, and limitation receipts
-   with benchmark contamination denied; and
-6. reproduce the complete bounded path in a fresh environment with no model
-   download, accelerator, optimizer, hidden database, or project-private path.
+1. publish only rights-classified bytes under a non-colliding tag with exact
+   hashes, attribution, English/Ukrainian instructions, limitations, and the
+   contamination boundary;
+2. prepare the Hugging Face dataset package and request operator approval
+   immediately before account use or upload;
+3. evaluate one real open-weight model across all 4,000 frozen cases, using an
+   already-local artifact or explicit approval before download or cost;
+4. publish all fourteen track results with exact model/tokenizer revisions,
+   decoding settings, saved outputs, and a local-run receipt; and
+5. prepare exact Lapa and lang-uk patches, request approval before external
+   submission, and require an independently produced run receipt before saying
+   adoption is demonstrated.
 
-The project stops at that no-training release. Closed #6170 is retained only as
-historical preregistration evidence and is not a future Foundry task. Downstream
-teams with compute may select a model, run the frozen recipe on their own
-corpus, and return results if they choose; the Foundry neither funds nor
-operates that work. The reviewer-intensive v0.2 acquisition remains closed as
-not planned. Public evaluation gold remains mechanically isolated from every
-model-learning or derived-rule view.
+The 4,000 cases are not 4,000 independent human judgments. The suite contains
+1,000 UA Eval 0.1.1 human-gold error anchors, 1,000 deterministic controls
+derived from accepted targets, and 2,000 evidence-graded protected or unresolved
+silver cases. Closed #6170 remains historical preregistration only. The
+reviewer-intensive v0.2 acquisition remains closed as not planned. Public
+evaluation data remains mechanically isolated from every model-learning or
+derived-rule view.
 
 ### Completed Foundry v1 reference build
 
@@ -360,7 +367,7 @@ or a claim that the 677-item benchmark measures general Ukrainian fluency.
 
 ### Later validation and collaboration
 
-After a usable reference build exists, it may be validated with Lapa,
+The shipped reference build and evaluation may be validated with Lapa,
 `lang-uk`, UA-GEC, and other open-weight Ukrainian teams through:
 
 - data slices they can inspect and reproduce;
@@ -368,17 +375,20 @@ After a usable reference build exists, it may be validated with Lapa,
 - failure-focused evaluation with protected legitimate variation; and
 - evidence-backed annotation guidelines.
 
-External feedback may prioritize later evidence adapters, acquisition, or
-release work.
-It is not a prerequisite for building the architecture, full-corpus profiler,
-silver correction intake, separate exporters, recipes, or reference validation.
-Hramatka teacher feedback follows the same optional-evidence rule.
+External feedback may prioritize later evidence adapters or acquisition. It was
+not a prerequisite for the completed Foundry implementation. It is, however,
+required before #6273 can claim that external adoption has been demonstrated.
+An adapter, fixture, internal CI run, or unanswered upstream submission is not
+adoption evidence. Hramatka teacher feedback follows the same optional-evidence
+rule.
 
 ## Downstream validation policy
 
-The Foundry project does not run model baselines or training experiments. It
-ships frozen artifacts that let a downstream team run them without asking this
-project to operate or fund compute.
+The Foundry project does not run training experiments. Under #6273 it may run a
+bounded evaluation-only baseline with an already-local open-weight model, or
+after explicit approval for the exact download, storage, runtime, and maximum
+cost. It still ships frozen artifacts that downstream teams can reproduce
+without a closed-model judge.
 
 A downstream result is useful evidence only when it answers a named question,
 such as:

--- a/scripts/projects/open_model_data/adoption_cli.py
+++ b/scripts/projects/open_model_data/adoption_cli.py
@@ -148,7 +148,9 @@ def export_lapa(*, foundry_run: Path, output_dir: Path) -> dict[str, Any]:
         lineage: list[dict[str, str]] = []
         for row in rows:
             _require(row.get("schema_version") == "foundry_faithful_source_view_v1", "not a faithful Foundry view")
-            _require(row.get("character_mask_spans") == [], "masked or rewritten row cannot enter Lapa pretraining export")
+            _require(
+                row.get("character_mask_spans") == [], "masked or rewritten row cannot enter Lapa pretraining export"
+            )
             text = row.get("text")
             _require(isinstance(text, str) and text, "empty Lapa text row")
             _require(foundry_cli.sha256_text(text) == row.get("text_sha256"), "Foundry text hash mismatch")
@@ -183,18 +185,31 @@ def export_lapa(*, foundry_run: Path, output_dir: Path) -> dict[str, Any]:
 
 
 def _validate_lang_uk_results(results: Mapping[str, Any]) -> str:
-    general = results.get("config_general")
+    model_name = results.get("model_name")
+    shots = results.get("n-shot")
     metrics = results.get("results")
-    _require(isinstance(general, dict) and isinstance(general.get("model_name"), str), "missing lang-uk model_name")
+    _require(isinstance(model_name, str) and model_name, "missing lang-uk model_name")
+    _require(isinstance(shots, dict) and shots, "missing lang-uk n-shot mapping")
     _require(isinstance(metrics, dict) and metrics, "missing lang-uk results")
+    _require(set(shots) == set(metrics), "lang-uk n-shot task set drift")
+    _require(
+        all(isinstance(value, int) and not isinstance(value, bool) and value >= 0 for value in shots.values()),
+        "lang-uk n-shot values must be nonnegative integers",
+    )
     for task_name, task_metrics in metrics.items():
         _require(isinstance(task_name, str) and isinstance(task_metrics, dict), "invalid lang-uk task")
+        numeric_metrics = 0
         for metric_name, value in task_metrics.items():
+            if metric_name == "alias":
+                _require(isinstance(value, str) and value, "lang-uk alias must be a string")
+                continue
             if metric_name == "qg_meta":
                 _require(isinstance(value, dict), "qg_meta must be an object")
                 continue
             _require(isinstance(value, int | float) and not isinstance(value, bool), "lang-uk metric must be numeric")
-    return general["model_name"]
+            numeric_metrics += 1
+        _require(numeric_metrics > 0, f"lang-uk task has no numeric metrics: {task_name}")
+    return model_name
 
 
 def package_lang_uk(
@@ -214,9 +229,14 @@ def package_lang_uk(
     broad_report = _read_json(broad_report_path)
     _require(broad_report.get("schema_version") == suite_cli.REPORT_SCHEMA, "wrong broad evaluation report schema")
     scoring = broad_report.get("scoring")
-    _require(isinstance(scoring, dict) and scoring.get("global_quality_score") is None, "broad report has a global score")
+    _require(
+        isinstance(scoring, dict) and scoring.get("global_quality_score") is None, "broad report has a global score"
+    )
     _require(scoring.get("closed_model_judge_used") is False, "closed model judge report rejected")
-    _require(set(broad_report.get("tracks", {})) == set(suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"]), "broad report track set drift")
+    _require(
+        set(broad_report.get("tracks", {})) == set(suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"]),
+        "broad report track set drift",
+    )
     _require(
         broad_report.get("cases_sha256") == suite_cli.sha256_file(suite_cli.CASES_PATH),
         "broad report is not bound to the current frozen case file",

--- a/scripts/projects/ua_open_weight_eval/run_mlx_model.py
+++ b/scripts/projects/ua_open_weight_eval/run_mlx_model.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Run one already-downloaded MLX model over a source-only UA Eval packet.
+
+The runner has no benchmark-gold dependency and performs no network access. It
+keeps an append-only local checkpoint so a long 4,000-case run can resume
+without regenerating completed items.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+REQUEST_SCHEMA = "ua_open_weight_eval_requests.v1"
+RESPONSE_SCHEMA = "ua_open_weight_eval_responses.v1"
+ALLOWED_ACTIONS = frozenset({"correct", "preserve", "abstain"})
+
+
+class RunnerError(ValueError):
+    """A source packet, model reply, or checkpoint is invalid."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_path(path: Path) -> str:
+    _require(path.is_dir(), "model must be an existing local directory")
+    digest = hashlib.sha256()
+    files = sorted(item for item in path.rglob("*") if item.is_file() or item.is_symlink())
+    _require(bool(files), "model directory contains no files")
+    for item in files:
+        _require(not item.is_symlink(), "model directory cannot contain symlinks")
+        relative = item.relative_to(path).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        size = item.stat().st_size
+        digest.update(size.to_bytes(8, "big"))
+        with item.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+    return digest.hexdigest()
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RunnerError(message)
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RunnerError(f"cannot read JSONL {path}: {exc}") from exc
+    rows: list[dict[str, Any]] = []
+    for number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RunnerError(f"invalid JSONL {path}:{number}: {exc}") from exc
+        _require(isinstance(value, dict), f"expected object at {path}:{number}")
+        rows.append(value)
+    _require(bool(rows), f"empty JSONL: {path}")
+    return rows
+
+
+def load_requests(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    rows = read_jsonl(path)
+    header, requests = rows[0], rows[1:]
+    _require(header.get("type") == "request_run", "request packet header is missing")
+    _require(header.get("schema_version") == REQUEST_SCHEMA, "request schema drift")
+    _require(header.get("gold_fields_supplied") == [], "request packet exposes gold fields")
+    _require(
+        header.get("input_fields") == ["item_id", "source", "source_sha256", "instruction_sha256"],
+        "request input field contract drift",
+    )
+    _require(header.get("case_count") == len(requests), "request count drift")
+    _require(len(requests) == 4000, "the frozen release requires exactly 4,000 requests")
+    instruction_sha256 = header.get("instruction_sha256")
+    _require(
+        isinstance(instruction_sha256, str) and instruction_sha256 == sha256_text(str(header.get("instruction", ""))),
+        "instruction hash drift",
+    )
+    seen: set[str] = set()
+    for row in requests:
+        _require(row.get("type") == "request", "non-request row in packet")
+        item_id = row.get("item_id")
+        source = row.get("source")
+        _require(isinstance(item_id, str) and item_id and item_id not in seen, "invalid or duplicate item_id")
+        _require(isinstance(source, str) and source, f"missing source for {item_id}")
+        _require(row.get("source_sha256") == sha256_text(source), f"source hash drift for {item_id}")
+        _require(row.get("instruction_sha256") == instruction_sha256, f"instruction drift for {item_id}")
+        payload = {
+            "item_id": item_id,
+            "source": source,
+            "source_sha256": row["source_sha256"],
+            "instruction_sha256": instruction_sha256,
+        }
+        _require(row.get("request_sha256") == sha256_text(canonical_json(payload)), f"request hash drift for {item_id}")
+        _require(
+            not {"expected", "target", "targets", "reference", "references", "edit", "edits"}.intersection(row),
+            f"gold field in {item_id}",
+        )
+        seen.add(item_id)
+    return header, requests
+
+
+def format_prompt(source: str) -> str:
+    source_json = json.dumps(source, ensure_ascii=False)
+    return (
+        "You are evaluating Ukrainian correction versus faithful preservation. "
+        "Return exactly one JSON object and no markdown or explanation. "
+        'The object must have the keys "action" and "output_text". '
+        '"action" must be "correct", "preserve", or "abstain". '
+        "Correct only a clearly warranted Ukrainian error. Preserve quotations, proper names, "
+        "historical or regional language, deliberate register, and genuinely acceptable text. "
+        "Use abstain when the evidence is insufficient. For preserve or abstain, copy the source "
+        f"exactly as output_text. Source JSON string: {source_json}"
+    )
+
+
+def parse_model_reply(reply: str) -> dict[str, str]:
+    decoder = json.JSONDecoder()
+    candidates: list[Mapping[str, Any]] = []
+    for index, character in enumerate(reply):
+        if character != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(reply[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            candidates.append(value)
+    _require(len(candidates) == 1, "model reply must contain exactly one JSON object")
+    value = candidates[0]
+    _require(set(value) == {"action", "output_text"}, "model reply field set drift")
+    action = value.get("action")
+    output_text = value.get("output_text")
+    _require(action in ALLOWED_ACTIONS, "model reply has an invalid action")
+    _require(isinstance(output_text, str) and output_text, "model reply has no output_text")
+    return {"action": str(action), "output_text": output_text}
+
+
+def load_checkpoint(path: Path, run_header: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(canonical_json(dict(run_header)) + "\n", encoding="utf-8")
+        return []
+    rows = read_jsonl(path)
+    _require(rows[0] == run_header, "checkpoint run header drift")
+    records = rows[1:]
+    seen: set[str] = set()
+    for record in records:
+        _require(set(record) == {"item_id", "request_sha256", "raw_generation", "response"}, "checkpoint field drift")
+        item_id = record.get("item_id")
+        response = record.get("response")
+        _require(isinstance(item_id, str) and item_id not in seen, "invalid or duplicate checkpoint item")
+        _require(isinstance(record.get("raw_generation"), str), f"missing raw generation for {item_id}")
+        _require(isinstance(response, dict), f"missing checkpoint response for {item_id}")
+        parse_model_reply(canonical_json(response))
+        seen.add(item_id)
+    return records
+
+
+def append_checkpoint(path: Path, record: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(canonical_json(dict(record)) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def write_responses(path: Path, header: Mapping[str, Any], records: Sequence[Mapping[str, Any]]) -> None:
+    rows = [dict(header)]
+    rows.extend({"item_id": record["item_id"], **record["response"]} for record in records)
+    temporary = path.with_name(f".{path.name}.tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary.write_text("".join(canonical_json(row) + "\n" for row in rows), encoding="utf-8")
+    temporary.replace(path)
+
+
+def load_mlx_generator(model_path: Path, max_tokens: int) -> Callable[[str], str]:
+    try:
+        import mlx.core as mx
+        from mlx_lm import generate, load
+        from mlx_lm.sample_utils import make_sampler
+    except ImportError as exc:
+        raise RunnerError("mlx-lm is not installed in the active .venv") from exc
+
+    model, tokenizer = load(str(model_path), lazy=False)
+    sampler = make_sampler(temp=0.0)
+
+    def generate_one(prompt: str) -> str:
+        messages = [{"role": "user", "content": prompt}]
+        rendered = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+        _require(isinstance(rendered, str), "tokenizer did not render a chat prompt")
+        mx.random.seed(0)
+        return generate(model, tokenizer, prompt=rendered, max_tokens=max_tokens, sampler=sampler, verbose=False)
+
+    return generate_one
+
+
+def run(args: argparse.Namespace, generator: Callable[[str], str] | None = None) -> dict[str, Any]:
+    model_path = args.model.expanduser().resolve()
+    _require(model_path.is_dir(), "model must be an existing local directory")
+    _require(
+        len(args.model_sha256) == 64 and all(character in "0123456789abcdef" for character in args.model_sha256),
+        "model_sha256 must be lowercase SHA-256",
+    )
+    _require(sha256_path(model_path) == args.model_sha256, "model path hash mismatch")
+    request_header, requests = load_requests(args.requests)
+    run_header = {
+        "type": "checkpoint_run",
+        "schema_version": "ua_open_weight_eval_mlx_checkpoint.v1",
+        "release_id": request_header["release_id"],
+        "requests_sha256": hashlib.sha256(args.requests.read_bytes()).hexdigest(),
+        "model": args.model_id,
+        "model_revision": args.model_revision,
+        "model_sha256": args.model_sha256,
+        "backend": "mlx-lm",
+        "decoding": {"temperature": 0.0, "max_tokens": args.max_tokens, "seed": 0},
+        "network_allowed": False,
+    }
+    records = load_checkpoint(args.state, run_header)
+    by_id = {str(record["item_id"]): record for record in records}
+    expected_prefix = [row["item_id"] for row in requests[: len(records)]]
+    _require(list(by_id) == expected_prefix, "checkpoint is not an exact request-order prefix")
+    for request, record in zip(requests, records, strict=False):
+        _require(record["request_sha256"] == request["request_sha256"], "checkpoint request hash drift")
+        _require(
+            parse_model_reply(record["raw_generation"]) == record["response"],
+            "checkpoint response does not match raw generation",
+        )
+    if generator is None:
+        generator = load_mlx_generator(model_path, args.max_tokens)
+
+    for position, request in enumerate(requests[len(records) :], len(records) + 1):
+        prompt = format_prompt(request["source"])
+        last_error = ""
+        for attempt in range(args.parse_retries + 1):
+            retry_prompt = prompt
+            if attempt:
+                retry_prompt += f" Previous reply was invalid ({last_error}); return only the required JSON object."
+            raw_generation = generator(retry_prompt)
+            try:
+                response = parse_model_reply(raw_generation)
+            except RunnerError as exc:
+                last_error = str(exc)
+                continue
+            record = {
+                "item_id": request["item_id"],
+                "request_sha256": request["request_sha256"],
+                "raw_generation": raw_generation,
+                "response": response,
+            }
+            append_checkpoint(args.state, record)
+            records.append(record)
+            break
+        else:
+            raise RunnerError(f"cannot parse model reply for {request['item_id']}: {last_error}")
+        if position % args.progress_every == 0 or position == len(requests):
+            print(f"mlx-runner: completed {position}/{len(requests)}", file=sys.stderr, flush=True)
+
+    response_header = {
+        "type": "run",
+        "schema_version": RESPONSE_SCHEMA,
+        "release_id": request_header["release_id"],
+        "model": args.model_id,
+        "model_revision": args.model_revision,
+        "model_sha256": args.model_sha256,
+        "backend": "mlx-lm",
+        "decoding": run_header["decoding"],
+        "network_allowed": False,
+        "closed_api_used": False,
+    }
+    write_responses(args.responses, response_header, records)
+    return {"status": "passed", "responses": len(records), "path": str(args.responses)}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", type=Path, required=True)
+    parser.add_argument("--responses", type=Path, required=True)
+    parser.add_argument("--state", type=Path, required=True)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--model-revision", required=True)
+    parser.add_argument("--model-sha256", required=True)
+    parser.add_argument("--max-tokens", type=int, default=160)
+    parser.add_argument("--parse-retries", type=int, default=2)
+    parser.add_argument("--progress-every", type=int, default=25)
+    args = parser.parse_args(argv)
+    _require(args.max_tokens > 0, "max_tokens must be positive")
+    _require(args.parse_retries >= 0, "parse_retries cannot be negative")
+    _require(args.progress_every > 0, "progress_every must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        result = run(parse_args(argv))
+    except (OSError, RunnerError) as exc:
+        print(f"mlx-runner: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/ua_open_weight_eval/run_mlx_model.py
+++ b/scripts/projects/ua_open_weight_eval/run_mlx_model.py
@@ -20,6 +20,13 @@ from typing import Any
 REQUEST_SCHEMA = "ua_open_weight_eval_requests.v1"
 RESPONSE_SCHEMA = "ua_open_weight_eval_responses.v1"
 ALLOWED_ACTIONS = frozenset({"correct", "preserve", "abstain"})
+OFFLINE_ENVIRONMENT = {
+    "HF_DATASETS_OFFLINE": "1",
+    "HF_HUB_DISABLE_TELEMETRY": "1",
+    "HF_HUB_OFFLINE": "1",
+    "TRANSFORMERS_OFFLINE": "1",
+    "UA_EVAL_NETWORK_ALLOWED": "0",
+}
 
 
 class RunnerError(ValueError):
@@ -55,6 +62,11 @@ def sha256_path(path: Path) -> str:
 def _require(condition: bool, message: str) -> None:
     if not condition:
         raise RunnerError(message)
+
+
+def enforce_offline_environment() -> None:
+    """Force supported model libraries into offline mode for every entry path."""
+    os.environ.update(OFFLINE_ENVIRONMENT)
 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -191,6 +203,7 @@ def write_responses(path: Path, header: Mapping[str, Any], records: Sequence[Map
 
 
 def load_mlx_generator(model_path: Path, max_tokens: int) -> Callable[[str], str]:
+    enforce_offline_environment()
     try:
         import mlx.core as mx
         from mlx_lm import generate, load
@@ -212,6 +225,7 @@ def load_mlx_generator(model_path: Path, max_tokens: int) -> Callable[[str], str
 
 
 def run(args: argparse.Namespace, generator: Callable[[str], str] | None = None) -> dict[str, Any]:
+    enforce_offline_environment()
     model_path = args.model.expanduser().resolve()
     _require(model_path.is_dir(), "model must be an existing local directory")
     _require(

--- a/scripts/projects/ua_open_weight_eval/suite_cli.py
+++ b/scripts/projects/ua_open_weight_eval/suite_cli.py
@@ -13,8 +13,10 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
+import zipfile
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -34,6 +36,76 @@ RECEIPT_PATH = RELEASE_ROOT / "release_receipt.json"
 V011_FREEZE = ROOT / "data/projects/ua_eval_harness/releases/v0.1.1/freeze_manifest.json"
 V011_MANIFEST = ROOT / "data/projects/ua_eval_harness/heldout_manifest_v1.json"
 V02_PACKET = ROOT / "data/projects/ua_eval_harness/v0.2/review_packet_priority_v1.jsonl"
+PUBLICATION_TAG = "ua-open-weight-eval-v0.1.0"
+PUBLICATION_DOC_ROOT = ROOT / "docs/projects/ua-open-weight-eval"
+PUBLICATION_FILES = (
+    (CONFIG_PATH, "build_config.json", "MIT", "deterministic build configuration"),
+    (CASES_PATH, "cases.jsonl", "LicenseRef-Row-Specific", "frozen evaluation cases"),
+    (SEEDS_PATH, "controlled_seeds.jsonl", "MIT", "project-authored silver seeds"),
+    (
+        RELEASE_ROOT / "local_run_config.example.json",
+        "local_run_config.example.json",
+        "MIT",
+        "offline runner configuration example",
+    ),
+    (
+        RECEIPT_PATH,
+        "release_receipt.json",
+        "MIT",
+        "frozen release and upstream hash receipt",
+    ),
+    (
+        RELEASE_ROOT / "saved_response.schema.json",
+        "saved_response.schema.json",
+        "MIT",
+        "saved-output JSON Schema",
+    ),
+    (
+        PUBLICATION_DOC_ROOT / "HUGGING_FACE_README.md",
+        "README.md",
+        "MIT",
+        "Hugging Face dataset card and bilingual quickstart",
+    ),
+    (
+        PUBLICATION_DOC_ROOT / "DATA_CARD.md",
+        "DATA_CARD.md",
+        "MIT",
+        "full data card and limitations",
+    ),
+    (
+        PUBLICATION_DOC_ROOT / "CONTAMINATION_POLICY.md",
+        "CONTAMINATION_POLICY.md",
+        "MIT",
+        "evaluation and learning-view separation policy",
+    ),
+    (
+        PUBLICATION_DOC_ROOT / "THIRD_PARTY_NOTICES.md",
+        "THIRD_PARTY_NOTICES.md",
+        "MIT",
+        "license, attribution, and modification notices",
+    ),
+    (
+        ROOT / "scripts/projects/ua_open_weight_eval/run_mlx_model.py",
+        "run_mlx_model.py",
+        "MIT",
+        "resumable source-only MLX open-weight runner",
+    ),
+    (ROOT / "LICENSE", "LICENSE-MIT.txt", "MIT", "repository-authored byte license text"),
+)
+CASE_RIGHTS_RULES = [
+    {
+        "case_id_prefix": "uaw-011-",
+        "cases": 2000,
+        "license_expression": "CC-BY-4.0",
+        "notice": "UA-GEC-derived error and control rows; retain attribution and modification notice.",
+    },
+    {
+        "case_id_prefix": "uaw-silver-",
+        "cases": 2000,
+        "license_expression": "MIT",
+        "notice": "Project-authored controlled or source-backed silver rows; external evidence bytes are not included.",
+    },
+]
 
 FROZEN_UPSTREAM_HASHES = {
     "data/projects/ua_eval_harness/releases/v0.1.1/freeze_manifest.json": (
@@ -334,7 +406,9 @@ def _validate_cases(cases: Sequence[Mapping[str, Any]], config: Mapping[str, Any
         _require(case.get("source_sha256") == sha256_text(source), "case source hash mismatch")
         expected = case.get("expected")
         _require(isinstance(expected, dict) and expected.get("action") in ALLOWED_ACTIONS, "invalid expected action")
-        _require(case.get("data_handling", {}).get("foundry_learning_eligible") is False, "evaluation leakage flag drift")
+        _require(
+            case.get("data_handling", {}).get("foundry_learning_eligible") is False, "evaluation leakage flag drift"
+        )
         without_hash = dict(case)
         claimed = without_hash.pop("case_sha256", None)
         _require(claimed == sha256_text(canonical_json(without_hash)), "case hash mismatch")
@@ -360,20 +434,14 @@ def build_release() -> dict[str, Any]:
         "counts": {
             "total": len(cases),
             "by_category": dict(sorted(Counter(case["category"] for case in cases).items())),
-            "by_evidence_grade": dict(
-                sorted(Counter(case["evidence"]["grade"] for case in cases).items())
-            ),
-            "by_track": dict(
-                sorted(Counter(track for case in cases for track in case["tracks"]).items())
-            ),
+            "by_evidence_grade": dict(sorted(Counter(case["evidence"]["grade"] for case in cases).items())),
+            "by_track": dict(sorted(Counter(track for case in cases for track in case["tracks"]).items())),
         },
         "artifacts": {
             "build_config": sha256_file(CONFIG_PATH),
             "controlled_seeds": sha256_file(SEEDS_PATH),
             "cases": sha256_text(encoded),
-            "foundry_firewall": sha256_file(
-                ROOT / "scripts/projects/open_model_data/model_view_exporter.py"
-            ),
+            "foundry_firewall": sha256_file(ROOT / "scripts/projects/open_model_data/model_view_exporter.py"),
             "local_run_config_example": sha256_file(RELEASE_ROOT / "local_run_config.example.json"),
             "saved_response_schema": sha256_file(RELEASE_ROOT / "saved_response.schema.json"),
             "suite_cli": sha256_file(Path(__file__)),
@@ -407,6 +475,181 @@ def verify_release() -> dict[str, Any]:
     return receipt
 
 
+def _validate_source_revision(source_revision: str) -> None:
+    _require(
+        len(source_revision) == 40 and all(character in "0123456789abcdef" for character in source_revision),
+        "source revision must be a full lowercase Git SHA",
+    )
+
+
+def publication_manifest(source_revision: str) -> dict[str, Any]:
+    """Return the complete, hash-bound public payload manifest."""
+    _validate_source_revision(source_revision)
+    receipt = verify_release()
+    cases = read_jsonl(CASES_PATH)
+    rights_counts = Counter(
+        "CC-BY-4.0" if str(case.get("case_id", "")).startswith("uaw-011-") else "MIT" for case in cases
+    )
+    _require(
+        rights_counts == {"CC-BY-4.0": 2000, "MIT": 2000},
+        "case rights selectors do not cover the frozen suite exactly",
+    )
+
+    files: list[dict[str, Any]] = []
+    output_names: set[str] = set()
+    for source, output_name, license_expression, role in PUBLICATION_FILES:
+        _require(source.is_file(), f"missing publication source: {source.relative_to(ROOT)}")
+        _require(output_name not in output_names, f"duplicate publication output: {output_name}")
+        _require(
+            Path(output_name).name == output_name,
+            f"nested publication output forbidden: {output_name}",
+        )
+        output_names.add(output_name)
+        files.append(
+            {
+                "bytes": source.stat().st_size,
+                "license_expression": license_expression,
+                "output_path": output_name,
+                "role": role,
+                "sha256": sha256_file(source),
+                "source_path": source.relative_to(ROOT).as_posix(),
+            }
+        )
+
+    return {
+        "schema_version": "ua_open_weight_eval_publication_manifest.v1",
+        "release_id": receipt["release_id"],
+        "release_tag": PUBLICATION_TAG,
+        "source_revision": source_revision,
+        "files": files,
+        "case_rights": {
+            "manifest_scope": "cases.jsonl",
+            "rules": CASE_RIGHTS_RULES,
+        },
+        "exclusions": [
+            "model weights and adapters",
+            "provider raw output and failed-attempt logs",
+            "private corpus and Google Drive bytes",
+            "non-redistributable literary or textbook content",
+            "VESUM dictionary data and derived evidence artifacts",
+            "UA Eval v0.2 pending-review material",
+        ],
+        "policies": {
+            "closed_model_judge_allowed": False,
+            "foundry_learning_eligible": False,
+            "global_quality_score_allowed": False,
+            "independent_human_judgments_claimed": 1000,
+            "total_cases": 4000,
+        },
+    }
+
+
+def _write_deterministic_zip(package_dir: Path, archive_path: Path) -> None:
+    _require(not archive_path.exists(), f"refusing to replace archive: {archive_path}")
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = PUBLICATION_TAG
+    temporary = archive_path.with_name(f".{archive_path.name}.tmp")
+    _require(not temporary.exists(), f"temporary archive already exists: {temporary}")
+    try:
+        with zipfile.ZipFile(
+            temporary,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+        ) as archive:
+            for path in sorted(item for item in package_dir.iterdir() if item.is_file()):
+                info = zipfile.ZipInfo(f"{prefix}/{path.name}", date_time=(1980, 1, 1, 0, 0, 0))
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o100644 << 16
+                archive.writestr(
+                    info,
+                    path.read_bytes(),
+                    compress_type=zipfile.ZIP_DEFLATED,
+                    compresslevel=9,
+                )
+        temporary.replace(archive_path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def package_publication(*, output_dir: Path, source_revision: str, archive_path: Path | None = None) -> dict[str, Any]:
+    """Create the exact GitHub/Hugging Face publication payload."""
+    _require(not output_dir.exists(), f"refusing to replace output directory: {output_dir}")
+    manifest = publication_manifest(source_revision)
+    output_dir.mkdir(parents=True)
+    try:
+        for item in manifest["files"]:
+            shutil.copyfile(ROOT / item["source_path"], output_dir / item["output_path"])
+        manifest_path = output_dir / "PUBLICATION_MANIFEST.json"
+        write_text_atomic(
+            manifest_path,
+            json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        )
+        checksum_files = sorted(path for path in output_dir.iterdir() if path.is_file())
+        checksums = "".join(f"{sha256_file(path)}  {path.name}\n" for path in checksum_files)
+        write_text_atomic(output_dir / "SHA256SUMS", checksums)
+        verification = verify_publication_package(output_dir)
+        if archive_path is not None:
+            _write_deterministic_zip(output_dir, archive_path)
+            verification["archive"] = {
+                "path": str(archive_path),
+                "bytes": archive_path.stat().st_size,
+                "sha256": sha256_file(archive_path),
+            }
+        return verification
+    except Exception:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+
+def verify_publication_package(package_dir: Path) -> dict[str, Any]:
+    """Verify a staged publication directory and reject extra bytes."""
+    _require(package_dir.is_dir(), "publication package directory is missing")
+    manifest_path = package_dir / "PUBLICATION_MANIFEST.json"
+    checksums_path = package_dir / "SHA256SUMS"
+    manifest = read_json(manifest_path)
+    _require(
+        manifest.get("schema_version") == "ua_open_weight_eval_publication_manifest.v1",
+        "publication manifest schema drift",
+    )
+    _require(manifest.get("release_tag") == PUBLICATION_TAG, "publication tag drift")
+    _validate_source_revision(str(manifest.get("source_revision", "")))
+    case_rights = manifest.get("case_rights")
+    _require(
+        isinstance(case_rights, dict) and case_rights.get("rules") == CASE_RIGHTS_RULES,
+        "publication case-rights drift",
+    )
+    files = manifest.get("files")
+    _require(isinstance(files, list) and files, "publication file manifest is empty")
+    expected_names = {item["output_path"] for item in files}
+    expected_names.update({manifest_path.name, checksums_path.name})
+    package_children = list(package_dir.iterdir())
+    _require(all(path.is_file() for path in package_children), "publication package has nested data")
+    actual_names = {path.name for path in package_children}
+    _require(actual_names == expected_names, "publication package has missing or extra files")
+    for item in files:
+        path = package_dir / item["output_path"]
+        _require(path.stat().st_size == item["bytes"], f"publication byte count drift: {path.name}")
+        _require(sha256_file(path) == item["sha256"], f"publication hash drift: {path.name}")
+    expected_checksums = "".join(
+        f"{sha256_file(path)}  {path.name}\n"
+        for path in sorted(
+            (package_dir / name for name in expected_names if name != checksums_path.name),
+            key=lambda path: path.name,
+        )
+    )
+    _require(checksums_path.read_text(encoding="utf-8") == expected_checksums, "SHA256SUMS drift")
+    return {
+        "status": "passed",
+        "release_id": manifest["release_id"],
+        "release_tag": manifest["release_tag"],
+        "source_revision": manifest["source_revision"],
+        "files": len(expected_names),
+        "manifest_sha256": sha256_file(manifest_path),
+        "sha256sums_sha256": sha256_file(checksums_path),
+    }
+
+
 def prepare_requests(output: Path) -> dict[str, Any]:
     verify_release()
     cases = read_jsonl(CASES_PATH)
@@ -427,9 +670,9 @@ def prepare_requests(output: Path) -> dict[str, Any]:
             "instruction_sha256": sha256_text(instruction),
         }
     ]
-    for case in cases:
+    for position, case in enumerate(cases, 1):
         payload = {
-            "item_id": case["case_id"],
+            "item_id": request_item_id(position),
             "source": case["source"],
             "source_sha256": case["source_sha256"],
             "instruction_sha256": sha256_text(instruction),
@@ -438,6 +681,11 @@ def prepare_requests(output: Path) -> dict[str, Any]:
     encoded = encode_jsonl(rows)
     write_text_atomic(output, encoded)
     return {"requests": len(cases), "path": str(output), "sha256": sha256_text(encoded)}
+
+
+def request_item_id(position: int) -> str:
+    _require(position > 0, "request position must be positive")
+    return f"uaw-request-{position:04d}"
 
 
 def validate_run_config(path: Path) -> dict[str, Any]:
@@ -460,12 +708,23 @@ def validate_run_config(path: Path) -> dict[str, Any]:
     )
     _require(sha256_path(model_path) == claimed_hash, "model path hash mismatch")
     command = config.get("command")
-    _require(isinstance(command, list) and command and all(isinstance(part, str) for part in command), "command must be a nonempty string array")
-    _require("{requests}" in command and "{responses}" in command, "command requires requests and responses placeholders")
+    _require(
+        isinstance(command, list) and command and all(isinstance(part, str) for part in command),
+        "command must be a nonempty string array",
+    )
+    _require(
+        "{requests}" in command and "{responses}" in command, "command requires requests and responses placeholders"
+    )
     executable = Path(command[0]).expanduser()
     _require(executable.is_absolute() and executable.is_file(), "runner executable must be an existing absolute file")
-    _require(executable.name.casefold() not in FORBIDDEN_COMMAND_EXECUTABLES, "network or closed-service client cannot be a local runner")
-    _require(not any("http://" in part.casefold() or "https://" in part.casefold() for part in command), "runner command cannot contain a network URL")
+    _require(
+        executable.name.casefold() not in FORBIDDEN_COMMAND_EXECUTABLES,
+        "network or closed-service client cannot be a local runner",
+    )
+    _require(
+        not any("http://" in part.casefold() or "https://" in part.casefold() for part in command),
+        "runner command cannot contain a network URL",
+    )
     _require(config.get("network_allowed") is False, "network_allowed must be false")
     return config
 
@@ -474,16 +733,10 @@ def run_local(config_path: Path, requests: Path, responses: Path, receipt_path: 
     config = validate_run_config(config_path)
     _require(requests.is_file(), "request packet is missing")
     command = [
-        part.replace("{requests}", str(requests.resolve())).replace(
-            "{responses}", str(responses.resolve())
-        )
+        part.replace("{requests}", str(requests.resolve())).replace("{responses}", str(responses.resolve()))
         for part in config["command"]
     ]
-    environment = {
-        key: os.environ[key]
-        for key in ("LANG", "LC_ALL", "PATH", "TMPDIR")
-        if key in os.environ
-    }
+    environment = {key: os.environ[key] for key in ("LANG", "LC_ALL", "PATH", "TMPDIR") if key in os.environ}
     environment.update(
         {
             "HF_HUB_OFFLINE": "1",
@@ -517,7 +770,7 @@ def _normalized_text(value: str) -> str:
 
 def score_saved(responses_path: Path, output: Path) -> dict[str, Any]:
     verify_release()
-    cases = {row["case_id"]: row for row in read_jsonl(CASES_PATH)}
+    cases = {request_item_id(position): row for position, row in enumerate(read_jsonl(CASES_PATH), 1)}
     raw_rows = read_jsonl(responses_path)
     if raw_rows[0].get("type") == "run":
         header = raw_rows.pop(0)
@@ -587,6 +840,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("build", help="rebuild the deterministic 4,000-case release")
     commands.add_parser("verify", help="verify frozen inputs and exact reproduction")
+    package = commands.add_parser(
+        "package-publication",
+        help="build the verified GitHub and Hugging Face payload",
+    )
+    package.add_argument("--output", type=Path, required=True)
+    package.add_argument("--source-revision", required=True)
+    package.add_argument("--archive", type=Path)
+    verify_package = commands.add_parser(
+        "verify-publication-package",
+        help="verify a staged publication payload",
+    )
+    verify_package.add_argument("--package", type=Path, required=True)
     prepare = commands.add_parser("prepare", help="write a source-only request packet")
     prepare.add_argument("--output", type=Path, required=True)
     validate = commands.add_parser("validate-run-config", help="validate an offline open-weight runner config")
@@ -609,6 +874,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = build_release()
         elif args.command == "verify":
             result = verify_release()
+        elif args.command == "package-publication":
+            result = package_publication(
+                output_dir=args.output,
+                source_revision=args.source_revision,
+                archive_path=args.archive,
+            )
+        elif args.command == "verify-publication-package":
+            result = verify_publication_package(args.package)
         elif args.command == "prepare":
             result = prepare_requests(args.output)
         elif args.command == "validate-run-config":

--- a/tests/test_open_model_adoption_cli.py
+++ b/tests/test_open_model_adoption_cli.py
@@ -38,11 +38,11 @@ def broad_report_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     responses_path = output / "responses.jsonl"
     response_rows = [
         {
-            "item_id": case["case_id"],
+            "item_id": suite_cli.request_item_id(position),
             "action": case["expected"]["action"],
             "output_text": case["expected"]["accepted_texts"][0],
         }
-        for case in suite_cli.read_jsonl(suite_cli.CASES_PATH)
+        for position, case in enumerate(suite_cli.read_jsonl(suite_cli.CASES_PATH), 1)
     ]
     responses_path.write_text(suite_cli.encode_jsonl(response_rows), encoding="utf-8")
     report_path = output / "broad-report.json"
@@ -54,8 +54,15 @@ def _write_lang_uk_results(path: Path) -> None:
     path.write_text(
         json.dumps(
             {
-                "config_general": {"model_name": "local/open-weight-fixture"},
-                "results": {"example_task": {"acc": 0.5, "qg_meta": {"seed": 42}}},
+                "model_name": "local/open-weight-fixture",
+                "n-shot": {"example_task": 0},
+                "results": {
+                    "example_task": {
+                        "alias": "example_task",
+                        "acc,none": 0.5,
+                        "qg_meta": {"seed": 42},
+                    }
+                },
             }
         ),
         encoding="utf-8",
@@ -148,9 +155,7 @@ def test_lang_uk_adapter_validates_saved_results_and_broad_tracks(
     )
     assert (output / results_path.name).read_bytes() == results_path.read_bytes()
     assert sidecar["model_name"] == "local/open-weight-fixture"
-    assert sidecar["broad_evaluation"]["tracks"] == sorted(
-        suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"]
-    )
+    assert sidecar["broad_evaluation"]["tracks"] == sorted(suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"])
     assert sidecar["broad_evaluation"]["global_score"] is None
     assert sidecar["closed_api_or_judge_used"] is False
     assert sidecar["external_submission_performed"] is False
@@ -205,8 +210,30 @@ def test_lang_uk_adapter_rejects_non_numeric_metrics(tmp_path: Path) -> None:
     with pytest.raises(adoption_cli.AdoptionError, match="numeric"):
         adoption_cli._validate_lang_uk_results(
             {
-                "config_general": {"model_name": "fixture"},
-                "results": {"task": {"acc": "not-a-number"}},
+                "model_name": "fixture",
+                "n-shot": {"task": 0},
+                "results": {"task": {"alias": "task", "acc,none": "not-a-number"}},
+            }
+        )
+
+
+def test_lang_uk_adapter_requires_authentic_lm_eval_top_level_shape() -> None:
+    with pytest.raises(adoption_cli.AdoptionError, match="missing lang-uk model_name"):
+        adoption_cli._validate_lang_uk_results(
+            {
+                "config_general": {"model_name": "legacy-fixture"},
+                "results": {"task": {"acc": 0.5}},
+            }
+        )
+
+
+def test_lang_uk_adapter_rejects_task_set_drift() -> None:
+    with pytest.raises(adoption_cli.AdoptionError, match="n-shot task set drift"):
+        adoption_cli._validate_lang_uk_results(
+            {
+                "model_name": "fixture",
+                "n-shot": {"different-task": 0},
+                "results": {"task": {"alias": "task", "acc,none": 0.5}},
             }
         )
 

--- a/tests/test_ua_open_weight_eval.py
+++ b/tests/test_ua_open_weight_eval.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from collections import Counter
 from pathlib import Path
 
 import pytest
+import yaml
 from jsonschema import Draft202012Validator
 
 from scripts.projects.open_model_data import model_view_exporter
-from scripts.projects.ua_open_weight_eval import suite_cli
+from scripts.projects.ua_open_weight_eval import run_mlx_model, suite_cli
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -57,6 +59,11 @@ def test_source_only_requests_expose_no_gold(tmp_path: Path) -> None:
     ]
     forbidden = {"expected", "target", "targets", "reference", "references", "edit", "edits"}
     assert all(not forbidden.intersection(row) for row in rows[1:])
+    assert [row["item_id"] for row in rows[1:]] == [suite_cli.request_item_id(position) for position in range(1, 4001)]
+    assert all(
+        not {"error", "correct_control", "protected", "unresolved"}.intersection(row["item_id"].split("-"))
+        for row in rows[1:]
+    )
 
 
 def test_saved_output_scoring_is_per_track_without_global_score(tmp_path: Path) -> None:
@@ -72,11 +79,11 @@ def test_saved_output_scoring_is_per_track_without_global_score(tmp_path: Path) 
     ]
     rows.extend(
         {
-            "item_id": case["case_id"],
+            "item_id": suite_cli.request_item_id(position),
             "action": case["expected"]["action"],
             "output_text": case["expected"]["accepted_texts"][0],
         }
-        for case in cases
+        for position, case in enumerate(cases, 1)
     )
     _write_jsonl(responses, rows)
     output = tmp_path / "report.json"
@@ -175,3 +182,188 @@ def test_foundry_firewall_loads_every_broad_eval_case() -> None:
 def test_saved_response_schema_is_valid() -> None:
     schema = suite_cli.read_json(suite_cli.RELEASE_ROOT / "saved_response.schema.json")
     Draft202012Validator.check_schema(schema)
+
+
+def test_publication_package_is_complete_rights_mapped_and_reproducible(tmp_path: Path) -> None:
+    source_revision = "a" * 40
+    first = tmp_path / "first"
+    first_archive = tmp_path / "first.zip"
+    receipt = suite_cli.package_publication(
+        output_dir=first,
+        source_revision=source_revision,
+        archive_path=first_archive,
+    )
+    assert receipt["status"] == "passed"
+    assert receipt["release_tag"] == "ua-open-weight-eval-v0.1.0"
+    assert receipt["source_revision"] == source_revision
+
+    manifest = suite_cli.read_json(first / "PUBLICATION_MANIFEST.json")
+    file_names = {item["output_path"] for item in manifest["files"]}
+    assert "cases.jsonl" in file_names
+    assert "THIRD_PARTY_NOTICES.md" in file_names
+    assert "README.md" in file_names
+    assert "run_mlx_model.py" in file_names
+    assert manifest["case_rights"]["rules"] == [
+        {
+            "case_id_prefix": "uaw-011-",
+            "cases": 2000,
+            "license_expression": "CC-BY-4.0",
+            "notice": "UA-GEC-derived error and control rows; retain attribution and modification notice.",
+        },
+        {
+            "case_id_prefix": "uaw-silver-",
+            "cases": 2000,
+            "license_expression": "MIT",
+            "notice": "Project-authored controlled or source-backed silver rows; external evidence bytes are not included.",
+        },
+    ]
+    assert all("provider raw output" not in item["source_path"] for item in manifest["files"])
+
+    second = tmp_path / "second"
+    second_archive = tmp_path / "second.zip"
+    suite_cli.package_publication(
+        output_dir=second,
+        source_revision=source_revision,
+        archive_path=second_archive,
+    )
+    assert suite_cli.sha256_file(first_archive) == suite_cli.sha256_file(second_archive)
+    with zipfile.ZipFile(first_archive) as archive:
+        assert all(name.startswith("ua-open-weight-eval-v0.1.0/") for name in archive.namelist())
+
+
+def test_publication_verifier_rejects_tampering_and_extra_bytes(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    suite_cli.package_publication(output_dir=package, source_revision="b" * 40)
+    (package / "cases.jsonl").write_text("tampered\n", encoding="utf-8")
+    with pytest.raises(suite_cli.SuiteError, match=r"byte count drift|hash drift"):
+        suite_cli.verify_publication_package(package)
+
+    package = tmp_path / "package-extra"
+    suite_cli.package_publication(output_dir=package, source_revision="b" * 40)
+    (package / "raw-provider-output.jsonl").write_text("{}\n", encoding="utf-8")
+    with pytest.raises(suite_cli.SuiteError, match="missing or extra files"):
+        suite_cli.verify_publication_package(package)
+
+
+def test_hugging_face_card_declares_test_split_and_discovery_metadata() -> None:
+    card = (suite_cli.PUBLICATION_DOC_ROOT / "HUGGING_FACE_README.md").read_text(encoding="utf-8")
+    _, metadata_text, _ = card.split("---", 2)
+    metadata = yaml.safe_load(metadata_text)
+    assert metadata["language"] == ["uk"]
+    assert metadata["license"] == ["cc-by-4.0", "mit"]
+    assert metadata["configs"] == [
+        {
+            "config_name": "default",
+            "data_files": [{"path": "cases.jsonl", "split": "test"}],
+        }
+    ]
+    assert "evaluation" in metadata["tags"]
+
+
+def test_mlx_runner_loads_only_source_packet_and_resumes(tmp_path: Path) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    suite_cli.prepare_requests(requests_path)
+    packet = run_mlx_model.read_jsonl(requests_path)
+    packet[0]["case_count"] = 2
+    packet = packet[:3]
+    packet[0]["case_count"] = 4000
+    fixture_request = packet[1]
+    packet.extend({**fixture_request, "item_id": f"fixture-{index:04d}"} for index in range(3998))
+    for row in packet[3:]:
+        row["source_sha256"] = run_mlx_model.sha256_text(row["source"])
+        payload = {
+            "item_id": row["item_id"],
+            "source": row["source"],
+            "source_sha256": row["source_sha256"],
+            "instruction_sha256": row["instruction_sha256"],
+        }
+        row["request_sha256"] = run_mlx_model.sha256_text(run_mlx_model.canonical_json(payload))
+    _write_jsonl(requests_path, packet)
+
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text("{}\n", encoding="utf-8")
+    state = tmp_path / "state.jsonl"
+    responses = tmp_path / "responses.jsonl"
+    args = run_mlx_model.parse_args(
+        [
+            "--requests",
+            str(requests_path),
+            "--responses",
+            str(responses),
+            "--state",
+            str(state),
+            "--model",
+            str(model),
+            "--model-id",
+            "fixture/model",
+            "--model-revision",
+            "a" * 40,
+            "--model-sha256",
+            run_mlx_model.sha256_path(model),
+            "--progress-every",
+            "4000",
+        ]
+    )
+    generated = 0
+
+    def generator(_: str) -> str:
+        nonlocal generated
+        generated += 1
+        return '{"action":"preserve","output_text":"fixture"}'
+
+    assert run_mlx_model.run(args, generator=generator)["responses"] == 4000
+    assert generated == 4000
+    assert run_mlx_model.run(args, generator=generator)["responses"] == 4000
+    assert generated == 4000
+    response_rows = run_mlx_model.read_jsonl(responses)
+    assert response_rows[0]["closed_api_used"] is False
+    assert len(response_rows) == 4001
+
+
+def test_mlx_runner_rejects_gold_and_ambiguous_model_replies(tmp_path: Path) -> None:
+    assert run_mlx_model.parse_model_reply('```json\n{"action":"preserve","output_text":"Текст."}\n```') == {
+        "action": "preserve",
+        "output_text": "Текст.",
+    }
+    with pytest.raises(run_mlx_model.RunnerError, match="exactly one JSON object"):
+        run_mlx_model.parse_model_reply(
+            '{"action":"preserve","output_text":"A"} {"action":"correct","output_text":"B"}'
+        )
+    prompt = run_mlx_model.format_prompt("Текст.")
+    assert "correct_control" not in prompt
+    assert "uaw-request" not in prompt
+
+    request_path = tmp_path / "gold.jsonl"
+    instruction = "fixture"
+    header = {
+        "type": "request_run",
+        "schema_version": run_mlx_model.REQUEST_SCHEMA,
+        "release_id": "fixture",
+        "case_count": 4000,
+        "gold_fields_supplied": [],
+        "input_fields": ["item_id", "source", "source_sha256", "instruction_sha256"],
+        "instruction": instruction,
+        "instruction_sha256": run_mlx_model.sha256_text(instruction),
+    }
+    source = "Текст."
+    payload = {
+        "item_id": "fixture-0000",
+        "source": source,
+        "source_sha256": run_mlx_model.sha256_text(source),
+        "instruction_sha256": header["instruction_sha256"],
+    }
+    requests = []
+    for index in range(4000):
+        item_payload = {**payload, "item_id": f"fixture-{index:04d}"}
+        requests.append(
+            {
+                "type": "request",
+                **item_payload,
+                "request_sha256": run_mlx_model.sha256_text(run_mlx_model.canonical_json(item_payload)),
+                "expected": "secret",
+            }
+        )
+    _write_jsonl(request_path, [header, *requests])
+    with pytest.raises(run_mlx_model.RunnerError, match="gold field"):
+        run_mlx_model.load_requests(request_path)

--- a/tests/test_ua_open_weight_eval.py
+++ b/tests/test_ua_open_weight_eval.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import zipfile
 from collections import Counter
 from pathlib import Path
@@ -367,3 +368,10 @@ def test_mlx_runner_rejects_gold_and_ambiguous_model_replies(tmp_path: Path) -> 
     _write_jsonl(request_path, [header, *requests])
     with pytest.raises(run_mlx_model.RunnerError, match="gold field"):
         run_mlx_model.load_requests(request_path)
+
+
+def test_mlx_runner_forces_offline_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in run_mlx_model.OFFLINE_ENVIRONMENT:
+        monkeypatch.setenv(name, "unsafe-value")
+    run_mlx_model.enforce_offline_environment()
+    assert {name: os.environ[name] for name in run_mlx_model.OFFLINE_ENVIRONMENT} == (run_mlx_model.OFFLINE_ENVIRONMENT)


### PR DESCRIPTION
## What changed

- adds a deterministic, rights-mapped GitHub/Hugging Face publication package for UA Open-Weight Eval v0.1.0
- adds an English/Ukrainian dataset card, third-party notices, contamination policy, and exact exclusion manifest
- replaces category-bearing generation IDs with opaque request IDs and adds a resumable offline MLX runner
- validates the authentic current lang-uk result schema and corrects the stale Lapa/lang-uk upstream locks
- reconciles Foundry control-plane documentation after the completed #6171/#6164 implementation phase

## Why

The repository-contained 4,000-case suite had no standalone publication-rights map, deterministic release asset builder, or literal source-only runner packet. The lang-uk adapter fixture also encoded a schema shape that current leaderboard results do not use. This PR resolves those release blockers without publishing model weights, calling a hosted model API, or claiming external adoption.

## Evidence

- frozen `cases.jsonl` remains `2164d7ba31322bf3cfbed8045ad3a5b6e759395175b2c1ab11172b9c0f1237db`
- `28 passed` across `tests/test_ua_open_weight_eval.py` and `tests/test_open_model_adoption_cli.py`
- Ruff, Markdownlint, JSON parsing, Hugging Face dataset-card validation, `git diff --check`, agent-trailer lint, diff-scoped OPSEC, and staged gitleaks pass
- the deterministic package contains 14 allowlisted files and rejects missing, extra, nested, or tampered bytes
- public model/package upload, model-weight download, model execution, and upstream maintainer submissions remain explicit operator approval gates

## Scope boundary

No UA Eval v0.1.1 bytes were changed. No UA Eval v0.2 pending-review material, VESUM evidence bytes, provider raw output, model weights, private corpus bytes, or training outputs are included. No global quality score or external-adoption claim is introduced.

Part of #6273.
