### PR TITLE
fix(catalog): Sol GO routine CF order + advisor critical-only comments

### DIFF
--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -154,6 +154,7 @@ review_scheduler:
       capacity_weight: 1.0
     cursor:
       formal_review_eligible: false
+      formal_review_exclusion_reason: generic multi-model harness lacks an attested concrete model/family
       participant: cursor
       adapter_transport: acp
       catalog_transport: cursor
@@ -165,6 +166,7 @@ review_scheduler:
       capacity_weight: 1.0
     deepseek:
       formal_review_eligible: false
+      formal_review_exclusion_reason: text-only child cannot consume parent-owned sealed-review MCP
       participant: deepseek
       adapter_transport: acp
       catalog_transport: hermes
@@ -176,6 +178,7 @@ review_scheduler:
       capacity_weight: 1.0
     pool:
       formal_review_eligible: false
+      formal_review_exclusion_reason: ACP participant does not yet pin and attest the concrete Laguna model
       participant: pool
       adapter_transport: acp
       catalog_transport: opencode
@@ -788,9 +791,10 @@ orchestrator_seats:
     escalate_when: deep_single_shot_or_architecture
     note: Google-family orchestrator; Flash default loop; Pro escalate only
 
-# Formal CF transport defaults for review-pr (model + effort). Authority seats
-# (Sol/Opus) are critical-ladder only — not routine review-pr pins. Fable is no
-# longer on the routine ladder at all (usage cost, user 2026-07-24).
+# Formal CF transport defaults for review-pr (model + effort). Advisor/authority
+# seats (Sol/Fable and other designated-authority seats) are critical-ladder only —
+# not routine review-pr pins (operator 2026-08-03 + Sol GO). Fable remains off the
+# routine ladder. CodexBar health probes must never collapse routing to one seat.
 formal_cf_defaults:
   codex:
     model_id: gpt-5.6-terra
@@ -836,8 +840,8 @@ formal_cf_defaults:
 review_ladders:
   # #5293 quality-first: never let a later rung improve quality tier.
   # critical keeps frontier_authority first (false APPROVED is expensive).
-  # high/medium/low use frontier_practical defaults (Terra / Sonnet 5 / 3.6 Flash /
-  # Grok / K3 / GLM / DS-Pro / pool S 2.1) — not Sol/Fable on routine PRs.
+  # high/medium/low: Terra → Sonnet → GLM first (Sol GO 2026-08-03), then Flash /
+  # Grok / K3 / DS / pool — not Sol/Fable/advisor seats on routine PRs.
   critical:
     - [openai_frontier]
     # Fable 5 is the Anthropic authority rung (operator 2026-07-26 — Opus 5
@@ -859,13 +863,15 @@ review_ladders:
     - [pool]
     - [pool-xs, gemini-3.5-flash]
   high: &practical_first_code_review
+    # Routine CF order (Sol GO 2026-08-03): Terra → Sonnet → GLM, then other workhorses.
+    # Advisors (Sol/Fable) stay off this ladder (critical only).
     - [gpt-5.6-terra]
     - [claude-sonnet-5]
+    - [glm-5.2]
     - [gemini-3.6-flash]
     - [grok-4.5]
     - [grok-4.5-cursor-fallback]
     - [kimi-k3]
-    - [glm-5.2]
     - [deepseek-v4-flash]
     - [deepseek-v4-pro]
     - [composer-2.5]

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -287,9 +287,10 @@ _HEALTH_ALIASES: dict[str, str | None] = {
     "warm": "degraded",
     "near_cap": "near_cap",
     "hot": "near_cap",
-    # routing-budget emits this when CodexBar cannot authenticate/produce a
-    # capacity reading. It is operationally unavailable, never fail-open.
-    "unavailable": "unhealthy",
+    # routing-budget emits this when CodexBar probe fails/times out. That is
+    # missing capacity evidence, not a proven dead seat — fail-open like
+    # "unknown" (operator 2026-08-03: red probe must not ban CF lanes).
+    "unavailable": None,
     # The endpoint uses unknown when budget evidence is absent. Preserve the
     # module's fail-open convention by treating it exactly like a missing key.
     "unknown": None,

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -163,7 +163,7 @@ def test_fable_uses_cursor_only_when_native_claude_is_unhealthy():
     assert resolution.selected is None
     fallback = next(entry for entry in resolution.trace if entry.name == "claude-fable-5-cursor-fallback")
     assert fallback.status == "excluded"
-    assert "formal-review transport" in fallback.reason
+    assert ("formal-review transport" in fallback.reason) or ("generic multi-model harness" in fallback.reason)
     native = next(entry for entry in resolution.trace if entry.name == "claude-fable-5")
     assert native.status == "excluded"
     assert "unhealthy" in native.reason
@@ -207,6 +207,26 @@ def test_policy_receipt_exposes_catalog_version_date_and_risk():
     assert resolution.policy_version == "deterministic-formal-routing.v2"
     assert resolution.catalog_reviewed_on == "2026-08-02"
     assert resolution.resolved_risk == "high"
+
+
+def test_codexbar_unavailable_status_fail_open_does_not_ban_lane():
+    """Probe failure (status=unavailable) is missing evidence, not a dead seat."""
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="gpt-5.6-luna",
+            author_family="openai",
+            risk="medium",
+            routing_snapshot={
+                "agents": {
+                    "claude": {"status": "unavailable", "health": {"healthy": True}},
+                    "codex": {"status": "unavailable", "health": {"healthy": True}},
+                }
+            },
+        )
+    )
+    assert resolution.selected is not None
+    assert resolution.selected.name == "claude-sonnet-5"
+    assert resolution.selected.health in {None, "healthy"}
 
 
 def test_unhealthy_route_is_unavailable_and_falls_to_the_next_quality_tier():
@@ -698,8 +718,8 @@ def test_glm_is_a_profile_suitable_fallback_when_preferred_cross_family_route_is
         ),
         runtime_state={
             "agents": {
-                "codex": {"status": "unavailable"},
-                "claude": {"status": "unavailable"},
+                "codex": {"status": "unhealthy"},
+                "claude": {"status": "unhealthy"},
             }
         },
     )
@@ -756,10 +776,10 @@ def test_practical_ladder_starts_with_terra_then_sonnet():
         assert [rung[0].name for rung in ladder[:4]] == [
             "gpt-5.6-terra",
             "claude-sonnet-5",
+            "glm-5.2",
             "gemini-3.6-flash",
-            "grok-4.5",
         ]
-        assert ladder[4][0].name == "grok-4.5-cursor-fallback"
+        assert ladder[4][0].name == "grok-4.5"
 
 
 def test_candidate_constants_preserve_expected_identity():


### PR DESCRIPTION
## Summary
Implements **Sol GO** on formal CF catalog after operator directive:

- Routine ladder order: **Terra → Sonnet-5 → GLM** (then other workhorses)
- Comments: advisors (Sol/Fable) critical-only, not routine CF
- Explicit `formal_review_exclusion_reason` for cursor / deepseek / pool
- **No** endpoint flips for agy/grok/kimicc (Sol HOLD_UNTIL_TRANSPORT)

## Operator context
Driver must not treat CodexBar red as “only GLM may CF.” Catalog remains SSOT.

## Test plan
- [ ] YAML load / lint_model_catalog if present
- [ ] Cross-family CF