### PR TITLE
feat(fleet-comms): deterministic quota-aware routing + migrations v6–v7 (#6293)

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -220,7 +220,7 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
   | codex | true |
   | cursor | false |
   | gemini | false |
-  | glm-local | false |
+  | glm-local | true |
   | grok | false |
   | kimi | false |
   <!-- fleet-roster-projection:end formal_review_eligible -->

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -88,7 +88,7 @@ Exact tables below must match `scripts/config/model_catalog.yaml` → `orchestra
 | codex | true |
 | cursor | false |
 | gemini | false |
-| glm-local | false |
+| glm-local | true |
 | grok | false |
 | kimi | false |
 <!-- fleet-roster-projection:end formal_review_eligible -->

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -98,8 +98,27 @@ Escalate when: architecture, hard multi-file judgment, high-stakes synthesis —
 
 ## Formal CF defaults (orchestrator-ready)
 
-Machine eligibility SSOT: `scripts/config/fleet_communications.yaml` →
-`endpoints[*].formal_review_eligible` (fail-closed until #5555–#5557).
+Machine eligibility and routing SSOT: `scripts/config/model_catalog.yaml` →
+`review_scheduler.endpoints`. It binds the exact model, family, sealed ACP
+participant, formal eligibility, and quota/credential bucket. The booleans in
+`fleet_communications.yaml` are a tested legacy status projection, not a
+second policy source.
+
+The orchestrator supplies semantic requirements: author model/family, role,
+profile, risk, capabilities, egress, isolation, and whether an exceptional pin
+is justified. The deterministic scheduler then applies this order:
+
+1. hard safety, availability, isolation, egress, context, and cross-family gates;
+2. task-role suitability and the best acceptable quality tier;
+3. only among equally suitable candidates in that tier, normalized rolling
+   assigned bytes, reserved bytes, capacity weight, verified quota headroom,
+   in-flight work, failures, and finally the exact-head stable hash.
+
+This is not round-robin and no LLM participates in routing. An idle or cheap
+model never outranks a stronger model for the requested job. Subscription calls
+still consume scarce quota and future optionality, so pressure can choose only
+inside an equivalent suitable pool or trigger a documented eligible fallback.
+Near-cap and open-circuit buckets receive no automatic work.
 
 <!-- fleet-roster-projection:begin formal_review_eligible -->
 | endpoint | formal_review_eligible |
@@ -109,7 +128,7 @@ Machine eligibility SSOT: `scripts/config/fleet_communications.yaml` →
 | codex | true |
 | cursor | false |
 | gemini | false |
-| glm-local | false |
+| glm-local | true |
 | grok | false |
 | kimi | false |
 <!-- fleet-roster-projection:end formal_review_eligible -->
@@ -117,15 +136,57 @@ Machine eligibility SSOT: `scripts/config/fleet_communications.yaml` →
 Practical seats @ **high** — not Sol/Fable on routine PRs:
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>              # codex / gpt-5.6-terra @ high
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude  # claude-sonnet-5 @ high
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer glm     # glm-5.2 LOCAL-ONLY
-# Authority escalate (critical / hard judgment only):
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --model gpt-5.6-sol --effort xhigh
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> \
+  --initiator codex/orchestrator \
+  --author-model gpt-5.6-sol --author-family openai \
+  --review-profile code --risk high
+
+# Exceptional pin: still passes every hard gate and uses the same reservation ledger.
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> \
+  --initiator codex/orchestrator \
+  --author-model gpt-5.6-sol --author-family openai \
+  --reviewer claude --override-reason "operator-requested Anthropic dissent"
+
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ...  # default Laguna S 2.1
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ... --model poolside/poolside/laguna-xs-2.1  # XS 2.1 light
 ```
+
+Automatic selection and admission occur in one `BEGIN IMMEDIATE` transaction
+in the shared Fleet Comms authority database. Reservations have a TTL; startup
+recovery expires orphaned holders. Retryable automatic transport failures
+settle and open the failed quota/credential circuit before another eligible
+bucket is selected. Explicit pins never switch provider unless
+`--allow-explicit-fallback` was also supplied. A completed identical exact-head
+request replays the durable verdict without a provider call or reservation.
+
+### Diagnose quota concentration
+
+- Open `runtime.html` → **Routing assignments**. `AUTOMATIC` and `EXPLICIT`
+  records are visually distinct and show initiator, author, task fit, selected
+  model/family, quota and credential bucket, quota freshness/headroom, work,
+  lifecycle, retry chain, replay state, and authority record ID.
+- Query `/api/runtime/routing-assignments` for the same read-only evidence.
+- Compare the decision trace's hard-gate and suitability reasons before blaming
+  load: a deliberately stronger suitable model may receive more work.
+- Confirm provider headroom with CodexBar. A timeout or malformed probe retains
+  the last known good record and exposes failure metadata separately.
+- Concentration among truly equivalent suitable candidates indicates stale
+  reservations, a shared credential bucket, circuit failures, or bad capacity
+  weights—not a reason to weaken the quality floor.
+
+### Migration, restart, and rollback
+
+Fleet Comms migration v7 is additive, idempotent, and applied on authority-store
+startup. During rollout, stop old orchestrator processes, restart the Fleet
+Comms/Runtime API processes with the repository's existing service launcher,
+then verify authority mode and the routing-assignment endpoint before resuming
+formal reviews. Do not delete or downgrade the v7 tables.
+
+To roll back, stop formal-review callers, revert the scheduler/bridge application
+change, restart those same processes, and leave the additive ledger tables in
+place for audit/recovery. The explicit message-plane environment override
+remains the separate Fleet Comms authority rollback control; changing it does
+not erase routing evidence.
 
 ### Poolside Laguna model types (exact IDs)
 

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -32,8 +32,69 @@ PROVIDER_TO_LANE = {
 
 # In-memory storage for the last successfully fetched usage data (lasts the lifetime of the process)
 _last_good_data: dict[str, tuple[float, dict[str, Any]]] = {}
+_last_failure_data: dict[str, dict[str, Any]] = {}
 _refresh_lock = threading.Lock()
 _refresh_thread: threading.Thread | None = None
+
+
+def _is_usable_capacity(data: dict[str, Any] | None) -> bool:
+    """Return whether a probe supplied authoritative capacity, not merely JSON."""
+    if not isinstance(data, dict) or data.get("status") != "healthy":
+        return False
+    weekly_used = data.get("weekly_used_pct")
+    return isinstance(weekly_used, (int, float)) and not isinstance(weekly_used, bool)
+
+
+def _failure_metadata(data: dict[str, Any]) -> dict[str, Any]:
+    """Keep failed-probe details separate from usable capacity observations."""
+    return {
+        "failure_kind": data.get("error_kind") or "unavailable",
+        "failure_code": data.get("error_code"),
+        "failure_message": data.get("auth_error") or "CodexBar usage data unavailable",
+        "last_failure_at": data.get("fetched_at") or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _record_probe_result(provider: str, data: dict[str, Any] | None) -> bool:
+    """Persist only usable capacity; retain failures as diagnostic metadata.
+
+    A CodexBar error is an observation about the failed probe, not a capacity
+    value.  In particular, it must never replace a valid last-known-good
+    sample, otherwise a single timeout turns a usable lane into unavailable.
+    """
+    if not _is_usable_capacity(data):
+        if isinstance(data, dict):
+            _last_failure_data[provider] = _failure_metadata(data)
+        return False
+
+    assert data is not None  # narrowed by _is_usable_capacity
+    snapshot = dict(data)
+    cache_set(f"codexbar_usage:{provider}", snapshot)
+    _last_good_data[provider] = (time.monotonic(), snapshot)
+    return True
+
+
+def _with_observation_metadata(
+    data: dict[str, Any],
+    *,
+    freshness: str,
+    age_s: float | None,
+    provider: str,
+) -> dict[str, Any]:
+    """Add a stable freshness/failure contract without changing capacity data."""
+    result = dict(data)
+    failure = _last_failure_data.get(provider) or {}
+    result.update(
+        {
+            "freshness": freshness,
+            "stale": freshness == "stale_last_good",
+            "age_s": age_s,
+            "failure_kind": failure.get("failure_kind"),
+            "last_failure_at": failure.get("last_failure_at"),
+            "last_failure_code": failure.get("failure_code"),
+        }
+    )
+    return result
 
 
 def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 2.0) -> dict[str, dict[str, Any]]:
@@ -56,13 +117,25 @@ def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 
         for provider, future in futures.items():
             try:
                 data = future.result()
-            except Exception:
-                data = None
-            if data is None:
-                continue
-            cache_set(f"codexbar_usage:{provider}", data)
-            _last_good_data[provider] = (time.monotonic(), data)
-            refreshed[provider] = data
+            except Exception as exc:
+                data = _normalize_provider_error(
+                    provider,
+                    {
+                        "message": f"CodexBar refresh failed: {exc}",
+                        "kind": "fetch_error",
+                        "code": "FETCH_ERROR",
+                    },
+                )
+            if _record_probe_result(provider, data):
+                # The explicit fresh caller may use only a confirmed capacity
+                # sample. Failed probes remain available through
+                # get_provider_usage_data() as diagnostic metadata.
+                refreshed[provider] = _with_observation_metadata(
+                    data,
+                    freshness="fresh",
+                    age_s=0.0,
+                    provider=provider,
+                )
     return refreshed
 
 
@@ -458,7 +531,7 @@ def _normalize_provider_error(provider: str, error: Any) -> dict[str, Any]:
 
 
 def trigger_background_refresh() -> None:
-    """Spawns a background thread to update the cache for all providers sequentially."""
+    """Start bounded parallel refreshes without making an API request wait."""
     global _refresh_thread
     with _refresh_lock:
         if _refresh_thread is not None and _refresh_thread.is_alive():
@@ -468,17 +541,10 @@ def trigger_background_refresh() -> None:
 
 
 def _run_all_refreshes() -> None:
-    # List of unique providers to refresh
+    # The background path must not serially spend six long CLI timeouts. Its
+    # bounded probes are parallel and failed probes cannot poison LKG data.
     providers = ["claude", "codex", "cursor", "gemini", "grok", "kimi"]
-    for provider in providers:
-        try:
-            data = fetch_codexbar_usage(provider)
-            if data is not None:
-                cache_key = f"codexbar_usage:{provider}"
-                cache_set(cache_key, data)
-                _last_good_data[provider] = (time.monotonic(), data)
-        except Exception:
-            pass
+    refresh_provider_usage_data(providers, timeout_s=2.0)
 
 
 def get_provider_usage_data(provider: str) -> dict[str, Any]:
@@ -492,11 +558,13 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
 
     if cached is not None:
         val, age = cached
-        if isinstance(val, dict):
-            res = dict(val)
-            res["stale"] = False
-            res["age_s"] = age
-            return res
+        if _is_usable_capacity(val):
+            return _with_observation_metadata(
+                val,
+                freshness="fresh",
+                age_s=age,
+                provider=provider,
+            )
 
     # Cache miss or expired: trigger update background thread
     trigger_background_refresh()
@@ -504,10 +572,12 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
     # Serve last good data as stale fallback
     if provider in _last_good_data:
         t_mono, val = _last_good_data[provider]
-        res = dict(val)
-        res["stale"] = True
-        res["age_s"] = time.monotonic() - t_mono
-        return res
+        return _with_observation_metadata(
+            val,
+            freshness="stale_last_good",
+            age_s=time.monotonic() - t_mono,
+            provider=provider,
+        )
 
     # Completely unavailable fallback
     lane = PROVIDER_TO_LANE.get(provider, provider)
@@ -518,7 +588,7 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         "window_minutes": None,
         "reset_description": None,
     }
-    return {
+    result = {
         "lane": lane,
         "primary_used_pct": None,
         "primary_remaining_pct": None,
@@ -537,6 +607,7 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         "pace_summary": None,
         "source": "codexbar",
         "fetched_at": None,
+        "freshness": "unavailable",
         "stale": False,
         "age_s": None,
         "status": "unavailable",
@@ -544,3 +615,18 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         "error_kind": "unavailable",
         "error_code": None,
     }
+    failure = _last_failure_data.get(provider)
+    if failure:
+        result.update(
+            {
+                "auth_error": failure["failure_message"],
+                "error_kind": failure["failure_kind"],
+                "error_code": failure["failure_code"],
+                "failure_kind": failure["failure_kind"],
+                "last_failure_at": failure["last_failure_at"],
+                "last_failure_code": failure["failure_code"],
+            }
+        )
+    else:
+        result.update({"failure_kind": "unavailable", "last_failure_at": None, "last_failure_code": None})
+    return result

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -783,10 +783,15 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
     cb_sourced_any = False
     cb_stale = False
     cb_max_age_s = None
+    cb_freshness: dict[str, str] = {}
     refreshed_codexbar = refresh_provider_usage_data(SUBSCRIPTION_LANES) if fresh_codexbar else {}
 
     for lane in SUBSCRIPTION_LANES:
         cb_data = refreshed_codexbar.get(lane) or get_provider_usage_data(lane)
+        if isinstance(cb_data, dict):
+            cb_freshness[lane] = str(cb_data.get("freshness") or (
+                "stale_last_good" if cb_data.get("stale") else "fresh"
+            ))
         if cb_data and cb_data.get("weekly_used_pct") is not None:
             cb_sourced_any = True
             weekly_used = cb_data["weekly_used_pct"]
@@ -832,7 +837,14 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 "will_last_to_reset": cb_data.get("will_last_to_reset"),
                 "pace_summary": cb_data.get("pace_summary"),
                 "stale": cb_data.get("stale", False),
+                "freshness": cb_data.get("freshness") or (
+                    "stale_last_good" if cb_data.get("stale") else "fresh"
+                ),
+                "age_s": cb_data.get("age_s"),
                 "fetched_at": cb_data.get("fetched_at"),
+                "failure_kind": cb_data.get("failure_kind"),
+                "last_failure_at": cb_data.get("last_failure_at"),
+                "last_failure_code": cb_data.get("last_failure_code"),
             }
 
             # Update authoritative keys in agents
@@ -895,11 +907,16 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 "will_last_to_reset": None,
                 "pace_summary": None,
                 "stale": cb_data.get("stale", False) if isinstance(cb_data, dict) else False,
+                "freshness": cb_data.get("freshness", "unavailable") if isinstance(cb_data, dict) else "unavailable",
+                "age_s": cb_data.get("age_s") if isinstance(cb_data, dict) else None,
                 "fetched_at": cb_data.get("fetched_at") if isinstance(cb_data, dict) else None,
                 "status": "unavailable",
                 "auth_error": err_msg,
                 "error_kind": err_kind,
                 "error_code": err_code,
+                "failure_kind": cb_data.get("failure_kind", err_kind) if isinstance(cb_data, dict) else err_kind,
+                "last_failure_at": cb_data.get("last_failure_at") if isinstance(cb_data, dict) else None,
+                "last_failure_code": cb_data.get("last_failure_code", err_code) if isinstance(cb_data, dict) else err_code,
             }
             if lane == "claude":
                 agents[lane]["interactive"]["status"] = "unavailable"
@@ -1146,6 +1163,8 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
             "stale_threshold_s": 900,
             "reset_imminent_hours": reset_hours,
             "codexbar_data_available": cb_sourced_any,
+            "codexbar_freshness": cb_freshness,
+            "codexbar_max_age_s": cb_max_age_s,
             "fresh_codexbar_requested": fresh_codexbar,
             "runtime_data_available": runtime_sourced_any,
             "usage_sources": {

--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -10,6 +10,12 @@ version: 1
 message_plane:
   default_mode: authority
 
+# Projection only. Formal-review policy, model pins, sealed participants, and
+# quota/credential buckets are canonical in model_catalog.yaml under
+# review_scheduler.endpoints. Keep these endpoint booleans synchronized for
+# legacy endpoint-status consumers; reviewer_resolver never reads this copy.
+formal_review_eligibility_source: scripts/config/model_catalog.yaml#review_scheduler.endpoints
+
 # formal_review_eligible is fail-closed until sealed CF isolation is proven and
 # the matching isolation issue closes (#5555 AGY, #5556 Kimi, #5557 Grok). GLM,
 # Claude, and Codex enter through the sealed exact-head ACP review path; other live lanes stay
@@ -121,5 +127,5 @@ endpoints:
     default_ttl_seconds: 3600
     retry_class: standard
     concurrency_limit: 1
-    formal_review_eligible: false
+    formal_review_eligible: true
     model_family_resolver: canonical-reviewer-resolver

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -40,6 +40,152 @@ policy:
       grok routes remain banned).
     - Composer 2.5 conservatively shares Moonshot independence lineage with Kimi.
 
