### PR TITLE
feat(review): route sealed reviews through authority

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -73,6 +73,12 @@ tr:last-child td { border-bottom: none; }
 .acpx-fact dt { color: var(--text3); font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
 .acpx-fact dd { margin: 5px 0 0; color: var(--text); font-size: 13px; overflow-wrap: anywhere; }
 .acpx-safety { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 12px; }
+.routing-status { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 12px; }
+.routing-detail { color: var(--text2); font-size: 12px; line-height: 1.45; }
+.routing-detail strong { color: var(--text); font-weight: 600; }
+.route-auto { background: rgba(57,210,192,0.14); color: var(--cyan); }
+.route-explicit { background: rgba(240,136,62,0.16); color: var(--orange); }
+.routing-table td { min-width: 135px; }
 @media (max-width: 820px) {
   .usage-row { grid-template-columns: 1fr; }
   .topbar { flex-wrap: wrap; }
@@ -139,6 +145,12 @@ tr:last-child td { border-bottom: none; }
     <div class="card-header"><h2 id="acpx-heading">&#8644; ACPX Shadow Transport</h2><div class="muted">Read-only evidence · last 7 days</div></div>
     <div class="banner" id="acpx-banner" role="status"></div>
     <div id="acpx-content" class="empty" aria-live="polite">Loading shadow transport snapshot...</div>
+  </section>
+
+  <section class="card purple" aria-labelledby="routing-assignments-heading">
+    <div class="card-header"><h2 id="routing-assignments-heading">&#129517; Routing assignments</h2><div class="muted">Read-only authority history · newest first</div></div>
+    <div class="banner" id="routing-assignments-banner" role="status"></div>
+    <div id="routing-assignments-content" class="empty" aria-live="polite">Loading routing authority history...</div>
   </section>
 
   <section class="card orange">
@@ -413,6 +425,68 @@ function renderRecent(records) {
   </table>`;
 }
 
+function displayRouteValue(value) {
+  if (value == null || value === '') return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function routingFact(label, value) {
+  return `<div class="routing-detail"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(displayRouteValue(value))}</div>`;
+}
+
+function routingReasoning(item) {
+  const reasoning = item.selection_reasoning && typeof item.selection_reasoning === 'object'
+    ? item.selection_reasoning : {};
+  return `<details><summary class="muted">Suitability-first decision evidence</summary>
+    <div class="routing-detail"><strong>Order:</strong> hard eligibility and capability gates → task fit / quality rank → quota, subscription opportunity cost, capacity, and failure tie-breakers.</div>
+    ${routingFact('Hard eligibility / capability', reasoning.hard_eligibility)}
+    ${routingFact('Task fit / quality', reasoning.task_fit_quality)}
+    ${routingFact('Quota / cost / capacity / failure tie-breakers', reasoning.tie_breakers)}
+    ${routingFact('Why cheaper or idle alternative was not selected', reasoning.cheaper_or_idle_not_selected)}
+  </details>`;
+}
+
+function renderRoutingAssignments(data) {
+  const content = document.getElementById('routing-assignments-content');
+  const plane = data && typeof data.plane === 'object' ? data.plane : {};
+  const assignments = Array.isArray(data?.assignments) ? data.assignments : [];
+  const availability = data?.availability || 'unavailable';
+  const planeMarkup = `<div class="routing-status">
+    <span class="pill ${plane.mode === 'authority' ? 'ok' : 'warn'}">Plane: ${escapeHtml(displayRouteValue(plane.mode))}</span>
+    <span class="pill info">${escapeHtml(displayRouteValue(plane.authority))}</span>
+    <span class="pill gray">${escapeHtml(displayRouteValue(plane.cutover))}</span>
+    <span class="pill ${availability === 'available' || availability === 'empty' ? 'ok' : 'err'}">History: ${escapeHtml(availability)}</span>
+  </div>`;
+  if (!assignments.length) {
+    const reason = data?.reason ? ` (${displayRouteValue(data.reason)})` : '';
+    content.innerHTML = `${planeMarkup}<div class="empty">No routing assignments available${escapeHtml(reason)}.</div>`;
+    return;
+  }
+  content.innerHTML = `${planeMarkup}<table class="routing-table">
+    <thead><tr><th>Authority / time</th><th>Initiator</th><th>Request</th><th>Resolved route</th><th>Quota &amp; work</th><th>Terminal</th></tr></thead>
+    <tbody>${assignments.map(item => {
+      const routeClass = item.automatic === true ? 'route-auto' : 'route-explicit';
+      const routeLabel = item.automatic === true ? 'AUTOMATIC' : 'EXPLICIT';
+      const details = [
+        routingFact('Policy', item.policy_version), routingFact('Reason', item.selection_reason), routingFact('Trace', item.selection_trace),
+        routingFact('Quota source / freshness / headroom', `${displayRouteValue(item.quota_source)} / ${displayRouteValue(item.quota_freshness)} / ${displayRouteValue(item.quota_headroom)}`),
+        routingFact('Estimated input / actual work / output / tokens', `${displayRouteValue(item.estimated_input_bytes)} / ${displayRouteValue(item.actual_work_bytes)} / ${displayRouteValue(item.actual_output_bytes)} / ${displayRouteValue(item.actual_tokens)}`),
+        routingFact('Reservation / expiry / started / settled', `${displayRouteValue(item.reservation_state)} / ${displayRouteValue(item.expires_at)} / ${displayRouteValue(item.started_at)} / ${displayRouteValue(item.settled_at)}`),
+        routingFact('Retry / failover / replay / cache', `${displayRouteValue(item.retry_chain)} / ${displayRouteValue(item.failover_chain)} / ${displayRouteValue(item.replay_status)} / ${displayRouteValue(item.cache_status)}`),
+      ].join('');
+      return `<tr>
+        <td>${routingFact('Decision ID', item.decision_id)}${routingFact('Event / state', `${displayRouteValue(item.decision_event)} / ${displayRouteValue(item.decision_state)}`)}${routingFact('Source authority ID', item.source_authority_id)}${routingFact('Authority key', item.authority_key)}${routingFact('Timestamp', formatTs(item.timestamp))}</td>
+        <td>${routingFact('Initiator', item.initiator)}${routingFact('Author model / family', `${displayRouteValue(item.author_model)} / ${displayRouteValue(item.author_family)}`)}</td>
+        <td><span class="pill ${routeClass}">${routeLabel}</span>${routingFact('Role / profile / risk', `${displayRouteValue(item.requested_role)} / ${displayRouteValue(item.requested_profile)} / ${displayRouteValue(item.requested_risk)}`)}${routingFact('Requested route', item.requested_route)}</td>
+        <td>${routingFact('Candidate', item.resolved_candidate)}${routingFact('Route', item.resolved_route)}${routingFact('Model / family', `${displayRouteValue(item.resolved_model)} / ${displayRouteValue(item.resolved_family)}`)}${routingReasoning(item)}</td>
+        <td>${routingFact('Quota bucket', item.quota_bucket)}${routingFact('Duration', formatDuration(item.duration_s))}</td>
+        <td>${routingFact('Terminal state', item.terminal_status)}${routingFact('Failure', item.failure_classification)}<details><summary class="muted">Decision details</summary>${details}</details></td>
+      </tr>`;
+    }).join('')}</tbody>
+  </table>`;
+}
+
 function stopRefresh() {
   if (refreshTimer) {
     clearInterval(refreshTimer);
@@ -434,6 +508,15 @@ async function loadRuntime() {
   } catch (error) {
     setBanner('acpx-banner', `ACPX snapshot unavailable: ${error.message}`);
     document.getElementById('acpx-content').innerHTML = '<div class="empty">Shadow transport evidence is unavailable. No agent or provider health is inferred.</div>';
+  }
+
+  try {
+    const data = await fetchJson('/api/runtime/routing-assignments?limit=100');
+    renderRoutingAssignments(data && typeof data === 'object' ? data : {});
+    setBanner('routing-assignments-banner', '');
+  } catch (error) {
+    setBanner('routing-assignments-banner', `Routing authority history unavailable: ${error.message}`);
+    document.getElementById('routing-assignments-content').innerHTML = '<div class="empty">Routing authority history is unavailable. No assignment or plane state is inferred.</div>';
   }
 
   try {

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -57,14 +57,13 @@ Contract captured empirically from the local ``acpx@0.13.0`` install
   selector produced a successful one-shot response, while the same runtime
   path with the selector stripped failed closed as ``AUTH_REQUIRED``.
 
-Confinement is structural, not probabilistic: every invocation either adapter
-builds passes ``--deny-all --no-fs --no-terminal --allowed-tools ""
---auth-policy fail --non-interactive-permissions fail --max-turns 1
---prompt-retries 0`` unconditionally. There is no code path that can loosen
-any of these — a caller cannot pass permission/tool overrides through
-``tool_config`` (the adapter allowlists a fixed set of keys — shadow/target
-markers plus local correlation/idempotency metadata — and rejects anything
-else before spawn).
+Confinement is structural, not probabilistic. Ordinary calls pass
+``--deny-all --no-fs --no-terminal --allowed-tools ""``. The one formal-review
+exception retains ``--no-fs`` and ``--no-terminal`` while admitting only five
+exact ``mcp__sealed_review__*`` tools from a parent-owned config and a
+content-verified helper; its permission policy defaults every other request to
+deny. The adapter rejects any different config, helper, interpreter, snapshot
+mode, or tool-config key before spawn.
 
 Issues: #6027, #6043, #6078, #6130, #6158.
 """
@@ -78,6 +77,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -153,6 +153,7 @@ _HERMES_REQUIRED_FLAGS: tuple[str, ...] = (
 )
 AGY_ACP_MODEL = "gemini-3.6-flash-high"
 CLAUDE_ACP_MODEL = "claude-sonnet-5"
+CLAUDE_ACP_MODELS = frozenset({CLAUDE_ACP_MODEL, "claude-fable-5"})
 GLM_ACP_MODEL = "glm-5.2"
 GLM_ACP_INVOCATION_MODEL = "zai-coding-plan/glm-5.2"
 DEEPSEEK_ACP_MODEL = "deepseek-v4-pro"
@@ -174,6 +175,23 @@ _TEXT_AGENT_PATH = _REPO_ROOT / "scripts" / "agent_runtime" / "acp_text_agent.mj
 _TEXT_AGENT_SHA256 = "42761e2bd9ab0e66f5e5779826777b46bd0761cc4673e13285e1fc37418ea679"
 _OPENCODE_DENY_ALL_CONFIG = json.dumps(
     {"permission": {"*": "deny"}, "tools": {"*": False}},
+    separators=(",", ":"),
+    sort_keys=True,
+)
+_OPENCODE_SEALED_REVIEW_CONFIG = json.dumps(
+    {
+        # OpenCode normalizes MCP tools to <server>_<tool>. Keep every
+        # built-in and every other MCP server denied while making only the
+        # parent-pinned sealed reader visible to the provider.
+        "permission": {"*": "deny", "sealed_review_*": "allow"},
+        # OpenCode otherwise replaces tool results above 50 KiB with a path in
+        # its local tool-output directory. The sealed reviewer cannot read
+        # that directory by design, so keep each bounded required-read result
+        # inline. The MCP itself still enforces the tighter 384 KiB streamed
+        # response and 2 MiB complete-evidence ceilings; 3 MiB leaves bounded
+        # room for the authenticated chunks' JSON envelope.
+        "tool_output": {"max_bytes": 3 * 1024 * 1024, "max_lines": 100_000},
+    },
     separators=(",", ":"),
     sort_keys=True,
 )
@@ -220,8 +238,94 @@ _ALLOWED_TOOL_CONFIG_KEYS = frozenset(
         "target_agent",
         "correlation_id",
         "idempotency_key",
+        "sealed_review_mcp_config",
     }
 )
+
+_SEALED_REVIEW_TOOL_NAMES = (
+    "mcp__sealed_review__list_files",
+    "mcp__sealed_review__read_file",
+    "mcp__sealed_review__read_required",
+    "mcp__sealed_review__read_required_all",
+    "mcp__sealed_review__search_text",
+)
+
+
+def _validate_sealed_review_mcp_config(raw: object, *, adapter_label: str) -> str | None:
+    """Validate the exact parent-owned MCP config before enabling any tool."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw or not Path(raw).is_absolute():
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config must be an absolute path")
+    config_path = Path(raw)
+    try:
+        config_stat = config_path.lstat()
+        payload = config_path.read_bytes()
+    except OSError as exc:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config is unreadable: {exc}") from exc
+    if (
+        not stat.S_ISREG(config_stat.st_mode)
+        or config_stat.st_uid != os.getuid()
+        or config_stat.st_mode & 0o077
+        or len(payload) > 16 * 1024
+    ):
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config ownership/mode/size is unsafe")
+    try:
+        config = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config is malformed") from exc
+    if not isinstance(config, dict) or set(config) != {"mcpServers"}:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config has unsupported keys")
+    servers = config.get("mcpServers")
+    if not isinstance(servers, list) or len(servers) != 1 or not isinstance(servers[0], dict):
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP config must define exactly one server")
+    server = servers[0]
+    if set(server) != {"name", "command", "args", "env"} or server.get("name") != "sealed_review":
+        raise AcpxShadowRefusalError(f"{adapter_label}: only the sealed_review server is permitted")
+    expected_python = str(_REPO_ROOT / ".venv" / "bin" / "python")
+    args = server.get("args")
+    if server.get("command") != expected_python or server.get("env") != []:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP runtime is not parent-pinned")
+    if not isinstance(args, list) or len(args) != 4 or args[:2] != ["-I", "-S"]:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP arguments are invalid")
+    helper = Path(args[2]) if isinstance(args[2], str) else Path()
+    snapshot = Path(args[3]) if isinstance(args[3], str) else Path()
+    try:
+        helper_stat = helper.lstat()
+        snapshot_stat = snapshot.lstat()
+        config_parent_stat = config_path.parent.lstat()
+        helper_parent_stat = helper.parent.lstat()
+        from scripts.review.isolation import _SEALED_READ_MCP_SOURCE, _has_review_temp_root_marker
+
+        expected_helper = hashlib.sha256(_SEALED_READ_MCP_SOURCE.encode("utf-8")).hexdigest()
+        observed_helper = hashlib.sha256(helper.read_bytes()).hexdigest()
+    except (ImportError, OSError) as exc:
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP roots are invalid") from exc
+    if (
+        not helper.is_absolute()
+        or not snapshot.is_absolute()
+        or not stat.S_ISREG(helper_stat.st_mode)
+        or not stat.S_ISDIR(snapshot_stat.st_mode)
+        or not stat.S_ISDIR(config_parent_stat.st_mode)
+        or not stat.S_ISDIR(helper_parent_stat.st_mode)
+        or helper_stat.st_uid != os.getuid()
+        or snapshot_stat.st_uid != os.getuid()
+        or config_parent_stat.st_uid != os.getuid()
+        or helper_parent_stat.st_uid != os.getuid()
+        or helper_stat.st_mode & 0o022
+        or snapshot_stat.st_mode & 0o022
+        or config_parent_stat.st_mode & 0o022
+        or helper_parent_stat.st_mode & 0o022
+        or observed_helper != expected_helper
+        or not config_path.parent.name.startswith("lu-review-write-")
+        or not helper.parent.name.startswith("lu-review-exec-")
+        or not snapshot.name.startswith("lu-review-view-")
+        or not _has_review_temp_root_marker(config_path.parent)
+        or not _has_review_temp_root_marker(helper.parent)
+        or not _has_review_temp_root_marker(snapshot)
+    ):
+        raise AcpxShadowRefusalError(f"{adapter_label}: sealed review MCP helper/snapshot failed validation")
+    return str(config_path)
 
 # Fixed ACPX built-ins available only through the runner-owned inter-agent
 # transport boundary (or its bounded discussion controller).  This is
@@ -234,7 +338,7 @@ ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     "claude": {
         "seat": "acpx-claude-shadow",
         "agent": "claude",
-        "model": CLAUDE_ACP_MODEL,
+        "model": None,
     },
     "kimi": {"seat": "acpx-kimi-shadow", "agent": "kimi", "model": None},
     "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},
@@ -280,6 +384,7 @@ ACPX_PARTICIPANT_EFFORTS: dict[str, str] = {
 # is applied after strict NDJSON parsing and before a Result can reach the
 # fleet-authority receipt.
 ACPX_PARSED_RESPONSE_LIMIT_BYTES = 512 * 1024
+ACPX_TOOL_CALL_LIMIT = 2048
 
 
 @dataclass(frozen=True)
@@ -731,8 +836,31 @@ def _require_compatible_acpx_binary(
     return binary, observed_version
 
 
-def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
-    """Shared structural confinement flags for every ACPX seat."""
+def _confinement_prefix_argv(
+    binary: str,
+    cwd: Path,
+    *,
+    sealed_review_mcp_config: str | None = None,
+) -> list[str]:
+    """Shared confinement, optionally admitting only sealed review tools."""
+    permission_args = ["--deny-all", "--allowed-tools", ""]
+    if sealed_review_mcp_config is not None:
+        permission_policy = json.dumps(
+            {
+                "autoApprove": list(_SEALED_REVIEW_TOOL_NAMES),
+                "defaultAction": "deny",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        permission_args = [
+            "--permission-policy",
+            permission_policy,
+            "--allowed-tools",
+            ",".join(_SEALED_REVIEW_TOOL_NAMES),
+            "--mcp-config",
+            sealed_review_mcp_config,
+        ]
     return [
         binary,
         "--cwd",
@@ -742,13 +870,11 @@ def _confinement_prefix_argv(binary: str, cwd: Path) -> list[str]:
         "--json-strict",
         "--auth-policy",
         "fail",
-        "--deny-all",
         "--non-interactive-permissions",
         "fail",
         "--no-fs",
         "--no-terminal",
-        "--allowed-tools",
-        "",
+        *permission_args,
         "--max-turns",
         "1",
         "--prompt-retries",
@@ -1024,7 +1150,7 @@ class AcpxAdapter:
     Normal communication reaches this seat only through the runner-owned ACP
     boundary. It is not a general-purpose ACPX adapter: it only ever builds
     one invocation shape (``codex exec``, one Codex ACP participant, no tools,
-    no fs/terminal capability, no session, no queue). Every other ACPX
+    no arbitrary fs/terminal capability, no session, no queue). Every other ACPX
     capability (persistent sessions, other agents, flows, compare) is out of
     scope for this seat and structurally unreachable through this class.
     """
@@ -1088,6 +1214,10 @@ class AcpxAdapter:
             adapter_label="AcpxAdapter",
             required_target="codex",
         )
+        sealed_review_mcp_config = _validate_sealed_review_mcp_config(
+            tc.get("sealed_review_mcp_config"),
+            adapter_label="AcpxAdapter",
+        )
 
         validated_task_id = _require_local_metadata_field("task_id", task_id)
         correlation_id = _require_local_metadata_field("correlation_id", tc.get("correlation_id"))
@@ -1106,7 +1236,11 @@ class AcpxAdapter:
             builtin_agent="codex",
         )
 
-        cmd: list[str] = _confinement_prefix_argv(binary, cwd)
+        cmd: list[str] = _confinement_prefix_argv(
+            binary,
+            cwd,
+            sealed_review_mcp_config=sealed_review_mcp_config,
+        )
         if model:
             cmd.extend(["--model", model])
         if effort is not None:
@@ -1202,6 +1336,8 @@ class AcpxAdapter:
         final_stop_reason: object = _MISSING_STOP_REASON
         stop_reason_response_count = 0
         tokens: int | None = None
+        tool_calls_by_id: dict[str, dict[str, Any]] = {}
+        tool_call_order: list[str] = []
 
         for event in events:
             if "params" in event and not isinstance(event["params"], dict):
@@ -1227,6 +1363,44 @@ class AcpxAdapter:
                         return self._closed(usage_error, stderr)
                     if usage_total is not None:
                         tokens = usage_total
+                elif update.get("sessionUpdate") in {"tool_call", "tool_call_update"}:
+                    tool_call_id = update.get("toolCallId")
+                    if not isinstance(tool_call_id, str) or not tool_call_id:
+                        return self._closed("unrecognized ACP toolCallId schema", stderr)
+                    if tool_call_id not in tool_calls_by_id:
+                        if len(tool_call_order) >= ACPX_TOOL_CALL_LIMIT:
+                            return self._closed("ACPX tool-call trace exceeds bounded limit", stderr)
+                        tool_call_order.append(tool_call_id)
+                        tool_calls_by_id[tool_call_id] = {
+                            "id": tool_call_id,
+                            "name": "",
+                            "title": "",
+                            "arguments": {},
+                            "result": None,
+                            "status": "pending",
+                        }
+                    record = tool_calls_by_id[tool_call_id]
+                    name = update.get("name")
+                    if isinstance(name, str) and name:
+                        record["name"] = name
+                    title = update.get("title")
+                    if isinstance(title, str) and title:
+                        record["title"] = title
+                    raw_input = update.get("rawInput")
+                    if raw_input is not None:
+                        if isinstance(raw_input, str):
+                            try:
+                                raw_input = json.loads(raw_input)
+                            except json.JSONDecodeError:
+                                raw_input = {"_raw": raw_input}
+                        record["arguments"] = raw_input if isinstance(raw_input, dict) else {"_raw": raw_input}
+                    status = update.get("status")
+                    if isinstance(status, str) and status:
+                        record["status"] = status
+                    if "rawOutput" in update:
+                        record["result"] = update.get("rawOutput")
+                    elif "content" in update:
+                        record["result"] = update.get("content")
                 continue
 
             has_result = "result" in event
@@ -1322,7 +1496,7 @@ class AcpxAdapter:
             rate_limited=False,
             session_id=None,
             tokens=tokens,
-            tool_calls=[],
+            tool_calls=[tool_calls_by_id[tool_call_id] for tool_call_id in tool_call_order],
         )
 
     @staticmethod
@@ -1369,6 +1543,7 @@ class _AcpxDiscussionAdapter:
     name: str
     target_agent: str
     fixed_model: str | None = None
+    allowed_models: frozenset[str] = frozenset()
     acpx_model: str | None = None
     fixed_effort: str | None = None
     forward_model_to_acpx: bool = True
@@ -1380,7 +1555,12 @@ class _AcpxDiscussionAdapter:
         _ = cwd
         return None
 
-    def _env_overrides(self) -> dict[str, str]:
+    def _env_overrides(
+        self,
+        *,
+        sealed_review_mcp_config: str | None = None,
+    ) -> dict[str, str]:
+        _ = sealed_review_mcp_config
         return {} if self.auth_env is None else {self.auth_env: "1"}
 
     def _env_unsets(self) -> tuple[str, ...]:
@@ -1410,10 +1590,19 @@ class _AcpxDiscussionAdapter:
             adapter_label=type(self).__name__,
             required_target=self.target_agent,
         )
+        sealed_review_mcp_config = _validate_sealed_review_mcp_config(
+            tc.get("sealed_review_mcp_config"),
+            adapter_label=type(self).__name__,
+        )
         if self.fixed_model is not None and model not in {None, self.fixed_model}:
             raise AcpxShadowRefusalError(
                 f"{type(self).__name__}: model={model!r} rejected; caller may only pass None "
                 f"or {self.fixed_model!r}"
+            )
+        if self.allowed_models and model is not None and model not in self.allowed_models:
+            raise AcpxShadowRefusalError(
+                f"{type(self).__name__}: model={model!r} rejected; allowed pins are "
+                f"{sorted(self.allowed_models)!r}"
             )
         if self.fixed_effort is not None and effort not in {None, self.fixed_effort}:
             raise AcpxShadowRefusalError(
@@ -1441,9 +1630,15 @@ class _AcpxDiscussionAdapter:
             cwd=cwd,
             builtin_agent=builtin_agent,
         )
-        cmd = _confinement_prefix_argv(binary, cwd)
+        cmd = _confinement_prefix_argv(
+            binary,
+            cwd,
+            sealed_review_mcp_config=sealed_review_mcp_config,
+        )
         if self.fixed_model is not None and self.forward_model_to_acpx:
             cmd.extend(["--model", self.acpx_model or self.fixed_model])
+        elif self.allowed_models:
+            cmd.extend(["--model", model or self.default_model])
         if custom_agent is None:
             cmd.extend([self.target_agent, "exec", "-f", "-"])
             custom_metadata: dict[str, Any] = {}
@@ -1464,9 +1659,13 @@ class _AcpxDiscussionAdapter:
             metadata["acpx_transport"] = True
         if self.fixed_model is not None:
             metadata["model"] = self.fixed_model
+        elif self.allowed_models:
+            metadata["model"] = model or self.default_model
         if self.fixed_effort is not None:
             metadata["effort"] = self.fixed_effort
         metadata.update(custom_metadata)
+        if sealed_review_mcp_config is not None:
+            metadata["tool_policy"] = "sealed-review-only"
         metadata.update(self._extra_metadata())
         if tc.get("acpx_transport") is True:
             # Keep the runner-sealed transport fields authoritative even if a
@@ -1480,7 +1679,9 @@ class _AcpxDiscussionAdapter:
             cwd=cwd,
             stdin_payload=prompt,
             output_file=None,
-            env_overrides=self._env_overrides(),
+            env_overrides=self._env_overrides(
+                sealed_review_mcp_config=sealed_review_mcp_config,
+            ),
             env_unsets=self._env_unsets(),
             liveness_paths=(),
             metadata=metadata,
@@ -1498,8 +1699,8 @@ class _AcpxDiscussionAdapter:
 class AcpxClaudeShadowAdapter(_AcpxDiscussionAdapter):
     name = "acpx-claude-shadow"
     target_agent = "claude"
-    fixed_model = CLAUDE_ACP_MODEL
-    default_model = fixed_model
+    allowed_models = CLAUDE_ACP_MODELS
+    default_model = CLAUDE_ACP_MODEL
     fixed_effort = "high"
 
 
@@ -1579,10 +1780,18 @@ class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
             "tool_policy": "deny-all",
         }
 
-    def _env_overrides(self) -> dict[str, str]:
+    def _env_overrides(
+        self,
+        *,
+        sealed_review_mcp_config: str | None = None,
+    ) -> dict[str, str]:
         return {
             GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
-            "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
+            "OPENCODE_CONFIG_CONTENT": (
+                _OPENCODE_SEALED_REVIEW_CONFIG
+                if sealed_review_mcp_config is not None
+                else _OPENCODE_DENY_ALL_CONFIG
+            ),
         }
 
 class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
@@ -1688,6 +1897,10 @@ class AcpxGrokShadowAdapter:
             adapter_label="AcpxGrokShadowAdapter",
             required_target="grok",
         )
+        sealed_review_mcp_config = _validate_sealed_review_mcp_config(
+            tc.get("sealed_review_mcp_config"),
+            adapter_label="AcpxGrokShadowAdapter",
+        )
 
         if model is not None and model != GROK_SHADOW_MODEL:
             raise AcpxShadowRefusalError(
@@ -1738,7 +1951,11 @@ class AcpxGrokShadowAdapter:
 
         profile_path = _require_grok_profile()
         agent_command = _build_grok_agent_command(grok_binary, profile_path)
-        cmd: list[str] = _confinement_prefix_argv(acpx_binary, cwd)
+        cmd: list[str] = _confinement_prefix_argv(
+            acpx_binary,
+            cwd,
+            sealed_review_mcp_config=sealed_review_mcp_config,
+        )
         # --agent is a single shell-safe command string. Do not combine with a
         # positional agent token (acpx grammar), and never emit built-in
         # "grok-build".

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -2939,12 +2939,17 @@ def resolve_inter_agent_route(
             f"ACP participant {participant!r} is not an enabled confined direct-only route"
         )
 
-    if model is not None and model != pinned_model:
+    selected_model = pinned_model
+    if pinned_model is None:
+        if model is not None:
+            _validate_catalog_model(participant=participant, model=model)
+            selected_model = model
+    elif model is not None and model != pinned_model:
         raise InterAgentTransportError(
             f"ACP participant {participant!r} only supports its registered model pin "
             f"{pinned_model!r}; got {model!r}"
         )
-    if pinned_model is not None:
+    else:
         _validate_catalog_model(participant=participant, model=pinned_model)
 
     pinned_effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
@@ -2957,7 +2962,7 @@ def resolve_inter_agent_route(
         participant=participant,
         seat=seat,
         target_agent=target_agent,
-        model=pinned_model,
+        model=selected_model,
         effort=pinned_effort,
     )
 
@@ -3005,6 +3010,7 @@ def invoke_inter_agent(
     effort: str | None = None,
     transport: str | None = None,
     metadata: Mapping[str, object] | None = None,
+    sealed_review_mcp_config: Path | None = None,
     hard_timeout: int = 300,
 ) -> Result:
     """Invoke one confined ACP participant through the normal communication seam.
@@ -3021,6 +3027,9 @@ def invoke_inter_agent(
         raise InterAgentTransportError("inter-agent prompt must be a non-empty string")
     if isinstance(hard_timeout, bool) or not isinstance(hard_timeout, int) or hard_timeout < 1:
         raise InterAgentTransportError("inter-agent hard_timeout must be a positive integer")
+    sealed_config = None
+    if sealed_review_mcp_config is not None:
+        sealed_config = str(Path(sealed_review_mcp_config))
 
     validated_task_id = _require_local_metadata_field(
         "task_id", task_id, adapter_label="InterAgentTransport"
@@ -3059,6 +3068,11 @@ def invoke_inter_agent(
                     "target_agent": route.target_agent,
                     "correlation_id": validated_correlation_id,
                     "idempotency_key": validated_idempotency_key,
+                    **(
+                        {"sealed_review_mcp_config": sealed_config}
+                        if sealed_config is not None
+                        else {}
+                    ),
                 },
                 hard_timeout=hard_timeout,
                 effort=route.effort,

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -29,12 +30,24 @@ from ._review_safety import (
 
 _PR_REF_RE = re.compile(r"^(?:#|pr-)?(?P<num>\d+)$", re.IGNORECASE)
 
-# Reviewer transport ids (not harness marketing names).
+# Reviewer request ids (not harness marketing names).
 REVIEWER_CODEX = "codex"
 REVIEWER_GLM = "glm"
 REVIEWER_CLAUDE = "claude"
 REVIEWER_AGY = "agy"
+REVIEWER_GROK = "grok"
+REVIEWER_KIMI = "kimi"
 REVIEWER_AUTO = "auto"
+
+EXPLICIT_REVIEWER_CANDIDATE: dict[str, str] = {
+    REVIEWER_CODEX: "gpt-5.6-terra",
+    REVIEWER_CLAUDE: "claude-sonnet-5",
+    REVIEWER_AGY: "gemini-3.6-flash",
+    REVIEWER_GLM: "glm-5.2",
+    REVIEWER_GROK: "grok-4.5",
+    REVIEWER_KIMI: "kimi-k3",
+    "kimicc": "kimi-k3",
+}
 
 # Practical formal CF pins — keep in sync with model_catalog formal_cf_defaults.
 FORMAL_CF_MODEL: dict[str, str] = {
@@ -42,12 +55,18 @@ FORMAL_CF_MODEL: dict[str, str] = {
     REVIEWER_CLAUDE: "claude-sonnet-5",
     REVIEWER_AGY: "gemini-3.6-flash-high",
     REVIEWER_GLM: "glm-5.2",
+    REVIEWER_GROK: "grok-4.5",
+    REVIEWER_KIMI: "kimi-code/k3",
+    "kimicc": "kimi-code/k3",
 }
 FORMAL_CF_EFFORT: dict[str, str] = {
     REVIEWER_CODEX: "high",
     REVIEWER_CLAUDE: "high",
     REVIEWER_AGY: "high",
     REVIEWER_GLM: "high",
+    REVIEWER_GROK: "high",
+    REVIEWER_KIMI: "high",
+    "kimicc": "high",
 }
 
 
@@ -182,16 +201,16 @@ def build_review_pr_prompt(
 
 
 def resolve_reviewer(selection: str, *, claude_available: bool | None = None) -> str:
-    """Return concrete reviewer transport; GLM is the preferred ACP CF seat."""
+    """Validate a semantic reviewer request; auto remains unresolved here."""
     choice = (selection or REVIEWER_AUTO).strip().lower()
     if choice == REVIEWER_AUTO:
-        _ = claude_available  # retained as a compatibility-only CLI hint
-        return REVIEWER_GLM
-    if choice in {REVIEWER_CODEX, REVIEWER_GLM, REVIEWER_CLAUDE, REVIEWER_AGY}:
+        _ = claude_available  # compatibility-only hint; never routing authority
+        return REVIEWER_AUTO
+    if choice in EXPLICIT_REVIEWER_CANDIDATE:
         return choice
     raise ReviewSafetyError(
         f"unsupported_reviewer: {selection!r} "
-        f"(choose auto|codex|glm|claude|agy)"
+        f"(choose auto|codex|glm|claude|agy|grok|kimi)"
     )
 
 
@@ -202,36 +221,178 @@ def formal_cf_pin(reviewer: str) -> tuple[str, str]:
     return model, effort
 
 
+def _headroom_band(record: dict[str, Any]) -> str:
+    status = str(record.get("status") or "unknown")
+    remaining = record.get("remaining_pct")
+    if status in {"hot", "near_cap", "unavailable", "unhealthy"}:
+        return "near_cap" if status in {"hot", "near_cap"} else "unavailable"
+    if isinstance(remaining, (int, float)) and not isinstance(remaining, bool):
+        if remaining <= 10:
+            return "near_cap"
+        if remaining <= 25:
+            return "constrained"
+        return "healthy"
+    return "unknown"
+
+
+def _routing_trace(resolution: Any) -> dict[str, Any]:
+    return {
+        "decision_order": [
+            "hard_eligibility",
+            "task_fit_suitability",
+            "quality_tier",
+            "quota_cost_capacity_failure_pressure",
+            "stable_exact_tie_break",
+        ],
+        "policy_version": resolution.policy_version,
+        "substitution_note": resolution.substitution_note,
+        "candidates": [
+            {
+                "name": item.name,
+                "model": item.concrete_model,
+                "family": item.family,
+                "route": item.route,
+                "status": item.status,
+                "reason": item.reason,
+                "suitability_rank": item.suitability_rank,
+                "quality_tier": item.quality_tier,
+                "health": item.health,
+                "selection_score": list(item.selection_score) if item.selection_score is not None else None,
+            }
+            for item in resolution.trace
+        ],
+    }
+
+
+def _semantic_request_matches(reservation: Any, request: Any) -> bool:
+    return all(
+        (
+            reservation.author_model == request.author_model,
+            reservation.author_family == request.author_family,
+            reservation.requested_role == request.requested_role,
+            reservation.requested_profile == request.requested_profile,
+            reservation.requested_risk == request.requested_risk,
+            reservation.route_mode == request.route_mode,
+            reservation.requested_reviewer == request.requested_reviewer,
+            reservation.estimated_input_bytes == request.estimated_input_bytes,
+        )
+    )
+
+
+def _usage_int(result: Any, *keys: str) -> int | None:
+    record = getattr(result, "usage_record", None)
+    if not isinstance(record, dict):
+        return None
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return None
+
+
+def _failure_classification(result: Any | None, exc: BaseException | None = None) -> str:
+    if result is not None:
+        if bool(getattr(result, "rate_limited", False)):
+            return "rate_limited"
+        record = getattr(result, "usage_record", None)
+        if isinstance(record, dict) and record.get("failure_code") in {
+            "provider_unavailable",
+            "rate_limited",
+            "timeout",
+            "transport_error",
+        }:
+            return str(record["failure_code"])
+        if bool(getattr(result, "stalled", False)):
+            return "timeout"
+    if exc is not None and "timeout" in type(exc).__name__.lower():
+        return "timeout"
+    return "transport_error"
+
+
+def _evidence_metrics(evidence: str) -> dict[str, int]:
+    """Extract the parent-computed, non-secret evidence byte receipt."""
+    marker = "AUTHORITATIVE SEALED REVIEW EVIDENCE\n"
+    end_marker = "\nEND AUTHORITATIVE SEALED REVIEW EVIDENCE"
+    try:
+        payload = evidence.split(marker, 1)[1].split(end_marker, 1)[0]
+        dossier = json.loads(payload.rsplit("\n", 1)[-1])
+        metrics = dossier.get("evidence_metrics", {})
+    except (IndexError, json.JSONDecodeError, AttributeError):
+        return {}
+    if not isinstance(metrics, dict):
+        return {}
+    return {
+        key: value
+        for key, value in metrics.items()
+        if isinstance(key, str)
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= 0
+    }
+
+
+def _transport_failure_receipt(
+    *,
+    classification: str,
+    result: Any | None,
+    exc: BaseException | None,
+) -> dict[str, Any]:
+    """Return bounded diagnostics without persisting provider response bodies."""
+    usage = getattr(result, "usage_record", None)
+    failure_code = usage.get("failure_code") if isinstance(usage, dict) else None
+    diagnostic = getattr(result, "stderr_excerpt", None)
+    if not diagnostic and exc is not None:
+        diagnostic = f"{type(exc).__name__}: {exc}"
+    return {
+        "failure_classification": classification,
+        "provider_failure_code": failure_code if isinstance(failure_code, str) else None,
+        "diagnostic": str(diagnostic)[:500] if diagnostic else None,
+        "transport": "acp",
+    }
+
+
+def _fallback_permitted(*, route_mode: str, allow_explicit_fallback: bool) -> bool:
+    """Automatic retries may change bucket; explicit pins require opt-in."""
+    return route_mode == "auto" or (route_mode == "explicit" and allow_explicit_fallback)
+
+
+def _routing_attempt_seed(authority_job: Any) -> int:
+    """Derive a monotonic retry namespace from durable authority attempts."""
+    value = getattr(authority_job, "attempt_count", 0)
+    return max(0, value) if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
 def handle_review_pr(args: argparse.Namespace) -> int:
     """CLI handler for ``review-pr``."""
     try:
         pr = parse_pr_number(str(args.pr))
-        reviewer = resolve_reviewer(args.reviewer, claude_available=args.claude_available)
-        model, effort = formal_cf_pin(reviewer)
-        if getattr(args, "model", None):
-            model = str(args.model).strip()
-        if getattr(args, "effort", None):
-            effort = str(args.effort).strip()
-        prompt = build_review_pr_prompt(
-            pr,
-            reviewer=reviewer,
-            model=model,
-            effort=effort,
-            extra=args.extra,
-        )
+        reviewer_request = resolve_reviewer(args.reviewer, claude_available=args.claude_available)
+        initiator = str(
+            getattr(args, "initiator", None)
+            or getattr(args, "from_llm", None)
+            or os.environ.get("SESSION_HANDOFF_AGENT")
+            or ""
+        ).strip()
+        author_model = str(getattr(args, "author_model", None) or "").strip()
+        author_family = str(getattr(args, "author_family", None) or "").strip()
+        if not initiator:
+            raise ReviewSafetyError("initiator_required: pass --initiator")
+        if not author_model or not author_family:
+            raise ReviewSafetyError("concrete_author_identity_required: pass --author-model and --author-family")
     except ReviewSafetyError as exc:
         print(f"review-pr: {exc}", file=sys.stderr)
         return 2
 
     task_id = args.task_id or f"review-pr-{pr}"
     if args.dry_run:
-        print(
-            f"review-pr dry-run pr={pr} reviewer={reviewer} "
-            f"model={model} effort={effort} task_id={task_id}"
+        dry_model = getattr(args, "model", None) or (
+            "deterministic-scheduler" if reviewer_request == REVIEWER_AUTO else FORMAL_CF_MODEL[reviewer_request]
         )
-        print(f"prompt_bytes={len(prompt.encode('utf-8'))}")
-        print("--- prompt ---")
-        print(prompt)
+        print(
+            f"review-pr dry-run pr={pr} reviewer_request={reviewer_request} "
+            f"model={dry_model} task_id={task_id} initiator={initiator} "
+            f"author={author_model}/{author_family}"
+        )
         return 0
     if args.background:
         print(
@@ -241,41 +402,73 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         )
         return 2
 
-    from_llm = (
-        getattr(args, "from_llm", None)
-        or os.environ.get("SESSION_HANDOFF_AGENT")
-        or os.environ.get("LEARN_UKRAINIAN_AGENT_NAME")
-        or "gemini"
-    )
     from agent_runtime.runner import invoke_inter_agent
 
-    from scripts.fleet_comms.authority import AuthorityService
+    from scripts.agent_runtime.adapters.acpx import ACPX_PARTICIPANT_EFFORTS
+    from scripts.api.state_router import compute_routing_budget
+    from scripts.fleet_comms.authority import AuthorityService, AuthorityStaleLeaseError
     from scripts.fleet_comms.review_publication import (
         SealedVerdict,
         parse_review_evidence,
         verdict_from_review_evidence,
     )
+    from scripts.fleet_comms.routing_reservations import (
+        RoutingReservationLedger,
+        RoutingReservationRequest,
+        RoutingReservationUnavailable,
+        RoutingSelection,
+    )
     from scripts.orchestration.task_identity import DEFAULT_REPOSITORY
+    from scripts.review.reviewer_resolver import (
+        REVIEW_CANDIDATES,
+        ResolverInputs,
+        resolve_author_family,
+    )
+    from scripts.review.reviewer_resolver import resolve_reviewer as resolve_canonical_reviewer
 
     from ._config import REPO_ROOT
     from ._review_worktree import (
         ReviewTarget,
         provision_review_worktree,
         validate_code_review_response,
+        verify_clean_review_evidence_reads,
     )
 
-    participant = {
-        REVIEWER_CODEX: "codex",
-        REVIEWER_CLAUDE: "claude",
-        REVIEWER_AGY: "agy",
-        REVIEWER_GLM: "glm",
-    }[reviewer]
-    family = {
-        REVIEWER_CODEX: "openai",
-        REVIEWER_CLAUDE: "anthropic",
-        REVIEWER_AGY: "google",
-        REVIEWER_GLM: "zhipu",
-    }[reviewer]
+    resolved_author_family = resolve_author_family(author_model, author_family)
+    if resolved_author_family != author_family:
+        print(
+            "review-pr: author model/family are unknown, ambiguous, or conflicting; refusing formal review",
+            file=sys.stderr,
+        )
+        return 2
+    requested_candidate = None
+    if reviewer_request != REVIEWER_AUTO:
+        requested_candidate = EXPLICIT_REVIEWER_CANDIDATE[reviewer_request]
+    explicit_model = str(getattr(args, "model", None) or "").strip() or None
+    if explicit_model:
+        matches = [candidate.name for candidate in REVIEW_CANDIDATES.values() if candidate.concrete_model == explicit_model]
+        if requested_candidate is not None:
+            valid_model_pin = REVIEW_CANDIDATES[requested_candidate].concrete_model == explicit_model
+        else:
+            valid_model_pin = len(matches) == 1
+            if valid_model_pin:
+                requested_candidate = matches[0]
+        if not valid_model_pin:
+            print("review-pr: --model must identify exactly the explicitly requested canonical candidate", file=sys.stderr)
+            return 2
+    route_mode = "explicit" if requested_candidate is not None else "auto"
+    override_reason = str(getattr(args, "override_reason", None) or "").strip() or None
+    if requested_candidate is not None and override_reason is None:
+        print("review-pr: explicit reviewer/model pin requires --override-reason", file=sys.stderr)
+        return 2
+    profile = str(getattr(args, "review_profile", None) or "code").strip().lower()
+    risk = str(getattr(args, "risk", None) or "medium").strip().lower()
+    requested_role = str(getattr(args, "role", None) or "").strip() or None
+    ledger_role = requested_role or f"{profile}:{risk}"
+    required_capabilities = frozenset(
+        getattr(args, "required_capability", None) or ("code_review", "sealed_evidence")
+    )
+    allow_explicit_fallback = bool(getattr(args, "allow_explicit_fallback", False))
     target = ReviewTarget(pr_number=pr)
     with provision_review_worktree(
         target,
@@ -285,7 +478,9 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         if checkout is None:  # pragma: no cover - target above is mandatory
             raise RuntimeError("sealed review snapshot was not provisioned")
         evidence = checkout.review_prompt_evidence("acp")
-        sealed_prompt = prompt + evidence
+        evidence_metrics = _evidence_metrics(evidence)
+        sealed_mcp_config = checkout.sealed_acp_tool_config()
+        estimated_input_bytes = checkout.sealed_evidence_input_bytes()
         timeout = 86400 if args.no_timeout else 1800
         worker_id = f"review-pr-acp:{os.getpid()}"
         authority_key = _formal_review_authority_key(
@@ -294,7 +489,28 @@ def handle_review_pr(args: argparse.Namespace) -> int:
             checkout.sha,
             checkout.patch_digest,
         )
-        with AuthorityService() as authority:
+        routing_request = RoutingReservationRequest(
+            authority_key=authority_key,
+            idempotency_key=f"{authority_key}:routing:0",
+            initiator=initiator,
+            author_model=author_model,
+            author_family=author_family,
+            requested_role=ledger_role,
+            requested_profile=profile,
+            requested_risk=risk,
+            route_mode=route_mode,
+            estimated_input_bytes=estimated_input_bytes,
+            requested_reviewer=requested_candidate,
+        )
+        try:
+            routing_budget = compute_routing_budget(fresh_codexbar=False)
+        except Exception as exc:
+            routing_budget = {
+                "agents": {},
+                "in_flight": {},
+                "diagnostics": {"stale": True, "routing_budget_error": type(exc).__name__},
+            }
+        with RoutingReservationLedger() as routing_ledger, AuthorityService() as authority:
             authority_job = authority.enqueue_formal_review(
                 repository=DEFAULT_REPOSITORY,
                 pr_number=pr,
@@ -307,65 +523,269 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                 authority_job.subject_id,
                 current_head_sha=checkout.sha,
             )
-            if authority_job.state in {"failed", "expired"}:
-                authority_job = authority.retry_job(authority_job.job_id)
-            elif authority_job.state == "dead_lettered":
-                authority_job = authority.redrive_job(authority_job.job_id)
+            routing_reservation = None
+            result = None
+            coverage_receipt = None
+            replayed = authority_job.state == "complete"
             if authority_job.state == "complete":
+                routing_reservation = routing_ledger.completed_replay(authority_key)
+                if routing_reservation is None or not _semantic_request_matches(routing_reservation, routing_request):
+                    print("review-pr: completed exact-head result lacks a matching routing authority receipt", file=sys.stderr)
+                    return 1
                 replay = authority.read_job_result(authority_job.job_id)
                 if replay is None:
                     print("review-pr: completed ACP attempt has no durable result", file=sys.stderr)
                     return 1
                 raw_response = replay.decode("utf-8")
             else:
-                lease = authority.claim_job(
-                    authority_job.job_id,
-                    worker_id,
-                    lease_seconds=timeout + 30,
-                )
-                previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
-                os.environ["LU_ACPX_TRANSPORT"] = "active"
-                try:
-                    result = invoke_inter_agent(
-                        participant,
-                        sealed_prompt,
-                        cwd=checkout.path,
-                        task_id=task_id,
-                        correlation_id=formal_job.review_id,
-                        idempotency_key=authority_key,
-                        source=from_llm,
+                if authority_job.state in {"failed", "expired"}:
+                    authority_job = authority.retry_job(authority_job.job_id)
+                elif authority_job.state == "dead_lettered":
+                    authority_job = authority.redrive_job(authority_job.job_id)
+                failed_quota_buckets: set[str] = set()
+                fallback_from: str | None = None
+                # A later CLI invocation must not reuse a terminal routing
+                # idempotency key from an earlier authority attempt. The
+                # authority attempt counter is durable and monotonic; gaps are
+                # harmless, while reuse could launch work without a fresh
+                # reservation after a repaired transport is retried.
+                reservation_attempt = _routing_attempt_seed(authority_job)
+                fallback_attempt = 0
+                while True:
+                    selection_diagnostic: dict[str, Any] = {}
+
+                    def select_inside_authority(
+                        context: Any,
+                        *,
+                        attempt_index: int = reservation_attempt,
+                        fallback_index: int = fallback_attempt,
+                        prior_candidate: str | None = fallback_from,
+                        diagnostic: dict[str, Any] = selection_diagnostic,
+                    ) -> RoutingSelection | None:
+                        snapshot = json.loads(json.dumps(routing_budget))
+                        agents = snapshot.setdefault("agents", {})
+                        for candidate in REVIEW_CANDIDATES.values():
+                            record = agents.setdefault(candidate.route, {})
+                            if not isinstance(record, dict):
+                                record = {}
+                                agents[candidate.route] = record
+                            usage = context.bucket_usage(candidate.quota_bucket, rolling_window_seconds=7 * 24 * 3600)
+                            circuit = context.bucket_circuit_state(candidate.quota_bucket, candidate.credential_bucket)
+                            codexbar = record.get("codexbar") if isinstance(record.get("codexbar"), dict) else {}
+                            scheduler = record.setdefault("scheduler", {})
+                            scheduler.update(
+                                {
+                                    "completed_input_bytes": usage.completed_window_bytes,
+                                    "active_reserved_input_bytes": usage.reserved_input_bytes,
+                                    "inflight": context.active_reservations(candidate.credential_bucket),
+                                    "failures": usage.recent_failures,
+                                    "circuit_open": bool(circuit and circuit.open_until and circuit.open_until > context.now),
+                                    "capacity_exhausted": (
+                                        context.available_slots(
+                                            candidate.credential_bucket,
+                                            candidate.credential_limit,
+                                        ) == 0
+                                        or context.quota_available_slots(
+                                            candidate.quota_bucket,
+                                            candidate.quota_limit,
+                                        ) == 0
+                                    ),
+                                    "quota_remaining_pct": record.get("remaining_pct"),
+                                    "quota_stale": codexbar.get("freshness") != "fresh",
+                                }
+                            )
+                        pin = requested_candidate if fallback_index == 0 else None
+                        resolution = resolve_canonical_reviewer(
+                            ResolverInputs(
+                                author_model=author_model,
+                                author_family=author_family,
+                                review_profile=profile,
+                                risk=risk,
+                                domain=profile,
+                                requested_role=requested_role,
+                                required_capabilities=required_capabilities,
+                                data_egress_policy=getattr(args, "data_egress_policy", None),
+                                isolation_required=bool(getattr(args, "isolation_required", True)),
+                                exact_head=authority_key,
+                                pinned_candidate=pin,
+                                pressure_override_reason=override_reason if pin else None,
+                            ),
+                            runtime_state=snapshot,
+                            excluded_quota_buckets=frozenset(failed_quota_buckets),
+                        )
+                        diagnostic.update(
+                            {
+                                "fail_closed_reason": resolution.fail_closed_reason,
+                                "trace": _routing_trace(resolution),
+                            }
+                        )
+                        selected = resolution.selected
+                        if selected is None:
+                            return None
+                        record = agents.get(selected.route, {})
+                        codexbar = record.get("codexbar") if isinstance(record, dict) and isinstance(record.get("codexbar"), dict) else {}
+                        fresh_at = codexbar.get("fetched_at") if isinstance(codexbar.get("fetched_at"), str) else None
+                        source = "codexbar_fresh" if codexbar.get("freshness") == "fresh" else (
+                            "codexbar_last_known_good" if codexbar.get("freshness") == "stale_last_good" else "unavailable"
+                        )
+                        return RoutingSelection(
+                            candidate=selected.name,
+                            route=selected.route,
+                            model=selected.concrete_model,
+                            family=selected.family,
+                            quota_bucket=selected.quota_bucket,
+                            credential_bucket=selected.credential_bucket,
+                            quota_limit=selected.quota_limit,
+                            credential_limit=selected.credential_limit,
+                            policy_version=resolution.policy_version,
+                            quota_snapshot=record if isinstance(record, dict) else {},
+                            quota_fresh_at=fresh_at,
+                            trace=_routing_trace(resolution),
+                            fallback_from=prior_candidate,
+                            retry_attempt=attempt_index,
+                            quota_source=source,
+                            quota_headroom_band=_headroom_band(record if isinstance(record, dict) else {}),
+                        )
+
+                    attempt_request = replace(
+                        routing_request,
+                        idempotency_key=f"{authority_key}:routing:{reservation_attempt}",
+                    )
+                    try:
+                        lease = authority.claim_job(
+                            authority_job.job_id,
+                            worker_id,
+                            lease_seconds=timeout + 30,
+                        )
+                    except AuthorityStaleLeaseError as exc:
+                        if str(exc) != "job_already_claimed":
+                            raise
+                        print(
+                            "review-pr: exact-head formal job is already active; "
+                            "no provider call or routing reservation was created",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    try:
+                        routing_reservation = routing_ledger.reserve_selection(
+                            attempt_request,
+                            select_inside_authority,
+                            ttl_seconds=timeout + 30,
+                        )
+                    except RoutingReservationUnavailable as exc:
+                        authority.finish_job(
+                            authority_job.job_id,
+                            worker_id=worker_id,
+                            fence_token=lease.fence_token,
+                            state="failed",
+                            result=json.dumps(
+                                {
+                                    "failure_classification": "no_admissible_route",
+                                    "detail": str(exc),
+                                    "selection": selection_diagnostic,
+                                },
+                                sort_keys=True,
+                            ).encode("utf-8"),
+                        )
+                        reason = selection_diagnostic.get("fail_closed_reason") or str(exc)
+                        print(f"review-pr: no admissible formal reviewer: {reason}", file=sys.stderr)
+                        return 1
+                    participant = REVIEW_CANDIDATES[routing_reservation.resolved_candidate].participant
+                    model = routing_reservation.resolved_model
+                    effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
+                    requested_effort = str(getattr(args, "effort", None) or "").strip() or None
+                    if requested_effort is not None and requested_effort != effort:
+                        routing_ledger.settle(
+                            routing_reservation.reservation_id,
+                            status="cancelled",
+                            terminal_evidence={"reason": "invalid_effort_pin"},
+                        )
+                        authority.finish_job(
+                            authority_job.job_id,
+                            worker_id=worker_id,
+                            fence_token=lease.fence_token,
+                            state="failed",
+                            result=b'{"failure_classification":"invalid_effort_pin"}',
+                        )
+                        print(
+                            f"review-pr: participant {participant} supports effort pin {effort!r}, "
+                            f"not {requested_effort!r}",
+                            file=sys.stderr,
+                        )
+                        return 2
+                    prompt = build_review_pr_prompt(
+                        pr,
+                        reviewer=routing_reservation.resolved_route,
                         model=model,
-                        effort=effort,
-                        hard_timeout=timeout,
+                        effort=effort or "provider_default",
+                        extra=args.extra,
                     )
-                except BaseException as exc:
+                    sealed_prompt = prompt + evidence
+                    routing_ledger.mark_started(routing_reservation.reservation_id)
+                    previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
+                    os.environ["LU_ACPX_TRANSPORT"] = "active"
+                    invocation_error: BaseException | None = None
+                    try:
+                        result = invoke_inter_agent(
+                            participant,
+                            sealed_prompt,
+                            cwd=checkout.path,
+                            task_id=task_id,
+                            correlation_id=formal_job.review_id,
+                            idempotency_key=authority_key,
+                            source=initiator,
+                            model=model,
+                            effort=effort,
+                            sealed_review_mcp_config=sealed_mcp_config,
+                            hard_timeout=timeout,
+                        )
+                    except BaseException as exc:
+                        invocation_error = exc
+                    finally:
+                        if previous_transport is None:
+                            os.environ.pop("LU_ACPX_TRANSPORT", None)
+                        else:
+                            os.environ["LU_ACPX_TRANSPORT"] = previous_transport
+                    raw_response = str(getattr(result, "response", "")) if result is not None else ""
+                    if invocation_error is None and result is not None and getattr(result, "ok", False):
+                        break
+                    classification = _failure_classification(result, invocation_error)
+                    failure_receipt = _transport_failure_receipt(
+                        classification=classification,
+                        result=result,
+                        exc=invocation_error,
+                    )
+                    routing_ledger.fail_and_release(
+                        routing_reservation.reservation_id,
+                        classification,
+                        actual_input_bytes=estimated_input_bytes,
+                        actual_output_bytes=len(raw_response.encode("utf-8")),
+                        actual_input_tokens=_usage_int(result, "input_tokens") if result is not None else None,
+                        actual_output_tokens=_usage_int(result, "output_tokens", "tokens") if result is not None else None,
+                        circuit_open_seconds=300,
+                    )
                     authority.finish_job(
                         authority_job.job_id,
                         worker_id=worker_id,
                         fence_token=lease.fence_token,
                         state="failed",
-                        result=json.dumps(
-                            {"error": type(exc).__name__, "transport": "acp"},
-                            sort_keys=True,
-                        ).encode("utf-8"),
+                        result=json.dumps(failure_receipt, sort_keys=True).encode("utf-8"),
                     )
-                    raise
-                finally:
-                    if previous_transport is None:
-                        os.environ.pop("LU_ACPX_TRANSPORT", None)
-                    else:
-                        os.environ["LU_ACPX_TRANSPORT"] = previous_transport
-                raw_response = str(getattr(result, "response", ""))
-                if not getattr(result, "ok", False):
-                    authority.finish_job(
-                        authority_job.job_id,
-                        worker_id=worker_id,
-                        fence_token=lease.fence_token,
-                        state="failed",
-                        result=raw_response.encode("utf-8"),
+                    can_fallback = _fallback_permitted(
+                        route_mode=route_mode,
+                        allow_explicit_fallback=allow_explicit_fallback,
                     )
-                    print("review-pr: ACP reviewer failed without bridge retry", file=sys.stderr)
-                    return 1
+                    if not can_fallback or fallback_attempt >= len(REVIEW_CANDIDATES) - 1:
+                        if invocation_error is not None:
+                            print(f"review-pr: ACP reviewer failed: {type(invocation_error).__name__}", file=sys.stderr)
+                        else:
+                            print("review-pr: ACP reviewer failed", file=sys.stderr)
+                        return 1
+                    failed_quota_buckets.add(routing_reservation.quota_bucket)
+                    fallback_from = routing_reservation.resolved_candidate
+                    reservation_attempt += 1
+                    fallback_attempt += 1
+                    authority_job = authority.retry_job(authority_job.job_id)
 
             if not raw_response:
                 if authority_job.state != "complete":
@@ -389,6 +809,13 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     evidence_root=checkout.path,
                     changed_lines=checkout.changed_line_numbers,
                 )
+                if not replayed:
+                    coverage_receipt = verify_clean_review_evidence_reads(
+                        result,
+                        engine="acp",
+                        evidence_root=checkout.path,
+                        changed_paths=checkout.changed_paths,
+                    )
             except BaseException:
                 if authority_job.state != "complete":
                     authority.finish_job(
@@ -398,6 +825,15 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         state="failed",
                         result=raw_response.encode("utf-8"),
                     )
+                    if routing_reservation is not None:
+                        routing_ledger.fail_and_release(
+                            routing_reservation.reservation_id,
+                            "result_invalid",
+                            actual_input_bytes=estimated_input_bytes,
+                            actual_output_bytes=len(raw_response.encode("utf-8")),
+                            actual_input_tokens=_usage_int(result, "input_tokens") if result is not None else None,
+                            actual_output_tokens=_usage_int(result, "output_tokens", "tokens") if result is not None else None,
+                        )
                 raise
             if authority_job.state != "complete":
                 authority.finish_job(
@@ -406,6 +842,24 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     fence_token=lease.fence_token,
                     state="complete",
                     result=canonical_response.encode("utf-8"),
+                )
+                routing_ledger.settle(
+                    routing_reservation.reservation_id,
+                    status="complete",
+                    actual_input_bytes=(
+                        coverage_receipt.get("total_delivered_bytes", estimated_input_bytes)
+                        if isinstance(coverage_receipt, dict)
+                        else estimated_input_bytes
+                    ),
+                    actual_output_bytes=len(canonical_response.encode("utf-8")),
+                    actual_input_tokens=_usage_int(result, "input_tokens"),
+                    actual_output_tokens=_usage_int(result, "output_tokens", "tokens"),
+                    terminal_evidence={
+                        "coverage_receipt": coverage_receipt or {},
+                        "unique_evidence_bytes": estimated_input_bytes,
+                        "serialized_prompt_bytes": len(evidence.encode("utf-8")),
+                        "evidence_metrics": evidence_metrics,
+                    },
                 )
             canonical = json.loads(canonical_response)
             review_evidence = parse_review_evidence(canonical)
@@ -421,8 +875,8 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                 head_sha=checkout.sha,
                 gate_kind="cross-family-review",
                 verdict=verdict,
-                model=model,
-                family=family,
+                model=routing_reservation.resolved_model,
+                family=routing_reservation.resolved_family,
                 harness="acp",
                 review_evidence=review_evidence,
             )
@@ -436,9 +890,19 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         "snapshot_artifact_id": formal_job.snapshot_artifact_id,
                         "authority_job_id": authority_job.job_id,
                         "verdict": verdict,
-                        "reviewer": reviewer,
-                        "model": model,
-                        "effort": effort,
+                        "reviewer_request": reviewer_request,
+                        "resolved_candidate": routing_reservation.resolved_candidate,
+                        "model": routing_reservation.resolved_model,
+                        "family": routing_reservation.resolved_family,
+                        "quota_bucket": routing_reservation.quota_bucket,
+                        "credential_bucket": routing_reservation.credential_bucket,
+                        "routing_reservation_id": routing_reservation.reservation_id,
+                        "exact_head_replay": replayed,
+                        "coverage_receipt": coverage_receipt,
+                        "evidence_metrics": evidence_metrics,
+                        "reported_input_tokens": _usage_int(result, "input_tokens"),
+                        "reported_output_tokens": _usage_int(result, "output_tokens", "tokens"),
+                        "serialized_prompt_bytes": len(evidence.encode("utf-8")),
                         "transport": "acp",
                     },
                     sort_keys=True,
@@ -452,27 +916,23 @@ def register_review_pr_parser(subparsers: Any) -> None:
         "review-pr",
         help="Pointer-only formal PR review (sealed isolation preferred)",
         description=(
-            "Canonical formal code-review entrypoint. Builds a thin pointer-only "
-            "prompt with a mandatory read-only contract. Default transport is "
-            "ACP with GLM-5.2 @ high over an immutable exact-head inline snapshot. "
-            "Codex and Claude selections are accepted only when their ACP route "
-            "implements the requested exact model pin."
+            "Canonical formal code-review entrypoint. The orchestrator supplies "
+            "semantic requirements; one deterministic suitability-first scheduler "
+            "atomically chooses and reserves the sealed ACP route. No LLM performs routing."
         ),
     )
     parser.add_argument("pr", help="PR number (e.g. 5443 or #5443)")
     parser.add_argument(
         "--reviewer",
         default=REVIEWER_AUTO,
-        help="auto|codex|glm|claude|agy (default: auto → GLM sealed ACP path)",
+        help="auto|codex|glm|claude|agy|grok|kimi (explicit routes are exceptional pins)",
     )
     parser.add_argument(
         "--model",
         default=None,
         help=(
-            "Override formal CF model pin "
-            "(default: codex→gpt-5.6-terra, claude→claude-sonnet-5, "
-            "agy→gemini-3.6-flash-high, glm→glm-5.2; "
-            "authority escalate: gpt-5.6-sol / claude-fable-5)"
+            "Exceptional exact canonical model pin; must agree with --reviewer and "
+            "requires --override-reason"
         ),
     )
     parser.add_argument(
@@ -482,16 +942,26 @@ def register_review_pr_parser(subparsers: Any) -> None:
             "Override formal CF effort pin (default: high; authority escalate: xhigh)"
         ),
     )
-    parser.add_argument(
-        "--claude-available",
-        dest="claude_available",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Hint for --reviewer auto (false selects glm local)",
-    )
+    parser.add_argument("--claude-available", dest="claude_available", action=argparse.BooleanOptionalAction,
+                        default=None, help="Deprecated compatibility hint; never routing authority")
     parser.add_argument("--task-id", help="Bridge task id (default: review-pr-<N>)")
     parser.add_argument("--extra", help="Optional extra scope text (kept under size cap)")
-    parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+    parser.add_argument("--initiator", "--from", dest="initiator", required=True,
+                        help="Concrete orchestrator identity persisted in routing authority")
+    parser.add_argument("--author-model", required=True, help="Concrete author model/seat identity")
+    parser.add_argument("--author-family", required=True, help="Concrete author model family")
+    parser.add_argument("--review-profile", choices=("code", "infra"), default="code")
+    parser.add_argument("--role", help="Optional exact canonical model role required for this review")
+    parser.add_argument("--risk", choices=("critical", "high", "medium", "low"), default="medium")
+    parser.add_argument("--required-capability", action="append",
+                        help="Repeatable hard capability gate (default: code_review + sealed_evidence)")
+    parser.add_argument("--data-egress-policy",
+                        help="Explicit data-egress policy token; gated routes fail closed when absent")
+    parser.add_argument("--isolation-required", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--override-reason",
+                        help="Required evidence for every exceptional explicit reviewer/model pin")
+    parser.add_argument("--allow-explicit-fallback", action="store_true",
+                        help="Permit an explicit pin to fail over after a retryable transport failure")
     parser.add_argument("--background", action="store_true")
     parser.add_argument("--no-timeout", action="store_true")
     parser.add_argument("--dry-run", action="store_true")

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -233,11 +233,21 @@ def _tool_result_succeeded(call: dict[str, Any]) -> bool:
     result = call.get("result")
     if result is None:
         return False
+    status = str(call.get("status") or "").strip().lower()
+    if status in {"error", "failed", "cancelled", "canceled"}:
+        return False
     if isinstance(result, dict):
         if result.get("isError") is True or result.get("is_error") is True:
             return False
         if "error" in result and result.get("error") not in {None, ""}:
             return False
+    # ACP completion status is harness-authored transport evidence. Once it
+    # says the call completed, do not scan the returned source bytes for error
+    # marker strings: reviewed code can legitimately contain the verifier's
+    # own markers, and treating those inert bytes as control data drops whole
+    # authentic chunks from the coverage receipt.
+    if status in {"completed", "complete", "success", "succeeded"}:
+        return True
     texts = _tool_result_texts(result)
     lowered = "\n".join(texts).lower()
     if any(
@@ -264,7 +274,7 @@ def _tool_result_texts(value: Any) -> list[str]:
         return texts
     if isinstance(value, dict):
         texts = []
-        for key in ("text", "content", "result"):
+        for key in ("text", "content", "result", "output"):
             if key in value:
                 texts.extend(_tool_result_texts(value[key]))
         return texts
@@ -292,7 +302,7 @@ def _mcp_chunk_payloads(result: Any) -> list[dict[str, Any]]:
             }.issubset(candidate):
                 payloads.append(candidate)
                 return
-            for key in ("text", "content", "result", "chunks"):
+            for key in ("text", "content", "result", "output", "chunks"):
                 if key in candidate:
                     visit(candidate[key], depth=depth + 1)
             return
@@ -427,8 +437,11 @@ def _codex_sealed_read_requests(
     arguments = call.get("arguments")
     if not isinstance(arguments, dict):
         return []
-    if name == "read_file" or name.endswith("sealed_review__read_file") or name.endswith(
-        "sealed_review.read_file"
+    if (
+        name == "read_file"
+        or name.endswith("sealed_review__read_file")
+        or name.endswith("sealed_review.read_file")
+        or name.endswith("sealed_review_read_file")
     ):
         request = _validated_codex_read_request(
             raw_path=arguments.get("path"),
@@ -437,8 +450,11 @@ def _codex_sealed_read_requests(
             evidence_root=evidence_root,
         )
         return [request] if request is not None else []
-    if name == "read_required" or name.endswith("sealed_review__read_required") or name.endswith(
-        "sealed_review.read_required"
+    if (
+        name == "read_required"
+        or name.endswith("sealed_review__read_required")
+        or name.endswith("sealed_review.read_required")
+        or name.endswith("sealed_review_read_required")
     ):
         return _required_stream_requests(
             evidence_root=evidence_root,
@@ -448,7 +464,9 @@ def _codex_sealed_read_requests(
         )
     if name == "read_required_all" or name.endswith(
         "sealed_review__read_required_all"
-    ) or name.endswith("sealed_review.read_required_all"):
+    ) or name.endswith("sealed_review.read_required_all") or name.endswith(
+        "sealed_review_read_required_all"
+    ):
         return _all_required_requests(
             evidence_root=evidence_root,
             required_paths=required_paths,
@@ -540,6 +558,7 @@ def _verify_codex_review_reads(
     _validate_review_read_sizes(evidence_root, required_paths)
     file_bytes = {path: (evidence_root / path).read_bytes() for path in required_paths}
     coverage: dict[str, list[tuple[int, int]]] = {path: [] for path in required_paths}
+    delivered_bytes: dict[str, int] = {path: 0 for path in required_paths}
     empty_reads: set[str] = set()
     for call in tool_calls:
         if not _tool_result_succeeded(call):
@@ -549,7 +568,7 @@ def _verify_codex_review_reads(
             evidence_root=evidence_root,
             required_paths=required_paths,
         )
-        if not requests:
+        if not requests and str(call.get("name") or ""):
             continue
         by_identity = {
             (request["path"], request["offset"]): request
@@ -559,6 +578,26 @@ def _verify_codex_review_reads(
         for payload in _mcp_chunk_payloads(call.get("result")):
             identity = (payload.get("path"), payload.get("offset"))
             request = by_identity.get(identity)
+            # ``name`` is an unstable optional ACP field. OpenCode currently
+            # emits the standard human-readable ``title`` plus rawInput and
+            # rawOutput, so authenticate a name-less call from the sealed
+            # payload itself. The payload remains bound to the parent snapshot
+            # by exact path, full-file digest, chunk digest, offsets, content,
+            # and the public chunk cap; title text alone never grants coverage.
+            if request is None and not str(call.get("name") or ""):
+                payload_path = payload.get("path")
+                payload_offset = payload.get("offset")
+                if (
+                    payload_path in coverage
+                    and isinstance(payload_offset, int)
+                    and not isinstance(payload_offset, bool)
+                    and payload_offset >= 0
+                ):
+                    request = {
+                        "path": payload_path,
+                        "offset": payload_offset,
+                        "max_bytes": SEALED_READ_CHUNK_BYTES,
+                    }
             if request is None:
                 continue
             rel_path = request["path"]
@@ -600,6 +639,7 @@ def _verify_codex_review_reads(
                 coverage[rel_path].append((0, 0))
             elif chunk_bytes:
                 coverage[rel_path].append((offset, next_offset))
+            delivered_bytes[rel_path] += chunk_bytes
 
     missing = [
         path
@@ -608,10 +648,16 @@ def _verify_codex_review_reads(
     ]
     if missing:
         raise ReviewWorktreeError("review_evidence_reads_incomplete:" + ",".join(missing))
+    unique_bytes = sum(len(file_bytes[path]) for path in required_paths)
+    total_delivered_bytes = sum(delivered_bytes.values())
     return {
         "mode": "hash_bound_byte_chunks",
         "covered_paths": list(required_paths),
         "covered_path_count": len(required_paths),
+        "bytes_delivered_per_artifact": delivered_bytes,
+        "unique_evidence_bytes": unique_bytes,
+        "total_delivered_bytes": total_delivered_bytes,
+        "duplicate_delivered_bytes": max(0, total_delivered_bytes - unique_bytes),
     }
 
 
@@ -712,7 +758,7 @@ def verify_clean_review_evidence_reads(
         raise ReviewWorktreeError("review_evidence_tool_trace_missing")
     required_paths = _required_review_read_paths(evidence_root, changed_paths)
     engine_key = engine.strip().lower().replace("-build", "")
-    if engine_key == "codex":
+    if engine_key in {"acp", "codex"}:
         proof = _verify_codex_review_reads(
             raw_calls,
             evidence_root=evidence_root,
@@ -962,6 +1008,57 @@ class ProvisionedReviewWorktree:
             cfg.pop("review_exec_root", None)
         return cfg
 
+    def sealed_acp_tool_config(self) -> Path:
+        """Stage one parent-owned MCP config exposing only sealed snapshot reads.
+
+        The reviewed tree never supplies the helper, interpreter, or MCP
+        configuration.  The adapter independently validates this exact shape
+        before it relaxes its default no-tools posture.
+        """
+        if self.write_root is None or self.exec_root is None:
+            raise ReviewWorktreeError("sealed_acp_roots_missing")
+        from scripts.review.isolation import _stage_sealed_read_mcp
+
+        python_bin = _REPO_ROOT / ".venv" / "bin" / "python"
+        if not python_bin.is_file() or not os.access(python_bin, os.X_OK):
+            raise ReviewWorktreeError(f"sealed_acp_python_missing:{python_bin}")
+        helper = self.exec_root / "sealed-read-mcp.py"
+        if not helper.exists():
+            helper = _stage_sealed_read_mcp(self.exec_root)
+        config_path = self.write_root / "sealed-review-acpx-mcp.json"
+        config = {
+            "mcpServers": [
+                {
+                    "name": "sealed_review",
+                    "command": str(python_bin),
+                    "args": ["-I", "-S", str(helper), str(self.path)],
+                    # ACPX's MCP schema requires an array even when no
+                    # environment entries are delegated to the child.
+                    "env": [],
+                }
+            ]
+        }
+        payload = (json.dumps(config, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+        try:
+            fd = os.open(
+                config_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                0o400,
+            )
+        except FileExistsError:
+            if config_path.read_bytes() != payload:
+                raise ReviewWorktreeError("sealed_acp_config_changed") from None
+            return config_path
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+        return config_path
+
+    def sealed_evidence_input_bytes(self) -> int:
+        """Portable assignment unit: unique bytes the reviewer must consume."""
+        required_paths = _required_review_read_paths(self.path, self.changed_paths)
+        _validate_review_read_sizes(self.path, required_paths)
+        return sum((self.path / path).stat().st_size for path in required_paths)
+
     def review_prompt_evidence(self, engine: str) -> str:
         """Return bounded, hash-bound metadata for sealed review artifacts.
 
@@ -1098,14 +1195,24 @@ class ProvisionedReviewWorktree:
         _validate_review_read_sizes(self.path, required_read_paths)
         inline_serialized: str | None = None
         inline_proof: dict[str, Any] | None = None
+        legacy_inline_bytes = 0
         if engine_key in {"acp", "codex", "claude"}:
-            inline_serialized, inline_proof = _inline_required_evidence(
+            candidate_inline, inline_proof = _inline_required_evidence(
                 self.path,
                 required_read_paths,
             )
-            if engine_key == "codex":
+            legacy_inline_bytes = len(candidate_inline.encode("utf-8"))
+            if engine_key in {"acp", "codex"}:
                 read_protocol = {
                     "tool": "mcp__sealed_review__read_file",
+                    "preferred_complete_tool": "sealed_review_read_required_all",
+                    "preferred_complete_instruction": (
+                        "Call sealed_review_read_required_all exactly once. If it fails "
+                        "closed with required_evidence_split_required, call "
+                        "sealed_review_read_required with index=0 and offset=0 and follow "
+                        "next_index/next_offset until eof=true. Use read_file for required "
+                        "paths only if the required stream fails."
+                    ),
                     "unit": "utf8_bytes",
                     "start_offset": 0,
                     "max_chunk_bytes": SEALED_READ_CHUNK_BYTES,
@@ -1141,7 +1248,10 @@ class ProvisionedReviewWorktree:
                     "codex_exec_batch_limit": MAX_CODEX_SEALED_READ_BATCH,
                     "required_paths": list(required_read_paths),
                 }
+                if engine_key == "codex":
+                    inline_serialized = candidate_inline
             else:
+                inline_serialized = candidate_inline
                 read_protocol = {
                     "tool": "Read",
                     "unit": "lines",
@@ -1186,7 +1296,7 @@ class ProvisionedReviewWorktree:
             },
             "changed_file_content_mode": (
                 "complete_inline_parent_bound"
-                if engine_key in {"acp", "codex", "claude"}
+                if engine_key in {"codex", "claude"}
                 else "complete_via_sealed_snapshot_read_tools"
             ),
             "sealed_snapshot_root": str(self.path),
@@ -1207,10 +1317,16 @@ class ProvisionedReviewWorktree:
             "patch_path": ".review-bundle/patch.diff",
             "patch_bytes": patch_stat.st_size,
             "files": files,
+            "evidence_metrics": {
+                "manifest_bytes": manifest_stat.st_size,
+                "patch_bytes": patch_stat.st_size,
+                "unique_evidence_bytes": sum((self.path / path).stat().st_size for path in required_read_paths),
+                "legacy_inline_serialized_bytes": legacy_inline_bytes,
+            },
             "read_protocol": read_protocol,
             "clean_verdict_gate": (
                 "parent_bound_inline_complete"
-                if engine_key in {"acp", "codex", "claude"}
+                if engine_key in {"codex", "claude"}
                 else "complete_tool_trace_coverage_required"
             ),
         }
@@ -1220,6 +1336,19 @@ class ProvisionedReviewWorktree:
             separators=(",", ":"),
             sort_keys=True,
         )
+        for _ in range(3):
+            serialized_bytes = len(serialized.encode("utf-8"))
+            dossier["evidence_metrics"]["serialized_prompt_bytes"] = serialized_bytes
+            dossier["evidence_metrics"]["duplicate_bytes_avoided"] = legacy_inline_bytes
+            updated = json.dumps(
+                dossier,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            if updated == serialized:
+                break
+            serialized = updated
         serialized_bytes = len(serialized.encode("utf-8"))
         if serialized_bytes > MAX_REVIEW_PROMPT_EVIDENCE_BYTES:
             raise ReviewWorktreeError(
@@ -1232,7 +1361,7 @@ class ProvisionedReviewWorktree:
             "the parent-bound inline section below; inspect all files before verdict. "
             "Do not re-read those required paths with tools. The sealed tools remain "
             "available only for targeted unchanged-context proof. "
-            if engine_key in {"acp", "codex", "claude"}
+            if engine_key in {"codex", "claude"}
             else ""
         )
         prompt_evidence = (
@@ -1246,6 +1375,8 @@ class ProvisionedReviewWorktree:
             "use a detached worktree, git, gh, or other shell command. "
             "Use the parent-bound evidence transport declared by the dossier. A clean "
             "verdict is rejected unless the trusted receipt proves complete delivery. "
+            "For ACP evidence, follow read_protocol.preferred_complete_instruction; it "
+            "avoids duplicate reads while preserving complete byte coverage. "
             f"{inline_instruction}"
             "The dossier "
             "authenticates those complete "

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -69,7 +69,8 @@ DYNAMIC_LOADERS = {
         "description": "Loads agent runtime adapters dynamically from scripts/agent_runtime/adapters/",
         "strategy": "walk_adapters",
         "calls": [
-            {"func": "import_module", "caller": "list_runtime_agents"}
+            {"func": "import_module", "caller": "list_runtime_agents"},
+            {"func": "import_module", "caller": "list_routing_assignments"},
         ]
     },
     "scripts.api.comms_router": {

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -19,7 +19,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from .config import BATCH_STATE_DIR
+from .config import BATCH_STATE_DIR, PROJECT_ROOT
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -41,7 +41,7 @@ from agent_runtime.adapters.acpx import (
 from agent_runtime.adapters.gemini import has_gemini_oauth_credentials, resolve_gemini_auth_mode
 from agent_runtime.usage import has_headroom
 
-from scripts.fleet_comms.message_plane import default_plane_root
+from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 from scripts.orchestration.codex_transport_health import (
     DEFAULT_CONFIG_PATH as CODEX_TRANSPORT_CONFIG_PATH,
 )
@@ -512,6 +512,187 @@ def recent_runtime_records(*, limit: int = 50) -> dict[str, Any]:
         })
     summaries.sort(key=lambda item: _parse_iso_datetime(item.get("ts")) or datetime.min.replace(tzinfo=UTC), reverse=True)
     return {"records": summaries[:record_limit]}
+
+
+def _routing_plane_status() -> dict[str, Any]:
+    """Expose the actual plane posture without inferring authority from rows."""
+    try:
+        raw = read_plane_status(repo_root=Path(PROJECT_ROOT), recent_limit=0)
+    except Exception:
+        raw = {"mode": "unavailable", "enabled": False}
+    mode = str(raw.get("mode") or "unavailable")
+    authority_active = mode == "authority"
+    return {
+        "mode": mode,
+        "enabled": bool(raw.get("enabled")),
+        "authority": "fleet_comms_authoritative" if authority_active else "file_handoffs_authoritative",
+        "cutover": "authority_active" if authority_active else "pre_flip_operator_gated",
+    }
+
+
+def _routing_value(record: dict[str, Any], *keys: str) -> Any:
+    """Read an optional compatible ledger field without fabricating values."""
+    for key in keys:
+        value = record.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _routing_first(*values: Any) -> Any:
+    """Return the first present field while preserving meaningful zero values."""
+    return next((value for value in values if value is not None), None)
+
+
+def _routing_trace_value(trace: dict[str, Any], *keys: str) -> Any:
+    """Read a trace field across policy-version-compatible names."""
+    return _routing_first(*(trace.get(key) for key in keys))
+
+
+def _routing_duration_s(record: dict[str, Any]) -> float | None:
+    direct = _routing_value(record, "duration_s", "duration_seconds")
+    if isinstance(direct, (int, float)) and not isinstance(direct, bool):
+        return float(direct)
+    lifecycle = record.get("lifecycle") if isinstance(record.get("lifecycle"), dict) else {}
+    started = _parse_iso_datetime(_routing_first(_routing_value(record, "started_at"), lifecycle.get("started_at")))
+    settled = _parse_iso_datetime(
+        _routing_first(_routing_value(record, "settled_at", "terminal_at"), lifecycle.get("settled_at"))
+    )
+    if started is None or settled is None:
+        return None
+    return max(0.0, round((settled - started).total_seconds(), 3))
+
+
+def _routing_assignment_item(record: dict[str, Any]) -> dict[str, Any]:
+    """Serialize an allowlisted, body-free routing decision for the Runtime UI."""
+    requested = record.get("requested") if isinstance(record.get("requested"), dict) else {}
+    resolved = record.get("resolved") if isinstance(record.get("resolved"), dict) else {}
+    quota_detail = record.get("quota") if isinstance(record.get("quota"), dict) else {}
+    quota_snapshot = _routing_first(
+        quota_detail.get("snapshot") if isinstance(quota_detail.get("snapshot"), dict) else None,
+        _routing_value(record, "quota_snapshot") if isinstance(_routing_value(record, "quota_snapshot"), dict) else None,
+    ) or {}
+    lifecycle = record.get("lifecycle") if isinstance(record.get("lifecycle"), dict) else {}
+    evidence = record.get("evidence") if isinstance(record.get("evidence"), dict) else {}
+    replay = record.get("replay") if isinstance(record.get("replay"), dict) else {}
+    retry = record.get("retry") if isinstance(record.get("retry"), dict) else {}
+    selection_trace = _routing_first(_routing_value(record, "selection_trace", "trace"), resolved.get("trace"))
+    trace = selection_trace if isinstance(selection_trace, dict) else {}
+    automatic = _routing_value(record, "automatic")
+    if not isinstance(automatic, bool):
+        automatic = _routing_value(record, "route_mode") == "auto" or requested.get("route_mode") == "auto"
+    return {
+        "decision_id": _routing_value(record, "decision_id"),
+        "decision_event": _routing_value(record, "event_type"),
+        "decision_state": _routing_value(record, "state"),
+        "source_authority_id": _routing_value(record, "source_authority_id", "reservation_id"),
+        "authority_key": _routing_value(record, "authority_key"),
+        "timestamp": _routing_value(record, "created_at", "timestamp"),
+        "initiator": _routing_first(_routing_value(record, "initiator"), requested.get("initiator")),
+        "author_model": _routing_first(_routing_value(record, "author_model"), requested.get("author_model")),
+        "author_family": _routing_first(_routing_value(record, "author_family"), requested.get("author_family")),
+        "requested_role": _routing_first(_routing_value(record, "requested_role"), requested.get("role")),
+        "requested_profile": _routing_first(_routing_value(record, "requested_profile"), requested.get("profile")),
+        "requested_risk": _routing_first(_routing_value(record, "requested_risk"), requested.get("risk")),
+        "requested_route": _routing_first(_routing_value(record, "requested_route"), requested.get("route")),
+        "automatic": automatic,
+        "resolved_candidate": _routing_first(_routing_value(record, "resolved_candidate", "candidate"), resolved.get("candidate")),
+        "resolved_route": _routing_first(_routing_value(record, "resolved_route", "route"), resolved.get("route")),
+        "resolved_model": _routing_first(_routing_value(record, "resolved_model", "model"), resolved.get("model")),
+        "resolved_family": _routing_first(_routing_value(record, "resolved_family", "family"), resolved.get("family")),
+        "quota_bucket": _routing_first(_routing_value(record, "quota_bucket"), quota_detail.get("bucket")),
+        "policy_version": _routing_first(_routing_value(record, "policy_version"), resolved.get("policy_version")),
+        "selection_reason": _routing_first(_routing_value(record, "selection_reason", "reason"), evidence.get("reason")),
+        "selection_trace": selection_trace,
+        "selection_reasoning": {
+            # The order is deliberate: a candidate must first be eligible and
+            # task-suitable before quota, opportunity cost, capacity, or
+            # failure posture can distinguish otherwise suitable routes.
+            "hard_eligibility": _routing_trace_value(
+                trace,
+                "hard_eligibility", "eligibility", "capability_gates", "gates",
+            ),
+            "task_fit_quality": _routing_trace_value(
+                trace,
+                "task_fit", "capability_fit", "strength", "quality_rank", "suitability",
+            ),
+            "tie_breakers": _routing_trace_value(
+                trace,
+                "tie_breakers", "quota_cost_capacity", "quota", "opportunity_cost", "failure_posture",
+            ),
+            "cheaper_or_idle_not_selected": _routing_trace_value(
+                trace,
+                "cheaper_or_idle_not_selected", "rejected_alternatives", "not_selected",
+            ),
+        },
+        "quota_source": _routing_first(_routing_value(record, "quota_source"), quota_snapshot.get("source")),
+        "quota_freshness": _routing_first(_routing_value(record, "quota_freshness", "quota_fresh_at"), quota_detail.get("fresh_at"), quota_snapshot.get("freshness")),
+        "quota_headroom": _routing_first(_routing_value(record, "quota_headroom"), quota_snapshot.get("headroom")),
+        "estimated_input_bytes": _routing_first(_routing_value(record, "estimated_input_bytes"), requested.get("estimated_input_bytes")),
+        "actual_input_bytes": _routing_value(record, "actual_input_bytes"),
+        "actual_output_bytes": _routing_value(record, "actual_output_bytes"),
+        "actual_work_bytes": _routing_first(_routing_value(record, "actual_work_bytes"), lifecycle.get("actual_bytes")),
+        "actual_tokens": _routing_first(_routing_value(record, "actual_tokens"), lifecycle.get("actual_tokens")),
+        "reservation_state": _routing_first(_routing_value(record, "reservation_state", "status"), lifecycle.get("status")),
+        "terminal_status": _routing_first(_routing_value(record, "terminal_status", "status"), lifecycle.get("status")),
+        "created_at": _routing_first(_routing_value(record, "created_at"), lifecycle.get("created_at")),
+        "expires_at": _routing_first(_routing_value(record, "expires_at"), lifecycle.get("expires_at")),
+        "started_at": _routing_first(_routing_value(record, "started_at"), lifecycle.get("started_at")),
+        "settled_at": _routing_first(_routing_value(record, "settled_at", "terminal_at"), lifecycle.get("settled_at")),
+        "duration_s": _routing_duration_s(record),
+        "failure_classification": _routing_first(_routing_value(record, "failure_classification"), lifecycle.get("failure_classification")),
+        "retry_chain": _routing_first(_routing_value(record, "retry_chain", "retry"), retry),
+        "failover_chain": _routing_value(record, "failover_chain", "failover"),
+        "replay_status": _routing_first(_routing_value(record, "replay_status", "replay"), replay),
+        "cache_status": _routing_value(record, "cache_status", "cache"),
+    }
+
+
+def list_routing_assignments(*, limit: int = 100) -> dict[str, Any]:
+    """Read persisted routing decisions through the optional authority ledger.
+
+    The routing-reservation store is owned by Fleet Comms. Runtime only calls
+    its optional read-only projection and reports a distinct unavailable state
+    until that authority is installed; an absent table is never treated as an
+    empty history.
+    """
+    record_limit = min(max(1, int(limit)), 100)
+    plane = _routing_plane_status()
+    try:
+        ledger = importlib.import_module("scripts.fleet_comms.routing_reservations")
+        reader = ledger.list_routing_decisions
+        rows = reader(root=default_plane_root(repo_root=Path(PROJECT_ROOT)), limit=record_limit)
+    except (ImportError, AttributeError):
+        return {
+            "availability": "unavailable",
+            "reason": "routing_decision_reader_unavailable",
+            "plane": plane,
+            "assignments": [],
+        }
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        return {
+            "availability": "unavailable",
+            "reason": "routing_decision_reader_failed",
+            "plane": plane,
+            "assignments": [],
+        }
+    if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        return {
+            "availability": "malformed",
+            "reason": "routing_decision_reader_malformed",
+            "plane": plane,
+            "assignments": [],
+        }
+    assignments = [_routing_assignment_item(row) for row in rows[:record_limit]]
+    assignments.sort(
+        key=lambda item: _parse_iso_datetime(item.get("timestamp")) or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    return {
+        "availability": "available" if assignments else "empty",
+        "plane": plane,
+        "assignments": assignments,
+    }
 
 
 def runtime_recent_outcomes_today() -> dict[str, int]:
@@ -1114,6 +1295,12 @@ async def runtime_headroom(
 @router.get("/recent")
 async def runtime_recent(limit: int = Query(50, ge=1, le=500)):
     return await asyncio.to_thread(recent_runtime_records, limit=limit)
+
+
+@router.get("/routing-assignments")
+async def runtime_routing_assignments(limit: int = Query(100, ge=1, le=100)):
+    """Read-only routing authority decisions and their actual plane posture."""
+    return await asyncio.to_thread(list_routing_assignments, limit=limit)
 
 
 @router.get("/transport-health")

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1657,7 +1657,7 @@ def test_supported_participant_registry_has_only_fixed_direct_seats():
         "claude": {
             "seat": "acpx-claude-shadow",
             "agent": "claude",
-            "model": "claude-sonnet-5",
+            "model": None,
         },
         "kimi": {"seat": "acpx-kimi-shadow", "agent": "kimi", "model": None},
         "kimicc": {"seat": "acpx-kimicc-shadow", "agent": "kimi", "model": "kimi-code/k3"},

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
+from agent_runtime.adapters.acpx import (
+    AcpxAdapter,
+    AcpxGlmShadowAdapter,
+    _confinement_prefix_argv,
+)
 from ai_agent_bridge import _review_pr as review_pr
 from ai_agent_bridge._review_safety import ReviewSafetyError
 
@@ -15,9 +23,11 @@ def test_parse_pr_number() -> None:
 
 
 def test_resolve_reviewer_auto() -> None:
-    assert review_pr.resolve_reviewer("auto", claude_available=None) == "glm"
-    assert review_pr.resolve_reviewer("auto", claude_available=False) == "glm"
+    assert review_pr.resolve_reviewer("auto", claude_available=None) == "auto"
+    assert review_pr.resolve_reviewer("auto", claude_available=False) == "auto"
     assert review_pr.resolve_reviewer("glm") == "glm"
+    assert review_pr.resolve_reviewer("grok") == "grok"
+    assert review_pr.resolve_reviewer("kimi") == "kimi"
 
 
 def test_formal_review_authority_key_is_bounded_and_opaque() -> None:
@@ -30,6 +40,48 @@ def test_formal_review_authority_key_is_bounded_and_opaque() -> None:
     assert key.startswith("formal-review:")
     assert len(key) == len("formal-review:") + 64
     assert "/" not in key
+
+
+def test_evidence_metrics_extracts_only_non_negative_integer_receipts() -> None:
+    dossier = {
+        "evidence_metrics": {
+            "unique_evidence_bytes": 123,
+            "legacy_inline_serialized_bytes": 456,
+            "invalid_bool": True,
+            "invalid_negative": -1,
+        }
+    }
+    evidence = (
+        "prefix\nAUTHORITATIVE SEALED REVIEW EVIDENCE\n"
+        f"{json.dumps(dossier)}\n"
+        "END AUTHORITATIVE SEALED REVIEW EVIDENCE\n"
+    )
+
+    assert review_pr._evidence_metrics(evidence) == {
+        "unique_evidence_bytes": 123,
+        "legacy_inline_serialized_bytes": 456,
+    }
+
+
+def test_transport_failure_receipt_is_bounded_and_body_free() -> None:
+    result = type(
+        "ResultFixture",
+        (),
+        {
+            "usage_record": {"failure_code": "result_invalid"},
+            "stderr_excerpt": "diagnostic" * 100,
+        },
+    )()
+
+    receipt = review_pr._transport_failure_receipt(
+        classification="transport_error",
+        result=result,
+        exc=None,
+    )
+
+    assert receipt["provider_failure_code"] == "result_invalid"
+    assert len(receipt["diagnostic"]) == 500
+    assert "response" not in receipt
 
 
 def test_canonical_review_response_unwraps_only_single_json_object() -> None:
@@ -59,3 +111,175 @@ def test_build_review_pr_prompt_has_contract_and_cap() -> None:
     assert "confidence` value MUST be a JSON number" in prompt
     assert 'correctness":"correct"' in prompt
     assert 'enum aliases such as `"pass"`' in prompt
+
+
+def test_acpx_parser_preserves_sealed_tool_coverage_trace() -> None:
+    payload = {
+        "path": ".review-bundle/patch.diff",
+        "sha256": "a" * 64,
+        "offset": 0,
+        "chunk_bytes": 3,
+        "chunk_sha256": "b" * 64,
+        "next_offset": 3,
+        "total_bytes": 3,
+        "eof": True,
+        "content": "abc",
+    }
+    events = [
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "call-1",
+                    "name": "mcp__sealed_review__read_file",
+                    "rawInput": {"path": ".review-bundle/patch.diff", "offset": 0, "max_bytes": 65536},
+                }
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call-1",
+                    "status": "completed",
+                    "rawOutput": payload,
+                }
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "{}"},
+                }
+            },
+        },
+        {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}},
+    ]
+
+    parsed = AcpxAdapter().parse_response(
+        stdout="\n".join(json.dumps(event) for event in events),
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert parsed.ok is True
+    assert parsed.tool_calls == [
+        {
+            "id": "call-1",
+            "name": "mcp__sealed_review__read_file",
+            "title": "",
+            "arguments": {"path": ".review-bundle/patch.diff", "offset": 0, "max_bytes": 65536},
+            "result": payload,
+            "status": "completed",
+        }
+    ]
+
+
+def test_acpx_sealed_review_confinement_allows_only_parent_reader_tools() -> None:
+    command = _confinement_prefix_argv(
+        "/trusted/acpx",
+        Path("/private/review"),
+        sealed_review_mcp_config="/private/review-config.json",
+    )
+
+    assert "--deny-all" not in command
+    assert command[command.index("--mcp-config") + 1] == "/private/review-config.json"
+    allowed = command[command.index("--allowed-tools") + 1].split(",")
+    assert allowed == [
+        "mcp__sealed_review__list_files",
+        "mcp__sealed_review__read_file",
+        "mcp__sealed_review__read_required",
+        "mcp__sealed_review__read_required_all",
+        "mcp__sealed_review__search_text",
+    ]
+    assert "--no-fs" in command and "--no-terminal" in command
+    policy = json.loads(command[command.index("--permission-policy") + 1])
+    assert policy["autoApprove"] == allowed
+    assert policy["defaultAction"] == "deny"
+
+
+def test_automatic_failover_and_explicit_no_silent_provider_change() -> None:
+    assert review_pr._fallback_permitted(route_mode="auto", allow_explicit_fallback=False) is True
+    assert review_pr._fallback_permitted(route_mode="explicit", allow_explicit_fallback=False) is False
+    assert review_pr._fallback_permitted(route_mode="explicit", allow_explicit_fallback=True) is True
+
+
+def test_routing_attempt_seed_never_reuses_a_prior_authority_attempt() -> None:
+    assert review_pr._routing_attempt_seed(type("Job", (), {"attempt_count": 3})()) == 3
+    assert review_pr._routing_attempt_seed(type("Job", (), {"attempt_count": True})()) == 0
+    assert review_pr._routing_attempt_seed(object()) == 0
+
+
+def test_glm_opencode_config_exposes_only_sealed_tools_for_formal_review() -> None:
+    adapter = AcpxGlmShadowAdapter()
+    ordinary = json.loads(adapter._env_overrides()["OPENCODE_CONFIG_CONTENT"])
+    sealed = json.loads(
+        adapter._env_overrides(
+            sealed_review_mcp_config="/private/review-config.json",
+        )["OPENCODE_CONFIG_CONTENT"]
+    )
+
+    assert ordinary == {"permission": {"*": "deny"}, "tools": {"*": False}}
+    assert sealed == {
+        "permission": {"*": "deny", "sealed_review_*": "allow"},
+        "tool_output": {"max_bytes": 3 * 1024 * 1024, "max_lines": 100_000},
+    }
+
+
+def test_acpx_parser_preserves_standard_title_without_unstable_name() -> None:
+    payload = {"path": "review.txt", "content": "ok"}
+    events = [
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "call-title-only",
+                    "title": "Read sealed review evidence",
+                    "kind": "read",
+                    "rawInput": {"path": "review.txt"},
+                }
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call-title-only",
+                    "status": "completed",
+                    "rawOutput": payload,
+                }
+            },
+        },
+        {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}},
+    ]
+
+    parsed = AcpxAdapter().parse_response(
+        stdout="\n".join(json.dumps(event) for event in events),
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert parsed.ok is True
+    assert parsed.tool_calls == [
+        {
+            "id": "call-title-only",
+            "name": "",
+            "title": "Read sealed review evidence",
+            "arguments": {"path": "review.txt"},
+            "result": payload,
+            "status": "completed",
+        }
+    ]

--- a/tests/ai_agent_bridge/test_review_pr_lifecycle.py
+++ b/tests/ai_agent_bridge/test_review_pr_lifecycle.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 from ai_agent_bridge import _review_pr
 
@@ -19,7 +21,9 @@ def _args(*, background: bool = False, dry_run: bool = False) -> Namespace:
         dry_run=dry_run,
         background=background,
         no_timeout=False,
-        from_llm="codex",
+        initiator="codex/orchestrator",
+        author_model="gpt-5.6-sol",
+        author_family="openai",
     )
 
 
