### PR TITLE
feat(entire): enable private native recall

### DIFF
--- a/.entire/private-recall.json
+++ b/.entire/private-recall.json
@@ -1,0 +1,78 @@
+{
+  "schema": "entire-private-recall.v1",
+  "enabled": true,
+  "required_cli_version": "0.8.42",
+  "source_repo": "learn-ukrainian/learn-ukrainian.github.io",
+  "checkpoint_repo": "learn-ukrainian/entire-checkpoints-private",
+  "entire_access_principals": [
+    {"handle": "github:krisztiankoos", "role": "writer"}
+  ],
+  "authoritative": false,
+  "automatic_intake": false,
+  "public_promotion": false,
+  "preflight": ["scripts/entire/private_mode_preflight.py"],
+  "operations": {
+    "search": [
+      "search",
+      "<query>",
+      "--json",
+      "--limit",
+      "<1-10>",
+      "--repo",
+      "learn-ukrainian/learn-ukrainian.github.io"
+    ],
+    "explain_metadata": ["checkpoint", "explain", "<id-or-sha>", "--json"],
+    "explain_full": [
+      "checkpoint",
+      "explain",
+      "<id-or-sha>",
+      "--full",
+      "--no-pager"
+    ],
+    "recap": ["recap", "--static", "<--day|--week|--month|--90>"],
+    "dispatch": [
+      "dispatch",
+      "--local",
+      "--all-branches",
+      "--since",
+      "<window>"
+    ],
+    "handoff": [
+      "dispatch",
+      "--local",
+      "--all-branches",
+      "--since",
+      "<window>"
+    ],
+    "resume": ["session", "resume", "<branch>"]
+  },
+  "external_disclosure_requires_operator_review": [
+    "search",
+    "explain_full",
+    "recap",
+    "dispatch",
+    "handoff"
+  ],
+  "operator_request_required": [
+    "explain_full",
+    "recap",
+    "dispatch",
+    "handoff",
+    "resume"
+  ],
+  "private_context_operations": [
+    "search",
+    "explain_full",
+    "recap",
+    "dispatch",
+    "handoff"
+  ],
+  "forbidden_flags": [
+    "--all-repos",
+    "--code",
+    "--generate",
+    "--force",
+    "--raw-transcript",
+    "--transcript"
+  ]
+}

--- a/.entire/private-recall.json
+++ b/.entire/private-recall.json
@@ -8,7 +8,7 @@
     {"handle": "github:krisztiankoos", "role": "writer"}
   ],
   "authoritative": false,
