### PR TITLE
feat(practice): strengthen heritage practice

### DIFF
--- a/data/lexicon/heritage_pairs.yaml
+++ b/data/lexicon/heritage_pairs.yaml
@@ -19,6 +19,7 @@ pairs:
   - antonenko
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   notes: has module frame
   frames:
@@ -46,6 +47,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   notes: безпечний correction dropped — not a manifest article yet
   frames:
@@ -73,6 +75,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: На стадіон прийшли ___ нашої команди.
@@ -100,6 +103,7 @@ pairs:
   - legacy-manifest
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: 'кількісна приблизність: «біля п''яти» (рос. около пяти)'
   authenticSense: просторове біля = поруч
@@ -135,6 +139,7 @@ pairs:
   sourceFamilies:
   - legacy-manifest
   cefrAvailability: b1
+  severity: russianism
   curator: legacy+fable-2026-07-06
   calqueSense: to seem / appear that (рос. выглядит = 'it seems')
   authenticSense: to look (well/ill); to peer out (гарно виглядати; виглядати у вікно)
@@ -169,6 +174,7 @@ pairs:
   - antonenko
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'краєвид: «гарний вид з вікна» (рос. вид)'
   authenticSense: вид = біологічний таксон; граматична категорія
@@ -201,6 +207,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: виняток із правила (рос. исключение)
   authenticSense: виключення = дія (виключення зі списку, з університету)
@@ -234,6 +241,7 @@ pairs:
   - antonenko
   - slovnyk-dicts
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: у значенні «тільки, суто» (рос. исключительно)
   authenticSense: виключно = як виняток
@@ -265,6 +273,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: розв'язання задачі/проблеми (рос. решение задачи)
   authenticSense: ухвалення рішення (вирішення питання по суті)
@@ -294,6 +303,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: розв'язати задачу/проблему (рос. решить задачу)
   authenticSense: вирішити = ухвалити рішення
@@ -325,6 +335,7 @@ pairs:
   - antonenko
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: світло/пристрій (рос. включить свет)
   authenticSense: включити до списку/складу
@@ -361,6 +372,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: двері/вікно/крамницю фізично (рос. открыть дверь)
   authenticSense: відкрити Америку, рахунок, засідання
@@ -394,6 +406,7 @@ pairs:
   - antonenko
   - slovnyk-dicts
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: прийменник «щодо» (рос. относительно)
   authenticSense: відносно = порівняно (відносно небагато)
@@ -428,6 +441,7 @@ pairs:
   - antonenko
   - slovnyk-dicts
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: ставлення до когось/стосунки (рос. отношение)
   authenticSense: математичне відношення; діловий документ
@@ -459,6 +473,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: листи/повідомлення (рос. отправить письмо)
   authenticSense: відправити поїзд, відправити службу
@@ -489,6 +504,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'про речі: «відсутність доказів» (рос. отсутствие)'
   authenticSense: відсутність людей (відсутній на зборах)
@@ -519,6 +535,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: ганити когось (рос. отчитать когось)
   authenticSense: відчитати = прочитати повністю (звіт, лекцію)
@@ -552,6 +569,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'правильний: «вірна відповідь» (рос. верный ответ)'
   authenticSense: вірний = відданий (вірний друг)
@@ -583,6 +601,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «у статті говориться» (рос. говорится)
   authenticSense: говорити як процес мовлення
@@ -612,7 +631,8 @@ pairs:
   sourceFamily: ua-gec
   sourceFamilies:
   - ua-gec
-  cefrAvailability: a2
+  cefrAvailability: a1
+  severity: russianism
   curator: fable-2026-07-06
   notes: Антоненко-збіг спурійний (функційне слово); GEC-цитата достатня
   frames:
@@ -641,6 +661,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: канцелярит «в даний час», «дана книга» (рос. данный)
   authenticSense: 'математичне: дана величина'
@@ -675,6 +696,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: медик, звертання до медика (рос. доктор)
   authenticSense: науковий ступінь (доктор наук)
@@ -706,6 +728,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: у значенні «інший» (рос. другой)
   authenticSense: порядковий числівник (другий раз, другий поверх)
@@ -744,6 +767,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: рутинний підсилювач під рос. действительно («я дійсно не бачив»)
   authenticSense: дійсний/дійсно — про чинність, реальність (дійсний квиток)
@@ -778,6 +802,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: загальне доручення/справа (рос. задача)
   authenticSense: математична задача
@@ -807,6 +832,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   notes: VESUM mislemmatized to verb залити; calqueLabel = залив (noun)
   frames:
@@ -833,6 +859,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «знаходить це дивним» (рос. находит это странным)
   authenticSense: знаходити загублене
@@ -865,6 +892,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'стале місцеперебування: «будинок знаходиться» (рос. находится)'
   authenticSense: знаходитися = бути знайденим (загублене знайшлося)
@@ -903,6 +931,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: вставне слово (рос. значит)
   authenticSense: дієслово значити = мати значення
@@ -934,6 +963,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   notes: простувати/прямувати corrections dropped — not manifest articles yet
   frames:
@@ -960,6 +990,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'ріг вулиці: «на кутку» (рос. на углу)'
   authenticSense: куток кімнати, затишний куток
@@ -989,6 +1020,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: 'будь-який: «любий варіант» (рос. любой)'
   authenticSense: любий = дорогий, коханий
@@ -1024,6 +1056,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'рослинний жир: «соняшникове масло» (рос. масло)'
   authenticSense: масло = тваринний жир (вершкове)
@@ -1055,6 +1088,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «мається великий вибір» (рос. имеется)
   authenticSense: матися = почуватися (як маєшся?)
@@ -1084,6 +1118,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: На завтра ___ підготувати короткий текст.
@@ -1116,6 +1151,7 @@ pairs:
   sourceFamilies:
   - slovnyk-dicts
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: часове «рік назад» (рос. год назад)
   authenticSense: просторовий напрямок (крок назад)
@@ -1145,6 +1181,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: початок у часі (рос. начало)
   authenticSense: філософське першоджерело, основа (вольове начало)
@@ -1176,6 +1213,7 @@ pairs:
   sourceFamilies:
   - legacy-manifest
   cefrAvailability: b1
+  severity: russianism
   curator: legacy+fable-2026-07-06
   calqueSense: week / a seven-day period (рос. неделя)
   authenticSense: Sunday (day of the week)
@@ -1208,6 +1246,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: Я хочу кави, ___ молока немає.
@@ -1233,6 +1272,7 @@ pairs:
   sourceFamily: mixed
   sourceFamilies: []
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: царина знань/діяльності (рос. область знаний)
   authenticSense: адміністративна область
@@ -1263,6 +1303,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: 'зовнішній образ: «облік сучасника» (рос. облик)'
   authenticSense: облік = облічування, реєстрація (взяти на облік)
@@ -1292,6 +1333,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «яким образом» (рос. каким образом)
   authenticSense: художній образ
@@ -1322,6 +1364,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'дія, що задовольняє потреби: «поштова обслуга»'
   authenticSense: обслуга = група людей, призначених виконувати роботу (військ. розрахунок)
@@ -1351,6 +1394,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: туристичний намет (рос. палатка)
   authenticSense: 'торговельна палатка — ятка, кіоск (СУМ: «тимчасове, звичайно літнє приміщення»)'
@@ -1382,6 +1426,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: У статті описано ___ погляд на проблему.
@@ -1408,7 +1453,8 @@ pairs:
   sourceFamilies:
   - slovnyk-dicts
   - ua-gec