@@ -28,9 +32,169 @@ def test_review_pr_background_bridge_worker_is_retired(capsys) -> None:
     assert "background bridge workers are retired" in capsys.readouterr().err
 
 
-def test_review_pr_dry_run_selects_glm_acp_pin(capsys) -> None:
+def test_review_pr_dry_run_keeps_auto_unresolved_until_authority_transaction(capsys) -> None:
     assert _review_pr.handle_review_pr(_args(dry_run=True)) == 0
     output = capsys.readouterr().out
-    assert "reviewer=glm" in output
-    assert "model=glm-5.2" in output
-    assert "effort=high" in output
+    assert "reviewer_request=auto" in output
+    assert "model=deterministic-scheduler" in output
+    assert "initiator=codex/orchestrator" in output
+
+
+def test_completed_exact_head_replays_without_provider_call(monkeypatch, capsys, tmp_path) -> None:
+    from agent_runtime import runner
+    from ai_agent_bridge import _review_worktree
+
+    from scripts.api import state_router
+    from scripts.fleet_comms import authority as authority_module
+    from scripts.fleet_comms import routing_reservations
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    reservation = SimpleNamespace(
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        requested_role="code:medium",
+        requested_profile="code",
+        requested_risk="medium",
+        route_mode="auto",
+        requested_reviewer=None,
+        estimated_input_bytes=123,
+        resolved_model="claude-sonnet-5",
+        resolved_family="anthropic",
+        resolved_candidate="claude-sonnet-5",
+        quota_bucket="claude",
+        credential_bucket="claude",
+        reservation_id="routing-reservation_fixture",
+    )
+
+    class FakeLedger:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def completed_replay(self, _key):
+            return reservation
+
+    job = SimpleNamespace(state="complete", job_id="job_fixture", subject_id="review_fixture")
+    formal = SimpleNamespace(review_id="review_fixture", snapshot_artifact_id="artifact_fixture")
+    accepted = []
+
+    class FakeAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_formal_review(self, **_kwargs):
+            return job
+
+        def require_publishable_formal_review(self, *_args, **_kwargs):
+            return formal
+
+        def read_job_result(self, _job_id):
+            return (
+                b'{"schema_version":"code-review-findings.v1","overall":'
+                b'{"correctness":"correct","explanation":"No findings.","confidence":0.95},"findings":[]}'
+            )
+
+        def accept_formal_review_verdict(self, _review_id, sealed):
+            accepted.append(sealed)
+
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(_review_worktree, "validate_code_review_response", lambda *_args, **_kwargs: "d" * 64)
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: {"agents": {}})
+    monkeypatch.setattr(routing_reservations, "RoutingReservationLedger", FakeLedger)
+    monkeypatch.setattr(authority_module, "AuthorityService", FakeAuthority)
+    monkeypatch.setattr(
+        runner,
+        "invoke_inter_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("provider call on replay")),
+    )
+
+    assert _review_pr.handle_review_pr(_args()) == 0
+    assert accepted and accepted[0].model == "claude-sonnet-5"
+    assert '"exact_head_replay": true' in capsys.readouterr().out
+
+
+def test_active_exact_head_exits_before_reservation_or_provider_call(monkeypatch, capsys, tmp_path) -> None:
+    from agent_runtime import runner
+    from ai_agent_bridge import _review_worktree
+
+    from scripts.api import state_router
+    from scripts.fleet_comms import authority as authority_module
+    from scripts.fleet_comms import routing_reservations
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    class FakeLedger:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def reserve_selection(self, *_args, **_kwargs):
+            raise AssertionError("routing reservation created for an already-active exact head")
+
+    job = SimpleNamespace(state="running", job_id="job_active", subject_id="review_active")
+    formal = SimpleNamespace(review_id="review_active", snapshot_artifact_id="artifact_active")
+
+    class FakeAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_formal_review(self, **_kwargs):
+            return job
+
+        def require_publishable_formal_review(self, *_args, **_kwargs):
+            return formal
+
+        def claim_job(self, *_args, **_kwargs):
+            raise authority_module.AuthorityStaleLeaseError("job_already_claimed")
+
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: {"agents": {}})
+    monkeypatch.setattr(routing_reservations, "RoutingReservationLedger", FakeLedger)
+    monkeypatch.setattr(authority_module, "AuthorityService", FakeAuthority)
+    monkeypatch.setattr(
+        runner,
+        "invoke_inter_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("duplicate provider call")),
+    )
+
+    assert _review_pr.handle_review_pr(_args()) == 1
+    assert "already active" in capsys.readouterr().err

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -15,11 +15,11 @@ from scripts.ai_agent_bridge._review_pr import (
 )
 
 
