### PR TITLE
fix(fleet): close driver leases on termination

### DIFF
--- a/scripts/launchers/claude.sh
+++ b/scripts/launchers/claude.sh
@@ -31,5 +31,5 @@ launcher_adapter_exec() {
   local cmd=(claude --model "$LC_MODEL")
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
-  exec "${cmd[@]}"
+  launcher_exec_command "${cmd[@]}"
 }

--- a/scripts/launchers/codex.sh
+++ b/scripts/launchers/codex.sh
@@ -159,5 +159,5 @@ launcher_adapter_exec() {
   fi
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
-  exec "${cmd[@]}"
+  launcher_exec_command "${cmd[@]}"
 }

--- a/scripts/launchers/gemini.sh
+++ b/scripts/launchers/gemini.sh
@@ -10,5 +10,5 @@ launcher_adapter_exec() {
   local cmd=(agy --model "$LC_MODEL")
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
-  exec "${cmd[@]}"
+  launcher_exec_command "${cmd[@]}"
 }

--- a/scripts/launchers/grok.sh
+++ b/scripts/launchers/grok.sh
@@ -10,5 +10,5 @@ launcher_adapter_exec() {
   local cmd=(grok --model "$LC_MODEL")
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
-  exec "${cmd[@]}"
+  launcher_exec_command "${cmd[@]}"
 }

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -362,14 +362,89 @@ launcher_claim_driver_lease() {
   claim_session_supervisor_env "$stream" "$LC_PROVIDER" "$LC_DRIVER_HARNESS" "$task_id" "$instance_id" "$LC_SESSION_ROOT" "start-${LC_PROVIDER}-driver.sh" "$LC_EPIC"
 }
 