+# Canonical sealed formal-review transports. Resolver policy consumes these
+# endpoint records before considering balance. A route with
+# formal_review_eligible: false may support advisory or implementation work,
+# but it is never selected as the formal cross-family gate.
+review_scheduler:
+  schema_version: review-scheduler.v1
+  policy_version: deterministic-formal-routing.v2
+  # Suitability is a semantic gate/rank, not a traffic-rotation weight. These
+  # ordered catalog roles are read from the selected model's `roles` field:
+  # an absent role fails closed, and pressure only breaks ties at one exact
+  # profile/risk suitability + quality tier.
+  profile_risk_role_order:
+    code:
+      critical: [critical_review]
+      high: [strong_review, standard_review, long_context_review, critical_review]
+      medium: [standard_review, strong_review, long_context_review, routine_review, critical_review]
+      low: [routine_review, standard_review, strong_review, long_context_review, critical_review]
+    infra:
+      critical: [critical_review, security_review]
+      high: [strong_review, security_review, standard_review, long_context_review, critical_review]
+      medium: [standard_review, strong_review, security_review, long_context_review, routine_review, critical_review]
+      low: [routine_review, standard_review, strong_review, security_review, long_context_review, critical_review]
+  automatic_near_cap_assignments: false
+  endpoints:
+    claude:
+      formal_review_eligible: true
+      models: [claude-fable-5, claude-sonnet-5]
+      participant: claude
+      adapter_transport: acp
+      catalog_transport: native_claude
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: claude
+      credential_bucket: claude
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    codex:
+      formal_review_eligible: true
+      models: [gpt-5.6-sol, gpt-5.6-terra]
+      participant: codex
+      adapter_transport: acp
+      catalog_transport: native_codex
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: codex
+      credential_bucket: codex
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    glm:
+      formal_review_eligible: true
+      models: [glm-5.2]
+      participant: glm
+      adapter_transport: acp
+      catalog_transport: opencode
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: glm
+      credential_bucket: glm
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    agy:
+      formal_review_eligible: false
+      formal_review_exclusion_reason: source-blind AGY ACP wrapper does not expose parent-owned MCP servers
+      models: [gemini-3.6-flash-high]
+      participant: agy
+      adapter_transport: acp
+      catalog_transport: agy
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: agy
+      credential_bucket: agy
+      quota_limit: 2
+      credential_limit: 2
+      capacity_weight: 1.0
+    grok:
+      formal_review_eligible: false
+      formal_review_exclusion_reason: native Grok ACP sealed MCP consumption is not yet authenticated end-to-end
+      models: [grok-4.5]
+      participant: grok
+      adapter_transport: acp
+      catalog_transport: native_grok
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: grok
+      credential_bucket: grok
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    kimi:
+      formal_review_eligible: false
+      formal_review_exclusion_reason: bare Kimi launcher is not the canonical K3 participant
+      models: []
+      participant: kimi
+      adapter_transport: acp
+      catalog_transport: native_kimi
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: kimi
+      credential_bucket: kimi
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    kimicc:
+      formal_review_eligible: false
+      formal_review_exclusion_reason: KimiCC K3 sealed MCP consumption is not yet authenticated end-to-end
+      models: [kimi-code/k3]
+      participant: kimicc
+      adapter_transport: acp
+      catalog_transport: native_kimi
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: kimi
+      credential_bucket: kimi
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    cursor:
+      formal_review_eligible: false
+      participant: cursor
+      adapter_transport: acp
+      catalog_transport: cursor
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: cursor
+      credential_bucket: cursor
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    deepseek:
+      formal_review_eligible: false
+      participant: deepseek
+      adapter_transport: acp
+      catalog_transport: hermes
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: deepseek
+      credential_bucket: deepseek
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+    pool:
+      formal_review_eligible: false
+      participant: pool
+      adapter_transport: acp
+      catalog_transport: opencode
+      sealed_executable: scripts.ai_agent_bridge._review_pr:invoke_inter_agent
+      quota_bucket: pool
+      credential_bucket: pool
+      quota_limit: 1
+      credential_limit: 1
+      capacity_weight: 1.0
+
 # Bounded execution routing after a frontier advisory pass. This is deliberately
 # separate from review_ladders: it selects an implementation/investigation lane,
 # not a formal reviewer or a release authority.
@@ -448,7 +594,7 @@ review_candidates:
     transport: native_codex
     invocation: .venv/bin/python scripts/delegate.py dispatch --agent codex
     review_profiles: [code, infra]
-    capabilities: [code_review]
+    capabilities: [code_review, isolation, sealed_evidence]
     advisory_only_for_author_families: [openai]
   gpt-5.6-terra:
     model_id: gpt-5.6-terra
@@ -456,14 +602,14 @@ review_candidates:
     transport: native_codex
     invocation: .venv/bin/python scripts/delegate.py dispatch --agent codex --model gpt-5.6-terra
     review_profiles: [code, infra]
-    capabilities: [code_review]
+    capabilities: [code_review, isolation, sealed_evidence]
   claude-fable-5:
     model_id: claude-fable-5
     route: claude
     transport: native_claude
     invocation: .venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-fable-5
     review_profiles: [code, infra]
-    capabilities: [code_review]
+    capabilities: [code_review, isolation, sealed_evidence]
   claude-fable-5-cursor-fallback:
     model_id: claude-fable-5
     route: cursor
@@ -504,9 +650,12 @@ review_candidates:
     capabilities: [code_review]
   kimi-k3:
     model_id: kimi-code/k3
-    route: kimi
+    # kimicc is the concrete K3 ACP participant; bare `kimi` is a launcher
+    # family and must never be serialized as the participant identity.
+    route: kimicc
     transport: native_kimi
     invocation: .venv/bin/python scripts/delegate.py dispatch --agent kimi --model k3
+    health_keys: [kimi]
     review_profiles: [code, infra]
     capabilities: [code_review]
   glm-5.2:
@@ -515,7 +664,7 @@ review_candidates:
     transport: opencode
     invocation: .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-glm
     review_profiles: [code, infra]
-    capabilities: [code_review]
+    capabilities: [code_review, isolation, sealed_evidence]
     requires_data_egress_policy: local_interactive
   claude-opus-5:
     model_id: claude-opus-5
@@ -530,7 +679,7 @@ review_candidates:
     transport: native_claude
     invocation: .venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-sonnet-5
     review_profiles: [code, infra]
-    capabilities: [code_review]
+    capabilities: [code_review, isolation, sealed_evidence]
   deepseek-v4-pro:
     model_id: deepseek-v4-pro
     route: deepseek

