### PR TITLE
docs(agents): dual-write epic handoffs to entire-context

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -182,6 +182,37 @@ End the session on your seat's handoff signal (canary FAIL-HANDOFF for grok/gemi
 the SessionStart / thread-handoff for Claude/Sonnet), not on a compact count. Keep the
 file handoff current — it stays authoritative through every plane mode (below).
 
+**Entire dual-write (Option A — operator GO 2026-08-02; file remains SSOT):** on every
+session handoff, also project public continuity into entire-context. This is
+**supplemental** (ADR-018): body-free locators only; never store residual narratives,
+task ids, or OPSEC-sensitive prose only in Entire; never treat Entire as handoff
+authority or retire the file on your own.
+
+```bash
+# 1) Index merge SHAs from this drive (idempotent)
+.venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha>   # repeat per merge
+
+# 2) Body-free capsule (≤5 items); optional: pass --locator-id clink_… from bootstrap
+.venv/bin/python -m scripts.entire_context handoff --query "<epic keywords>" \
+  | tee "${SESSION_HANDOFF_DIR:-.claude}/${SESSION_EPIC:-epic}-epic/entire-handoff-capsule.json"
+
+# 3) Attest consumption when locators informed the handoff
+.venv/bin/python -m scripts.entire_context record-use \
+  --task-id <epic-or-stream-id> --consumer <harness> --purpose handoff \
+  --locator-id clink_…   # repeat up to the locators used
+
+# 4) Fleet receipt: issue/PR numbers only (no residual tables, no secrets)
+.venv/bin/python -m scripts.fleet_comms channel publish <stream-channel> \
+  "handoff dual-write: file=SSOT entire=capsule. Next issues #… Merged PRs #…" \
+  --sender "$SESSION_HANDOFF_AGENT" --source <harness> --kind state \
+  --idempotency-key "handoff-<epic>-<date>"
+```
+
+**Cold-start companion (not a substitute for the file):** after §0 orient,
+`status` + `search --query "<epic keywords>"` (and optional `handoff --query`) so
+promoted SHAs surface before dispatch. Empty results mean “nothing indexed for that
+needle,” not “no work” — fall through to GH issues + file handoff.
+
 ### 8a. Required live-driver inbox drain — before handoff
 Immediately before writing or signalling handoff, make one final live-loop drain. Read
 and apply every `unread` or `read-but-not-live-consumed` entry, then run:
@@ -191,6 +222,7 @@ and apply every `unread` or `read-but-not-live-consumed` entry, then run:
 ```
 Record any action or unresolved request in the authoritative file handoff after this
 drain; never claim the handoff is complete because a one-shot worker acknowledged it.
+Then run the Entire dual-write steps in §8.
 
 ---
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -182,19 +182,34 @@ End the session on your seat's handoff signal (canary FAIL-HANDOFF for grok/gemi
 the SessionStart / thread-handoff for Claude/Sonnet), not on a compact count. Keep the
 file handoff current — it stays authoritative through every plane mode (below).
 
+**Skill source of truth is git, not deploy trees.** Edit only
+`agents_extensions/shared/skills/drive-epic/SKILL.md` (this file). Never implement or
+“fix” process in `.claude/skills/` or other deploy-rsync targets — those copies are
+overwritten on the next agents_extensions deploy and are not durable.
+
 **Entire dual-write (Option A — operator GO 2026-08-02; file remains SSOT):** on every
 session handoff, also project public continuity into entire-context. This is
 **supplemental** (ADR-018): body-free locators only; never store residual narratives,
 task ids, or OPSEC-sensitive prose only in Entire; never treat Entire as handoff
 authority or retire the file on your own.
 
+Durable sinks for the dual-write (not private deploy trees):
+
+| Sink | What to write | Survives |
+| --- | --- | --- |
+| **File handoff** (local operational SSOT; gitignored `.claude/<epic>-epic/*` or `docs/session-state/` when the epic uses a tracked pointer) | Next queue, residual narrative | Local session / tracked pointer as applicable |
+| **entire-context projection** (`batch_state/entire-context/…` via CLI) | `bootstrap-git` + capsule via `handoff` + `record-use` | Rebuildable local projection |
+| **Fleet-comms channel** | Issue/PR numbers only | Plane authority |
+| **GitHub issues** | Residual / next work | Public queue SSOT |
+
 ```bash
-# 1) Index merge SHAs from this drive (idempotent)
+# 1) Index merge SHAs from this drive (idempotent) — writes the local projection
 .venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha>   # repeat per merge
 
-# 2) Body-free capsule (≤5 items); optional: pass --locator-id clink_… from bootstrap
-.venv/bin/python -m scripts.entire_context handoff --query "<epic keywords>" \
-  | tee "${SESSION_HANDOFF_DIR:-.claude}/${SESSION_EPIC:-epic}-epic/entire-handoff-capsule.json"
+# 2) Body-free capsule to stdout (≤5 items). Optional: --locator-id clink_… from bootstrap.
+#    Do NOT treat a tee into .claude/ as durable process storage (deploy-wiped).
+#    Optional scratch only: batch_state/ (gitignored runtime), never skills trees.
+.venv/bin/python -m scripts.entire_context handoff --query "<epic keywords>"
 
 # 3) Attest consumption when locators informed the handoff
 .venv/bin/python -m scripts.entire_context record-use \

--- a/docs/runbooks/entire-context-handoff-dualwrite.md
+++ b/docs/runbooks/entire-context-handoff-dualwrite.md
@@ -1,0 +1,55 @@
+# Entire-context handoff dual-write (Option A)
+
+**Status:** operator GO 2026-08-02 · **Authority:** file handoff remains SSOT  
+**Skill (git SSOT):** `agents_extensions/shared/skills/drive-epic/SKILL.md` §8  
+**Not durable:** `.claude/skills/**` deploy copies (rsync overwrite on agents deploy)
+
+## Purpose
+
+Epic drivers dual-write **public continuity** into entire-context while keeping the
+local operational handoff file as seat SSOT. Entire does **not** replace GitHub,
+fleet-comms, or file handoffs (ADR-018).
+
+## Durable sinks
+
+| Sink | Content |
+| --- | --- |
+| File handoff (local gitignored operational) | Residual narrative, next queue |
+| `python -m scripts.entire_context` projection | `bootstrap-git`, `handoff` capsule (stdout), `record-use` |
+| Fleet-comms channel | Issue/PR numbers only |
+| GitHub issues | Product residual / next work |
+
+Do **not** tee capsules into `.claude/` as process storage. Optional scratch only under
+`batch_state/` (runtime, gitignored).
+
+## Commands (end of session)
+
+```bash
+.venv/bin/python -m scripts.entire_context bootstrap-git <40-hex-sha>   # per merge
+.venv/bin/python -m scripts.entire_context handoff --query "<epic keywords>"
+.venv/bin/python -m scripts.entire_context record-use \
+  --task-id <epic-or-stream-id> --consumer <harness> --purpose handoff \
+  --locator-id clink_…
+.venv/bin/python -m scripts.fleet_comms channel publish <stream-channel> \
+  "handoff dual-write: … Next issues #… Merged PRs #…" \
+  --sender "$SESSION_HANDOFF_AGENT" --source <harness> --kind state \
+  --idempotency-key "handoff-<epic>-<date>"
+```
+
+## Cold start
+
+```bash
+.venv/bin/python -m scripts.entire_context status
+.venv/bin/python -m scripts.entire_context search --query "<epic keywords>"
+```
+
+Empty search = nothing indexed for that needle — fall through to GH + file handoff.
+Query ranking is a single substring (prefer path tokens / SHAs, not full sentences).
+
+## Atlas snapshot (2026-08-02, tool-backed)
+
+Merged: #6267 · #6265 · #6270. Closed: #6135 · #6259 · #6269.  
+Measure after hydrate: missing_curated_keys=0, missing_practice_indexes=0, B=5093.  
+Next: #6188 · #6137–#6139 · #6143.
+
+X-Agent: grok/handoff-entire-dualwrite


### PR DESCRIPTION
## Summary
Implements **Option A** dual-write handoff for epic drivers (operator GO 2026-08-02):

- **File handoff remains SSOT** (no Entire authority cutover; ADR-018 intact)
- On every §8 handoff, also: `bootstrap-git` merge SHAs → `entire_context handoff` capsule → `record-use` → fleet-comms receipt with **issue/PR numbers only**
- Cold-start companion: `status` + `search` after orient

## Out of scope
- Retiring local handoff files
- Storing residual narratives / task ids in Entire
- Plane mode changes

## Verification
- Skill text only; no runtime code change
- Live dual-write already exercised on atlas drive (`record-use` consumer grok, capsule under `.claude/atlas-epic/`)

X-Agent: grok/handoff-entire-dualwrite