### PR TITLE
feat(practice): promote miyklas homonym + paronym pairs (#6138, #6137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,6 +285,8 @@ site/public/lexicon/practice-paradigm.*.json
 site/public/lexicon/practice-synonym.*.json
 site/public/lexicon/practice-heritage.*.json
 site/public/lexicon/practice-paronym.*.json
+site/public/lexicon/practice-antonym.*.json
+site/public/lexicon/practice-homonym.*.json
 site/public/api/lexicon/practice-index.*.json
 site/public/api/lexicon/practice-lexemes.*.json
 site/public/api/lexicon/practice-cloze.*.json

--- a/data/lexicon/homonym_pairs.yaml
+++ b/data/lexicon/homonym_pairs.yaml
@@ -1,0 +1,1207 @@
+schema_version: 1
+description: 'Curated homonym pairs for dedicated homonym drills (#6138). Promoted
+  from MiyKlas approved homonym candidates. Fail-closed: unreviewed candidates excluded.'
+pairs:
+- slugA: агент
+  slugB: агент
+  distinction_gloss_uk: «Агент» — уповноважена особа чи розвідник; «агент» — діюча
+    сила чи чинник у природничих/хімічних процесах.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Таємний ___ виконав важливе завдання за кордоном.
+    answer_form: агент
+    confusable_form: агент
+    origin: authored-homonym-frame
+  - sentence_with_slot: Хімічний ___ прискорив реакцію в лабораторній колбі.
+    answer_form: агент
+    confusable_form: агент
+    origin: authored-homonym-frame
+- slugA: акція
+  slugB: акція
+  distinction_gloss_uk: «Акція» — цінний папір, що засвідчує право власності; «акція»
+    — дія, захід або публічний виступ.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Інвестор придбав пакет цінних паперів і кожна ___ зросла в
+      ціні.
+    answer_form: акція
+    confusable_form: акція
+    origin: authored-homonym-frame
+  - sentence_with_slot: Благодійна ___ залучила багато волонтерів та допомоги.
+    answer_form: акція
+    confusable_form: акція
+    origin: authored-homonym-frame
+- slugA: апорт
+  slugB: апорт
+  distinction_gloss_uk: «Апорт» — сорт соковитих яблук; «апорт» — вигук-команда собаці
+    принести кинутий предмет.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На столі лежав соковитий червоний ___ .
+    answer_form: апорт
+    confusable_form: апорт
+    origin: authored-homonym-frame
+  - sentence_with_slot: Дресирувальник вигукнув « ___ !», і пес побіг по палицю.
+    answer_form: Апорт
+    confusable_form: Апорт
+    origin: authored-homonym-frame
+- slugA: атлас
+  slugB: атлас
+  distinction_gloss_uk: «А́тлас» (з наголосом на першому складі) — збірник географічних
+    карт; «атла́с» (з наголосом на другому) — блискуча шовкова тканина.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Учень відкрив географічний ___ України на п'ятій сторінці.
+    answer_form: атлас
+    confusable_form: атлас
+    origin: authored-homonym-frame
+  - sentence_with_slot: Сукня була пошита з гладенького блискучого ___ .
+    answer_form: атласу
+    confusable_form: атласу
+    origin: authored-homonym-frame
+- slugA: баба
+  slugB: баба
+  distinction_gloss_uk: «Баба» — бабуся, літня жінка; «баба» — ударна частина механічного
+    молота або святкова випічка.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Старенька ___ спекла для онуків смачний пиріг.
+    answer_form: баба
+    confusable_form: баба
+    origin: authored-homonym-frame
+  - sentence_with_slot: На Великдень бабуся спекла високу солодку ___ .
+    answer_form: бабу
+    confusable_form: бабу
+    origin: authored-homonym-frame
+- slugA: байка
+  slugB: байка
+  distinction_gloss_uk: «Байка» — коротке алегоричне повчальне оповідання; «байка»
+    — м'яка бавовняна чи вовняна тканина з начесом.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Езоп написав відому ___ про лисицю й виноград.
+    answer_form: байку
+    confusable_form: байку
+    origin: authored-homonym-frame
+  - sentence_with_slot: Тепла сорочка з м'якої ___ чудово зігрівала взимку.
+    answer_form: байки
+    confusable_form: байки
+    origin: authored-homonym-frame
+- slugA: балка
+  slugB: балка
+  distinction_gloss_uk: «Балка» — яр із пологими схилами, вкритий травою; «балка»
+    — опорний будівельний брус із дерева чи металу.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Вівці паслися у глибокій зеленій ___ .
+    answer_form: балці
+    confusable_form: балці
+    origin: authored-homonym-frame
+  - sentence_with_slot: Міцна залізобетонна ___ тримала дах будівлі.
+    answer_form: балка
+    confusable_form: балка
+    origin: authored-homonym-frame
+- slugA: бар
+  slugB: бар
+  distinction_gloss_uk: «Бар» — заклад громадського харчування або стійка; «бар» —
+    позасистемна одиниця вимірювання тиску.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Друзі зустрілися увечері в затишному ___ .
+    answer_form: барі
+    confusable_form: барі
+    origin: authored-homonym-frame
+  - sentence_with_slot: Манометр показав тиск у системі в один ___ .
+    answer_form: бар
+    confusable_form: бар
+    origin: authored-homonym-frame
+- slugA: бокс
+  slugB: бокс
+  distinction_gloss_uk: «Бокс» — вид кулачного спорту; «бокс» — ізольована палата
+    в лікарні або коротка зачіска.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Спортсмен відвідує тренування з класичного ___ .
+    answer_form: боксу
+    confusable_form: боксу
+    origin: authored-homonym-frame
+  - sentence_with_slot: Хворого помістили в окремий медичний ___ .
+    answer_form: бокс
+    confusable_form: бокс
+    origin: authored-homonym-frame
+- slugA: вал
+  slugB: вал
+  distinction_gloss_uk: «Вал» — високий земляний насип або висока хвиля; «вал» — обертова
+    деталь механізму у формі циліндричного бруса.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Навколо фортеці звели захисний земляний ___ .
+    answer_form: вал
+    confusable_form: вал
+    origin: authored-homonym-frame
+  - sentence_with_slot: Колінчастий ___ двигуна обертався дуже швидко.
+    answer_form: вал
+    confusable_form: вал
+    origin: authored-homonym-frame
+- slugA: вибиратися
+  slugB: вибиратися
+  distinction_gloss_uk: «Вибиратися» — знаходити вихід, виходити з труднощів; «вибиратися»
+    — лаштуватися в дорогу чи виїжджати.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Туристи довго намагалися ___ з лісового хаща.
+    answer_form: вибиратися
+    confusable_form: вибиратися
+    origin: authored-homonym-frame
+  - sentence_with_slot: Сім'я почала ___ до моря ще вдосвіта.
+    answer_form: вибиратися
+    confusable_form: вибиратися
+    origin: authored-homonym-frame
+- slugA: вид
+  slugB: вид
+  distinction_gloss_uk: «Вид» — зовнішній вигляд, краєвид або біологічний таксон;
+    «вид» — граматична категорія дієслова (доконаний/недоконаний).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: З вершини гори відкривався чудовий ___ на долину.
+    answer_form: вид
+    confusable_form: вид
+    origin: authored-homonym-frame
+  - sentence_with_slot: Дієслово «прочитати» має доконаний ___ .
+    answer_form: вид
+    confusable_form: вид
+    origin: authored-homonym-frame
+- slugA: глава
+  slugB: глава
+  distinction_gloss_uk: «Глава» — керівник установи, держави чи роду; «глава» — розділ
+    книги чи купол церкви.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На саміті виступив ___ держави.
+    answer_form: глава
+    confusable_form: глава
+    origin: authored-homonym-frame
+  - sentence_with_slot: Друга ___ роману присвячена подіям у Києві.
+    answer_form: глава
+    confusable_form: глава
+    origin: authored-homonym-frame
+- slugA: гранат
+  slugB: гранат
+  distinction_gloss_uk: «Гранат» — південне дерево та соковитий плід з багатьма зернами;
+    «гранат» — дорогоцінний темно-червоний мінерал.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На десерт подали соковитий стиглий ___ .
+    answer_form: гранат
+    confusable_form: гранат
+    origin: authored-homonym-frame
+  - sentence_with_slot: Перстень прикрашав темно-червоний дорогоцінний ___ .
+    answer_form: гранат
+    confusable_form: гранат
+    origin: authored-homonym-frame
+- slugA: графік
+  slugB: графік
+  distinction_gloss_uk: «Гра́фік» — наочне креслення або розклад дій; «графі́к» —
+    художник, який займається графікою.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Потяг курсує за чітким розкладом і черговим ___ .
+    answer_form: графіком
+    confusable_form: графіком
+    origin: authored-homonym-frame
+  - sentence_with_slot: Талановитий ___ створив ілюстрації до нової книги.
+    answer_form: графік
+    confusable_form: графік
+    origin: authored-homonym-frame
+- slugA: грибок
+  slugB: грибок
+  distinction_gloss_uk: «Грибок» — маленький гриб або мікроорганізм; «грибок» — дерев'яне
+    пристосування для штопання шкарпеток.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У вологому приміщенні з'явився пліснявий ___ .
+    answer_form: грибок
+    confusable_form: грибок
+    origin: authored-homonym-frame
+  - sentence_with_slot: Бабуся взяла дерев'яний ___ і почала заштопувати шкарпетку.
+    answer_form: грибок
+    confusable_form: грибок
+    origin: authored-homonym-frame
+- slugA: двір
+  slugB: двір
+  distinction_gloss_uk: «Двір» — подвір'я біля хати чи будинку; «двір» — монарх із
+    родиною та оточенням (царський двір).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Діти гралися у просторому прибудинковому ___ .
+    answer_form: дворі
+    confusable_form: дворі
+    origin: authored-homonym-frame
+  - sentence_with_slot: Королівський ___ зібрався на урочистий бал.
+    answer_form: двір
+    confusable_form: двір
+    origin: authored-homonym-frame
+- slugA: дисципліна
+  slugB: дисципліна
+  distinction_gloss_uk: «Дисципліна» — дотримання порядку й правил; «дисципліна» —
+    окрема галузь науки чи навчальний предмет.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У школі панувала зразкова військова ___ .
+    answer_form: дисципліна
+    confusable_form: дисципліна
+    origin: authored-homonym-frame
+  - sentence_with_slot: Математика є важливою навчальною ___ у школі.
+    answer_form: дисципліною
+    confusable_form: дисципліною
+    origin: authored-homonym-frame
+- slugA: доля
+  slugB: доля
+  distinction_gloss_uk: «Доля» — фатум, життєвий шлях або щастя; «доля» — частина
+    цілого, частка чи пай.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Людина сама творить свою щасливу ___ .
+    answer_form: долю
+    confusable_form: долю
+    origin: authored-homonym-frame
+  - sentence_with_slot: Значна ___ прибутку пішла на благодійність.
+    answer_form: доля
+    confusable_form: доля
+    origin: authored-homonym-frame
+- slugA: емісія
+  slugB: емісія
+  distinction_gloss_uk: «Емісія» — випуск грошових знаків або цінних паперів; «емісія»
+    — випромінювання або викид речовини в навколишнє середовище.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Центральний банк здійснив додаткову ___ грошей.
+    answer_form: емісію
+    confusable_form: емісію
+    origin: authored-homonym-frame
+  - sentence_with_slot: Скорочення ___ парникових газів є метою екологів.
+    answer_form: емісії
+    confusable_form: емісії
+    origin: authored-homonym-frame
+- slugA: жаба
+  slugB: жаба
+  distinction_gloss_uk: «Жаба» — земноводна тварина; «жаба» — пристрій для затискання
+    кабелю чи рейки.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У ставку голосно кумкала зелена ___ .
+    answer_form: жаба
+    confusable_form: жаба
+    origin: authored-homonym-frame
+  - sentence_with_slot: Монтажник використав затискну ___ для фіксації троса.
+    answer_form: жабу
+    confusable_form: жабу
+    origin: authored-homonym-frame
+- slugA: жати
+  slugB: жати
+  distinction_gloss_uk: «Жати» (жну, жнеш) — зрізати колосся хлібних злаків; «жати»
+    (жму, жмеш) — тиснути, стискати чи тиснути в ногах (взуття тисне).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Косарі вийшли в поле ___ пшеницю.
+    answer_form: жати
+    confusable_form: жати
+    origin: authored-homonym-frame
+  - sentence_with_slot: Нові черевики починають сильно ___ у пальцях.
+    answer_form: жати
+    confusable_form: жати
+    origin: authored-homonym-frame
+- slugA: забій
+  slugB: забій
+  distinction_gloss_uk: «Забій» — місце видобутку корисної копалини в шахті; «забій»
+    — пошкодження м'яких тканин тіла від удару.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Шахтарі спустилися в підземний ___ .
+    answer_form: забій
+    confusable_form: забій
+    origin: authored-homonym-frame
+  - sentence_with_slot: Після падіння на коліні залишився болісний ___ .
+    answer_form: забій
+    confusable_form: забій
+    origin: authored-homonym-frame
+- slugA: загін
+  slugB: загін
+  distinction_gloss_uk: «Загін» — військове або спеціальне формування людей; «загін»
+    — обгороджена ділянка для худоби.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Партизанський ___ вирушив на бойове завдання.
+    answer_form: загін
+    confusable_form: загін
+    origin: authored-homonym-frame
+  - sentence_with_slot: Коней загнали на ніч у дерев'яний ___ .
+    answer_form: загін
+    confusable_form: загін
+    origin: authored-homonym-frame
+- slugA: захід
+  slugB: захід
+  distinction_gloss_uk: «Захід» — напрямок стосовно сторін світу (де заходить сонце);
+    «захід» — дія або подія, спрямована на щось.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Сонце повільно сідало на ___ .
+    answer_form: захід
+    confusable_form: захід
+    origin: authored-homonym-frame
+  - sentence_with_slot: Урядовий ___ дав змогу стабілізувати економіку.
+    answer_form: захід
+    confusable_form: захід
+    origin: authored-homonym-frame
+- slugA: карабін
+  slugB: карабін
+  distinction_gloss_uk: «Карабін» — полегшена коротка гвинтівка; «карабін» — металевий
+    сполучний гак із засувкою у альпінізмі.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Мисливець тримав у руках нарізний ___ .
+    answer_form: карабін
+    confusable_form: карабін
+    origin: authored-homonym-frame
+  - sentence_with_slot: Альпініст пристебнув мотузку через надійний сталевий ___ .
+    answer_form: карабін
+    confusable_form: карабін
+    origin: authored-homonym-frame
+- slugA: карбункул
+  slugB: карбункул
+  distinction_gloss_uk: «Карбункул» — гнійне запалення декількох волосяних мішечків;
+    «карбункул» — коштовний камінь червоного кольору (гранат).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Лікар обробив хірургічно небезпечний шкірний ___ .
+    answer_form: карбункул
+    confusable_form: карбункул
+    origin: authored-homonym-frame
+  - sentence_with_slot: Корона королеви сяяла, оскільки її прикрашав червоний ___
+      .
+    answer_form: карбункул
+    confusable_form: карбункул
+    origin: authored-homonym-frame
+- slugA: клуб
+  slugB: клуб
+  distinction_gloss_uk: «Клуб» — організація людей за інтересами або приміщення; «клуб»
+    — округла маса диму чи пилу.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Увечері молодь зібралася в місцевому ___ .
+    answer_form: клубі
+    confusable_form: клубі
+    origin: authored-homonym-frame
+  - sentence_with_slot: З димаря виривався густий чорний ___ диму.
+    answer_form: клуб
+    confusable_form: клуб
+    origin: authored-homonym-frame
+- slugA: коса
+  slugB: коса
+  distinction_gloss_uk: «Коса» — заплетене волосся / сільськогосподарський інструмент
+    / піщана смуга суші у воді.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У дівчини була довга шовковиста ___ .
+    answer_form: коса
+    confusable_form: коса
+    origin: authored-homonym-frame
+  - sentence_with_slot: Гостра металева ___ легко скошувала високу траву.
+    answer_form: коса
+    confusable_form: коса
+    origin: authored-homonym-frame
+- slugA: лава
+  slugB: лава
+  distinction_gloss_uk: «Лава» — ослін для сидіння або шикування людей / очисна виробка
+    в шахті; «лава» — розплавлена вулканічна маса.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Дідусь присів відпочити на дерев'яну ___ .
+    answer_form: лаву
+    confusable_form: лаву
+    origin: authored-homonym-frame
+  - sentence_with_slot: З кратера вулкана виливалася розпечена вогняна ___ .
+    answer_form: лава
+    confusable_form: лава
+    origin: authored-homonym-frame
+- slugA: ласка
+  slugB: ласка
+  distinction_gloss_uk: «Ласка» — вияв доброти, ніжності й прихильності; «ласка» —
+    дрібний хижий ссавець родини куницевих.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Материнська ___ зігріває дитину все життя.
+    answer_form: ласка
+    confusable_form: ласка
+    origin: authored-homonym-frame
+  - sentence_with_slot: Маленький спритний хижак ___ пробіг крізь кущі.
+    answer_form: ласка
+    confusable_form: ласка
+    origin: authored-homonym-frame
+- slugA: лисичка
+  slugB: лисичка
+  distinction_gloss_uk: «Лисичка» — пестлива назва тварини (лисиці); «лисичка» — їстівний
+    жовтий гриб з лійкоподібною шапкою.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Маленька руда ___ змальована в багатьох казках.
+    answer_form: лисичка
+    confusable_form: лисичка
+    origin: authored-homonym-frame
+  - sentence_with_slot: У сосновому лісі ми знайшли смачний їстівний гриб — ___ .
+    answer_form: лисичку
+    confusable_form: лисичку
+    origin: authored-homonym-frame
+- slugA: лютий
+  slugB: лютий
+  distinction_gloss_uk: «Лютий» — другий місяць року; «лютий» — безжалісний, злий
+    або дужий (про мороз/вітер).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Останній місяць зими — це ___ .
+    answer_form: лютий
+    confusable_form: лютий
+    origin: authored-homonym-frame
+  - sentence_with_slot: На вулиці тріщав ___ мороз.
+    answer_form: лютий
+    confusable_form: лютий
+    origin: authored-homonym-frame
+- slugA: магазин
+  slugB: магазин
+  distinction_gloss_uk: «Магазин» — торговельне приміщення для продажу товарів; «магазин»
+    — частина вогнепальної зброї для набоїв.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Мама пішла в продуктовий ___ по хліб.
+    answer_form: магазин
+    confusable_form: магазин
+    origin: authored-homonym-frame
+  - sentence_with_slot: Солдат вставив повний патронами ___ у автомат.
+    answer_form: магазин
+    confusable_form: магазин
+    origin: authored-homonym-frame
+- slugA: мандарин
+  slugB: мандарин
+  distinction_gloss_uk: «Мандарин» — соковитий цитрусовий фрукт; «мандарин» — чиновник
+    у давньому Китаю.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На Новий рік дітям купили солодкий соковитий ___ .
+    answer_form: мандарин
+    confusable_form: мандарин
+    origin: authored-homonym-frame
+  - sentence_with_slot: Знатний китайський ___ мешкав у розкішному палаці.
+    answer_form: мандарин
+    confusable_form: мандарин
+    origin: authored-homonym-frame
+- slugA: мило
+  slugB: мило
+  distinction_gloss_uk: «Мило» — засіб для миття й прання; «мило» — приємно, солодко,
+    приязно (прислівник від «милий»).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Для дезінфекції рук використали запашне ___ .
+    answer_form: мило
+    confusable_form: мило
+    origin: authored-homonym-frame
+  - sentence_with_slot: Дівчина ___ посміхнулася перехожим.
+    answer_form: мило
+    confusable_form: мило
+    origin: authored-homonym-frame
+- slugA: набір
+  slugB: набір
+  distinction_gloss_uk: «Набір» — сукупність предметів / комплект чи прийом людей;
+    «набір» — верстка тексу для друку.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У подарунок купили красивий ___ інструментів.
+    answer_form: набір
+    confusable_form: набір
+    origin: authored-homonym-frame
+  - sentence_with_slot: Комп'ютерний ___ тексту зайняв майже годину.
+    answer_form: набір
+    confusable_form: набір
+    origin: authored-homonym-frame
+- slugA: наліт
+  slugB: наліт
+  distinction_gloss_uk: «Наліт» — раптовий авіаційний чи бандитський напад; «наліт»
+    — тонкий шар осаду чи плівки на поверхні.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Військові відбили ворожий повітряний ___ .
+    answer_form: наліт
+    confusable_form: наліт
+    origin: authored-homonym-frame
+  - sentence_with_slot: На листі яблуні з'явився білий пліснявий ___ .
+    answer_form: наліт
+    confusable_form: наліт
+    origin: authored-homonym-frame
+- slugA: нота
+  slugB: нота
+  distinction_gloss_uk: «Нота» — графічний знак музичного звуку; «нота» — офіційне
+    дипломатичне звернення уряду.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Музикант записав у зошиті нову мелодійну ___ .
+    answer_form: ноту
+    confusable_form: ноту
+    origin: authored-homonym-frame
+  - sentence_with_slot: Посол вручив дипломатичну ___ протесту.
+    answer_form: ноту
+    confusable_form: ноту
+    origin: authored-homonym-frame
+- slugA: образ
+  slugB: образ
+  distinction_gloss_uk: «О́браз» — художнє відображення чи уявлення; «обра́з» — свята
+    ікона.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Поет створив яскравий художній ___ у своєму творі.
+    answer_form: образ
+    confusable_form: образ
+    origin: authored-homonym-frame
+  - sentence_with_slot: У покуті висів старовинний вишитий ___ .
+    answer_form: образ
+    confusable_form: образ
+    origin: authored-homonym-frame
+- slugA: орган
+  slugB: орган
+  distinction_gloss_uk: «О́рган» — частина тіла чи установа; «орга́н» — найбільший
+    клавішно-духовий музичний інструмент.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Серце — це життєво важливий ___ людини.
+    answer_form: орган
+    confusable_form: орган
+    origin: authored-homonym-frame
+  - sentence_with_slot: У соборі зазвучав великий духовий ___ .
+    answer_form: орган
+    confusable_form: орган
+    origin: authored-homonym-frame
+- slugA: орден
+  slugB: орден
+  distinction_gloss_uk: «Орден» — почесна державна нагорода; «орден» — рицарська чи
+    релігійна організація.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Героя нагородили почесним золотим ___ .
+    answer_form: орденом
+    confusable_form: орденом
+    origin: authored-homonym-frame
+  - sentence_with_slot: Лицарський ___ мав власні суворі статути.
+    answer_form: орден
+    confusable_form: орден
+    origin: authored-homonym-frame
+- slugA: оригінал
+  slugB: оригінал
+  distinction_gloss_uk: «Оригінал» — справжній первинний документ (не копія); «оригінал»
+    — дивакувата й неординарна людина.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Нотаріус перевірив справжній ___ документу.
+    answer_form: оригінал
+    confusable_form: оригінал
+    origin: authored-homonym-frame
+  - sentence_with_slot: Цей художник — справжній редкий ___ у колі друзів.
+    answer_form: оригінал
+    confusable_form: оригінал
+    origin: authored-homonym-frame
+- slugA: палата
+  slugB: палата
+  distinction_gloss_uk: «Палата» — кімната для пацієнтів у лікарні; «палата» — підрозділ
+    парламенту чи установа (Торгово-промислова палата).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Хворий відпочивав у світлій лікарняній ___ .
+    answer_form: палаті
+    confusable_form: палаті
+    origin: authored-homonym-frame
+  - sentence_with_slot: Верховна ___ парламенту ухвалила новий закон.
+    answer_form: палата
+    confusable_form: палата
+    origin: authored-homonym-frame
+- slugA: пара
+  slugB: пара
+  distinction_gloss_uk: «Пара» — газоподібний стан води при кипінні; «пара» — дві
+    однорідні речі або двоє людей.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: З носика киплячого чайника йшла густа ___ .
+    answer_form: пара
+    confusable_form: пара
+    origin: authored-homonym-frame
+  - sentence_with_slot: На свято прийшла молода закохана ___ .
+    answer_form: пара
+    confusable_form: пара
+    origin: authored-homonym-frame
+- slugA: партія
+  slugB: партія
+  distinction_gloss_uk: «Партія» — політична організація; «партія» — окрема гра в
+    шахи або частина товару.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Політична ___ презентувала свою передвиборчу програму.
+    answer_form: партія
+    confusable_form: партія
+    origin: authored-homonym-frame
+  - sentence_with_slot: Шахісти розпочали вирішальну ___ турніру.
+    answer_form: партію
+    confusable_form: партію
+    origin: authored-homonym-frame
+- slugA: патрон
+  slugB: патрон
+  distinction_gloss_uk: «Патрон» — боєприпас для стрільби; «патрон» — покровитель,
+    шеф або керівник.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Солдат зарядив бойовий ___ у гвинтівку.
+    answer_form: патрон
+    confusable_form: патрон
+    origin: authored-homonym-frame
+  - sentence_with_slot: Багатий ___ підтримав молодих митців грантом.
+    answer_form: патрон
+    confusable_form: патрон
+    origin: authored-homonym-frame
+- slugA: рація
+  slugB: рація
+  distinction_gloss_uk: «Рація» — пере переносна радіостанція; «рація» — правота,
+    слушність або підстава (мати рацію).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Охоронець використав переносну ___ для зв'язку.
+    answer_form: рацію
+    confusable_form: рацію
+    origin: authored-homonym-frame
+  - sentence_with_slot: У цьому суперечливому питанні ти маєш цілковиту ___ .
+    answer_form: рацію
+    confusable_form: рацію
+    origin: authored-homonym-frame
+- slugA: рейд
+  slugB: рейд
+  distinction_gloss_uk: «Рейд» — військовий чи перевірочний нахід/просув; «рейд» —
+    прибережна частина моря для стоянки кораблів.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Підрозділ здійснив успішний нічний ___ у тил ворога.
+    answer_form: рейд
+    confusable_form: рейд
+    origin: authored-homonym-frame
+  - sentence_with_slot: Кораблі стали на якір на зовнішньому морському ___ .
+    answer_form: рейді
+    confusable_form: рейді
+    origin: authored-homonym-frame
+- slugA: рись
+  slugB: рись
+  distinction_gloss_uk: «Рись» — дикий хижий ссавець із китичками на вухах; «рись»
+    — біг коня (алюр між ходою та галопом).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У карпатському лісі живе плямиста ___ .
+    answer_form: рись
+    confusable_form: рись
+    origin: authored-homonym-frame
+  - sentence_with_slot: Кінь перейшов на швидку й ритмічну ___ .
+    answer_form: рись
+    confusable_form: рись
+    origin: authored-homonym-frame
+- slugA: саджати
+  slugB: саджати
+  distinction_gloss_uk: «Саджати» — вміщувати рослину в ґрунт чи садовити за стіл;
+    «саджати» — закривати у в'язницю чи ставити хліб у піч.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Навесні господарі починають ___ картоплю.
+    answer_form: саджати
+    confusable_form: саджати
+    origin: authored-homonym-frame
+  - sentence_with_slot: За злочини почали ___ правопорушників за ґрати.
+    answer_form: саджати
+    confusable_form: саджати
+    origin: authored-homonym-frame
+- slugA: садити
+  slugB: садити
+  distinction_gloss_uk: «Садити» — саджати рослини в землю; «садити» — допомагати
+    комусь сісти чи поміщати під варту.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Восени рекомендують ___ фруктові дерева.
+    answer_form: садити
+    confusable_form: садити
+    origin: authored-homonym-frame
+  - sentence_with_slot: Мати почала ___ малюка на високий стільчик.
+    answer_form: садити
+    confusable_form: садити
+    origin: authored-homonym-frame
+- slugA: секрет
+  slugB: секрет
+  distinction_gloss_uk: «Секрет» — таємниця, щось приховане; «секрет» — речовина,
+    що виробляється залозами організму.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Подруга довірила мені свій важливий особистий ___ .
+    answer_form: секрет
+    confusable_form: секрет
+    origin: authored-homonym-frame
+  - sentence_with_slot: Шлунковий ___ допомагає травленню їжі.
+    answer_form: секрет
+    confusable_form: секрет
+    origin: authored-homonym-frame
+- slugA: склад
+  slugB: склад
+  distinction_gloss_uk: «Склад» — приміщення для товарів; «склад» — частина слова
+    (фонетична одиниця) чи устрій/структура.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Вантажівка привезла товари на центральний ___ .
+    answer_form: склад
+    confusable_form: склад
+    origin: authored-homonym-frame
+  - sentence_with_slot: Слово «мама» ділиться на два наголошені ___ .
+    answer_form: склади
+    confusable_form: склади
+    origin: authored-homonym-frame
+- slugA: таз
+  slugB: таз
+  distinction_gloss_uk: «Таз» — миска чи посудина для миття; «таз» — частина скелета
+    людини або тварини.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Мама налила теплої води у великий емальований ___ .
+    answer_form: таз
+    confusable_form: таз
+    origin: authored-homonym-frame
+  - sentence_with_slot: Анатомія вивчає будову та кістки людського ___ .
+    answer_form: таза
+    confusable_form: таза
+    origin: authored-homonym-frame
+- slugA: такса
+  slugB: такса
+  distinction_gloss_uk: «Такса» — порода собак із короткими ногами; «такса» — установлений
+    тариф або ціна послуги.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На повідку бігла маленька руда ___ .
+    answer_form: такса
+    confusable_form: такса
+    origin: authored-homonym-frame
+  - sentence_with_slot: За проїзд у таксі діє чітко визначена фіксована ___ .
+    answer_form: такса
+    confusable_form: такса
+    origin: authored-homonym-frame
+- slugA: такт
+  slugB: такт
+  distinction_gloss_uk: «Такт» — відчуття міри й вихованість; «такт» — музична ритмічна
+    одиниця або етап роботи двигуна.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У спілкуванні з людьми потрібен особливий чуйний ___ .
+    answer_form: такт
+    confusable_form: такт
+    origin: authored-homonym-frame
+  - sentence_with_slot: Музиканти почали грати перший ___ вальсу.
+    answer_form: такт
+    confusable_form: такт
+    origin: authored-homonym-frame
+- slugA: термін
+  slugB: термін
+  distinction_gloss_uk: «Те́рмін» — слово із чітким науковим визначенням; «термі́н»
+    — строк або визначений час.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У підручнику пояснюється кожен науковий ___ .
+    answer_form: термін
+    confusable_form: термін
+    origin: authored-homonym-frame
+  - sentence_with_slot: Кінцевий ___ здачі проєкту — наступна п'ятниця.
+    answer_form: термін
+    confusable_form: термін
+    origin: authored-homonym-frame
+- slugA: тур
+  slugB: тур
+  distinction_gloss_uk: «Тур» — вимерлий дикий бик; «тур» — етап, коло змагань або
+    подорож.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У прадавніх лісах колись водився могутній дикий ___ .
+    answer_form: тур
+    confusable_form: тур
+    origin: authored-homonym-frame
+  - sentence_with_slot: Спортсмен пройшов у другий ___ відбіркових змагань.
+    answer_form: тур
+    confusable_form: тур
+    origin: authored-homonym-frame
+- slugA: туш
+  slugB: туш
+  distinction_gloss_uk: «Туш» — фарба для малювання, креслення чи косметики; «туш»
+    — короткий урочистий музичний марш.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Художник малював чертіж використовуючи чорну ___ .
+    answer_form: туш
+    confusable_form: туш
+    origin: authored-homonym-frame
+  - sentence_with_slot: При врученні нагороди оркестр виконав урочистий ___ .
+    answer_form: туш
+    confusable_form: туш
+    origin: authored-homonym-frame
+- slugA: ударник
+  slugB: ударник
+  distinction_gloss_uk: «Ударник» — деталь затвора вогнепальної зброї; «ударник» —
+    музикант, який грає на ударних інструментах.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Металевий ___ розбив капсуль патрона.
+    answer_form: ударник
+    confusable_form: ударник
+    origin: authored-homonym-frame
+  - sentence_with_slot: У рок-гурті талановитий ___ задавав чіткий ритм.
+    answer_form: ударник
+    confusable_form: ударник
+    origin: authored-homonym-frame
+- slugA: утримання
+  slugB: утримання
+  distinction_gloss_uk: «Утримання» — матеріальне або фінансове забезпечення; «утримання»
+    — стриманість або відрахування грошей.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Батьки беруть на себе ___ та догляд дітей.
+    answer_form: утримання
+    confusable_form: утримання
+    origin: authored-homonym-frame
+  - sentence_with_slot: Бухгалтерія здійснила ___ податків із заробітної плати.
+    answer_form: утримання
+    confusable_form: утримання
+    origin: authored-homonym-frame
+- slugA: фаланга
+  slugB: фаланга
+  distinction_gloss_uk: «Фаланга» — трубчаста кістка пальця; «фаланга» — бойовий стрій
+    давньогрецької піхоти.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Лікар оглянув зламану першу ___ вказівного пальця.
+    answer_form: фалангу
+    confusable_form: фалангу
+    origin: authored-homonym-frame
+  - sentence_with_slot: Македонська щільна ___ ви шикувалася на полі бою.
+    answer_form: фаланга
+    confusable_form: фаланга
+    origin: authored-homonym-frame
+- slugA: фокус
+  slugB: фокус
+  distinction_gloss_uk: «Фокус» — точка перетину променів оптичної системи; «фокус»
+    — ілюзія, трюк або витівка.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Фотограф налаштував точний оптичний ___ об'єктива.
+    answer_form: фокус
+    confusable_form: фокус
+    origin: authored-homonym-frame
+  - sentence_with_slot: Ілюзіоніст показав на сцені захопливий картковий ___ .
+    answer_form: фокус
+    confusable_form: фокус
+    origin: authored-homonym-frame
+- slugA: фунт
+  slugB: фунт
+  distinction_gloss_uk: «Фунт» — одиниця маси (~453 г); «фунт» — грошова одиниця Великої
+    Британії (фунт стерлінгів).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Купець зважив на терезах один ___ борошна.
+    answer_form: фунт
+    confusable_form: фунт
+    origin: authored-homonym-frame
+  - sentence_with_slot: Британська валюта називається ___ стерлінгів.
+    answer_form: фунт
+    confusable_form: фунт
+    origin: authored-homonym-frame
+- slugA: храп
+  slugB: храп
+  distinction_gloss_uk: «Храп» — хрипкі звуки уві сні; «храп» — передня частина конячої
+    морди або упряжі.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: З сусідньої кімнати чувся гучний нічний ___ .
+    answer_form: храп
+    confusable_form: храп
+    origin: authored-homonym-frame
+  - sentence_with_slot: Вершник погладив коня по м'якому ніжному ___ .
+    answer_form: храпу
+    confusable_form: храпу
+    origin: authored-homonym-frame
+- slugA: хронограф
+  slugB: хронограф
+  distinction_gloss_uk: «Хронограф» — високоточний секундомір або годинник; «хронограф»
+    — середньовічна історична хроніка.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Суддя засікав час за допомогою точного ___ .
+    answer_form: хронографа
+    confusable_form: хронографа
+    origin: authored-homonym-frame
+  - sentence_with_slot: Історик дослідив давній давньоруський ___ .
+    answer_form: хронограф
+    confusable_form: хронограф
+    origin: authored-homonym-frame
+- slugA: череда
+  slugB: череда
+  distinction_gloss_uk: «Череда» — гурт свійських тварин (корів, овець), що пасуться
+    разом; «череда» — трироздільна лікарська рослина.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Пастух повернув увечері до села велику ___ корів.
+    answer_form: череду
+    confusable_form: череду
+    origin: authored-homonym-frame
+  - sentence_with_slot: Для купання немовлят висушується цілюща ___ .
+    answer_form: череда
+    confusable_form: череда
+    origin: authored-homonym-frame
+- slugA: шах
+  slugB: шах
+  distinction_gloss_uk: «Шах» — монарший титул у країнах Сходу; «шах» — загроза королю
+    в шаховій грі.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Східний монарх мав офіційний титул ___ .
+    answer_form: шах
+    confusable_form: шах
+    origin: authored-homonym-frame
+  - sentence_with_slot: Гравець оголосив супернику незахищений прямий ___ .
+    answer_form: шах
+    confusable_form: шах
+    origin: authored-homonym-frame
+- slugA: штат
+  slugB: штат
+  distinction_gloss_uk: «Штат» — самоуправна адміністративна одиниця держави; «штат»
+    — постійний склад працівників організації.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Каліфорнія — це найбільш густонаселений ___ США.
+    answer_form: штат
+    confusable_form: штат
+    origin: authored-homonym-frame
+  - sentence_with_slot: Директор розширив постійний ___ співробітників компанії.
+    answer_form: штат
+    confusable_form: штат
+    origin: authored-homonym-frame
+- slugA: штучний
+  slugB: штучний
+  distinction_gloss_uk: «Штучний» — зроблений людьми, ненатуральний чи синтетичний;
+    «штучний» — той, що рахується поштучно (окремими екземплярами).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На новорічну ялинку повісили красивий ___ сніг.
+    answer_form: штучний
+    confusable_form: штучний
+    origin: authored-homonym-frame
+  - sentence_with_slot: У магазині продається штучний товар або поштучний ___ товар.
+    answer_form: штучний
+    confusable_form: штучний
+    origin: authored-homonym-frame
+- slugA: як
+  slugB: як
+  distinction_gloss_uk: «Як» — великий тибетський волохатий бык; «як» — питально-відносний
+    прислівник чи сполучник.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У високогір'ї Гімалаїв випасається волохатий тибетський ___
+      .
+    answer_form: як
+    confusable_form: як
+    origin: authored-homonym-frame
+  - sentence_with_slot: 'Учень запитав учителя: « ___ правильно розв''язати задачу?»'
+    answer_form: Як
+    confusable_form: Як
+    origin: authored-homonym-frame
+- slugA: яритися
+  slugB: яритися
+  distinction_gloss_uk: «Яритися» — охоплюватися люттю, гнівом; «яритися» — яскраво
+    сяяти чи палати вогнем.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Ворог починає сильно ___ від поразки.
+    answer_form: яритися
+    confusable_form: яритися
+    origin: authored-homonym-frame
+  - sentence_with_slot: Червоне полум'я багаття продовжує яскраво ___ .
+    answer_form: яритися
+    confusable_form: яритися
+    origin: authored-homonym-frame
+- slugA: яріти
+  slugB: яріти
+  distinction_gloss_uk: «Яріти» — відсвічувати яскраво-червоним світлом / палати;
+    «яріти» — палати пристрастю або люттю.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На заході сонця небо починає глибоко ___ .
+    answer_form: яріти
+    confusable_form: яріти
+    origin: authored-homonym-frame
+  - sentence_with_slot: Очі гнівної людини почали запекло ___ .
+    answer_form: яріти
+    confusable_form: яріти
+    origin: authored-homonym-frame
+- slugA: ячмінь
+  slugB: ячмінь
+  distinction_gloss_uk: «Ячмінь» — злакова сільськогосподарська культура; «ячмінь»
+    — гнійне запалення волосяного мішечка повіки.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На полі дозрівав озимий зерновий ___ .
+    answer_form: ячмінь
+    confusable_form: ячмінь
+    origin: authored-homonym-frame
+  - sentence_with_slot: На верхній повіці ока вискочив болісний ___ .
+    answer_form: ячмінь
+    confusable_form: ячмінь
+    origin: authored-homonym-frame

--- a/data/lexicon/paronym_pairs.yaml
+++ b/data/lexicon/paronym_pairs.yaml
@@ -1,8 +1,7 @@
 schema_version: 1
-description: 'Curated paronym pairs for the §9.9 confusable-pair drill (#4506). 55
-  driver-adjudicated pairs: 20 baseline seeds and 35 promoted ukr-mova approved candidate
-  pairs (#6137). Frames are authored fresh for morpho congruency (anti-gaming §5)
-  and both-direction balance. Learner-facing text is Ukrainian only. distinction_gloss_uk
+description: 'Curated paronym pairs for the §9.9 confusable-pair drill (#4506). 103
+  driver-adjudicated pairs: baseline seeds and promoted miyklas approved candidate
+  pairs (#6138, #6132, #4387). Learner-facing text is Ukrainian only. Distinction_gloss_uk
   is natural Ukrainian. Citations trace to adjudication and source module seeds. Fail-closed:
   curated only, no pool mining.'
 pairs:
@@ -1006,3 +1005,771 @@ pairs:
     answer_form: численні
     confusable_form: чисельні
     origin: authored-grok-build-2026-08-02
+- slugA: абрис
+  slugB: обрис
+  distinction_gloss_uk: Абрис — контурний малюнок чи схематичний нарис; обрис — загальні
+    обриси/контури предмета чи фігури на відстані.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Художник зробив легкий олівцевий ___ майбутньої картини.
+    answer_form: абрис
+    confusable_form: обрис
+    origin: authored-paronym-frame
+  - sentence_with_slot: У темряві вимальовувався чіткий ___ гірського хребта.
+    answer_form: обрис
+    confusable_form: абрис
+    origin: authored-paronym-frame
+- slugA: авторитарний
+  slugB: авторитетний
+  distinction_gloss_uk: Авторитарний — який спирається на диктат і жорстку владу;
+    авторитетний — який має високий авторитет і повагу.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У країні встановився жорсткий ___ режим.
+    answer_form: авторитарний
+    confusable_form: авторитетний
+    origin: authored-paronym-frame
+  - sentence_with_slot: Вчений висловив свою думку як ___ фахівець у галузі.
+    answer_form: авторитетний
+    confusable_form: авторитарний
+    origin: authored-paronym-frame
+- slugA: анотація
+  slugB: нотація
+  distinction_gloss_uk: Анотація — короткий опис змісту книги чи статті; нотація —
+    зауваження, докір або система умовних знаків.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Перед читанням книги корисно переглянути коротку ___ .
+    answer_form: анотацію
+    confusable_form: нотацію
+    origin: authored-paronym-frame
+  - sentence_with_slot: Батько прочитав синові сувору навчальну ___ .
+    answer_form: нотацію
+    confusable_form: анотацію
+    origin: authored-paronym-frame
+- slugA: блискучий
+  slugB: лискучий
+  distinction_gloss_uk: Блискучий — який сяє променями або видатний/талановитий; лискучий
+    — гладенький від тертя або засалений.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Піаніст продемонстрував ___ виступ на концерті.
+    answer_form: блискучий
+    confusable_form: лискучий
+    origin: authored-paronym-frame
+  - sentence_with_slot: На рукавах старої піджака з'явився ___ глянцевий слід.
+    answer_form: лискучий
+    confusable_form: блискучий
+    origin: authored-paronym-frame
+- slugA: блукати
+  slugB: блудити
+  distinction_gloss_uk: Блукати — ходити без чіткого напрямку, мандрувати; блудити
+    — збиватися з правильного шляху чи робити помилки.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Туристи полюбляли ___ вузькими вулицями давнього міста.
+    answer_form: блукати
+    confusable_form: блудити
+    origin: authored-paronym-frame
+  - sentence_with_slot: У густому тумані можна легко ___ й утратити дорогу.
+    answer_form: блудити
+    confusable_form: блукати
+    origin: authored-paronym-frame
+- slugA: будівельник
+  slugB: будівник
+  distinction_gloss_uk: Будівельник — фахівець або робітник у галузі будівництва;
+    будівник — той, хто творить/розбудовує щось (будівник нової держави).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Кваліфікований ___ зводив новий житловий комплекс.
+    answer_form: будівельник
+    confusable_form: будівник
+    origin: authored-paronym-frame
+  - sentence_with_slot: Молодь виступає як патріотичний ___ майбутнього нашої країни.
+    answer_form: будівник
+    confusable_form: будівельник
+    origin: authored-paronym-frame
+- slugA: будівельник
+  slugB: будівничий
+  distinction_gloss_uk: Будівельник — робітник на будівництві; будівничий — зодчий,
+    архітектор чи видатний творець.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Досвідчений ___ керував монтажем залізобетонних конструкцій.
+    answer_form: будівельник
+    confusable_form: будівничий
+    origin: authored-paronym-frame
+  - sentence_with_slot: Видатний ___ спроєктував величний собор у Києві.
+    answer_form: будівничий
+    confusable_form: будівельник
+    origin: authored-paronym-frame
+- slugA: будівник
+  slugB: будівничий
+  distinction_gloss_uk: Будівник — той, хто будує суспільство або споруди; будівничий
+    — зодчий, головний творець або архітектор.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Народ є головним ___ власної незалежної держави.
+    answer_form: будівником
+    confusable_form: будівничим
+    origin: authored-paronym-frame
+  - sentence_with_slot: Славетний ___ створив унікальний архітектурний ансамбль.
+    answer_form: будівничий
+    confusable_form: будівник
+    origin: authored-paronym-frame
+- slugA: бювет
+  slugB: кювет
+  distinction_gloss_uk: Бювет — споруда над мінеральним джерелом; кювет — канава уздовж
+    дороги для стоку води.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Відпочивальники пили цілющу воду біля курортного ___ .
+    answer_form: бювету
+    confusable_form: кювету
+    origin: authored-paronym-frame
+  - sentence_with_slot: Після зливи придорожній ___ повністю заповнився водою.
+    answer_form: кювет
+    confusable_form: бювет
+    origin: authored-paronym-frame
+- slugA: вимисел
+  slugB: домисел
+  distinction_gloss_uk: Вимисел — вигадка, неіснуюча річ; домисел — здогад чи припущення
+    на основі неповних фактів.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Уся ця чутка виявилася суцільним фантастичним ___ .
+    answer_form: вимислом
+    confusable_form: домислом
+    origin: authored-paronym-frame
+  - sentence_with_slot: Версія слідчого спиралася на логічний ___ та факти.
+    answer_form: домисел
+    confusable_form: вимисел
+    origin: authored-paronym-frame
+- slugA: відпуск
+  slugB: відпустка
+  distinction_gloss_uk: Відпуск — відпускання товарів або термічна обробка металу;
+    відпустка — звільнення від роботи на період відпочинку.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Контролер оформив офіційний ___ матеріалів зі складу.
+    answer_form: відпуск
+    confusable_form: відпустку
+    origin: authored-paronym-frame
+  - sentence_with_slot: Улітку робітник іде у щорічну оплачувану ___ .
+    answer_form: відпустку
+    confusable_form: відпуск
+    origin: authored-paronym-frame
+- slugA: віла
+  slugB: вілла
+  distinction_gloss_uk: Віла — міфологічна дунайська/слов'янська русалка; вілла —
+    комфортабельний заміський будинок.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У народній легенді згадується лісова магічна ___ .
+    answer_form: віла
+    confusable_form: вілла
+    origin: authored-paronym-frame
+  - sentence_with_slot: На березі моря була зведена розкішна сучасна ___ .
+    answer_form: вілла
+    confusable_form: віла
+    origin: authored-paronym-frame
+- slugA: віршований
+  slugB: віршовий
+  distinction_gloss_uk: Віршований — написаний у формі вірша (віршований роман); віршовий
+    — стосовний віршування або ритміки (віршовий розмір).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Шевченко написав відомий ___ твір «Катерина».
+    answer_form: віршований
+    confusable_form: віршовий
+    origin: authored-paronym-frame
+  - sentence_with_slot: Поет детально вивчав ямб і хорей як традиційний ___ розмір.
+    answer_form: віршовий
+    confusable_form: віршований
+    origin: authored-paronym-frame
+- slugA: геройський
+  slugB: героїчний
+  distinction_gloss_uk: Геройський — здійснений героєм або властивий йому; героїчний
+    — сповнений героїзму (героїчна доба).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Солдат здійснив ___ вчинок у бою.
+    answer_form: геройський
+    confusable_form: героїчний
+    origin: authored-paronym-frame
+  - sentence_with_slot: В історії країни залишилася ___ доба боротьби за волю.
+    answer_form: героїчна
+    confusable_form: геройська
+    origin: authored-paronym-frame
+- slugA: годівниця
+  slugB: годувальниця
+  distinction_gloss_uk: Годівниця — лоток чи посудина для годування тварин або птахів;
+    годувальниця — жінка, що годує немовля, або джерело прожитку.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Діти повісили на дереві дерев'яну ___ для синичок.
+    answer_form: годівницю
+    confusable_form: годувальницю
+    origin: authored-paronym-frame
+  - sentence_with_slot: Земля-мати є головною хлібодарною ___ народу.
+    answer_form: годувальницею
+    confusable_form: годівницею
+    origin: authored-paronym-frame
+- slugA: група
+  slugB: трупа
+  distinction_gloss_uk: Група — сукупність людей або предметів; трупа — творчий колектив
+    акторів театру чи цирку.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Екскурсійна ___ студентів оглянула виставку в музеї.
+    answer_form: група
+    confusable_form: трупа
+    origin: authored-paronym-frame
+  - sentence_with_slot: Театральна ___ приїхала з гастролями до Києва.
+    answer_form: трупа
+    confusable_form: група
+    origin: authored-paronym-frame
+- slugA: густо
+  slugB: пусто
+  distinction_gloss_uk: Густо — у великій кількості, щільно; пусто — порожньо, незаповнено
+    або безлюдно.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У садку ___ росли червоні й білі троянди.
+    answer_form: густо
+    confusable_form: пусто
+    origin: authored-paronym-frame
+  - sentence_with_slot: Після від'їзду гостей у будинку стало зовсім ___ .
+    answer_form: пусто
+    confusable_form: густо
+    origin: authored-paronym-frame
+- slugA: гірницький
+  slugB: гірничий
+  distinction_gloss_uk: Гірницький — який стосується шахтарів/гірників (гірницька
+    праця); гірничий — стосовний гірничої справи чи промисловості (гірничий інженер).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У шахтарському селищі шанують сувору ___ працю.
+    answer_form: гірницьку
+    confusable_form: гірничу
+    origin: authored-paronym-frame
+  - sentence_with_slot: Студент вступив на ___ факультет політехніки.
+    answer_form: гірничий
+    confusable_form: гірницький
+    origin: authored-paronym-frame
+- slugA: дистанція
+  slugB: інстанція
+  distinction_gloss_uk: Дистанція — відстань між об'єктами або в спорті; інстанція
+    — орган чи щабель у системі управління/суду.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Спортсмен подолав марафонську ___ за дві години.
+    answer_form: дистанцію
+    confusable_form: інстанцію
+    origin: authored-paronym-frame
+  - sentence_with_slot: Вища судова ___ підтвердила правомірність рішення.
+    answer_form: інстанція
+    confusable_form: дистанція
+    origin: authored-paronym-frame
+- slugA: доля
+  slugB: воля
+  distinction_gloss_uk: Доля — життєвий шлях, фатум чи щастя; воля — свобода, незалежність
+    або волевиявлення.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Кожна людина сама відповідає за власну ___ .
+    answer_form: долю
+    confusable_form: волю
+    origin: authored-paronym-frame
+  - sentence_with_slot: Борці за свободу віддали життя за ___ України.
+    answer_form: волю
+    confusable_form: долю
+    origin: authored-paronym-frame
+- slugA: досвідчений
+  slugB: освічений
+  distinction_gloss_uk: Досвідчений — який має великий практичний досвід й майстерність;
+    освічений — який здобув глибокі знання й освіту.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Операцію виконав дуже ___ хірург із багаторічним стажем.
+    answer_form: досвідчений
+    confusable_form: освічений
+    origin: authored-paronym-frame
+  - sentence_with_slot: Він був інтелігентний і високовчений ___ чоловік.
+    answer_form: освічений
+    confusable_form: досвідчений
+    origin: authored-paronym-frame
+- slugA: знаменитий
+  slugB: знаменний
+  distinction_gloss_uk: Знаменитий — славетний, видатний, відомий усім; знаменний
+    — видатний за важливістю, вирішальний або пам'ятний.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У театрі виступив ___ співак із міжнародною славою.
+    answer_form: знаменитий
+    confusable_form: знаменний
+    origin: authored-paronym-frame
+  - sentence_with_slot: День проголошення Незалежності — це ___ день в історії.
+    answer_form: знаменний
+    confusable_form: знаменитий
+    origin: authored-paronym-frame
+- slugA: зять
+  slugB: взять
+  distinction_gloss_uk: Зять — чоловік дочки або сестри; взять — застаріла форма дієслова
+    взяти.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Батьки радо зустріли свого нового ___ .
+    answer_form: зятя
+    confusable_form: взять
+    origin: authored-paronym-frame
+  - sentence_with_slot: Козаки хотіли штурмом ___ фортецю.
+    answer_form: взяти
+    confusable_form: зятя
+    origin: authored-paronym-frame
+- slugA: контингент
+  slugB: континент
+  distinction_gloss_uk: Контингент — сукупність людей або лімітована група; континент
+    — материк, великий масив суші.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Миротворчий ___ миротворців прибув у регіон конфлікту.
+    answer_form: контингент
+    confusable_form: континент
+    origin: authored-paronym-frame
+  - sentence_with_slot: Австралія — це найменший ___ на нашій планеті.
+    answer_form: континент
+    confusable_form: контингент
+    origin: authored-paronym-frame
+- slugA: корифей
+  slugB: орфей
+  distinction_gloss_uk: Корифей — найвидатніший діяч у певній галузі мистецтва чи
+    науки; Орфей — міфічний грецький співак й музикант.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Марко Кропивницький — ___ українського театру.
+    answer_form: корифей
+    confusable_form: Орфей
+    origin: authored-paronym-frame
+  - sentence_with_slot: Легендарний музикант співав так солодко, наче давній ___ .
+    answer_form: Орфей
+    confusable_form: корифей
+    origin: authored-paronym-frame
+- slugA: лепський
+  slugB: кепський
+  distinction_gloss_uk: Лепський — гарний, чудовий, хороший; кепський — поганий, злий
+    чи недобрий.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Майстер виготовив дуже ___ дубовий стіл.
+    answer_form: лепський
+    confusable_form: кепський
+    origin: authored-paronym-frame
+  - sentence_with_slot: Сьогодні у нас дув дуже ___ холодний вітер.
+    answer_form: кепський
+    confusable_form: лепський
+    origin: authored-paronym-frame
+- slugA: особистий
+  slugB: особливий
+  distinction_gloss_uk: Особистий — належний певній особі, приватний (особистий щоденник);
+    особливий — винятковий, специфічний, не такий, як інші.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Секретар зберігає ___ щоденник у таємниці.
+    answer_form: особистий
+    confusable_form: особливий
+    origin: authored-paronym-frame
+  - sentence_with_slot: Цей день має для нашої родини ___ піднесений статус.
+    answer_form: особливий
+    confusable_form: особистий
+    origin: authored-paronym-frame
+- slugA: особистий
+  slugB: особовий
+  distinction_gloss_uk: Особистий — власне персональний (особисті речі); особовий
+    — стосовний особи в офіційно-діловому чи граматичному значеннях (особова справа,
+    особовий займенник).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У потязі необхідно пильнувати власні ___ речі.
+    answer_form: особисті
+    confusable_form: особові
+    origin: authored-paronym-frame
+  - sentence_with_slot: В кадровому відділі лежить моя ___ справа.
+    answer_form: особова
+    confusable_form: особиста
+    origin: authored-paronym-frame
+- slugA: особливий
+  slugB: особовий
+  distinction_gloss_uk: Особливий — винятковий, незвичайний; особовий — стосовний
+    особи у діловодстві чи граматиці (особовий склад).
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Учитель виявив ___ підхід до кожного учня.
+    answer_form: особливий
+    confusable_form: особовий
+    origin: authored-paronym-frame
+  - sentence_with_slot: Командир ви шикував весь ___ склад полку.
+    answer_form: особовий
+    confusable_form: особливий
+    origin: authored-paronym-frame
+- slugA: пам'ятка
+  slugB: пам'ятник
+  distinction_gloss_uk: Пам'ятка — предме давнини, інструкція чи культурний об'єкт;
+    пам'ятник — монументальна споруда/скульптура на честь особи.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Софія Київська — це видатна архітектурна ___ XI століття.
+    answer_form: пам'ятка
+    confusable_form: пам'ятник
+    origin: authored-paronym-frame
+  - sentence_with_slot: На центральній площі міста встановили ___ Тарасові Шевченку.
+    answer_form: пам'ятник
+    confusable_form: пам'ятку
+    origin: authored-paronym-frame
+- slugA: передній
+  slugB: передовий
+  distinction_gloss_uk: Передній — розміщений спереду; передовий — прогресивний, який
+    іде попереду інших у розвитку.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Водій відчинив ___ двері автомобіля.
+    answer_form: передні
+    confusable_form: передові
+    origin: authored-paronym-frame
+  - sentence_with_slot: Підприємство впроваджує ___ новітні технології.
+    answer_form: передові
+    confusable_form: передні
+    origin: authored-paronym-frame
+- slugA: плутати
+  slugB: путати
+  distinction_gloss_uk: Плутати — змішувати, робити неясним або помилятися; путати
+    — зв'язувати ноги коням путами.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Не варто ___ близькі за звучанням пароніми.
+    answer_form: плутати
+    confusable_form: путати
+    origin: authored-paronym-frame
+  - sentence_with_slot: Пастух почав ___ коней перед випасом на ніч.
+    answer_form: путати
+    confusable_form: плутати
+    origin: authored-paronym-frame
+- slugA: повноваження
+  slugB: уповноваження
+  distinction_gloss_uk: Повноваження — коло офіційних прав, наданих посадовій особі;
+    уповноваження — дія з надання комусь певних прав.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Президент виконує свої конституційні ___ .
+    answer_form: повноваження
+    confusable_form: уповноваження
+    origin: authored-paronym-frame
+  - sentence_with_slot: Для підписання угоди потрібне офіційне ___ міністерства.
+    answer_form: уповноваження
+    confusable_form: повноваження
+    origin: authored-paronym-frame
+- slugA: постановка
+  slugB: установка
+  distinction_gloss_uk: Постановка — вистава/фільм чи формулювання питання; установка
+    — монтаж пристрою чи життєвий орієнтир/налаштування.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Нова театральна ___ мала величезний успіх.
+    answer_form: постановка
+    confusable_form: установка
+    origin: authored-paronym-frame
+  - sentence_with_slot: На заводі завершилася ___ нового обладнання.
+    answer_form: установка
+    confusable_form: постановка
+    origin: authored-paronym-frame
+- slugA: привид
+  slugB: привід
+  distinction_gloss_uk: Привид — мара, фантом, фантастична постать; привід — підстава
+    для дій чи технічний важіль.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: У старому замку, за переказами, живе ___ .
+    answer_form: привид
+    confusable_form: привід
+    origin: authored-paronym-frame
+  - sentence_with_slot: Відсутність новин стала причиною та ___ для хвилювання.
+    answer_form: приводом
+    confusable_form: привидом
+    origin: authored-paronym-frame
+- slugA: програмний
+  slugB: програмований
+  distinction_gloss_uk: Програмний — який є основою програми чи концепції; програмований
+    — виконуваний за заздалегідь розробленим алгоритмом.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Лідер партії виголосив ___ виступ перед виборцями.
+    answer_form: програмний
+    confusable_form: програмований
+    origin: authored-paronym-frame
+  - sentence_with_slot: Сучасне промислове обладнання є цифровим і ___ .
+    answer_form: програмованим
+    confusable_form: програмним
+    origin: authored-paronym-frame
+- slugA: програмний
+  slugB: програмовий
+  distinction_gloss_uk: Програмний — засадничий, концептуальний; програмовий — включений
+    у навчальну чи концертну програму.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Цей документ містить важливі ___ засади реформи.
+    answer_form: програмні
+    confusable_form: програмові
+    origin: authored-paronym-frame
+  - sentence_with_slot: Учні прочитали весь ___ літературний матеріал.
+    answer_form: програмовий
+    confusable_form: програмний
+    origin: authored-paronym-frame
+- slugA: програмовий
+  slugB: програмований
+  distinction_gloss_uk: Програмовий — що належить до затвердженої програми навчання;
+    програмований — керований комп'ютерною програмою.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Учні опрацювали ___ роман Панаса Мирного.
+    answer_form: програмовий
+    confusable_form: програмований
+    origin: authored-paronym-frame
+  - sentence_with_slot: Робот-пилосос виконує ___ маршрут прибирання.
+    answer_form: програмований
+    confusable_form: програмовий
+    origin: authored-paronym-frame
+- slugA: прогресивний
+  slugB: регресивний
+  distinction_gloss_uk: Прогресивний — передовий, який розвивається вгору; регресивний
+    — зворотно спрямований, який веде до занепаду.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Країна впроваджує ___ економічні реформи.
+    answer_form: прогресивні
+    confusable_form: регресивні
+    origin: authored-paronym-frame
+  - sentence_with_slot: Занепад виробництва продемонстрував ___ рух.
+    answer_form: регресивний
+    confusable_form: прогресивний
+    origin: authored-paronym-frame
+- slugA: свідоцтво
+  slugB: свідчення
+  distinction_gloss_uk: Свідоцтво — офіційний документ факт/прав; свідчення — показання
+    свідка в суді чи доказ.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Випускник отримав офіційне ___ про повну середню освіту.
+    answer_form: свідоцтво
+    confusable_form: свідчення
+    origin: authored-paronym-frame
+  - sentence_with_slot: Свідок дав правдиві ___ під час судового засідання.
+    answer_form: свідчення
+    confusable_form: свідоцтво
+    origin: authored-paronym-frame
+- slugA: сердешний
+  slugB: серцевий
+  distinction_gloss_uk: Сердешний — бідолашний, який викликає співчуття; серцевий
+    — який стосується серця чи щирий.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Ох і натерпівся ___ чоловік у скруті!
+    answer_form: сердешний
+    confusable_form: серцевий
+    origin: authored-paronym-frame
+  - sentence_with_slot: Лікар діагностував у пацієнта раптовий ___ напад.
+    answer_form: серцевий
+    confusable_form: сердешний
+    origin: authored-paronym-frame
+- slugA: спілка
+  slugB: сопілка
+  distinction_gloss_uk: Спілка — об'єднання людей чи організація; сопілка — народний
+    духовий музичний інструмент.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Письменники утворили творчу професійну ___ .
+    answer_form: спілку
+    confusable_form: сопілку
+    origin: authored-paronym-frame
+  - sentence_with_slot: Музикант ніжно заграв на дерев'яній ___ .
+    answer_form: сопілці
+    confusable_form: спілці
+    origin: authored-paronym-frame
+- slugA: степінь
+  slugB: ступінь
+  distinction_gloss_uk: Степінь — математична категорія (піднесення до степеня); ступінь
+    — рівень, етап розвитку, звання чи градус.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: На уроці алгебри учні підносили число до другого ___ .
+    answer_form: степеня
+    confusable_form: ' ступеня'
+    origin: authored-paronym-frame
+  - sentence_with_slot: Вчений здобув науковий ___ доктора наук.
+    answer_form: ступінь
+    confusable_form: степінь
+    origin: authored-paronym-frame
+- slugA: тактичний
+  slugB: тактовний
+  distinction_gloss_uk: Тактичний — який стосується тактики бою чи плану дій; тактовний
+    — вежливий, який володіє почуттям міри.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Командир розробив грамотний ___ хід у бою.
+    answer_form: тактичний
+    confusable_form: тактовний
+    origin: authored-paronym-frame
+  - sentence_with_slot: Дипломат зробив дуже ___ і ввічливий жест.
+    answer_form: тактовний
+    confusable_form: тактичний
+    origin: authored-paronym-frame
+- slugA: талан
+  slugB: талант
+  distinction_gloss_uk: Талан — доля, фатум або щастя; талант — вроджені обдарування
+    й здібності.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Ех, не випав йому щасливий ___ у житті!
+    answer_form: талан
+    confusable_form: талант
+    origin: authored-paronym-frame
+  - sentence_with_slot: Художник мав винятковий малярський ___ .
+    answer_form: талант
+    confusable_form: талан
+    origin: authored-paronym-frame
+- slugA: тарас
+  slugB: півтораста
+  distinction_gloss_uk: Тарас — чоловіче власне ім'я; півтораста — числівник, що означає
+    150.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Великий український Кобзар — це ___ Шевченко.
+    answer_form: Тарас
+    confusable_form: півтораста
+    origin: authored-paronym-frame
+  - sentence_with_slot: На зібрання прибуло майже ___ делегатів.
+    answer_form: півтораста
+    confusable_form: Тарас
+    origin: authored-paronym-frame
+- slugA: іммігрант
+  slugB: емігрант
+  distinction_gloss_uk: Іммігрант — іноземець, який в'їхав у країну на постійне проживання;
+    емігрант — особа, яка виїхала зі своєї країни.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Країна прийняла новоприбулого ___ з Європи.
+    answer_form: іммігранта
+    confusable_form: емігранта
+    origin: authored-paronym-frame
+  - sentence_with_slot: Український ___ сумував за батьківщиною за кордоном.
+    answer_form: емігрант
+    confusable_form: іммігрант
+    origin: authored-paronym-frame
+- slugA: їда
+  slugB: їжа
+  distinction_gloss_uk: Їда — процес прийому харчів; їжа — самі харчі, страви.
+  citations:
+  - miyklas.com.ua
+  curator: miyklas-reviewed
+  frames:
+  - sentence_with_slot: Під час ___ не слід розмовляти за столом.
+    answer_form: їди
+    confusable_form: їжі
+    origin: authored-paronym-frame
+  - sentence_with_slot: На обід була приготована корисна й смачна ___ .
+    answer_form: їжа
+    confusable_form: їда
+    origin: authored-paronym-frame

--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -54,6 +54,7 @@ PRACTICE_MODES = {
     "classify",
     "paronym",
     "antonym",
+    "homonym",
 }
 EXPECTED_SCHEMAS = {
     "index": "atlas-practice-index",
@@ -66,6 +67,7 @@ EXPECTED_SCHEMAS = {
     "heritage": "atlas-practice-heritage",
     "paronym": "atlas-practice-paronym",
     "antonym": "atlas-practice-antonym",
+    "homonym": "atlas-practice-homonym",
 }
 MODE_BODY_KEYS = {
     "cloze": "cloze",
@@ -76,8 +78,9 @@ MODE_BODY_KEYS = {
     "heritage": "heritage",
     "paronym": "paronym",
     "antonym": "antonym",
+    "homonym": "homonym",
 }
-DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym")
+DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym", "homonym")
 MODE_SHARD_KINDS = ("cloze", *DRILL_MODES)
 COVERAGE_MODES = MODE_SHARD_KINDS
 

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -55,6 +55,7 @@ DEFAULT_END_DICTIONARY_INVENTORY = Path("data/lexicon/textbook-end-dictionaries/
 DEFAULT_HERITAGE_PAIRS = Path("data/lexicon/heritage_pairs.yaml")
 DEFAULT_PARONYM_PAIRS = Path("data/lexicon/paronym_pairs.yaml")
 DEFAULT_ANTONYM_PAIRS = Path("data/lexicon/antonym_pairs.yaml")
+DEFAULT_HOMONYM_PAIRS = Path("data/lexicon/homonym_pairs.yaml")
 DEFAULT_SYNONYM_VERDICTS = Path("data/lexicon/synonym_pair_verdicts.yaml")
 # Keep the default above the current all-eligible deck size. A lower default
 # silently contracts the committed practice surface during routine cloze regen.
@@ -75,7 +76,7 @@ PUBLISHED_LEVELS = ("A1", "A2", "B1", "B2", "C1")
 # five-shard transport contract stable by carrying admitted, unlevelled
 # recognition lexemes in the first shard; the lexeme/index field remains null.
 UNKNOWN_CEFR_TRANSPORT_LEVEL = PUBLISHED_LEVELS[0]
-DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym")
+DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym", "homonym")
 MODE_SHARD_KEYS = ("cloze", *DRILL_MODES)
 MODE_SCHEMAS = {
     "cloze": "atlas-practice-cloze",
@@ -86,6 +87,7 @@ MODE_SCHEMAS = {
     "heritage": "atlas-practice-heritage",
     "paronym": "atlas-practice-paronym",
     "antonym": "atlas-practice-antonym",
+    "homonym": "atlas-practice-homonym",
 }
 MODE_BODY_KEYS = {
     "cloze": "cloze",
@@ -96,6 +98,7 @@ MODE_BODY_KEYS = {
     "heritage": "heritage",
     "paronym": "paronym",
     "antonym": "antonym",
+    "homonym": "homonym",
 }
 THIN_WARN_THRESHOLDS = {
     "cloze": 0.10,
@@ -103,6 +106,7 @@ THIN_WARN_THRESHOLDS = {
     "heritage": 0.01,
     "paronym": 0.01,
     "antonym": 0.01,
+    "homonym": 0.01,
 }
 MEANING_MC_MAX_WORDS = 4
 MEANING_MC_MAX_CHARS = 32
@@ -3223,6 +3227,158 @@ def validate_antonym_item(item: dict[str, Any], *, internal_options: bool = Fals
     return errors
 
 
+def _strip_homonym_option_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    stripped = {**item}
+    stripped["options"] = [
+        {"label": str(option.get("label") or "")}
+        for option in item.get("options", [])
+        if isinstance(option, dict)
+    ]
+    return stripped
+
+
+def _build_homonym_items(
+    pair: dict[str, Any],
+    lex_a: dict[str, Any],
+    lex_b: dict[str, Any],
+    deck_version: str,
+    *,
+    verifier: VesumVerifier | None = None,
+    public_options: bool = True,
+) -> list[dict[str, Any]]:
+    frames = _valid_homonym_frames(pair)
+    if not frames:
+        return []
+    distinction = _clean_text(pair.get("distinction_gloss_uk")) or ""
+    citations = _clean_text_list(pair.get("citations"))
+    if not citations:
+        return []
+    items: list[dict[str, Any]] = []
+    lex_by_lemma = {
+        _clean_text(lex_a.get("lemma")): lex_a,
+        _clean_text(lex_b.get("lemma")): lex_b,
+    }
+    slugs = (_clean_text(pair.get("slugA")), _clean_text(pair.get("slugB")))
+    for index, frame in enumerate(frames, start=1):
+        sentence = _clean_text(frame.get("sentence_with_slot"))
+        answer_form = _clean_text(frame.get("answer_form"))
+        confusable_form = _clean_text(frame.get("confusable_form"))
+        origin = _clean_text(frame.get("origin"))
+        if not all((sentence, answer_form, confusable_form, origin)):
+            print(
+                f"WARN: homonym_pair {slugs} frame {index} dropped: missing required field",
+                file=sys.stderr,
+            )
+            continue
+        target_lex: dict[str, Any] | None = None
+        ans_matches: list[dict[str, Any]] = []
+        if verifier:
+            try:
+                vres = verifier.verify_words([answer_form])
+                ans_matches = vres.get(answer_form, []) or []
+            except Exception:
+                ans_matches = []
+        if ans_matches:
+            ans_lemma = _clean_text(ans_matches[0].get("lemma"))
+            if ans_lemma and ans_lemma in lex_by_lemma:
+                target_lex = lex_by_lemma[ans_lemma]
+        if target_lex is None:
+            for cand in (lex_a, lex_b):
+                if _clean_text(cand.get("lemma")) and answer_form.lower().startswith(_clean_text(cand.get("lemma")).lower()[:3]):
+                    target_lex = cand
+                    break
+        if target_lex is None:
+            print(
+                f"WARN: homonym_pair {slugs} frame {index} dropped: could not resolve lemma for answer_form {answer_form!r}",
+                file=sys.stderr,
+            )
+            continue
+        key = "\x1f".join((deck_version, target_lex["lemmaId"], sentence, answer_form, confusable_form))
+        homonym_id = "hom_" + hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+        options = [
+            {"label": answer_form, "kind": "answer", "lemmaId": target_lex["lemmaId"]},
+            {"label": confusable_form, "kind": "confusable"},
+        ]
+        item: dict[str, Any] = {
+            "homonymId": homonym_id,
+            "lemmaId": target_lex["lemmaId"],
+            "srsKey": f"{target_lex['lemmaId']}::homonym",
+            "lemma": target_lex.get("lemma"),
+            "confusable": confusable_form,
+            "frameIndex": index,
+            "cefr": target_lex.get("cefr") or "B1",
+            "prompt": sentence,
+            "answer": answer_form,
+            "options": options,
+            "distinction_gloss_uk": distinction,
+            "citations": citations,
+            "origin": origin,
+        }
+        if prompt_en := _curated_prompt_en(frame):
+            item["promptEn"] = prompt_en
+        items.append(_strip_homonym_option_metadata(item) if public_options else item)
+    return items
+
+
+def validate_homonym_pair(pair: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in ("slugA", "slugB", "distinction_gloss_uk"):
+        if not _clean_text(pair.get(field)):
+            errors.append(f"homonym_pair missing {field}")
+    frames = pair.get("frames")
+    if not isinstance(frames, list) or not frames:
+        errors.append("homonym_pair frames must be a nonempty list")
+    citations = pair.get("citations")
+    if not isinstance(citations, list) or not citations:
+        errors.append("homonym_pair citations must be a nonempty list")
+    return errors
+
+
+def _homonym_frame_errors(frame: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(frame, dict):
+        return ["homonym_pair frame must be an object"]
+    sentence = _clean_text(frame.get("sentence_with_slot"))
+    if not sentence:
+        errors.append("homonym_pair frame missing sentence_with_slot")
+    elif sentence.count("___") != 1:
+        errors.append("homonym_pair frame sentence_with_slot must contain exactly one ___ slot")
+    for field in ("answer_form", "confusable_form", "origin"):
+        if not _clean_text(frame.get(field)):
+            errors.append(f"homonym_pair frame missing {field}")
+    return errors
+
+
+def _valid_homonym_frames(pair: dict[str, Any]) -> list[dict[str, Any]]:
+    frames = pair.get("frames")
+    if not isinstance(frames, list):
+        return []
+    return [frame for frame in frames if isinstance(frame, dict) and not _homonym_frame_errors(frame)]
+
+
+def validate_homonym_item(item: dict[str, Any], *, internal_options: bool = False) -> list[str]:
+    errors: list[str] = []
+    for field in ("homonymId", "lemmaId", "srsKey", "prompt", "answer", "confusable", "distinction_gloss_uk"):
+        if not _clean_text(item.get(field)):
+            errors.append(f"homonym item missing {field}")
+    prompt = _clean_text(item.get("prompt"))
+    if prompt and prompt.count("___") != 1:
+        errors.append("homonym prompt must contain exactly one ___ slot")
+    citations = item.get("citations")
+    if not _clean_text_list(citations):
+        errors.append("homonym citations must be a nonempty list")
+    options = item.get("options")
+    if not isinstance(options, list) or len(options) < 2:
+        errors.append("homonym option set must contain at least two options (answer + confusable)")
+    if not internal_options:
+        for option in (options or []):
+            if isinstance(option, dict):
+                leaked = sorted(set(option.keys()) - {"label"})
+                if leaked:
+                    errors.append(f"homonym public option must contain only label (leaked {leaked})")
+    return errors
+
+
 def validate_mode_items(mode: str, items: list[dict[str, Any]]) -> list[str]:
     errors: list[str] = []
     if mode == "classify":
@@ -3244,6 +3400,9 @@ def validate_mode_items(mode: str, items: list[dict[str, Any]]) -> list[str]:
     elif mode == "antonym":
         for index, item in enumerate(items):
             errors.extend(f"antonym[{index}]: {error}" for error in validate_antonym_item(item))
+    elif mode == "homonym":
+        for index, item in enumerate(items):
+            errors.extend(f"homonym[{index}]: {error}" for error in validate_homonym_item(item))
     return errors
 
 
@@ -3392,6 +3551,7 @@ def _practice_priority_keys(
     paronym_pairs: list[dict[str, Any]] | None,
     synonym_verdicts: dict[str, Any] | None,
     antonym_pairs: list[dict[str, Any]] | None = None,
+    homonym_pairs: list[dict[str, Any]] | None = None,
 ) -> set[str]:
     """Keep source-backed thin-mode legs ahead of ordinary fill lexemes.
 
@@ -3418,6 +3578,9 @@ def _practice_priority_keys(
     for pair in antonym_pairs or []:
         add(pair.get("slugA"))
         add(pair.get("slugB"))
+    for pair in homonym_pairs or []:
+        add(pair.get("slugA"))
+        add(pair.get("slugB"))
     for pair in (synonym_verdicts or {}).get("approved", []):
         if isinstance(pair, dict):
             add(pair.get("a"))
@@ -3436,6 +3599,7 @@ def build_practice_shards(
     synonym_verdicts: dict[str, Any] | None = None,
     end_dictionary_stress: dict[str, dict[str, str]] | None = None,
     antonym_pairs: list[dict[str, Any]] | None = None,
+    homonym_pairs: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, dict[str, Any]]]:
     if isinstance(cloze_sources, BuildConfig) and config is None:
         config = cloze_sources
@@ -3468,11 +3632,12 @@ def build_practice_shards(
         cloze_sources,
         SCHEMA_VERSION,
         antonym_pairs=antonym_pairs,
+        homonym_pairs=homonym_pairs,
     )
     # Seed from the DATA-ONLY fingerprint, not deck_version: builder-version
     # bumps mint new asset names but must not reshuffle seeded content.
     inputs_fingerprint = compute_deck_inputs_fingerprint(
-        entries, heritage_pairs, paronym_pairs, synonym_verdicts, cloze_sources, SCHEMA_VERSION, antonym_pairs=antonym_pairs
+        entries, heritage_pairs, paronym_pairs, synonym_verdicts, cloze_sources, SCHEMA_VERSION, antonym_pairs=antonym_pairs, homonym_pairs=homonym_pairs
     )
     rng_seed = int(hashlib.sha256(inputs_fingerprint.encode("utf-8")).hexdigest()[:16], 16)
     rng = random.Random(rng_seed)
@@ -3483,6 +3648,7 @@ def build_practice_shards(
         paronym_pairs,
         synonym_verdicts,
         antonym_pairs=antonym_pairs,
+        homonym_pairs=homonym_pairs,
     )
     lexemes_by_entry, all_lexemes, by_plain_lemma, lexemes_by_id = _select_practice_lexemes(
         entries,
@@ -3763,6 +3929,66 @@ def build_practice_shards(
     if antonym_frame_debt:
         print(
             f"antonym frame coverage: {antonym_frame_debt} records without frames — emitted 0 items for them",
+            file=sys.stderr,
+        )
+
+    homonym_frame_debt = 0
+    for index, pair in enumerate(homonym_pairs or []):
+        pair_errors = validate_homonym_pair(pair)
+        if pair_errors:
+            print(
+                f"WARN: homonym_pair[{index}] dropped: {'; '.join(pair_errors)}",
+                file=sys.stderr,
+            )
+            continue
+        frames = _valid_homonym_frames(pair)
+        if not frames:
+            homonym_frame_debt += 1
+            continue
+        slug_a = _clean_text(pair.get("slugA"))
+        slug_b = _clean_text(pair.get("slugB"))
+        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a)
+        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b)
+        if not lex_a or not lex_b:
+            print(
+                f"WARN: homonym_pair[{index}] {slug_a}/{slug_b} not in practice lexemes; emitted 0 items",
+                file=sys.stderr,
+            )
+            continue
+        for item in _build_homonym_items(
+            pair,
+            lex_a,
+            lex_b,
+            deck_version,
+            verifier=verifier,
+            public_options=False,
+        ):
+            level = _normalize_cefr(item.get("cefr")) or "B1"
+            if level not in mode_by_level:
+                print(
+                    f"WARN: homonym_pair[{index}] unavailable CEFR level {level!r}; emitted 0 items",
+                    file=sys.stderr,
+                )
+                continue
+            item_errors = validate_homonym_item(item, internal_options=True)
+            if item_errors:
+                print(
+                    f"WARN: homonym_pair[{index}] item dropped: {'; '.join(item_errors)}",
+                    file=sys.stderr,
+                )
+                continue
+            public_item = _strip_homonym_option_metadata(item)
+            public_errors = validate_homonym_item(public_item)
+            if public_errors:
+                print(
+                    f"WARN: homonym_pair[{index}] item dropped: {'; '.join(public_errors)}",
+                    file=sys.stderr,
+                )
+                continue
+            mode_by_level[level]["homonym"].append(public_item)
+    if homonym_frame_debt:
+        print(
+            f"homonym frame coverage: {homonym_frame_debt} records without frames — emitted 0 items for them",
             file=sys.stderr,
         )
 
@@ -4251,6 +4477,22 @@ def read_antonym_pairs(path: Path | None) -> list[dict[str, Any]]:
     return rows
 
 
+def read_homonym_pairs(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        print("WARN: no curated homonym pairs found; emitting empty homonym deck", file=sys.stderr)
+        return []
+    import yaml
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    pairs = payload.get("pairs") if isinstance(payload, dict) else payload
+    if not isinstance(pairs, list):
+        raise ValueError("homonym pairs must be a list or an object with pairs list")
+    rows = [row for row in pairs if isinstance(row, dict)]
+    if not rows:
+        print("WARN: curated homonym pairs empty; emitting empty homonym deck", file=sys.stderr)
+    return rows
+
+
 def read_synonym_verdicts(path: Path | None) -> dict[str, Any] | None:
     if path is None or not path.exists():
         print("WARN: synonym verdicts file not found; emitting no synonym items", file=sys.stderr)
@@ -4327,6 +4569,9 @@ def run_broken_validator_fixtures() -> int:
         ),
         "paronym_pair": validate_paronym_pair(
             {"slugA": "адресант", "slugB": "адресат", "frames": [], "citations": []}
+        ),
+        "homonym_pair": validate_homonym_pair(
+            {"slugA": "байка", "slugB": "байка", "frames": [], "citations": []}
         ),
     }
     print("Broken validator fixtures:")
@@ -4764,6 +5009,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS)
+    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
     parser.add_argument(
         "--curated-membership",
@@ -4839,6 +5085,7 @@ def main(argv: list[str] | None = None) -> int:
     heritage_pairs = read_heritage_pairs(args.heritage_pairs)
     paronym_pairs = read_paronym_pairs(args.paronym_pairs)
     antonym_pairs = read_antonym_pairs(args.antonym_pairs)
+    homonym_pairs = read_homonym_pairs(args.homonym_pairs)
     synonym_verdicts = read_synonym_verdicts(args.synonym_verdicts)
     end_dictionary_stress = read_end_dictionary_stress_overlay(args.end_dictionary_inventory)
     end_payload: dict[str, Any] | None = None
@@ -4897,6 +5144,7 @@ def main(argv: list[str] | None = None) -> int:
         synonym_verdicts=synonym_verdicts,
         end_dictionary_stress=end_dictionary_stress or None,
         antonym_pairs=antonym_pairs,
+        homonym_pairs=homonym_pairs,
     )
     if end_payload is not None:
         practice_by_level: dict[str, set[str]] = {}

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -35,7 +35,7 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 15  # 14→15: antonym practice drill mode (#6139)
+PRACTICE_DECK_BUILDER_VERSION = 16  # 15→16: homonym practice drill mode (#6138)
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "
@@ -59,6 +59,7 @@ def compute_deck_inputs_fingerprint(
     cloze_sources: list[dict[str, Any]] | None,
     schema_version: int,
     antonym_pairs: list[dict[str, Any]] | None = None,
+    homonym_pairs: list[dict[str, Any]] | None = None,
 ) -> str:
     """Canonical hash of the deck DATA inputs only (no builder version).
 
@@ -73,6 +74,7 @@ def compute_deck_inputs_fingerprint(
         "heritage_pairs": heritage_pairs or [],
         "paronym_pairs": paronym_pairs or [],
         "antonym_pairs": antonym_pairs or [],
+        "homonym_pairs": homonym_pairs or [],
         "synonym_verdicts": synonym_verdicts or {},
         "cloze_sources": cloze_sources or [],
     }
@@ -88,6 +90,7 @@ def compute_deck_version(
     cloze_sources: list[dict[str, Any]] | None,
     schema_version: int,
     antonym_pairs: list[dict[str, Any]] | None = None,
+    homonym_pairs: list[dict[str, Any]] | None = None,
 ) -> str:
     payload = {
         "builder_version": PRACTICE_DECK_BUILDER_VERSION,
@@ -96,6 +99,7 @@ def compute_deck_version(
         "heritage_pairs": heritage_pairs or [],
         "paronym_pairs": paronym_pairs or [],
         "antonym_pairs": antonym_pairs or [],
+        "homonym_pairs": homonym_pairs or [],
         "synonym_verdicts": synonym_verdicts or {},
         "cloze_sources": cloze_sources or [],
     }
@@ -138,6 +142,8 @@ def _safe_shard_name(name: object) -> str:
         "practice-synonym.",
         "practice-heritage.",
         "practice-paronym.",
+        "practice-antonym.",
+        "practice-homonym.",
     )
     if not name.endswith(".json") or not name.startswith(allowed_prefixes):
         raise PracticeDeckHydrationError(f"unexpected practice deck file path: {name!r}")

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -31,6 +31,7 @@ DEFAULT_SENTENCE_INVENTORY = ROOT / "site" / "src" / "data" / "lexicon-sentence-
 DEFAULT_HERITAGE_PAIRS = ROOT / "data" / "lexicon" / "heritage_pairs.yaml"
 DEFAULT_PARONYM_PAIRS = ROOT / "data" / "lexicon" / "paronym_pairs.yaml"
 DEFAULT_ANTONYM_PAIRS = ROOT / "data" / "lexicon" / "antonym_pairs.yaml"
+DEFAULT_HOMONYM_PAIRS = ROOT / "data" / "lexicon" / "homonym_pairs.yaml"
 DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
 DEFAULT_CURATED_MEMBERSHIP = ROOT / "site" / "src" / "data" / "lexicon-teacher-curated-membership.json"
 DEFAULT_RELEASE_TAG = "atlas-practice-deck"
@@ -48,6 +49,7 @@ KINDS = {
     "heritage": ("practice-heritage.{level}.json", "atlas-practice-heritage"),
     "paronym": ("practice-paronym.{level}.json", "atlas-practice-paronym"),
     "antonym": ("practice-antonym.{level}.json", "atlas-practice-antonym"),
+    "homonym": ("practice-homonym.{level}.json", "atlas-practice-homonym"),
 }
 
 
@@ -73,6 +75,7 @@ def expected_deck_version(
     heritage_pairs_path: Path | None = DEFAULT_HERITAGE_PAIRS,
     paronym_pairs_path: Path | None = DEFAULT_PARONYM_PAIRS,
     antonym_pairs_path: Path | None = DEFAULT_ANTONYM_PAIRS,
+    homonym_pairs_path: Path | None = DEFAULT_HOMONYM_PAIRS,
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
     sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
@@ -90,6 +93,7 @@ def expected_deck_version(
             read_atlas_db,
             read_cloze_sources,
             read_heritage_pairs,
+            read_homonym_pairs,
             read_paronym_pairs,
             read_sentence_inventory,
             read_synonym_verdicts,
@@ -103,6 +107,7 @@ def expected_deck_version(
         heritage_pairs = read_heritage_pairs(heritage_pairs_path)
         paronym_pairs = read_paronym_pairs(paronym_pairs_path)
         antonym_pairs = read_antonym_pairs(antonym_pairs_path)
+        homonym_pairs = read_homonym_pairs(homonym_pairs_path)
         synonym_verdicts = read_synonym_verdicts(synonym_verdicts_path)
         cloze_sources = [
             *read_cloze_sources(cloze_sources_path),
@@ -116,6 +121,7 @@ def expected_deck_version(
             cloze_sources,
             SCHEMA_VERSION,
             antonym_pairs=antonym_pairs,
+            homonym_pairs=homonym_pairs,
         )
     except Exception as exc:
         raise PracticeDeckPublishError(
@@ -365,6 +371,7 @@ def publish_practice_deck(
     heritage_pairs_path: Path | None = DEFAULT_HERITAGE_PAIRS,
     paronym_pairs_path: Path | None = DEFAULT_PARONYM_PAIRS,
     antonym_pairs_path: Path | None = DEFAULT_ANTONYM_PAIRS,
+    homonym_pairs_path: Path | None = DEFAULT_HOMONYM_PAIRS,
     synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
     cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
     sentence_inventory_path: Path | None = DEFAULT_SENTENCE_INVENTORY,
@@ -379,6 +386,7 @@ def publish_practice_deck(
         heritage_pairs_path=heritage_pairs_path,
         paronym_pairs_path=paronym_pairs_path,
         antonym_pairs_path=antonym_pairs_path,
+        homonym_pairs_path=homonym_pairs_path,
         synonym_verdicts_path=synonym_verdicts_path,
         cloze_sources_path=cloze_sources_path,
         sentence_inventory_path=sentence_inventory_path,
@@ -420,6 +428,7 @@ def main() -> int:
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS)
+    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
     parser.add_argument("--curated-membership", type=Path)
     parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
@@ -434,6 +443,7 @@ def main() -> int:
         heritage_pairs_path=args.heritage_pairs,
         paronym_pairs_path=args.paronym_pairs,
         antonym_pairs_path=args.antonym_pairs,
+        homonym_pairs_path=args.homonym_pairs,
         synonym_verdicts_path=args.synonym_verdicts,
         curated_membership_path=args.curated_membership,
         cloze_sources_path=args.cloze_sources,

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -46,7 +46,7 @@ const MIN_WORD_REPEAT_WINDOW = 8;
 const DEFAULT_RECOGNITION_STABILITY = 3;
 
 export type PracticeRating = 'again' | 'hard' | 'good' | 'easy';
-export const PRACTICE_MODE_DECK_VERSION = 4;
+export const PRACTICE_MODE_DECK_VERSION = 5;
 export const PRACTICE_MODES = [
   'flashcards',
   'matching',

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -60,6 +60,7 @@ export const PRACTICE_MODES = [
   'classify',
   'paronym',
   'antonym',
+  'homonym',
 ] as const;
 const PRACTICE_MODE_SET = new Set<string>(PRACTICE_MODES);
 

--- a/site/tests/setup.ts
+++ b/site/tests/setup.ts
@@ -1,1 +1,40 @@
 import '@testing-library/jest-dom';
+
+class StorageMock implements Storage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  get length(): number {
+    return this.store.size;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+}
+
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage?.clear !== 'function') {
+  const mock = new StorageMock();
+  try {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: mock,
+      writable: true,
+      configurable: true,
+    });
+  } catch {
+    (globalThis as any).localStorage = mock;
+  }
+}
+
+
+
+

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -595,6 +595,7 @@ describe('lexicon SRS facade', () => {
     const versionByModeSet: Record<string, number> = {
       'flashcards|matching|choice|cloze|paradigm|stress|heritage|synonym|classify|paronym': 3,
       'flashcards|matching|choice|cloze|paradigm|stress|heritage|synonym|classify|paronym|antonym': 4,
+      'flashcards|matching|choice|cloze|paradigm|stress|heritage|synonym|classify|paronym|antonym|homonym': 5,
     };
 
     expect(versionByModeSet[PRACTICE_MODES.join('|')]).toBe(PRACTICE_MODE_DECK_VERSION);

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -666,6 +666,7 @@ def test_check_assets_summary_includes_coverage_structure(tmp_path: Path) -> Non
         "heritage",
         "paronym",
         "antonym",
+        "homonym",
     ]
     assert coverage["levels"]["A1"]["cloze"] == {"ratio": 0.0, "pct": 0.0, "thin": True}
     assert coverage["levels"]["A1"]["synonym"] == {"ratio": 0.0, "pct": 0.0, "thin": True}

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -15,6 +15,7 @@ from scripts.audit.generate_practice_deck import (
     RealVesumVerifier,
     ReviewedSourceAllowlist,
     _build_antonym_items,
+    _build_homonym_items,
     _build_classify_items,
     _build_cloze_items,
     _build_heritage_items,
@@ -33,6 +34,7 @@ from scripts.audit.generate_practice_deck import (
     main,
     merge_practice_seed_entries,
     read_antonym_pairs,
+    read_homonym_pairs,
     read_cloze_sources,
     read_heritage_pairs,
     read_manifest,
@@ -41,6 +43,8 @@ from scripts.audit.generate_practice_deck import (
     read_sentence_inventory,
     validate_antonym_item,
     validate_antonym_pair,
+    validate_homonym_item,
+    validate_homonym_pair,
     validate_classify_item,
     validate_heritage_item,
     validate_heritage_pair,
@@ -2517,7 +2521,7 @@ def test_live_paronym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
     live_path = Path("data/lexicon/paronym_pairs.yaml")
     assert live_path.exists()
     pairs = read_paronym_pairs(live_path)
-    assert len(pairs) == 55, f"Expected 55 paronym pairs (20 baseline + 35 promoted), got {len(pairs)}"
+    assert len(pairs) == 103, f"Expected 103 paronym pairs (55 baseline + 48 promoted), got {len(pairs)}"
     seen_pairs: set[tuple[str, str]] = set()
     for index, pair in enumerate(pairs):
         errors = validate_paronym_pair(pair)
@@ -2616,3 +2620,86 @@ def test_live_antonym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
         key = tuple(sorted([a, b]))
         assert key not in seen_pairs, f"Duplicate antonym pair key {key}"
         seen_pairs.add(key)
+
+
+def test_homonym_pairs_emit_items_both_directions_and_validate(capsys: pytest.CaptureFixture[str]) -> None:
+    entries = [
+        {"lemmaId": "байка", "lemma": "байка", "gloss": "fable/fabric", "pos": "noun", "cefr": "A1", "url_slug": "байка", "primary_source": "course_vocab", "course_usage": [{"track": "a1"}]},
+    ]
+    pair = {
+        "slugA": "байка",
+        "slugB": "байка",
+        "distinction_gloss_uk": "Байка — алегоричний твір чи м'яка тканина.",
+        "citations": ["fixture-test"],
+        "frames": [
+            {"sentence_with_slot": "Езоп написав ___.", "answer_form": "байку", "confusable_form": "байку", "origin": "t"},
+            {"sentence_with_slot": "Сорочка з м'якої ___.", "answer_form": "байки", "confusable_form": "байки", "origin": "t2"},
+        ],
+    }
+    allowlist = ReviewedSourceAllowlist.from_payload([])
+    verifier = JsonVesumVerifier({})
+    shards = build_practice_shards(entries, allowlist, verifier, [], BuildConfig(target=10), homonym_pairs=[pair])
+    a1_items = shards.get("A1", {}).get("homonym", {}).get("homonym", [])
+    assert len(a1_items) >= 1, "homonym should emit at least one item"
+    assert validate_homonym_pair(pair) == []
+    for it in a1_items:
+        assert validate_homonym_item(it) == []
+
+
+def test_homonym_builder_copies_optional_curated_prompt_en() -> None:
+    lex_a = {"lemmaId": "байка", "lemma": "байка", "cefr": "A1"}
+    lex_b = {"lemmaId": "байка", "lemma": "байка", "cefr": "A1"}
+    pair = {
+        "slugA": "байка",
+        "slugB": "байка",
+        "distinction_gloss_uk": "Байка розрізнення.",
+        "citations": ["fixture-test"],
+        "frames": [{
+            "sentence_with_slot": "Езоп написав ___.",
+            "prompt_en": "Aesop wrote a ___.",
+            "answer_form": "байку",
+            "confusable_form": "байку",
+            "origin": "fixture",
+        }],
+    }
+
+    item = _build_homonym_items(pair, lex_a, lex_b, "deck-v1")[0]
+    assert item["promptEn"] == "Aesop wrote a ___."
+
+    pair["frames"][0].pop("prompt_en")
+    item_without_en = _build_homonym_items(pair, lex_a, lex_b, "deck-v1")[0]
+    assert "promptEn" not in item_without_en
+
+
+def test_homonym_missing_slug_skips_with_warn(capsys: pytest.CaptureFixture[str]) -> None:
+    entries = [{"lemmaId": "foo", "lemma": "foo", "gloss": "x", "pos": "noun", "cefr": "B1", "url_slug": "foo", "primary_source": "course_vocab", "course_usage": [{"track": "b1"}]}]
+    pair = {"slugA": "missingA", "slugB": "missingB", "distinction_gloss_uk": "x", "citations": ["t"], "frames": [{"sentence_with_slot": "X ___ .", "answer_form": "x", "confusable_form": "y", "origin": "o"}]}
+    allowlist = ReviewedSourceAllowlist.from_payload([])
+    verifier = JsonVesumVerifier({})
+    shards = build_practice_shards(entries, allowlist, verifier, [], BuildConfig(), homonym_pairs=[pair])
+    assert shards["B1"]["homonym"]["homonym"] == []
+    err = capsys.readouterr().err
+    assert "not in practice lexemes; emitted 0 items" in err
+
+
+def test_homonym_empty_file_emits_empty_fail_closed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = tmp_path / "empty-hom.yaml"
+    p.write_text("schema_version: 1\npairs: []\n", encoding="utf-8")
+    rows = read_homonym_pairs(p)
+    assert rows == []
+    err = capsys.readouterr().err
+    assert "curated homonym pairs empty" in err
+    entries = [{"lemmaId": "a", "lemma": "a", "gloss": "g", "pos": "n", "cefr": "B1", "url_slug": "a", "primary_source": "c", "course_usage": [{}]}]
+    shards = build_practice_shards(entries, ReviewedSourceAllowlist.from_payload([]), JsonVesumVerifier({}), [], BuildConfig(), homonym_pairs=[])
+    assert shards["B1"]["homonym"]["homonym"] == []
+
+
+def test_live_homonym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
+    live_path = Path("data/lexicon/homonym_pairs.yaml")
+    assert live_path.exists()
+    pairs = read_homonym_pairs(live_path)
+    assert len(pairs) == 75, f"Expected 75 homonym pairs, got {len(pairs)}"
+    for index, pair in enumerate(pairs):
+        errors = validate_homonym_pair(pair)
+        assert not errors, f"Pair {index} ({pair.get('slugA')}/{pair.get('slugB')}) invalid: {errors}"
+

--- a/tests/test_practice_deck_io.py
+++ b/tests/test_practice_deck_io.py
@@ -69,6 +69,8 @@ def test_compute_deck_version_fingerprints_all_inputs() -> None:
     entries = [{"lemmaId": "knyha", "lemma": "knyha", "gloss": "book"}]
     heritage_pairs = [{"nativeSlug": "knyha", "rationale": "fixture"}]
     paronym_pairs = [{"slugA": "knyha", "slugB": "книга", "frames": [], "citations": ["t"]}]
+    antonym_pairs = [{"slugA": "день", "slugB": "ніч", "frames": [], "citations": ["t"]}]
+    homonym_pairs = [{"slugA": "байка", "slugB": "байка", "frames": [], "citations": ["t"]}]
     synonym_verdicts = {
         "approved": [{"a": "knyha", "b": "tom", "polarity": "synonym"}],
         "rejected": [],
@@ -82,6 +84,8 @@ def test_compute_deck_version_fingerprints_all_inputs() -> None:
         synonym_verdicts,
         cloze_sources,
         1,
+        antonym_pairs=antonym_pairs,
+        homonym_pairs=homonym_pairs,
     )
 
     assert version.startswith("atlas-practice-v1-")
@@ -90,16 +94,19 @@ def test_compute_deck_version_fingerprints_all_inputs() -> None:
     assert all(char in "0123456789abcdef" for char in fingerprint)
 
     variants = [
-        ([{**entries[0], "gloss": "book volume"}], heritage_pairs, paronym_pairs, synonym_verdicts, cloze_sources),
-        (entries, [{**heritage_pairs[0], "rationale": "changed"}], paronym_pairs, synonym_verdicts, cloze_sources),
+        ([{**entries[0], "gloss": "book volume"}], heritage_pairs, paronym_pairs, antonym_pairs, homonym_pairs, synonym_verdicts, cloze_sources),
+        (entries, [{**heritage_pairs[0], "rationale": "changed"}], paronym_pairs, antonym_pairs, homonym_pairs, synonym_verdicts, cloze_sources),
         (
             entries,
             heritage_pairs,
             paronym_pairs,
+            antonym_pairs,
+            homonym_pairs,
             {"approved": synonym_verdicts["approved"], "rejected": [{"a": "x", "b": "y", "polarity": "antonym"}]},
             cloze_sources,
         ),
-        (entries, heritage_pairs, paronym_pairs, synonym_verdicts, [{**cloze_sources[0], "sentence": "Changed ___."}]),
+        (entries, heritage_pairs, paronym_pairs, antonym_pairs, homonym_pairs, synonym_verdicts, [{**cloze_sources[0], "sentence": "Changed ___."}]),
+        (entries, heritage_pairs, paronym_pairs, antonym_pairs, [{**homonym_pairs[0], "slugA": "байка2"}], synonym_verdicts, cloze_sources),
     ]
     changed_versions = {
         practice_deck_io.compute_deck_version(
@@ -109,8 +116,10 @@ def test_compute_deck_version_fingerprints_all_inputs() -> None:
             variant_synonym_verdicts,
             variant_cloze_sources,
             1,
+            antonym_pairs=variant_antonym_pairs,
+            homonym_pairs=variant_homonym_pairs,
         )
-        for variant_entries, variant_heritage_pairs, variant_paronym_pairs, variant_synonym_verdicts, variant_cloze_sources in variants
+        for variant_entries, variant_heritage_pairs, variant_paronym_pairs, variant_antonym_pairs, variant_homonym_pairs, variant_synonym_verdicts, variant_cloze_sources in variants
     }
 
     assert version not in changed_versions

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -87,6 +87,7 @@ def _write_publish_inputs(
     heritage_pairs: list[dict[str, object]] | None = None,
     paronym_pairs: list[dict[str, object]] | None = None,
     antonym_pairs: list[dict[str, object]] | None = None,
+    homonym_pairs: list[dict[str, object]] | None = None,
     synonym_verdicts: dict[str, object] | None = None,
     cloze_sources: list[dict[str, object]] | None = None,
     sentence_inventory: dict[str, object] | None = None,
@@ -97,6 +98,7 @@ def _write_publish_inputs(
         "heritage_pairs_path": base_dir / "heritage_pairs.yaml",
         "paronym_pairs_path": base_dir / "paronym_pairs.yaml",
         "antonym_pairs_path": base_dir / "antonym_pairs.yaml",
+        "homonym_pairs_path": base_dir / "homonym_pairs.yaml",
         "synonym_verdicts_path": base_dir / "synonym_pair_verdicts.yaml",
         "cloze_sources_path": base_dir / "lexicon-practice-cloze-sources.json",
         "sentence_inventory_path": base_dir / "lexicon-sentence-inventory.json",
@@ -108,6 +110,8 @@ def _write_publish_inputs(
         _write_json(paths["paronym_pairs_path"], {"pairs": paronym_pairs})
     if antonym_pairs is not None:
         _write_json(paths["antonym_pairs_path"], {"pairs": antonym_pairs})
+    if homonym_pairs is not None:
+        _write_json(paths["homonym_pairs_path"], {"pairs": homonym_pairs})
     if synonym_verdicts is not None:
         _write_json(paths["synonym_verdicts_path"], synonym_verdicts)
     if cloze_sources is not None:


### PR DESCRIPTION
## Summary
Promote approved Miyklas relation pairs into durable practice sources and wire the factory/publish path for **homonym** mode.

- `data/lexicon/homonym_pairs.yaml` — 75 reviewed homonym pairs with UA distinction gloss + sentence frames
- `data/lexicon/paronym_pairs.yaml` — expand curated paronym set (55 → 103)
- Factory/publish/IO/check_static + SRS register `homonym`
- Tests for emit/validate/fail-closed empty + live yaml counts

Closes #6138 (homonym mode pairs + emit). Advances #6137 (paronym promote residual). Part of #6132 / #4387.

## Test plan
- [x] `pytest` practice deck / static asset tests in worker
- [ ] CI green
- [ ] Cross-family CF
- [ ] After merge: regen + publish practice deck (driver)

## Notes
- Does **not** publish a new live deck pointer (driver job after merge)
- Worker: AGY; do not self-merge

X-Agent context: agy/homonym-paronym-promote