### PR TITLE
fix(security): close CodeQL #343 and zizmor #344

### DIFF
--- a/.github/workflows/entire-kimi-agent.yml
+++ b/.github/workflows/entire-kimi-agent.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.0"

--- a/scripts/api/entire_context_router.py
+++ b/scripts/api/entire_context_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 from pathlib import Path
@@ -24,6 +25,7 @@ from .config import LIVE_REPO_ROOT, PROJECT_ROOT
 from .repository_authority import preparation_data_root
 
 router = APIRouter(tags=["entire-context"])
+logger = logging.getLogger(__name__)
 
 _PROJECTION_COUNT_STATES = ("pending", "promoted", "tombstoned")
 _ACP_HEALTH_NUMBER_FIELDS = ("attempts", "failures", "lag_seconds", "retries")
@@ -251,10 +253,27 @@ def entire_context_search(
             limit=limit,
         )
     except RecallInputError as exc:
+        # Map to a closed set of stable API codes; never return raw exception
+        # text to HTTP clients (CodeQL py/stack-trace-exposure).
+        code = "invalid_request"
+        if exc.args:
+            for candidate in (
+                "query_invalid",
+                "seed_invalid",
+                "locator_id_invalid",
+                "handoff_seed_limit",
+            ):
+                if exc.args[0] == candidate:
+                    code = candidate
+                    break
+            else:
+                logger.exception(
+                    "unexpected RecallInputError in entire-context search"
+                )
         return {
             "schema": "ec-search.v1",
             "available": True,
-            "error": str(exc),
+            "error": code,
             "results": [],
         }
     except (sqlite3.Error, KeyError, TypeError, ValueError):


### PR DESCRIPTION
## Summary
- Close Code Scanning alert [#343](https://github.com/learn-ukrainian/learn-ukrainian.github.io/security/code-scanning/343) (`py/stack-trace-exposure`) by mapping `RecallInputError` to a closed set of API error codes instead of returning exception text from the Entire Context search endpoint.
- Close Code Scanning alert [#344](https://github.com/learn-ukrainian/learn-ukrainian.github.io/security/code-scanning/344) (`zizmor/artipacked`) by setting `persist-credentials: false` on checkout in `.github/workflows/entire-kimi-agent.yml`.

## Test plan
- [x] `pytest tests/test_entire_context_live.py -k "search or Recall or invalid"`
- [ ] CI green
- [ ] Code Scanning alerts auto-close after merge analysis

Stream: devops (#5703)

Made with [Cursor](https://cursor.com)