-def test_auto_prefers_glm_for_cross_family_review():
-    assert resolve_reviewer("auto") == "glm"
+def test_auto_remains_semantic_until_the_deterministic_scheduler_runs():
+    assert resolve_reviewer("auto") == "auto"
     assert resolve_reviewer("codex") == "codex"
     assert resolve_reviewer("agy") == "agy"
-    assert resolve_reviewer("auto", claude_available=False) == "glm"
+    assert resolve_reviewer("auto", claude_available=False) == "auto"
 
 
 def test_formal_cf_pins_are_practical_seats_at_high():
@@ -32,7 +32,7 @@ def test_formal_cf_pins_are_practical_seats_at_high():
 
 
 def test_formal_cross_family_pins_match_enabled_acp_routes():
-    for reviewer in ("claude", "agy", "glm"):
+    for reviewer in ("agy", "glm"):
         model, effort = formal_cf_pin(reviewer)
         assert ACPX_SUPPORTED_PARTICIPANTS[reviewer]["model"] == model
         assert ACPX_PARTICIPANT_EFFORTS[reviewer] == effort
@@ -51,11 +51,13 @@ def test_review_pr_dry_run_emits_model_and_effort(capsys):
         from_llm = "grok"
         background = False
         no_timeout = False
+        initiator = "grok/orchestrator"
+        author_model = "grok-4.5"
+        author_family = "xai"
 
     rc = handle_review_pr(Args())
     assert rc == 0
     out = capsys.readouterr().out
