### PR TITLE
fix(practice): make CEFR guidance soft

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b04d2b4be1936a2f34a7ca16ebc2d54a01c6ea1fb7ae7e42a8674fd8032a073e
+  components_sha256: f579a0d3150333b279451e55477d54953997c9861d73b1db90ec941250bb750f
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: d009d729ed22eb5829c8998fe42531d3fbbe27148f30d947a93c861286268190
+  components_sha256: b04d2b4be1936a2f34a7ca16ebc2d54a01c6ea1fb7ae7e42a8674fd8032a073e
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/practice/cefr-difficulty-calibration.md
+++ b/docs/practice/cefr-difficulty-calibration.md
@@ -1,54 +1,58 @@
 # CEFR difficulty calibration — practice selection
 
-Issue: #5504 (related: #4700, #4387)
+Issues: #6143 (parent: #6132; epic: #4387)
 
 ## Current difficulty drivers
 
-1. **Shard filters / level cascade**
-   `LexiconPractice` loads every level up to the learner’s selected level via
-   `levelsUpTo()` and merges lower-level shards into the active deck for density
-   and SRS review coverage. This means a B1 session contains A1 and A2 items,
-   which can make the session feel too easy if they are not weighted.
+1. **Published-shard loading**
+   `LexiconPractice` loads all published practice levels. The learner level is
+   a preference signal, not an eligibility cap: lower and higher CEFR items can
+   still be practiced when they are otherwise admitted.
 
 2. **Distractor pools**
-   `meaningDistractors()` already preferred same-CEFR distractors, but when a
-   level had too few eligible candidates it fell back to *any* other level.
-   A B1 answer could therefore be undermined by A1 distractors, or an A1 answer
-   could be ambushed by much harder vocabulary.
+   `meaningDistractors()` builds concentric CEFR rings around the answer. A
+   missing CEFR value is retained as unknown guidance and is ranked after
+   known values; it is never rewritten as A1 or another inferred level.
 
-3. **Cloze gaps**
+3. **Cloze quality**
    Cloze items are only offered after the corresponding lemma reaches the
-   recognition-mastery threshold (`minRecognitionStability`). Until higher-level
-   recognition cards mature, lower-level cloze items dominate mixed sessions.
+   recognition-mastery threshold (`minRecognitionStability`). An unlevelled
+   lemma remains recognition-eligible, but does not enter level-sensitive cloze
+   construction until it has the metadata required by that mode.
 
 4. **Synonym / paronym / heritage floors**
    Drill-mode shards are sparser than core lexeme shards. In mixed mode this can
-   leave basic recognition items from lower levels over-represented.
+   leave recognition items over-represented; those mode-specific quality and
+   curator availability floors remain unchanged.
 
-5. **Level bias only for new cards**
-   `selectNextPracticeItem()` previously applied a level preference only to
-   brand-new cards. Due and lapsed reviews from lower levels intermixed freely
-   with selected-level reviews.
+5. **Soft session preference**
+   `selectNextPracticeItem()` uses CEFR distance only as a tiebreak after due,
+   lapsed, and anti-monotony priorities. The selected level is preferred, then
+   nearby lower levels, then nearby higher levels; unknown CEFR is last among
+   otherwise equivalent candidates.
 
 ## Fixes
 
-- `rankCandidates()` now applies a **CEFR-distance penalty** to every candidate,
-  not just new cards. Within the same urgency bucket, items at the selected
-  learner level are preferred over lower-level items, while still preserving the
-  higher priority of due/lapsed cards and mode variety.
+- `rankCandidates()` now applies a **CEFR-distance preference** to every
+  candidate, not just new cards. Due and lapsed cards remain primary, so this
+  preference cannot hide a genuinely urgent review.
 
 - `meaningDistractors()` builds **concentric CEFR rings** around the answer.
-  It exhausts the closest ring before moving outward, keeping multiple-choice
-  options semantically comparable and preventing huge level leaps.
+  It exhausts the closest known ring before moving outward, while preserving
+  nullable CEFR metadata for unlevelled recognition entries.
 
-- Existing mode eligibility is unchanged (index `modes` + recognition mastery
-  for cloze). Better item selection reduces the perceived dilution instead of
-  lowering quality bars by hiding valid reviews or easier modes.
+- The factory keeps the existing lemma-quality/course-anchor gate. Missing CEFR
+  no longer drops an admitted recognition lexeme: its index and lexeme records
+  carry `cefr: null`, transported in the A1 shard solely for compatibility.
+  It receives recognition modes only; VESUM, cloze, and curated drill gates are
+  not lowered.
+- Custom imports use the same rule: an Atlas-attested candidate with a real
+  gloss can be saved without CEFR. No UI or builder fallback assigns A1.
 
 ## Spot-check expectations
 
-- **A1**: only A1 items exist in the deck, so level bias is a no-op.
-- **A2**: A2 due reviews are preferred over same-urgency A1 reviews; a much
-  more overdue A1 card still wins because urgency is the primary sort key.
-- **B1**: B1 new cards and due reviews are preferred over A2/A1 ties; lower-
-  level cards still appear when they are genuinely due.
+- **A1**: A1 items are preferred; other published levels remain eligible.
+- **A2**: A2 due reviews are preferred over same-urgency nearby levels; a much
+  more overdue card still wins because urgency is the primary sort key.
+- **B1**: B1 items are preferred over equally urgent nearby items, while A1/A2,
+  B2/C1, and nullable-CEFR recognition items remain available.

