### PR TITLE
docs(agents): document entire handoff needle rules

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -224,9 +224,12 @@ Durable sinks for the dual-write (not private deploy trees):
 ```
 
 **Cold-start companion (not a substitute for the file):** after §0 orient,
-`status` + `search --query "<epic keywords>"` (and optional `handoff --query`) so
-promoted SHAs surface before dispatch. Empty results mean “nothing indexed for that
-needle,” not “no work” — fall through to GH issues + file handoff.
+`status` + `search --query "<path-or-sha-needle>"` (and optional `handoff --query`)
+so promoted SHAs surface before dispatch. Ranking is **one substring** (prefer path
+tokens like `practice` or a full SHA — not multi-word sentences). Empty search =
+nothing indexed for that needle; `handoff --query` with zero hits may return
+`seed_invalid` — use `--locator-id` from bootstrap/search instead. Fall through to
+GH issues + file handoff.
 
 ### 8a. Required live-driver inbox drain — before handoff
 Immediately before writing or signalling handoff, make one final live-loop drain. Read

--- a/docs/runbooks/entire-context-handoff-dualwrite.md
+++ b/docs/runbooks/entire-context-handoff-dualwrite.md
@@ -44,7 +44,16 @@ Do **not** tee capsules into `.claude/` as process storage. Optional scratch onl
 ```
 
 Empty search = nothing indexed for that needle — fall through to GH + file handoff.
-Query ranking is a single substring (prefer path tokens / SHAs, not full sentences).
+
+**Needle rules (tool-proved):** ranking treats the query as **one substring**, not
+tokenized English. Prefer path fragments / SHAs (`practice`, `generate_practice`,
+full 40-hex). Multi-word phrases like `practice membership` often score 0.
+
+- `search --query "practice"` → hits when paths contain `practice`
+- `handoff --query "practice"` → capsule when ≥1 scored hit
+- `handoff --query "practice membership"` → can return `{"error":"seed_invalid"}`
+  when the full phrase matches nothing — then pass `--locator-id clink_…` from
+  `bootstrap-git` / `search` instead
 
 ## Atlas snapshot (2026-08-02, tool-backed)
 


### PR DESCRIPTION
## Summary
Tool-proved during dual-write handoff test:

- `handoff --query "practice"` works
- `handoff --query "practice membership"` → `seed_invalid` (full phrase scores 0)

Documents needle rules in git SSOT skill + runbook (not deploy trees).

X-Agent: grok/handoff-needle-note