-  cefrAvailability: a2
+  cefrAvailability: a1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: батько (рос. папа)
   authenticSense: Папа Римський
@@ -1440,6 +1486,7 @@ pairs:
   - antonenko
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'приблизна кількість: «пару хвилин» (рос. пара минут)'
   authenticSense: пара = двоє, комплект (пара шкарпеток)
@@ -1473,6 +1520,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: У ___ стоїть шафа для взуття.
@@ -1498,6 +1546,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: обмін листами (рос. переписка)
   authenticSense: переписування = процес копіювання написаного
@@ -1527,6 +1576,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   notes: VESUM mislemmatized полу→пола(поділ одягу); calqueLabel fixed to пол
   frames:
@@ -1555,6 +1605,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: ситуація, стан (рос. положение)
   authenticSense: пункт документа; позиція тіла
@@ -1586,6 +1637,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: публікація в соцмережі (рос./англ. пост)
   authenticSense: військовий пост; релігійний піст — окрема лексема
@@ -1616,6 +1668,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: Цей художник ще ___.
@@ -1643,6 +1696,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   notes: трудівник kept as display correction; manifest gate applies to nativeSlug only
   frames:
@@ -1674,6 +1728,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: приймати участь (рос. принимать участие)
   authenticSense: приймати гостей, приймати рішення
@@ -1705,6 +1760,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: присвоїти звання/права (рос. присвоить звание)
   authenticSense: присвоїти = привласнити чуже
@@ -1734,6 +1790,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: дорожній затор (рос. пробка)
   authenticSense: пробка = корок (закорковування)
@@ -1767,6 +1824,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   calqueSense: піднімати питання/тему (рос. поднимать вопрос)
   authenticSense: фізично піднімати
@@ -1796,6 +1854,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: передплата газет/журналів (рос. подписка)
   authenticSense: підписка = письмове зобов'язання, ствердження підписом
@@ -1826,6 +1885,7 @@ pairs:
   sourceFamilies:
   - antonenko
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: про ідеї, чутки, вплив («розповсюджувати ідеї»)
   authenticSense: розповсюджувати = фізично роздавати (книжки, листівки)
@@ -1856,6 +1916,7 @@ pairs:
   sourceFamilies:
   - legacy-manifest
   cefrAvailability: b1
+  severity: russianism
   curator: legacy+fable-2026-07-06
   frames:
   - sentence_with_slot: Наш ___ урок почнеться о дев’ятій.
@@ -1887,6 +1948,7 @@ pairs:
   - antonenko
   - slovnyk-dicts
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «в чому справа», «це не моя справа» (рос. дело)
   authenticSense: юридична/ділова справа
@@ -1918,6 +1980,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: Ми помітили ___ дат у двох документах.
@@ -1943,6 +2006,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   notes: native lemma normalized from GEC surface склянку; rationale softened per agy review (SUM attests стакан as рідко)
   frames:
@@ -1971,6 +2035,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: Перед поїздкою оформили ___ для всієї родини.
@@ -1996,6 +2061,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   notes: rationale softened per agy review (Котляревський attestation exists)
   frames:
@@ -2022,6 +2088,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   notes: rationale register-based per agy review (Мирний/Сосюра attestations)
   frames:
@@ -2048,6 +2115,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'образне/зображальне тло: «на фоні подій»'
   authenticSense: фізичний термін (радіаційний фон)
@@ -2078,6 +2146,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: a2
+  severity: russianism
   curator: fable-2026-07-06
   frames:
   - sentence_with_slot: Після відпочинку мені стало ___.
@@ -2105,6 +2174,7 @@ pairs:
   - slovnyk-dicts
   - ua-gec
   cefrAvailability: a2
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: 'годинниковий час: «який час?» (рос. который час)'
   authenticSense: час як загальне поняття
@@ -2134,6 +2204,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: enrichment
   curator: fable-2026-07-06
   calqueSense: «чисто технічний» (рос. чисто технический)
   authenticSense: чисто = охайно, без бруду
@@ -2163,6 +2234,7 @@ pairs:
   sourceFamilies:
   - ua-gec
   cefrAvailability: b1
+  severity: russianism
   curator: fable-2026-07-06
   notes: lemma fixed from surface
   frames:
@@ -2174,3 +2246,440 @@ pairs:
     answer_form: капелюх
     calque_form: шляпу
     origin: authored-codex-2026-07-06