+launcher_close_driver_lease() {
+  # Close only the exact exported, fenced lease. The store operation is
+  # idempotent, so a bounded retry is safe when the first client invocation is
+  # interrupted after the transaction commits but before it returns.
+  [ "${LC_DRIVER_LEASE_CLOSED:-0}" = "1" ] && return 0
+
+  local attempt
+  for attempt in 1 2; do
+    if "$LC_SESSION_ROOT/.venv/bin/python" \
+        -m agents_extensions.shared.session_streams hook close >/dev/null 2>&1; then
+      LC_DRIVER_LEASE_CLOSED=1
+      return 0
+    fi
+    if [ "$attempt" -eq 1 ]; then
+      continue
+    else
+      break
+    fi
+  done
+  launcher_error "failed to close the exact ${LC_PROVIDER} driver lease after two attempts."
+  return 1
+}
+
 launcher_close_failed_driver_lease() {
   # A provider canary runs after the lease claim. Close the exact exported
   # session-stream envelope before refusing the launch, so another certified
   # driver is not blocked behind this failed cold start until its TTL expires.
-  if ! "$LC_SESSION_ROOT/.venv/bin/python" \
-      -m agents_extensions.shared.session_streams hook close >/dev/null 2>&1; then
-    launcher_error "failed to close the ${LC_PROVIDER} driver lease after provider canary failure."
+  launcher_close_driver_lease || true
+}
+
+launcher_forward_driver_signal() {
+  local signal="$1"
+  local exit_code="$2"
+  trap - "$signal"
+  if [ -n "${LC_DRIVER_CHILD_PID:-}" ] && kill -0 "$LC_DRIVER_CHILD_PID" 2>/dev/null; then
+    kill -s "$signal" "$LC_DRIVER_CHILD_PID" 2>/dev/null || true
+    wait "$LC_DRIVER_CHILD_PID" 2>/dev/null || true
   fi
+  LC_DRIVER_CHILD_PID=""
+  launcher_close_driver_lease || true
+  trap - EXIT INT TERM HUP
+  exit "$exit_code"
+}
+
+launcher_exec_command() {
+  # Interactive sessions retain the direct exec contract. A lease-owning
+  # driver keeps this small supervisor shell alive so normal exit and
+  # termination signals can atomically close the exact fenced session.
+  if [ "$LC_MODE" != "driver" ] || [ "${LC_DRIVER_LEASE_ENABLED:-1}" != "1" ]; then
+    exec "$@"
+  fi
+
+  local provider_rc=0
+  local close_rc=0
+  LC_DRIVER_CHILD_PID=""
+  LC_DRIVER_LEASE_CLOSED=0
+  trap 'launcher_close_driver_lease || true' EXIT
+  trap 'launcher_forward_driver_signal INT 130' INT
+  trap 'launcher_forward_driver_signal TERM 143' TERM
+  trap 'launcher_forward_driver_signal HUP 129' HUP
+
+  # Explicitly duplicate stdin: Bash otherwise redirects asynchronous commands
+  # from /dev/null when job control is disabled, which would break TUIs. Reset
+  # the background subshell's inherited signal dispositions before exec so
+  # forwarded INT/TERM/HUP reach the provider rather than being ignored.
+  (
+    trap - INT TERM HUP
+    exec "$@"
+  ) 0<&0 &
+  LC_DRIVER_CHILD_PID=$!
+  if wait "$LC_DRIVER_CHILD_PID"; then
+    provider_rc=0
+  else
+    provider_rc=$?
+  fi
+  LC_DRIVER_CHILD_PID=""
+  launcher_close_driver_lease || close_rc=$?
+  trap - EXIT INT TERM HUP
+
+  if [ "$close_rc" -ne 0 ] && [ "$provider_rc" -eq 0 ]; then
+    return "$close_rc"
+  fi
+  return "$provider_rc"
 }
 
 launcher_bind_drive_epic() {

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -164,6 +164,7 @@ launcher_defaults() {
   LC_DRY_RUN="${LAUNCHER_DRY_RUN:-0}"
   LC_EPIC=""
   LC_GOVERNOR="0"
+  LC_DRIVER_LEASE_CLAIMED=0
   LC_FORWARD_ARGS=()
 }
 
@@ -360,6 +361,7 @@ launcher_claim_driver_lease() {
   task_id="${SESSION_TASK_ID:-launcher-${LC_PROVIDER}-driver}"
   instance_id="${SESSION_INSTANCE_ID:-${LC_PROVIDER}-$$}"
   claim_session_supervisor_env "$stream" "$LC_PROVIDER" "$LC_DRIVER_HARNESS" "$task_id" "$instance_id" "$LC_SESSION_ROOT" "start-${LC_PROVIDER}-driver.sh" "$LC_EPIC"
+  LC_DRIVER_LEASE_CLAIMED=1
 }
 
 launcher_close_driver_lease() {
@@ -410,7 +412,9 @@ launcher_exec_command() {
   # Interactive sessions retain the direct exec contract. A lease-owning
   # driver keeps this small supervisor shell alive so normal exit and
   # termination signals can atomically close the exact fenced session.
-  if [ "$LC_MODE" != "driver" ] || [ "${LC_DRIVER_LEASE_ENABLED:-1}" != "1" ]; then
+  if [ "$LC_MODE" != "driver" ] \
+      || [ "${LC_DRIVER_LEASE_ENABLED:-1}" != "1" ] \
+      || [ "${LC_DRIVER_LEASE_CLAIMED:-0}" != "1" ]; then
     exec "$@"
   fi
 

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -1180,7 +1180,8 @@ def test_real_cross_family_driver_launchers_refuse_before_second_provider_execut
         SessionStreamDatabase(primary / ".agent/session-streams/v1/session-streams.sqlite3")
     ).dump_stream("epic:5703")
     assert len(stream["sessions"]) == 1
-    assert stream["sessions"][0]["state"] == "open"
+    assert stream["sessions"][0]["state"] == "closed"
+    assert stream["lease"]["state"] == "released"
     assert stream["lease"]["holder_agent"] == first_provider
 
 
@@ -1200,9 +1201,10 @@ def test_real_grok_driver_recovers_dead_unexpired_holder_via_session_supervisor(
     assert launched.returncode == 0, launched.stderr + launched.stdout
     assert started["grok"].exists()
     stream = store.dump_stream("epic:5703")
-    assert sorted(session["state"] for session in stream["sessions"]) == ["closed", "open"]
+    assert [session["state"] for session in stream["sessions"]] == ["closed", "closed"]
     assert stream["lease"]["generation"] == 2
     assert stream["lease"]["holder_agent"] == "grok"
+    assert stream["lease"]["state"] == "released"
 
 
 def test_real_grok_driver_refuses_expired_app_thread_holder_before_provider_executes(
@@ -1274,5 +1276,6 @@ def test_real_grok_driver_launches_single_holder(tmp_path: Path) -> None:
     stream = SessionStreamStore(
         SessionStreamDatabase(primary / ".agent/session-streams/v1/session-streams.sqlite3")
     ).dump_stream("epic:5703")
-    assert [session["state"] for session in stream["sessions"]] == ["open"]
+    assert [session["state"] for session in stream["sessions"]] == ["closed"]
     assert stream["lease"]["holder_agent"] == "grok"
+    assert stream["lease"]["state"] == "released"

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
+import time
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import LeaseHolder, utc_now
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+from scripts.session_supervisor import LaunchRole, SessionSupervisor
 
 REPO = Path(__file__).resolve().parents[1]
 PUBLIC = (
@@ -211,6 +219,253 @@ def test_canary_failure_closes_lease_and_refuses_driver_launch(tmp_path: Path) -
     # absent and recreates the six-hour lease leak for every provider driver.
     assert close_marker.is_file()
     assert "PROVIDER_EXEC" not in result.stdout
+
+
+def _core_driver_exit_fixture(
+    tmp_path: Path,
+    *,
+    provider_body: str,
+    failed_close_attempts: int = 0,
+) -> tuple[Path, Path, Path, Path]:
+    """Build a provider-neutral driver with observable close attempts."""
+    root = tmp_path / "repo"
+    for relative in (
+        "start-claude-driver.sh",
+        "scripts/lib/handoff_identity.sh",
+        "scripts/lib/launcher_core.sh",
+        "scripts/lib/session_supervisor.sh",
+        "scripts/lib/deploy_extensions.sh",
+    ):
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO / relative, destination)
+
+    close_attempts = tmp_path / "close-attempts"
+    close_marker = tmp_path / "lease-closed"
+    child_started = tmp_path / "child-started"
+    python_stub = root / ".venv" / "bin" / "python"
+    python_stub.parent.mkdir(parents=True)
+    python_stub.write_text(
+        f'''#!/usr/bin/env bash
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" ]]; then
+  cat <<'JSON'
+{{"identity":{{"lease":{{"session_id":"session-test","lease_id":"lease-test","generation":1,"fencing_token":1,"expires_at":"2026-07-23T00:00:00Z"}}}}}}
+JSON
+  exit 0
+fi
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "agents_extensions.shared.session_streams" ]]; then
+  count=0
+  if [[ -f {os.fspath(close_attempts)!r} ]]; then count="$(< {os.fspath(close_attempts)!r})"; fi
+  count=$((count + 1))
+  printf '%s\n' "$count" > {os.fspath(close_attempts)!r}
+  if [[ "$count" -le {failed_close_attempts} ]]; then exit 1; fi
+  touch {os.fspath(close_marker)!r}
+  exit 0
+fi
+exec {os.fspath(REPO / ".venv" / "bin" / "python")!r} "$@"
+''',
+        encoding="utf-8",
+    )
+    python_stub.chmod(0o755)
+
+    provider = root / "provider.sh"
+    provider.write_text(
+        f"#!/usr/bin/env bash\ntouch {os.fspath(child_started)!r}\n{provider_body}\n",
+        encoding="utf-8",
+    )
+    provider.chmod(0o755)
+
+    adapter = root / "scripts" / "launchers" / "claude.sh"
+    adapter.parent.mkdir(parents=True, exist_ok=True)
+    adapter.write_text(
+        f"""#!/usr/bin/env bash
+launcher_adapter_validate() {{ :; }}
+launcher_adapter_preflight() {{ :; }}
+launcher_adapter_canary() {{ return 0; }}
+launcher_adapter_exec() {{ launcher_exec_command {os.fspath(provider)!r}; }}
+""",
+        encoding="utf-8",
+    )
+    adapter.chmod(0o755)
+    initialized = subprocess.run(
+        ["git", "init", "-q", "-b", "main", os.fspath(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert initialized.returncode == 0, initialized.stderr
+    return root / "start-claude-driver.sh", close_attempts, close_marker, child_started
+
+
+def test_driver_normal_exit_closes_with_bounded_idempotent_retry(tmp_path: Path) -> None:
+    launcher, close_attempts, close_marker, child_started = _core_driver_exit_fixture(
+        tmp_path,
+        provider_body="exit 7",
+        failed_close_attempts=1,
+    )
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    result = subprocess.run(
+        ["bash", os.fspath(launcher), "--epic", "devops"],
+        cwd=launcher.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 7
+    assert child_started.is_file()
+    assert close_marker.is_file()
+    assert close_attempts.read_text(encoding="utf-8").strip() == "2"
+
+
+@pytest.mark.parametrize(
+    ("termination_signal", "expected_exit"),
+    ((signal.SIGINT, 130), (signal.SIGTERM, 143), (signal.SIGHUP, 129)),
+)
+def test_driver_termination_forwards_signal_and_closes_exact_lease(
+    tmp_path: Path,
+    termination_signal: signal.Signals,
+    expected_exit: int,
+) -> None:
+    launcher, close_attempts, close_marker, child_started = _core_driver_exit_fixture(
+        tmp_path,
+        provider_body="trap 'exit 0' INT TERM HUP\nwhile :; do sleep 0.1; done",
+    )
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    process = subprocess.Popen(
+        ["bash", os.fspath(launcher), "--epic", "devops"],
+        cwd=launcher.parent,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    for _ in range(100):
+        if child_started.is_file():
+            break
+        process.poll()
+        if process.returncode is not None:
+            break
+        time.sleep(0.02)
+    assert child_started.is_file()
+
+    process.send_signal(termination_signal)
+    stdout, stderr = process.communicate(timeout=10)
+    assert process.returncode == expected_exit, stdout + stderr
+    assert close_marker.is_file()
+    assert close_attempts.read_text(encoding="utf-8").strip() == "1"
+
+
+def test_all_driver_adapters_use_common_closure_wrapper() -> None:
+    for provider in ("claude", "codex", "gemini", "grok"):
+        body = (REPO / "scripts" / "launchers" / f"{provider}.sh").read_text(encoding="utf-8")
+        assert 'launcher_exec_command "${cmd[@]}"' in body
+
+
+def test_real_store_driver_close_successor_and_expired_recovery(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    for relative in (
+        "start-claude-driver.sh",
+        "scripts/lib/handoff_identity.sh",
+        "scripts/lib/launcher_core.sh",
+        "scripts/lib/session_supervisor.sh",
+        "scripts/lib/deploy_extensions.sh",
+        "scripts/config/issue_streams.yaml",
+    ):
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO / relative, destination)
+    python_bin = root / ".venv" / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    python_bin.symlink_to(REPO / ".venv" / "bin" / "python")
+    provider = root / "provider.sh"
+    provider.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    provider.chmod(0o755)
+    adapter = root / "scripts" / "launchers" / "claude.sh"
+    adapter.parent.mkdir(parents=True, exist_ok=True)
+    adapter.write_text(
+        f"""#!/usr/bin/env bash
+launcher_adapter_validate() {{ :; }}
+launcher_adapter_preflight() {{ :; }}
+launcher_adapter_canary() {{ return 0; }}
+launcher_adapter_exec() {{ launcher_exec_command {os.fspath(provider)!r}; }}
+""",
+        encoding="utf-8",
+    )
+    adapter.chmod(0o755)
+    subprocess.run(["git", "init", "-q", "-b", "main", os.fspath(root)], check=True, timeout=30)
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env["PYTHONPATH"] = os.fspath(REPO)
+
+    result = subprocess.run(
+        ["bash", os.fspath(root / "start-claude-driver.sh"), "--epic", "devops"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+    database = SessionStreamDatabase(root / ".agent/session-streams/v1/session-streams.sqlite3")
+    store = SessionStreamStore(database)
+    history = store.dump_stream("epic:5703")
+    assert history["sessions"][0]["state"] == "closed"
+    assert history["lease"]["state"] == "released"
+    assert [event["event_type"] for event in history["lease_events"]] == ["acquired", "released"]
+
+    supervisor = SessionSupervisor(store, repo_root=root)
+    successor = supervisor.open_driver(
+        role=LaunchRole.DRIVER,
+        stream_id="epic:5703",
+        holder=LeaseHolder(
+            agent="codex",
+            harness="codex-cli",
+            instance_id="successor-after-clean-close",
+            process_id=os.getpid(),
+        ),
+        lineage_id="lineage-successor-after-clean-close",
+        ttl_seconds=300,
+    )
+    assert successor.generation == 2
+    assert successor.fencing_token == 2
+    assert supervisor.close_driver(role=LaunchRole.DRIVER, lease=successor) == "closed"
+
+    expired_stream = "epic:4708"
+    store.open_session(
+        stream_id=expired_stream,
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="expired-dead-holder",
+            process_id=999_999_009,
+        ),
+        lineage_id="lineage-expired-dead-holder",
+        ttl_seconds=30,
+        now=utc_now() - timedelta(minutes=5),
+    )
+    rerouted = supervisor.open_driver(
+        role=LaunchRole.DRIVER,
+        stream_id=expired_stream,
+        holder=LeaseHolder(
+            agent="codex",
+            harness="codex-cli",
+            instance_id="ttl-reroute-successor",
+            process_id=os.getpid(),
+        ),
+        lineage_id="lineage-ttl-reroute-successor",
+        ttl_seconds=300,
+    )
+    assert rerouted.generation == 2
+    assert rerouted.fencing_token == 2
+    recovered_history = store.dump_stream(expired_stream)
+    assert [session["state"] for session in recovered_history["sessions"]] == ["closed", "open"]
+    assert "force_closed" in [event["event_type"] for event in recovered_history["lease_events"]]
+    assert supervisor.close_driver(role=LaunchRole.DRIVER, lease=rerouted) == "closed"
 
 
 def test_harness_contracts_and_redacted_kimi_glm_credentials(tmp_path: Path) -> None:

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -380,7 +380,11 @@ def test_real_store_driver_close_successor_and_expired_recovery(tmp_path: Path) 
         shutil.copy2(REPO / relative, destination)
     python_bin = root / ".venv" / "bin" / "python"
     python_bin.parent.mkdir(parents=True)
-    python_bin.symlink_to(REPO / ".venv" / "bin" / "python")
+    python_bin.write_text(
+        f"#!/usr/bin/env bash\nexec {os.fspath(REPO / '.venv' / 'bin' / 'python')!r} \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_bin.chmod(0o755)
     provider = root / "provider.sh"
     provider.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
     provider.chmod(0o755)

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -106,6 +106,9 @@ if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" ]]; then
 JSON
   exit 0
 fi
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "agents_extensions.shared.session_streams" ]]; then
+  exit 0
+fi
 if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_canary.codex_lane" ]]; then
   exit 0
 fi


### PR DESCRIPTION
## What changed

- keep the common driver supervisor alive around Claude, Codex, Gemini, and Grok driver processes
- close the exact fenced session lease on clean exit and INT/TERM/HUP
- forward termination signals to the provider process and preserve its exit code
- retry the idempotent close operation once after an ambiguous client failure
- retain direct `exec` for interactive and lease-free routes

## Root cause

The common launcher claimed a fenced session lease and then each provider adapter used `exec`. Replacing the launcher shell meant no clean-exit or signal trap remained to close the lease, leaving successors dependent on crash recovery.

## Verification

- 109 focused launcher/session-stream tests passed
- real SQLite lifecycle canary: clean close + released lease, generation/fence increment for successor, expired dead-holder force-close and reroute
- INT, TERM, and HUP signal forwarding/closure tests
- Ruff, Bash syntax, ShellCheck (excluding pre-existing source-resolution/Codex warnings), diff check
- OPSEC staged scan: zero leaks
- X-Agent trailer lint passed

Refs #5880
Refs #4707