### PR TITLE
fix(cursor): ignore rate-limit text in successful output

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -33,7 +33,7 @@ from .base import InvocationPlan
 
 _logger = logging.getLogger(__name__)
 
-# Stderr/stdout phrases that indicate the provider rate-limited us.
+# Stderr phrases that indicate the provider rate-limited a failed call.
 _RATE_LIMIT_PATTERNS = (
     r"usage limit reached",
     r"rate limit",
@@ -301,9 +301,6 @@ class CursorAdapter:
         _ = plan
         _ = call_start_time
 
-        # Detect rate limits
-        rate_limited = bool(_RATE_LIMIT_RE.search(f"{stdout}\n{stderr}"))
-
         # Parse JSONL events
         events = parse_json_events(stdout, source="cursor", logger=_logger)
         tool_calls = normalize_tool_calls(events)
@@ -349,6 +346,19 @@ class CursorAdapter:
             if transcript_response:
                 response = transcript_response
                 tool_calls = normalize_tool_calls(transcript_events)
+
+        # Cursor's stream-json stdout contains much more than the assistant's
+        # response: it can echo the user prompt and tool output verbatim. Those
+        # successful payloads routinely mention rate-limit state or files such
+        # as ``test_agent_runtime_rate_limit.py``. Treating any matching stdout
+        # token as a provider failure discards completed work and poisons the
+        # lane's cooldown history. Cursor does not document a dedicated rate-
+        # limit exit code, so follow the same conservative boundary as the
+        # Claude adapter: only a failed/empty-response call with a matching
+        # stderr diagnostic is rate-limited.
+        usable_response = bool(response)
+        failed_call = returncode != 0 or not usable_response
+        rate_limited = failed_call and bool(_RATE_LIMIT_RE.search(stderr or ""))
 
         ok = returncode == 0 and bool(response) and not rate_limited
 

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -206,6 +206,46 @@ def test_cursor_adapter_parse_response_success(adapter):
     assert result.tool_calls[0]["name"] == "mcp__sources__search_text"
 
 
+def test_cursor_adapter_successful_echoed_rate_limit_text_is_not_rate_limited(adapter):
+    """Prompt/tool text is part of stream-json stdout, not a provider signal."""
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Inspect tests/test_agent_runtime_rate_limit.py",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Completed successfully; a prior task was rate limited.",
+                        }
+                    ],
+                }
+            ),
+        ]
+    )
+
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.rate_limited is False
+    assert result.response == "Completed successfully; a prior task was rate limited."
+
+
 def test_cursor_agent_trivial_invoke_smoke():
     if os.environ.get("CI"):
         pytest.skip("real cursor-agent smoke test is skipped in CI")


### PR DESCRIPTION
Closes #6292

## Summary
- stop scanning successful Cursor stream-json stdout for rate-limit phrases
- classify rate limits only on failed or empty calls with matching stderr evidence
- add a regression test for echoed prompts and successful assistant text mentioning rate limits

## Evidence
- 395 focused and surrounding runtime/delegation tests passed
- Ruff and OPSEC checks passed
- source-blind Cursor runtime canary: exit 0, usable response, rate_limited=false

## Scope
No routing, quota policy, CLI flag, or model-selection changes.