+- calqueLabel: завідуючий
+  calqueSurfaces:
+  - завідуючий
+  nativeSlug: завідувач
+  nativeLemma: завідувач
+  kind: lexical
+  corrections:
+  - завідувач
+  rationale: 'Посаду називаємо іменником: завідувач бібліотеки, не завідуючий бібліотекою.'
+  citations:
+  - state-standard:glazova-11
+  - state-standard:zabolotnyi-7
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: ___ бібліотеки допоміг відвідувачам.
+    answer_form: Завідувач
+    calque_form: Завідуючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: узагальнюючий
+  calqueSurfaces:
+  - узагальнюючий
+  nativeSlug: узагальнювальний
+  nativeLemma: узагальнювальний
+  kind: lexical
+  corrections:
+  - узагальнювальний
+  rationale: 'Для назви вправи вживаємо прикметник узагальнювальний, не узагальнюючий.'
+  citations:
+  - state-standard:glazova-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Наприкінці уроку вчитель дав ___ вправу.
+    answer_form: узагальнювальну
+    calque_form: узагальнюючу
+    origin: authored-codex-2026-08-03
+- calqueLabel: зволожуючий
+  calqueSurfaces:
+  - зволожуючий
+  nativeSlug: зволожувальний
+  nativeLemma: зволожувальний
+  kind: lexical
+  corrections:
+  - зволожувальний
+  rationale: 'Для засобу догляду вживаємо зволожувальний крем, не зволожуючий.'
+  citations:
+  - state-standard:glazova-11
+  - state-standard:zabolotnyi-7
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Узимку я користуюся ___ кремом.
+    answer_form: зволожувальним
+    calque_form: зволожуючим
+    origin: authored-codex-2026-08-03
+- calqueLabel: знеболюючий
+  calqueSurfaces:
+  - знеболюючий
+  nativeSlug: знеболювальний
+  nativeLemma: знеболювальний
+  kind: lexical
+  corrections:
+  - знеболювальний
+  rationale: 'Для назви медичного засобу вживаємо знеболювальний, не знеболюючий.'
+  citations:
+  - state-standard:glazova-11
+  - state-standard:zabolotnyi-7
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Лікар призначив ___ засіб.
+    answer_form: знеболювальний
+    calque_form: знеболюючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: хвилюючий
+  calqueSurfaces:
+  - хвилюючий
+  nativeSlug: зворушливий
+  nativeLemma: зворушливий
+  kind: lexical
+  corrections:
+  - зворушливий
+  rationale: 'У значенні емоційно зворушливий спогад точніше зворушливий, не хвилюючий.'
+  citations:
+  - state-standard:glazova-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Вона розповіла ___ історію.
+    answer_form: зворушливу
+    calque_form: хвилюючу
+    origin: authored-codex-2026-08-03
+- calqueLabel: діючий
+  calqueSurfaces:
+  - діючий
+  nativeSlug: чинний
+  nativeLemma: чинний
+  kind: sense_restricted
+  corrections:
+  - чинний
+  rationale: 'У значенні «той, що має юридичну силу» вживаємо чинний, не діючий.'
+  citations:
+  - state-standard:glazova-11
+  - state-standard:avramenko-11
+  - state-standard:avramenko-7
+  - state-standard:zabolotnyi-7
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  calqueSense: 'чинний квиток, закон або документ (рос. действующий)'
+  authenticSense: 'активний вулкан або дія, що відбувається'
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES); frame is sense-scoped.'
+  frames:
+  - sentence_with_slot: Перевірте, чи маєте ___ квиток.
+    answer_form: чинний
+    calque_form: діючий
+    origin: authored-codex-2026-08-03
+    disambiguated: true
+- calqueLabel: підростаючий
+  calqueSurfaces:
+  - підростаючий
+  nativeSlug: молодий
+  nativeLemma: молодий
+  kind: lexical
+  corrections:
+  - молодий
+  rationale: 'У сполуці про покоління вживаємо молоде, не підростаюче.'
+  citations:
+  - state-standard:glazova-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Бібліотека готує програму для ___ покоління.
+    answer_form: молодого
+    calque_form: підростаючого
+    origin: authored-codex-2026-08-03
+- calqueLabel: головуючий
+  calqueSurfaces:
+  - головуючий
+  nativeSlug: голова
+  nativeLemma: голова
+  kind: lexical
+  corrections:
+  - голова
+  rationale: 'На зборах уживаємо голова зборів, не головуючий на зборах.'
+  citations:
+  - state-standard:avramenko-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py; the administrative meeting context is B1 guidance.'
+  frames:
+  - sentence_with_slot: ___ зборів оголосив порядок денний.
+    answer_form: Голова
+    calque_form: Головуючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: домінуючий
+  calqueSurfaces:
+  - домінуючий
+  nativeSlug: основний
+  nativeLemma: основний
+  kind: lexical
+  corrections:
+  - основний
+  rationale: 'У сполуці домінуючий принцип уживаємо основний принцип.'
+  citations:
+  - state-standard:avramenko-11
+  - antonenko:101 Пануючий чи панівний
+  sourceFamily: mixed
+  sourceFamilies:
+  - state-standard
+  - antonenko
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: У доповіді названо ___ чинник успіху.
+    answer_form: основний
+    calque_form: домінуючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: оточуючий
+  calqueSurfaces:
+  - оточуючий
+  nativeSlug: навколишній
+  nativeLemma: навколишній
+  kind: lexical
+  corrections:
+  - навколишній
+  rationale: 'Для простору навколо нас уживаємо навколишній, не оточуючий.'
+  citations:
+  - state-standard:zabolotnyi-7
+  - state-standard:zabolotnyi-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Ми прибрали ___ територію школи.
+    answer_form: навколишню
+    calque_form: оточуючу
+    origin: authored-codex-2026-08-03
+- calqueLabel: розквітаючий
+  calqueSurfaces:
+  - розквітаючий
+  nativeSlug: розквітлий
+  nativeLemma: розквітлий
+  kind: lexical
+  corrections:
+  - розквітлий
+  rationale: 'Для вже розкритого бузку вживаємо розквітлий, не розквітаючий.'
+  citations:
+  - state-standard:avramenko-7
+  - antonenko:144 Дієприкметник
+  sourceFamily: mixed
+  sourceFamilies:
+  - state-standard
+  - antonenko
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: У саду пахнув ___ бузок.
+    answer_form: розквітлий
+    calque_form: розквітаючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: опадаючий
+  calqueSurfaces:
+  - опадаючий
+  nativeSlug: опалий
+  nativeLemma: опалий
+  kind: lexical
+  corrections:
+  - опалий
+  rationale: 'Для листя, що вже опало, вживаємо опалий, не опадаючий.'
+  citations:
+  - state-standard:avramenko-7
+  - antonenko:144 Дієприкметник
+  sourceFamily: mixed
+  sourceFamilies:
+  - state-standard
+  - antonenko
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Стежку вкривало ___ листя.
+    answer_form: опале
+    calque_form: опадаюче
+    origin: authored-codex-2026-08-03
+- calqueLabel: жовтіючий
+  calqueSurfaces:
+  - жовтіючий
+  nativeSlug: пожовклий
+  nativeLemma: пожовклий
+  kind: lexical
+  corrections:
+  - пожовклий
+  rationale: 'Для листа, що вже пожовк, вживаємо пожовклий, не жовтіючий.'
+  citations:
+  - state-standard:avramenko-7
+  - antonenko:144 Дієприкметник
+  sourceFamily: mixed
+  sourceFamilies:
+  - state-standard
+  - antonenko
+  cefrAvailability: b1
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: На підвіконні лежав ___ лист.
+    answer_form: пожовклий
+    calque_form: жовтіючий
+    origin: authored-codex-2026-08-03
+- calqueLabel: бувший
+  calqueSurfaces:
+  - бувший
+  nativeSlug: колишній
+  nativeLemma: колишній
+  kind: lexical
+  corrections:
+  - колишній
+  rationale: 'Прикметник бувший не відповідає українській нормі; уживаємо колишній.'
+  citations:
+  - state-standard:avramenko-11
+  sourceFamily: state-standard
+  sourceFamilies:
+  - state-standard
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Він зустрів ___ колегу.
+    answer_form: колишнього
+    calque_form: бувшого
+    origin: authored-codex-2026-08-03
+- calqueLabel: міроприємство
+  calqueSurfaces:
+  - міроприємство
+  nativeSlug: захід
+  nativeLemma: захід
+  kind: lexical
+  corrections:
+  - захід
+  rationale: 'Для організованої події вживаємо захід або заходи, не міроприємство.'
+  citations:
+  - antonenko:44 Міра, захід
+  - state-standard:glazova-10
+  sourceFamily: mixed
+  sourceFamilies:
+  - antonenko
+  - state-standard
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Reviewed in scripts/lexicon/calque_corrections.py (CURATED_CALQUES).'
+  frames:
+  - sentence_with_slot: Школа провела благодійний ___.
+    answer_form: захід
+    calque_form: міроприємство
+    origin: authored-codex-2026-08-03
+- calqueLabel: уверх
+  calqueSurfaces:
+  - уверх
+  nativeSlug: вгору
+  nativeLemma: вгору
+  kind: lexical
+  corrections:
+  - вгору
+  rationale: 'UA-GEC фіксує уверх → вгору як F/Calque.'
+  citations:
+  - ua-gec:F/Calque id=3091
+  sourceFamily: ua-gec
+  sourceFamilies:
+  - ua-gec
+  cefrAvailability: a2
+  severity: enrichment
+  curator: codex-2026-08-03
+  notes: 'Direct reviewed UA-GEC gold pair; this is a standard variant preference, so it is enrichment rather than a Russianism.'
+  frames:
+  - sentence_with_slot: Птах злетів ___.
+    answer_form: вгору
+    calque_form: уверх
+    origin: authored-codex-2026-08-03
+- calqueLabel: стулі
+  calqueSurfaces:
+  - стулі
+  nativeSlug: стільці
+  nativeLemma: стільці
+  kind: lexical
+  corrections:
+  - стільці
+  rationale: 'UA-GEC фіксує стулі → стільці як F/Calque.'
+  citations:
+  - ua-gec:F/Calque id=3106
+  sourceFamily: ua-gec
+  sourceFamilies:
+  - ua-gec
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  notes: 'Direct reviewed UA-GEC gold pair; frame is project-authored.'
+  frames:
+  - sentence_with_slot: У класі стояли нові ___.
+    answer_form: стільці
+    calque_form: стулі
+    origin: authored-codex-2026-08-03
+- calqueLabel: удалився
+  calqueSurfaces:
+  - удалився
+  nativeSlug: пішов
+  nativeLemma: пішов
+  kind: sense_restricted
+  corrections:
+  - пішов
+  rationale: 'UA-GEC фіксує удалився → пішов як F/Calque.'
+  citations:
+  - ua-gec:F/Calque id=3352
+  sourceFamily: ua-gec
+  sourceFamilies:
+  - ua-gec
+  cefrAvailability: a2
+  severity: russianism
+  curator: codex-2026-08-03
+  calqueSense: залишив приміщення або відійшов (калькований руховий контекст)
+  authenticSense: не оцінюється поза руховим контекстом
+  notes: 'Direct reviewed UA-GEC gold pair, restricted to the left or withdrew sense; standard удався meanings are excluded. Frame is project-authored.'
+  frames:
+  - sentence_with_slot: Він мовчки ___ з кімнати.
+    answer_form: пішов
+    calque_form: удалився
+    origin: authored-codex-2026-08-03
+    disambiguated: true

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f579a0d3150333b279451e55477d54953997c9861d73b1db90ec941250bb750f
+  components_sha256: eaebeaf781ed29e311fd4e39513463b6cfe00e3fee2709ec38707aa8eae5dd49
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/practice/heritage-pairs-growth.md
+++ b/docs/practice/heritage-pairs-growth.md
@@ -1,0 +1,64 @@
+# Heritage pairs: reviewed growth and delivery
+
+**Scope:** #6140 · parent #6132 · umbrella #4387
+
+`data/lexicon/heritage_pairs.yaml` is the reviewed source of truth for the
+Heritage practice mode. A pair is a practice item only when its native slug
+resolves to a public practice lexeme and it has a source, an authored frame,
+and an explicit severity. This prevents raw corpus suggestions from becoming
+learner-facing corrections.
+
+## Review path
+
+| Source layer | What it establishes | Pair admission rule |
+| --- | --- | --- |
+| Antonenko-Davydovych and State-Standard textbook citations collected in `scripts/lexicon/calque_corrections.py` | A reviewed correction and its sense restriction | Copy the cited correction only after the native lemma resolves in the public Atlas and add a project-authored frame. |
+| UA-GEC v2 `F/Calque` gold evidence (`data/ua-gec-gold/ua-gec-gold.json`) | An annotated source → correction pair under CC-BY-4.0 | Keep the exact UA-GEC ID in `citations`; do not treat a raw frequency row as an independent correction. |
+| Atlas `heritage_status` / `is_russianism` | Additional evidence when the calque itself has an Atlas entry | Use it to support severity, never to override a sense restriction or invent a replacement. |
+
+The 2026-08-03 batch grows the source from 72 to 90 pairs. Its additions are
+the 15 rows whose native counterparts already resolve from
+`CURATED_CALQUES`, plus the direct UA-GEC gold pairs `3091`, `3106`, and
+`3352`. Candidate rows without a resolvable public native practice lemma,
+only a phrase replacement, a morphology-only correction, or insufficient
+sense evidence remain candidates rather than cards.
+
+## Severity and level guidance
+
+Every pair has one of two textual learner-facing values:
+
+- `russianism` — direct Russian-calque / surzhyk evidence or an explicit
+  Atlas classifier citation; the feedback is firm in the frame's stated
+  sense.
+- `enrichment` — a reviewed alternative or sense-limited doublet where the
+  frame teaches a richer native choice without treating every use of the
+  other form as wrong.
+
+The initial migration uses those directly recorded signals in the pair's
+citations, rationale, and curator notes. It deliberately does not infer
+severity from spelling or a raw `russian_shadow` flag.
+
+`cefrAvailability` is curator guidance, not a global hard exclusion. It may
+be `a1`, `a2`, or `b1`; omitted guidance retains the B1 default. The factory
+places a card no lower than both the native lexeme's level and the curator's
+explicit guidance. Consequently, an easy native can be admitted at A1 without
+lowering unrelated B1 cards. Two existing, source-backed everyday pairs,
+`да → так` and `папа → тато`, are curator-admitted to A1. The new
+`головуючий → голова` pair remains B1 because its meeting context is not A1
+practice, and `удалився → пішов` remains A2 with its motion sense restricted.
+
+## Factory and release path
+
+1. Validate the YAML and native lexeme resolution with the practice-deck tests.
+2. Run `make practice-deck` after hydrating the Atlas manifest and supplying
+   the explicit VESUM shadow database required by the factory.
+3. Inspect `site/public/lexicon/practice-heritage.{level}.json`; count the
+   A1 cards and the emitted `severity` values.
+4. Run `make practice-deck-publish` only after the generated shards and their
+   expected deck version agree. It uploads the immutable release asset and
+   updates `site/src/data/lexicon-practice-deck.pointer.json`.
+5. Hydrate the practice package for a local user-visible smoke test; the
+   pointer, rather than local shards, is the deployed source.
+
+`site/public/lexicon/` is generated and may be absent from a sparse checkout.
+Never hand-edit a shard or a release pointer to make these numbers change.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -122,6 +122,7 @@ NO_PAIR_PROBABILITY = {
     "C2": 0.45,
 }
 HERITAGE_KINDS = frozenset({"lexical", "sense_restricted"})