-    assert "reviewer=glm" in out
-    assert "model=glm-5.2" in out
-    assert "effort=high" in out
-    assert "glm-5.2 @ effort=high" in out
+    assert "reviewer_request=auto" in out
+    assert "model=deterministic-scheduler" in out
+    assert "initiator=grok/orchestrator" in out

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -18,6 +18,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from ai_agent_bridge import _agy, _claude, _cli, _codex, _grok_build
 from ai_agent_bridge import _review_worktree as review_worktree
 
+from scripts.agent_runtime.adapters.acpx import (
+    AcpxShadowRefusalError,
+    _validate_sealed_review_mcp_config,
+)
 from scripts.review.isolation import create_review_temp_root
 from scripts.review.snapshot import (
     ReviewSnapshot,
@@ -291,6 +295,65 @@ def test_review_prompt_evidence_is_complete_hash_bound_and_json_escaped(
     grok_dossier = json.loads(grok_line)
     assert "content" not in grok_dossier["files"][0]
     assert grok_dossier["sealed_snapshot_root"] == str(small_checkout.path)
+
+
+def test_acp_prompt_uses_sealed_chunks_and_reports_avoided_inline_bytes(tmp_path: Path) -> None:
+    content = "evidence-line\n" * 20_000
+    checkout = _prompt_evidence_checkout(tmp_path / "acp-snapshot", present_content=content)
+
+    prompt = checkout.review_prompt_evidence("acp")
+    dossier = json.loads(next(line for line in prompt.splitlines() if line.startswith("{")))
+
+    assert "AUTHORITATIVE INLINE REVIEW CONTENT" not in prompt
+    assert dossier["changed_file_content_mode"] == "complete_via_sealed_snapshot_read_tools"
+    assert dossier["clean_verdict_gate"] == "complete_tool_trace_coverage_required"
+    assert dossier["read_protocol"]["tool"] == "mcp__sealed_review__read_file"
+    assert dossier["read_protocol"]["preferred_complete_tool"] == (
+        "sealed_review_read_required_all"
+    )
+    assert "exactly once" in dossier["read_protocol"]["preferred_complete_instruction"]
+    assert dossier["evidence_metrics"]["unique_evidence_bytes"] == checkout.sealed_evidence_input_bytes()
+    assert dossier["evidence_metrics"]["legacy_inline_serialized_bytes"] > 200_000
+    assert dossier["evidence_metrics"]["duplicate_bytes_avoided"] == dossier["evidence_metrics"][
+        "legacy_inline_serialized_bytes"
+    ]
+    assert len(prompt.encode("utf-8")) < 10_000
+
+
+def test_sealed_acp_config_is_parent_owned_and_snapshot_pinned(tmp_path: Path) -> None:
+    snapshot_root = create_review_temp_root(prefix="lu-review-view-", dir=tmp_path)
+    checkout = _prompt_evidence_checkout(snapshot_root)
+    write_root = create_review_temp_root(prefix="lu-review-write-", dir=tmp_path)
+    exec_root = create_review_temp_root(prefix="lu-review-exec-", dir=tmp_path)
+    checkout = replace(checkout, write_root=write_root, exec_root=exec_root)
+
+    config_path = checkout.sealed_acp_tool_config()
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    server = config["mcpServers"][0]
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o400
+    assert server["name"] == "sealed_review"
+    assert server["command"].endswith("/.venv/bin/python")
+    assert server["args"][:2] == ["-I", "-S"]
+    assert server["args"][3] == str(checkout.path)
+    assert server["env"] == []
+    assert Path(server["args"][2]).read_text(encoding="utf-8").startswith("#!/usr/bin/python3\nimport hashlib")
+    assert _validate_sealed_review_mcp_config(
+        str(config_path), adapter_label="fixture"
+    ) == str(config_path)
+    assert checkout.sealed_acp_tool_config() == config_path
+
+    write_root.chmod(0o777)
+    with pytest.raises(AcpxShadowRefusalError, match="helper/snapshot failed validation"):
+        _validate_sealed_review_mcp_config(str(config_path), adapter_label="fixture")
+    write_root.chmod(0o700)
+
+    config_path.chmod(0o600)
+    config["mcpServers"].append({"name": "attacker", "command": "/bin/sh", "args": [], "env": {}})
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    config_path.chmod(0o400)
+    with pytest.raises(AcpxShadowRefusalError, match="exactly one server"):
+        _validate_sealed_review_mcp_config(str(config_path), adapter_label="fixture")
 
 
 def _codex_read_calls(
@@ -600,6 +663,80 @@ def test_codex_read_payload_accepts_normalized_content_list(tmp_path: Path) -> N
         changed_paths=checkout.changed_paths,
     )
     assert proof["covered_path_count"] == 3
+
+
+def test_acp_title_only_trace_authenticates_hash_bound_sealed_payloads(tmp_path: Path) -> None:
+    checkout = _prompt_evidence_checkout(tmp_path / "acp-title-only-result")
+    calls = _codex_read_calls(checkout)
+    for call in calls:
+        call["name"] = ""
+        call["title"] = "Read sealed review evidence"
+        call["arguments"] = {}
+
+    proof = review_worktree.verify_clean_review_evidence_reads(
+        SimpleNamespace(tool_calls=calls),
+        engine="acp",
+        evidence_root=checkout.path,
+        changed_paths=checkout.changed_paths,
+    )
+
+    assert proof["mode"] == "hash_bound_byte_chunks"
+    assert proof["covered_path_count"] == 3
+
+
+def test_acp_opencode_output_wrapper_authenticates_sealed_payloads(tmp_path: Path) -> None:
+    checkout = _prompt_evidence_checkout(tmp_path / "acp-opencode-output-result")
+    calls = _codex_read_calls(checkout)
+    for call in calls:
+        wrapped = call["result"]
+        assert isinstance(wrapped, dict)
+        content = wrapped["content"]
+        assert isinstance(content, list)
+        call["name"] = ""
+        call["title"] = "Read sealed review evidence"
+        call["arguments"] = {}
+        call["result"] = {
+            "output": content[0]["text"],
+            "metadata": {"truncated": False},
+        }
+
+    proof = review_worktree.verify_clean_review_evidence_reads(
+        SimpleNamespace(tool_calls=calls),
+        engine="acp",
+        evidence_root=checkout.path,
+        changed_paths=checkout.changed_paths,
+    )
+
+    assert proof["mode"] == "hash_bound_byte_chunks"
+    assert proof["covered_path_count"] == 3
+
+
+def test_acp_completed_status_keeps_source_error_markers_inert(tmp_path: Path) -> None:
+    checkout = _prompt_evidence_checkout(
+        tmp_path / "acp-inert-error-markers",
+        present_content='MARKERS = "<persisted-output> tool result was too large"\n',
+    )
+    calls = _codex_read_calls(checkout)
+    for call in calls:
+        call["status"] = "completed"
+
+    proof = review_worktree.verify_clean_review_evidence_reads(
+        SimpleNamespace(tool_calls=calls),
+        engine="acp",
+        evidence_root=checkout.path,
+        changed_paths=checkout.changed_paths,
+    )
+    assert proof["covered_path_count"] == 3
+
+    for call in calls:
+        call.pop("status")
+    with pytest.raises(review_worktree.ReviewWorktreeError, match="reads_incomplete"):
+        review_worktree.verify_clean_review_evidence_reads(
+            SimpleNamespace(tool_calls=calls),
+            engine="acp",
+            evidence_root=checkout.path,
+            changed_paths=checkout.changed_paths,
+        )
 
 
 def test_codex_exec_read_trace_accepts_only_canonical_nested_mcp_calls(tmp_path: Path) -> None:

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
+import types
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -90,6 +92,191 @@ def _write_acp_db(root, conversations: list[tuple], events: list[tuple]) -> None
         connection.commit()
     finally:
         connection.close()
+
+
+def test_routing_assignments_api_projects_authority_records(monkeypatch):
+    """Runtime renders the optional ledger as body-free routing history."""
+    ledger = types.SimpleNamespace(
+        list_routing_decisions=lambda **_kwargs: [
+            {
+                "reservation_id": "reservation-001",
+                "authority_key": "route-key-1",
+                "initiator": "codex",
+                "author_model": "gpt-5.6-terra",
+                "author_family": "openai",
+                "requested_role": "implementation",
+                "requested_profile": "standard",
+                "requested_risk": "medium",
+                "requested_route": "codex",
+                "route_mode": "auto",
+                "resolved_candidate": "codex-terra",
+                "resolved_route": "codex",
+                "resolved_model": "gpt-5.6-terra",
+                "resolved_family": "openai",
+                "quota_bucket": "codex_weekly",
+                "policy_version": "routing-v1",
+                "selection_reason": "capacity available",
+                "selection_trace": "rank=1",
+                "quota_snapshot": {"source": "codexbar", "freshness": "fresh", "headroom": "70%"},
+                "estimated_input_bytes": 400,
+                "actual_input_bytes": 380,
+                "actual_output_bytes": 120,
+                "actual_tokens": 95,
+                "created_at": "2026-08-02T09:00:00Z",
+                "expires_at": "2026-08-02T09:05:00Z",
+                "started_at": "2026-08-02T09:00:10Z",
+                "settled_at": "2026-08-02T09:00:25Z",
+                "status": "complete",
+                "retry_chain": "none",
+                "failover_chain": "none",
+                "replay_status": "new",
+                "cache_status": "miss",
+            },
+            {
+                "reservation_id": "reservation-002",
+                "initiator": "operator",
+                "route_mode": "explicit",
+                "resolved_route": "claude",
+                "created_at": "2026-08-02T08:00:00Z",
+                "status": "failed",
+                "failure_classification": "provider_unavailable",
+            },
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "scripts.fleet_comms.routing_reservations", ledger)
+    monkeypatch.setattr(
+        runtime_router,
+        "_routing_plane_status",
+        lambda: {
+            "mode": "shadow",
+            "enabled": True,
+            "authority": "file_handoffs_authoritative",
+            "cutover": "pre_flip_operator_gated",
+        },
+    )
+
+    response = client.get("/api/runtime/routing-assignments?limit=10")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["availability"] == "available"
+    assert data["plane"]["mode"] == "shadow"
+    assert data["plane"]["authority"] == "file_handoffs_authoritative"
+    automatic, explicit = data["assignments"]
+    assert automatic["source_authority_id"] == "reservation-001"
+    assert automatic["initiator"] == "codex"
+    assert automatic["automatic"] is True
+    assert automatic["quota_freshness"] == "fresh"
+    assert automatic["duration_s"] == 15.0
+    assert explicit["initiator"] == "operator"
+    assert explicit["automatic"] is False
+    assert explicit["failure_classification"] == "provider_unavailable"
+
+
+def test_routing_assignments_reports_absent_or_malformed_reader(monkeypatch):
+    def missing_reader(_name: str):
+        raise ImportError
+
+    monkeypatch.setattr(runtime_router.importlib, "import_module", missing_reader)
+    missing = runtime_router.list_routing_assignments()
+    assert missing["availability"] == "unavailable"
+    assert missing["assignments"] == []
+
+    malformed = types.SimpleNamespace(list_routing_decisions=lambda **_kwargs: {"not": "a list"})
+    monkeypatch.setattr(runtime_router.importlib, "import_module", lambda _name: malformed)
+    result = runtime_router.list_routing_assignments()
+    assert result["availability"] == "malformed"
+    assert result["assignments"] == []
+
+
+def test_routing_assignment_serializer_accepts_authority_ledger_shape():
+    item = runtime_router._routing_assignment_item(
+        {
+            "decision_id": "decision-1",
+            "event_type": "settled",
+            "state": "complete",
+            "reservation_id": "authority-1",
+            "authority_key": "head-role",
+            "created_at": "2026-08-02T10:00:00Z",
+            "evidence": {"reason": "headroom available"},
+            "requested": {
+                "initiator": "dispatcher",
+                "author_model": "gpt-5.6-sol",
+                "author_family": "openai",
+                "role": "review",
+                "profile": "strict",
+                "risk": "high",
+                "route_mode": "explicit",
+                "estimated_input_bytes": 0,
+            },
+            "resolved": {
+                "candidate": "claude-opus",
+                "route": "claude",
+                "model": "claude-opus-4-6",
+                "family": "anthropic",
+                "policy_version": "routing-v2",
+                "trace": {
+                    "gates": "cross-family review required",
+                    "task_fit": "strong review capability",
+                    "tie_breakers": "quota fresh",
+                    "cheaper_or_idle_not_selected": "candidate lacks required family",
+                },
+            },
+            "quota": {"bucket": "claude-weekly", "snapshot": {"source": "codexbar", "headroom": 0}, "fresh_at": "2026-08-02T09:59:00Z"},
+            "retry": {"attempt": 2, "terminal_status": "complete", "failure_classification": None},
+            "replay": {"authority_key": "head-role", "idempotency_key": "idempotent", "completed": True},
+            "lifecycle": {
+                "status": "complete",
+                "created_at": "2026-08-02T10:00:00Z",
+                "expires_at": "2026-08-02T10:05:00Z",
+                "started_at": "2026-08-02T10:00:05Z",
+                "settled_at": "2026-08-02T10:00:15Z",
+                "actual_bytes": 0,
+                "actual_tokens": 0,
+                "failure_classification": None,
+            },
+        }
+    )
+
+    assert item["decision_id"] == "decision-1"
+    assert item["decision_event"] == "settled"
+    assert item["decision_state"] == "complete"
+    assert item["source_authority_id"] == "authority-1"
+    assert item["initiator"] == "dispatcher"
+    assert item["automatic"] is False
+    assert item["resolved_model"] == "claude-opus-4-6"
+    assert item["quota_headroom"] == 0
+    assert item["estimated_input_bytes"] == 0
+    assert item["actual_input_bytes"] is None
+    assert item["actual_work_bytes"] == 0
+    assert item["actual_tokens"] == 0
+    assert item["duration_s"] == 10.0
+    assert item["retry_chain"]["attempt"] == 2
+    assert item["replay_status"]["completed"] is True
+    assert item["selection_reasoning"] == {
+        "hard_eligibility": "cross-family review required",
+        "task_fit_quality": "strong review capability",
+        "tie_breakers": "quota fresh",
+        "cheaper_or_idle_not_selected": "candidate lacks required family",
+    }
+
+
+def test_runtime_dashboard_labels_routing_authority_and_explicitness():
+    html = (DASHBOARDS / "runtime.html").read_text(encoding="utf-8")
+    for expected in (
+        "/api/runtime/routing-assignments?limit=100",
+        "Decision ID",
+        "Event / state",
+        "Source authority ID",
+        "Initiator",
+        "AUTOMATIC",
+        "EXPLICIT",
+        "Suitability-first decision evidence",
+        "Why cheaper or idle alternative was not selected",
+        "Plane:",
+        "plane.authority",
+    ):
+        assert expected in html
 
 
 def test_agents_endpoint_returns_known_adapters():


### PR DESCRIPTION
## Summary

- route `review-pr --reviewer auto` through the deterministic authority introduced by #6297
- claim exact-head authority before atomically reserving reviewer quota and credential capacity
- deliver full review evidence through a parent-owned, hash-bound sealed MCP reader while keeping provider filesystem and terminal access disabled
- require complete byte coverage before accepting a clean verdict, persist directional usage/evidence metrics, and replay completed exact-head results without another provider call
- expose routing assignments and decision history in the Runtime API and dashboard
- preserve explicit reviewer pins only as audited overrides; automatic failover remains policy-controlled

## Routing semantics

This is suitability-first, never round-robin: hard eligibility gates and semantic task fit determine the admissible quality tier first. Quota, in-flight reservations, failures, and cost break ties only inside that equally suitable tier.

## Verification

- `412 passed` across agent runtime, ACPX, review-pr lifecycle/pins/worktree, Runtime API, and import-pinning suites
- Ruff passed on all changed Python files
- `py_compile` passed on all changed production Python files
- `git diff --check` passed
- agent trailer lint passed
- OPSEC leak audit passed on all 13 changed files

Depends on merged routing foundation #6297.

Closes #6293