--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -24,6 +24,7 @@ if str(AUDIT_DIR) not in sys.path:
 
 from generate_practice_deck import (
     THIN_WARN_THRESHOLDS,
+    UNKNOWN_CEFR_TRANSPORT_LEVEL,
     validate_classify_item,
     validate_classify_session_cap,
     validate_heritage_item,
@@ -79,6 +80,11 @@ MODE_BODY_KEYS = {
 DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym")
 MODE_SHARD_KINDS = ("cloze", *DRILL_MODES)
 COVERAGE_MODES = MODE_SHARD_KINDS
+
+
+def _cefr_matches_transport(value: object, level: str) -> bool:
+    """Accept a nullable lexical CEFR only in the documented transport shard."""
+    return value == level or (level == UNKNOWN_CEFR_TRANSPORT_LEVEL and value is None)
 
 
 def _read_json(path: Path, errors: list[str]) -> Any:
@@ -383,7 +389,7 @@ def _check_level(
             errors.append(f"{prefix} missing lemmaId")
         elif str(lemma_id) not in lexeme_by_id:
             errors.append(f"{prefix} lemmaId {lemma_id!r} missing from lexeme shard")
-        if item.get("cefr") != level:
+        if not _cefr_matches_transport(item.get("cefr"), level):
             errors.append(f"{prefix} cefr {item.get('cefr')!r} != {level!r}")
         modes = item.get("modes")
         if not isinstance(modes, list) or "flashcards" not in modes:
@@ -411,7 +417,7 @@ def _check_level(
         for field in ("lemmaId", "lemma", "lemmaPlain", "gloss"):
             if not _has_text(lexeme.get(field)):
                 errors.append(f"{prefix} missing {field}")
-        if lexeme.get("cefr") != level:
+        if not _cefr_matches_transport(lexeme.get("cefr"), level):
             errors.append(f"{prefix} cefr {lexeme.get('cefr')!r} != {level!r}")
 
     for index, item in enumerate(cloze_items):

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -71,6 +71,10 @@ SCHEMA_VERSION = 1
 CEFR_ORDER = ("A1", "A2", "B1", "B2", "C1", "C2")
 CEFR_RANK = {level: index for index, level in enumerate(CEFR_ORDER)}
 PUBLISHED_LEVELS = ("A1", "A2", "B1", "B2", "C1")
+# CEFR is lexical guidance, not an admission requirement.  Keep the published
+# five-shard transport contract stable by carrying admitted, unlevelled
+# recognition lexemes in the first shard; the lexeme/index field remains null.
+UNKNOWN_CEFR_TRANSPORT_LEVEL = PUBLISHED_LEVELS[0]
 DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym")
 MODE_SHARD_KEYS = ("cloze", *DRILL_MODES)
 MODE_SCHEMAS = {
@@ -1094,6 +1098,10 @@ def _eligible_decoys(
     for lexeme in lexemes:
         if lexeme["lemmaId"] == answer["lemmaId"]:
             continue
+        # Unknown CEFR is valid for recognition, but cannot participate in a
+        # level-bounded cloze option set without inventing a placement.
+        if not lexeme.get("cefr") or not answer.get("cefr"):
+            continue
         if lexeme.get("pos") != answer.get("pos"):
             continue
         if CEFR_RANK[lexeme["cefr"]] > CEFR_RANK[answer["cefr"]]:
@@ -1165,6 +1173,8 @@ def _eligible_dictionary_decoys(
     seen_labels: set[str] = {answer_label}
     for lexeme in lexemes:
         if lexeme["lemmaId"] == answer["lemmaId"]:
+            continue
+        if not lexeme.get("cefr") or not answer.get("cefr"):
             continue
         if _option_pos_bucket(lexeme.get("pos")) != answer_bucket:
             continue
@@ -1573,14 +1583,14 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     lemma = _clean_text(entry.get("lemma"))
     gloss = _clean_text(entry.get("gloss"))
     level = _cefr_level(entry)
-    if not lemma or not gloss or not level:
+    if not lemma or not gloss:
         return None
     lemma_plain = _plain(lemma)
     pos = _clean_text(entry.get("pos"))
     gloss_clean = _gloss_clean(gloss)
     meaning_mc_eligible = _meaning_mc_eligible(gloss_clean, lemma_plain, pos)
-    # Recognition (matching/choice/flashcard) needs only lemma+gloss+level, so the word is
-    # ALWAYS kept. Attach the paradigm for flashcard declensions ONLY when every form
+    # Recognition (matching/choice/flashcard) needs only lemma+gloss, so an admitted
+    # word stays in the deck even when CEFR is unknown. Attach the paradigm for flashcard declensions ONLY when every form
     # VESUM-verifies; otherwise blank it so the UI never displays an unverified declension.
     paradigm = _paradigm(entry)
     if not _verify_paradigm(lemma_plain, pos, paradigm, verifier):
@@ -1975,6 +1985,8 @@ def _category_set_payload(set_id: str, value: str, level: str) -> dict[str, Any]
 
 
 def _build_classify_items(entry: dict[str, Any], lexeme: dict[str, Any]) -> list[dict[str, Any]]:
+    if not _normalize_cefr(lexeme.get("cefr")):
+        return []
     morphology = _morphology(entry)
     if not morphology:
         return []
@@ -2026,6 +2038,8 @@ def _single_surface(value: Any) -> str | None:
 
 
 def _build_paradigm_items(lexeme: dict[str, Any]) -> list[dict[str, Any]]:
+    if not _normalize_cefr(lexeme.get("cefr")):
+        return []
     cases = lexeme.get("paradigm", {}).get("cases")
     if not isinstance(cases, dict):
         return []
@@ -2199,6 +2213,8 @@ def _valid_synonym_distractors(
     for lexeme in lexemes:
         if lexeme["lemmaId"] in {prompt["lemmaId"], answer["lemmaId"]}:
             continue
+        if not lexeme.get("cefr"):
+            continue
         if lexeme.get("pos") != answer.get("pos"):
             continue
         if _headword(lexeme["gloss"]) in blocked_heads:
@@ -2341,10 +2357,12 @@ def _build_synonym_items(
     link back to one another through the current relation sections.
     """
     for entry, lexeme in lexemes_by_entry:
+        if not lexeme.get("cefr"):
+            continue
         for polarity, section_name in (("synonym", "synonyms"), ("antonym", "antonyms")):
             for target_label in _section_items(entry, section_name):
                 target = by_plain_lemma.get(_plain(target_label))
-                if not target:
+                if not target or not target.get("cefr"):
                     continue
                 pair_key = _synonym_pair_key(lexeme["lemma"], target["lemma"], polarity)
                 flagged_a2_exception = pair_key in a2_exception_set
@@ -2374,7 +2392,7 @@ def _build_synonym_items(
     for pair_key in sorted(approved_set):
         prompt_a = by_plain_lemma.get(pair_key[0])
         prompt_b = by_plain_lemma.get(pair_key[1])
-        if not prompt_a or not prompt_b:
+        if not prompt_a or not prompt_b or not prompt_a.get("cefr") or not prompt_b.get("cefr"):
             continue
 
         both_legs_a2 = prompt_a["cefr"] == "A2" and prompt_b["cefr"] == "A2"
@@ -2636,6 +2654,8 @@ def _build_heritage_items(
     # flag) is a hard pedagogy gate — level-local placement must never drop
     # BELOW it (#4719: b1-flagged calque drills were served at A1).
     lexeme_level = _normalize_cefr(lexeme.get("cefr"))
+    if not lexeme_level:
+        return []
     floor = _heritage_availability_level(pair)
     level = max(
         (lvl for lvl in (lexeme_level, floor) if lvl),
@@ -2727,6 +2747,8 @@ def _build_paronym_items(
     verifier: VesumVerifier | None = None,
     public_options: bool = True,
 ) -> list[dict[str, Any]]:
+    if not _normalize_cefr(lex_a.get("cefr")) or not _normalize_cefr(lex_b.get("cefr")):
+        return []
     frames = _valid_paronym_frames(pair)
     if not frames:
         return []
@@ -2770,7 +2792,7 @@ def _build_paronym_items(
                 if _clean_text(cand.get("lemma")) and answer_form.lower().startswith(_clean_text(cand.get("lemma")).lower()[:3]):
                     target_lex = cand
                     break
-        if target_lex is None:
+        if target_lex is None or not target_lex.get("cefr"):
             print(
                 f"WARN: paronym_pair {slugs} frame {index} dropped: could not resolve lemma for answer_form {answer_form!r}",
                 file=sys.stderr,
@@ -2791,7 +2813,7 @@ def _build_paronym_items(
             "answer": answer_form,
             "confusable": confusable_form,
             "frameIndex": index,
-            "cefr": target_lex.get("cefr") or "B1",
+            "cefr": target_lex["cefr"],
             "options": options,
             "distinction_gloss_uk": distinction,
             "citations": citations,
@@ -3492,6 +3514,10 @@ def build_practice_shards(
         for level in CEFR_ORDER
     }
     for _entry, lexeme in lexemes_by_entry:
+        # Unlevelled entries stay eligible for recognition.  Cloze and the
+        # level-sensitive optional drills retain their existing gates.
+        if not lexeme.get("cefr"):
+            continue
         if config.cloze_enabled and is_surface_admitted(_entry, SURFACE_CLOZE):
             source_rows = [
                 *cloze_by_lemma_id.get(lexeme["lemmaId"], []),
@@ -3747,7 +3773,12 @@ def build_practice_shards(
 
     shards: dict[str, dict[str, dict[str, Any]]] = {}
     for level in PUBLISHED_LEVELS:
-        level_lexemes = [lexeme for lexeme in all_lexemes if lexeme["cefr"] == level]
+        level_lexemes = [
+            lexeme
+            for lexeme in all_lexemes
+            if lexeme["cefr"] == level
+            or (level == UNKNOWN_CEFR_TRANSPORT_LEVEL and lexeme["cefr"] is None)
+        ]
         if not level_lexemes:
             continue
         level_cloze = cloze_by_level[level]
@@ -3787,7 +3818,7 @@ def build_practice_shards(
                 {
                     "lemmaId": lexeme["lemmaId"],
                     "lemma": lexeme["lemma"],
-                    "cefr": level,
+                    "cefr": lexeme.get("cefr"),
                     "modes": modes,
                     "hasCloze": bool(cloze_ids),
                     "clozeIds": cloze_ids,

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -651,8 +651,8 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
 }) => {
   await context.clearCookies();
 
-  // Fixture index: 3 single-mode items, so the full-level estimate is a small, exact
-  // number (not a live-corpus count that could drift) — well under the 8-per-session cap.
+  // The soft-CEFR planner reports the honest capped new-card estimate for the selected level;
+  // assert that rendered count rather than the old hard-CEFR fixture cardinality.
   await page.route('**/lexicon/practice-index.A1.json', (route) =>
     route.fulfill({
       contentType: 'application/json',
@@ -692,8 +692,8 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
   await page.goto('/words-of-the-day/practice/');
 
   const estimate = page.getByTestId('practice-session-scope');
-  // Before selecting the custom deck, the estimate describes the full (3-item) fixture level.
-  await expect(estimate).toContainText('3 нов');
+  // Before selecting the custom deck, the estimate reports the full-level soft-CEFR scope.
+  await expect(estimate).toContainText('8 нових');
 
   await page.getByRole('button', { name: /E2E Scope Deck/ }).click();
 

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -651,15 +651,13 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
 }) => {
   await context.clearCookies();
 
-  // The soft-CEFR planner reports the honest capped new-card estimate for the selected level;
-  // assert that rendered count rather than the old hard-CEFR fixture cardinality.
-  await page.route('**/lexicon/practice-index.A1.json', (route) =>
-    route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        deckVersion: 'e2e-scope-fixture',
-        level: 'A1',
-        items: ['a', 'b', 'c'].map((suffix) => ({
+  // Soft CEFR makes every published level eligible, so mock every index shard to keep the
+  // full-level estimate deterministic: eight controlled A1 cards, no background-level drift.
+  await page.route('**/lexicon/practice-index.*.json', (route) => {
+    const { pathname } = new URL(route.request().url());
+    const level = pathname.match(/practice-index\.([A-Z0-9]+)\.json$/)?.[1] ?? 'A1';
+    const items = level === 'A1'
+      ? ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((suffix) => ({
           lemmaId: `e2eScope${suffix}`,
           lemma: `e2eScope${suffix}`,
           cefr: 'A1',
@@ -667,10 +665,13 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
           hasCloze: false,
           clozeIds: [],
           newOrder: 0,
-        })),
-      }),
-    }),
-  );
+        }))
+      : [];
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ deckVersion: 'e2e-scope-fixture', level, items }),
+    });
+  });
   await page.addInitScript(() => {
     window.localStorage.setItem(
       'learn_ukrainian_custom_sets_v1',

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -142,8 +142,9 @@ export function LexiconCustomDeckManager({
   }, [chromeLocale]);
 
   // Extract candidate words, then classify each against the VESUM-verified
-  // Atlas index: attested words get a real CEFR level + gloss, everything
-  // else is flagged "unverified" and left deselected (#5882 — no silent invent).
+  // Atlas index: attested words get a real gloss and optional CEFR guidance;
+  // everything else is flagged "unverified" and left deselected (#5882 — no
+  // silent invent).
   const processTextToCandidates = useCallback(async (words: string[], defaultTitle = ''): Promise<void> => {
     const uniqueWords = Array.from(new Set(words.map((w) => w.toLowerCase().trim()).filter((w) => w.length >= 2)));
 
@@ -197,8 +198,8 @@ export function LexiconCustomDeckManager({
   const cefrCounts = useMemo(() => summarizePasteCandidates(candidates), [candidates]);
 
   // Toggle individual word selection. Selecting (not deselecting) is fail-closed:
-  // a candidate with no real Atlas CEFR level can never be flipped to selected,
-  // so `selected` always predicts what will actually be saved (#6073 F001).
+  // an attested row with missing CEFR needs a real gloss; known-CEFR rows retain
+  // the legacy attested path, and missing CEFR remains guidance metadata (#6073 F001).
   const toggleCandidateSelection = useCallback((index: number) => {
     setCandidates((prev) =>
       prev.map((item, idx) => {
@@ -210,10 +211,9 @@ export function LexiconCustomDeckManager({
     );
   }, []);
 
-  // Bulk toggle for a specific CEFR level. Unverified candidates have no CEFR
-  // group and are intentionally excluded from bulk-select (#6073 F001) — never
-  // invent a level to make them selectable, and never let a bulk action move
-  // them into a saved deck.
+  // Bulk toggle for a specific CEFR level. Unverified and unlevelled candidates
+  // have no CEFR group; they are handled by the default selection and final
+  // attestation/gloss gate rather than assigned an invented level.
   const toggleGroupSelection = useCallback((group: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2', enable: boolean) => {
     setCandidates((prev) =>
       prev.map((item) => (item.cefr === group ? { ...item, selected: enable } : item))
@@ -224,10 +224,10 @@ export function LexiconCustomDeckManager({
   const handleSaveDeck = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      // Fail-closed final gate (#6073 F001): only atlas-attested candidates with a
-      // real CEFR level are ever materialized into a saved deck, regardless of how
-      // `selected` got set — no unverified/no-CEFR word can reach practice and hit
-      // a downstream level-invent fallback.
+      // Fail-closed final gate (#6073 F001): only Atlas-attested candidates are
+      // materialized; a missing-CEFR row also needs a real gloss, regardless of
+      // how `selected` got set. CEFR remains nullable and no downstream fallback
+      // may invent it.
       const selectedWords = selectSaveEligiblePasteCandidates(candidates).map((c) => c.text);
       if (selectedWords.length === 0 || !deckTitle.trim()) return;
 
@@ -614,9 +614,8 @@ export function LexiconCustomDeckManager({
                     ))}
                   </div>
 
-                  {/* Bulk group toggles by CEFR level. Unverified candidates have no
-                      level group and are deliberately excluded — never bulk-select
-                      them into a saved deck (#6073 F001). */}
+                  {/* Bulk group toggles by CEFR level. Unverified and unlevelled
+                      candidates have no group; no level is invented for them. */}
                   <div style={{ display: 'flex', gap: '0.3rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
                     {(['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const).map((group) => (
                       <React.Fragment key={group}>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -79,7 +79,7 @@ import {
 import {
   CEFR_LEVELS,
   LEARNER_LEVEL_STORAGE_KEY,
-  filterByCumulativeLevel,
+  prioritizeByLearnerLevel,
   normalizeCefrLevel,
   type CefrLevel,
 } from '../lib/lexicon/levels';
@@ -303,7 +303,7 @@ function ensureDeckCustomSetCoverage(
       newIndexItems.push({
         lemmaId: atlas?.slug ?? key,
         lemma: atlas?.lemma ?? cleanKey,
-        cefr: atlas?.cefr ?? 'A1',
+        cefr: atlas?.cefr ?? null,
         modes: hasCloze
           ? ['flashcards', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage']
           : ['flashcards', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage'],
@@ -319,7 +319,7 @@ function ensureDeckCustomSetCoverage(
         ipa: null,
         gloss: atlas?.gloss ?? cleanKey,
         pos: null,
-        cefr: atlas?.cefr ?? 'A1',
+        cefr: atlas?.cefr ?? null,
         heritage: null,
         severity: null,
         paradigm: { cases: {} },
@@ -889,13 +889,14 @@ function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[])
       paradigm: legacy.paradigm ?? { cases: {} },
     };
   });
+  const deckGuidanceLevel = lexemes.find((entry) => entry.cefr)?.cefr ?? 'unknown';
   return {
     deckVersion: 'test-fixture',
-    level: lexemes[0]?.cefr ?? 'A1',
+    level: deckGuidanceLevel,
     index: lexemes.map((entry, index) => ({
       lemmaId: entry.lemmaId,
       lemma: entry.lemma,
-      cefr: entry.cefr ?? 'A1',
+      cefr: entry.cefr ?? null,
       modes: entry.meaningMcEligible ? ['flashcards', 'matching', 'choice'] : ['flashcards'],
       hasCloze: false,
       clozeIds: [],
@@ -968,8 +969,9 @@ function orderedChoiceOptions(
   return options;
 }
 
-function cefrRank(level: string): number {
-  return CEFR_LEVELS.indexOf(level as CefrLevel);
+function cefrRank(level: string | null | undefined): number {
+  const rank = CEFR_LEVELS.indexOf(level as CefrLevel);
+  return rank >= 0 ? rank : CEFR_LEVELS.length;
 }
 
 export function meaningDistractors(
@@ -979,7 +981,7 @@ export function meaningDistractors(
 ): PracticeLexeme[] {
   const answerHeadword = glossHeadword(answer);
   const answerLength = glossLabel(answer).length;
-  const answerRank = cefrRank(answer.cefr ?? 'A1');
+  const answerRank = cefrRank(answer.cefr);
   const candidatePool = deck.lexemes.filter(
     (candidate) =>
       candidate.lemmaId !== answer.lemmaId &&
@@ -993,7 +995,7 @@ export function meaningDistractors(
   // distractors or an A1 answer from being ambushed by C1 vocabulary.
   const rings = new Map<number, PracticeLexeme[]>();
   for (const candidate of candidatePool) {
-    const gap = Math.abs(cefrRank(candidate.cefr ?? 'A1') - answerRank);
+    const gap = Math.abs(cefrRank(candidate.cefr) - answerRank);
     const bucket = rings.get(gap) ?? [];
     bucket.push(candidate);
     rings.set(gap, bucket);
@@ -1302,10 +1304,9 @@ function writeLearnerLevel(level: CefrLevel): void {
   }
 }
 
-/** CEFR levels at or below `level` (cumulative: B1 -> A1, A2, B1). */
-function levelsUpTo(level: CefrLevel): CefrLevel[] {
-  const cap = CEFR_LEVELS.indexOf(level);
-  return CEFR_LEVELS.slice(0, cap + 1);
+/** All published practice shards; learner level is a preference, not a hard cap. */
+function levelsForPractice(): CefrLevel[] {
+  return [...PUBLISHED_PRACTICE_LEVELS] as CefrLevel[];
 }
 
 /** Concatenate per-level decks into one cumulative deck (CEFR shards are disjoint). */
@@ -1584,7 +1585,7 @@ function LexiconPracticeIsland({
   const pendingOutcomeRef = useRef<CompletionOutcome | null>(null);
   const advanceButtonRef = useRef<HTMLButtonElement | null>(null);
   // Selection ref used to stabilize the in-flight item across live deck merges (pool growth from
-  // background lower-level shards). While history length is unchanged we keep returning the
+  // background level shards). While history length is unchanged we keep returning the
   // prior selection object so a B1 card is not yanked when an A1/A2 shard lands mid-item.
   const committedSelectionRef = useRef<{ selection: PracticeSelection; historyLen: number } | null>(null);
   // Deduping cache for shard JSON fetches (by full URL) so index shards fetched by the eager
@@ -1788,7 +1789,7 @@ function LexiconPracticeIsland({
     void (async () => {
       try {
         const batches = await Promise.all(
-          levelsUpTo(learnerLevel).map(async (shardLevel) => {
+          levelsForPractice().map(async (shardLevel) => {
             const url = `${shardBaseUrl}/practice-index.${shardLevel}.json`;
             try {
               const shard = await getShardJson<PracticeIndexShard>(url, shardJsonCacheRef.current);
@@ -1809,7 +1810,7 @@ function LexiconPracticeIsland({
   }, [deck, learnerLevel, shardBaseUrl]);
 
   // D2 (design delta 2026-07-26): the Words-of-the-Day zone renders the SAME 12
-  // lemmas as /words-of-the-day/ — pickDaily(filterByCumulativeLevel(pool, level),
+  // lemmas as /words-of-the-day/ — pickDaily(prioritizeByLearnerLevel(pool, level),
   // dateSeed(now), 12) over /lexicon/daily-pool.json. This is recomputed fresh
   // from (pool, level, date) on every run rather than reused from a persisted
   // snapshot, so there is no stale cache to silently pin the carousel on one
@@ -1865,7 +1866,7 @@ function LexiconPracticeIsland({
             '/lexicon/daily-pool.json',
             shardJsonCacheRef.current,
           );
-          const eligiblePool = filterByCumulativeLevel(pool, learnerLevel);
+          const eligiblePool = prioritizeByLearnerLevel(pool, learnerLevel);
           picks = pickDaily(
             eligiblePool,
             dateSeed(now) + reRollSeed(dailyReRollCount),
@@ -1877,17 +1878,16 @@ function LexiconPracticeIsland({
           // pool is empty.
           const levelsForDailyPreview = picks.length > 0
             ? picks.map((word) => word.cefr)
-            : levelsUpTo(learnerLevel);
+            : levelsForPractice();
           representedLevels = new Set(
             levelsForDailyPreview.filter((cefr): cefr is string => Boolean(cefr)),
           );
         } else {
           // A deck's words can sit at any level (or none — an unverified custom
           // import). Resolve its keys across the learner's complete accessible
-          // range, the same A1..learnerLevel set `filterByCumulativeLevel`
-          // uses for atlas-global picks. That gives level-less custom keys their
-          // verified metadata without loading shards above the learner's level.
-          representedLevels = new Set<string>(levelsUpTo(learnerLevel));
+          // range used for atlas-global picks. That gives level-less custom keys
+          // their verified metadata without treating a missing CEFR as A1.
+          representedLevels = new Set<string>(levelsForPractice());
         }
 
         // The atlas branch can skip this fetch once `deck` already covers the
@@ -2116,7 +2116,7 @@ function LexiconPracticeIsland({
       sessionSeed,
       poolFilter: sessionPhase === 'active' ? poolFilter : undefined,
     });
-    // Stabilize in-flight selection across live merges from background lower-level shards.
+    // Stabilize in-flight selection across live merges from background level shards.
     // The selector cache (per deck identity) produces a new pool, but we keep the exact
     // prior selection object (for same history length) so the user is not yanked mid-item
     // and #4740/#4744 flows are unperturbed. Once history advances on complete, fresh pick
@@ -2263,18 +2263,17 @@ function LexiconPracticeIsland({
     try {
       let nextDeck = current;
       let nextClozeLoaded = clozeLoaded;
-      const levels = levelsUpTo(level);
-      const targetLevel = level;
-      const lowerLevels = levels.slice(0, -1);
+      const levels = levelsForPractice();
+      const targetLevel = levels.includes(level) ? level : levels[0]!;
+      const otherLevels = levels.filter((lv) => lv !== targetLevel);
       const needDrills = includeCloze && (force || !clozeLoaded);
       const deckLemmaKeys = resolveDeckLemmaKeys(deckFilter, customSets);
       let deckKeyResolutions: Map<string, DeckKeyResolution> | null = null;
 
       if (!nextDeck) {
         // PROGRESSIVE: Load the SELECTED level's core shards (index + lexemes) FIRST.
-        // The session can start on this deck immediately; lower levels are backgrounded.
-        // This eliminates the 21-shard/8.9MB wait for B1 (and general multi-level).
-        // A1 is unaffected (no lower levels).
+        // The session can start on this deck immediately; every other published level
+        // is backgrounded because the learner level is a preference, not a cap.
         const indexUrl = `${shardBaseUrl}/practice-index.${targetLevel}.json`;
         const lexUrl = `${shardBaseUrl}/practice-lexemes.${targetLevel}.json`;
         const [indexShard, lexemeShard] = await Promise.all([
@@ -2291,19 +2290,19 @@ function LexiconPracticeIsland({
           nextDeck = ensureDeckCustomSetCoverage(nextDeck, deckLemmaKeys, deckKeyResolutions);
         }
         // The first committed deck must already contain Atlas-enriched custom
-        // entries; background lower-level growth may safely extend it after this.
+        // entries; background growth may safely extend it after this.
         if (deckRequestId.current === requestId) setDeck(nextDeck);
 
-        // Fire-and-forget background load of lower-level *cores*. Merge into live pool
+        // Fire-and-forget background load of the remaining *cores*. Merge into live pool
         // as they arrive; selector cache per deck identity (#4656) receives the new deck
         // object and recomputes candidates for the grown pool on next select (stabilized
         // for in-flight item).
-        if (lowerLevels.length > 0) {
+        if (otherLevels.length > 0) {
           void (async () => {
             const bgId = deckRequestId.current;
-            const lowerCores = (
+            const otherCores = (
               await Promise.all(
-                lowerLevels.map(async (lv) => {
+                otherLevels.map(async (lv) => {
                   try {
                     const iUrl = `${shardBaseUrl}/practice-index.${lv}.json`;
                     const lUrl = `${shardBaseUrl}/practice-lexemes.${lv}.json`;
@@ -2319,10 +2318,10 @@ function LexiconPracticeIsland({
                 }),
               )
             ).filter((d): d is PracticeDeckData => d !== null);
-            if (deckRequestId.current !== bgId || lowerCores.length === 0) return;
+            if (deckRequestId.current !== bgId || otherCores.length === 0) return;
             setDeck((prev) => {
-              if (!prev) return mergeDecks(lowerCores, level);
-              return extendWithLowerDecks(prev, lowerCores);
+              if (!prev) return mergeDecks(otherCores, level);
+              return extendWithLowerDecks(prev, otherCores);
             });
           })();
         }
@@ -2330,7 +2329,7 @@ function LexiconPracticeIsland({
 
       if (needDrills) {
         // Load drill shards for the *selected* level (may block this call if mode requires
-        // them, e.g. initialMode=cloze or mixed). Lower drill shards are always background.
+        // them, e.g. initialMode=cloze or mixed). Other drill shards are background.
         // This also defers drill-kind shards for basic modes (flashcards etc) until a
         // drill mode surfaces (optional path kept clean).
         const drillUrls = [
@@ -2397,12 +2396,12 @@ function LexiconPracticeIsland({
 
         nextClozeLoaded = true;
 
-        // Background lower drills (merge live when they land).
-        if (lowerLevels.length > 0) {
+        // Background drills for the remaining published levels (merge live when they land).
+        if (otherLevels.length > 0) {
           void (async () => {
             const bgId = deckRequestId.current;
-            const lowerDrillBatches = await Promise.all(
-              lowerLevels.map(async (lv) => {
+            const otherDrillBatches = await Promise.all(
+              otherLevels.map(async (lv) => {
                 const urls = [
                   `${shardBaseUrl}/practice-cloze.${lv}.json`,
                   `${shardBaseUrl}/practice-stress.${lv}.json`,
@@ -2433,14 +2432,14 @@ function LexiconPracticeIsland({
               if (!prev) return prev;
               return {
                 ...prev,
-                cloze: [...(prev.cloze ?? []), ...lowerDrillBatches.flatMap((b) => b.cloze)],
-                stress: [...(prev.stress ?? []), ...lowerDrillBatches.flatMap((b) => b.stress)],
-                classify: [...(prev.classify ?? []), ...lowerDrillBatches.flatMap((b) => b.classify)],
-                paradigm: [...(prev.paradigm ?? []), ...lowerDrillBatches.flatMap((b) => b.paradigm)],
-                synonym: [...(prev.synonym ?? []), ...lowerDrillBatches.flatMap((b) => b.synonym)],
-                paronym: [...(prev.paronym ?? []), ...lowerDrillBatches.flatMap((b) => b.paronym)],
-                heritage: [...(prev.heritage ?? []), ...lowerDrillBatches.flatMap((b) => b.heritage)],
-                antonym: [...(prev.antonym ?? []), ...lowerDrillBatches.flatMap((b) => b.antonym)],
+                cloze: [...(prev.cloze ?? []), ...otherDrillBatches.flatMap((b) => b.cloze)],
+                stress: [...(prev.stress ?? []), ...otherDrillBatches.flatMap((b) => b.stress)],
+                classify: [...(prev.classify ?? []), ...otherDrillBatches.flatMap((b) => b.classify)],
+                paradigm: [...(prev.paradigm ?? []), ...otherDrillBatches.flatMap((b) => b.paradigm)],
+                synonym: [...(prev.synonym ?? []), ...otherDrillBatches.flatMap((b) => b.synonym)],
+                paronym: [...(prev.paronym ?? []), ...otherDrillBatches.flatMap((b) => b.paronym)],
+                heritage: [...(prev.heritage ?? []), ...otherDrillBatches.flatMap((b) => b.heritage)],
+                antonym: [...(prev.antonym ?? []), ...otherDrillBatches.flatMap((b) => b.antonym)],
               };
             });
           })();
@@ -2491,7 +2490,7 @@ function LexiconPracticeIsland({
       let matchedIndexItem = initialMatch;
       if (!matchedIndexItem) {
         const indexShards = await Promise.all(
-          levelsUpTo(learnerLevel).map((level) =>
+          levelsForPractice().map((level) =>
             getShardJson<PracticeIndexShard>(
               `${shardBaseUrl}/practice-index.${level}.json`,
               shardJsonCacheRef.current,
@@ -2511,9 +2510,12 @@ function LexiconPracticeIsland({
         return;
       }
 
-      // The cumulative index is small. Load only the resolved level's core deck next,
-      // retaining the progressive lower-level loading strategy for practice content.
-      const matchedLevel = normalizeCefrLevel(matchedIndexItem.cefr, learnerLevel);
+      // The cumulative index is small. A null lexical CEFR is transported in
+      // the first published shard; keep that transport fact separate from the
+      // missing lexical metadata rather than assigning it A1.
+      const matchedLevel = matchedIndexItem.cefr
+        ? normalizeCefrLevel(matchedIndexItem.cefr, learnerLevel)
+        : levelsForPractice()[0]!;
       let loadedDeck = initialMatch
         ? initialDeck
         : await ensureDeck(shouldLoadCloze('mixed'), { level: matchedLevel, force: true });

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1380,7 +1380,13 @@ async function getShardJson<T>(url: string, cache: Map<string, Promise<unknown>>
   let p = cache.get(url) as Promise<T> | undefined;
   if (!p) {
     p = fetch(url).then((res) => {
-      if (!res.ok) throw new Error(`Shard fetch failed: ${url}`);
+      if (!res.ok) {
+        // Tag the HTTP status so callers can tell an unpublished shard (404,
+        // soft-skippable) from a real load fault (network / server error).
+        const err = new Error(`Shard fetch failed: ${url}`) as Error & { status?: number };
+        err.status = res.status;
+        throw err;
+      }
       return res.json() as Promise<T>;
     });
     // On failure allow retry next time
@@ -2490,15 +2496,24 @@ function LexiconPracticeIsland({
       let matchedIndexItem = initialMatch;
       if (!matchedIndexItem) {
         const indexShards = await Promise.all(
-          levelsForPractice().map((level) =>
-            getShardJson<PracticeIndexShard>(
-              `${shardBaseUrl}/practice-index.${level}.json`,
-              shardJsonCacheRef.current,
-            ),
-          ),
+          levelsForPractice().map(async (level) => {
+            try {
+              return await getShardJson<PracticeIndexShard>(
+                `${shardBaseUrl}/practice-index.${level}.json`,
+                shardJsonCacheRef.current,
+              );
+            } catch (err) {
+              // A 404 means the level is not published yet: skip it and keep
+              // scanning the remaining shards — the focused lemma may live in
+              // another published level. Any other fault is a real load failure
+              // and must surface as the fetch-error fallback.
+              if ((err as { status?: number } | null)?.status === 404) return null;
+              throw err;
+            }
+          }),
         );
         matchedIndexItem = resolvePracticeIndexItem(
-          indexShards.flatMap((shard) => shard.items ?? []),
+          indexShards.flatMap((shard) => shard?.items ?? []),
           target,
         );
       }

--- a/site/src/lib/lexicon/levels.ts
+++ b/site/src/lib/lexicon/levels.ts
@@ -10,7 +10,7 @@ const CEFR_RANK = new Map<CefrLevel, number>(
 );
 
 export interface DailyLevelRow {
-  cefr?: string;
+  cefr?: string | null;
 }
 
 export interface LexiconBrowseRow {
@@ -89,18 +89,52 @@ export function normalizeLevelFilter(value: unknown): LevelFilter {
     : "all";
 }
 
+/**
+ * Return all rows in a deterministic order that prefers the learner's level.
+ * CEFR is guidance only: higher-level, lower-level, and unlevelled rows remain
+ * eligible. Unknown or malformed CEFR values sort after known levels without
+ * receiving an inferred placement.
+ */
+export function prioritizeByLearnerLevel<T extends DailyLevelRow>(
+  rows: readonly T[],
+  selectedLevel: unknown,
+): T[] {
+  const targetRank = CEFR_RANK.get(normalizeCefrLevel(selectedLevel)) ?? 0;
+
+  return rows
+    .map((row, index) => {
+      const level = parseCefrLevel(row.cefr);
+      const known = level !== null;
+      const rank = known ? (CEFR_RANK.get(level) ?? CEFR_LEVELS.length) : CEFR_LEVELS.length;
+      return {
+        row,
+        index,
+        known,
+        rank,
+        distance: known ? Math.abs(rank - targetRank) : 0,
+        aboveTarget: known && rank > targetRank ? 1 : 0,
+      };
+    })
+    .sort(
+      (left, right) =>
+        Number(right.known) - Number(left.known) ||
+        left.distance - right.distance ||
+        left.aboveTarget - right.aboveTarget ||
+        left.rank - right.rank ||
+        left.index - right.index,
+    )
+    .map(({ row }) => row);
+}
+
+/**
+ * Backward-compatible name for callers outside practice. Practice itself uses
+ * `prioritizeByLearnerLevel`; this function no longer applies a hard cap.
+ */
 export function filterByCumulativeLevel<T extends DailyLevelRow>(
   rows: readonly T[],
   selectedLevel: unknown,
 ): T[] {
-  const cap = normalizeCefrLevel(selectedLevel);
-  const capRank = CEFR_RANK.get(cap) ?? 0;
-
-  return rows.filter((row) => {
-    const level = parseCefrLevel(row.cefr);
-    if (!level) return false;
-    return (CEFR_RANK.get(level) ?? Number.POSITIVE_INFINITY) <= capRank;
-  });
+  return prioritizeByLearnerLevel(rows, selectedLevel);
 }
 
 export function filterRowsByLevel<T extends { c?: string }>(

--- a/site/src/lib/lexicon/paste-text-vocab.ts
+++ b/site/src/lib/lexicon/paste-text-vocab.ts
@@ -6,10 +6,9 @@
  * doubles as a client-side attestation source with zero extra bundle cost.
  * A pasted word is "atlas_attested" only when it resolves to a real Atlas
  * row; everything else is "unverified" and deselected by default so no
- * unattested string is ever silently treated as confirmed vocabulary. An
- * attested row with no parseable CEFR level is also left deselected — it
- * needs manual review, and no level is ever invented (e.g. defaulting it
- * to A1) just to make it selectable.
+ * unattested string is ever silently treated as confirmed vocabulary. CEFR is
+ * optional guidance: an attested row with a real learner gloss remains
+ * selectable even when no CEFR level is published, without inventing one.
  */
 
 import { CEFR_LEVELS, parseCefrLevel, type CefrLevel } from './levels';
@@ -78,8 +77,9 @@ export function classifyPasteCandidates(
         status: 'atlas_attested',
         atlasSlug: row.s,
         gloss: cleanGloss(row.g),
-        // No parseable CEFR level → leave deselected for manual review, never invent one.
-        selected: cefr !== null,
+        // Missing CEFR is still eligible guidance-wise when the row has a real
+        // gloss; preserve the legacy attested selection for rows with CEFR.
+        selected: cefr !== null || cleanGloss(row.g) !== null,
       };
     }
     return {
@@ -95,13 +95,14 @@ export function classifyPasteCandidates(
 
 /**
  * A candidate is safe to persist into a saved deck only when it resolves to a
- * real Atlas row with a real CEFR level. Unverified words and attested rows
- * with no parseable CEFR level are never save-eligible — nothing downstream
- * (e.g. a practice-session level fallback) may invent a level just because a
- * bulk toggle or a stray click left `selected` true on an unqualified row.
+ * real Atlas row. A missing-CEFR row additionally needs a real learner gloss so
+ * it is displayable without a level fallback; known-CEFR rows retain the
+ * existing attested path. CEFR remains nullable and no downstream fallback may
+ * invent a level just because a bulk toggle or stray click left `selected` true.
  */
 export function isSaveEligiblePasteCandidate(candidate: PasteCandidate): boolean {
-  return candidate.status === 'atlas_attested' && candidate.cefr !== null;
+  return candidate.status === 'atlas_attested' &&
+    (candidate.cefr !== null || candidate.gloss !== null);
 }
 
 /**

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -106,7 +106,8 @@ export interface PracticeDeckEntry extends PracticeLexeme {
 export interface PracticeIndexItem {
   lemmaId: string;
   lemma: string;
-  cefr: string;
+  /** Nullable lexical guidance; null means no CEFR was attested. */
+  cefr: string | null;
   modes: PracticeMode[];
   hasCloze: boolean;
   clozeIds: string[];
@@ -1594,17 +1595,17 @@ function urgencyBucket(candidate: PracticeSelection, nowTime: number): number {
 }
 
 /**
- * Prefer items at the selected learner level. The penalty is one rank per CEFR
- * step below the selected level, so B1 sessions prefer B1 over A2 and A2 over A1
- * when urgency and variety are otherwise tied. It never applies to items above
- * the selected level because `levelsUpTo` never loads them, and it is a tiebreak
- * only — a genuinely more-due lower-level card still wins.
+ * Prefer items near the selected learner level. CEFR is a tiebreak only: due and
+ * lapsed urgency still wins, higher/lower levels remain eligible, and an unknown
+ * level receives no invented placement and sorts after known guidance.
  */
 function levelMatchBias(candidate: PracticeSelection, deckLevel: string): number {
   const deckRank = cefrRank(deckLevel);
   const itemRank = cefrRank(candidate.indexItem.cefr);
-  if (deckRank < 0 || itemRank < 0) return 0;
-  return Math.max(0, deckRank - itemRank);
+  if (deckRank >= CEFR_LEVELS.length) return 0;
+  if (itemRank >= CEFR_LEVELS.length) return CEFR_LEVELS.length * 2 + 1;
+  // Prefer the learner's level, then the lower level when equally distant.
+  return Math.abs(deckRank - itemRank) * 2 + (itemRank > deckRank ? 1 : 0);
 }
 
 function applyPoolFilter(
@@ -2075,7 +2076,7 @@ export function combinePracticeShards(
 }
 
 /**
- * Extend a base deck (initially the selected level only) with lower-level decks.
+ * Extend a base deck (initially the selected level only) with other level decks.
  * Produces a new deck object so WeakMap selector caches (#4656) key off the new identity.
  */
 export function extendWithLowerDecks(base: PracticeDeckData, lowers: PracticeDeckData[]): PracticeDeckData {
@@ -2590,8 +2591,9 @@ export function validateDailyPracticeDeckSnapshot(
   return snapshot;
 }
 
-function cefrRank(cefr: string): number {
-  return CEFR_LEVELS.indexOf(cefr as CefrLevel);
+function cefrRank(cefr: string | null | undefined): number {
+  const rank = CEFR_LEVELS.indexOf(cefr as CefrLevel);
+  return rank >= 0 ? rank : CEFR_LEVELS.length;
 }
 
 export function selectDailyPracticeDeckItems(
@@ -2605,10 +2607,10 @@ export function selectDailyPracticeDeckItems(
     lemmaId: string;
     lemma: string;
     earliestDue: number;
-    cefr: string;
+    cefr: string | null;
     newOrder: number;
   }> = [];
-  const newLemmas: Array<{ lemmaId: string; lemma: string; cefr: string; newOrder: number }> = [];
+  const newLemmas: Array<{ lemmaId: string; lemma: string; cefr: string | null; newOrder: number }> = [];
 
   for (const item of indexItems) {
     const { lemmaId, lemma, cefr, newOrder, modes } = item;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -48,7 +48,7 @@ function okJson(body: unknown): Response {
 }
 
 function notFoundResponse(): Response {
-  return { ok: false, json: async () => ({}) } as unknown as Response;
+  return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
 }
 
 /** D2: the Words-of-the-Day zone now fetches this pool directly (see `dailyPoolFixture`). */
@@ -1323,7 +1323,7 @@ describe('LexiconPractice', () => {
     expect(screen.getAllByText(withPos!.pos!).length).toBeGreaterThan(0);
   });
 
-  test('resolves a level-less custom deck key from the learner cumulative shards', async () => {
+  test('resolves a level-less custom deck key across the published practice shards', async () => {
     const cat = lexeme('кіт', 'кіт', 'cat', {
       nominative: 'кіт',
       accusative: 'кота',
@@ -1387,7 +1387,9 @@ describe('LexiconPractice', () => {
       'href',
       '/lexicon/%D0%BA%D1%96%D1%82/',
     );
-    expect(requested.some((url) => url.includes('practice-lexemes.A2.json'))).toBe(false);
+    // Soft CEFR (#6143): the learner level is a preference, not a cap, so the
+    // level-less custom key resolves against all published shards (A2 included).
+    expect(requested.some((url) => url.includes('practice-lexemes.A2.json'))).toBe(true);
   });
 
   test('falls back to the Atlas index for a custom deck word outside practice lexemes', async () => {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -27,7 +27,7 @@ import {
   type PracticeRating,
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
-import { LEARNER_LEVEL_STORAGE_KEY, filterByCumulativeLevel, type CefrLevel } from '@site/src/lib/lexicon/levels';
+import { LEARNER_LEVEL_STORAGE_KEY, prioritizeByLearnerLevel, type CefrLevel } from '@site/src/lib/lexicon/levels';
 import {
   CUSTOM_SETS_STORAGE_KEY,
   filterTeacherClozeItems,
@@ -1276,7 +1276,7 @@ describe('LexiconPractice', () => {
       });
 
       const dayOnePool = dailyPoolFixture({ A1: 24 });
-      const eligiblePool = filterByCumulativeLevel(dayOnePool, 'A1');
+      const eligiblePool = prioritizeByLearnerLevel(dayOnePool, 'A1');
       const expectedDayTwoDefaultIds = pickDaily(
         eligiblePool,
         dateSeed(new Date(2026, 5, 24)),
@@ -1694,7 +1694,7 @@ describe('LexiconPractice', () => {
     );
   });
 
-  test('caps the practice pool at the learner level (cumulative, never higher levels)', async () => {
+  test('keeps higher published levels eligible while preferring the learner level', async () => {
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'B1');
     const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3, B2: 5, C1: 4 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
@@ -1703,18 +1703,19 @@ describe('LexiconPractice', () => {
 
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
-    // A1+A2+B1 load (cumulative); B2/C1 are above the learner level and must never be fetched.
+    // The selected B1 shard is eager; all other published levels remain eligible
+    // and are fetched in the background.
     await waitFor(() =>
       expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true),
     );
     expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true);
-    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(false);
-    expect(requested.some((u) => u.includes('practice-index.C1'))).toBe(false);
+    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.C1'))).toBe(true);
   });
 
-  test('level selector re-caps the pool and persists the shared learner-level key', async () => {
+  test('level selector changes the soft preference and persists the shared learner-level key', async () => {
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
     const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
@@ -1730,7 +1731,7 @@ describe('LexiconPractice', () => {
     );
     expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
-    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(false);
+    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(true);
   });
 
   test('flashcard rating persists mode-specific SRS progress', async () => {

--- a/site/tests/unit/lexicon-levels.test.ts
+++ b/site/tests/unit/lexicon-levels.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import {
-  filterByCumulativeLevel,
   filterRowsByLevel,
   populatedUkrainianLetters,
+  prioritizeByLearnerLevel,
 } from '@site/src/lib/lexicon/levels';
 
-describe('filterByCumulativeLevel', () => {
+describe('prioritizeByLearnerLevel', () => {
   const rows = [
     { lemma: 'ранок', cefr: 'A1' },
     { lemma: 'площа', cefr: 'A2' },
@@ -14,20 +14,19 @@ describe('filterByCumulativeLevel', () => {
     { lemma: 'невідоме' },
   ];
 
-  test('defaults invalid or missing selections to the A1 floor', () => {
-    expect(filterByCumulativeLevel(rows, undefined).map((row) => row.lemma)).toEqual([
-      'ранок',
-    ]);
-    expect(filterByCumulativeLevel(rows, 'C0').map((row) => row.lemma)).toEqual([
-      'ранок',
-    ]);
+  test('defaults invalid or missing selections to an A1 preference without excluding rows', () => {
+    const expected = ['ранок', 'площа', 'громада', 'відтінок', 'невідоме'];
+    expect(prioritizeByLearnerLevel(rows, undefined).map((row) => row.lemma)).toEqual(expected);
+    expect(prioritizeByLearnerLevel(rows, 'C0').map((row) => row.lemma)).toEqual(expected);
   });
 
-  test('includes all lower levels through the selected cap', () => {
-    expect(filterByCumulativeLevel(rows, 'B1').map((row) => row.lemma)).toEqual([
-      'ранок',
-      'площа',
+  test('prefers the selected level and keeps higher and unlevelled rows eligible', () => {
+    expect(prioritizeByLearnerLevel(rows, 'B1').map((row) => row.lemma)).toEqual([
       'громада',
+      'площа',
+      'відтінок',
+      'ранок',
+      'невідоме',
     ]);
   });
 });

--- a/site/tests/unit/paste-text-vocab.test.ts
+++ b/site/tests/unit/paste-text-vocab.test.ts
@@ -13,6 +13,7 @@ import { parsePlainTextWithTranslations } from '@site/src/lib/lexicon/document-i
 const SAMPLE_ROWS: AtlasAttestationRow[] = [
   { l: 'привіт', s: 'pryvit', g: 'hello', c: 'A1' },
   { l: 'книжка', s: 'knyzhka', g: 'book', c: 'A2' },
+  { l: 'ґудзик', s: 'gudzyk', g: 'button', c: undefined },
   { l: 'абракадабра', s: 'abrakadabra-slug', g: null, c: undefined },
 ];
 
@@ -62,7 +63,17 @@ describe('classifyPasteCandidates', () => {
     });
   });
 
-  test('never invents a CEFR level for an Atlas row missing one, and leaves it deselected', () => {
+  test('keeps a glossed Atlas row with no CEFR selected without inventing a level', () => {
+    const [candidate] = classifyPasteCandidates(['ґудзик'], index);
+    expect(candidate).toMatchObject({
+      status: 'atlas_attested',
+      cefr: null,
+      gloss: 'button',
+      selected: true,
+    });
+  });
+
+  test('keeps an attested row with no CEFR and no gloss deselected', () => {
     const [candidate] = classifyPasteCandidates(['абракадабра'], index);
     expect(candidate).toMatchObject({
       status: 'atlas_attested',
@@ -97,18 +108,18 @@ describe('summarizePasteCandidates', () => {
     expect(summary.byLevel.B1).toBe(0);
   });
 
-  test('does not count an attested word with no CEFR level as selected or leveled', () => {
+  test('counts a glossed attested word with no CEFR as selected but not leveled', () => {
     const index = buildAtlasAttestationIndex(SAMPLE_ROWS);
     const candidates = classifyPasteCandidates(
-      ['привіт', 'абракадабра'],
+      ['привіт', 'ґудзик', 'абракадабра'],
       index,
     );
     const summary = summarizePasteCandidates(candidates);
-    expect(summary.total).toBe(2);
-    // both resolve to real Atlas rows, so both count as attested...
-    expect(summary.attested).toBe(2);
-    // ...but the one with no parseable CEFR level is deselected, not invented as A1
-    expect(summary.selected).toBe(1);
+    expect(summary.total).toBe(3);
+    // all three resolve to real Atlas rows, so all count as attested...
+    expect(summary.attested).toBe(3);
+    // ...the glossed no-CEFR row remains selected but is not invented as A1
+    expect(summary.selected).toBe(2);
     expect(summary.byLevel.A1).toBe(1);
   });
 
@@ -132,12 +143,17 @@ describe('isSaveEligiblePasteCandidate (#6073 F001 — fail-closed save gate)', 
     expect(isSaveEligiblePasteCandidate(candidate)).toBe(true);
   });
 
+  test('an atlas-attested word with a real gloss but no CEFR is save-eligible', () => {
+    const [candidate] = classifyPasteCandidates(['ґудзик'], index);
+    expect(isSaveEligiblePasteCandidate(candidate)).toBe(true);
+  });
+
   test('an unverified word is never save-eligible, even if manually selected', () => {
     const [candidate] = classifyPasteCandidates(['вигаданеслово'], index);
     expect(isSaveEligiblePasteCandidate({ ...candidate, selected: true })).toBe(false);
   });
 
-  test('an atlas-attested word with no parseable CEFR level is never save-eligible, even if manually selected', () => {
+  test('an attested word without a gloss is never save-eligible, even if manually selected', () => {
     const [candidate] = classifyPasteCandidates(['абракадабра'], index);
     expect(isSaveEligiblePasteCandidate({ ...candidate, selected: true })).toBe(false);
   });
@@ -148,7 +164,7 @@ describe('selectSaveEligiblePasteCandidates (#6073 F001 — final materializatio
 
   test('keeps only selected candidates that are also save-eligible', () => {
     const candidates: PasteCandidate[] = classifyPasteCandidates(
-      ['привіт', 'книжка', 'вигаданеслово', 'абракадабра'],
+      ['привіт', 'книжка', 'ґудзик', 'вигаданеслово', 'абракадабра'],
       index,
     );
     // Simulate a bulk-select/individual-click bug upstream that force-selected
@@ -156,7 +172,7 @@ describe('selectSaveEligiblePasteCandidates (#6073 F001 — final materializatio
     const corrupted = candidates.map((c) => ({ ...c, selected: true }));
     const materialized = selectSaveEligiblePasteCandidates(corrupted);
 
-    expect(materialized.map((c) => c.text)).toEqual(['привіт', 'книжка']);
+    expect(materialized.map((c) => c.text)).toEqual(['привіт', 'книжка', 'ґудзик']);
   });
 
   test('drops a save-eligible candidate the user deselected', () => {

--- a/site/tests/unit/practice-session.test.ts
+++ b/site/tests/unit/practice-session.test.ts
@@ -21,6 +21,7 @@ import {
   readPracticeSessionSnapshot,
   resolveSessionCompletion,
   saveState,
+  selectDailyPracticeDeckItems,
   selectNextPracticeItem,
   sessionPoolAllowsCandidate,
   writeNewCardsDailyState,
@@ -49,11 +50,11 @@ function lexeme(lemmaId: string, lemma = lemmaId): PracticeLexeme {
   };
 }
 
-function indexItem(lemmaId: string, order: number): PracticeIndexItem {
+function indexItem(lemmaId: string, order: number, cefr: string | null = 'A1'): PracticeIndexItem {
   return {
     lemmaId,
     lemma: lemmaId,
-    cefr: 'A1',
+    cefr,
     modes: ['flashcards'],
     hasCloze: false,
     clozeIds: [],
@@ -92,6 +93,17 @@ beforeEach(() => {
 });
 
 describe('practice session helpers', () => {
+  test('keeps an unlevelled index item eligible and ranks it after known guidance', () => {
+    const index = [indexItem('unknown', 0, null), indexItem('known', 1, 'A1')];
+
+    expect(
+      selectDailyPracticeDeckItems(index, new Map(), NOW).map((item) => [item.lemmaId, item.cefr]),
+    ).toEqual([
+      ['known', 'A1'],
+      ['unknown', null],
+    ]);
+  });
+
   test('today-ring denominator excludes uncapped deck size', () => {
     const index = Array.from({ length: 50 }, (_, i) => indexItem(`w${i}`, i));
     const denominator = computeTodayRingDenominator(index, {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1103,6 +1103,33 @@ def test_real_manifest_shapes_still_yield_recognition_lexemes() -> None:
     assert shards["B1"]["index"]["items"][0]["lemmaId"] == "pamiat"
 
 
+def test_course_anchored_lexeme_without_cefr_stays_recognition_eligible() -> None:
+    entry = {
+        "lemma": "ґудзик",
+        "url_slug": "gudzik",
+        "gloss": "button",
+        "pos": "noun",
+        "primary_source": "course_vocab",
+        "course_usage": [{"module_num": 2, "slug": "clothes"}],
+    }
+
+    shards = build_practice_shards(
+        [entry],
+        ReviewedSourceAllowlist.from_payload([]),
+        JsonVesumVerifier({}),
+        config=BuildConfig(target=1),
+        synonym_verdicts={"approved": [], "rejected": []},
+    )
+
+    index_item = shards["A1"]["index"]["items"][0]
+    lexeme = shards["A1"]["lexemes"]["lexemes"][0]
+    assert index_item["lemmaId"] == "gudzik"
+    assert index_item["cefr"] is None
+    assert index_item["modes"] == ["flashcards", "matching", "choice"]
+    assert lexeme["cefr"] is None
+    assert shards["A1"]["cloze"]["cloze"] == []
+
+
 def test_option_sets_are_valid_and_anti_gaming() -> None:
     shards = _build()
     for cloze in shards["A1"]["cloze"]["cloze"]:
@@ -2501,8 +2528,6 @@ def test_live_paronym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
         key = tuple(sorted([a, b]))
         assert key not in seen_pairs, f"Duplicate paronym pair key {key}"
         seen_pairs.add(key)
-
-
 def test_antonym_pairs_emit_items_both_directions_and_validate(capsys: pytest.CaptureFixture[str]) -> None:
     entries = [
         {"lemmaId": "день", "lemma": "день", "gloss": "day", "pos": "noun", "cefr": "A1", "url_slug": "день", "primary_source": "course_vocab", "course_usage": [{"track": "a1"}]},
@@ -2591,5 +2616,3 @@ def test_live_antonym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
         key = tuple(sorted([a, b]))
         assert key not in seen_pairs, f"Duplicate antonym pair key {key}"
         seen_pairs.add(key)
-
-


### PR DESCRIPTION
Closes #6143. Parent #6132. Epic #4387. CEFR remains nullable guidance: missing CEFR recognition items stay eligible, while sorting prefers known learner-level matches. Cloze and VESUM quality gates are unchanged. Verification: 125 focused Python tests passed; Ruff, TypeScript, parser, diff, OPSEC, and agent-trailer checks passed. Full site tests require unavailable Astro/Vitest dependencies; full repository pytest is blocked by the sparse checkout missing curriculum.