+HERITAGE_SEVERITIES = frozenset({"russianism", "enrichment"})
 HERITAGE_DEFAULT_AVAILABILITY = "B1"
 SYNONYM_DEFAULT_AVAILABILITY = "B1"
 HERITAGE_OPTION_LEAK_PATTERN = re.compile(
@@ -2572,6 +2573,9 @@ def _clean_text_list(value: Any) -> list[str]:
 
 
 def _heritage_availability_level(pair: dict[str, Any]) -> str:
+    # CEFR is a curator-facing guidance signal, not a hard exclusion from a
+    # learner's path.  B1 remains the default for unreviewed placement, while
+    # a curator may explicitly admit an easy native replacement at A1.
     return _normalize_cefr(pair.get("cefrAvailability")) or HERITAGE_DEFAULT_AVAILABILITY
 
 
@@ -2774,9 +2778,9 @@ def _build_heritage_items(
     # drill items through the same-level index/lexeme shards — so the item must
     # sit AT OR ABOVE the lexeme's shard (cumulative loading pulls lower-level
     # lexeme shards in, keeping the join resolvable). But the curator
-    # availability floor (§9.5, agy-reviewed: B1+ default, A2 only by curator
-    # flag) is a hard pedagogy gate — level-local placement must never drop
-    # BELOW it (#4719: b1-flagged calque drills were served at A1).
+    # availability floor is a curator-selected guidance floor — level-local
+    # placement must never drop below it, but explicitly A1-admitted pairs are
+    # allowed when the native lemma and pedagogy are suitable (#6140).
     lexeme_level = _normalize_cefr(lexeme.get("cefr"))
     if not lexeme_level:
         return []
@@ -2828,6 +2832,7 @@ def _build_heritage_items(
             "nativeLemma": _clean_text(pair.get("nativeLemma")) or lexeme["lemma"],
             "calqueLabel": _clean_text(pair.get("calqueLabel")) or calque_form,
             "kind": _clean_text(pair.get("kind")) or "lexical",
+            "severity": _clean_text(pair.get("severity")) or "enrichment",
             "prompt": sentence,
             "answer": answer_form,
             "calque": calque_form,
@@ -3113,6 +3118,9 @@ def validate_heritage_pair(pair: dict[str, Any]) -> list[str]:
         errors.append("heritage_pair missing sourceFamily")
     if not _clean_text(pair.get("rationale")):
         errors.append("heritage_pair missing rationale")
+    severity = _clean_text(pair.get("severity"))
+    if severity not in HERITAGE_SEVERITIES:
+        errors.append("heritage_pair severity must be russianism or enrichment")
     kind = _clean_text(pair.get("kind"))
     if kind not in HERITAGE_KINDS:
         errors.append("heritage_pair kind must be lexical or sense_restricted")
@@ -3122,8 +3130,8 @@ def validate_heritage_pair(pair: dict[str, Any]) -> list[str]:
         if not _clean_text(pair.get("authenticSense")):
             errors.append("sense_restricted heritage_pair missing authenticSense")
     availability = _clean_text(pair.get("cefrAvailability"))
-    if availability and _normalize_cefr(availability) not in {"A2", "B1"}:
-        errors.append("heritage_pair cefrAvailability must be a2 or b1")
+    if availability and _normalize_cefr(availability) not in {"A1", "A2", "B1"}:
+        errors.append("heritage_pair cefrAvailability must be a1, a2, or b1")
     frames = pair.get("frames")
     if frames is None:
         return errors

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -364,6 +364,12 @@ interface HeritageFeedback {
   citations?: string[];
 }
 
+function heritageSeverityLabel(severity: PracticeHeritageItem['severity']): { uk: string; en: string } {
+  return severity === 'russianism'
+    ? { uk: 'Російська калька', en: 'Russian calque' }
+    : { uk: 'Лексичне збагачення', en: 'Vocabulary enrichment' };
+}
+
 interface ParonymFeedback {
   kind: 'correct' | 'wrong';
   textUk: string;
@@ -4247,10 +4253,15 @@ function PracticeHeritage({
     ? displayPracticeForm(selectedLabel ?? item.answer, learnerLevel)
     : '___';
   const sentenceEnglish = postAnswerSentenceEnglish(feedback, item.promptEn);
+  const severityLabel = heritageSeverityLabel(item.severity);
   return (
     <div className="lexicon-heritage" data-testid="practice-heritage">
       <p className="heritage-task">
         <PracticeChromeLabel k="practice.chooseNative" />
+      </p>
+      <p className="heritage-severity" data-testid="practice-heritage-severity">
+        <span lang="uk">{severityLabel.uk}</span>
+        {showEnglishSubtitles ? <span className="btn-sub" lang="en">/ {severityLabel.en}</span> : null}
       </p>
       <p className="heritage-sentence">
         <span>{before}</span>

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-abbfa02c16246ea7.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-550fb9e8cce25572.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-abbfa02c16246ea7",
+  "deck_version": "atlas-practice-v1-550fb9e8cce25572",
   "package_schema_version": 1,
-  "gz_sha256": "7052f296f057f890acc1242457b3ccdaa69370645ada3d0ace04a3321f3f8d06",
-  "package_sha256": "808c52264f5bce96195731659b2c3ed2f1cfacf730d02e833ba5390b19c01564",
-  "gz_bytes": 1754077,
-  "package_bytes": 23212452,
+  "gz_sha256": "0c466b6681b947ad1ed5f1491683a6b44037d3ec21abfe2cdfbfe6eb5c43a090",
+  "package_sha256": "649cc7da7152ec161803e38bf582496fd4271698c59167e4084cb7e2fcc43ce7",
+  "gz_bytes": 1757424,
+  "package_bytes": 23226315,
   "file_count": 55,
   "files": [
     {
@@ -14,8 +14,8 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 288192,
-      "sha256": "bc97ae452675a7a23e152b0c206a175a368e77ed88e49b96fefe46bce0a02374",
+      "bytes": 288217,
+      "sha256": "c7574140b88479abb0387532098ee629e9b04e0d83e3eec6abf17d5ed737b667",
       "counts": {
         "lexemes": 1469,
         "cloze": 1147,
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 533384,
-      "sha256": "48cd68401df43783b81f186c95ed0c4ad13e7d8ee38a10333903eb0e27487d49"
+      "sha256": "6672c6e7f7852aa262e9641a519d871386f44b75cadbd9870e22cdc40e5efd9e"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 1908884,
-      "sha256": "dd8d4e4758596e4ce91139102ce079fe33e76a0177708e8f68acb047e971af02"
+      "bytes": 1908974,
+      "sha256": "6c66ac9300ce2802754ff888238b97b04d082594ea828fd7bcbffaf38a591859"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 347979,
-      "sha256": "3f569c90c0c7ddcfc72d369a7fc0a2b9898f52433f4ce763229a4f87ab24abcb"
+      "sha256": "f6096597bfd9121959e3a1810e3f95385d5df034e8b155c7a0a5c467f7e6b6f4"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 369714,
-      "sha256": "4fd47a88ae463e47e3c8cdd657b84230252d0b232acf7292f1cc32150a0c48c3"
+      "sha256": "5733b4592ecaa559620a8f965bd993c64d726529cbd5cde12b87246d6b0e3d0d"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 622510,
-      "sha256": "cc1015acd7566b10622598db149f9c24d6b5ee22642d525b2e60cca9b54c5f78"
+      "sha256": "28549f8cd75da7e3661de6d2f9f4dec604cb49f07a8bd2947264079e8a8e7fcd"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,15 +69,15 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 255,
-      "sha256": "95defa09db6a35f9bae3346587157ea9493cb1437a5ba8cba1741159cf9d6bd9"
+      "sha256": "99f7fcfb2f7ea6ead8f6f64b78b9c2e88015586adb926e1ee43a108742168d8e"
     },
     {
       "path": "practice-heritage.A1.json",
       "kind": "heritage",
       "level": "A1",
       "schema": "atlas-practice-heritage",
-      "bytes": 257,
-      "sha256": "5ba4f159eceb67d1364bd928c0f5d827ccf71d8ef1f18893e6844a543a4ab185"
+      "bytes": 3076,
+      "sha256": "483ad0e943f3e2bef7f7adc1fc906ae56f061de8da51f5d99f8d5394167518e6"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,7 +85,7 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 8555,
-      "sha256": "f59dc40e8d964ed0091f9fe257acc5d958cc0e4ddf74cd8c061bf221e7fa2c5b"
+      "sha256": "d954e481cec9edd21f3f97534c65b35420d79faa16b12a137d1fd85c19111862"
     },
     {
       "path": "practice-antonym.A1.json",
@@ -93,7 +93,7 @@
       "level": "A1",
       "schema": "atlas-practice-antonym",
       "bytes": 61300,
-      "sha256": "d776611c02035e51fbbccd9a0dfa770afb71745cef4d3f592a53daecec47ecc8"
+      "sha256": "0af83618b11915ea82465ef5f08b476971d285494c510f13739ca4d7daea953b"
     },
     {
       "path": "practice-homonym.A1.json",
@@ -101,15 +101,15 @@
       "level": "A1",
       "schema": "atlas-practice-homonym",
       "bytes": 8559,
-      "sha256": "07f98aa49daabd138ec19bce6a50894a052be5cf187712d7dd79d9913cdd824e"
+      "sha256": "7cf4763e4adb1ad6d1cc82fa9b57674d5b7238410864abbe69733e1610ab7c0f"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 306218,
-      "sha256": "e225013f526d29f4f75f3e83987b1a09b62f19f709fac618abcc5020448fd979",
+      "bytes": 306284,
+      "sha256": "80b45329128b85d3e2a31bdbf86e5eaa0ae85a2eac4a793b5bea45357e126115",
       "counts": {
         "lexemes": 1491,
         "cloze": 1164,
@@ -122,32 +122,32 @@
       "kind": "lexemes",
       "level": "A2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 555107,
-      "sha256": "96dbfbb54be0ebd91a4c79940d50d0615cc572134f7275175e584c210763fb04"
+      "bytes": 555121,
+      "sha256": "98db9245beb98a45bde1f8646c0a1663684d24383a0846d1248c689574209d82"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1996323,
-      "sha256": "7e69b5039797578ab3b7ad3c565df58e1ecf2907ec14ab17f1a2ff6a060bb11a"
+      "bytes": 1996189,
+      "sha256": "8678a73dfdb0bb7cd4115b93486da92f81ab70b4b41f1820e590aaff6f8a142b"
     },
     {
       "path": "practice-stress.A2.json",
       "kind": "stress",
       "level": "A2",
       "schema": "atlas-practice-stress",
-      "bytes": 400658,
-      "sha256": "2a840555dfed908195e18eb679438743922cc863cf901be27cd07b076e8c39ca"
+      "bytes": 400633,
+      "sha256": "6e1a278636086c43a5fb08bba4be741d3c2162ca447dbcac8e75116574002f54"
     },
     {
       "path": "practice-classify.A2.json",
       "kind": "classify",
       "level": "A2",
       "schema": "atlas-practice-classify",
-      "bytes": 1041763,
-      "sha256": "aa1898a1a2a1eb923c65169203cbfc4794022abd726df74d5ce82bb90f23bfdd"
+      "bytes": 1041486,
+      "sha256": "360d37910ee556e4f4776032e6815e9679b1934ecce10efbfbb2ac10001efc1a"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -155,7 +155,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 600001,
-      "sha256": "d9a60472b2bb8b2ca15314a5d3329bb69889db22a10a8fb38572ab5788ad9833"
+      "sha256": "2c8d278d8b42644f2652133c7afe8f05441604dff5eb1ed2075bdb13611ba9dc"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -163,15 +163,15 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 5119,
-      "sha256": "4b695d73380fbe14d608efd915a9da44348086a20084833cade597a2f3bb39a9"
+      "sha256": "219fd14e5b4c3c0a22d982a8b20954519c6fdd895cd7823cb8e51b11cacb6784"
     },
     {
       "path": "practice-heritage.A2.json",
       "kind": "heritage",
       "level": "A2",
       "schema": "atlas-practice-heritage",
-      "bytes": 33411,
-      "sha256": "9b09baaffa64622b1437c8c534514d50720d15261eaba986c5efb326eaea7621"
+      "bytes": 37399,
+      "sha256": "5b5c5c7a63c537629a7143c9f00b54b9cdc4b8fae4836a48045614ae0d505164"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -179,7 +179,7 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 7817,
-      "sha256": "cc5c920af4bfa329cda2e895ba404f47855fb45bc36134d601ebb2a581ecf1cb"
+      "sha256": "6fbba6dd77bba7906859403bf816d704993fcc5723f8f951b7651addc520708e"
     },
     {
       "path": "practice-antonym.A2.json",
@@ -187,7 +187,7 @@
       "level": "A2",
       "schema": "atlas-practice-antonym",
       "bytes": 35536,
-      "sha256": "03c88049234f3b468777181c285bc717fa67bf401972c3d416eb63c3cf49352c"
+      "sha256": "eb51e8add15232851a1bfc40605742d6b54e70b8610297b75252f4ec6e838e12"
     },
     {
       "path": "practice-homonym.A2.json",
@@ -195,15 +195,15 @@
       "level": "A2",
       "schema": "atlas-practice-homonym",
       "bytes": 10915,
-      "sha256": "62a240b2607dbef2b723ffbacefbe54f64b9a70a3083b9ab7ca5f6a746e302fb"
+      "sha256": "3b48c6b0cb8ce532fe50c9f759cab7944c476724a77ad064da4df675edfaee74"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 344648,
-      "sha256": "102e46ab374dd4c2b784554d6a710dc68ce4daa0d2f57b3b2a88356951ca9e0b",
+      "bytes": 344680,
+      "sha256": "a0c002bf67c2926d0f80265a43f5ed6194cca09644eb979969a530b59d05907d",
       "counts": {
         "lexemes": 1662,
         "cloze": 1296,
@@ -217,15 +217,15 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 647675,
-      "sha256": "ad6faff87e226f89cb2014bca2e911a4e9ad80081fe33b4d346d4995e654b584"
+      "sha256": "05442f06982820bdc917c0be72855b849aacc2a1fdebdeb4117ba23bc561c90a"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 2216838,
-      "sha256": "79c27cde87727460fc9f8da4f79d245c19bd895c7dc5e237b4abe2588359ae22"
+      "bytes": 2217200,
+      "sha256": "96cb7d60d7fdcd91a6f2f1cf02139e2df7358f46a970d84825dbfd653d65598b"
     },
     {
       "path": "practice-stress.B1.json",
@@ -233,7 +233,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 473674,
-      "sha256": "e4a515218424f7bed6e4598dbda081cbbd48687b91d5f07fd40fa3cb67b1bd4f"
+      "sha256": "08cfbfbea5e500df55dee4756116ec5cd06c928ca7a17b75a35abc416f3b55a3"
     },
     {
       "path": "practice-classify.B1.json",
@@ -241,7 +241,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1396888,
-      "sha256": "8da5540ac21b4498955c32ab9f8532f34ff8822c613baa185f7db7744f2ed68e"
+      "sha256": "0e7a2cb72eee58bfefa5fa0acdcaf69cb7222547a0fd5a1bcc2da6aebc8a4dcd"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -249,7 +249,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 789682,
-      "sha256": "7ddcaf40c59317f7685dcd3e4ea71d1b27752716ac1d32b28039601a7ffade78"
+      "sha256": "40689b451d782d7e8f1a502360ddd6b161de7a1b798ada666f56d064cde5032f"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -257,15 +257,15 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 383492,
-      "sha256": "3af742c423023f49e1421abbe6348caddd833326baa6b453afb25df027e04e49"
+      "sha256": "3ef9cc857ea4235406e19ae34fbabdb61432ff00ca6bb428220e0ae2a5771528"
     },
     {
       "path": "practice-heritage.B1.json",
       "kind": "heritage",
       "level": "B1",
       "schema": "atlas-practice-heritage",
-      "bytes": 81937,
-      "sha256": "2c9ae0715ef16282f0738546cbe7ddf280a512ea8e62f2cfe07898dfdc180360"
+      "bytes": 86452,
+      "sha256": "48436d184c3a733316e3ad57cb2abdd64fbf3c6ceb816b902646044c705b25ca"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -273,7 +273,7 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 5411,
-      "sha256": "de8ba9c770300c41f8b30c184f2c1d7855654842bcefc1b0daf1bbf78ccafd13"
+      "sha256": "a8ee84f599ade2dbe664fb5c268f5c996b2bc9d307b3c300055e06295a740d16"
     },
     {
       "path": "practice-antonym.B1.json",
@@ -281,7 +281,7 @@
       "level": "B1",
       "schema": "atlas-practice-antonym",
       "bytes": 24894,
-      "sha256": "cd7513a4dfdf96ba2a3750165364b6f50079cf8103c0028dec4c4fdbef1859a9"
+      "sha256": "0ebadc319eedce66303e04f48feedc7611574d5c5e70b3814dc1e94e72a3014c"
     },
     {
       "path": "practice-homonym.B1.json",
@@ -289,20 +289,20 @@
       "level": "B1",
       "schema": "atlas-practice-homonym",
       "bytes": 6273,
-      "sha256": "b54c87aa7c1c6f558af4cea7dfe90868c20009bbc647f54e02cd41b394226517"
+      "sha256": "f8631547cf91fc0610c54b24edf0519ab2e4af4e92f2125ec852455cdaf7520a"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 200287,
-      "sha256": "82520440adfd5204b153abd33949da1598441e78a1357bdbd09a72402536718f",
+      "bytes": 200489,
+      "sha256": "b9c5dad4e80038397054a3e866e543c43fb703000a8487bf1244a358feb5fb42",
       "counts": {
-        "lexemes": 951,
+        "lexemes": 952,
         "cloze": 726,
         "clozeEligibleLexemes": 726,
-        "clozeCoverage": 0.7634
+        "clozeCoverage": 0.7626
       }
     },
     {
@@ -310,32 +310,32 @@
       "kind": "lexemes",
       "level": "B2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 384452,
-      "sha256": "f82a6c47785c8744bb29193f9b68d63ec517da48afddd5b6771e14cda09ba3f2"
+      "bytes": 384753,
+      "sha256": "594bb920d25bc7c295f99e67f83e858e2d1af69f3d4b59db60b177a8bd76dc8f"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 1261758,
-      "sha256": "7f91efc0556f345fa9449a917376f6571722f0d03b627f27ad3dceb48f1969ca"
+      "bytes": 1261818,
+      "sha256": "88273246d0320b42a24ed32f3085f79b3e3bdb32317faf88c8d80b8a73976b42"
     },
     {
       "path": "practice-stress.B2.json",
       "kind": "stress",
       "level": "B2",
       "schema": "atlas-practice-stress",
-      "bytes": 285880,
-      "sha256": "5f060899a1bb2588756909d464e71785195d86aecb9c12677db2f8ee8a47799b"
+      "bytes": 286229,
+      "sha256": "0858ae7c6282933098e83324f3a1fda8d9d656aec090370baed8ff5299e7bd5c"
     },
     {
       "path": "practice-classify.B2.json",
       "kind": "classify",
       "level": "B2",
       "schema": "atlas-practice-classify",
-      "bytes": 804831,
-      "sha256": "ec0025766c889cb937ef507c83cd0bef6cdc402e4263ca301d324a29c2af887b"
+      "bytes": 805410,
+      "sha256": "d0594f68c34e493151b2c4212cc1a8526ca51f68d187b44249862d56291c56bd"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -343,7 +343,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 511862,
-      "sha256": "f53a8f39563920167c069548ca1daa5feafc664df417de284d5664fc4519a6b9"
+      "sha256": "79993b5cca4de04d0465b4b617fca0da617aff6ea9aae6dde90b51d147bb13e2"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -351,15 +351,15 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 97752,
-      "sha256": "f8cdf89d71e049729842393cb6607386575776d5eea24f46d9472a5a5ad869c5"
+      "sha256": "03fce85b588d12691d2cbea24fd17af3f03691c7e5a9cede14ec842a6b8eb5e4"
     },
     {
       "path": "practice-heritage.B2.json",
       "kind": "heritage",
       "level": "B2",
       "schema": "atlas-practice-heritage",
-      "bytes": 13177,
-      "sha256": "c3d76b4497214594f2f0f7351b1145f9602e0a432ce5b7a14b160b900bbfe12e"
+      "bytes": 14363,
+      "sha256": "1eaac2ad94ce08da85b23d7dd5513b4ce48b42ef5bcffad04700085708e67972"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -367,7 +367,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 1704,
-      "sha256": "cc8eda725360a5852746e7a6be957066a6d71c248674f4e27e5c8d5697b329a5"
+      "sha256": "864d2b13d7685ed33164c30e731e17f61dd4491c42e3323b903708d949366eb2"
     },
     {
       "path": "practice-antonym.B2.json",
@@ -375,7 +375,7 @@
       "level": "B2",
       "schema": "atlas-practice-antonym",
       "bytes": 6305,
-      "sha256": "761265e22bd25d9b061d2f122ccaa3cfda26e5654ed8b9b2d3b98c20e2c0f5f5"
+      "sha256": "c19247573f170c26a25015bc7f870b9f35b006e8b564e001a3791bfe61addc98"
     },
     {
       "path": "practice-homonym.B2.json",
@@ -383,20 +383,20 @@
       "level": "B2",
       "schema": "atlas-practice-homonym",
       "bytes": 4008,
-      "sha256": "d70b31eed309e239631cc81d48ef75f369246bc8816c4a15746e7867190b25c9"
+      "sha256": "472bdfe02fa2dd0b39d07f90ccea7dbe20a9f9b4841c5e1187e432f9f0bca987"
     },
     {
       "path": "practice-index.C1.json",
       "kind": "index",
       "level": "C1",
       "schema": "atlas-practice-index",
-      "bytes": 86357,
-      "sha256": "36fb1f27b561f4d5159cf1bdee05712f6481669e7e0269020eacb6954290be2f",
+      "bytes": 86225,
+      "sha256": "7a962d68b7d05e5a27f8616d3c762ca0ec420c74c61ecdc9fb59d8dc0adf62a0",
       "counts": {
-        "lexemes": 427,
+        "lexemes": 426,
         "cloze": 191,
         "clozeEligibleLexemes": 191,
-        "clozeCoverage": 0.4473
+        "clozeCoverage": 0.4484
       }
     },
     {
@@ -404,56 +404,56 @@
       "kind": "lexemes",
       "level": "C1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 171694,
-      "sha256": "9785150c3553009d0a1fa4587b1a3a74d2ba9954fc518d93ff16df9404fc23d2"
+      "bytes": 170730,
+      "sha256": "889f4394d9015241d8b09feacf0a32e5c6a31baf54c792aae4d2ac3539aa60c6"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 334463,
-      "sha256": "4a1598f80d258fcb1197fef0485c8ddd4db0e24f1f252725f47d8395c390cf4a"
+      "bytes": 334609,
+      "sha256": "dd3a6a426bd7db0c1681295c832c2f0eb7fe2e88cfa0c2c27720439dd6a5068d"
     },
     {
       "path": "practice-stress.C1.json",
       "kind": "stress",
       "level": "C1",
       "schema": "atlas-practice-stress",
-      "bytes": 126390,
-      "sha256": "37eec19b6636965e42994a6aa1817a87d5179f61696b7c93819df72d8631f066"
+      "bytes": 125977,
+      "sha256": "b227ffe01309d40142201d685d8abb6398c6c187db24b7b19af6bf0b6dca8439"
     },
     {
       "path": "practice-classify.C1.json",
       "kind": "classify",
       "level": "C1",
       "schema": "atlas-practice-classify",
-      "bytes": 340810,
-      "sha256": "414ea4c9db32dbfc0f2893d4eefa7543488402daebcdfe9855a74fac18138c57"
+      "bytes": 339104,
+      "sha256": "432fafb83082caa146e28b168be854012a12b072a80862c0ec5206f9aa239873"
     },
     {
       "path": "practice-paradigm.C1.json",
       "kind": "paradigm",
       "level": "C1",
       "schema": "atlas-practice-paradigm",
-      "bytes": 240983,
-      "sha256": "593083384e88e70a370801934b82fe702144a2cc53c1595440ed5dbdc36f78a6"
+      "bytes": 237061,
+      "sha256": "8c4b8e283226e9d3303056eb8048f693b9a3ba7318c5ddf506a421a46a8acdca"
     },
     {
       "path": "practice-synonym.C1.json",
       "kind": "synonym",
       "level": "C1",
       "schema": "atlas-practice-synonym",
-      "bytes": 34669,
-      "sha256": "f8e8f73cb74fd6132fb849b6606347888dbe0c514c96a0227207986489edee41"
+      "bytes": 34665,
+      "sha256": "b3d387f678919a2cea878d25408e502d67234c739ae039485b83d7b113f2f7ef"
     },
     {
       "path": "practice-heritage.C1.json",
       "kind": "heritage",
       "level": "C1",
       "schema": "atlas-practice-heritage",
-      "bytes": 2060,
-      "sha256": "11a39e86c5debc90d74847c5a9a865d81decce610065c8fb6c36be8dffe81f10"
+      "bytes": 7454,
+      "sha256": "2c43b8c459eb14925d6f3b83c70488365bdb987d2ab010350338385192352e25"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -461,7 +461,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 3130,
-      "sha256": "b62630cb69cb162cd53f0bc546bdf9e7a7b01c20ddf7007e48b06c4eeae4e7e5"
+      "sha256": "197289f7411b24b1de5f996fe1946cab16620995c5048515f752c65264b3b3cf"
     },
     {
       "path": "practice-antonym.C1.json",
@@ -469,7 +469,7 @@
       "level": "C1",
       "schema": "atlas-practice-antonym",
       "bytes": 2607,
-      "sha256": "4c11de471f6002c3a6566fafdddecaed2f1f8c665f1809e452d5d5cd755106b7"
+      "sha256": "7c870c981b8e466995924b63e15c0c0827b50687b76f45c981d54e098e9015e7"
     },
     {
       "path": "practice-homonym.C1.json",
@@ -477,7 +477,7 @@
       "level": "C1",
       "schema": "atlas-practice-homonym",
       "bytes": 255,
-      "sha256": "41cd6ef56f7cc5e047212fe435349047beeb9ced4eea7c3239a3647c28d8ec19"
+      "sha256": "f8936aac7722573fca079dec5929eb7bf0a087a6e6be9e6e71a10ba7a5922b66"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -244,6 +244,8 @@ export interface PracticeHeritageItem {
   nativeLemma?: string;
   calqueLabel?: string;
   kind: 'lexical' | 'sense_restricted' | string;
+  /** Curator-adjudicated learner-facing tone for the selected calque context. */
+  severity: 'russianism' | 'enrichment';
   prompt: string;
   /** Optional English meaning of the Ukrainian prompt sentence. */
   promptEn?: string;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -415,6 +415,7 @@ function heritagePracticeItem(): PracticeHeritageItem {
     nativeLemma: 'дім',
     calqueLabel: 'дом',
     kind: 'lexical',
+    severity: 'russianism',
     prompt: 'Я бачу ___ щодня.',
     promptEn: 'I see ___ every day.',
     answer: 'дім',
@@ -1867,6 +1868,7 @@ describe('LexiconPractice', () => {
 
     expect(screen.getByTestId('practice-heritage')).toBeInTheDocument();
     expect(screen.getByText('Оберіть питоме українське слово.')).toBeInTheDocument();
+    expect(screen.getByTestId('practice-heritage-severity')).toHaveTextContent('Російська калька');
     expect(screen.getByText(/Я бачу/)).toBeInTheDocument();
 
     mixedRender.unmount();

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -206,6 +206,7 @@ function heritageItem(lemmaId: string, heritageId = `${lemmaId}:heritage:1`): Pr
     nativeLemma: lemmaId,
     calqueLabel: `${lemmaId}-calque`,
     kind: 'lexical',
+    severity: 'enrichment',
     prompt: 'Я бачу ___ щодня.',
     answer: lemmaId,
     calque: `${lemmaId}-calque`,

--- a/tests/fixtures/lexicon-practice-heritage-pairs.yaml
+++ b/tests/fixtures/lexicon-practice-heritage-pairs.yaml
@@ -13,6 +13,7 @@ pairs:
       - fixture:heritage
     sourceFamily: fixture
     cefrAvailability: a2
+    severity: enrichment
     frames:
       - sentence_with_slot: Я читаю ___.
         answer_form: книгу

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -19,6 +19,7 @@ from scripts.audit.generate_practice_deck import (
     _build_classify_items,
     _build_cloze_items,
     _build_heritage_items,
+    _heritage_availability_level,
     _build_lexeme,
     _build_paradigm_items,
     _build_paronym_items,
@@ -855,6 +856,28 @@ def test_heritage_item_ids_and_options_are_deterministic() -> None:
     assert first["heritageId"] == second["heritageId"]
     assert first["options"] == second["options"]
     assert first["heritageId"] != changed_version["heritageId"]
+
+
+def test_heritage_a1_admission_is_explicit_and_emitted_with_severity() -> None:
+    pair = _fixture_heritage_pair()
+    pair["cefrAvailability"] = "a1"
+    pair["severity"] = "russianism"
+    lexemes = _fixture_lexemes()
+
+    assert _heritage_availability_level(pair) == "A1"
+    item = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    assert item["cefr"] == "A1"
+    assert item["severity"] == "russianism"
+
+
+def test_heritage_pair_requires_known_severity_and_allows_a1_guidance() -> None:
+    pair = _fixture_heritage_pair()
+    pair["cefrAvailability"] = "a1"
+    pair["severity"] = "enrichment"
+    assert validate_heritage_pair(pair) == []
+
+    pair["severity"] = "warning"
+    assert "heritage_pair severity must be russianism or enrichment" in validate_heritage_pair(pair)
 
 
 def test_stress_position_preserves_non_stress_combining_marks() -> None:
@@ -2747,4 +2770,3 @@ def test_live_homonym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
     for index, pair in enumerate(pairs):
         errors = validate_homonym_pair(pair)
         assert not errors, f"Pair {index} ({pair.get('slugA')}/{pair.get('slugB')}) invalid: {errors}"
-


### PR DESCRIPTION
## Summary

- add source-backed `russianism` / `enrichment` severity to all 90 heritage pairs and display it as learner-visible text
- permit curator-reviewed A1 availability guidance, yielding four A1 heritage cards from two everyday source-backed pairs
- grow the reviewed set from 72 to 90 and document the source-to-publish workflow
- regenerate and publish immutable practice deck `atlas-practice-v1-550fb9e8cce25572`

Closes #6140
Refs #6132 #4387

## Acceptance evidence

- [x] All pairs validate an explicit `severity`; factory emission and UI text are covered by tests.
- [x] `cefrAvailability: a1` is valid curator guidance; the A1 heritage shard is no longer empty solely because of the B1 default.
- [x] Reviewed growth uses 15 existing State Standard/Antonenko `CURATED_CALQUES` entries plus UA-GEC F/Calque gold IDs 3091, 3106, and 3352; exclusions and next-batch path are documented.
- [x] Factory shards and published pointer were regenerated and hydrated.

```text
pairs_before=72 pairs_after=90
heritage_A1_before=0 heritage_A1_after=4
severity: russianism=41 enrichment=49
```

## Validation

- `.venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_publish_practice_deck.py -q --tb=short` (117 passed)
- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py`
- `./node_modules/.bin/markdownlint-cli2 docs/practice/heritage-pairs-growth.md`
- `cd site && ./node_modules/.bin/vitest run tests/unit/LexiconPractice.test.tsx tests/unit/lexicon-srs.test.ts` (189 passed)
- `npm --prefix site run hydrate:practice`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

## Review state

Draft while the required independent cross-family PR review runs. Do not merge from this PR.