### PR TITLE
fix(foundry): fail closed without heritage evidence

### DIFF
--- a/scripts/projects/open_model_data/language_contact_detector.py
+++ b/scripts/projects/open_model_data/language_contact_detector.py
@@ -1206,6 +1206,13 @@ def run_detector_on_text(
     owns_runtime = runtime is None
     active_runtime = runtime or EvidenceRuntime(active_config, input_root)
     try:
+        # Heritage evidence is a required part of the detector's conservative
+        # classification stack.  Recording it as unavailable while continuing
+        # with morphology and R2U evidence would turn a degraded evidence
+        # runtime into candidate production, violating the fail-closed
+        # contract exercised by the public API and streaming caller alike.
+        if not active_runtime.heritage_available:
+            return []
         tokens = tokenize_with_offsets(text)
         if not tokens:
             active_runtime.rows_without_prefilter_signal += 1


### PR DESCRIPTION
## Outcome

Restores the completed #6167 fail-closed evidence contract: if the configured heritage evidence adapter is unavailable, record-level language-contact detection emits no candidate instead of continuing with a degraded evidence stack.

Closes #6303

## Scope

- one guard in `run_detector_on_text`
- no schema, fixture, corpus, receipt, configuration, or generated-data change
- unrelated Entire PR #6300 remains unchanged

## Verification

- current `main` reproduces `test_missing_evidence_adapters_fail_closed` standalone
- repair branch: all 30 language-contact detector tests pass
- Ruff passed
- diff integrity passed
- X-Agent trailer passed
- OPSEC: one changed file, zero leaks