-  "automatic_intake": false,
+  "automatic_intake": true,
   "public_promotion": false,
   "preflight": ["scripts/entire/private_mode_preflight.py"],
   "operations": {
@@ -54,7 +54,6 @@
     "handoff"
   ],
   "operator_request_required": [
-    "explain_full",
     "recap",
     "dispatch",
     "handoff",

--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -17,14 +17,16 @@ effort: low
 
 # Entire context recall (body-free intake + private native tools)
 
-**Automatic intake:** On any non-trivial task, the accountable root runs
-`status` + `search` once **before** prioritization or dispatch. If the results
-matter, the root creates at most one verified `handoff` capsule (at most five
-cards and 8 KiB) and gives that same capsule to every participant that needs
-it. Children consume the capsule; they do not repeat a fleet-wide search merely
-because they use a different provider. Run `record-use` only when verified
-locators materially informed the work. Do not wait for the operator to say
-“use Entire.” Skip only for pure one-line questions or when the module is
+**Automatic intake:** On any non-trivial task, the accountable root runs local
+`status` + `search`, then the private-mode preflight, once **before**
+prioritization or dispatch. When the preflight is green, run one bounded,
+repository-scoped native Entire search in the root's private context; inspect a
+full checkpoint only when it materially restores exact continuity. If local
+results matter, the root may create one verified `handoff` capsule (at most
+five cards and 8 KiB) for participants. Children consume that body-free capsule
+and never receive native session bodies. Run `record-use` only when verified
+local locators materially informed the work. Do not wait for the operator to
+say “use Entire.” Skip only for pure one-line questions or when the module is
 missing/disabled (note that once).
 
 This skill is the canonical agent-facing contract for the public context layer.
@@ -35,20 +37,19 @@ it never mutates them.
 
 ## Hard privacy and scope rules
 
-- **Body-free only.** Results are locator cards and verified canonical excerpts
+- **Shared capsules are body-free only.** Results distributed to other seats
+  are locator cards and verified canonical excerpts
   (commit parents/touched paths/timestamps; ACP terminal metadata with
   `content_included: false`). Never request, emit, or persist transcripts,
   prompts, responses, subjects, artifacts, raw captures, secrets, or
   AI-generated summaries.
-- **Automatic context stays body-free.** Never place raw prompts, transcripts,
-  responses, session bodies, generated recaps, or generated summaries in an
-  intake prompt or distributed capsule. Human investigation with optional
-  Entire product tools remains private and manual; its output is not promoted
-  automatically.
-- **No Entire dependency for automatic intake.** Entire CLI 0.8.42 stays
-  pinned, optional, and non-load-bearing. The automatic body-free workflow
-  makes **zero** Entire CLI invocations and zero network calls. Native Entire
-  tools are a separate private, operator-authorized mode defined below; they
+- **Native context stays private to the root.** Never place native prompts,
+  transcripts, responses, session bodies, generated recaps, or generated
+  summaries in a distributed capsule or public evidence. The root may consume
+  search and task-relevant full explain privately after a green preflight.
+- **No load-bearing Entire dependency.** Entire CLI 0.8.42 stays pinned,
+  optional, and fail-open. A preflight or provider failure falls back to the
+  local body-free workflow and cannot alter task disposition. Native tools
   never create public `refs/entire/*` or become fleet evidence.
 - **Fail closed.** Missing, stale, tombstoned, partial-terminal, unsupported,
   or digest-mismatched evidence is omitted with a machine reason. Never inject
@@ -162,15 +163,17 @@ entire dispatch --local --all-branches --since <window>
 
 `dispatch` is also the native private handoff surface. The accountable root may
 consume search and explain results inside its private task context. Never place
-prompt-bearing output in automatic intake, a distributed capsule, a public
-issue/PR, or formal-review evidence; external disclosure requires operator
-review. Full explain requires a task that needs exact continuity and must not
-be fanned out to workers. Full explain, recap/dispatch, and worktree-mutating
-resume/rewind require a present operator request. `--all-repos`, `--code`,
-`--generate`, `--force`, `--raw-transcript`, and `--transcript` remain
-forbidden. Entire review is supplemental and never satisfies the sealed Fleet
-formal-review gate. Provider failure, an empty search index, or a rate limit
-must be reported truthfully and never changes the canonical workflow outcome.
+prompt-bearing output in a distributed capsule, a public issue/PR, or
+formal-review evidence; external disclosure requires operator review. Full
+explain requires a task that needs exact continuity and must not be fanned out
+to workers. `--all-repos`, `--code`, `--generate`, `--force`,
+`--raw-transcript`, and `--transcript` remain forbidden. Full explain is
+allowed without a second operator prompt when exact continuity is relevant.
+Recap/dispatch and worktree-mutating resume/rewind still require a present
+operator request. Entire review is supplemental and never satisfies the sealed
+Fleet formal-review gate. Provider failure, an empty search index, or a rate
+limit must be reported truthfully and never changes the canonical workflow
+outcome.
 
 Current official product references:
 

--- a/agents_extensions/shared/skills/entire-context/SKILL.md
+++ b/agents_extensions/shared/skills/entire-context/SKILL.md
@@ -15,7 +15,7 @@ when-to-use: >
 effort: low
 ---
 
-# Entire context recall (public, body-free)
+# Entire context recall (body-free intake + private native tools)
 
 **Automatic intake:** On any non-trivial task, the accountable root runs
 `status` + `search` once **before** prioritization or dispatch. If the results
@@ -45,10 +45,11 @@ it never mutates them.
   intake prompt or distributed capsule. Human investigation with optional
   Entire product tools remains private and manual; its output is not promoted
   automatically.
-- **No Entire dependency.** Entire CLI 0.8.42 stays pinned, optional, and
-  non-load-bearing. This workflow makes **zero** Entire CLI invocations and
-  zero network calls. Do not run `entire` login, search, checkpoint, attach,
-  resume, push, or create `refs/entire/*`.
+- **No Entire dependency for automatic intake.** Entire CLI 0.8.42 stays
+  pinned, optional, and non-load-bearing. The automatic body-free workflow
+  makes **zero** Entire CLI invocations and zero network calls. Native Entire
+  tools are a separate private, operator-authorized mode defined below; they
+  never create public `refs/entire/*` or become fleet evidence.
 - **Fail closed.** Missing, stale, tombstoned, partial-terminal, unsupported,
   or digest-mismatched evidence is omitted with a machine reason. Never inject
   an omitted item into your context, and never fabricate coverage for a kind
@@ -134,21 +135,42 @@ or call GitHub, Fleet, Monitor, Entire, or the network. Missing, malformed,
 nonterminal, stale, unpublished, hash-mismatched, or digest-drifted inputs are
 omitted fail-closed.
 
-## Product prompt workflow and optional Entire tools
+## Product prompt workflow and private native Entire mode
 
 For product-style prompts, invoke the local body-free workflow in this order:
 `search` for search-past-work, `explain-change` for an exact provenance path,
 and `handoff` for a bounded capsule. Use the `.venv/bin/python` commands above;
 they are the canonical recall path.
 
-Native `entire blame --json` is allowed only for local attribution. Prompt-
-bearing `entire why`, logged-in cloud search, generated recap, investigate
-findings, session handoff, and Entire review are optional **human/operator
-investigation tools**. They may help a person search past agent work, recap a
-private session, explain why code exists, investigate a change, or prepare a
-private handoff. Their output never automatically enters a canonical capsule,
-changes fleet state, or proves review. Entire review is supplemental and never
-satisfies the sealed Fleet formal-review gate.
+The operator-authorized private mode in `.entire/private-recall.json` permits
+the accountable root to use native Entire search, explain, recap, dispatch,
+and private handoff when those tools materially help the task. Before first
+use, run `.venv/bin/python -m scripts.entire.private_mode_preflight` and require
+its body-free receipt to report `"ready": true`. It verifies routing, private
+checkpoint visibility, public-ref absence, authentication, exact private
+Entire ACLs on both mirrors, mirror readiness, and the exact 0.8.42 pin without
+printing command output or local paths. Use only these shapes:
+
+```bash
+entire search "<query>" --json --limit <1-10> \
+  --repo learn-ukrainian/learn-ukrainian.github.io
+entire checkpoint explain <checkpoint-id-or-sha> --json
+entire checkpoint explain <checkpoint-id-or-sha> --full --no-pager
+entire recap --static <--day|--week|--month|--90>
+entire dispatch --local --all-branches --since <window>
+```
+
+`dispatch` is also the native private handoff surface. The accountable root may
+consume search and explain results inside its private task context. Never place
+prompt-bearing output in automatic intake, a distributed capsule, a public
+issue/PR, or formal-review evidence; external disclosure requires operator
+review. Full explain requires a task that needs exact continuity and must not
+be fanned out to workers. Full explain, recap/dispatch, and worktree-mutating
+resume/rewind require a present operator request. `--all-repos`, `--code`,
+`--generate`, `--force`, `--raw-transcript`, and `--transcript` remain
+forbidden. Entire review is supplemental and never satisfies the sealed Fleet
+formal-review gate. Provider failure, an empty search index, or a rate limit
+must be reported truthfully and never changes the canonical workflow outcome.
 
 Current official product references:
 
@@ -204,3 +226,8 @@ A missing, disabled, or unreadable projection yields a body-free status
 payload (`"available": false`) with exit code 0 for read commands — recall is
 optional and must never block or mutate your canonical workflow. If recall is
 unavailable, continue with the authoritative systems directly.
+
+A failed private-mode preflight has the same posture: report its body-free
+issue code, fall back to local body-free recall, and continue. Never weaken the
+private destination, public-ref, authentication, mirror ACL/readiness, or
+pinned-version checks to make a native command run.

--- a/docs/architecture/adr/adr-018-entire-acp-context-layer.md
+++ b/docs/architecture/adr/adr-018-entire-acp-context-layer.md
@@ -8,6 +8,7 @@
 [#5880](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5880),
 [#6162](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162),
 [#6183](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6183),
+[#6278](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6278),
 [architecture research and advisor receipt](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162#issuecomment-5150430545),
 [rollout plan](../../plans/2026-08-01-entire-acp-context-layer-rollout.md)
 
@@ -44,12 +45,37 @@ content. An LLM may use an Entire search result only as a locator; before any
 context is injected, the locator is resolved against the authoritative local
 system and its digest is verified.
 
-The public agent workflow is deliberately stricter than the optional product
+The automatic fleet workflow remains stricter than the optional product
 experience described in Entire's documentation. It uses the repository's
-local, body-free projection and makes no cloud Entire call. Human operators may
-privately use Entire search, recap/review, why/blame/investigate, and session
-handoff for investigation, but those bodies and generated findings do not enter
-automatic agent context or become fleet evidence.
+local, body-free projection for shared capsules. Under the operator amendment
+below, the accountable root may also use Entire's private native search and
+session tools after proving the private boundary; those bodies and generated
+findings do not enter shared automatic capsules or become fleet evidence.
+
+### Operator amendment: private native recall (2026-08-02)
+
+The operator authorizes body-bearing Entire retrieval because checkpoint
+storage is separated from the public product origin. Native recall is allowed
+only after a live preflight proves all of these facts:
+
+- CLI remains pinned to 0.8.42 and Entire authentication is valid;
+- `learn-ukrainian/entire-checkpoints-private` is private and contains the
+  canonical checkpoint ref;
+- the public product origin contains zero `entire/*` branches;
+- the checkpoint mirror and public-upstream source mirror are ready and their
+  Entire ACLs contain only the operator.
+
+The source code remains public on GitHub by product choice. That does not make
+its Entire mirror public to other Entire users: the preflight checks the live
+Entire control-plane collaborator list and fails unless only the operator can
+pull either mirror.
+
+After that receipt, the accountable root may use bounded repository-scoped
+search, explain, recap, local dispatch, and explicit handoff for real session
+continuity. Full explain stays within the root's private working context;
+raw-transcript flags remain prohibited. Generated summaries and worktree-
+mutating resume/rewind remain operator-directed. Native Entire remains optional
+and non-authoritative.
 
 ### Authority boundary
 
@@ -125,9 +151,10 @@ The automatic corpus is body-free and mechanically extracted:
 
 The bridge does not compose intent, outcome, rationale, titles, headings, or
 summaries. Prompts, transcripts, responses, session bodies, ACP subjects, and
-generated recaps remain outside automatic context. Richer reusable memory is a
-deferred tier consisting only of approved canonical repository artifacts; it
-does not authorize automatic body ingestion.
+generated recaps remain outside the shared automatic context. The accountable
+root may inspect richer private session memory after the live preflight, but it
+must re-ground consequential facts in canonical repository evidence before
+publishing or distributing them.
 
 ### Failure and privacy rules
 
@@ -139,11 +166,14 @@ does not authorize automatic body ingestion.
 - The approved private checkpoint repository is hard-coded and verified before
   every push-capable operation. The public `origin` is always rejected as a
   checkpoint destination.
-- `checkpoint explain --full`, `--raw-transcript`, `--transcript`, generated
-  explanations, and Entire Dispatch are prohibited in automated integration.
-- Logged-in semantic search, recap, review, why/blame/investigate, and session
-  handoff remain manual operator tools. Their bodies and generated output are
-  excluded from the public automated workflow.
+- `checkpoint explain --full` requires a green private preflight and a task
+  that needs exact continuity; its output stays in the accountable root's
+  private working context. `--raw-transcript` and `--transcript` remain
+  prohibited.
+- Logged-in semantic search and metadata-only explain may be used by the root
+  after preflight. Generated recap/dispatch and worktree-mutating session
+  operations require an explicit operator request. None of their output enters
+  the shared automatic capsule by default.
 - Entire's own review or investigate workflows may assist discussion, but they
   never satisfy the repository formal-review gate.
 
@@ -219,10 +249,11 @@ than the original cloud-search sketch:
 | `tests/test_entire_native_onboarding.py` | Composed fail-open capture hooks for the host harnesses `codex`, `claude-code`, and `opencode`, with private routing checks. |
 | `scripts/entire/external_agents/entire-agent-kimi/` | Explicit standalone Kimi Code adapter; hosted Kimi/GLM continue to use their host integration. |
 
-This evidence does not prove cloud semantic-search privacy, generated recap
-safety, arbitrary metadata-card ingestion, or a need for an ACP plugin. Those
-capabilities remain outside automatic recall and do not change the authority
-table.
+Private repository routing, public-ref absence, authenticated access, ready
+mirrors, and full checkpoint readability are now proved by the #6278 preflight
+and source-blind canary. Cloud result quality, generated-summary accuracy,
+arbitrary metadata-card ingestion, and a need for an ACP plugin are distinct
+questions; they do not change the authority table.
 
 ## Verification
 

--- a/docs/architecture/adr/adr-018-entire-acp-context-layer.md
+++ b/docs/architecture/adr/adr-018-entire-acp-context-layer.md
@@ -30,12 +30,12 @@ durable, body-free receipts. Making Entire authoritative would duplicate those
 systems and enlarge the failure and privacy domains.
 
 The privacy boundary is strict. Checkpoint storage may use only
-`learn-ukrainian/entire-checkpoints-private`. Public Entire shadow refs,
-transcript or prompt bodies, and AI-generated summaries are forbidden. Entire
-documents redaction as best-effort and states that local shadow refs can contain
-raw working-tree snapshots. The public checkout's `origin` is the public
-product repository, so an explicit private-destination guard is a prerequisite,
-not a follow-up.
+`learn-ukrainian/entire-checkpoints-private`. Public Entire shadow refs and
+public disclosure of transcript, prompt, or generated-summary bodies are
+forbidden. Entire documents redaction as best-effort and states that local
+shadow refs can contain raw working-tree snapshots. The public checkout's
+`origin` is the public product repository, so an explicit private-destination
+guard is a prerequisite, not a follow-up.
 
 ## Decision
 
@@ -70,12 +70,12 @@ its Entire mirror public to other Entire users: the preflight checks the live
 Entire control-plane collaborator list and fails unless only the operator can
 pull either mirror.
 
-After that receipt, the accountable root may use bounded repository-scoped
-search, explain, recap, local dispatch, and explicit handoff for real session
-continuity. Full explain stays within the root's private working context;
-raw-transcript flags remain prohibited. Generated summaries and worktree-
-mutating resume/rewind remain operator-directed. Native Entire remains optional
-and non-authoritative.
+After that receipt, the accountable root automatically runs bounded,
+repository-scoped search and may use explain for real session continuity. Full
+explain stays within the root's private working context; raw-transcript flags
+remain prohibited. Generated recap/dispatch and worktree-mutating
+resume/rewind remain operator-directed. Native Entire remains optional and
+non-authoritative.
 
 ### Authority boundary
 
@@ -135,9 +135,10 @@ The first implementation stores these relationships in an existing
 authoritative receipt path or a rebuildable local projection after a separate
 schema review. It does not invent synthetic Entire sessions. Arbitrary
 metadata-card ingestion into Entire itself is optional and may be added only if
-a 0.8.42 canary proves a supported body-free path. If native session capture
-necessarily stores forbidden transcript or prompt bodies, hooks remain disabled
-and the phase is recorded as blocked by the pinned product capability.
+a 0.8.42 canary proves a documented path. Native session capture stores
+redacted prompt and transcript bodies in the private checkpoint repository;
+that is permitted by the operator amendment and remains isolated from the
+shared automatic corpus.
 
 ### Searchable corpus
 
@@ -212,15 +213,15 @@ plugin could technically be written.
   as native Codex or Claude seats.
 - Entire adds ranked cross-system discovery without becoming another source of
   truth.
-- Every context byte injected into an agent still comes from a canonical local
+- Every shared or published context byte still comes from a canonical local
   system and carries a verifiable locator.
 
 **Negative / risks**:
 
-- Metadata-only search has intentionally narrower semantic value than indexing
-  transcripts; the no-body policy is a real product limitation.
-- Search that requires Entire login introduces a cloud-egress decision and may
-  remain disabled.
+- Native semantic search and full explain increase the private egress and
+  access-control surface; the live preflight must remain green before use.
+- Provider indexing can return empty or delayed results even when local
+  checkpoint explain works, so native search remains optional.
 - Context-link reconciliation and digest verification add a new projection to
   operate and test.
 - The feature is useful only where the agent or its accountable harness can
@@ -261,8 +262,8 @@ The decision is successful only if staged canaries prove all of the following:
 
 - every push-capable Entire operation targets the approved private repository;
 - product repositories retain zero public Entire shadow refs;
-- checkpoint samples contain zero forbidden bodies, prompts, summaries, or
-  secrets;
+- checkpoint samples stay only in the approved private repository and contain
+  no unredacted secrets;
 - duplicate and retry paths create one context link;
 - an Entire outage leaves canonical workflow outputs byte-for-byte unchanged;
 - every hydrated item resolves and matches its canonical digest;

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -26,8 +26,8 @@ Do not run `entire agent add codex`, `entire agent add claude-code`, or
 JSON installers drop project timeout/status metadata, while its stock OpenCode
 plugin requires the tracked `entire-exit.ts` termination companion for
 OpenCode 1.17.13. Change the canonical sources
-under `agents_extensions/`, run the project deployment workflow under the
-required rail receipt, and keep the onboarding contract tests green. A separate
+under `agents_extensions/`, run the normal worktree/PR/review deployment
+workflow, and keep the onboarding contract tests green. A separate
 `entire-agent-<harness>` adapter is justified only by a failed source-blind
 native-host canary.
 
@@ -51,11 +51,31 @@ scripts.entire_context`. These commands read local verified projections and
 produce locator cards or bounded capsules; they do not invoke Entire or the
 network.
 
-Native `entire blame --json` is allowed for local attribution. Prompt-bearing
-`entire why`, cloud `entire search`, generated recap, investigate findings, and
-Entire review remain optional manual tools. None automatically enters a canonical
-capsule. Entire review is supplemental and never satisfies the Fleet
-formal-review gate.
+The operator-authorized private mode is declared in
+`.entire/private-recall.json`. Before a prompt-bearing native operation,
+`.venv/bin/python -m scripts.entire.private_mode_preflight` proves the GitHub
+repository is private, the public origin has zero Entire branches, the private
+checkpoint ref exists, authentication works, both mirrors are ready and expose
+an operator-only Entire ACL, and the CLI remains pinned. The public GitHub
+source remains public, but its Entire mirror is not pullable by other Entire
+users. A green receipt permits repository-scoped native search,
+metadata or task-required full explain, static recap, and local
+dispatch/handoff. The accountable root may consume results in its private task
+context. They never automatically enter a shared capsule or public GitHub
+evidence, and external disclosure requires operator review. Entire review is
+supplemental and never satisfies the Fleet formal-review gate.
+
+The 2026-08-02 source-blind canary proved: authenticated Entire activity saw
+eight checkpoints across the public/private source repositories; the public
+branch listed three checkpoints; exact checkpoint explain returned a
+metadata-only JSON envelope; and static recap returned non-empty output without
+printing its body. Source-scoped cloud checkpoint search was reachable but
+returned zero checkpoint/session matches, while cloud dispatch was unavailable
+(source-repository 404 followed by private-target rate limiting). Local native
+full explain is now proved readable without emitting its body, so exact private
+session continuity does not depend on cloud search quality. Empty cloud search
+and provider rate limits remain truthful optional-provider states, not
+canonical workflow failures.
 
 The typed local resolver inventory is deliberately narrow: an open GitHub issue
 must have exactly one fresh issue-stream membership; a GitHub PR needs a

--- a/docs/entire/PUBLIC-SOURCE-PILOT.md
+++ b/docs/entire/PUBLIC-SOURCE-PILOT.md
@@ -52,16 +52,17 @@ produce locator cards or bounded capsules; they do not invoke Entire or the
 network.
 
 The operator-authorized private mode is declared in
-`.entire/private-recall.json`. Before a prompt-bearing native operation,
+`.entire/private-recall.json`. At non-trivial task intake and before a
+prompt-bearing native operation,
 `.venv/bin/python -m scripts.entire.private_mode_preflight` proves the GitHub
 repository is private, the public origin has zero Entire branches, the private
 checkpoint ref exists, authentication works, both mirrors are ready and expose
 an operator-only Entire ACL, and the CLI remains pinned. The public GitHub
 source remains public, but its Entire mirror is not pullable by other Entire
-users. A green receipt permits repository-scoped native search,
-metadata or task-required full explain, static recap, and local
-dispatch/handoff. The accountable root may consume results in its private task
-context. They never automatically enter a shared capsule or public GitHub
+users. A green receipt enables automatic repository-scoped native search and
+metadata or task-required full explain in the accountable root's private task
+context. Static recap and local dispatch/handoff remain operator-requested.
+Native results never automatically enter a shared capsule or public GitHub
 evidence, and external disclosure requires operator review. Entire review is
 supplemental and never satisfies the Fleet formal-review gate.
 

--- a/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
+++ b/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
@@ -98,13 +98,13 @@ flowchart LR
     Canonical -->|"canonical bytes + digest"| Resolver
     Resolver -->|"verified excerpts only"| Capsule
     Capsule --> Agent
-    Entire -.->|"manual operator investigation only"| Agent
+    Entire -.->|"preflight-gated private recall"| Agent
 ```
 
 The local projection ranks possible history. The resolver decides whether a
 result is safe and true. Canonical systems provide every byte that enters the
-LLM's automatic context. Optional Entire product output stays outside that
-automatic path.
+shared automatic context. Preflight-gated Entire product output may enter the
+accountable root's private context but stays outside shared capsules.
 
 ## Search corpus and context-link contract
 
@@ -254,13 +254,13 @@ Initial workflows:
 - `review-with-intent`: supply verified context to the reviewer without
   changing the formal-review gate.
 
-Local body-free search is implemented. Logged-in cloud Entire search remains a
-manual operator investigation tool and is never invoked by the public skill.
-Its results do not enter automatic capsules.
+Local body-free search and preflight-gated private Entire search are
+implemented. Native results may enter the accountable root's private context
+but do not enter automatic shared capsules or public evidence by default.
 
 Exit gate:
 
-- zero transcript bytes in command output consumed by the workflow;
+- zero transcript bytes in the shared automatic workflow;
 - hard query/result/context size caps;
 - every injected excerpt carries canonical namespace, ID, and digest;
 - a judged query set shows recall@10 of at least 0.70 for questions answerable
@@ -327,7 +327,7 @@ if any of the following occurs:
 - a push targets a product or unapproved remote;
 - a public product remote gains an Entire shadow ref;
 - a prompt, transcript, AI-generated summary, secret, or raw private body
-  reaches the checkpoint remote or a search result;
+  reaches a public or unauthorized destination;
 - an Entire failure changes an ACP, Fleet, Monitor, lease, rollover, review, or
   GitHub outcome;
 - hydration injects an unresolved or digest-mismatched item; or

--- a/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
+++ b/docs/plans/2026-08-01-entire-acp-context-layer-rollout.md
@@ -1,10 +1,11 @@
 # Entire 0.8.42 context-layer and ACP integration rollout
 
-**Status:** Plan of record; local body-free context links and recall implemented,
-remaining product/cloud capabilities deferred
+**Status:** Plan of record; local body-free context links and private native
+Entire workflows implemented, with provider search/dispatch canaries tracked
 **Owner:** Infra harness stream, #4707
 **Tracking:** [#6162](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6162),
-[#6183](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6183)
+[#6183](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6183),
+[#6278](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6278)
 **Decision:** [ADR-018](../architecture/adr/adr-018-entire-acp-context-layer.md)
 **Version boundary:** stable Entire CLI 0.8.42 only
 
@@ -43,10 +44,11 @@ journal:
 - [Investigate why code exists](https://docs.entire.io/learn/investigate-why-code-exists)
   describes explain/why/blame/investigate-style provenance work.
 
-These sources establish useful private investigation workflows. They do not
-authorize project automation to send prompts, transcripts, responses, session
-bodies, or generated summaries to an agent. The public workflow therefore
-remains stricter, local, body-free, and independent of logged-in cloud search.
+These sources establish useful private investigation workflows. Automatic
+intake remains stricter, local, body-free, and independent of logged-in cloud
+search. The operator-authorized private mode may give native Entire output to
+the accountable root, but never promotes prompt-bearing output to public or
+distributed evidence without operator review.
 
 ## Installed 0.8.42 capability matrix
 
@@ -63,11 +65,11 @@ claim.
 | Branch checkpoint backend | Existing private pilot | Proven pilot baseline. |
 | Ref-per-checkpoint backend | `configure --checkpoint-backend refs`; official 0.8.42 announcement | Canary for concurrency, routing, cleanup, and leakage before adoption. |
 | Checkpoint metadata | `checkpoint explain --json` promises no transcript bytes in command output | Allowed only after remote-storage inspection; safe output does not prove safe stored bytes. |
-| Full/raw transcript output | `--full`, `--raw-transcript`, `--transcript` | Prohibited in automation. |
-| Search | `checkpoint search --json`; requires Entire login and service | Disabled until egress, retention, result-shape, and privacy approval. |
+| Full/raw transcript output | `--full`, `--raw-transcript`, `--transcript` | Full explain is operator-authorized for exact private continuity; raw transcript flags remain prohibited. |
+| Search | `entire search --json`; requires Entire login and service | Allowed for the exact source repo after the private preflight; output stays in the accountable root's task context. |
 | Attach and resume | `session attach`; `session resume`; private pilot attach retry was idempotent | Recovery use proven; broader use remains canary-gated. |
-| Recap | `recap --static` reports sessions/checkpoints/tokens/files/tools/skills | Disabled until cloud/local behavior and field policy are proved. |
-| Dispatch | `dispatch --local` or server summary | Prohibited because project policy forbids AI-generated session summaries. |
+| Recap | `recap --static` reports sessions/checkpoints/tokens/files/tools/skills | Operator-authorized in private context; external disclosure requires operator review. |
+| Dispatch | `dispatch --local` or server summary | Operator-authorized private handoff; never canonical or formal-review evidence. |
 | Generated explanation | `checkpoint explain --generate` | Prohibited for the same reason. |
 | Labs review/investigate/import/why/blame/experts | Listed by `entire labs`; explicitly experimental | Advisory canaries only; never authoritative. |
 | External-agent plugin | Standalone Kimi Code adapter implemented; no ACP-wide plugin | Use only for the actual standalone `kimi` harness; the general ACP plugin remains deferred. |

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -42,7 +42,7 @@ caps or live modes.
 | **`scripts/delegate.py dispatch`** | Isolated implementation execution in a worktree | Durable fleet authority or formal CF |
 | **Fleet-comms + file handoffs** | Durable coordination and authority today; **file dual-write remains authoritative in every current plane mode** | Competing message buses; silent plane/retention/eligibility flips |
 | **ACPX** | Routine first-choice structured transport for eligible two-seat read-only communication; fleet launchers make `discuss` select it automatically for Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek; not a coordination plane | Persistent sessions, backlog, auto-retries, unrestricted chat, plane flips, review eligibility |
-| **Entire context recall** | Optional, body-free historical discovery and provenance through verified local locator cards | Task state, live discussion, terminal receipts, source code authority, rollover, Monitor state, or formal review |
+| **Entire context recall** | Optional automatic body-free discovery plus preflight-gated private native session search/explain/recap | Task state, live discussion, terminal receipts, source code authority, rollover, Monitor state, or formal review |
 | **Buzz** | **Explicitly deferred** | Anything in this rollout — relay-as-authority conflicts with the current authority model |
 
 ### Entire recall onboarding matrix
@@ -72,8 +72,12 @@ For each non-trivial task, the accountable root performs this contract:
    materially help, create at most one `handoff` capsule (five cards, 8 KiB)
    and give that same capsule to the participants that need it.
 3. Keep raw prompts, transcripts, responses, session bodies, generated recaps,
-   and generated summaries out of automatic context. Do not run cloud Entire
-   commands from the public skill.
+   and generated summaries out of the shared automatic capsule. When richer
+   private history is useful, run
+   `.venv/bin/python -m scripts.entire.private_mode_preflight`; after a green
+   receipt (including operator-only Entire ACLs for both mirrors) the
+   accountable root may use bounded native Entire search/explain without
+   distributing raw bodies to other seats.
 4. Run `record-use` only for locators that were verified and materially
    informed the task. Search delivery alone is not use.
 5. Continue normally when recall is unavailable. Git/GitHub remain
@@ -81,14 +85,19 @@ For each non-trivial task, the accountable root performs this contract:
    discussion and terminal receipts; Monitor for runtime state; rollover for
    continuity; sealed Fleet review for the formal review gate.
 
-The operator may privately use Entire's product workflows for
+After the private preflight passes, the accountable root or operator may use
+Entire's product workflows for
 [skills](https://docs.entire.io/learn/skills),
 [search](https://docs.entire.io/learn/search-past-agent-work),
 [review and recap](https://docs.entire.io/learn/review-and-recap-agent-work), or
 [why/blame/investigation and session handoff](https://docs.entire.io/learn/investigate-why-code-exists).
 These are investigation aids, not fleet evidence. Their prompts, results,
-transcripts, generated explanations, and summaries are not admitted to the
-automatic capsule and do not change task, review, or merge disposition.
+transcripts, generated explanations, and summaries stay in the accountable
+root's private context, are not admitted to the shared automatic capsule, and
+do not change task, review, or merge disposition. Full explain and generated
+summaries require a task that actually needs them; raw-transcript flags remain
+prohibited. Session resume or rewind additionally requires an explicit operator
+request because it mutates a worktree.
 
 ### Human overview pages
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -72,12 +72,11 @@ For each non-trivial task, the accountable root performs this contract:
    materially help, create at most one `handoff` capsule (five cards, 8 KiB)
    and give that same capsule to the participants that need it.
 3. Keep raw prompts, transcripts, responses, session bodies, generated recaps,
-   and generated summaries out of the shared automatic capsule. When richer
-   private history is useful, run
+   and generated summaries out of the shared automatic capsule. At intake run
    `.venv/bin/python -m scripts.entire.private_mode_preflight`; after a green
-   receipt (including operator-only Entire ACLs for both mirrors) the
-   accountable root may use bounded native Entire search/explain without
-   distributing raw bodies to other seats.
+   receipt (including operator-only Entire ACLs for both mirrors), the
+   accountable root runs bounded native Entire search and may explain a
+   relevant checkpoint without distributing raw bodies to other seats.
 4. Run `record-use` only for locators that were verified and materially
    informed the task. Search delivery alone is not use.
 5. Continue normally when recall is unavailable. Git/GitHub remain

--- a/scripts/entire/private_mode_preflight.py
+++ b/scripts/entire/private_mode_preflight.py
@@ -1,0 +1,204 @@
+"""Prove the private Entire boundary before prompt-bearing native recall."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.entire.validate_checkpoint_routing import validate
+except ModuleNotFoundError:  # Direct script execution from the repository root.
+    from validate_checkpoint_routing import validate
+
+PINNED_VERSION = "0.8.42"
+CHECKPOINT_REF = "refs/heads/entire/checkpoints/v1"
+SOURCE_REPOSITORY = "learn-ukrainian/learn-ukrainian.github.io"
+
+Runner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+def _run(command: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _load_json(result: subprocess.CompletedProcess[str]) -> Any:
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError):
+        return None
+
+
+def _invoke(runner: Runner, command: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner(command, cwd)
+    except (OSError, subprocess.SubprocessError):
+        return subprocess.CompletedProcess(list(command), 127, "", "")
+
+
+def preflight(root: Path, *, runner: Runner = _run) -> dict[str, Any]:
+    """Return a body-free receipt; never include command output or local paths."""
+    root = root.resolve()
+    checks: dict[str, bool] = {}
+    issues: list[str] = []
+
+    routing_error = validate(root)
+    checks["routing_allowlist"] = routing_error is None
+    if routing_error is not None:
+        issues.append("routing_allowlist_failed")
+        return {
+            "schema": "entire-private-preflight.v1",
+            "ready": False,
+            "checks": checks,
+            "issues": issues,
+        }
+
+    settings = json.loads((root / ".entire/settings.json").read_text(encoding="utf-8"))
+    policy = json.loads((root / ".entire/private-recall.json").read_text(encoding="utf-8"))
+    checkpoint_repo = settings["strategy_options"]["checkpoint_remote"]["repo"]
+    expected_principals = policy["entire_access_principals"]
+
+    version = _invoke(runner, ("entire", "version"), root)
+    checks["pinned_cli"] = version.returncode == 0 and f"Entire CLI {PINNED_VERSION}" in version.stdout
+
+    private_repo = _load_json(
+        _invoke(
+            runner,
+            (
+                "gh",
+                "repo",
+                "view",
+                checkpoint_repo,
+                "--json",
+                "isPrivate,visibility",
+            ),
+            root,
+        )
+    )
+    checks["checkpoint_repository_private"] = bool(
+        isinstance(private_repo, dict)
+        and private_repo.get("isPrivate") is True
+        and private_repo.get("visibility") == "PRIVATE"
+    )
+
+    public_refs = _invoke(runner, ("git", "ls-remote", "--heads", "origin", "entire/*"), root)
+    checks["public_origin_clean"] = public_refs.returncode == 0 and not public_refs.stdout.strip()
+
+    private_refs = _invoke(
+        runner,
+        (
+            "git",
+            "ls-remote",
+            "--heads",
+            f"https://github.com/{checkpoint_repo}.git",
+            "entire/*",
+        ),
+        root,
+    )
+    private_ref_names = {line.split("\t", 1)[1] for line in private_refs.stdout.splitlines() if "\t" in line}
+    checks["private_checkpoint_ref"] = private_refs.returncode == 0 and CHECKPOINT_REF in private_ref_names
+
+    auth = _invoke(runner, ("entire", "auth", "status"), root)
+    checks["entire_authenticated"] = auth.returncode == 0
+
+    mirrors = _load_json(
+        _invoke(
+            runner,
+            (
+                "entire",
+                "repo",
+                "mirror",
+                "list",
+                "--name",
+                "learn-ukrainian",
+                "--json",
+            ),
+            root,
+        )
+    )
+    mirror_rows = mirrors if isinstance(mirrors, list) else []
+    private_mirror = next(
+        (
+            row
+            for row in mirror_rows
+            if isinstance(row, dict) and f"{row.get('owner')}/{row.get('repo')}" == checkpoint_repo
+        ),
+        None,
+    )
+    source_mirror = next(
+        (
+            row
+            for row in mirror_rows
+            if isinstance(row, dict) and f"{row.get('owner')}/{row.get('repo')}" == SOURCE_REPOSITORY
+        ),
+        None,
+    )
+    checks["private_mirror_ready"] = bool(
+        private_mirror and private_mirror.get("isPrivate") is True and private_mirror.get("status") == "ready"
+    )
+    checks["source_mirror_ready"] = bool(source_mirror and source_mirror.get("status") == "ready")
+
+    def _mirror_principals(repository: str, mirror: dict[str, Any] | None) -> Any:
+        if not mirror or not isinstance(mirror.get("clusterHost"), str):
+            return None
+        return _load_json(
+            _invoke(
+                runner,
+                (
+                    "entire",
+                    "repo",
+                    "mirror",
+                    "collaborators",
+                    "list",
+                    f"github.com/{repository}",
+                    mirror["clusterHost"],
+                    "--json",
+                ),
+                root,
+            )
+        )
+
+    def _normalize_principals(value: Any) -> list[dict[str, Any]] | None:
+        if not isinstance(value, list) or not all(isinstance(row, dict) for row in value):
+            return None
+        return [{"handle": row.get("handle"), "role": row.get("role")} for row in value]
+
+    if checks["private_mirror_ready"]:
+        private_principals = _normalize_principals(_mirror_principals(checkpoint_repo, private_mirror))
+        checks["checkpoint_mirror_access_private"] = private_principals == expected_principals
+    if checks["source_mirror_ready"]:
+        source_principals = _normalize_principals(_mirror_principals(SOURCE_REPOSITORY, source_mirror))
+        checks["source_mirror_access_private"] = source_principals == expected_principals
+
+    issues.extend(f"{name}_failed" for name, passed in checks.items() if not passed)
+    return {
+        "schema": "entire-private-preflight.v1",
+        "ready": not issues,
+        "checks": checks,
+        "issues": issues,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify private Entire routing without reading session bodies.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    receipt = preflight(args.repo_root)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0 if receipt["ready"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/entire/validate_checkpoint_routing.py
+++ b/scripts/entire/validate_checkpoint_routing.py
@@ -1,14 +1,91 @@
-"""Validate that Entire product routing matches the public egress allowlist."""
+"""Validate Entire checkpoint routing and the private native-recall policy."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
+PRIVATE_CHECKPOINT_REPO = "learn-ukrainian/entire-checkpoints-private"
+EXPECTED_PRIVATE_RECALL = {
+    "schema": "entire-private-recall.v1",
+    "enabled": True,
+    "required_cli_version": "0.8.42",
+    "source_repo": "learn-ukrainian/learn-ukrainian.github.io",
+    "checkpoint_repo": PRIVATE_CHECKPOINT_REPO,
+    "entire_access_principals": [{"handle": "github:krisztiankoos", "role": "writer"}],
+    "authoritative": False,
+    "automatic_intake": False,
+    "public_promotion": False,
+    "preflight": ["scripts/entire/private_mode_preflight.py"],
+    "operations": {
+        "search": [
+            "search",
+            "<query>",
+            "--json",
+            "--limit",
+            "<1-10>",
+            "--repo",
+            "learn-ukrainian/learn-ukrainian.github.io",
+        ],
+        "explain_metadata": ["checkpoint", "explain", "<id-or-sha>", "--json"],
+        "explain_full": [
+            "checkpoint",
+            "explain",
+            "<id-or-sha>",
+            "--full",
+            "--no-pager",
+        ],
+        "recap": ["recap", "--static", "<--day|--week|--month|--90>"],
+        "dispatch": ["dispatch", "--local", "--all-branches", "--since", "<window>"],
+        "handoff": ["dispatch", "--local", "--all-branches", "--since", "<window>"],
+        "resume": ["session", "resume", "<branch>"],
+    },
+    "external_disclosure_requires_operator_review": [
+        "search",
+        "explain_full",
+        "recap",
+        "dispatch",
+        "handoff",
+    ],
+    "operator_request_required": [
+        "explain_full",
+        "recap",
+        "dispatch",
+        "handoff",
+        "resume",
+    ],
+    "private_context_operations": [
+        "search",
+        "explain_full",
+        "recap",
+        "dispatch",
+        "handoff",
+    ],
+    "forbidden_flags": [
+        "--all-repos",
+        "--code",
+        "--generate",
+        "--force",
+        "--raw-transcript",
+        "--transcript",
+    ],
+}
+
+
+def _read_object(path: Path) -> dict | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
 
 def validate(root: Path) -> str | None:
-    settings = json.loads((root / ".entire/settings.json").read_text())
-    allowlist = json.loads((root / ".entire/phase05-allowlist.json").read_text())
+    settings = _read_object(root / ".entire/settings.json")
+    allowlist = _read_object(root / ".entire/phase05-allowlist.json")
+    policy = _read_object(root / ".entire/private-recall.json")
+    if settings is None or allowlist is None or policy is None:
+        return "Entire routing configuration must contain valid JSON objects"
     try:
         remote = settings["strategy_options"]["checkpoint_remote"]
         endpoints = allowlist["checkpoint_endpoints"]
@@ -21,6 +98,12 @@ def validate(root: Path) -> str | None:
         return "checkpoint_endpoints must contain exactly one destination"
     if remote.get("repo") != allowed_repo:
         return "checkpoint_remote.repo does not match the egress allowlist"
+    if allowed_repo != PRIVATE_CHECKPOINT_REPO:
+        return "checkpoint destination must be the approved private repository"
+    if policy != EXPECTED_PRIVATE_RECALL:
+        return "private recall policy does not match the canonical private-only contract"
+    if policy["checkpoint_repo"] != allowed_repo:
+        return "private recall policy does not match checkpoint routing"
     return None
 
 

--- a/scripts/entire/validate_checkpoint_routing.py
+++ b/scripts/entire/validate_checkpoint_routing.py
@@ -14,7 +14,7 @@ EXPECTED_PRIVATE_RECALL = {
     "checkpoint_repo": PRIVATE_CHECKPOINT_REPO,
     "entire_access_principals": [{"handle": "github:krisztiankoos", "role": "writer"}],
     "authoritative": False,
-    "automatic_intake": False,
+    "automatic_intake": True,
     "public_promotion": False,
     "preflight": ["scripts/entire/private_mode_preflight.py"],
     "operations": {
@@ -48,7 +48,6 @@ EXPECTED_PRIVATE_RECALL = {
         "handoff",
     ],
     "operator_request_required": [
-        "explain_full",
         "recap",
         "dispatch",
         "handoff",

--- a/tests/test_entire_checkpoint_routing.py
+++ b/tests/test_entire_checkpoint_routing.py
@@ -3,28 +3,30 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scripts.entire.validate_checkpoint_routing import validate
+from scripts.entire.validate_checkpoint_routing import EXPECTED_PRIVATE_RECALL, validate
 
 
 def _write_config(root: Path, *, configured: str, allowed: list[str]) -> None:
     entire = root / ".entire"
     entire.mkdir()
     (entire / "settings.json").write_text(
-        json.dumps(
-            {
-                "strategy_options": {
-                    "checkpoint_remote": {"provider": "github", "repo": configured}
-                }
-            }
-        )
+        json.dumps({"strategy_options": {"checkpoint_remote": {"provider": "github", "repo": configured}}})
     )
     (entire / "phase05-allowlist.json").write_text(
         json.dumps({"checkpoint_endpoints": [{"github_repo": repo} for repo in allowed]})
     )
+    (entire / "private-recall.json").write_text(
+        json.dumps(EXPECTED_PRIVATE_RECALL),
+        encoding="utf-8",
+    )
 
 
 def test_accepts_matching_single_private_destination(tmp_path: Path) -> None:
-    _write_config(tmp_path, configured="org/private", allowed=["org/private"])
+    _write_config(
+        tmp_path,
+        configured="learn-ukrainian/entire-checkpoints-private",
+        allowed=["learn-ukrainian/entire-checkpoints-private"],
+    )
 
     assert validate(tmp_path) is None
 
@@ -36,9 +38,7 @@ def test_live_public_config_is_consistent() -> None:
 def test_rejects_routing_drift(tmp_path: Path) -> None:
     _write_config(tmp_path, configured="org/private", allowed=["org/other"])
 
-    assert validate(tmp_path) == (
-        "checkpoint_remote.repo does not match the egress allowlist"
-    )
+    assert validate(tmp_path) == ("checkpoint_remote.repo does not match the egress allowlist")
 
 
 def test_rejects_multiple_destinations(tmp_path: Path) -> None:
@@ -48,6 +48,4 @@ def test_rejects_multiple_destinations(tmp_path: Path) -> None:
         allowed=["org/private", "org/other"],
     )
 
-    assert validate(tmp_path) == (
-        "checkpoint_endpoints must contain exactly one destination"
-    )
+    assert validate(tmp_path) == ("checkpoint_endpoints must contain exactly one destination")

--- a/tests/test_entire_native_onboarding.py
+++ b/tests/test_entire_native_onboarding.py
@@ -55,13 +55,13 @@ def test_private_native_recall_policy_is_exact_and_non_authoritative() -> None:
 
     assert policy == EXPECTED_PRIVATE_RECALL
     assert validate(ROOT) is None
-    assert policy["automatic_intake"] is False
+    assert policy["automatic_intake"] is True
     assert policy["public_promotion"] is False
     assert policy["authoritative"] is False
     assert "--all-repos" in policy["forbidden_flags"]
     assert policy["operations"]["search"][-1] == ("learn-ukrainian/learn-ukrainian.github.io")
     assert "--full" in policy["operations"]["explain_full"]
-    assert "explain_full" in policy["operator_request_required"]
+    assert "explain_full" not in policy["operator_request_required"]
     assert "--raw-transcript" in policy["forbidden_flags"]
     assert "--transcript" in policy["forbidden_flags"]
 
@@ -97,9 +97,9 @@ def _write_routing_fixture(root: Path, policy: dict) -> None:
     (entire_dir / "private-recall.json").write_text(json.dumps(policy), encoding="utf-8")
 
 
-def test_private_recall_validator_rejects_automatic_intake(tmp_path: Path) -> None:
+def test_private_recall_validator_rejects_disabled_automatic_intake(tmp_path: Path) -> None:
     policy = copy.deepcopy(EXPECTED_PRIVATE_RECALL)
-    policy["automatic_intake"] = True
+    policy["automatic_intake"] = False
     _write_routing_fixture(tmp_path, policy)
 
     assert validate(tmp_path) == ("private recall policy does not match the canonical private-only contract")

--- a/tests/test_entire_native_onboarding.py
+++ b/tests/test_entire_native_onboarding.py
@@ -2,27 +2,27 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import subprocess
 import tomllib
 from pathlib import Path
 
+from scripts.entire.validate_checkpoint_routing import EXPECTED_PRIVATE_RECALL, validate
+
 ROOT = Path(__file__).resolve().parents[1]
 CODEX_HOOKS = ROOT / "agents_extensions" / "codex" / "hooks.json"
 CODEX_CONFIG = ROOT / "agents_extensions" / "codex" / "config.toml"
 CLAUDE_SETTINGS = ROOT / "agents_extensions" / "shared" / "settings.json"
 ENTIRE_SETTINGS = ROOT / ".entire" / "settings.json"
+PRIVATE_RECALL = ROOT / ".entire" / "private-recall.json"
 OPENCODE_PLUGIN = ROOT / ".opencode" / "plugins" / "entire.ts"
 OPENCODE_EXIT_TRAP = ROOT / ".opencode" / "plugins" / "entire-exit.ts"
 
 
 def _hook_commands(payload: dict, event: str) -> list[dict]:
-    return [
-        hook
-        for entry in payload["hooks"][event]
-        for hook in entry.get("hooks", [])
-    ]
+    return [hook for entry in payload["hooks"][event] for hook in entry.get("hooks", [])]
 
 
 def _entire_hooks(payload: dict, harness: str) -> list[dict]:
@@ -50,6 +50,69 @@ def test_entire_settings_are_pinned_private_and_nontelemetric() -> None:
     }
 
 
+def test_private_native_recall_policy_is_exact_and_non_authoritative() -> None:
+    policy = json.loads(PRIVATE_RECALL.read_text(encoding="utf-8"))
+
+    assert policy == EXPECTED_PRIVATE_RECALL
+    assert validate(ROOT) is None
+    assert policy["automatic_intake"] is False
+    assert policy["public_promotion"] is False
+    assert policy["authoritative"] is False
+    assert "--all-repos" in policy["forbidden_flags"]
+    assert policy["operations"]["search"][-1] == ("learn-ukrainian/learn-ukrainian.github.io")
+    assert "--full" in policy["operations"]["explain_full"]
+    assert "explain_full" in policy["operator_request_required"]
+    assert "--raw-transcript" in policy["forbidden_flags"]
+    assert "--transcript" in policy["forbidden_flags"]
+
+
+def _write_routing_fixture(root: Path, policy: dict) -> None:
+    entire_dir = root / ".entire"
+    entire_dir.mkdir()
+    (entire_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "strategy_options": {
+                    "checkpoint_remote": {
+                        "provider": "github",
+                        "repo": "learn-ukrainian/entire-checkpoints-private",
+                    }
+                },
+                "telemetry": False,
+                "external_agents": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (entire_dir / "phase05-allowlist.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "checkpoint_endpoints": [{"github_repo": "learn-ukrainian/entire-checkpoints-private"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (entire_dir / "private-recall.json").write_text(json.dumps(policy), encoding="utf-8")
+
+
+def test_private_recall_validator_rejects_automatic_intake(tmp_path: Path) -> None:
+    policy = copy.deepcopy(EXPECTED_PRIVATE_RECALL)
+    policy["automatic_intake"] = True
+    _write_routing_fixture(tmp_path, policy)
+
+    assert validate(tmp_path) == ("private recall policy does not match the canonical private-only contract")
+
+
+def test_private_recall_validator_rejects_broader_search_scope(tmp_path: Path) -> None:
+    policy = copy.deepcopy(EXPECTED_PRIVATE_RECALL)
+    policy["operations"]["search"][-1] = "*"
+    _write_routing_fixture(tmp_path, policy)
+
+    assert validate(tmp_path) == ("private recall policy does not match the canonical private-only contract")
+
+
 def test_codex_cli_and_desktop_share_four_composed_entire_hooks() -> None:
     hooks = json.loads(CODEX_HOOKS.read_text(encoding="utf-8"))
     config = tomllib.loads(CODEX_CONFIG.read_text(encoding="utf-8"))
@@ -57,19 +120,19 @@ def test_codex_cli_and_desktop_share_four_composed_entire_hooks() -> None:
 
     assert config["features"]["hooks"] is True
     assert len(entire_hooks) == 4
-    assert {
-        command["command"].rsplit(" ", 1)[-1].rstrip("'")
-        for command in entire_hooks
-    } == {"session-start", "post-tool-use", "user-prompt-submit", "stop"}
+    assert {command["command"].rsplit(" ", 1)[-1].rstrip("'") for command in entire_hooks} == {
+        "session-start",
+        "post-tool-use",
+        "user-prompt-submit",
+        "stop",
+    }
     assert all(command["timeout"] == 30 for command in entire_hooks)
     assert all("if ! command -v entire" in command["command"] for command in entire_hooks)
 
     # Existing project hook semantics must survive onboarding unchanged. The
     # stock 0.8.42 installer rewrites these objects and drops this metadata.
     session_setup = next(
-        hook
-        for hook in _hook_commands(hooks, "SessionStart")
-        if "session-setup.sh" in hook["command"]
+        hook for hook in _hook_commands(hooks, "SessionStart") if "session-setup.sh" in hook["command"]
     )
     assert session_setup == {
         "type": "command",
@@ -78,11 +141,7 @@ def test_codex_cli_and_desktop_share_four_composed_entire_hooks() -> None:
         "statusMessage": "Checking learn-ukrainian session state",
         "additionalContextLimit": 1200,
     }
-    policy = next(
-        hook
-        for hook in _hook_commands(hooks, "PreToolUse")
-        if "codex_hook_entry.sh" in hook["command"]
-    )
+    policy = next(hook for hook in _hook_commands(hooks, "PreToolUse") if "codex_hook_entry.sh" in hook["command"])
     assert policy["timeout"] == 45
     assert policy["statusMessage"] == "Running Codex tool policy"
 
@@ -103,15 +162,9 @@ def test_claude_hosted_models_share_seven_composed_claude_code_hooks() -> None:
         if "entire hooks" not in hook["command"]
     }
     assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/session-setup.sh"]["timeout"] == 10
-    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/guard-primary-checkout-write.py"][
-        "timeout"
-    ] == 5
-    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/thread-lease-heartbeat.sh"][
-        "timeout"
-    ] == 3
-    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/release-thread-lease.sh"][
-        "timeout"
-    ] == 5
+    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/guard-primary-checkout-write.py"]["timeout"] == 5
+    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/thread-lease-heartbeat.sh"]["timeout"] == 3
+    assert existing["$CLAUDE_PROJECT_DIR/.claude/hooks/release-thread-lease.sh"]["timeout"] == 5
 
 
 def test_entire_hooks_fail_open_when_cli_is_unavailable() -> None:

--- a/tests/test_entire_private_mode.py
+++ b/tests/test_entire_private_mode.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+from scripts.entire.private_mode_preflight import preflight
+from scripts.entire.validate_checkpoint_routing import EXPECTED_PRIVATE_RECALL
+
+
+def _write_config(root: Path) -> None:
+    entire = root / ".entire"
+    entire.mkdir()
+    (entire / "settings.json").write_text(
+        json.dumps(
+            {
+                "strategy_options": {
+                    "checkpoint_remote": {
+                        "provider": "github",
+                        "repo": "learn-ukrainian/entire-checkpoints-private",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (entire / "phase05-allowlist.json").write_text(
+        json.dumps({"checkpoint_endpoints": [{"github_repo": "learn-ukrainian/entire-checkpoints-private"}]}),
+        encoding="utf-8",
+    )
+    (entire / "private-recall.json").write_text(
+        json.dumps(EXPECTED_PRIVATE_RECALL),
+        encoding="utf-8",
+    )
+
+
+def _completed(command: Sequence[str], stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(list(command), returncode, stdout, "")
+
+
+def _healthy_runner(command: Sequence[str], _cwd: Path):
+    key = tuple(command)
+    if key == ("entire", "version"):
+        return _completed(command, "Entire CLI 0.8.42\n")
+    if key[:4] == ("gh", "repo", "view", "learn-ukrainian/entire-checkpoints-private"):
+        return _completed(command, '{"isPrivate":true,"visibility":"PRIVATE"}\n')
+    if key == ("git", "ls-remote", "--heads", "origin", "entire/*"):
+        return _completed(command)
+    if key[:4] == ("git", "ls-remote", "--heads", "https://github.com/learn-ukrainian/entire-checkpoints-private.git"):
+        return _completed(command, "abc\trefs/heads/entire/checkpoints/v1\n")
+    if key == ("entire", "auth", "status"):
+        return _completed(command, "logged in\n")
+    if key[:5] == ("entire", "repo", "mirror", "list", "--name"):
+        return _completed(
+            command,
+            json.dumps(
+                [
+                    {
+                        "clusterHost": "aws-eu-central-1.entire.io",
+                        "owner": "learn-ukrainian",
+                        "repo": "entire-checkpoints-private",
+                        "isPrivate": True,
+                        "status": "ready",
+                    },
+                    {
+                        "clusterHost": "aws-eu-central-1.entire.io",
+                        "owner": "learn-ukrainian",
+                        "repo": "learn-ukrainian.github.io",
+                        "status": "ready",
+                    },
+                ]
+            ),
+        )
+    if key[:6] == (
+        "entire",
+        "repo",
+        "mirror",
+        "collaborators",
+        "list",
+        "github.com/learn-ukrainian/entire-checkpoints-private",
+    ):
+        return _completed(
+            command,
+            '[{"handle":"github:krisztiankoos","role":"writer"}]',
+        )
+    if key[:6] == (
+        "entire",
+        "repo",
+        "mirror",
+        "collaborators",
+        "list",
+        "github.com/learn-ukrainian/learn-ukrainian.github.io",
+    ):
+        return _completed(
+            command,
+            '[{"handle":"github:krisztiankoos","role":"writer"}]',
+        )
+    raise AssertionError(f"unexpected command: {key}")
+
+
+def test_private_mode_preflight_accepts_the_full_private_boundary(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+
+    receipt = preflight(tmp_path, runner=_healthy_runner)
+
+    assert receipt["ready"] is True
+    assert receipt["issues"] == []
+    assert all(receipt["checks"].values())
+    assert "output" not in json.dumps(receipt)
+
+
+def test_private_mode_preflight_fails_closed_without_private_visibility(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def public_runner(command: Sequence[str], cwd: Path):
+        if tuple(command[:4]) == (
+            "gh",
+            "repo",
+            "view",
+            "learn-ukrainian/entire-checkpoints-private",
+        ):
+            return _completed(command, '{"isPrivate":false,"visibility":"PUBLIC"}\n')
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=public_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["checkpoint_repository_private"] is False
+    assert receipt["issues"] == ["checkpoint_repository_private_failed"]
+
+
+def test_private_mode_preflight_fails_closed_when_public_refs_exist(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def leaked_ref_runner(command: Sequence[str], cwd: Path):
+        if tuple(command) == (
+            "git",
+            "ls-remote",
+            "--heads",
+            "origin",
+            "entire/*",
+        ):
+            return _completed(command, "abc\trefs/heads/entire/checkpoints/v1\n")
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=leaked_ref_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["public_origin_clean"] is False
+    assert receipt["issues"] == ["public_origin_clean_failed"]
+
+
+def test_private_mode_preflight_fails_closed_on_version_drift(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+
+    def drifted_runner(command: Sequence[str], cwd: Path):
+        if tuple(command) == ("entire", "version"):
+            return _completed(command, "Entire CLI 0.9.0\n")
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=drifted_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["pinned_cli"] is False
+    assert receipt["issues"] == ["pinned_cli_failed"]
+
+
+def test_private_mode_preflight_returns_body_free_failure_on_command_timeout(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def timeout_runner(command: Sequence[str], cwd: Path):
+        if tuple(command) == ("entire", "version"):
+            raise subprocess.TimeoutExpired(command, timeout=30)
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=timeout_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["pinned_cli"] is False
+    assert receipt["issues"] == ["pinned_cli_failed"]
+    assert "output" not in json.dumps(receipt)
+
+
+def test_private_mode_preflight_fails_closed_without_checkpoint_ref(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def missing_ref_runner(command: Sequence[str], cwd: Path):
+        if tuple(command[:4]) == (
+            "git",
+            "ls-remote",
+            "--heads",
+            "https://github.com/learn-ukrainian/entire-checkpoints-private.git",
+        ):
+            return _completed(command)
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=missing_ref_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["private_checkpoint_ref"] is False
+    assert receipt["issues"] == ["private_checkpoint_ref_failed"]
+
+
+def test_private_mode_preflight_fails_closed_without_entire_auth(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+
+    def unauthenticated_runner(command: Sequence[str], cwd: Path):
+        if tuple(command) == ("entire", "auth", "status"):
+            return _completed(command, returncode=1)
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=unauthenticated_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["entire_authenticated"] is False
+    assert receipt["issues"] == ["entire_authenticated_failed"]
+
+
+def test_private_mode_preflight_fails_closed_without_ready_mirror(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def syncing_mirror_runner(command: Sequence[str], cwd: Path):
+        if tuple(command[:5]) == ("entire", "repo", "mirror", "list", "--name"):
+            return _completed(
+                command,
+                json.dumps(
+                    [
+                        {
+                            "clusterHost": "aws-eu-central-1.entire.io",
+                            "owner": "learn-ukrainian",
+                            "repo": "entire-checkpoints-private",
+                            "isPrivate": True,
+                            "status": "syncing",
+                        },
+                        {
+                            "clusterHost": "aws-eu-central-1.entire.io",
+                            "owner": "learn-ukrainian",
+                            "repo": "learn-ukrainian.github.io",
+                            "status": "ready",
+                        },
+                    ]
+                ),
+            )
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=syncing_mirror_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["private_mirror_ready"] is False
+    assert receipt["issues"] == ["private_mirror_ready_failed"]
+
+
+def test_private_mode_preflight_rejects_extra_source_mirror_access(
+    tmp_path: Path,
+) -> None:
+    _write_config(tmp_path)
+
+    def extra_collaborator_runner(command: Sequence[str], cwd: Path):
+        if tuple(command[:6]) == (
+            "entire",
+            "repo",
+            "mirror",
+            "collaborators",
+            "list",
+            "github.com/learn-ukrainian/learn-ukrainian.github.io",
+        ):
+            return _completed(
+                command,
+                json.dumps(
+                    [
+                        {"handle": "github:krisztiankoos", "role": "writer"},
+                        {"handle": "github:unexpected", "role": "reader"},
+                    ]
+                ),
+            )
+        return _healthy_runner(command, cwd)
+
+    receipt = preflight(tmp_path, runner=extra_collaborator_runner)
+
+    assert receipt["ready"] is False
+    assert receipt["checks"]["source_mirror_access_private"] is False
+    assert receipt["issues"] == ["source_mirror_access_private_failed"]


### PR DESCRIPTION
## Summary

- automatically run repository-scoped native Entire recall for non-trivial task intake after a live private-boundary preflight
- require CLI 0.8.42, private checkpoint routing/ref, zero public Entire refs, authentication, ready mirrors, and operator-only Entire ACLs on both mirrors
- allow task-relevant full explain in the accountable root private context while keeping shared capsules and public evidence body-free
- keep recap/dispatch and worktree-mutating resume/rewind explicitly operator-requested

## Verification

- 187 focused tests passed
- Ruff passed on changed Python
- markdownlint passed on all five changed Markdown/skill files
- staged OPSEC and X-Agent trailer checks passed
- live private preflight passed all 10 checks
- repository-scoped native search executed without emitting content
- local full checkpoint retrieval was previously proven readable without emitting its body

## Provider truth

- the public GitHub source remains public, but the Entire control plane exposes both mirrors only to `github:krisztiankoos`
- source-scoped cloud search is reachable but currently returns zero indexed results
- provider failure falls back to local body-free recall and cannot change canonical task disposition

## Review

- sealed cross-family review: APPROVED by `gemini-3.6-flash-high` at exact head `91a10dd37e`
- review receipt: https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6279#issuecomment-5158957863
- Claude Sonnet 5 was selected first but its ACP transport failed before verdict (`max-turns=1`); no failed result was counted as review

Refs #6278