--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -424,6 +424,99 @@ _V5_STATEMENTS = (
        END""",
 )
 
+# #6293: shared, transactionally admitted routing reservations.  This is
+# intentionally part of the Fleet Comms authority SQLite rather than a
+# worktree-local cache: quota admission must serialize across every initiator.
+_V6_STATEMENTS = (
+    """CREATE TABLE IF NOT EXISTS routing_reservations (
+        reservation_id TEXT PRIMARY KEY,
+        authority_key TEXT NOT NULL,
+        attempt INTEGER NOT NULL CHECK (attempt > 0),
+        idempotency_key TEXT NOT NULL,
+        request_sha256 TEXT NOT NULL,
+        initiator TEXT NOT NULL,
+        author_model TEXT NOT NULL,
+        author_family TEXT NOT NULL,
+        requested_role TEXT NOT NULL,
+        requested_profile TEXT NOT NULL,
+        requested_risk TEXT NOT NULL,
+        route_mode TEXT NOT NULL CHECK (route_mode IN ('auto', 'explicit')),
+        resolved_candidate TEXT NOT NULL,
+        resolved_route TEXT NOT NULL,
+        resolved_model TEXT NOT NULL,
+        resolved_family TEXT NOT NULL,
+        quota_bucket TEXT NOT NULL,
+        policy_version TEXT NOT NULL,
+        estimated_input_bytes INTEGER NOT NULL CHECK (estimated_input_bytes >= 0),
+        quota_snapshot_json TEXT NOT NULL,
+        quota_fresh_at TEXT,
+        trace_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        started_at TEXT,
+        settled_at TEXT,
+        status TEXT NOT NULL CHECK (status IN (
+            'reserved', 'running', 'complete', 'failed', 'expired', 'cancelled'
+        )),
+        actual_bytes INTEGER,
+        actual_tokens INTEGER,
+        failure_classification TEXT,
+        terminal_sha256 TEXT,
+        UNIQUE (authority_key, attempt),
+        UNIQUE (authority_key, idempotency_key)
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_routing_reservations_active_bucket ON routing_reservations(quota_bucket, status, expires_at)",
+    "CREATE INDEX IF NOT EXISTS idx_routing_reservations_authority ON routing_reservations(authority_key, attempt DESC)",
+    """CREATE TABLE IF NOT EXISTS routing_reservation_decisions (
+        decision_id TEXT PRIMARY KEY,
+        reservation_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        state TEXT NOT NULL,
+        evidence_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (reservation_id) REFERENCES routing_reservations(reservation_id)
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_routing_reservation_decisions_reservation ON routing_reservation_decisions(reservation_id, created_at)",
+    """CREATE TRIGGER IF NOT EXISTS routing_reservation_decisions_immutable_update
+       BEFORE UPDATE ON routing_reservation_decisions
+       BEGIN
+         SELECT RAISE(ABORT, 'routing_reservation_decision_immutable');
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS routing_reservation_decisions_immutable_delete
+       BEFORE DELETE ON routing_reservation_decisions
+       BEGIN
+         SELECT RAISE(ABORT, 'routing_reservation_decision_immutable');
+       END""",
+    """CREATE TABLE IF NOT EXISTS routing_circuit_state (
+        route_key TEXT PRIMARY KEY,
+        recent_failure_count INTEGER NOT NULL DEFAULT 0 CHECK (recent_failure_count >= 0),
+        last_failure_at TEXT,
+        last_failure_classification TEXT,
+        open_until TEXT,
+        updated_at TEXT NOT NULL
+    )""",
+)
+
+# #6293 follow-up: admission is credential-scoped while accounting remains
+# quota-scoped.  Keep this forward-only because v6 may already exist in a
+# shared authority database when a process restarts.
+_V7_STATEMENTS = (
+    "ALTER TABLE routing_reservations ADD COLUMN credential_bucket TEXT NOT NULL DEFAULT ''",
+    "UPDATE routing_reservations SET credential_bucket = quota_bucket WHERE credential_bucket = ''",
+    "ALTER TABLE routing_reservations ADD COLUMN semantic_sha256 TEXT NOT NULL DEFAULT ''",
+    "UPDATE routing_reservations SET semantic_sha256 = request_sha256 WHERE semantic_sha256 = ''",
+    "ALTER TABLE routing_reservations ADD COLUMN requested_reviewer TEXT",
+    "ALTER TABLE routing_reservations ADD COLUMN fallback_from TEXT",
+    "ALTER TABLE routing_reservations ADD COLUMN retry_attempt INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE routing_reservations ADD COLUMN quota_source TEXT NOT NULL DEFAULT 'unknown'",
+    "ALTER TABLE routing_reservations ADD COLUMN quota_headroom_band TEXT NOT NULL DEFAULT 'unknown'",
+    "ALTER TABLE routing_reservations ADD COLUMN actual_input_bytes INTEGER",
+    "ALTER TABLE routing_reservations ADD COLUMN actual_output_bytes INTEGER",
+    "ALTER TABLE routing_reservations ADD COLUMN actual_input_tokens INTEGER",
+    "ALTER TABLE routing_reservations ADD COLUMN actual_output_tokens INTEGER",
+    "CREATE INDEX IF NOT EXISTS idx_routing_reservations_active_credential ON routing_reservations(credential_bucket, status, expires_at)",
+)
+
 MIGRATIONS = (
     Migration(version=1, name="fleet-comms-v1-contracts", statements=_V1_STATEMENTS),
     Migration(
@@ -441,6 +534,16 @@ MIGRATIONS = (
         version=5,
         name="fleet-comms-v5-authority-immutability",
         statements=_V5_STATEMENTS,
+    ),
+    Migration(
+        version=6,
+        name="fleet-comms-v6-routing-reservations",
+        statements=_V6_STATEMENTS,
+    ),
+    Migration(
+        version=7,
+        name="fleet-comms-v7-routing-credential-admission",
+        statements=_V7_STATEMENTS,
     ),
 )
 

--- a/scripts/fleet_comms/routing_reservations.py
+++ b/scripts/fleet_comms/routing_reservations.py
@@ -1,0 +1,1049 @@
+"""Transactional routing reservations in the shared Fleet Comms authority store.
+
+This module deliberately owns admission and durable evidence, not routing
+policy.  Callers provide their already-approved policy/resolver callback to
+``reserve``; the callback sees current bucket occupancy and circuit evidence
+while the ledger's ``BEGIN IMMEDIATE`` transaction is held.  Therefore a
+candidate selected by policy is admitted (or rejected for capacity) in the
+same serialization boundary, without copying reviewer-resolver policy here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.contracts import new_id
+from scripts.fleet_comms.migrations import apply_migrations
+from scripts.fleet_comms.paths import default_plane_root
+
+ReservationStatus = Literal["reserved", "running", "complete", "failed", "expired", "cancelled"]
+RouteMode = Literal["auto", "explicit"]
+TerminalStatus = Literal["complete", "failed", "cancelled"]
+
+_ACTIVE_STATUSES = frozenset({"reserved", "running"})
+_TERMINAL_STATUSES = frozenset({"complete", "failed", "expired", "cancelled"})
+_SETTLEABLE_STATUSES = frozenset({"complete", "failed", "cancelled"})
+
+
+class RoutingReservationError(RuntimeError):
+    """Routing reservation admission or lifecycle operation was refused."""
+
+
+class RoutingReservationUnavailable(RoutingReservationError):
+    """No policy-approved route can be admitted at the current quota state."""
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingReservationRequest:
+    """Stable input to one exact-head routing decision.
+
+    ``authority_key`` must encode every dimension that makes two requests
+    non-interchangeable (at minimum the immutable head and requested role).
+    It is intentionally supplied by the caller because this ledger does not
+    know repository or reviewer-resolver policy semantics.
+    """
+
+    authority_key: str
+    idempotency_key: str
+    initiator: str
+    author_model: str
+    author_family: str
+    requested_role: str
+    requested_profile: str
+    requested_risk: str
+    route_mode: RouteMode
+    estimated_input_bytes: int
+    requested_reviewer: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingSelection:
+    """Policy's selected candidate, supplied while the admission transaction is open."""
+
+    candidate: str
+    route: str
+    model: str
+    family: str
+    quota_bucket: str
+    credential_bucket: str
+    quota_limit: int
+    credential_limit: int
+    policy_version: str
+    quota_snapshot: Mapping[str, Any]
+    quota_fresh_at: str | None = None
+    trace: Mapping[str, Any] | None = None
+    fallback_from: str | None = None
+    retry_attempt: int = 0
+    quota_source: str = "unknown"
+    quota_headroom_band: str = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingCircuitState:
+    route_key: str
+    recent_failure_count: int
+    last_failure_at: str | None
+    last_failure_classification: str | None
+    open_until: str | None
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingBucketUsage:
+    """Durable admission facts for one quota bucket at the transaction point."""
+
+    quota_bucket: str
+    rolling_window_seconds: int
+    inflight_reservations: int
+    reserved_input_bytes: int
+    completed_window_bytes: int
+    recent_failures: int
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingReservation:
+    reservation_id: str
+    authority_key: str
+    attempt: int
+    idempotency_key: str
+    request_sha256: str
+    semantic_sha256: str
+    initiator: str
+    author_model: str
+    author_family: str
+    requested_role: str
+    requested_profile: str
+    requested_risk: str
+    route_mode: str
+    requested_reviewer: str | None
+    resolved_candidate: str
+    resolved_route: str
+    resolved_model: str
+    resolved_family: str
+    quota_bucket: str
+    credential_bucket: str
+    policy_version: str
+    estimated_input_bytes: int
+    quota_snapshot: dict[str, Any]
+    quota_fresh_at: str | None
+    fallback_from: str | None
+    retry_attempt: int
+    quota_source: str
+    quota_headroom_band: str
+    trace: dict[str, Any]
+    created_at: str
+    expires_at: str
+    started_at: str | None
+    settled_at: str | None
+    status: str
+    actual_bytes: int | None
+    actual_tokens: int | None
+    actual_input_bytes: int | None
+    actual_output_bytes: int | None
+    actual_input_tokens: int | None
+    actual_output_tokens: int | None
+    failure_classification: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingReservationDecision:
+    decision_id: str
+    reservation_id: str
+    event_type: str
+    state: str
+    evidence: dict[str, Any]
+    created_at: str
+
+
+class RoutingSelectionContext:
+    """Read-only admission facts exposed to the caller's policy callback."""
+
+    def __init__(self, ledger: RoutingReservationLedger, *, now: str) -> None:
+        self._ledger = ledger
+        self.now = now
+
+    def active_reservations(self, credential_bucket: str) -> int:
+        """Return active holders for one credential within this transaction."""
+        return self._ledger._active_credential_count(_required(credential_bucket, "credential_bucket"))
+
+    def available_slots(self, credential_bucket: str, credential_limit: int) -> int:
+        """Return credential-scoped capacity left under policy's supplied limit."""
+        limit = _positive_int(credential_limit, "credential_limit")
+        return max(0, limit - self.active_reservations(credential_bucket))
+
+    def active_quota_reservations(self, quota_bucket: str) -> int:
+        """Return active holders sharing one provider/account quota bucket."""
+        return self._ledger._active_quota_count(_required(quota_bucket, "quota_bucket"))
+
+    def quota_available_slots(self, quota_bucket: str, quota_limit: int) -> int:
+        """Return quota-bucket capacity left within the admission transaction."""
+        limit = _positive_int(quota_limit, "quota_limit")
+        return max(0, limit - self.active_quota_reservations(quota_bucket))
+
+    def bucket_usage(self, quota_bucket: str, *, rolling_window_seconds: int = 3600) -> RoutingBucketUsage:
+        """Return quota accounting in an explicit rolling completion window."""
+        return self._ledger._bucket_usage(
+            _required(quota_bucket, "quota_bucket"),
+            now_iso=self.now,
+            rolling_window_seconds=rolling_window_seconds,
+        )
+
+    def circuit_state(self, route_key: str) -> RoutingCircuitState | None:
+        return self._ledger._circuit_state(_required(route_key, "route_key"))
+
+    def bucket_circuit_state(self, quota_bucket: str, credential_bucket: str) -> RoutingCircuitState | None:
+        """Read the no-immediate-retry circuit for a quota/credential pairing."""
+        return self._ledger._circuit_state(self._ledger._circuit_key(quota_bucket, credential_bucket))
+
+
+Selector = Callable[[RoutingSelectionContext], RoutingSelection | None]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return (value or _utc_now()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: str, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise RoutingReservationError(f"invalid_{field}") from exc
+    if parsed.tzinfo is None:
+        raise RoutingReservationError(f"invalid_{field}")
+    return parsed.astimezone(UTC)
+
+
+def _now(value: str | None) -> tuple[datetime, str]:
+    parsed = _utc_now() if value is None else _parse_iso(value, field="now")
+    return parsed, _iso(parsed)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _mapping(value: Mapping[str, Any] | None, *, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    try:
+        decoded = json.loads(_canonical_json(dict(value)))
+    except (TypeError, ValueError) as exc:
+        raise RoutingReservationError(f"{field}_must_be_json_object") from exc
+    if not isinstance(decoded, dict):  # pragma: no cover - dict() guarantees this
+        raise RoutingReservationError(f"{field}_must_be_json_object")
+    return decoded
+
+
+def _required(value: str, field: str) -> str:
+    normalized = " ".join(str(value or "").split())
+    if not normalized:
+        raise RoutingReservationError(f"{field}_required")
+    return normalized
+
+
+def _positive_int(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RoutingReservationError(f"{field}_must_be_positive")
+    return value
+
+
+def _nonnegative_int(value: int | None, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RoutingReservationError(f"{field}_must_be_nonnegative")
+    return value
+
+
+class RoutingReservationLedger:
+    """Shared authority SQLite ledger for one-at-a-time routing admission."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore | None = None,
+        root: Path | None = None,
+    ) -> None:
+        self.store = store or ArtifactStore(root=root)
+        self._owns_store = store is None
+        self._conn = self.store.connection
+        apply_migrations(self._conn)
+
+    def close(self) -> None:
+        if self._owns_store:
+            self.store.close()
+
+    def __enter__(self) -> RoutingReservationLedger:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def reserve_selection(
+        self,
+        request: RoutingReservationRequest,
+        selector: Selector,
+        *,
+        ttl_seconds: int = 300,
+        now: str | None = None,
+    ) -> RoutingReservation:
+        """Replay or atomically select and admit a route.
+
+        The policy callback is invoked *inside* the write transaction.  It may
+        inspect only the context's durable occupancy and circuit facts; this
+        module performs no candidate ranking or resolver-policy substitution.
+        """
+        req, request_sha, semantic_sha = self._validate_request(request)
+        ttl = _positive_int(ttl_seconds, "ttl_seconds")
+        current, current_iso = _now(now)
+        with self._write_transaction():
+            self._recover_expired_tx(current_iso)
+            idempotent = self._conn.execute(
+                """SELECT * FROM routing_reservations
+                   WHERE authority_key = ? AND idempotency_key = ?""",
+                (req.authority_key, req.idempotency_key),
+            ).fetchone()
+            if idempotent is not None:
+                if str(idempotent["request_sha256"]) != request_sha:
+                    raise RoutingReservationError("idempotency_key_reused_with_different_request")
+                return self._reservation_from_row(idempotent)
+
+            latest = self._conn.execute(
+                """SELECT * FROM routing_reservations
+                   WHERE authority_key = ?
+                   ORDER BY attempt DESC LIMIT 1""",
+                (req.authority_key,),
+            ).fetchone()
+            if latest is not None and str(latest["semantic_sha256"]) != semantic_sha:
+                raise RoutingReservationError("authority_key_semantic_conflict")
+            if latest is not None and str(latest["status"]) in _ACTIVE_STATUSES:
+                # A distinct initiator joins the same exact-head decision rather
+                # than causing a second selection or a quota herd.
+                return self._reservation_from_row(latest)
+
+            selection = selector(RoutingSelectionContext(self, now=current_iso))
+            if selection is None:
+                raise RoutingReservationUnavailable("no_policy_approved_route")
+            selected = self._validate_selection(selection)
+            circuit = self._circuit_state(self._circuit_key(selected.quota_bucket, selected.credential_bucket))
+            if circuit is not None and circuit.open_until is not None and circuit.open_until > current_iso:
+                raise RoutingReservationUnavailable("credential_bucket_circuit_open")
+            active_credential_count = self._active_credential_count(selected.credential_bucket)
+            if active_credential_count >= selected.credential_limit:
+                raise RoutingReservationUnavailable("credential_bucket_exhausted")
+            active_quota_count = self._active_quota_count(selected.quota_bucket)
+            if active_quota_count >= selected.quota_limit:
+                raise RoutingReservationUnavailable("quota_bucket_exhausted")
+
+            attempt_row = self._conn.execute(
+                "SELECT COALESCE(MAX(attempt), 0) + 1 FROM routing_reservations WHERE authority_key = ?",
+                (req.authority_key,),
+            ).fetchone()
+            attempt = int(attempt_row[0])
+            reservation_id = new_id("routing-reservation")
+            expires_at = _iso(current + timedelta(seconds=ttl))
+            self._conn.execute(
+                """INSERT INTO routing_reservations(
+                    reservation_id, authority_key, attempt, idempotency_key, request_sha256, semantic_sha256,
+                    initiator, author_model, author_family, requested_role, requested_profile,
+                    requested_risk, route_mode, requested_reviewer, resolved_candidate, resolved_route,
+                    resolved_model, resolved_family, quota_bucket, policy_version,
+                    credential_bucket, fallback_from, retry_attempt, quota_source, quota_headroom_band,
+                    estimated_input_bytes, quota_snapshot_json, quota_fresh_at, trace_json,
+                    created_at, expires_at, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'reserved')""",
+                (
+                    reservation_id,
+                    req.authority_key,
+                    attempt,
+                    req.idempotency_key,
+                    request_sha,
+                    semantic_sha,
+                    req.initiator,
+                    req.author_model,
+                    req.author_family,
+                    req.requested_role,
+                    req.requested_profile,
+                    req.requested_risk,
+                    req.route_mode,
+                    req.requested_reviewer,
+                    selected.candidate,
+                    selected.route,
+                    selected.model,
+                    selected.family,
+                    selected.quota_bucket,
+                    selected.policy_version,
+                    selected.credential_bucket,
+                    selected.fallback_from,
+                    selected.retry_attempt,
+                    selected.quota_source,
+                    selected.quota_headroom_band,
+                    req.estimated_input_bytes,
+                    _canonical_json(selected.quota_snapshot),
+                    selected.quota_fresh_at,
+                    _canonical_json(selected.trace),
+                    current_iso,
+                    expires_at,
+                ),
+            )
+            self._append_decision_tx(
+                reservation_id,
+                event_type="reserved",
+                state="reserved",
+                evidence={
+                    "authority_key": req.authority_key,
+                    "attempt": attempt,
+                    "active_credential_before": active_credential_count,
+                    "active_quota_before": active_quota_count,
+                    "credential_bucket": selected.credential_bucket,
+                    "credential_limit": selected.credential_limit,
+                    "quota_bucket": selected.quota_bucket,
+                    "quota_limit": selected.quota_limit,
+                    "policy_version": selected.policy_version,
+                    "route_mode": req.route_mode,
+                    "trace": selected.trace,
+                },
+                created_at=current_iso,
+            )
+            return self._get_reservation_tx(reservation_id)
+
+    def reserve(
+        self,
+        request: RoutingReservationRequest,
+        selector: Selector,
+        *,
+        ttl_seconds: int = 300,
+        now: str | None = None,
+    ) -> RoutingReservation:
+        """Backward-compatible alias for :meth:`reserve_selection`."""
+        return self.reserve_selection(request, selector, ttl_seconds=ttl_seconds, now=now)
+
+    def start(self, reservation_id: str, *, now: str | None = None) -> RoutingReservation:
+        """Mark a reservation running; repeated calls are idempotent."""
+        rid = _required(reservation_id, "reservation_id")
+        _, current_iso = _now(now)
+        with self._write_transaction():
+            self._recover_expired_tx(current_iso)
+            row = self._get_reservation_tx(rid)
+            if row.status == "reserved":
+                self._conn.execute(
+                    "UPDATE routing_reservations SET status = 'running', started_at = ? WHERE reservation_id = ?",
+                    (current_iso, rid),
+                )
+                self._append_decision_tx(rid, "started", "running", {}, current_iso)
+                return self._get_reservation_tx(rid)
+            if row.status == "running":
+                return row
+            return row
+
+    def mark_started(self, reservation_id: str, *, now: str | None = None) -> RoutingReservation:
+        """Explicit lifecycle name used by routing adapters."""
+        return self.start(reservation_id, now=now)
+
+    def settle(
+        self,
+        reservation_id: str,
+        *,
+        status: TerminalStatus,
+        actual_input_bytes: int | None = None,
+        actual_output_bytes: int | None = None,
+        actual_input_tokens: int | None = None,
+        actual_output_tokens: int | None = None,
+        failure_classification: str | None = None,
+        terminal_evidence: Mapping[str, Any] | None = None,
+        circuit_open_seconds: int = 0,
+        now: str | None = None,
+    ) -> RoutingReservation:
+        """Terminally settle or release capacity; exact repeated settlement replays."""
+        rid = _required(reservation_id, "reservation_id")
+        if status not in _SETTLEABLE_STATUSES:
+            raise RoutingReservationError("invalid_terminal_status")
+        input_bytes = _nonnegative_int(actual_input_bytes, "actual_input_bytes")
+        output_bytes = _nonnegative_int(actual_output_bytes, "actual_output_bytes")
+        input_tokens = _nonnegative_int(actual_input_tokens, "actual_input_tokens")
+        output_tokens = _nonnegative_int(actual_output_tokens, "actual_output_tokens")
+        actual_byte_count = (input_bytes or 0) + (output_bytes or 0)
+        actual_token_count = (input_tokens or 0) + (output_tokens or 0)
+        open_seconds = _nonnegative_int(circuit_open_seconds, "circuit_open_seconds")
+        classification = _required(failure_classification, "failure_classification") if status == "failed" else None
+        evidence = _mapping(terminal_evidence, field="terminal_evidence")
+        if status != "failed" and failure_classification is not None:
+            raise RoutingReservationError("failure_classification_requires_failed_status")
+        _, current_iso = _now(now)
+        terminal_payload = {
+            "actual_input_bytes": input_bytes,
+            "actual_output_bytes": output_bytes,
+            "actual_input_tokens": input_tokens,
+            "actual_output_tokens": output_tokens,
+            "failure_classification": classification,
+            "status": status,
+            "terminal_evidence": evidence,
+        }
+        terminal_sha = hashlib.sha256(_canonical_json(terminal_payload).encode("utf-8")).hexdigest()
+        with self._write_transaction():
+            self._recover_expired_tx(current_iso)
+            row = self._get_reservation_tx(rid)
+            if row.status in _TERMINAL_STATUSES:
+                stored = self._conn.execute(
+                    "SELECT terminal_sha256 FROM routing_reservations WHERE reservation_id = ?", (rid,)
+                ).fetchone()
+                if str(stored["terminal_sha256"] or "") != terminal_sha:
+                    raise RoutingReservationError("terminal_settlement_conflict")
+                return row
+            self._conn.execute(
+                """UPDATE routing_reservations
+                   SET status = ?, settled_at = ?, actual_bytes = ?, actual_tokens = ?,
+                       actual_input_bytes = ?, actual_output_bytes = ?,
+                       actual_input_tokens = ?, actual_output_tokens = ?,
+                       failure_classification = ?, terminal_sha256 = ?
+                   WHERE reservation_id = ?""",
+                (
+                    status,
+                    current_iso,
+                    actual_byte_count,
+                    actual_token_count,
+                    input_bytes,
+                    output_bytes,
+                    input_tokens,
+                    output_tokens,
+                    classification,
+                    terminal_sha,
+                    rid,
+                ),
+            )
+            settled = self._get_reservation_tx(rid)
+            self._append_decision_tx(rid, "settled", status, terminal_payload, current_iso)
+            if status == "failed":
+                self._record_failure_tx(settled, classification, int(open_seconds or 0), current_iso)
+            return settled
+
+    def fail_and_release(
+        self,
+        reservation_id: str,
+        failure_classification: str,
+        *,
+        actual_input_bytes: int | None = None,
+        actual_output_bytes: int | None = None,
+        actual_input_tokens: int | None = None,
+        actual_output_tokens: int | None = None,
+        circuit_open_seconds: int = 0,
+        now: str | None = None,
+    ) -> RoutingReservation:
+        """Convenience form of failure settlement with capacity release."""
+        return self.settle(
+            reservation_id,
+            status="failed",
+            actual_input_bytes=actual_input_bytes,
+            actual_output_bytes=actual_output_bytes,
+            actual_input_tokens=actual_input_tokens,
+            actual_output_tokens=actual_output_tokens,
+            failure_classification=failure_classification,
+            circuit_open_seconds=circuit_open_seconds,
+            now=now,
+        )
+
+    def get(self, reservation_id: str) -> RoutingReservation:
+        rid = _required(reservation_id, "reservation_id")
+        row = self._conn.execute("SELECT * FROM routing_reservations WHERE reservation_id = ?", (rid,)).fetchone()
+        if row is None:
+            raise RoutingReservationError("reservation_not_found")
+        return self._reservation_from_row(row)
+
+    def completed_replay(self, authority_key: str) -> RoutingReservation | None:
+        """Return the latest completed exact-head decision without mutating state."""
+        row = self._conn.execute(
+            """SELECT * FROM routing_reservations
+               WHERE authority_key = ? AND status = 'complete'
+               ORDER BY attempt DESC LIMIT 1""",
+            (_required(authority_key, "authority_key"),),
+        ).fetchone()
+        return self._reservation_from_row(row) if row is not None else None
+
+    def decisions(self, reservation_id: str) -> tuple[RoutingReservationDecision, ...]:
+        rid = _required(reservation_id, "reservation_id")
+        rows = self._conn.execute(
+            """SELECT * FROM routing_reservation_decisions
+               WHERE reservation_id = ? ORDER BY created_at, decision_id""",
+            (rid,),
+        ).fetchall()
+        return tuple(self._decision_from_row(row) for row in rows)
+
+    def circuit_state(self, route_key: str) -> RoutingCircuitState | None:
+        return self._circuit_state(_required(route_key, "route_key"))
+
+    def bucket_circuit_state(self, quota_bucket: str, credential_bucket: str) -> RoutingCircuitState | None:
+        """Read circuit state for the admission bucket pairing."""
+        return self._circuit_state(self._circuit_key(quota_bucket, credential_bucket))
+
+    def recover_expired(self, *, now: str | None = None) -> tuple[RoutingReservation, ...]:
+        """Bounded public recovery hook for expired/orphaned active reservations."""
+        _, current_iso = _now(now)
+        with self._write_transaction():
+            ids = self._recover_expired_tx(current_iso)
+            return tuple(self._get_reservation_tx(rid) for rid in ids)
+
+    def _validate_request(self, request: RoutingReservationRequest) -> tuple[RoutingReservationRequest, str, str]:
+        if not isinstance(request, RoutingReservationRequest):
+            raise RoutingReservationError("routing_reservation_request_required")
+        estimated = _nonnegative_int(request.estimated_input_bytes, "estimated_input_bytes")
+        if request.route_mode not in {"auto", "explicit"}:
+            raise RoutingReservationError("invalid_route_mode")
+        normalized = RoutingReservationRequest(
+            authority_key=_required(request.authority_key, "authority_key"),
+            idempotency_key=_required(request.idempotency_key, "idempotency_key"),
+            initiator=_required(request.initiator, "initiator"),
+            author_model=_required(request.author_model, "author_model"),
+            author_family=_required(request.author_family, "author_family"),
+            requested_role=_required(request.requested_role, "requested_role"),
+            requested_profile=_required(request.requested_profile, "requested_profile"),
+            requested_risk=_required(request.requested_risk, "requested_risk"),
+            route_mode=request.route_mode,
+            estimated_input_bytes=int(estimated or 0),
+            requested_reviewer=(
+                _required(request.requested_reviewer, "requested_reviewer")
+                if request.requested_reviewer is not None
+                else None
+            ),
+        )
+        semantic_payload = {
+            "author_family": normalized.author_family,
+            "author_model": normalized.author_model,
+            "authority_key": normalized.authority_key,
+            "estimated_input_bytes": normalized.estimated_input_bytes,
+            "requested_profile": normalized.requested_profile,
+            "requested_reviewer": normalized.requested_reviewer,
+            "requested_risk": normalized.requested_risk,
+            "requested_role": normalized.requested_role,
+            "route_mode": normalized.route_mode,
+        }
+        semantic_sha = hashlib.sha256(_canonical_json(semantic_payload).encode("utf-8")).hexdigest()
+        request_sha = hashlib.sha256(
+            _canonical_json({**semantic_payload, "initiator": normalized.initiator}).encode("utf-8")
+        ).hexdigest()
+        return normalized, request_sha, semantic_sha
+
+    def _validate_selection(self, selection: RoutingSelection) -> RoutingSelection:
+        if not isinstance(selection, RoutingSelection):
+            raise RoutingReservationError("routing_selection_required")
+        freshness = selection.quota_fresh_at
+        if freshness is not None:
+            _parse_iso(freshness, field="quota_fresh_at")
+        return RoutingSelection(
+            candidate=_required(selection.candidate, "resolved_candidate"),
+            route=_required(selection.route, "resolved_route"),
+            model=_required(selection.model, "resolved_model"),
+            family=_required(selection.family, "resolved_family"),
+            quota_bucket=_required(selection.quota_bucket, "quota_bucket"),
+            credential_bucket=_required(selection.credential_bucket, "credential_bucket"),
+            quota_limit=_positive_int(selection.quota_limit, "quota_limit"),
+            credential_limit=_positive_int(selection.credential_limit, "credential_limit"),
+            policy_version=_required(selection.policy_version, "policy_version"),
+            quota_snapshot=_mapping(selection.quota_snapshot, field="quota_snapshot"),
+            quota_fresh_at=freshness,
+            trace=_mapping(selection.trace, field="trace"),
+            fallback_from=(
+                _required(selection.fallback_from, "fallback_from") if selection.fallback_from is not None else None
+            ),
+            retry_attempt=int(_nonnegative_int(selection.retry_attempt, "retry_attempt") or 0),
+            quota_source=_required(selection.quota_source, "quota_source"),
+            quota_headroom_band=_required(selection.quota_headroom_band, "quota_headroom_band"),
+        )
+
+    def _active_credential_count(self, credential_bucket: str) -> int:
+        row = self._conn.execute(
+            """SELECT COUNT(*) AS count FROM routing_reservations
+               WHERE credential_bucket = ? AND status IN ('reserved', 'running')""",
+            (credential_bucket,),
+        ).fetchone()
+        return int(row["count"])
+
+    def _active_quota_count(self, quota_bucket: str) -> int:
+        row = self._conn.execute(
+            """SELECT COUNT(*) AS count FROM routing_reservations
+               WHERE quota_bucket = ? AND status IN ('reserved', 'running')""",
+            (quota_bucket,),
+        ).fetchone()
+        return int(row["count"])
+
+    def _bucket_usage(self, quota_bucket: str, *, now_iso: str, rolling_window_seconds: int) -> RoutingBucketUsage:
+        window_seconds = _positive_int(rolling_window_seconds, "rolling_window_seconds")
+        window_start = _iso(_parse_iso(now_iso, field="now") - timedelta(seconds=window_seconds))
+        row = self._conn.execute(
+            """SELECT
+                   SUM(CASE WHEN status IN ('reserved', 'running') THEN 1 ELSE 0 END) AS inflight,
+                   SUM(CASE WHEN status IN ('reserved', 'running') THEN estimated_input_bytes ELSE 0 END) AS reserved_bytes,
+                   SUM(CASE WHEN status = 'complete' AND settled_at >= ?
+                       THEN COALESCE(actual_input_bytes, 0) + COALESCE(actual_output_bytes, 0)
+                       ELSE 0 END) AS completed_bytes,
+                   SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failures
+               FROM routing_reservations WHERE quota_bucket = ?""",
+            (window_start, quota_bucket),
+        ).fetchone()
+        return RoutingBucketUsage(
+            quota_bucket=quota_bucket,
+            rolling_window_seconds=window_seconds,
+            inflight_reservations=int(row["inflight"] or 0),
+            reserved_input_bytes=int(row["reserved_bytes"] or 0),
+            completed_window_bytes=int(row["completed_bytes"] or 0),
+            recent_failures=int(row["failures"] or 0),
+        )
+
+    def _recover_expired_tx(self, now_iso: str) -> tuple[str, ...]:
+        rows = self._conn.execute(
+            """SELECT reservation_id FROM routing_reservations
+               WHERE status IN ('reserved', 'running') AND expires_at <= ?
+               ORDER BY created_at, reservation_id LIMIT 256""",
+            (now_iso,),
+        ).fetchall()
+        recovered: list[str] = []
+        for row in rows:
+            rid = str(row["reservation_id"])
+            payload = {
+                "failure_classification": "ttl_expired_orphan",
+                "status": "expired",
+            }
+            terminal_sha = hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+            cursor = self._conn.execute(
+                """UPDATE routing_reservations
+                   SET status = 'expired', settled_at = ?, failure_classification = ?,
+                       terminal_sha256 = ?
+                   WHERE reservation_id = ? AND status IN ('reserved', 'running')""",
+                (now_iso, "ttl_expired_orphan", terminal_sha, rid),
+            )
+            if cursor.rowcount == 1:
+                self._append_decision_tx(rid, "recovered_expired", "expired", payload, now_iso)
+                self._record_failure_tx(
+                    self._get_reservation_tx(rid),
+                    "ttl_expired_orphan",
+                    0,
+                    now_iso,
+                )
+                recovered.append(rid)
+        return tuple(recovered)
+
+    def _record_failure_tx(
+        self,
+        reservation: RoutingReservation,
+        classification: str,
+        open_seconds: int,
+        now_iso: str,
+    ) -> None:
+        circuit_key = self._circuit_key(reservation.quota_bucket, reservation.credential_bucket)
+        prior = self._circuit_state(circuit_key)
+        failures = 1 if prior is None else prior.recent_failure_count + 1
+        open_until = _iso(_parse_iso(now_iso, field="now") + timedelta(seconds=open_seconds)) if open_seconds else None
+        self._conn.execute(
+            """INSERT INTO routing_circuit_state(
+                route_key, recent_failure_count, last_failure_at,
+                last_failure_classification, open_until, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(route_key) DO UPDATE SET
+                recent_failure_count = excluded.recent_failure_count,
+                last_failure_at = excluded.last_failure_at,
+                last_failure_classification = excluded.last_failure_classification,
+                open_until = excluded.open_until,
+                updated_at = excluded.updated_at""",
+            (circuit_key, failures, now_iso, classification, open_until, now_iso),
+        )
+        self._append_decision_tx(
+            reservation.reservation_id,
+            "circuit_recorded",
+            "failed",
+            {"open_until": open_until, "recent_failure_count": failures},
+            now_iso,
+        )
+
+    def _append_decision_tx(
+        self,
+        reservation_id: str,
+        event_type: str,
+        state: str,
+        evidence: Mapping[str, Any],
+        created_at: str,
+    ) -> None:
+        self._conn.execute(
+            """INSERT INTO routing_reservation_decisions(
+                decision_id, reservation_id, event_type, state, evidence_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                new_id("routing-decision"),
+                reservation_id,
+                _required(event_type, "event_type"),
+                _required(state, "state"),
+                _canonical_json(_mapping(evidence, field="evidence")),
+                created_at,
+            ),
+        )
+
+    def _get_reservation_tx(self, reservation_id: str) -> RoutingReservation:
+        row = self._conn.execute(
+            "SELECT * FROM routing_reservations WHERE reservation_id = ?", (reservation_id,)
+        ).fetchone()
+        if row is None:
+            raise RoutingReservationError("reservation_not_found")
+        return self._reservation_from_row(row)
+
+    def _circuit_state(self, route_key: str) -> RoutingCircuitState | None:
+        row = self._conn.execute("SELECT * FROM routing_circuit_state WHERE route_key = ?", (route_key,)).fetchone()
+        if row is None:
+            return None
+        return RoutingCircuitState(
+            route_key=str(row["route_key"]),
+            recent_failure_count=int(row["recent_failure_count"]),
+            last_failure_at=str(row["last_failure_at"]) if row["last_failure_at"] is not None else None,
+            last_failure_classification=(
+                str(row["last_failure_classification"]) if row["last_failure_classification"] is not None else None
+            ),
+            open_until=str(row["open_until"]) if row["open_until"] is not None else None,
+            updated_at=str(row["updated_at"]),
+        )
+
+    @staticmethod
+    def _circuit_key(quota_bucket: str, credential_bucket: str) -> str:
+        return f"{_required(quota_bucket, 'quota_bucket')}\x1f{_required(credential_bucket, 'credential_bucket')}"
+
+    @staticmethod
+    def _reservation_from_row(row: sqlite3.Row) -> RoutingReservation:
+        return RoutingReservation(
+            reservation_id=str(row["reservation_id"]),
+            authority_key=str(row["authority_key"]),
+            attempt=int(row["attempt"]),
+            idempotency_key=str(row["idempotency_key"]),
+            request_sha256=str(row["request_sha256"]),
+            semantic_sha256=str(row["semantic_sha256"]),
+            initiator=str(row["initiator"]),
+            author_model=str(row["author_model"]),
+            author_family=str(row["author_family"]),
+            requested_role=str(row["requested_role"]),
+            requested_profile=str(row["requested_profile"]),
+            requested_risk=str(row["requested_risk"]),
+            route_mode=str(row["route_mode"]),
+            requested_reviewer=(str(row["requested_reviewer"]) if row["requested_reviewer"] is not None else None),
+            resolved_candidate=str(row["resolved_candidate"]),
+            resolved_route=str(row["resolved_route"]),
+            resolved_model=str(row["resolved_model"]),
+            resolved_family=str(row["resolved_family"]),
+            quota_bucket=str(row["quota_bucket"]),
+            credential_bucket=str(row["credential_bucket"]),
+            policy_version=str(row["policy_version"]),
+            estimated_input_bytes=int(row["estimated_input_bytes"]),
+            quota_snapshot=json.loads(str(row["quota_snapshot_json"])),
+            quota_fresh_at=str(row["quota_fresh_at"]) if row["quota_fresh_at"] is not None else None,
+            fallback_from=str(row["fallback_from"]) if row["fallback_from"] is not None else None,
+            retry_attempt=int(row["retry_attempt"]),
+            quota_source=str(row["quota_source"]),
+            quota_headroom_band=str(row["quota_headroom_band"]),
+            trace=json.loads(str(row["trace_json"])),
+            created_at=str(row["created_at"]),
+            expires_at=str(row["expires_at"]),
+            started_at=str(row["started_at"]) if row["started_at"] is not None else None,
+            settled_at=str(row["settled_at"]) if row["settled_at"] is not None else None,
+            status=str(row["status"]),
+            actual_bytes=int(row["actual_bytes"]) if row["actual_bytes"] is not None else None,
+            actual_tokens=int(row["actual_tokens"]) if row["actual_tokens"] is not None else None,
+            actual_input_bytes=(int(row["actual_input_bytes"]) if row["actual_input_bytes"] is not None else None),
+            actual_output_bytes=(int(row["actual_output_bytes"]) if row["actual_output_bytes"] is not None else None),
+            actual_input_tokens=(int(row["actual_input_tokens"]) if row["actual_input_tokens"] is not None else None),
+            actual_output_tokens=(
+                int(row["actual_output_tokens"]) if row["actual_output_tokens"] is not None else None
+            ),
+            failure_classification=(
+                str(row["failure_classification"]) if row["failure_classification"] is not None else None
+            ),
+        )
+
+    @staticmethod
+    def _decision_from_row(row: sqlite3.Row) -> RoutingReservationDecision:
+        return RoutingReservationDecision(
+            decision_id=str(row["decision_id"]),
+            reservation_id=str(row["reservation_id"]),
+            event_type=str(row["event_type"]),
+            state=str(row["state"]),
+            evidence=json.loads(str(row["evidence_json"])),
+            created_at=str(row["created_at"]),
+        )
+
+    class _WriteTransaction:
+        def __init__(self, ledger: RoutingReservationLedger) -> None:
+            self.ledger = ledger
+
+        def __enter__(self) -> None:
+            self.ledger._conn.execute("BEGIN IMMEDIATE")
+
+        def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+            if exc_type is None:
+                try:
+                    self.ledger._conn.commit()
+                except Exception:
+                    self.ledger._conn.rollback()
+                    raise
+            else:
+                self.ledger._conn.rollback()
+            return False
+
+    def _write_transaction(self) -> _WriteTransaction:
+        return self._WriteTransaction(self)
+
+
+def open_routing_reservation_ledger(root: Path | None = None) -> RoutingReservationLedger:
+    """Open the shared Fleet Comms routing-reservation ledger."""
+    return RoutingReservationLedger(root=root)
+
+
+def list_routing_decisions(*, root: Path | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    """Read recent routing evidence without creating, migrating, or writing SQLite.
+
+    A missing plane or pre-v6 schema is deliberately reported as an empty
+    projection.  Runtime readers must never turn an observation into a writer.
+    """
+    bounded_limit = _positive_int(limit, "limit")
+    plane_root = Path(root).resolve() if root is not None else default_plane_root()
+    db_path = plane_root / "comms.sqlite3"
+    if not db_path.is_file():
+        return []
+    try:
+        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+    except sqlite3.Error:
+        return []
+    try:
+        required_tables = {"routing_reservations", "routing_reservation_decisions"}
+        tables = {
+            str(row["name"])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?)",
+                tuple(sorted(required_tables)),
+            )
+        }
+        if tables != required_tables:
+            return []
+        rows = connection.execute(
+            """SELECT d.decision_id, d.reservation_id, d.event_type, d.state,
+                      d.evidence_json, d.created_at AS decision_created_at,
+                      r.authority_key, r.attempt, r.idempotency_key, r.initiator,
+                      r.author_model, r.author_family, r.requested_role,
+                      r.requested_profile, r.requested_risk, r.route_mode, r.requested_reviewer,
+                      r.estimated_input_bytes, r.resolved_candidate,
+                      r.resolved_route, r.resolved_model, r.resolved_family,
+                      r.quota_bucket, r.credential_bucket, r.policy_version, r.quota_snapshot_json,
+                      r.quota_fresh_at, r.trace_json, r.created_at, r.expires_at,
+                      r.started_at, r.settled_at, r.status, r.actual_bytes,
+                      r.actual_tokens, r.actual_input_bytes, r.actual_output_bytes,
+                      r.actual_input_tokens, r.actual_output_tokens, r.failure_classification,
+                      r.fallback_from, r.retry_attempt, r.quota_source, r.quota_headroom_band
+               FROM routing_reservation_decisions d
+               JOIN routing_reservations r ON r.reservation_id = d.reservation_id
+               ORDER BY d.created_at DESC, d.decision_id DESC LIMIT ?""",
+            (bounded_limit,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        connection.close()
+    return [_routing_decision_projection(row) for row in rows]
+
+
+def _routing_decision_projection(row: sqlite3.Row) -> dict[str, Any]:
+    """Return the dashboard allowlist; omit resolver inputs and any payload bodies."""
+    return {
+        "decision_id": str(row["decision_id"]),
+        "reservation_id": str(row["reservation_id"]),
+        "authority_key": str(row["authority_key"]),
+        "event_type": str(row["event_type"]),
+        "state": str(row["state"]),
+        "evidence": json.loads(str(row["evidence_json"])),
+        "created_at": str(row["decision_created_at"]),
+        "requested": {
+            "initiator": str(row["initiator"]),
+            "author_model": str(row["author_model"]),
+            "author_family": str(row["author_family"]),
+            "role": str(row["requested_role"]),
+            "profile": str(row["requested_profile"]),
+            "risk": str(row["requested_risk"]),
+            "route_mode": str(row["route_mode"]),
+            "automatic": str(row["route_mode"]) == "auto",
+            "requested_reviewer": (str(row["requested_reviewer"]) if row["requested_reviewer"] is not None else None),
+            "exceptional_pin": str(row["route_mode"]) == "explicit",
+            "estimated_input_bytes": int(row["estimated_input_bytes"]),
+        },
+        "resolved": {
+            "candidate": str(row["resolved_candidate"]),
+            "route": str(row["resolved_route"]),
+            "model": str(row["resolved_model"]),
+            "family": str(row["resolved_family"]),
+            "policy_version": str(row["policy_version"]),
+            "trace": json.loads(str(row["trace_json"])),
+        },
+        "quota": {
+            "bucket": str(row["quota_bucket"]),
+            "credential_bucket": str(row["credential_bucket"]),
+            "snapshot": json.loads(str(row["quota_snapshot_json"])),
+            "fresh_at": str(row["quota_fresh_at"]) if row["quota_fresh_at"] is not None else None,
+            "source": str(row["quota_source"]),
+            "headroom_band": str(row["quota_headroom_band"]),
+        },
+        "retry": {
+            "attempt": int(row["attempt"]),
+            "fallback_from": str(row["fallback_from"]) if row["fallback_from"] is not None else None,
+            "retry_attempt": int(row["retry_attempt"]),
+            "terminal_status": str(row["status"]),
+            "failure_classification": (
+                str(row["failure_classification"]) if row["failure_classification"] is not None else None
+            ),
+        },
+        "replay": {
+            "authority_key": str(row["authority_key"]),
+            "idempotency_key": str(row["idempotency_key"]),
+            "completed": str(row["status"]) == "complete",
+        },
+        "lifecycle": {
+            "status": str(row["status"]),
+            "created_at": str(row["created_at"]),
+            "expires_at": str(row["expires_at"]),
+            "started_at": str(row["started_at"]) if row["started_at"] is not None else None,
+            "settled_at": str(row["settled_at"]) if row["settled_at"] is not None else None,
+            "actual_bytes": int(row["actual_bytes"]) if row["actual_bytes"] is not None else None,
+            "actual_tokens": int(row["actual_tokens"]) if row["actual_tokens"] is not None else None,
+            "failure_classification": (
+                str(row["failure_classification"]) if row["failure_classification"] is not None else None
+            ),
+            "actual_input_bytes": (int(row["actual_input_bytes"]) if row["actual_input_bytes"] is not None else None),
+            "actual_output_bytes": (
+                int(row["actual_output_bytes"]) if row["actual_output_bytes"] is not None else None
+            ),
+            "actual_input_tokens": (
+                int(row["actual_input_tokens"]) if row["actual_input_tokens"] is not None else None
+            ),
+            "actual_output_tokens": (
+                int(row["actual_output_tokens"]) if row["actual_output_tokens"] is not None else None
+            ),
+        },
+    }
+
+
+__all__ = [
+    "RoutingBucketUsage",
+    "RoutingCircuitState",
+    "RoutingReservation",
+    "RoutingReservationDecision",
+    "RoutingReservationError",
+    "RoutingReservationLedger",
+    "RoutingReservationRequest",
+    "RoutingReservationUnavailable",
+    "RoutingSelection",
+    "RoutingSelectionContext",
+    "list_routing_decisions",
+    "open_routing_reservation_ledger",
+]

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -29,11 +29,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
+from scripts.agent_runtime.adapters.acpx import ACPX_PARTICIPANT_CATALOG_TRANSPORTS, ACPX_SUPPORTED_PARTICIPANTS
 from scripts.agent_runtime.agent_identity import normalize_seat, tools_writer_runtime_agent
 from scripts.audit import model_families
 from scripts.review.model_catalog import VALID_REVIEW_PROFILES, VALID_RISKS, load_model_catalog
+from scripts.review.reviewer_scheduler import circuit_exclusion_reason, selection_key
 
 CandidateStatus = Literal["eligible", "selected", "advisory_only", "excluded"]
+_SEALED_REVIEW_EXECUTABLE = "scripts.ai_agent_bridge._review_pr:invoke_inter_agent"
 
 # --- family resolution -------------------------------------------------------
 
@@ -152,6 +155,7 @@ class ReviewerCandidate:
     transport: str
     invocation: str
     quality_tier: str
+    model_roles: frozenset[str] = field(default_factory=frozenset)
     health_keys: frozenset[str] = field(default_factory=frozenset)
     requires_silence_timeout: bool = False
     # Fail-closed data-egress gate: eligible only when the caller's
@@ -168,15 +172,36 @@ class ReviewerCandidate:
     # hard-excluded on a same-family match (e.g. openai_frontier for an
     # OpenAI-family author: still consulted, never the formal gate).
     advisory_only_for_author_families: frozenset[str] = field(default_factory=frozenset)
+    endpoint: str = ""
+    formal_review_eligible: bool = False
+    formal_review_exclusion_reason: str = ""
+    participant: str = ""
+    adapter_transport: str = ""
+    catalog_transport: str = ""
+    sealed_executable: str = ""
+    quota_bucket: str = ""
+    credential_bucket: str = ""
+    quota_limit: int = 0
+    credential_limit: int = 0
+    capacity_weight: float = 1.0
 
 
 _MODEL_CATALOG = load_model_catalog()
+_SCHEDULER_POLICY = _MODEL_CATALOG["review_scheduler"]
+_SCHEDULER_POLICY_VERSION = _SCHEDULER_POLICY["policy_version"]
 
 
 def _catalog_candidate(name: str) -> ReviewerCandidate:
     raw = _MODEL_CATALOG["review_candidates"][name]
     model_id = raw["model_id"]
     model = _MODEL_CATALOG["models"][model_id]
+    endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(raw["route"], {})
+    endpoint_models = endpoint.get("models", [])
+    endpoint_formal = bool(endpoint.get("formal_review_eligible", False))
+    model_formal = isinstance(endpoint_models, list) and model_id in endpoint_models
+    exclusion_reason = str(endpoint.get("formal_review_exclusion_reason", ""))
+    if endpoint_formal and not model_formal:
+        exclusion_reason = f"sealed endpoint {raw['route']!r} is not pinned for model {model_id!r}"
     return ReviewerCandidate(
         name=name,
         family=model["family"],
@@ -185,6 +210,7 @@ def _catalog_candidate(name: str) -> ReviewerCandidate:
         transport=raw["transport"],
         invocation=raw["invocation"],
         quality_tier=model["tier"],
+        model_roles=frozenset(model["roles"]),
         health_keys=frozenset(raw.get("health_keys", [])),
         requires_silence_timeout=bool(raw.get("requires_silence_timeout", False)),
         requires_data_egress_policy=raw.get("requires_data_egress_policy"),
@@ -192,6 +218,18 @@ def _catalog_candidate(name: str) -> ReviewerCandidate:
         capabilities=frozenset(raw.get("capabilities", [])),
         domain_excluded_from=frozenset(raw.get("domain_excluded_from", [])),
         advisory_only_for_author_families=frozenset(raw.get("advisory_only_for_author_families", [])),
+        endpoint=raw["route"],
+        formal_review_eligible=endpoint_formal and model_formal,
+        formal_review_exclusion_reason=exclusion_reason,
+        participant=endpoint.get("participant", ""),
+        adapter_transport=endpoint.get("adapter_transport", ""),
+        catalog_transport=endpoint.get("catalog_transport", ""),
+        sealed_executable=endpoint.get("sealed_executable", ""),
+        quota_bucket=endpoint.get("quota_bucket", ""),
+        credential_bucket=endpoint.get("credential_bucket", ""),
+        quota_limit=int(endpoint.get("quota_limit", 0)),
+        credential_limit=int(endpoint.get("credential_limit", 0)),
+        capacity_weight=float(endpoint.get("capacity_weight", 0)),
     )
 
 
@@ -249,6 +287,9 @@ _HEALTH_ALIASES: dict[str, str | None] = {
     "warm": "degraded",
     "near_cap": "near_cap",
     "hot": "near_cap",
+    # routing-budget emits this when CodexBar cannot authenticate/produce a
+    # capacity reading. It is operationally unavailable, never fail-open.
+    "unavailable": "unhealthy",
     # The endpoint uses unknown when budget evidence is absent. Preserve the
     # module's fail-open convention by treating it exactly like a missing key.
     "unknown": None,
@@ -302,6 +343,10 @@ def normalize_routing_snapshot(snapshot: Mapping[str, object] | None) -> dict[st
         if status is None and isinstance(health, Mapping) and health.get("healthy") is True:
             normalized[str(route)] = "healthy"
             continue
+        if status is None:
+            # A transaction-local scheduler snapshot may carry only pressure
+            # counters. Health remains fail-open when it is genuinely absent.
+            continue
         normalized_status = _normalize_health_status(status, label=f"agents.{route}")
         if normalized_status is not None:
             normalized[str(route)] = normalized_status
@@ -318,6 +363,9 @@ class ResolverInputs:
     risk: str = "medium"
     domain: str = "code"
     required_capabilities: frozenset[str] = field(default_factory=frozenset)
+    # Optional exact catalog model role (for example ``security_review``).
+    # When omitted, profile/risk role suitability comes from model_catalog.
+    requested_role: str | None = None
     # Fail-closed: None/unrecognized means the strictest reading, not "anything goes."
     data_egress_policy: str | None = None
     isolation_required: bool = False
@@ -330,6 +378,17 @@ class ResolverInputs:
     # bare ambiguous-harness author_model; optional corroboration otherwise —
     # a mismatch against the resolved family is a fail-closed conflict.
     author_family: str | None = None
+    # Exact PR head used solely for a stable final tie-break among equal
+    # quality/pressure candidates. It never relaxes a hard policy gate.
+    exact_head: str | None = None
+    # Formal review is the resolver's normal mode. Advisory callers may opt
+    # out only when they are not attempting to satisfy the cross-family gate.
+    formal_review: bool = True
+    # An explicit pin is an exceptional pressure override. It still receives
+    # every safety, independence, egress, isolation, executable and circuit
+    # gate; a missing reason fails closed.
+    pinned_candidate: str | None = None
+    pressure_override_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -345,6 +404,53 @@ class CandidateResult:
     status: CandidateStatus
     reason: str | None
     health: str | None
+    suitability_rank: int | None = None
+    # Pure deterministic balancing receipt for eligible candidates. The tuple
+    # is deliberately opaque-but-stable so ledger callers can persist the
+    # exact decision without this resolver acquiring storage authority.
+    selection_score: tuple[object, ...] | None = None
+
+    @property
+    def quota_bucket(self) -> str:
+        """Canonical quota bucket for persistence with this pure receipt."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return str(endpoint.get("quota_bucket", ""))
+
+    @property
+    def credential_bucket(self) -> str:
+        """Credential-sharing bucket bound to the sealed ACP participant."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return str(endpoint.get("credential_bucket", ""))
+
+    @property
+    def quota_limit(self) -> int:
+        """Rolling-window accounting capacity supplied to ledger admission."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return int(endpoint.get("quota_limit", 0))
+
+    @property
+    def credential_limit(self) -> int:
+        """Shared credential admission capacity supplied to the ledger."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return int(endpoint.get("credential_limit", 0))
+
+    @property
+    def participant(self) -> str:
+        """Exact ACPX participant used by the sealed review executable."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return str(endpoint.get("participant", ""))
+
+    @property
+    def adapter_transport(self) -> str:
+        """Runner-owned adapter transport, distinct from catalog model transport."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return str(endpoint.get("adapter_transport", ""))
+
+    @property
+    def sealed_executable(self) -> str:
+        """Canonical review-pr execution boundary that invokes the participant."""
+        endpoint = _MODEL_CATALOG["review_scheduler"]["endpoints"].get(self.route, {})
+        return str(endpoint.get("sealed_executable", ""))
 
 
 @dataclass(frozen=True)
@@ -385,6 +491,33 @@ def _hard_exclusion_reason(candidate: ReviewerCandidate, inputs: ResolverInputs)
     the caller's job — this only covers filters that apply regardless."""
     if candidate.always_excluded_reason:
         return candidate.always_excluded_reason
+    if inputs.formal_review:
+        if not candidate.formal_review_eligible:
+            return candidate.formal_review_exclusion_reason or (
+                "formal-review transport is not eligible for a sealed cross-family gate"
+            )
+        if not candidate.endpoint or candidate.endpoint != candidate.route:
+            return "sealed endpoint identity is missing or does not match the candidate route"
+        if not candidate.participant or not candidate.sealed_executable:
+            return "sealed ACP participant or review executable identity is missing"
+        if candidate.adapter_transport != "acp":
+            return "formal-review candidate is not bound to the ACP adapter transport"
+        if candidate.sealed_executable != _SEALED_REVIEW_EXECUTABLE:
+            return "candidate is not bound to the sealed review-pr ACP executable"
+        if candidate.participant not in ACPX_SUPPORTED_PARTICIPANTS:
+            return "candidate ACP participant is not enabled by the runner-owned adapter registry"
+        if ACPX_PARTICIPANT_CATALOG_TRANSPORTS.get(candidate.participant) != candidate.catalog_transport:
+            return "candidate catalog transport does not match its runner-owned ACP participant"
+        if candidate.transport != candidate.catalog_transport:
+            return "candidate transport does not match its ACPX catalog transport"
+        if (
+            not candidate.quota_bucket
+            or not candidate.credential_bucket
+            or candidate.quota_limit < 1
+            or candidate.credential_limit < 1
+            or candidate.capacity_weight <= 0
+        ):
+            return "formal-review capacity configuration is invalid"
     review_profile = inputs.review_profile.strip().casefold()
     if review_profile not in candidate.review_profiles:
         return (
@@ -407,6 +540,28 @@ def _hard_exclusion_reason(candidate: ReviewerCandidate, inputs: ResolverInputs)
         return f"missing required capabilities: {sorted(missing)}"
     if inputs.isolation_required and "isolation" not in candidate.capabilities:
         return "isolation required but candidate does not support process isolation"
+    return None
+
+
+def _suitability_rank(candidate: ReviewerCandidate, inputs: ResolverInputs) -> int | None:
+    """Return catalog-backed semantic suitability, or fail closed.
+
+    This intentionally precedes quality and all resource pressure. It is not a
+    probabilistic score and has no rotation term: a lower integer means a
+    better profile/risk role match among candidates that passed hard gates.
+    """
+    requested_role = (inputs.requested_role or "").strip()
+    if requested_role:
+        return 0 if requested_role in candidate.model_roles else None
+    profile = inputs.review_profile.strip().casefold()
+    risk = inputs.risk.strip().casefold()
+    try:
+        ordered_roles = _SCHEDULER_POLICY["profile_risk_role_order"][profile][risk]
+    except (KeyError, TypeError):
+        return None
+    for rank, role in enumerate(ordered_roles):
+        if role in candidate.model_roles:
+            return rank
     return None
 
 
@@ -473,6 +628,21 @@ def evaluate_candidate(
             reason=reason,
             health=health,
         )
+    circuit_reason = circuit_exclusion_reason(candidate, inputs.routing_snapshot)
+    if circuit_reason:
+        return CandidateResult(
+            name=candidate.name,
+            concrete_model=candidate.concrete_model,
+            family=candidate.family,
+            route=candidate.route,
+            transport=candidate.transport,
+            invocation=candidate.invocation,
+            quality_tier=candidate.quality_tier,
+            requires_silence_timeout=candidate.requires_silence_timeout,
+            status="excluded",
+            reason=circuit_reason,
+            health=health,
+        )
     if health == "unhealthy":
         return CandidateResult(
             name=candidate.name,
@@ -485,6 +655,37 @@ def evaluate_candidate(
             requires_silence_timeout=candidate.requires_silence_timeout,
             status="excluded",
             reason="lane health is unhealthy — route is operationally unavailable",
+            health=health,
+        )
+    if health == "near_cap" and inputs.pinned_candidate != candidate.name:
+        return CandidateResult(
+            name=candidate.name,
+            concrete_model=candidate.concrete_model,
+            family=candidate.family,
+            route=candidate.route,
+            transport=candidate.transport,
+            invocation=candidate.invocation,
+            quality_tier=candidate.quality_tier,
+            requires_silence_timeout=candidate.requires_silence_timeout,
+            status="excluded",
+            reason="quota bucket is near cap — automatic assignments are prohibited",
+            health=health,
+        )
+
+    suitability_rank = _suitability_rank(candidate, inputs)
+    if suitability_rank is None:
+        requested = inputs.requested_role or f"{inputs.review_profile}/{inputs.risk} catalog suitability"
+        return CandidateResult(
+            name=candidate.name,
+            concrete_model=candidate.concrete_model,
+            family=candidate.family,
+            route=candidate.route,
+            transport=candidate.transport,
+            invocation=candidate.invocation,
+            quality_tier=candidate.quality_tier,
+            requires_silence_timeout=candidate.requires_silence_timeout,
+            status="excluded",
+            reason=f"missing required review role suitability: {requested}",
             health=health,
         )
 
@@ -500,15 +701,20 @@ def evaluate_candidate(
         status="eligible",
         reason=None,
         health=health,
+        suitability_rank=suitability_rank,
     )
 
 
 def resolve_reviewer(
     inputs: ResolverInputs,
     ladder: tuple[tuple[ReviewerCandidate, ...], ...] | None = None,
+    *,
+    runtime_state: Mapping[str, object] | None = None,
+    excluded_quota_buckets: frozenset[str] = frozenset(),
 ) -> ReviewerResolution:
-    """Walk the ladder in order; the first rung with an eligible candidate
-    wins (health breaks ties within that rung). Advisory-only candidates
+    """Apply hard policy then balance the best eligible quality tier.
+
+    Advisory-only candidates
     (e.g. ``openai_frontier`` for an OpenAI-family author) are always
     surfaced separately, regardless of which rung is selected.
 
@@ -518,6 +724,10 @@ def resolve_reviewer(
     disambiguation, or a conflicting override). See
     :func:`resolve_author_family`.
     """
+    if runtime_state is not None:
+        # The state owner injects a transaction-consistent snapshot. This
+        # module never reads a database or service to fill it in.
+        inputs = replace(inputs, routing_snapshot=runtime_state)
     risk = (inputs.risk or "").strip().lower()
     review_profile = (inputs.review_profile or "").strip().casefold()
     if review_profile not in VALID_REVIEW_PROFILES:
@@ -526,7 +736,7 @@ def resolve_reviewer(
             advisory=(),
             trace=(),
             substitution_note=None,
-            policy_version=_MODEL_CATALOG["schema_version"],
+            policy_version=_SCHEDULER_POLICY_VERSION,
             catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
             resolved_risk=risk,
             fail_closed_reason=(
@@ -542,26 +752,25 @@ def resolve_reviewer(
             advisory=(),
             trace=(),
             substitution_note=None,
-            policy_version=_MODEL_CATALOG["schema_version"],
+            policy_version=_SCHEDULER_POLICY_VERSION,
             catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
             resolved_risk=risk,
             fail_closed_reason=(f"unsupported review risk {inputs.risk!r}; expected one of {sorted(VALID_RISKS)}"),
         )
     active_ladder = ladder if ladder is not None else REVIEW_LADDERS[risk]
     try:
-        normalized_snapshot = normalize_routing_snapshot(inputs.routing_snapshot)
+        normalize_routing_snapshot(inputs.routing_snapshot)
     except ValueError as exc:
         return ReviewerResolution(
             selected=None,
             advisory=(),
             trace=(),
             substitution_note=None,
-            policy_version=_MODEL_CATALOG["schema_version"],
+            policy_version=_SCHEDULER_POLICY_VERSION,
             catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
             resolved_risk=risk,
             fail_closed_reason=f"invalid routing snapshot: {exc}",
         )
-    inputs = replace(inputs, routing_snapshot=normalized_snapshot)
 
     author_family = resolve_author_family(inputs.author_model, inputs.author_family)
     if author_family in UNRESOLVED_AUTHOR_FAMILIES:
@@ -583,57 +792,134 @@ def resolve_reviewer(
             advisory=(),
             trace=(),
             substitution_note=None,
-            policy_version=_MODEL_CATALOG["schema_version"],
+            policy_version=_SCHEDULER_POLICY_VERSION,
             catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
             resolved_risk=risk,
             fail_closed_reason=reason,
+        )
+
+    if inputs.pinned_candidate and not (inputs.pressure_override_reason or "").strip():
+        return ReviewerResolution(
+            selected=None,
+            advisory=(),
+            trace=(),
+            substitution_note=None,
+            policy_version=_SCHEDULER_POLICY_VERSION,
+            catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+            resolved_risk=risk,
+            fail_closed_reason="explicit reviewer pin requires a non-empty pressure_override_reason",
         )
 
     trace: list[CandidateResult] = []
     advisory: list[CandidateResult] = []
     selected: CandidateResult | None = None
     selected_rung_index: int | None = None
+    # A ladder orders fallbacks, not traffic. Candidates in separate YAML
+    # rungs with the same semantic suitability and catalog tier form one
+    # balancing set, so insertion order cannot pin traffic or promote an idle
+    # weaker model over a better task fit.
+    eligible_by_fit_and_tier: dict[tuple[int, int], list[tuple[ReviewerCandidate, CandidateResult, int]]] = {}
+    tier_for_candidate = {
+        name: _MODEL_CATALOG["quality_tiers"][candidate.quality_tier]
+        for name, candidate in REVIEW_CANDIDATES.items()
+    }
 
     for rung_index, rung in enumerate(active_ladder):
-        rung_eligible: list[CandidateResult] = []
         for candidate in rung:
             result = evaluate_candidate(candidate, inputs, author_family=author_family)
+            if result.status == "eligible" and candidate.quota_bucket in excluded_quota_buckets:
+                result = replace(
+                    result,
+                    status="excluded",
+                    reason=(
+                        f"quota bucket {candidate.quota_bucket!r} is already reserved by an active formal review"
+                    ),
+                )
+            if result.status == "eligible":
+                result = replace(
+                    result,
+                    selection_score=selection_key(
+                        candidate,
+                        snapshot=inputs.routing_snapshot,
+                        exact_head=inputs.exact_head,
+                        policy_version=_SCHEDULER_POLICY_VERSION,
+                    ),
+                )
             trace.append(result)
             if result.status == "advisory_only":
                 advisory.append(result)
             elif result.status == "eligible":
-                rung_eligible.append(result)
+                fit_key = (result.suitability_rank or 0, tier_for_candidate[candidate.name])
+                eligible_by_fit_and_tier.setdefault(fit_key, []).append((candidate, result, rung_index))
 
-        if selected is None and rung_eligible:
-            best = min(rung_eligible, key=lambda r: _health_rank(r.health))
-            promoted = CandidateResult(
-                name=best.name,
-                concrete_model=best.concrete_model,
-                family=best.family,
-                route=best.route,
-                transport=best.transport,
-                invocation=best.invocation,
-                quality_tier=best.quality_tier,
-                requires_silence_timeout=best.requires_silence_timeout,
-                status="selected",
-                reason=None,
-                health=best.health,
+    if inputs.pinned_candidate:
+        pinned = [
+            item for entries in eligible_by_fit_and_tier.values() for item in entries if item[0].name == inputs.pinned_candidate
+        ]
+        if not pinned:
+            return ReviewerResolution(
+                selected=None,
+                advisory=tuple(advisory),
+                trace=tuple(trace),
+                substitution_note=None,
+                policy_version=_SCHEDULER_POLICY_VERSION,
+                catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+                resolved_risk=risk,
+                fail_closed_reason=f"explicit reviewer pin {inputs.pinned_candidate!r} failed a hard eligibility gate",
             )
-            for i, entry in enumerate(trace):
-                if entry is best:
-                    trace[i] = promoted
-                    break
-            selected = promoted
-            selected_rung_index = rung_index
+        candidate, best, selected_rung_index = pinned[0]
+        selected = best
+    elif eligible_by_fit_and_tier:
+        best_fit_and_tier = min(eligible_by_fit_and_tier)
+        candidate, best, selected_rung_index = min(
+            eligible_by_fit_and_tier[best_fit_and_tier],
+            key=lambda item: item[1].selection_score or (),
+        )
+        selected = best
+
+    if selected is not None:
+        promoted = CandidateResult(
+            name=best.name,
+            concrete_model=best.concrete_model,
+            family=best.family,
+            route=best.route,
+            transport=best.transport,
+            invocation=best.invocation,
+            quality_tier=best.quality_tier,
+            requires_silence_timeout=best.requires_silence_timeout,
+            status="selected",
+            reason=None,
+            health=best.health,
+            suitability_rank=best.suitability_rank,
+            selection_score=best.selection_score,
+        )
+        for i, entry in enumerate(trace):
+            if entry is best:
+                trace[i] = promoted
+                break
+        selected = promoted
 
     substitution_notes: list[str] = []
     if selected is not None and selected_rung_index is not None:
-        if selected_rung_index > 0:
+        higher_quality_tier_exists = any(
+            _suitability_rank(candidate, inputs) == selected.suitability_rank
+            and _MODEL_CATALOG["quality_tiers"][candidate.quality_tier]
+            < _MODEL_CATALOG["quality_tiers"][selected.quality_tier]
+            for rung in active_ladder
+            for candidate in rung
+        )
+        if higher_quality_tier_exists:
             substitution_notes.append(
                 f"fell back to {selected.name}: no eligible candidate remained in "
-                f"{selected_rung_index} higher-quality rung(s)"
+                "a higher-quality tier"
             )
-        selected_rung_names = {candidate.name for candidate in active_ladder[selected_rung_index]}
+        selected_tier = _MODEL_CATALOG["quality_tiers"][selected.quality_tier]
+        selected_rung_names = {
+            candidate.name
+            for rung in active_ladder
+            for candidate in rung
+            if _MODEL_CATALOG["quality_tiers"][candidate.quality_tier] == selected_tier
+        }
         rung_results = [entry for entry in trace if entry.name in selected_rung_names]
         unavailable = [
             entry.name
@@ -641,19 +927,13 @@ def resolve_reviewer(
             if entry.status == "excluded"
             and entry.reason == "lane health is unhealthy — route is operationally unavailable"
         ]
-        better_health_than = [
-            entry.name
-            for entry in rung_results
-            if entry.status == "eligible" and _health_rank(selected.health) < _health_rank(entry.health)
-        ]
         if unavailable:
             substitution_notes.append(
                 f"selected {selected.name}: same-quality route(s) unavailable by health: {', '.join(unavailable)}"
             )
-        if better_health_than:
+        if inputs.pinned_candidate:
             substitution_notes.append(
-                f"selected {selected.name} over {', '.join(better_health_than)} by lane health "
-                "within the same quality rung"
+                f"explicit pressure override selected {selected.name}: {inputs.pressure_override_reason.strip()}"
             )
 
     return ReviewerResolution(
@@ -661,7 +941,7 @@ def resolve_reviewer(
         advisory=tuple(advisory),
         trace=tuple(trace),
         substitution_note="; ".join(substitution_notes) or None,
-        policy_version=_MODEL_CATALOG["schema_version"],
+        policy_version=_SCHEDULER_POLICY_VERSION,
         catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
         resolved_risk=risk,
     )

--- a/scripts/review/reviewer_scheduler.py
+++ b/scripts/review/reviewer_scheduler.py
@@ -1,0 +1,130 @@
+"""Deterministic, side-effect-free balancing for eligible formal reviewers.
+
+Hard policy remains in :mod:`reviewer_resolver`.  This module intentionally
+does not query Fleet Comms, CodexBar, or process state: callers pass a bounded
+routing-budget snapshot and this code makes one reproducible choice from it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RoutingMetrics:
+    """The route-local signals used only after hard eligibility succeeds."""
+
+    completed_input_bytes: int | None = None
+    active_reserved_input_bytes: int | None = None
+    quota_remaining_pct: float | None = None
+    quota_fresh: bool = True
+    inflight: int = 0
+    failures: int = 0
+    circuit_open: bool = False
+    capacity_exhausted: bool = False
+
+    @property
+    def load_bytes(self) -> int | None:
+        if self.completed_input_bytes is None and self.active_reserved_input_bytes is None:
+            return None
+        return (self.completed_input_bytes or 0) + (self.active_reserved_input_bytes or 0)
+
+
+def _number(value: object, *, minimum: float = 0) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < minimum:
+        return None
+    return float(value)
+
+
+def _integer(value: object) -> int:
+    number = _number(value)
+    return int(number) if number is not None else 0
+
+
+def _route_record(candidate: Any, snapshot: Mapping[str, object] | None) -> Mapping[str, object]:
+    if not isinstance(snapshot, Mapping):
+        return {}
+    agents = snapshot.get("agents")
+    if not isinstance(agents, Mapping):
+        return {}
+    keys = (candidate.name, candidate.route, candidate.concrete_model, *sorted(candidate.health_keys))
+    for key in keys:
+        record = agents.get(key)
+        if isinstance(record, Mapping):
+            return record
+    return {}
+
+
+def metrics_for(candidate: Any, snapshot: Mapping[str, object] | None) -> RoutingMetrics:
+    """Extract tolerant route-local scheduler metrics from one API snapshot."""
+    record = _route_record(candidate, snapshot)
+    diagnostics = snapshot.get("diagnostics") if isinstance(snapshot, Mapping) else None
+    runtime = record.get("runtime") if isinstance(record.get("runtime"), Mapping) else {}
+    scheduler = record.get("scheduler") if isinstance(record.get("scheduler"), Mapping) else {}
+    in_flight = snapshot.get("in_flight") if isinstance(snapshot, Mapping) else {}
+    inflight_value = in_flight.get(candidate.route) if isinstance(in_flight, Mapping) else None
+
+    completed = scheduler.get("completed_input_bytes", record.get("completed_input_bytes"))
+    reserved = scheduler.get("active_reserved_input_bytes", record.get("active_reserved_input_bytes"))
+    remaining = scheduler.get("quota_remaining_pct", record.get("remaining_pct"))
+    stale = scheduler.get("quota_stale")
+    if stale is None and isinstance(diagnostics, Mapping):
+        stale = diagnostics.get("stale")
+    circuit_open = bool(
+        scheduler.get("circuit_open", record.get("circuit_open", runtime.get("circuit_open", False)))
+    )
+    return RoutingMetrics(
+        completed_input_bytes=(int(_number(completed)) if _number(completed) is not None else None),
+        active_reserved_input_bytes=(int(_number(reserved)) if _number(reserved) is not None else None),
+        quota_remaining_pct=_number(remaining),
+        quota_fresh=not bool(stale),
+        inflight=_integer(scheduler.get("inflight", inflight_value)),
+        failures=_integer(scheduler.get("failures", runtime.get("error", record.get("failures", 0)))),
+        circuit_open=circuit_open,
+        capacity_exhausted=bool(scheduler.get("capacity_exhausted", False)),
+    )
+
+
+def circuit_exclusion_reason(candidate: Any, snapshot: Mapping[str, object] | None) -> str | None:
+    """Return a hard operational exclusion without balancing candidates."""
+    metrics = metrics_for(candidate, snapshot)
+    if metrics.circuit_open:
+        return "route circuit is open — transport is operationally unavailable"
+    if metrics.capacity_exhausted:
+        return "credential bucket has no unreserved concurrency slot"
+    return None
+
+
+def stable_tie_break(*, exact_head: str | None, policy_version: str, candidate_name: str) -> str:
+    """Stable final tie-break; never derive traffic from YAML insertion order."""
+    material = "\0".join((exact_head or "no-exact-head", policy_version, candidate_name))
+    return sha256(material.encode("utf-8")).hexdigest()
+
+
+def selection_key(candidate: Any, *, snapshot: Mapping[str, object] | None, exact_head: str | None, policy_version: str) -> tuple[object, ...]:
+    """Return a total order for candidates that already passed every hard gate."""
+    metrics = metrics_for(candidate, snapshot)
+    weight = float(candidate.capacity_weight)
+    load = metrics.load_bytes
+    # Fresh capacity evidence outranks stale last-known-good evidence, and both
+    # outrank a route with no usable headroom signal. This keeps an unknown
+    # account from looking infinitely available merely because it has no
+    # recorded work. Fairness then compares normalized work only within the
+    # same conservative evidence class.
+    load_unknown = load is None
+    normalized_load = (load / weight) if load is not None else 0.0
+    headroom_unknown = metrics.quota_remaining_pct is None
+    capacity_evidence_rank = 2 if headroom_unknown else (0 if metrics.quota_fresh else 1)
+    headroom = -(metrics.quota_remaining_pct or 0.0)
+    return (
+        capacity_evidence_rank,
+        load_unknown,
+        normalized_load,
+        headroom,
+        metrics.inflight,
+        metrics.failures,
+        stable_tie_break(exact_head=exact_head, policy_version=policy_version, candidate_name=candidate.name),
+    )

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -10,6 +12,7 @@ from scripts.analytics.cost_report import CostRecord
 from scripts.api import codexbar_usage as codexbar_usage_mod
 from scripts.api import state_router
 from scripts.api.codexbar_usage import _normalize_provider_data
+from scripts.api.state_helpers import cache_invalidate
 
 # Real Claude usage JSON snapshot
 CLAUDE_FIXTURE = """[
@@ -809,3 +812,70 @@ def test_dashboard_routing_html_renders_unavailable_explicitly():
     assert "unavailable" in out
     assert 'class="bar unavailable"' in out
 
+
+def test_failed_refresh_never_poison_last_known_good_capacity(monkeypatch):
+    """The two-second timeout regression keeps the prior usable capacity."""
+    provider = "codex"
+    cache_invalidate("codexbar_usage:")
+    codexbar_usage_mod._last_good_data.pop(provider, None)
+    codexbar_usage_mod._last_failure_data.pop(provider, None)
+    healthy = _normalize_provider_data(provider, json.loads(CODEX_FIXTURE)[0])
+    timeout = codexbar_usage_mod._normalize_provider_error(
+        provider,
+        {"kind": "timeout", "code": "TIMEOUT", "message": "timed out after 2s"},
+    )
+    results = iter([healthy, timeout])
+    monkeypatch.setattr(codexbar_usage_mod, "fetch_codexbar_usage", lambda *_args, **_kwargs: next(results))
+
+    assert provider in codexbar_usage_mod.refresh_provider_usage_data([provider], timeout_s=2.0)
+    # Expire the short TTL to force use of the LKG branch rather than the
+    # still-valid cache entry. The timeout must remain diagnostic-only.
+    cache_invalidate(f"codexbar_usage:{provider}")
+    assert codexbar_usage_mod.refresh_provider_usage_data([provider], timeout_s=2.0) == {}
+
+    result = codexbar_usage_mod.get_provider_usage_data(provider)
+    assert result["freshness"] == "stale_last_good"
+    assert result["weekly_used_pct"] == 62.0
+    assert result["failure_kind"] == "timeout"
+    assert result["last_failure_at"]
+
+
+def test_malformed_or_provider_failure_is_unavailable_without_lkg(monkeypatch):
+    provider = "kimi"
+    cache_invalidate("codexbar_usage:")
+    codexbar_usage_mod._last_good_data.pop(provider, None)
+    codexbar_usage_mod._last_failure_data.pop(provider, None)
+    malformed = codexbar_usage_mod._normalize_provider_error(
+        provider,
+        {"kind": "malformed_json", "code": "MALFORMED_JSON", "message": "malformed"},
+    )
+    monkeypatch.setattr(codexbar_usage_mod, "fetch_codexbar_usage", lambda *_args, **_kwargs: malformed)
+
+    assert codexbar_usage_mod.refresh_provider_usage_data([provider], timeout_s=2.0) == {}
+    result = codexbar_usage_mod.get_provider_usage_data(provider)
+    assert result["freshness"] == "unavailable"
+    assert result["failure_kind"] == "malformed_json"
+    assert result["last_failure_at"]
+
+
+def test_cache_miss_starts_background_refresh_without_waiting(monkeypatch):
+    provider = "grok"
+    cache_invalidate("codexbar_usage:")
+    codexbar_usage_mod._last_good_data.pop(provider, None)
+    codexbar_usage_mod._last_failure_data.pop(provider, None)
+    monkeypatch.setattr(codexbar_usage_mod, "_refresh_thread", None)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_background() -> None:
+        entered.set()
+        release.wait(timeout=1.0)
+
+    monkeypatch.setattr(codexbar_usage_mod, "_run_all_refreshes", slow_background)
+    started = time.monotonic()
+    result = codexbar_usage_mod.get_provider_usage_data(provider)
+    elapsed = time.monotonic() - started
+    release.set()
+    assert entered.wait(timeout=0.5)
+    assert elapsed < 0.2
+    assert result["freshness"] == "unavailable"

--- a/tests/test_fleet_comms_contracts.py
+++ b/tests/test_fleet_comms_contracts.py
@@ -51,8 +51,9 @@ def test_endpoint_registry_formal_review_eligibility_is_fail_closed() -> None:
 
     assert by_name["claude"].formal_review_eligible is True
     assert by_name["codex"].formal_review_eligible is True
+    assert by_name["glm-local"].formal_review_eligible is True
 
-    for name in ("agy", "grok", "kimi", "cursor", "gemini", "glm-local"):
+    for name in ("agy", "grok", "kimi", "cursor", "gemini"):
         assert name in by_name, f"missing registry endpoint: {name}"
         assert by_name[name].formal_review_eligible is False, name
 
@@ -74,7 +75,7 @@ def test_every_live_provider_uses_only_acp_transport() -> None:
     glm, requested = registry.resolve("glm-local")
     assert requested == "glm-local"
     assert glm.name == "glm-local"
-    assert glm.formal_review_eligible is False
+    assert glm.formal_review_eligible is True
 
 
 def test_endpoint_registry_rejects_duplicate_aliases(tmp_path: Path) -> None:

--- a/tests/test_fleet_comms_routing_reservations.py
+++ b/tests/test_fleet_comms_routing_reservations.py
@@ -1,0 +1,247 @@
+"""Focused durability and contention coverage for routing reservations (#6293)."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.migrations import MIGRATIONS, apply_migrations
+from scripts.fleet_comms.routing_reservations import (
+    RoutingReservationError,
+    RoutingReservationLedger,
+    RoutingReservationRequest,
+    RoutingReservationUnavailable,
+    RoutingSelection,
+    list_routing_decisions,
+)
+
+
+def _root(tmp_path: Path) -> Path:
+    return tmp_path / "fleet-comms" / "v1"
+
+
+def _request(authority_key: str, idempotency_key: str, initiator: str = "codex") -> RoutingReservationRequest:
+    return RoutingReservationRequest(
+        authority_key=authority_key,
+        idempotency_key=idempotency_key,
+        initiator=initiator,
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        requested_role="formal-review",
+        requested_profile="critical",
+        requested_risk="high",
+        route_mode="auto",
+        estimated_input_bytes=1200,
+    )
+
+
+def _selection(context: object) -> RoutingSelection:
+    usage = context.bucket_usage("codex-weekly")  # type: ignore[attr-defined]
+    assert usage.inflight_reservations >= 0
+    assert context.available_slots("codex-api-key-a", 1) >= 0  # type: ignore[attr-defined]
+    assert context.quota_available_slots("codex-weekly", 1) >= 0  # type: ignore[attr-defined]
+    return RoutingSelection(
+        candidate="codex",
+        route="codex-primary",
+        model="gpt-5.6-sol",
+        family="openai",
+        quota_bucket="codex-weekly",
+        credential_bucket="codex-api-key-a",
+        quota_limit=1,
+        credential_limit=1,
+        policy_version="resolver-v1",
+        quota_snapshot={"remaining": 1},
+        quota_fresh_at="2035-01-01T00:00:00Z",
+        trace={"source": "pure-policy"},
+    )
+
+
+def test_v6_migration_is_idempotent_and_has_authority_tables(tmp_path: Path) -> None:
+    connection = sqlite3.connect(tmp_path / "comms.sqlite3")
+    try:
+        assert apply_migrations(connection) == MIGRATIONS[-1].version == 7
+        assert apply_migrations(connection) == 7
+        tables = {row[0] for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        assert {"routing_reservations", "routing_reservation_decisions", "routing_circuit_state"} <= tables
+    finally:
+        connection.close()
+
+
+def _reserve(root: Path, authority_key: str, initiator: str) -> str:
+    with RoutingReservationLedger(root=root) as ledger:
+        try:
+            return ledger.reserve_selection(
+                _request(authority_key, f"idempotency-{initiator}", initiator),
+                _selection,
+                now="2035-01-01T00:00:00Z",
+            ).reservation_id
+        except RoutingReservationUnavailable:
+            return "unavailable"
+
+
+def test_shared_bucket_concurrency_prevents_overallocation(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    with RoutingReservationLedger(root=root):
+        pass
+    simultaneous = (("head-grok", "grok"), ("head-codex", "codex"), ("head-claude", "claude"))
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        outcomes = list(pool.map(lambda item: _reserve(root, *item), simultaneous))
+    assert outcomes.count("unavailable") == 2
+    assert len({outcome for outcome in outcomes if outcome != "unavailable"}) == 1
+
+
+def test_exact_head_replay_expiry_recovery_and_failure_release(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    with RoutingReservationLedger(root=root) as ledger:
+        first = ledger.reserve_selection(
+            _request("repo:1:head", "attempt-1"),
+            _selection,
+            ttl_seconds=1,
+            now="2035-01-01T00:00:00Z",
+        )
+        joined = ledger.reserve_selection(
+            _request("repo:1:head", "attempt-2", "other"),
+            _selection,
+            now="2035-01-01T00:00:00Z",
+        )
+        assert joined.reservation_id == first.reservation_id
+        assert ledger.mark_started(first.reservation_id, now="2035-01-01T00:00:00Z").status == "running"
+        assert ledger.recover_expired(now="2035-01-01T00:00:02Z")[0].status == "expired"
+
+        retry = ledger.reserve_selection(_request("repo:1:head", "attempt-3"), _selection, now="2035-01-01T00:00:03Z")
+        failed = ledger.fail_and_release(
+            retry.reservation_id,
+            "provider_unavailable",
+            circuit_open_seconds=30,
+            now="2035-01-01T00:00:04Z",
+        )
+        assert failed.status == "failed"
+        circuit = ledger.bucket_circuit_state("codex-weekly", "codex-api-key-a")
+        assert circuit is not None and circuit.recent_failure_count == 2
+
+        with pytest.raises(RoutingReservationUnavailable, match="credential_bucket_circuit_open"):
+            ledger.reserve_selection(_request("repo:2:head", "attempt-4"), _selection, now="2035-01-01T00:00:05Z")
+
+        released = ledger.reserve_selection(
+            _request("repo:2:head", "attempt-5"),
+            lambda context: replace(_selection(context), credential_bucket="codex-api-key-b"),
+            now="2035-01-01T00:00:05Z",
+        )
+        assert released.status == "reserved"
+
+
+def test_idempotent_settlement_completed_replay_and_append_only_evidence(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    with RoutingReservationLedger(root=root) as ledger:
+        reservation = ledger.reserve_selection(
+            _request("repo:9:head", "attempt-1"), _selection, now="2035-01-01T00:00:00Z"
+        )
+        settled = ledger.settle(
+            reservation.reservation_id,
+            status="complete",
+            actual_input_bytes=1200,
+            actual_output_bytes=300,
+            actual_input_tokens=160,
+            actual_output_tokens=40,
+            now="2035-01-01T00:00:01Z",
+        )
+        assert (
+            ledger.settle(
+                reservation.reservation_id,
+                status="complete",
+                actual_input_bytes=1200,
+                actual_output_bytes=300,
+                actual_input_tokens=160,
+                actual_output_tokens=40,
+                now="2035-01-01T00:00:02Z",
+            )
+            == settled
+        )
+        assert ledger.completed_replay("repo:9:head") == settled
+        usage = ledger._bucket_usage("codex-weekly", now_iso="2035-01-01T00:00:02Z", rolling_window_seconds=60)
+        assert usage.completed_window_bytes == 1500 and usage.reserved_input_bytes == 0
+        decisions = ledger.decisions(reservation.reservation_id)
+        assert [decision.event_type for decision in decisions] == ["reserved", "settled"]
+        with pytest.raises(sqlite3.IntegrityError, match="routing_reservation_decision_immutable"):
+            ledger._conn.execute(
+                "UPDATE routing_reservation_decisions SET state = 'tampered' WHERE decision_id = ?",
+                (decisions[0].decision_id,),
+            )
+
+    evidence = list_routing_decisions(root=root, limit=10)
+    assert evidence[0]["authority_key"] == "repo:9:head"
+    assert evidence[0]["requested"]["role"] == "formal-review"
+    assert evidence[0]["resolved"]["route"] == "codex-primary"
+    assert evidence[0]["quota"]["bucket"] == "codex-weekly"
+    assert evidence[0]["quota"]["credential_bucket"] == "codex-api-key-a"
+    assert evidence[0]["retry"]["attempt"] == 1
+    assert evidence[0]["replay"]["completed"] is True
+    assert evidence[0]["lifecycle"]["actual_input_tokens"] == 160
+    assert evidence[0]["lifecycle"]["actual_output_tokens"] == 40
+
+
+def test_read_projection_does_not_create_or_migrate_missing_plane(tmp_path: Path) -> None:
+    root = _root(tmp_path) / "missing"
+    assert list_routing_decisions(root=root) == []
+    assert not root.exists()
+
+
+def test_same_authority_key_semantic_conflict_fails_closed(tmp_path: Path) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        ledger.reserve_selection(_request("repo:semantic:head", "first"), _selection, now="2035-01-01T00:00:00Z")
+        changed = replace(_request("repo:semantic:head", "second"), requested_risk="critical")
+        with pytest.raises(RoutingReservationError, match="authority_key_semantic_conflict"):
+            ledger.reserve_selection(changed, _selection, now="2035-01-01T00:00:01Z")
+
+
+def test_credential_admission_and_completed_bytes_are_independent_of_quota_bucket(
+    tmp_path: Path,
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        first = ledger.reserve_selection(_request("repo:credential-a", "first"), _selection, now="2035-01-01T00:00:00Z")
+
+        def other_quota_same_credential(context: object) -> RoutingSelection:
+            return replace(_selection(context), quota_bucket="shared-accounting-bucket")
+
+        with pytest.raises(RoutingReservationUnavailable, match="credential_bucket_exhausted"):
+            ledger.reserve_selection(
+                _request("repo:credential-b", "second"),
+                other_quota_same_credential,
+                now="2035-01-01T00:00:01Z",
+            )
+        ledger.settle(
+            first.reservation_id,
+            status="complete",
+            actual_input_bytes=8,
+            actual_output_bytes=4,
+            actual_input_tokens=2,
+            actual_output_tokens=1,
+            now="2035-01-01T00:00:02Z",
+        )
+        current = ledger._bucket_usage("codex-weekly", now_iso="2035-01-01T00:00:30Z", rolling_window_seconds=60)
+        expired = ledger._bucket_usage("codex-weekly", now_iso="2035-01-01T00:02:30Z", rolling_window_seconds=60)
+        assert current.completed_window_bytes == 12
+        assert expired.completed_window_bytes == 0
+
+
+def test_quota_bucket_admission_is_shared_across_distinct_credentials(tmp_path: Path) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        ledger.reserve_selection(
+            _request("repo:quota-a", "first"),
+            _selection,
+            now="2035-01-01T00:00:00Z",
+        )
+
+        def same_quota_other_credential(context: object) -> RoutingSelection:
+            return replace(_selection(context), credential_bucket="codex-api-key-b")
+
+        with pytest.raises(RoutingReservationUnavailable, match="quota_bucket_exhausted"):
+            ledger.reserve_selection(
+                _request("repo:quota-b", "second"),
+                same_quota_other_credential,
+                now="2035-01-01T00:00:01Z",
+            )

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -99,7 +99,7 @@ def test_full_flow_target_freeze_expansion_cycle_reviewer_findings(tmp_path):
     # Practical formal CF default: Terra @ medium risk (Sol only on critical).
     assert resolution["selected"]["name"] == "gpt-5.6-terra"
     assert resolution["selected"]["route"] == "codex"
-    assert resolution["policy_version"] == "model-catalog.v1"
+    assert resolution["policy_version"] == "deterministic-formal-routing.v2"
     assert resolution["resolved_risk"] == "medium"
 
     raise_proc = _run_cli(

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from pathlib import Path
+
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -17,6 +20,7 @@ from scripts.review.reviewer_resolver import (
     KIMI_K3,
     POOL,
     QWEN,
+    REVIEW_CANDIDATES,
     REVIEW_LADDERS,
     TERRA,
     UNKNOWN_AUTHOR_FAMILY,
@@ -59,6 +63,21 @@ def test_family_resolution_across_model_and_harness_aliases():
     }
     for seat, expected_family in cases.items():
         assert resolve_family(seat) == expected_family, seat
+
+
+def test_fleet_endpoint_eligibility_is_a_projection_of_model_catalog() -> None:
+    root = Path(__file__).resolve().parent.parent
+    catalog = yaml.safe_load((root / "scripts/config/model_catalog.yaml").read_text(encoding="utf-8"))
+    fleet = yaml.safe_load((root / "scripts/config/fleet_communications.yaml").read_text(encoding="utf-8"))
+    assert fleet["formal_review_eligibility_source"].endswith("#review_scheduler.endpoints")
+    policy = catalog["review_scheduler"]["endpoints"]
+    aliases = {"glm-local": "glm"}
+    for endpoint in fleet["endpoints"]:
+        policy_name = aliases.get(endpoint["name"], endpoint["name"])
+        if policy_name in policy:
+            assert endpoint["formal_review_eligible"] is policy[policy_name]["formal_review_eligible"]
+        else:
+            assert endpoint["formal_review_eligible"] is False
 
 
 def test_family_resolution_unknown_and_bare_cursor_are_not_fabricated():
@@ -141,9 +160,10 @@ def test_fable_uses_cursor_only_when_native_claude_is_unhealthy():
         )
     )
 
-    assert resolution.selected.name == "claude-fable-5-cursor-fallback"
-    assert resolution.selected.concrete_model == "claude-fable-5"
-    assert resolution.selected.transport == "cursor"
+    assert resolution.selected is None
+    fallback = next(entry for entry in resolution.trace if entry.name == "claude-fable-5-cursor-fallback")
+    assert fallback.status == "excluded"
+    assert "formal-review transport" in fallback.reason
     native = next(entry for entry in resolution.trace if entry.name == "claude-fable-5")
     assert native.status == "excluded"
     assert "unhealthy" in native.reason
@@ -165,7 +185,7 @@ def test_fable_keeps_native_claude_when_native_health_is_degraded():
 
 def test_high_risk_kimi_author_gets_claude_not_composer():
     resolution = resolve_reviewer(ResolverInputs(author_model="kimi-code/k3", risk="critical"))
-    assert resolution.selected.name == "openai_frontier"
+    assert resolution.selected.name == "claude-fable-5"
     composer = next(entry for entry in resolution.trace if entry.name == "composer-2.5")
     assert composer.status == "excluded"
     assert "same family" in composer.reason
@@ -174,7 +194,7 @@ def test_high_risk_kimi_author_gets_claude_not_composer():
 def test_medium_risk_uses_sonnet_and_keeps_pool_eligible():
     resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk="medium"))
     assert resolution.selected.name == "claude-sonnet-5"
-    assert next(entry for entry in resolution.trace if entry.name == "pool").status == "eligible"
+    assert next(entry for entry in resolution.trace if entry.name == "pool").status == "excluded"
 
 
 def test_low_risk_pool_author_gets_terra_before_economical_routes():
@@ -184,7 +204,7 @@ def test_low_risk_pool_author_gets_terra_before_economical_routes():
 
 def test_policy_receipt_exposes_catalog_version_date_and_risk():
     resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk="high"))
-    assert resolution.policy_version == "model-catalog.v1"
+    assert resolution.policy_version == "deterministic-formal-routing.v2"
     assert resolution.catalog_reviewed_on == "2026-08-02"
     assert resolution.resolved_risk == "high"
 
@@ -274,10 +294,10 @@ def test_pre_launch_is_healthy_and_unknown_is_fail_open():
     )
     missing = resolve_reviewer(ResolverInputs(author_model="codex", risk="medium"))
     assert unknown.selected.name == missing.selected.name == "claude-sonnet-5"
-    assert "no eligible candidate" in unknown.substitution_note
+    assert unknown.substitution_note is None
 
 
-def test_near_cap_cannot_promote_a_lower_quality_tier():
+def test_near_cap_receives_no_new_automatic_assignment():
     resolution = resolve_reviewer(
         ResolverInputs(
             author_model="claude",
@@ -285,9 +305,10 @@ def test_near_cap_cannot_promote_a_lower_quality_tier():
             routing_snapshot={"codex": "near_cap", "cursor": "healthy"},
         )
     )
-    assert resolution.selected.name == "gpt-5.6-terra"
-    assert resolution.selected.health == "near_cap"
-    assert resolution.substitution_note is None
+    assert resolution.selected is None
+    terra = next(item for item in resolution.trace if item.name == "gpt-5.6-terra")
+    assert terra.status == "excluded"
+    assert "automatic assignments are prohibited" in terra.reason
 
 
 def test_all_top_tier_routes_unavailable_fall_to_next_quality_tier():
@@ -302,7 +323,7 @@ def test_all_top_tier_routes_unavailable_fall_to_next_quality_tier():
     resolution = resolve_reviewer(
         ResolverInputs(author_model="kimi-code/k3", risk="critical", routing_snapshot=snapshot)
     )
-    assert resolution.selected.name == "grok-4.5"
+    assert resolution.selected is None
 
 
 def test_native_grok_dark_falls_to_explicit_cursor_grok():
@@ -317,9 +338,8 @@ def test_native_grok_dark_falls_to_explicit_cursor_grok():
     resolution = resolve_reviewer(
         ResolverInputs(author_model="claude", risk="high", routing_snapshot=snapshot)
     )
-    assert resolution.selected.name == "grok-4.5-cursor-fallback"
-    assert resolution.selected.transport == "cursor"
-    assert resolution.selected.concrete_model == "grok-4.5"
+    assert resolution.selected is None
+    assert next(item for item in resolution.trace if item.name == "grok-4.5-cursor-fallback").status == "excluded"
 
 
 def test_missing_health_signal_is_fail_open():
@@ -352,8 +372,7 @@ def test_health_breaks_ties_only_within_the_same_remaining_quality_rung():
             },
         )
     )
-    assert resolution.selected.name == "kimi-k3"
-    assert resolution.selected.health == "near_cap"
+    assert resolution.selected is None
 
 
 def test_deepseek_flash_receipt_uses_entire_native_opencode_high_route():
@@ -376,19 +395,15 @@ def test_deepseek_flash_receipt_uses_entire_native_opencode_high_route():
             data_egress_policy="local_interactive",
         )
     )
-    assert resolution.selected.name == "deepseek-v4-flash"
-    assert resolution.selected.transport == "opencode"
-    assert resolution.selected.requires_silence_timeout is False
-    assert resolution.selected.invocation.endswith(
-        "opencode run --model deepseek-direct/deepseek-v4-flash --variant high"
-    )
+    assert resolution.selected is None
+    assert next(item for item in resolution.trace if item.name == "deepseek-v4-flash").status == "excluded"
 
 
 def test_folk_content_excludes_both_deepseek_models():
     for candidate in (DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH):
         result = evaluate_candidate(
             candidate,
-            ResolverInputs(author_model="claude", domain="folk_content"),
+            ResolverInputs(author_model="claude", domain="folk_content", formal_review=False),
             author_family="anthropic",
         )
         assert result.status == "excluded"
@@ -405,7 +420,9 @@ def test_glm_data_egress_gate_is_fail_closed():
         assert result.status == "excluded"
     eligible = evaluate_candidate(
         GLM,
-        ResolverInputs(author_model="claude", data_egress_policy="local_interactive"),
+        ResolverInputs(
+            author_model="claude", data_egress_policy="local_interactive", requested_role="security_review"
+        ),
         author_family="anthropic",
     )
     assert eligible.status == "eligible"
@@ -424,7 +441,9 @@ def test_qwen_is_excluded_from_automatic_routing():
 def test_required_capabilities_and_isolation_fail_closed():
     missing = evaluate_candidate(
         POOL,
-        ResolverInputs(author_model="claude", required_capabilities=frozenset({"vesum_mcp"})),
+        ResolverInputs(
+            author_model="claude", required_capabilities=frozenset({"vesum_mcp"}), formal_review=False
+        ),
         author_family="anthropic",
     )
     assert missing.status == "excluded"
@@ -432,7 +451,7 @@ def test_required_capabilities_and_isolation_fail_closed():
 
     isolation = evaluate_candidate(
         GROK_4_5,
-        ResolverInputs(author_model="claude", isolation_required=True),
+        ResolverInputs(author_model="claude", isolation_required=True, formal_review=False),
         author_family="anthropic",
     )
     assert isolation.status == "excluded"
@@ -442,7 +461,7 @@ def test_required_capabilities_and_isolation_fail_closed():
 def test_review_profile_is_a_hard_eligibility_filter():
     result = evaluate_candidate(
         GROK_4_5,
-        ResolverInputs(author_model="claude", review_profile="content"),
+        ResolverInputs(author_model="claude", review_profile="content", formal_review=False),
         author_family="anthropic",
     )
     assert result.status == "excluded"
@@ -466,6 +485,248 @@ def test_custom_ladder_still_supported_for_focused_callers():
     )
     assert resolution.selected is None
     assert resolution.trace[0].status == "excluded"
+
+
+def test_same_tier_balancing_is_stable_and_yaml_order_independent():
+    sonnet = REVIEW_CANDIDATES["claude-sonnet-5"]
+    inputs = ResolverInputs(author_model="gemini", exact_head="a" * 40)
+    forward = resolve_reviewer(inputs, ladder=((TERRA, sonnet),))
+    reverse = resolve_reviewer(inputs, ladder=((sonnet, TERRA),))
+
+    assert forward.selected is not None
+    assert forward.selected.name == reverse.selected.name
+    assert forward.selected.selection_score == reverse.selected.selection_score
+    assert forward.selected.selection_score is not None
+
+
+def test_load_capacity_headroom_and_freshness_balance_only_within_best_tier():
+    sonnet = REVIEW_CANDIDATES["claude-sonnet-5"]
+    ladder = ((TERRA, sonnet),)
+    inputs = ResolverInputs(author_model="gemini", exact_head="b" * 40, requested_role="implementation")
+    capacity_weighted = {
+        "agents": {
+            "codex": {"scheduler": {"completed_input_bytes": 500, "active_reserved_input_bytes": 0}},
+            "claude": {"scheduler": {"completed_input_bytes": 600, "active_reserved_input_bytes": 0}},
+        }
+    }
+    weighted_terra = replace(TERRA, capacity_weight=2.0)
+    weighted = resolve_reviewer(inputs, ladder=((weighted_terra, sonnet),), runtime_state=capacity_weighted)
+    assert weighted.selected.name == "gpt-5.6-terra"
+
+    headroom = {
+        "agents": {
+            "codex": {"scheduler": {"completed_input_bytes": 10, "quota_remaining_pct": 5}},
+            "claude": {"scheduler": {"completed_input_bytes": 10, "quota_remaining_pct": 90}},
+        }
+    }
+    selected = resolve_reviewer(inputs, ladder=ladder, runtime_state=headroom)
+    assert selected.selected.name == "claude-sonnet-5"
+
+    stale_codex = {
+        "agents": {
+            "codex": {"scheduler": {"completed_input_bytes": 10, "quota_stale": True}},
+            "claude": {"scheduler": {"completed_input_bytes": 10, "quota_stale": False}},
+        }
+    }
+    assert resolve_reviewer(inputs, ladder=ladder, runtime_state=stale_codex).selected.name == "claude-sonnet-5"
+
+    # A stale route with deceptively low recorded load must not outrank a
+    # fresh, verified route solely because its last-known-good counter is old.
+    stale_low_load = {
+        "agents": {
+            "codex": {
+                "scheduler": {
+                    "completed_input_bytes": 0,
+                    "quota_remaining_pct": 90,
+                    "quota_stale": True,
+                }
+            },
+            "claude": {
+                "scheduler": {
+                    "completed_input_bytes": 100,
+                    "quota_remaining_pct": 90,
+                    "quota_stale": False,
+                }
+            },
+        }
+    }
+    assert resolve_reviewer(inputs, ladder=ladder, runtime_state=stale_low_load).selected.name == "claude-sonnet-5"
+
+
+def test_deterministic_stress_follows_capacity_only_for_equally_suitable_authority_models():
+    sol = REVIEW_CANDIDATES["openai_frontier"]
+    fable = replace(REVIEW_CANDIDATES["claude-fable-5"], capacity_weight=2.0)
+    counts = {"openai_frontier": 0, "claude-fable-5": 0}
+    assigned_bytes = {"codex": 0, "claude": 0}
+
+    for index in range(120):
+        snapshot = {
+            "agents": {
+                route: {
+                    "status": "healthy",
+                    "scheduler": {
+                        "completed_input_bytes": assigned,
+                        "active_reserved_input_bytes": 0,
+                        "quota_remaining_pct": 75,
+                    },
+                }
+                for route, assigned in assigned_bytes.items()
+            }
+        }
+        resolution = resolve_reviewer(
+            ResolverInputs(author_model="gemini", risk="critical", exact_head=f"{index:040x}"),
+            ladder=((sol, fable),),
+            runtime_state=snapshot,
+        )
+        selected = resolution.selected
+        assert selected is not None
+        counts[selected.name] += 1
+        assigned_bytes[selected.route] += 1_000
+
+    assert counts == {"openai_frontier": 40, "claude-fable-5": 80}
+    assert assigned_bytes == {"codex": 40_000, "claude": 80_000}
+
+
+def test_weaker_idle_or_cheaper_route_never_beats_the_best_suitable_quality_tier():
+    weaker = REVIEW_CANDIDATES["pool-xs"]
+    resolution = resolve_reviewer(
+        ResolverInputs(author_model="gemini", formal_review=False, exact_head="e" * 40),
+        ladder=((TERRA,), (weaker,)),
+        runtime_state={
+            "agents": {
+                "codex": {
+                    "scheduler": {
+                        "completed_input_bytes": 9_000_000,
+                        "active_reserved_input_bytes": 1_000_000,
+                        "quota_remaining_pct": 1,
+                    }
+                },
+                "pool": {
+                    "scheduler": {
+                        "completed_input_bytes": 0,
+                        "active_reserved_input_bytes": 0,
+                        "quota_remaining_pct": 100,
+                    }
+                },
+            }
+        },
+    )
+    assert resolution.selected.name == "gpt-5.6-terra"
+    assert resolution.selected.quality_tier == "frontier_practical"
+    weaker_trace = next(item for item in resolution.trace if item.name == "pool-xs")
+    assert weaker_trace.status == "excluded"
+    assert "suitability" in weaker_trace.reason
+
+
+def test_near_cap_falls_to_a_healthy_same_quality_suitable_candidate():
+    sonnet = REVIEW_CANDIDATES["claude-sonnet-5"]
+    resolution = resolve_reviewer(
+        ResolverInputs(author_model="gemini", risk="high"),
+        ladder=((sonnet, TERRA),),
+        runtime_state={"agents": {"claude": {"status": "near_cap"}, "codex": {"status": "healthy"}}},
+    )
+    assert resolution.selected.name == "gpt-5.6-terra"
+    sonnet_trace = next(item for item in resolution.trace if item.name == "claude-sonnet-5")
+    assert sonnet_trace.status == "excluded"
+    assert "near cap" in sonnet_trace.reason
+
+
+def test_circuit_and_shared_bucket_are_hard_exclusions_before_balancing():
+    sonnet = REVIEW_CANDIDATES["claude-sonnet-5"]
+    ladder = ((TERRA, sonnet),)
+    inputs = ResolverInputs(author_model="gemini", exact_head="c" * 40)
+    circuit = resolve_reviewer(
+        inputs,
+        ladder=ladder,
+        runtime_state={"agents": {"codex": {"scheduler": {"circuit_open": True}}}},
+    )
+    assert circuit.selected.name == "claude-sonnet-5"
+    assert "circuit is open" in next(item.reason for item in circuit.trace if item.name == "gpt-5.6-terra")
+
+    bucket = resolve_reviewer(inputs, ladder=ladder, excluded_quota_buckets=frozenset({"codex"}))
+    assert bucket.selected.name == "claude-sonnet-5"
+    assert "already reserved" in next(item.reason for item in bucket.trace if item.name == "gpt-5.6-terra")
+
+    full_credential = resolve_reviewer(
+        inputs,
+        ladder=ladder,
+        runtime_state={"agents": {"codex": {"scheduler": {"capacity_exhausted": True}}}},
+    )
+    assert full_credential.selected.name == "claude-sonnet-5"
+    assert "no unreserved concurrency slot" in next(
+        item.reason for item in full_credential.trace if item.name == "gpt-5.6-terra"
+    )
+
+
+def test_explicit_pin_requires_reason_and_cannot_bypass_formal_transport_gate():
+    sonnet = REVIEW_CANDIDATES["claude-sonnet-5"]
+    missing_reason = resolve_reviewer(
+        ResolverInputs(author_model="gemini", pinned_candidate=sonnet.name), ladder=((TERRA, sonnet),)
+    )
+    assert missing_reason.selected is None
+    assert "pressure_override_reason" in missing_reason.fail_closed_reason
+
+    unsafe = resolve_reviewer(
+        ResolverInputs(
+            author_model="gemini",
+            pinned_candidate="grok-4.5-cursor-fallback",
+            pressure_override_reason="native capacity incident",
+        ),
+        ladder=((REVIEW_CANDIDATES["grok-4.5-cursor-fallback"],),),
+    )
+    assert unsafe.selected is None
+    assert "hard eligibility" in unsafe.fail_closed_reason
+
+
+def test_formal_ineligible_and_k3_participant_identity_are_explicit():
+    k3 = REVIEW_CANDIDATES["kimi-k3"]
+    assert k3.route == "kimicc"
+    resolution = resolve_reviewer(ResolverInputs(author_model="codex"), ladder=((k3,),))
+    assert resolution.selected is None
+    assert "not yet authenticated end-to-end" in resolution.trace[0].reason
+
+
+def test_glm_is_a_profile_suitable_fallback_when_preferred_cross_family_route_is_unavailable():
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="gpt-5.6-sol",
+            author_family="openai",
+            review_profile="infra",
+            risk="high",
+            data_egress_policy="local_interactive",
+            exact_head="f" * 40,
+        ),
+        runtime_state={
+            "agents": {
+                "codex": {"status": "unavailable"},
+                "claude": {"status": "unavailable"},
+            }
+        },
+    )
+
+    assert resolution.selected is not None
+    assert resolution.selected.name == "glm-5.2"
+    assert resolution.selected.family == "zhipu"
+    assert resolution.selected.suitability_rank == 1
+
+
+def test_sealed_acpx_receipt_exposes_participant_and_credential_bucket_sharing():
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude", exact_head="d" * 40))
+    selected = resolution.selected
+    assert selected is not None
+    assert selected.participant == "codex"
+    assert selected.adapter_transport == "acp"
+    assert selected.sealed_executable == "scripts.ai_agent_bridge._review_pr:invoke_inter_agent"
+    assert selected.quota_bucket == "codex"
+    assert selected.credential_bucket == "codex"
+    assert selected.quota_limit == selected.credential_limit == 1
+
+    # K3 is the explicit kimicc ACPX participant, and it shares Kimi's
+    # credential/quota buckets rather than creating a fictitious account.
+    kimi = REVIEW_CANDIDATES["kimi-k3"]
+    assert kimi.participant == "kimicc"
+    assert kimi.quota_bucket == kimi.credential_bucket == "kimi"
+    assert kimi.quota_limit == kimi.credential_limit == 1
 
 
 def test_every_risk_ladder_has_unique_candidates_and_a_cross_family_outcome():


### PR DESCRIPTION
## Summary

First ordered slice of #6293. This PR adds the shared deterministic routing foundation used by every orchestrator:

- suitability-first, quality-preserving reviewer resolution with no LLM and no round-robin routing
- weighted least-assigned balancing only among equivalent candidates
- canonical model/endpoint/quota/credential metadata in `model_catalog.yaml`
- atomic `BEGIN IMMEDIATE` reservations in the fleet-wide authority database
- bounded TTL recovery, idempotent settlement, retry/circuit evidence, and read-only decision history
- CodexBar fresh/LKG/unavailable cache semantics that prevent timeout poisoning
- catalog-to-resolver projections and deterministic decision receipts for the Runtime slice in PR 2

The bridge/sealed-evidence integration is intentionally the second ordered PR so both remain below the 20-file hard limit.

## Root cause

The existing `review-pr --reviewer auto` path bypassed the canonical resolver and directly selected GLM. Account pressure was observed by agent name without one atomic shared reservation, so simultaneous orchestrators could select the same subscription and YAML order could accidentally pin traffic.

## Routing rule

Hard safety and availability gates run first. The scheduler then chooses the best task-fit and acceptable quality tier. Quota pressure, weighted completed/reserved bytes, verified freshness/headroom, inflight work, and failures only break ties among sufficiently suitable candidates. A cheaper or idle weaker model never wins merely to balance a chart.

## Verification

- `105 passed` across resolver, scheduler, reservation, Fleet Comms contract, CodexBar, closeout, and API import-pinning tests
- deterministic stress result: weight 1:2 produced exactly 40:80 assignments and 40,000:80,000 input bytes
- Ruff, `py_compile`, `git diff --check`, OPSEC lint, and agent-trailer lint passed
- closeout finding fixed: GLM's cataloged security/long-context strengths now make it a lower-priority suitable fallback instead of an unreachable formally eligible route

## Delivery

Fixes progress on #6293; linked fleet/infrastructure stream epic #4707.

X-Agent: codex/6293-deterministic-fleet-routing
