### PR TITLE
fix(eval): use zero-volume HF Jobs transport

### DIFF
--- a/data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.json
+++ b/data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.json
@@ -3,6 +3,7 @@
     "approved_at": "2026-08-02",
     "issue": 6273,
     "maximum_provider_cost_usd": 6.0,
+    "no_volume_remedy_approved_at": "2026-08-02",
     "no_automatic_paid_retry": true,
     "provider": "Hugging Face Jobs"
   },
@@ -45,6 +46,7 @@
   "runner": {
     "backend": "vllm",
     "batch_size": 25,
+    "checkpoint_upload_every_cases": 25,
     "fallback_backend": "llama.cpp",
     "fallback_requires_new_approval_after_paid_failure": true,
     "gpu_memory_utilization": 0.9,
@@ -92,6 +94,19 @@
       "overcorrection",
       "protected_text"
     ]
+  },
+  "transport": {
+    "cpu_preflight": {
+      "container_amd64_digest": "sha256:8859bd6ca943079262c27e38b7119cdacede77c463139a15651dd340087a6cc9",
+      "container_image": "python:3.12.8-slim",
+      "flavor": "cpu-basic",
+      "maximum_cost_usd": 0.001,
+      "timeout_seconds": 300,
+      "usd_per_hour": 0.01
+    },
+    "mode": "private-dataset-direct-api",
+    "mounted_volumes": 0,
+    "staging_dataset_suffix": "ua-open-weight-eval-staging-6273"
   },
   "tokenizer": {
     "allowed_files": {

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -65,7 +65,7 @@ is the single source of truth for membership (auditor:
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
-| open-model-data | closed #6164 (successor to closed #6056); active child #6273 | The Foundry implementation, portable tool, model-ready exports, open-weight evaluation suite, and adoption adapters are shipped. #6273 owns the official Gemma 4 QAT Q4_0 HF Jobs baseline, results publication, a separate Lapa-baseline follow-up, and the remaining external receipt boundary. Training and researcher outreach remain out of scope for the baseline task. |
+| open-model-data | closed #6164 (successor to closed #6056); active child #6273 | The Foundry implementation, portable tool, model-ready exports, open-weight evaluation suite, and adoption adapters are shipped. #6273 owns the official Gemma 4 QAT Q4_0 HF Jobs baseline through a CPU-gated, zero-volume direct-upload transport, results publication, a separate Lapa-baseline follow-up, and the remaining external receipt boundary. Training and researcher outreach remain out of scope for the baseline task. |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |

--- a/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md
+++ b/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md
@@ -45,18 +45,30 @@ reconciled through the unique job labels before another attempt is considered.
 A paid vLLM compatibility failure is preserved and requires new approval before
 a llama.cpp fallback attempt.
 
+Before any GPU launch, a five-minute CPU Basic transport preflight must pass.
+Its maximum time-based charge is USD 0.000833 at USD 0.01/hour, below the
+operator's USD 0.001 preflight ceiling. The preflight must show that the
+container entered the provider runtime, downloaded the exact private staged
+bundle at an immutable commit, verified every file hash, and directly uploaded
+one harmless receipt. A failed preflight prohibits a GPU launch.
+
 ## Durable and private progress
 
-Hugging Face Jobs deletes its ephemeral filesystem at termination. The worker
-therefore writes an exact-prefix append-only checkpoint to a private mounted
-Hugging Face Bucket after every completed request. Its header binds the suite,
-request selection, model and tokenizer revisions, artifact hash, runner hash,
-runtime versions, and decoding settings. A resume is accepted only when all
-bindings match and the checkpoint rows are the exact expected request-order
-prefix.
+Hugging Face Jobs deletes its ephemeral filesystem at termination. This launch
+therefore has no repository or bucket mounts and passes zero `--volume`
+arguments. After the container enters the provider runtime, a minimal bootstrap
+downloads the exact reviewed transport from the private staging dataset at an
+immutable commit, verifies its hash, and executes it. The transport then
+downloads and verifies the frozen code, suite, configuration, and pinned plugin
+before model execution.
 
-The bucket mount is authorized when the Job is created, so no token is passed
-to the Job. The public model is downloaded without a token. See the official
+The worker uploads its exact-prefix append-only checkpoint directly to the
+private staging dataset through the authenticated Hub API after each 25-case
+batch. Its header binds the suite, request selection, model and tokenizer
+revisions, artifact hash, runner hash, runtime versions, decoding settings, and
+private artifact prefix. A resume is accepted only when all bindings match and
+the checkpoint rows are the exact expected request-order prefix. The prior
+bucket-mount remedy is disproven and must not be retried. See the official
 [Jobs persistence guidance](https://huggingface.co/docs/hub/en/jobs-manage).
 
 Raw generations, parse failures, private checkpoints, and provider logs remain
@@ -80,8 +92,13 @@ environment:
 
 The prepared source-only request packet has SHA-256
 `9f624c54857ea8517162c555bc876f34f76a783e3f9feeaf9db4d6c91a9a18bd`.
-The complete ignored job bundle has SHA-256
-`c7efff840695dc0d9e8c7de236f0f787e30ae41c5a60d246f61202436bcf24f5`.
+The reviewed bundle is staged only after its exact Git head passes independent
+review and CI. `stage-transport` creates or reuses the private
+`krisztiankoos/ua-open-weight-eval-staging-6273` dataset, uploads the bundle
+under `bundles/<bundle-sha256>`, and returns the immutable dataset commit used
+by both the CPU preflight and any authorized GPU launch. `verify-transport`
+then re-downloads the staged files and verifies their exact set, sizes, and
+hashes before a provider job is submitted.
 
 ## Result publication boundary
 

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -16,9 +16,12 @@
 > operator separately authorized release and external-validation work under
 > #6273 on 2026-08-02, then superseded the proposed local M1/MLX baseline with
 > an official Gemma 4 QAT Q4_0 evaluation on one Hugging Face Jobs L40S. That
-> decision authorizes one 100-case canary and, only after a 25%-buffered budget
-> projection passes, one full 4,000-case run within USD 6.00 total provider
-> cost. Researcher outreach and model training remain prohibited in this task.
+> decision authorizes a no-volume CPU Basic transport preflight, one 100-case
+> L40S canary only after that preflight passes, and, only after a 25%-buffered
+> budget projection passes, one full 4,000-case run within USD 6.00 total
+> provider cost. Private checkpoints use authenticated direct dataset uploads;
+> repository and bucket mounts are prohibited. Researcher outreach and model
+> training remain prohibited in this task.
 > **Recorded:** 2026-07-30; Foundry direction and existing-asset baseline
 > refreshed 2026-08-02
 > **Applies to:** Ukrainian model evaluation, dataset work, training-data
@@ -107,7 +110,10 @@ the Foundry release.
   is the active post-completion release and external-validation child of #6164.
   It owns rights-complete publication, a real fourteen-track open-weight result,
   concrete Lapa and lang-uk submissions after approval, and the external run
-  receipt required before an adoption claim.
+  receipt required before an adoption claim. Its current provider path is a
+  hash-first, zero-volume HF Jobs transport: a five-minute CPU Basic preflight
+  must prove private download, hash verification, and direct receipt upload
+  before the authorized L40S canary can launch.
 - [#6057](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6057)
   is closed as not planned under the solo-operator model while preserving the
   completed v0.2 error analysis and frozen design. Its reviewer-intensive

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -643,7 +643,7 @@ def reconcile_provider_inspection(
     _require(isinstance(job_id, str) and JOB_ID_PATTERN.fullmatch(job_id) is not None, "provider job ID drift")
     expected_flavor = "cpu-basic" if mode == "preflight" else "l40sx1"
     _require(inspection.get("flavor") == expected_flavor, "provider hardware drift")
-    _require(inspection.get("volumes") == [], "provider attached a prohibited volume")
+    _require(inspection.get("volumes", []) == [], "provider attached a prohibited volume")
     _require(inspection.get("secrets") == ["HF_TOKEN"], "provider secret contract drift")
     labels = inspection.get("labels")
     _require(isinstance(labels, dict), "provider labels are missing")

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -579,7 +579,13 @@ def job_command(
         command.extend(["--label", f"{key}={value}"])
     command.extend(["--secrets", "HF_TOKEN", "--env", "HF_HUB_DISABLE_TELEMETRY=1"])
     if mode in RUN_MODES:
-        command.extend(["--env", "VLLM_BATCH_INVARIANT=1", "--env", "VLLM_ENABLE_V1_MULTIPROCESSING=0"])
+        command.extend(
+            [
+                "--env", "ACCELERATOR=l40sx1",
+                "--env", "VLLM_BATCH_INVARIANT=1",
+                "--env", "VLLM_ENABLE_V1_MULTIPROCESSING=0",
+            ]
+        )
     command.extend(["--", image, "sh", "-lc", shell_command])
     _require("--volume" not in command and "-v" not in command, "volume transport is prohibited")
     _require("--expose" not in command and "--ssh" not in command, "endpoint exposure drift")

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -29,6 +30,7 @@ from scripts.projects.ua_open_weight_eval import hf_jobs_worker, suite_cli
 
 CONFIG_PATH = ROOT / "data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.json"
 WORKER_PATH = ROOT / "scripts/projects/ua_open_weight_eval/hf_jobs_worker.py"
+TRANSPORT_PATH = ROOT / "scripts/projects/ua_open_weight_eval/hf_jobs_transport.py"
 LICENSE_PATH = ROOT / "LICENSE"
 THIRD_PARTY_PATH = ROOT / "docs/projects/ua-open-weight-eval/THIRD_PARTY_NOTICES.md"
 PUBLIC_FILES = frozenset(
@@ -46,6 +48,7 @@ PUBLIC_FILES = frozenset(
 )
 CATEGORIES = ("error", "correct_control", "protected", "unresolved")
 RUN_MODES = frozenset({"canary", "full"})
+LAUNCH_MODES = frozenset({"preflight", *RUN_MODES})
 JOB_ID_PATTERN = re.compile(r"[a-f0-9]{20,64}")
 
 
@@ -97,6 +100,14 @@ def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:
     _require(config["authorization"]["issue"] == 6273, "authorization issue drift")
     _require(config["authorization"]["maximum_provider_cost_usd"] == 6.0, "cost ceiling drift")
     _require(config["authorization"]["no_automatic_paid_retry"] is True, "retry policy drift")
+    preflight = config["transport"]["cpu_preflight"]
+    _require(config["transport"]["mounted_volumes"] == 0, "volume transport is prohibited")
+    _require(preflight["flavor"] == "cpu-basic" and preflight["timeout_seconds"] == 300, "CPU preflight drift")
+    _require(preflight["maximum_cost_usd"] == 0.001, "CPU preflight cost ceiling drift")
+    _require(
+        preflight["timeout_seconds"] / 3600 * preflight["usd_per_hour"] <= preflight["maximum_cost_usd"],
+        "CPU preflight timeout exceeds its cost ceiling",
+    )
     _require(config["suite"]["cases_sha256"] == sha256_file(suite_cli.CASES_PATH), "frozen cases drift")
     _require(config["suite"]["tracks"] == suite_cli.read_json(suite_cli.CONFIG_PATH)["tracks"], "track drift")
     return config
@@ -174,6 +185,7 @@ def prepare_bundle(output_dir: Path, *, plugin_wheel: Path | None = None) -> dic
     write_atomic(output_dir / "canary_selection.json", selection)
     shutil.copyfile(CONFIG_PATH, output_dir / "run_config.json")
     shutil.copyfile(WORKER_PATH, output_dir / "hf_jobs_worker.py")
+    shutil.copyfile(TRANSPORT_PATH, output_dir / "hf_jobs_transport.py")
     plugin = config["runtime"]["vllm_gguf_plugin"]
     plugin_output = output_dir / plugin["filename"]
     if plugin_wheel is None:
@@ -192,6 +204,7 @@ def prepare_bundle(output_dir: Path, *, plugin_wheel: Path | None = None) -> dic
         "requests_sha256": sha256_file(requests),
         "selection_sha256": selection["selection_sha256"],
         "config_sha256": sha256_file(output_dir / "run_config.json"),
+        "transport_sha256": sha256_file(output_dir / "hf_jobs_transport.py"),
         "worker_sha256": sha256_file(output_dir / "hf_jobs_worker.py"),
     }
     manifest["bundle_sha256"] = sha256_text(canonical_json(manifest))
@@ -207,6 +220,7 @@ def verify_bundle(bundle: Path) -> dict[str, Any]:
     expected = {
         "BUNDLE_MANIFEST.json",
         "canary_selection.json",
+        "hf_jobs_transport.py",
         "hf_jobs_worker.py",
         "requests.jsonl",
         "run_config.json",
@@ -230,172 +244,331 @@ def verify_bundle(bundle: Path) -> dict[str, Any]:
     return manifest
 
 
+def verify_staged_transport(*, bundle: Path, repo_id: str, revision: str) -> dict[str, Any]:
+    from huggingface_hub import HfApi, hf_hub_download
+
+    manifest = verify_bundle(bundle)
+    _require(re.fullmatch(r"[a-f0-9]{40}", revision) is not None, "transport revision must be immutable")
+    prefix = f"bundles/{manifest['bundle_sha256']}"
+    api = HfApi(token=os.environ.get("HF_TOKEN"))
+    info = api.repo_info(repo_id=repo_id, repo_type="dataset", revision=revision)
+    _require(bool(getattr(info, "private", False)), "transport dataset must remain private")
+    expected = {path.name for path in bundle.iterdir() if path.is_file()}
+    observed = {
+        item.path.removeprefix(f"{prefix}/")
+        for item in api.list_repo_tree(repo_id=repo_id, repo_type="dataset", path_in_repo=prefix, revision=revision)
+        if getattr(item, "path", "").startswith(f"{prefix}/")
+    }
+    _require(observed == expected, "staged transport contains missing or extra files")
+    verified: list[dict[str, Any]] = []
+    for name in sorted(expected):
+        remote = Path(
+            hf_hub_download(
+                repo_id=repo_id,
+                repo_type="dataset",
+                revision=revision,
+                filename=f"{prefix}/{name}",
+                token=True,
+            )
+        )
+        local = bundle / name
+        _require(remote.stat().st_size == local.stat().st_size, f"staged byte drift: {name}")
+        digest = sha256_file(remote)
+        _require(digest == sha256_file(local), f"staged hash drift: {name}")
+        verified.append({"path": name, "bytes": remote.stat().st_size, "sha256": digest})
+    return {
+        "schema_version": "ua_open_weight_eval_hf_jobs_transport_stage.v1",
+        "status": "verified",
+        "repository": repo_id,
+        "revision": revision,
+        "prefix": prefix,
+        "bundle_sha256": manifest["bundle_sha256"],
+        "files": verified,
+        "private": True,
+    }
+
+
+def stage_transport_bundle(*, bundle: Path, repo_id: str) -> dict[str, Any]:
+    from huggingface_hub import CommitOperationAdd, HfApi
+
+    manifest = verify_bundle(bundle)
+    _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/ua-open-weight-eval-staging-6273", repo_id) is not None, "invalid staging repository")
+    token = os.environ.get("HF_TOKEN")
+    _require(bool(token), "HF_TOKEN is required to stage the private transport")
+    api = HfApi(token=token)
+    api.create_repo(repo_id=repo_id, repo_type="dataset", private=True, exist_ok=True)
+    _require(bool(api.repo_info(repo_id=repo_id, repo_type="dataset").private), "staging repository is not private")
+    prefix = f"bundles/{manifest['bundle_sha256']}"
+    operations = [
+        CommitOperationAdd(path_in_repo=f"{prefix}/{path.name}", path_or_fileobj=path)
+        for path in sorted(bundle.iterdir())
+        if path.is_file()
+    ]
+    commit = api.create_commit(
+        repo_id=repo_id,
+        repo_type="dataset",
+        operations=operations,
+        commit_message=f"stage reviewed no-volume bundle {manifest['bundle_sha256'][:12]}",
+    )
+    revision = getattr(commit, "oid", None)
+    _require(isinstance(revision, str), "staging commit is missing")
+    return verify_staged_transport(bundle=bundle, repo_id=repo_id, revision=revision)
+
+
+def verify_preflight_receipt(
+    *, bundle: Path, repo_id: str, revision: str, path_in_repo: str, job_id: str
+) -> dict[str, Any]:
+    from huggingface_hub import hf_hub_download
+
+    manifest = verify_bundle(bundle)
+    _require(JOB_ID_PATTERN.fullmatch(job_id) is not None, "invalid preflight job ID")
+    _require(re.fullmatch(r"[a-f0-9]{40}", revision) is not None, "preflight receipt revision must be immutable")
+    expected_path = f"artifacts/{manifest['bundle_sha256']}/preflight/{job_id}/transport_receipt.json"
+    _require(path_in_repo == expected_path, "preflight receipt path drift")
+    source = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            filename=path_in_repo,
+            token=True,
+        )
+    )
+    receipt = read_json(source)
+    _require(
+        receipt.get("schema_version") == "ua_open_weight_eval_hf_jobs_transport_receipt.v1"
+        and receipt.get("status") == "passed"
+        and receipt.get("mode") == "preflight",
+        "preflight receipt status drift",
+    )
+    _require(receipt.get("job_id") == job_id and receipt.get("hardware_flavor") == "cpu-basic", "preflight identity drift")
+    transport = receipt.get("transport")
+    _require(isinstance(transport, Mapping), "preflight transport evidence is missing")
+    _require(transport.get("repository") == repo_id, "preflight repository drift")
+    _require(transport.get("bundle_sha256") == manifest["bundle_sha256"], "preflight bundle drift")
+    _require(transport.get("all_hashes_verified") is True, "preflight hash verification failed")
+    _require(transport.get("mounted_volumes") == 0, "preflight used a prohibited volume")
+    facts = receipt.get("facts")
+    _require(isinstance(facts, Mapping), "preflight facts are missing")
+    _require(facts.get("receipt_uploaded_directly") is True, "preflight direct upload was not proven")
+    _require(facts.get("model_execution_started") is False, "preflight unexpectedly started model execution")
+    return {
+        "schema_version": "ua_open_weight_eval_hf_jobs_preflight_verification.v1",
+        "status": "passed",
+        "job_id": job_id,
+        "repository": repo_id,
+        "revision": revision,
+        "path": path_in_repo,
+        "receipt_sha256": sha256_file(source),
+        "bundle_sha256": manifest["bundle_sha256"],
+    }
+
+
+def gate_gpu_canary(
+    *,
+    verification: Mapping[str, Any],
+    provider_receipt: Mapping[str, Any],
+    bundle_manifest: Mapping[str, Any],
+    repo_id: str,
+) -> dict[str, Any]:
+    _require(
+        verification.get("schema_version") == "ua_open_weight_eval_hf_jobs_preflight_verification.v1"
+        and verification.get("status") == "passed",
+        "CPU preflight verification did not pass",
+    )
+    _require(verification.get("bundle_sha256") == bundle_manifest["bundle_sha256"], "CPU preflight bundle drift")
+    _require(verification.get("repository") == repo_id, "CPU preflight repository drift")
+    _require(
+        provider_receipt.get("schema_version") == "ua_open_weight_eval_hf_jobs_provider_receipt.v1"
+        and provider_receipt.get("mode") == "preflight"
+        and provider_receipt.get("stage") == "COMPLETED",
+        "CPU preflight provider receipt did not complete",
+    )
+    _require(provider_receipt.get("job_id") == verification.get("job_id"), "CPU preflight job ID drift")
+    _require(provider_receipt.get("hardware_flavor") == "cpu-basic", "CPU preflight hardware drift")
+    _require(float(provider_receipt.get("provider_derived_cost_usd", math.inf)) <= 0.001, "CPU preflight cost exceeded")
+    payload = {
+        "schema_version": "ua_open_weight_eval_hf_jobs_canary_gate.v1",
+        "status": "passed",
+        "preflight_job_id": verification["job_id"],
+        "bundle_sha256": bundle_manifest["bundle_sha256"],
+        "transport_repository": repo_id,
+        "transport_revision": provider_receipt["labels"]["transport"],
+        "preflight_cost_usd": provider_receipt["provider_derived_cost_usd"],
+    }
+    payload["gate_sha256"] = sha256_text(canonical_json(payload))
+    return payload
+
+
+def _bootstrap_source() -> str:
+    return """import argparse,hashlib,json,os,sys
+from pathlib import Path
+from huggingface_hub import hf_hub_download
+p=argparse.ArgumentParser()
+p.add_argument('--mode',required=True)
+p.add_argument('--transport-repo',required=True)
+p.add_argument('--transport-revision',required=True)
+p.add_argument('--transport-prefix',required=True)
+p.add_argument('--artifact-prefix',required=True)
+p.add_argument('--bundle-sha256',required=True)
+p.add_argument('--requests-sha256')
+p.add_argument('--work-root',required=True)
+a,_=p.parse_known_args()
+mp=Path(hf_hub_download(repo_id=a.transport_repo,repo_type='dataset',revision=a.transport_revision,filename=f'{a.transport_prefix}/BUNDLE_MANIFEST.json',token=True))
+m=json.loads(mp.read_text(encoding='utf-8'))
+u={k:v for k,v in m.items() if k!='bundle_sha256'}
+assert m.get('schema_version')=='ua_open_weight_eval_hf_jobs_bundle.v1'
+assert m.get('bundle_sha256')==a.bundle_sha256==hashlib.sha256(json.dumps(u,ensure_ascii=False,sort_keys=True,separators=(',',':')).encode()).hexdigest()
+r=next(x for x in m['files'] if x['path']=='hf_jobs_transport.py')
+tp=Path(hf_hub_download(repo_id=a.transport_repo,repo_type='dataset',revision=a.transport_revision,filename=f'{a.transport_prefix}/hf_jobs_transport.py',token=True))
+assert tp.stat().st_size==r['bytes'] and hashlib.sha256(tp.read_bytes()).hexdigest()==r['sha256']
+os.execvp('python',['python',str(tp),*sys.argv[1:]])
+"""
+
+
+def _verify_launch_inputs(
+    *, namespace: str, transport_repo: str, transport_revision: str, transport_prefix: str, manifest: Mapping[str, Any]
+) -> None:
+    _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}", namespace) is not None, "invalid namespace")
+    _require(transport_repo == f"{namespace}/ua-open-weight-eval-staging-6273", "unexpected staging dataset repository")
+    _require(re.fullmatch(r"[a-f0-9]{40}", transport_revision) is not None, "transport revision must be immutable")
+    _require(
+        transport_prefix == f"bundles/{manifest['bundle_sha256']}",
+        "transport prefix is not bound to the bundle digest",
+    )
+
+
 def job_command(
     *,
     mode: str,
     namespace: str,
-    bucket: str,
     bundle: Path,
-    bundle_mount: str,
+    transport_repo: str,
+    transport_revision: str,
+    transport_prefix: str,
     hf_cli: Path,
     timeout_seconds: int,
     projection: Mapping[str, Any] | None = None,
+    preflight_gate: Mapping[str, Any] | None = None,
 ) -> list[str]:
-    _require(mode in RUN_MODES, "invalid run mode")
-    _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}", namespace) is not None, "invalid namespace")
-    _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}", bucket) is not None, "invalid bucket")
+    _require(mode in LAUNCH_MODES, "invalid launch mode")
     _require(hf_cli.is_absolute() and hf_cli.is_file() and os.access(hf_cli, os.X_OK), "HF CLI must be executable")
     manifest = verify_bundle(bundle)
     config = load_config(bundle / "run_config.json")
-    expected_mount_prefix = f"hf://buckets/{namespace}/jobs-artifacts/"
-    _require(bundle_mount.startswith(expected_mount_prefix), "input bundle mount is outside jobs-artifacts")
-    mount_name = bundle_mount.removeprefix(expected_mount_prefix)
-    _require(
-        re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", mount_name) is not None,
-        "invalid input bundle mount",
+    _verify_launch_inputs(
+        namespace=namespace,
+        transport_repo=transport_repo,
+        transport_revision=transport_revision,
+        transport_prefix=transport_prefix,
+        manifest=manifest,
     )
-    _require(
-        mount_name.endswith(manifest["bundle_sha256"][:8]),
-        "input bundle mount digest suffix drift",
-    )
-    observed_cli = subprocess.run(
-        [str(hf_cli), "--version"], check=False, capture_output=True, text=True
-    )
+    observed_cli = subprocess.run([str(hf_cli), "--version"], check=False, capture_output=True, text=True)
     _require(observed_cli.returncode == 0, "HF CLI version probe failed")
     _require(
         observed_cli.stdout.strip() == config["runtime"]["huggingface_hub_cli_version"],
         "HF CLI version drift",
     )
-    bucket_probe = subprocess.run(
-        [str(hf_cli), "buckets", "list", f"{namespace}/{bucket}", "--format", "json"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    _require(bucket_probe.returncode == 0, "output bucket probe failed")
-    raw_bucket_entries = bucket_probe.stdout.strip()
-    try:
-        bucket_entries = json.loads(raw_bucket_entries) if raw_bucket_entries else []
-    except json.JSONDecodeError as exc:
-        raise BaselineError("output bucket probe was not JSON") from exc
-    _require(
-        isinstance(bucket_entries, list) and bool(bucket_entries),
-        "output bucket is not mount-ready",
-    )
-    if mode == "canary":
-        _require(projection is None, "canary launch must not accept a full-run projection")
-        _require(timeout_seconds == config["canary"]["timeout_seconds"], "canary timeout drift")
+    if mode == "preflight":
+        preflight = config["transport"]["cpu_preflight"]
+        _require(projection is None, "preflight must not accept a projection")
+        _require(preflight_gate is None, "preflight must not accept a canary gate")
+        _require(timeout_seconds == preflight["timeout_seconds"] == 300, "preflight timeout drift")
+        flavor = "cpu-basic"
+        image = f"{preflight['container_image']}@{preflight['container_amd64_digest']}"
+        installer = "python -m pip install --disable-pip-version-check --no-cache-dir"
+        artifact_prefix = f"artifacts/{manifest['bundle_sha256']}/preflight"
     else:
-        _require(isinstance(projection, Mapping), "full launch requires the passed canary projection")
-        _require(
-            projection.get("schema_version") == "ua_open_weight_eval_hf_jobs_projection.v1"
-            and projection.get("status") == "passed",
-            "full launch requires a passed projection",
-        )
-        expected_bindings = {
-            "cases_sha256": config["suite"]["cases_sha256"],
-            "model_revision": config["model"]["revision"],
-            "model_sha256": config["model"]["artifact_sha256"],
-        }
-        _require(projection.get("bindings") == expected_bindings, "full projection binding drift")
-        authorization = projection.get("authorization")
-        _require(isinstance(authorization, Mapping), "full projection authorization is missing")
-        _require(
-            float(authorization.get("maximum_total_cost_usd", -1))
-            == config["authorization"]["maximum_provider_cost_usd"],
-            "full projection cost ceiling drift",
-        )
-        _require(
-            float(authorization.get("combined_projected_cost_usd", math.inf))
-            <= config["authorization"]["maximum_provider_cost_usd"],
-            "full projection exceeds the total cost ceiling",
-        )
-        maximum_timeout = int(authorization.get("maximum_full_timeout_seconds", 0))
-        _require(
-            0 < timeout_seconds <= maximum_timeout,
-            "full timeout exceeds the remaining-budget projection",
-        )
+        flavor = "l40sx1"
+        image = f"{config['runtime']['container_image']}@{config['runtime']['container_amd64_digest']}"
+        installer = "uv pip install --system"
+        artifact_prefix = f"artifacts/{manifest['bundle_sha256']}/{mode}"
+        if mode == "canary":
+            _require(projection is None, "canary launch must not accept a full-run projection")
+            _require(timeout_seconds == config["canary"]["timeout_seconds"], "canary timeout drift")
+            _require(isinstance(preflight_gate, Mapping), "canary launch requires a passed CPU preflight gate")
+            _require(
+                preflight_gate.get("schema_version") == "ua_open_weight_eval_hf_jobs_canary_gate.v1"
+                and preflight_gate.get("status") == "passed",
+                "canary launch requires a passed CPU preflight gate",
+            )
+            _require(preflight_gate.get("bundle_sha256") == manifest["bundle_sha256"], "canary gate bundle drift")
+            _require(preflight_gate.get("transport_repository") == transport_repo, "canary gate repository drift")
+            _require(preflight_gate.get("transport_revision") == transport_revision[:16], "canary gate revision drift")
+        else:
+            _require(preflight_gate is None, "full launch does not accept a CPU preflight gate")
+            _require(isinstance(projection, Mapping), "full launch requires the passed canary projection")
+            _require(
+                projection.get("schema_version") == "ua_open_weight_eval_hf_jobs_projection.v1"
+                and projection.get("status") == "passed",
+                "full launch requires a passed projection",
+            )
+            expected_bindings = {
+                "cases_sha256": config["suite"]["cases_sha256"],
+                "model_revision": config["model"]["revision"],
+                "model_sha256": config["model"]["artifact_sha256"],
+            }
+            _require(projection.get("bindings") == expected_bindings, "full projection binding drift")
+            authorization = projection.get("authorization")
+            _require(isinstance(authorization, Mapping), "full projection authorization is missing")
+            _require(
+                float(authorization.get("maximum_total_cost_usd", -1))
+                == config["authorization"]["maximum_provider_cost_usd"],
+                "full projection cost ceiling drift",
+            )
+            _require(
+                float(authorization.get("combined_projected_cost_usd", math.inf))
+                <= config["authorization"]["maximum_provider_cost_usd"],
+                "full projection exceeds the total cost ceiling",
+            )
+            maximum_timeout = int(authorization.get("maximum_full_timeout_seconds", 0))
+            _require(0 < timeout_seconds <= maximum_timeout, "full timeout exceeds the remaining-budget projection")
     _require(timeout_seconds > 0 and timeout_seconds % 60 == 0, "timeout must be positive whole minutes")
-    plugin_name = config["runtime"]["vllm_gguf_plugin"]["filename"]
-    worker_parts = [
-        "uv",
-        "pip",
-        "install",
-        "--system",
-        f"/workspace/{plugin_name}",
-        "&&",
-        "python",
-        "/workspace/hf_jobs_worker.py",
-        "--mode",
-        mode,
-        "--config",
-        "/workspace/run_config.json",
-        "--requests",
-        "/workspace/requests.jsonl",
-        "--requests-sha256",
-        manifest["requests_sha256"],
-        "--output-root",
-        f"/output/{mode}",
+    transport_args = [
+        "--mode", mode,
+        "--transport-repo", transport_repo,
+        "--transport-revision", transport_revision,
+        "--transport-prefix", transport_prefix,
+        "--artifact-prefix", artifact_prefix,
+        "--bundle-sha256", manifest["bundle_sha256"],
+        "--work-root", "/tmp/ua-open-weight-eval",
     ]
-    if mode == "canary":
-        worker_parts.extend(["--selection", "/workspace/canary_selection.json"])
-    shell_command = " ".join(worker_parts)
-    image = f"{config['runtime']['container_image']}@{config['runtime']['container_amd64_digest']}"
+    if mode in RUN_MODES:
+        transport_args.extend(["--requests-sha256", manifest["requests_sha256"]])
+    bootstrap = shlex.join(["python", "-c", _bootstrap_source(), *transport_args])
+    shell_command = f"{installer} huggingface_hub=={config['runtime']['huggingface_hub_cli_version']} && {bootstrap}"
     labels = {
         "bundle_sha256": manifest["bundle_sha256"],
         "issue": "6273",
         "mode": mode,
         "suite": config["suite"]["cases_sha256"][:16],
         "timeout_seconds": str(timeout_seconds),
+        "transport": transport_revision[:16],
     }
     if projection is not None:
         labels["projection"] = sha256_text(canonical_json(projection))[:16]
     command = [
-        str(hf_cli),
-        "jobs",
-        "run",
-        "--detach",
-        "--flavor",
-        "l40sx1",
-        "--timeout",
-        f"{timeout_seconds // 60}m",
-        "--namespace",
-        namespace,
-        "--name",
-        f"ua-open-weight-eval-gemma4-{mode}",
+        str(hf_cli), "jobs", "run", "--detach",
+        "--flavor", flavor,
+        "--timeout", f"{timeout_seconds // 60}m",
+        "--namespace", namespace,
+        "--name", f"ua-open-weight-eval-gemma4-{mode}",
     ]
     for key, value in sorted(labels.items()):
         command.extend(["--label", f"{key}={value}"])
-    command.extend(
-        [
-            "--env",
-            "ACCELERATOR=l40sx1",
-            "--env",
-            "HF_HUB_DISABLE_TELEMETRY=1",
-            "--env",
-            "VLLM_BATCH_INVARIANT=1",
-            "--env",
-            "VLLM_ENABLE_V1_MULTIPROCESSING=0",
-            "--volume",
-            f"{bundle_mount}:/workspace:ro",
-            "--volume",
-            f"hf://buckets/{namespace}/{bucket}:/output:rw",
-            "--",
-            image,
-            "bash",
-            "-lc",
-            shell_command,
-        ]
-    )
+    command.extend(["--secrets", "HF_TOKEN", "--env", "HF_HUB_DISABLE_TELEMETRY=1"])
+    if mode in RUN_MODES:
+        command.extend(["--env", "VLLM_BATCH_INVARIANT=1", "--env", "VLLM_ENABLE_V1_MULTIPROCESSING=0"])
+    command.extend(["--", image, "sh", "-lc", shell_command])
+    _require("--volume" not in command and "-v" not in command, "volume transport is prohibited")
     _require("--expose" not in command and "--ssh" not in command, "endpoint exposure drift")
-    _require(not any("token" in part.casefold() for part in command), "launch command contains a token-shaped argument")
+    _require(command.count("--secrets") == 1 and "HF_TOKEN=" not in " ".join(command), "secret transport drift")
     return command
 
 
 def launch_once(
     *, command: Sequence[str], mode: str, state_path: Path, execute: bool
 ) -> dict[str, Any]:
-    _require(mode in RUN_MODES, "invalid launch mode")
+    _require(mode in LAUNCH_MODES, "invalid launch mode")
     if state_path.exists():
         state = read_json(state_path)
     else:
@@ -435,12 +608,21 @@ def launch_once(
 
 
 def reconcile_provider_inspection(
-    *, inspection: Mapping[str, Any], mode: str, config: Mapping[str, Any], bundle_manifest: Mapping[str, Any]
+    *,
+    inspection: Mapping[str, Any],
+    mode: str,
+    config: Mapping[str, Any],
+    bundle_manifest: Mapping[str, Any],
+    transport_revision: str,
 ) -> dict[str, Any]:
-    _require(mode in RUN_MODES, "invalid reconciliation mode")
+    _require(mode in LAUNCH_MODES, "invalid reconciliation mode")
+    _require(re.fullmatch(r"[a-f0-9]{40}", transport_revision) is not None, "invalid transport revision")
     job_id = inspection.get("id")
     _require(isinstance(job_id, str) and JOB_ID_PATTERN.fullmatch(job_id) is not None, "provider job ID drift")
-    _require(inspection.get("flavor") == "l40sx1", "provider hardware drift")
+    expected_flavor = "cpu-basic" if mode == "preflight" else "l40sx1"
+    _require(inspection.get("flavor") == expected_flavor, "provider hardware drift")
+    _require(inspection.get("volumes") == [], "provider attached a prohibited volume")
+    _require(inspection.get("secrets") == ["HF_TOKEN"], "provider secret contract drift")
     labels = inspection.get("labels")
     _require(isinstance(labels, dict), "provider labels are missing")
     expected_labels = {
@@ -448,6 +630,7 @@ def reconcile_provider_inspection(
         "issue": "6273",
         "mode": mode,
         "suite": config["suite"]["cases_sha256"][:16],
+        "transport": transport_revision[:16],
     }
     _require(all(labels.get(key) == value for key, value in expected_labels.items()), "provider labels drift")
     allowed_labels = set(expected_labels) | {"name", "timeout_seconds"}
@@ -465,19 +648,28 @@ def reconcile_provider_inspection(
     _require(isinstance(running_seconds, int) and not isinstance(running_seconds, bool), "provider duration drift")
     timeout_seconds = int(labels.get("timeout_seconds", 0))
     _require(0 <= running_seconds <= timeout_seconds, "provider duration exceeds authorization")
-    cost = round(running_seconds * config["pricing"]["usd_per_minute"] / 60, 6)
-    _require(cost <= config["authorization"]["maximum_provider_cost_usd"], "provider cost exceeds authorization")
+    billed_minutes = math.ceil(running_seconds / 60) if running_seconds else 0
+    if mode == "preflight":
+        hourly_price = float(config["transport"]["cpu_preflight"]["usd_per_hour"])
+        maximum_cost = float(config["transport"]["cpu_preflight"]["maximum_cost_usd"])
+    else:
+        hourly_price = float(config["pricing"]["usd_per_hour"])
+        maximum_cost = float(config["authorization"]["maximum_provider_cost_usd"])
+    price_per_minute = hourly_price / 60
+    cost = round(billed_minutes * price_per_minute, 6)
+    _require(cost <= maximum_cost, "provider cost exceeds authorization")
     return {
         "schema_version": "ua_open_weight_eval_hf_jobs_provider_receipt.v1",
         "job_id": job_id,
         "mode": mode,
         "stage": stage,
-        "hardware_flavor": "l40sx1",
+        "hardware_flavor": expected_flavor,
         "ports_exposed": False,
         "ssh_enabled": False,
         "provider_running_seconds": running_seconds,
+        "provider_billed_minutes": billed_minutes,
         "provider_derived_cost_usd": cost,
-        "pricing_usd_per_minute": config["pricing"]["usd_per_minute"],
+        "pricing_usd_per_minute": price_per_minute,
         "timeout_seconds": timeout_seconds,
         "labels": expected_labels | {"timeout_seconds": str(timeout_seconds)},
     }
@@ -780,21 +972,43 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     prepare.add_argument("--plugin-wheel", type=Path)
     verify = commands.add_parser("verify-bundle")
     verify.add_argument("--bundle", type=Path, required=True)
+    stage = commands.add_parser("stage-transport")
+    stage.add_argument("--bundle", type=Path, required=True)
+    stage.add_argument("--repo", required=True)
+    verify_transport = commands.add_parser("verify-transport")
+    verify_transport.add_argument("--bundle", type=Path, required=True)
+    verify_transport.add_argument("--repo", required=True)
+    verify_transport.add_argument("--revision", required=True)
+    verify_preflight = commands.add_parser("verify-preflight")
+    verify_preflight.add_argument("--bundle", type=Path, required=True)
+    verify_preflight.add_argument("--repo", required=True)
+    verify_preflight.add_argument("--revision", required=True)
+    verify_preflight.add_argument("--path", required=True)
+    verify_preflight.add_argument("--job-id", required=True)
+    gate_canary = commands.add_parser("gate-canary")
+    gate_canary.add_argument("--verification", type=Path, required=True)
+    gate_canary.add_argument("--provider-receipt", type=Path, required=True)
+    gate_canary.add_argument("--bundle", type=Path, required=True)
+    gate_canary.add_argument("--repo", required=True)
+    gate_canary.add_argument("--output", type=Path, required=True)
     launch = commands.add_parser("launch")
-    launch.add_argument("--mode", choices=sorted(RUN_MODES), required=True)
+    launch.add_argument("--mode", choices=sorted(LAUNCH_MODES), required=True)
     launch.add_argument("--namespace", required=True)
-    launch.add_argument("--bucket", required=True)
     launch.add_argument("--bundle", type=Path, required=True)
-    launch.add_argument("--bundle-mount", required=True)
+    launch.add_argument("--transport-repo", required=True)
+    launch.add_argument("--transport-revision", required=True)
+    launch.add_argument("--transport-prefix", required=True)
     launch.add_argument("--hf-cli", type=Path, required=True)
     launch.add_argument("--timeout-seconds", type=int, required=True)
     launch.add_argument("--projection", type=Path)
+    launch.add_argument("--preflight-gate", type=Path)
     launch.add_argument("--state", type=Path, required=True)
     launch.add_argument("--execute", action="store_true")
     reconcile = commands.add_parser("reconcile-provider")
     reconcile.add_argument("--inspection", type=Path, required=True)
-    reconcile.add_argument("--mode", choices=sorted(RUN_MODES), required=True)
+    reconcile.add_argument("--mode", choices=sorted(LAUNCH_MODES), required=True)
     reconcile.add_argument("--bundle", type=Path, required=True)
+    reconcile.add_argument("--transport-revision", required=True)
     reconcile.add_argument("--output", type=Path, required=True)
     project = commands.add_parser("project-full")
     project.add_argument("--worker-receipt", type=Path, required=True)
@@ -817,16 +1031,38 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = prepare_bundle(args.output, plugin_wheel=args.plugin_wheel)
         elif args.command == "verify-bundle":
             result = verify_bundle(args.bundle)
+        elif args.command == "stage-transport":
+            result = stage_transport_bundle(bundle=args.bundle, repo_id=args.repo)
+        elif args.command == "verify-transport":
+            result = verify_staged_transport(bundle=args.bundle, repo_id=args.repo, revision=args.revision)
+        elif args.command == "verify-preflight":
+            result = verify_preflight_receipt(
+                bundle=args.bundle,
+                repo_id=args.repo,
+                revision=args.revision,
+                path_in_repo=args.path,
+                job_id=args.job_id,
+            )
+        elif args.command == "gate-canary":
+            result = gate_gpu_canary(
+                verification=read_json(args.verification),
+                provider_receipt=read_json(args.provider_receipt),
+                bundle_manifest=verify_bundle(args.bundle),
+                repo_id=args.repo,
+            )
+            write_atomic(args.output, result)
         elif args.command == "launch":
             command = job_command(
                 mode=args.mode,
                 namespace=args.namespace,
-                bucket=args.bucket,
                 bundle=args.bundle,
-                bundle_mount=args.bundle_mount,
+                transport_repo=args.transport_repo,
+                transport_revision=args.transport_revision,
+                transport_prefix=args.transport_prefix,
                 hf_cli=args.hf_cli.resolve(),
                 timeout_seconds=args.timeout_seconds,
                 projection=read_json(args.projection) if args.projection is not None else None,
+                preflight_gate=read_json(args.preflight_gate) if args.preflight_gate is not None else None,
             )
             result = launch_once(command=command, mode=args.mode, state_path=args.state, execute=args.execute)
         elif args.command == "reconcile-provider":
@@ -835,6 +1071,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 mode=args.mode,
                 config=load_config(),
                 bundle_manifest=verify_bundle(args.bundle),
+                transport_revision=args.transport_revision,
             )
             write_atomic(args.output, result)
         elif args.command == "project-full":

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -346,6 +346,11 @@ def verify_preflight_receipt(
     _require(isinstance(transport, Mapping), "preflight transport evidence is missing")
     _require(transport.get("repository") == repo_id, "preflight repository drift")
     _require(transport.get("bundle_sha256") == manifest["bundle_sha256"], "preflight bundle drift")
+    transport_revision = transport.get("revision")
+    _require(
+        isinstance(transport_revision, str) and re.fullmatch(r"[a-f0-9]{40}", transport_revision) is not None,
+        "preflight transport revision drift",
+    )
     _require(transport.get("all_hashes_verified") is True, "preflight hash verification failed")
     _require(transport.get("mounted_volumes") == 0, "preflight used a prohibited volume")
     facts = receipt.get("facts")
@@ -361,6 +366,7 @@ def verify_preflight_receipt(
         "path": path_in_repo,
         "receipt_sha256": sha256_file(source),
         "bundle_sha256": manifest["bundle_sha256"],
+        "transport_revision": transport_revision,
     }
 
 
@@ -387,13 +393,21 @@ def gate_gpu_canary(
     _require(provider_receipt.get("job_id") == verification.get("job_id"), "CPU preflight job ID drift")
     _require(provider_receipt.get("hardware_flavor") == "cpu-basic", "CPU preflight hardware drift")
     _require(float(provider_receipt.get("provider_derived_cost_usd", math.inf)) <= 0.001, "CPU preflight cost exceeded")
+    labels = provider_receipt.get("labels")
+    _require(isinstance(labels, Mapping), "CPU preflight provider labels are missing")
+    transport_revision = verification.get("transport_revision")
+    _require(
+        isinstance(transport_revision, str) and re.fullmatch(r"[a-f0-9]{40}", transport_revision) is not None,
+        "CPU preflight transport revision drift",
+    )
+    _require(labels.get("transport") == transport_revision[:16], "CPU preflight transport label drift")
     payload = {
         "schema_version": "ua_open_weight_eval_hf_jobs_canary_gate.v1",
         "status": "passed",
         "preflight_job_id": verification["job_id"],
         "bundle_sha256": bundle_manifest["bundle_sha256"],
         "transport_repository": repo_id,
-        "transport_revision": provider_receipt["labels"]["transport"],
+        "transport_revision": transport_revision,
         "preflight_cost_usd": provider_receipt["provider_derived_cost_usd"],
     }
     payload["gate_sha256"] = sha256_text(canonical_json(payload))
@@ -493,7 +507,15 @@ def job_command(
             )
             _require(preflight_gate.get("bundle_sha256") == manifest["bundle_sha256"], "canary gate bundle drift")
             _require(preflight_gate.get("transport_repository") == transport_repo, "canary gate repository drift")
-            _require(preflight_gate.get("transport_revision") == transport_revision[:16], "canary gate revision drift")
+            _require(preflight_gate.get("transport_revision") == transport_revision, "canary gate revision drift")
+            gate_sha256 = preflight_gate.get("gate_sha256")
+            unsigned_gate = {key: value for key, value in preflight_gate.items() if key != "gate_sha256"}
+            _require(
+                isinstance(gate_sha256, str)
+                and re.fullmatch(r"[a-f0-9]{64}", gate_sha256) is not None
+                and gate_sha256 == sha256_text(canonical_json(unsigned_gate)),
+                "canary gate SHA-256 drift",
+            )
         else:
             _require(preflight_gate is None, "full launch does not accept a CPU preflight gate")
             _require(isinstance(projection, Mapping), "full launch requires the passed canary projection")

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Hash-first Hugging Face Jobs transport with no mounted volumes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+JOB_ID_PATTERN = re.compile(r"[a-f0-9]{20,64}")
+SHA256_PATTERN = re.compile(r"[a-f0-9]{64}")
+REPO_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/[A-Za-z0-9][A-Za-z0-9_.-]{0,95}")
+SAFE_PATH_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.\-/]{0,255}")
+TRANSPORT_RECEIPT_SCHEMA = "ua_open_weight_eval_hf_jobs_transport_receipt.v1"
+
+
+class TransportError(ValueError):
+    """Raised when the no-volume transport contract cannot be satisfied."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise TransportError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _safe_path(value: str, *, label: str) -> str:
+    _require(SAFE_PATH_PATTERN.fullmatch(value) is not None, f"invalid {label}")
+    _require(".." not in value.split("/"), f"unsafe {label}")
+    return value.strip("/")
+
+
+def verify_manifest(value: Mapping[str, Any], expected_bundle_sha256: str) -> list[dict[str, Any]]:
+    _require(value.get("schema_version") == "ua_open_weight_eval_hf_jobs_bundle.v1", "bundle schema drift")
+    _require(SHA256_PATTERN.fullmatch(expected_bundle_sha256) is not None, "invalid expected bundle SHA-256")
+    unsigned = {key: item for key, item in value.items() if key != "bundle_sha256"}
+    observed = sha256_bytes(canonical_json(unsigned).encode("utf-8"))
+    _require(value.get("bundle_sha256") == expected_bundle_sha256 == observed, "bundle digest drift")
+    records = value.get("files")
+    _require(isinstance(records, list) and bool(records), "bundle file records are missing")
+    paths: set[str] = set()
+    verified: list[dict[str, Any]] = []
+    for raw in records:
+        _require(isinstance(raw, dict), "bundle file record drift")
+        path = _safe_path(str(raw.get("path", "")), label="bundle file path")
+        _require("/" not in path, "bundle files must be flat")
+        _require(path not in paths, "duplicate bundle file path")
+        size = raw.get("bytes")
+        digest = raw.get("sha256")
+        _require(isinstance(size, int) and not isinstance(size, bool) and size >= 0, "bundle byte record drift")
+        _require(isinstance(digest, str) and SHA256_PATTERN.fullmatch(digest) is not None, "bundle hash record drift")
+        paths.add(path)
+        verified.append({"path": path, "bytes": size, "sha256": digest})
+    required = {
+        "canary_selection.json",
+        "hf_jobs_transport.py",
+        "hf_jobs_worker.py",
+        "requests.jsonl",
+        "run_config.json",
+    }
+    _require(required.issubset(paths), "bundle runtime files are missing")
+    return verified
+
+
+def download_verified_bundle(
+    *, repo_id: str, revision: str, prefix: str, bundle_sha256: str, output: Path
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    from huggingface_hub import hf_hub_download
+
+    _require(REPO_ID_PATTERN.fullmatch(repo_id) is not None, "invalid transport repository")
+    _require(re.fullmatch(r"[a-f0-9]{40}", revision) is not None, "transport revision must be an immutable commit")
+    prefix = _safe_path(prefix, label="transport prefix")
+    output.mkdir(parents=True, exist_ok=False)
+    manifest_source = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            filename=f"{prefix}/BUNDLE_MANIFEST.json",
+            token=True,
+        )
+    )
+    manifest = json.loads(manifest_source.read_text(encoding="utf-8"))
+    _require(isinstance(manifest, dict), "bundle manifest is not an object")
+    records = verify_manifest(manifest, bundle_sha256)
+    downloaded: list[dict[str, Any]] = []
+    for record in records:
+        source = Path(
+            hf_hub_download(
+                repo_id=repo_id,
+                repo_type="dataset",
+                revision=revision,
+                filename=f"{prefix}/{record['path']}",
+                token=True,
+            )
+        )
+        destination = output / record["path"]
+        destination.write_bytes(source.read_bytes())
+        _require(destination.stat().st_size == record["bytes"], f"download byte drift: {record['path']}")
+        digest = sha256_file(destination)
+        _require(digest == record["sha256"], f"download hash drift: {record['path']}")
+        downloaded.append({**record, "verified_sha256": digest})
+    (output / "BUNDLE_MANIFEST.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest, downloaded
+
+
+def upload_json(*, repo_id: str, path_in_repo: str, value: Mapping[str, Any], commit_message: str) -> str:
+    from huggingface_hub import HfApi
+
+    payload = (json.dumps(dict(value), ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    info = HfApi(token=os.environ["HF_TOKEN"]).upload_file(
+        path_or_fileobj=io.BytesIO(payload),
+        path_in_repo=_safe_path(path_in_repo, label="upload path"),
+        repo_id=repo_id,
+        repo_type="dataset",
+        commit_message=commit_message,
+    )
+    oid = getattr(info, "oid", None)
+    _require(isinstance(oid, str) and re.fullmatch(r"[a-f0-9]{40}", oid) is not None, "upload commit is missing")
+    return oid
+
+
+def run_preflight(args: argparse.Namespace, files: list[dict[str, Any]]) -> dict[str, Any]:
+    job_id = os.environ.get("JOB_ID", "")
+    _require(JOB_ID_PATTERN.fullmatch(job_id) is not None, "missing or invalid Hugging Face Job ID")
+    _require(os.environ.get("ACCELERATOR") == "none", "CPU preflight unexpectedly has an accelerator")
+    receipt = {
+        "schema_version": TRANSPORT_RECEIPT_SCHEMA,
+        "status": "passed",
+        "mode": "preflight",
+        "job_id": job_id,
+        "hardware_flavor": "cpu-basic",
+        "container_reached_running": True,
+        "transport": {
+            "repository": args.transport_repo,
+            "revision": args.transport_revision,
+            "prefix": args.transport_prefix,
+            "bundle_sha256": args.bundle_sha256,
+            "downloaded_files": files,
+            "all_hashes_verified": True,
+            "mounted_volumes": 0,
+        },
+        "facts": {
+            "model_execution_started": False,
+            "model_weights_downloaded": False,
+            "receipt_uploaded_directly": True,
+        },
+    }
+    path = f"{_safe_path(args.artifact_prefix, label='artifact prefix')}/{job_id}/transport_receipt.json"
+    receipt["upload_commit"] = upload_json(
+        repo_id=args.transport_repo,
+        path_in_repo=path,
+        value=receipt,
+        commit_message=f"transport preflight receipt {job_id}",
+    )
+    receipt["artifact_path"] = path
+    return receipt
+
+
+def run_worker(args: argparse.Namespace, root: Path) -> int:
+    config = json.loads((root / "run_config.json").read_text(encoding="utf-8"))
+    plugin = config["runtime"]["vllm_gguf_plugin"]["filename"]
+    install = subprocess.run(
+        ["uv", "pip", "install", "--system", str(root / plugin)],
+        check=False,
+    )
+    _require(install.returncode == 0, "verified plugin installation failed")
+    output = root / "output"
+    command = [
+        "python",
+        str(root / "hf_jobs_worker.py"),
+        "--mode",
+        args.mode,
+        "--config",
+        str(root / "run_config.json"),
+        "--requests",
+        str(root / "requests.jsonl"),
+        "--requests-sha256",
+        args.requests_sha256,
+        "--output-root",
+        str(output),
+        "--artifact-repo",
+        args.transport_repo,
+        "--artifact-prefix",
+        _safe_path(args.artifact_prefix, label="artifact prefix"),
+    ]
+    if args.mode == "canary":
+        command.extend(["--selection", str(root / "canary_selection.json")])
+    return subprocess.run(command, check=False).returncode
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["preflight", "canary", "full"], required=True)
+    parser.add_argument("--transport-repo", required=True)
+    parser.add_argument("--transport-revision", required=True)
+    parser.add_argument("--transport-prefix", required=True)
+    parser.add_argument("--artifact-prefix", required=True)
+    parser.add_argument("--bundle-sha256", required=True)
+    parser.add_argument("--requests-sha256")
+    parser.add_argument("--work-root", type=Path, default=Path("/workspace"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    _require(bool(os.environ.get("HF_TOKEN")), "HF_TOKEN is required for private direct transport")
+    _require(not args.work_root.exists(), "work root already exists")
+    _, files = download_verified_bundle(
+        repo_id=args.transport_repo,
+        revision=args.transport_revision,
+        prefix=args.transport_prefix,
+        bundle_sha256=args.bundle_sha256,
+        output=args.work_root,
+    )
+    if args.mode == "preflight":
+        receipt = run_preflight(args, files)
+        print(canonical_json(receipt))
+        return 0
+    _require(isinstance(args.requests_sha256, str), "request SHA-256 is required for model execution")
+    return run_worker(args, args.work_root)
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except Exception as exc:
+        print(canonical_json({"status": "failed", "error_type": type(exc).__name__, "error": str(exc)}), file=sys.stderr)
+        raise
+    raise SystemExit(exit_code)

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
@@ -134,7 +134,9 @@ def upload_json(*, repo_id: str, path_in_repo: str, value: Mapping[str, Any], co
     from huggingface_hub import HfApi
 
     payload = (json.dumps(dict(value), ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    info = HfApi(token=os.environ["HF_TOKEN"]).upload_file(
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    _require(bool(api.repo_info(repo_id=repo_id, repo_type="dataset").private), "artifact repository is not private")
+    info = api.upload_file(
         path_or_fileobj=io.BytesIO(payload),
         path_in_repo=_safe_path(path_in_repo, label="upload path"),
         repo_id=repo_id,

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
@@ -151,13 +151,15 @@ def upload_json(*, repo_id: str, path_in_repo: str, value: Mapping[str, Any], co
 def run_preflight(args: argparse.Namespace, files: list[dict[str, Any]]) -> dict[str, Any]:
     job_id = os.environ.get("JOB_ID", "")
     _require(JOB_ID_PATTERN.fullmatch(job_id) is not None, "missing or invalid Hugging Face Job ID")
-    _require(os.environ.get("ACCELERATOR") == "none", "CPU preflight unexpectedly has an accelerator")
+    accelerator = os.environ.get("ACCELERATOR")
+    _require(accelerator in {None, "", "none"}, "CPU preflight unexpectedly exposes a GPU accelerator")
     receipt = {
         "schema_version": TRANSPORT_RECEIPT_SCHEMA,
         "status": "passed",
         "mode": "preflight",
         "job_id": job_id,
         "hardware_flavor": "cpu-basic",
+        "accelerator_environment": accelerator,
         "container_reached_running": True,
         "transport": {
             "repository": args.transport_repo,

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_worker.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_worker.py
@@ -2,9 +2,10 @@
 """Run the frozen UA Open-Weight Eval packet on one Hugging Face GPU Job.
 
 The worker is deliberately self-contained so the exact reviewed file can be
-mounted into a Job. It downloads one pinned public GGUF artifact, verifies its
-bytes before loading it, writes resumable private checkpoint state to a durable
-bucket mount, and emits complete parsed responses without an LLM judge.
+downloaded into a Job and hash-verified before execution. It downloads one
+pinned public GGUF artifact, verifies its bytes before loading it, uploads
+resumable private checkpoint state directly to a private Hub dataset, and emits
+complete parsed responses without an LLM judge.
 """
 
 from __future__ import annotations
@@ -36,7 +37,6 @@ JOB_ID_PATTERN = re.compile(r"[a-f0-9]{20,64}")
 OFFLINE_GENERATION_ENVIRONMENT = {
     "HF_DATASETS_OFFLINE": "1",
     "HF_HUB_DISABLE_TELEMETRY": "1",
-    "HF_HUB_OFFLINE": "1",
     "TRANSFORMERS_OFFLINE": "1",
     "VLLM_BATCH_INVARIANT": "1",
     "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
@@ -91,6 +91,63 @@ def append_durable(path: Path, value: Mapping[str, Any]) -> None:
         handle.write(canonical_json(dict(value)) + "\n")
         handle.flush()
         os.fsync(handle.fileno())
+
+
+class HubArtifactStore:
+    """Direct authenticated persistence for private checkpoints and receipts."""
+
+    def __init__(self, repo_id: str, prefix: str) -> None:
+        _require(
+            re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/[A-Za-z0-9][A-Za-z0-9_.-]{0,95}",
+                repo_id,
+            )
+            is not None,
+            "invalid artifact repository",
+        )
+        _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.\-/]{0,255}", prefix) is not None, "invalid artifact prefix")
+        _require(".." not in prefix.split("/"), "unsafe artifact prefix")
+        _require(bool(os.environ.get("HF_TOKEN")), "HF_TOKEN is required for direct checkpoint upload")
+        self.repo_id = repo_id
+        self.prefix = prefix.strip("/")
+
+    def remote_path(self, name: str) -> str:
+        _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", name) is not None, "invalid artifact name")
+        return f"{self.prefix}/{name}"
+
+    def download_optional(self, name: str, destination: Path) -> bool:
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError
+
+        try:
+            source = Path(
+                hf_hub_download(
+                    repo_id=self.repo_id,
+                    repo_type="dataset",
+                    filename=self.remote_path(name),
+                    token=True,
+                )
+            )
+        except EntryNotFoundError:
+            return False
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+        return True
+
+    def upload(self, path: Path, name: str) -> str:
+        from huggingface_hub import HfApi
+
+        _require(path.is_file(), f"artifact is missing: {name}")
+        info = HfApi(token=os.environ["HF_TOKEN"]).upload_file(
+            path_or_fileobj=path,
+            path_in_repo=self.remote_path(name),
+            repo_id=self.repo_id,
+            repo_type="dataset",
+            commit_message=f"persist {name} for {os.environ.get('JOB_ID', 'unknown-job')}",
+        )
+        oid = getattr(info, "oid", None)
+        _require(isinstance(oid, str) and re.fullmatch(r"[a-f0-9]{40}", oid) is not None, "artifact upload commit drift")
+        return oid
 
 
 def generation_totals(records: Sequence[Mapping[str, Any]], resumed_count: int) -> dict[str, float | int]:
@@ -251,6 +308,8 @@ def verify_config(config: Mapping[str, Any]) -> None:
     _require(config.get("model", {}).get("multimodal_projector_used") is False, "projector must remain excluded")
     _require(config.get("runner", {}).get("temperature") == 0.0, "temperature drift")
     _require(config.get("runner", {}).get("seed") == 0, "seed drift")
+    _require(config.get("runner", {}).get("checkpoint_upload_every_cases") == 25, "checkpoint cadence drift")
+    _require(config.get("transport", {}).get("mounted_volumes") == 0, "mounted volumes are prohibited")
 
 
 def verify_tokenizer_files(root: Path, tokenizer_config: Mapping[str, Any]) -> dict[str, Any]:
@@ -417,6 +476,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     _require(os.environ.get("ACCELERATOR") == "l40sx1", "ACCELERATOR must be l40sx1")
     job_id = os.environ.get("JOB_ID", "")
     _require(JOB_ID_PATTERN.fullmatch(job_id) is not None, "missing or invalid Hugging Face Job ID")
+    artifact_store = HubArtifactStore(args.artifact_repo, args.artifact_prefix)
 
     request_header, requests = load_requests(args.requests)
     _require(sha256_file(args.requests) == args.requests_sha256, "request packet SHA-256 drift")
@@ -455,14 +515,20 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "max_tokens": config["runner"]["max_tokens"],
             "parse_retries": config["runner"]["parse_retries"],
         },
-        "network_during_generation": False,
+        "network_during_generation": "private_checkpoint_upload_only",
     }
     checkpoint_path = args.output_root / "checkpoint.jsonl"
+    artifact_store.download_optional("checkpoint.jsonl", checkpoint_path)
     records = load_checkpoint(checkpoint_path, checkpoint_header, selected)
+    checkpoint_commit = artifact_store.upload(checkpoint_path, "checkpoint.jsonl")
     resumed_count = len(records)
     batch_seconds: list[float] = []
     retry_seconds: list[float] = []
     batch_size = int(config["runner"]["batch_size"])
+    _require(
+        batch_size == int(config["runner"]["checkpoint_upload_every_cases"]),
+        "checkpoint upload cadence must equal the batch size",
+    )
     retries = int(config["runner"]["parse_retries"])
     position = len(records)
     while position < len(selected):
@@ -512,6 +578,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             append_durable(checkpoint_path, record)
             records.append(record)
         position += len(batch)
+        checkpoint_commit = artifact_store.upload(checkpoint_path, "checkpoint.jsonl")
         print(f"hf-jobs-worker: completed {position}/{len(selected)}", file=sys.stderr, flush=True)
     generation = generation_totals(records, resumed_count)
     generation_seconds = float(generation["generation_seconds"])
@@ -531,7 +598,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "backend": "vllm",
         "backend_version": versions["vllm"],
         "decoding": checkpoint_header["decoding"],
-        "network_allowed_during_generation": False,
+        "network_allowed_during_generation": True,
+        "network_use": "private_checkpoint_upload_only",
         "closed_api_used": False,
         "job_id": job_id,
         "hardware_flavor": "l40sx1",
@@ -541,6 +609,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     responses_text = "".join(canonical_json(row) + "\n" for row in response_rows)
     responses_path = args.output_root / "responses.jsonl"
     write_atomic(responses_path, responses_text)
+    responses_commit = artifact_store.upload(responses_path, "responses.jsonl")
     ended_at = time.time()
     total_seconds = time.monotonic() - started_monotonic
     receipt = {
@@ -597,6 +666,10 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "checkpoint_sha256": sha256_file(checkpoint_path),
             "responses_sha256": sha256_file(responses_path),
             "response_count": len(records),
+            "private_artifact_repository": artifact_store.repo_id,
+            "private_artifact_prefix": artifact_store.prefix,
+            "checkpoint_upload_commit": checkpoint_commit,
+            "responses_upload_commit": responses_commit,
         },
         "facts": {
             "closed_model_judge_used": False,
@@ -607,7 +680,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "training_performed": False,
         },
     }
-    write_atomic(args.output_root / "worker_receipt.json", receipt)
+    receipt_path = args.output_root / "worker_receipt.json"
+    write_atomic(receipt_path, receipt)
+    artifact_store.upload(receipt_path, "worker_receipt.json")
     return receipt
 
 
@@ -619,6 +694,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--requests-sha256", required=True)
     parser.add_argument("--selection", type=Path)
     parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--artifact-repo", required=True)
+    parser.add_argument("--artifact-prefix", required=True)
     return parser.parse_args(argv)
 
 
@@ -636,8 +713,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             "error": str(exc),
             "traceback": traceback.format_exc(),
         }
+        failure_path = args.output_root / "failure.private.json"
         with contextlib.suppress(OSError):
-            write_atomic(args.output_root / "failure.private.json", failure)
+            write_atomic(failure_path, failure)
+        with contextlib.suppress(BaseException):
+            HubArtifactStore(args.artifact_repo, args.artifact_prefix).upload(failure_path, "failure.private.json")
         print(canonical_json({key: value for key, value in failure.items() if key != "traceback"}), file=sys.stderr)
         return 2
     print(canonical_json({"status": result["status"], "mode": result["mode"], "job_id": result["job"]["id"]}))

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_worker.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_worker.py
@@ -97,6 +97,8 @@ class HubArtifactStore:
     """Direct authenticated persistence for private checkpoints and receipts."""
 
     def __init__(self, repo_id: str, prefix: str) -> None:
+        from huggingface_hub import HfApi
+
         _require(
             re.fullmatch(
                 r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/[A-Za-z0-9][A-Za-z0-9_.-]{0,95}",
@@ -110,6 +112,11 @@ class HubArtifactStore:
         _require(bool(os.environ.get("HF_TOKEN")), "HF_TOKEN is required for direct checkpoint upload")
         self.repo_id = repo_id
         self.prefix = prefix.strip("/")
+        self.api = HfApi(token=os.environ["HF_TOKEN"])
+        _require(
+            bool(self.api.repo_info(repo_id=repo_id, repo_type="dataset").private),
+            "artifact repository is not private",
+        )
 
     def remote_path(self, name: str) -> str:
         _require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", name) is not None, "invalid artifact name")
@@ -135,10 +142,8 @@ class HubArtifactStore:
         return True
 
     def upload(self, path: Path, name: str) -> str:
-        from huggingface_hub import HfApi
-
         _require(path.is_file(), f"artifact is missing: {name}")
-        info = HfApi(token=os.environ["HF_TOKEN"]).upload_file(
+        info = self.api.upload_file(
             path_or_fileobj=path,
             path_in_repo=self.remote_path(name),
             repo_id=self.repo_id,

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -151,8 +151,9 @@ def test_job_commands_use_hash_first_private_transport_without_volumes(
         "status": "passed",
         "bundle_sha256": "b" * 64,
         "transport_repository": "operator/ua-open-weight-eval-staging-6273",
-        "transport_revision": "a" * 16,
+        "transport_revision": "a" * 40,
     }
+    preflight_gate["gate_sha256"] = hf_jobs_baseline.sha256_text(hf_jobs_baseline.canonical_json(preflight_gate))
     monkeypatch.setattr(hf_jobs_baseline, "verify_bundle", lambda _: manifest)
     monkeypatch.setattr(hf_jobs_baseline, "load_config", lambda *args, **kwargs: config)
     command = hf_jobs_baseline.job_command(
@@ -184,6 +185,19 @@ def test_job_commands_use_hash_first_private_transport_without_volumes(
         f"{config['runtime']['container_image']}@{config['runtime']['container_amd64_digest']}"
     )
     assert command[separator + 2 : separator + 4] == ["sh", "-lc"]
+    tampered_gate = {**preflight_gate, "preflight_cost_usd": 0.002}
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="gate SHA-256 drift"):
+        hf_jobs_baseline.job_command(
+            mode="canary",
+            namespace="operator",
+            bundle=bundle,
+            transport_repo="operator/ua-open-weight-eval-staging-6273",
+            transport_revision="a" * 40,
+            transport_prefix=f"bundles/{'b' * 64}",
+            hf_cli=hf_cli,
+            timeout_seconds=1200,
+            preflight_gate=tampered_gate,
+        )
 
     preflight = hf_jobs_baseline.job_command(
         mode="preflight",
@@ -287,6 +301,36 @@ def test_transport_manifest_and_cpu_receipt_are_hash_bound_and_direct_uploaded(
     assert receipt["transport"]["mounted_volumes"] == 0
     assert receipt["transport"]["all_hashes_verified"] is True
     assert receipt["facts"]["receipt_uploaded_directly"] is True
+
+
+def test_direct_artifact_uploads_fail_closed_if_dataset_is_not_private(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    class PublicRepoApi:
+        def __init__(self, *, token: str) -> None:
+            assert token == "not-a-real-token"
+
+        def repo_info(self, *, repo_id: str, repo_type: str) -> SimpleNamespace:
+            assert repo_id == "operator/ua-open-weight-eval-staging-6273"
+            assert repo_type == "dataset"
+            return SimpleNamespace(private=False)
+
+    monkeypatch.setenv("HF_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(huggingface_hub, "HfApi", PublicRepoApi)
+    with pytest.raises(hf_jobs_transport.TransportError, match="not private"):
+        hf_jobs_transport.upload_json(
+            repo_id="operator/ua-open-weight-eval-staging-6273",
+            path_in_repo="artifacts/receipt.json",
+            value={"harmless": True},
+            commit_message="test receipt",
+        )
+    with pytest.raises(hf_jobs_worker.WorkerError, match="not private"):
+        hf_jobs_worker.HubArtifactStore(
+            "operator/ua-open-weight-eval-staging-6273",
+            "artifacts/bundle/canary",
+        )
 
 
 def test_partial_checkpoint_is_accepted_as_exact_prefix(tmp_path: Path) -> None:
@@ -504,6 +548,7 @@ def test_cpu_preflight_reconciliation_rounds_billing_by_started_minute() -> None
         "job_id": "a" * 24,
         "bundle_sha256": "b" * 64,
         "repository": "operator/ua-open-weight-eval-staging-6273",
+        "transport_revision": "c" * 40,
     }
     gate = hf_jobs_baseline.gate_gpu_canary(
         verification=verification,
@@ -513,6 +558,18 @@ def test_cpu_preflight_reconciliation_rounds_billing_by_started_minute() -> None
     )
     assert gate["status"] == "passed"
     assert gate["preflight_cost_usd"] == 0.000333
+    assert gate["transport_revision"] == "c" * 40
+    assert gate["gate_sha256"] == hf_jobs_baseline.sha256_text(
+        hf_jobs_baseline.canonical_json({key: value for key, value in gate.items() if key != "gate_sha256"})
+    )
+    malformed = {**receipt, "labels": None}
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="labels are missing"):
+        hf_jobs_baseline.gate_gpu_canary(
+            verification=verification,
+            provider_receipt=malformed,
+            bundle_manifest={"bundle_sha256": "b" * 64},
+            repo_id="operator/ua-open-weight-eval-staging-6273",
+        )
     failed = {**receipt, "stage": "ERROR"}
     with pytest.raises(hf_jobs_baseline.BaselineError, match="did not complete"):
         hf_jobs_baseline.gate_gpu_canary(

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -174,6 +174,7 @@ def test_job_commands_use_hash_first_private_transport_without_volumes(
     assert "operator/ua-open-weight-eval-staging-6273" in joined
     assert "--secrets HF_TOKEN" in joined
     assert "HF_TOKEN=" not in joined
+    assert "--env ACCELERATOR=l40sx1" in joined
     assert "--volume" not in command
     assert "-v" not in command
     assert "hf://buckets/" not in joined
@@ -215,6 +216,7 @@ def test_job_commands_use_hash_first_private_transport_without_volumes(
     assert config["transport"]["cpu_preflight"]["container_amd64_digest"] in preflight_joined
     assert "--volume" not in preflight
     assert "--secrets HF_TOKEN" in preflight_joined
+    assert "ACCELERATOR=" not in preflight_joined
     with pytest.raises(hf_jobs_baseline.BaselineError, match="passed CPU preflight gate"):
         hf_jobs_baseline.job_command(
             mode="canary",

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -286,7 +286,7 @@ def test_transport_manifest_and_cpu_receipt_are_hash_bound_and_direct_uploaded(
         hf_jobs_transport.verify_manifest(manifest, "b" * 64)
 
     monkeypatch.setenv("JOB_ID", "c" * 24)
-    monkeypatch.setenv("ACCELERATOR", "none")
+    monkeypatch.delenv("ACCELERATOR", raising=False)
     monkeypatch.setenv("HF_TOKEN", "not-a-real-token")
     monkeypatch.setattr(hf_jobs_transport, "upload_json", lambda **kwargs: "d" * 40)
     args = SimpleNamespace(
@@ -298,9 +298,13 @@ def test_transport_manifest_and_cpu_receipt_are_hash_bound_and_direct_uploaded(
     )
     receipt = hf_jobs_transport.run_preflight(args, files)
     assert receipt["status"] == "passed"
+    assert receipt["accelerator_environment"] is None
     assert receipt["transport"]["mounted_volumes"] == 0
     assert receipt["transport"]["all_hashes_verified"] is True
     assert receipt["facts"]["receipt_uploaded_directly"] is True
+    monkeypatch.setenv("ACCELERATOR", "l40sx1")
+    with pytest.raises(hf_jobs_transport.TransportError, match="GPU accelerator"):
+        hf_jobs_transport.run_preflight(args, files)
 
 
 def test_direct_artifact_uploads_fail_closed_if_dataset_is_not_private(
@@ -481,7 +485,6 @@ def test_provider_reconciliation_uses_server_duration_and_refuses_endpoints() ->
         "status": {"stage": "COMPLETED", "expose_urls": None, "ssh_url": None},
         "durations": {"running_secs": 600},
         "secrets": ["HF_TOKEN"],
-        "volumes": [],
     }
     receipt = hf_jobs_baseline.reconcile_provider_inspection(
         inspection=inspection,

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -5,24 +5,22 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from scripts.projects.ua_open_weight_eval import hf_jobs_baseline, hf_jobs_worker, suite_cli
+from scripts.projects.ua_open_weight_eval import hf_jobs_baseline, hf_jobs_transport, hf_jobs_worker, suite_cli
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> None:
     path.write_text("".join(suite_cli.canonical_json(row) + "\n" for row in rows), encoding="utf-8")
 
 
-def _write_fake_hf_cli(path: Path, *, bucket_rows: list[dict] | None = None) -> None:
-    rows = bucket_rows if bucket_rows is not None else [{"path": ".keep", "size": 55, "type": "file"}]
+def _write_fake_hf_cli(path: Path) -> None:
     path.write_text(
         "#!/bin/sh\n"
         'if [ "$1" = "--version" ]; then\n'
         "  echo 1.25.1\n"
-        'elif [ "$1" = "buckets" ]; then\n'
-        f"  echo '{json.dumps(rows)}'\n"
         "else\n"
         "  exit 1\n"
         "fi\n",
@@ -51,7 +49,20 @@ def test_config_freezes_official_qat_artifact_runtime_and_budget() -> None:
     assert config["pricing"]["usd_per_minute"] == 0.03
     assert config["authorization"]["maximum_provider_cost_usd"] == 6.0
     assert config["authorization"]["no_automatic_paid_retry"] is True
-    assert "checkpoint_every_cases" not in config["runner"]
+    assert config["runner"]["checkpoint_upload_every_cases"] == 25
+    assert config["transport"] == {
+        "cpu_preflight": {
+            "container_amd64_digest": "sha256:8859bd6ca943079262c27e38b7119cdacede77c463139a15651dd340087a6cc9",
+            "container_image": "python:3.12.8-slim",
+            "flavor": "cpu-basic",
+            "maximum_cost_usd": 0.001,
+            "timeout_seconds": 300,
+            "usd_per_hour": 0.01,
+        },
+        "mode": "private-dataset-direct-api",
+        "mounted_volumes": 0,
+        "staging_dataset_suffix": "ua-open-weight-eval-staging-6273",
+    }
 
 
 def test_balanced_canary_is_deterministic_category_balanced_and_track_covering() -> None:
@@ -123,7 +134,9 @@ def test_tokenizer_verifier_checks_git_blobs_and_lfs_hashes(tmp_path: Path) -> N
         hf_jobs_worker.verify_tokenizer_files(tmp_path, config)
 
 
-def test_job_command_is_pinned_private_and_has_no_secret_surface(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_job_commands_use_hash_first_private_transport_without_volumes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     config = hf_jobs_baseline.load_config()
     bundle = tmp_path / "bundle"
     bundle.mkdir()
@@ -133,55 +146,83 @@ def test_job_command_is_pinned_private_and_has_no_secret_surface(tmp_path: Path,
         "bundle_sha256": "b" * 64,
         "requests_sha256": "r" * 64,
     }
+    preflight_gate = {
+        "schema_version": "ua_open_weight_eval_hf_jobs_canary_gate.v1",
+        "status": "passed",
+        "bundle_sha256": "b" * 64,
+        "transport_repository": "operator/ua-open-weight-eval-staging-6273",
+        "transport_revision": "a" * 16,
+    }
     monkeypatch.setattr(hf_jobs_baseline, "verify_bundle", lambda _: manifest)
     monkeypatch.setattr(hf_jobs_baseline, "load_config", lambda *args, **kwargs: config)
     command = hf_jobs_baseline.job_command(
         mode="canary",
         namespace="operator",
-        bucket="ua-open-weight-eval-6273",
         bundle=bundle,
-        bundle_mount="hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-bbbbbbbb",
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        transport_revision="a" * 40,
+        transport_prefix=f"bundles/{'b' * 64}",
         hf_cli=hf_cli,
         timeout_seconds=1200,
+        preflight_gate=preflight_gate,
     )
     joined = " ".join(command)
     assert "--flavor l40sx1" in joined
     assert "--timeout 20m" in joined
     assert config["runtime"]["container_amd64_digest"] in joined
-    assert "hf://buckets/operator/ua-open-weight-eval-6273:/output:rw" in joined
-    assert "hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-bbbbbbbb:/workspace:ro" in joined
-    assert f"{bundle.resolve()}:/workspace:ro" not in joined
+    assert "operator/ua-open-weight-eval-staging-6273" in joined
+    assert "--secrets HF_TOKEN" in joined
+    assert "HF_TOKEN=" not in joined
+    assert "--volume" not in command
+    assert "-v" not in command
+    assert "hf://buckets/" not in joined
     assert "--expose" not in command
     assert "--ssh" not in command
     assert "--json" not in command
-    assert "HF_TOKEN" not in joined
-    assert "--selection /workspace/canary_selection.json" in joined
     separator = command.index("--")
     assert command[separator + 1] == (
         f"{config['runtime']['container_image']}@{config['runtime']['container_amd64_digest']}"
     )
-    assert command[separator + 2 : separator + 4] == ["bash", "-lc"]
-    _write_fake_hf_cli(hf_cli, bucket_rows=[])
-    with pytest.raises(hf_jobs_baseline.BaselineError, match="not mount-ready"):
+    assert command[separator + 2 : separator + 4] == ["sh", "-lc"]
+
+    preflight = hf_jobs_baseline.job_command(
+        mode="preflight",
+        namespace="operator",
+        bundle=bundle,
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        transport_revision="a" * 40,
+        transport_prefix=f"bundles/{'b' * 64}",
+        hf_cli=hf_cli,
+        timeout_seconds=300,
+    )
+    preflight_joined = " ".join(preflight)
+    assert "--flavor cpu-basic" in preflight_joined
+    assert "--timeout 5m" in preflight_joined
+    assert config["transport"]["cpu_preflight"]["container_amd64_digest"] in preflight_joined
+    assert "--volume" not in preflight
+    assert "--secrets HF_TOKEN" in preflight_joined
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="passed CPU preflight gate"):
         hf_jobs_baseline.job_command(
             mode="canary",
             namespace="operator",
-            bucket="ua-open-weight-eval-6273",
             bundle=bundle,
-            bundle_mount="hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-bbbbbbbb",
+            transport_repo="operator/ua-open-weight-eval-staging-6273",
+            transport_revision="a" * 40,
+            transport_prefix=f"bundles/{'b' * 64}",
             hf_cli=hf_cli,
             timeout_seconds=1200,
         )
-    _write_fake_hf_cli(hf_cli)
-    with pytest.raises(hf_jobs_baseline.BaselineError, match="digest suffix drift"):
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="bound to the bundle"):
         hf_jobs_baseline.job_command(
             mode="canary",
             namespace="operator",
-            bucket="ua-open-weight-eval-6273",
             bundle=bundle,
-            bundle_mount="hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-deadbeef",
+            transport_repo="operator/ua-open-weight-eval-staging-6273",
+            transport_revision="a" * 40,
+            transport_prefix="bundles/deadbeef",
             hf_cli=hf_cli,
             timeout_seconds=1200,
+            preflight_gate=preflight_gate,
         )
 
 
@@ -204,6 +245,48 @@ def test_launch_preview_is_free_but_execute_prevents_any_second_attempt(
     assert launched["status"] == "launched"
     with pytest.raises(hf_jobs_baseline.BaselineError, match="automatic retry is prohibited"):
         hf_jobs_baseline.launch_once(command=command, mode="canary", state_path=state, execute=True)
+
+
+def test_transport_manifest_and_cpu_receipt_are_hash_bound_and_direct_uploaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = [
+        {"path": name, "bytes": 1, "sha256": "a" * 64}
+        for name in (
+            "canary_selection.json",
+            "hf_jobs_transport.py",
+            "hf_jobs_worker.py",
+            "requests.jsonl",
+            "run_config.json",
+        )
+    ]
+    unsigned = {
+        "schema_version": "ua_open_weight_eval_hf_jobs_bundle.v1",
+        "issue": 6273,
+        "files": files,
+    }
+    digest = hf_jobs_transport.sha256_bytes(hf_jobs_transport.canonical_json(unsigned).encode())
+    manifest = {**unsigned, "bundle_sha256": digest}
+    assert hf_jobs_transport.verify_manifest(manifest, digest) == files
+    with pytest.raises(hf_jobs_transport.TransportError, match="digest drift"):
+        hf_jobs_transport.verify_manifest(manifest, "b" * 64)
+
+    monkeypatch.setenv("JOB_ID", "c" * 24)
+    monkeypatch.setenv("ACCELERATOR", "none")
+    monkeypatch.setenv("HF_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(hf_jobs_transport, "upload_json", lambda **kwargs: "d" * 40)
+    args = SimpleNamespace(
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        transport_revision="e" * 40,
+        transport_prefix=f"bundles/{digest}",
+        artifact_prefix=f"artifacts/{digest}/preflight",
+        bundle_sha256=digest,
+    )
+    receipt = hf_jobs_transport.run_preflight(args, files)
+    assert receipt["status"] == "passed"
+    assert receipt["transport"]["mounted_volumes"] == 0
+    assert receipt["transport"]["all_hashes_verified"] is True
+    assert receipt["facts"]["receipt_uploaded_directly"] is True
 
 
 def test_partial_checkpoint_is_accepted_as_exact_prefix(tmp_path: Path) -> None:
@@ -313,9 +396,10 @@ def test_full_launch_timeout_is_bound_to_passed_projection(tmp_path: Path, monke
     command = hf_jobs_baseline.job_command(
         mode="full",
         namespace="operator",
-        bucket="ua-open-weight-eval-6273",
         bundle=bundle,
-        bundle_mount="hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-bbbbbbbb",
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        transport_revision="a" * 40,
+        transport_prefix=f"bundles/{'b' * 64}",
         hf_cli=hf_cli,
         timeout_seconds=maximum_timeout,
         projection=projection,
@@ -325,9 +409,10 @@ def test_full_launch_timeout_is_bound_to_passed_projection(tmp_path: Path, monke
         hf_jobs_baseline.job_command(
             mode="full",
             namespace="operator",
-            bucket="ua-open-weight-eval-6273",
             bundle=bundle,
-            bundle_mount="hf://buckets/operator/jobs-artifacts/hf-job-bundle-v4-bbbbbbbb",
+            transport_repo="operator/ua-open-weight-eval-staging-6273",
+            transport_revision="a" * 40,
+            transport_prefix=f"bundles/{'b' * 64}",
             hf_cli=hf_cli,
             timeout_seconds=maximum_timeout + 60,
             projection=projection,
@@ -347,15 +432,19 @@ def test_provider_reconciliation_uses_server_duration_and_refuses_endpoints() ->
             "name": "ua-open-weight-eval-gemma4-canary",
             "suite": config["suite"]["cases_sha256"][:16],
             "timeout_seconds": "1200",
+            "transport": "c" * 16,
         },
         "status": {"stage": "COMPLETED", "expose_urls": None, "ssh_url": None},
         "durations": {"running_secs": 600},
+        "secrets": ["HF_TOKEN"],
+        "volumes": [],
     }
     receipt = hf_jobs_baseline.reconcile_provider_inspection(
         inspection=inspection,
         mode="canary",
         config=config,
         bundle_manifest=manifest,
+        transport_revision="c" * 40,
     )
     assert receipt["provider_derived_cost_usd"] == 0.3
     inspection["labels"]["c"] = ""
@@ -365,6 +454,7 @@ def test_provider_reconciliation_uses_server_duration_and_refuses_endpoints() ->
             mode="canary",
             config=config,
             bundle_manifest=manifest,
+            transport_revision="c" * 40,
         )
     inspection["labels"].pop("c")
     inspection["status"]["expose_urls"] = ["https://example.invalid"]
@@ -374,6 +464,62 @@ def test_provider_reconciliation_uses_server_duration_and_refuses_endpoints() ->
             mode="canary",
             config=config,
             bundle_manifest=manifest,
+            transport_revision="c" * 40,
+        )
+
+
+def test_cpu_preflight_reconciliation_rounds_billing_by_started_minute() -> None:
+    config = hf_jobs_baseline.load_config()
+    inspection = {
+        "id": "a" * 24,
+        "flavor": "cpu-basic",
+        "labels": {
+            "bundle_sha256": "b" * 64,
+            "issue": "6273",
+            "mode": "preflight",
+            "name": "ua-open-weight-eval-gemma4-preflight",
+            "suite": config["suite"]["cases_sha256"][:16],
+            "timeout_seconds": "300",
+            "transport": "c" * 16,
+        },
+        "status": {"stage": "COMPLETED", "expose_urls": None, "ssh_url": None},
+        "durations": {"running_secs": 61},
+        "secrets": ["HF_TOKEN"],
+        "volumes": [],
+    }
+    receipt = hf_jobs_baseline.reconcile_provider_inspection(
+        inspection=inspection,
+        mode="preflight",
+        config=config,
+        bundle_manifest={"bundle_sha256": "b" * 64},
+        transport_revision="c" * 40,
+    )
+    assert receipt["provider_billed_minutes"] == 2
+    assert receipt["provider_derived_cost_usd"] == 0.000333
+    assert receipt["provider_derived_cost_usd"] <= 0.001
+
+    verification = {
+        "schema_version": "ua_open_weight_eval_hf_jobs_preflight_verification.v1",
+        "status": "passed",
+        "job_id": "a" * 24,
+        "bundle_sha256": "b" * 64,
+        "repository": "operator/ua-open-weight-eval-staging-6273",
+    }
+    gate = hf_jobs_baseline.gate_gpu_canary(
+        verification=verification,
+        provider_receipt=receipt,
+        bundle_manifest={"bundle_sha256": "b" * 64},
+        repo_id="operator/ua-open-weight-eval-staging-6273",
+    )
+    assert gate["status"] == "passed"
+    assert gate["preflight_cost_usd"] == 0.000333
+    failed = {**receipt, "stage": "ERROR"}
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="did not complete"):
+        hf_jobs_baseline.gate_gpu_canary(
+            verification=verification,
+            provider_receipt=failed,
+            bundle_manifest={"bundle_sha256": "b" * 64},
+            repo_id="operator/ua-open-weight-eval-staging-6273",
         )
 
 


### PR DESCRIPTION
## Summary

- replace the disproven HF bucket/repository mount path with a plain zero-volume Jobs transport
- stage the exact reviewed bundle privately, download it at an immutable commit after runtime start, and verify every hash before execution
- add the mandatory five-minute CPU Basic preflight and hard-gate the one authorized L40S canary on its direct-upload receipt and provider reconciliation
- persist GPU checkpoints and receipts by authenticated direct upload to the private staging dataset

## Authorization and limits

Relates to #6273 and implements the operator's **GO NO-VOLUME REMEDY**. The CPU preflight is fixed at five minutes / at most USD 0.001. It does not launch a GPU. The canary remains one L40S, 100 cases, 20 minutes / USD 0.60, and the cumulative phase ceiling remains USD 6.00 with no automatic paid retry.

## Verification

- `pytest -q tests/test_ua_open_weight_eval.py tests/test_ua_open_weight_eval_hf_jobs.py` — 28 passed
- `ruff check` on the changed Python surfaces — passed
- `py_compile` on baseline, transport, and worker — passed
- markdownlint on changed docs — passed
- OPSEC leak audit — passed
- source-blind launch preview — emitted CPU Basic / 5m / pinned image / bare secret / zero-volume command; no provider submission

Formal cross-family review and provider execution are gated after this exact head.
