### PR TITLE
fix(practice): learner layout P0 fixes for non-power-user affordances

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: eaebeaf781ed29e311fd4e39513463b6cfe00e3fee2709ec38707aa8eae5dd49
+  components_sha256: 19aac4f20ee34578db7379faf2260a2aba68014e56cf8a23b825ad339d7cda2c
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1731,6 +1731,10 @@ components:
       - name: tagColor
         type: string
         description: tagColor prop.
+        ukrainian_text: 'false'
+      - name: heritageLabel
+        type: string
+        description: heritageLabel prop.
         ukrainian_text: 'false'
     example:
       card: <PracticeFlashcardData>

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -11,6 +11,23 @@ function trackConsoleErrors(page: Page): string[] {
   return errors;
 }
 
+/**
+ * Opus P0-1 folded Drive sync + deck filter behind a `<details>` disclosure
+ * (`data-testid="practice-secondary-tools"`), below the mode grid. Deck chips,
+ * the "Manage Decks" action, and the switch-session-offer it can surface all
+ * live inside that fold — open it before touching any of them. Idempotent: a
+ * caller can invoke it repeatedly across deck switches within one test.
+ */
+async function openSecondaryTools(page: Page): Promise<void> {
+  const panel = page.getByTestId('practice-secondary-tools');
+  await expect(panel).toBeVisible();
+  const open = await panel.getAttribute('open');
+  if (open === null) {
+    await panel.locator('summary').click();
+  }
+  await expect(panel).toHaveAttribute('open', '');
+}
+
 test('browse supports search, category, and letter entry points without dumping all cards', async ({ page }) => {
   await page.goto('/lexicon/browse/');
 
@@ -537,6 +554,9 @@ test('A5: switching level with a session in progress offers a fresh session; acc
   // The A1 setup session is over; deplete A1 so A2's background lower-level merge (which
   // always fetches A1 as a lower level) cannot reintroduce it into the accepted pool.
   fixtures.depleteLowerLevel('A1');
+  // The switch-session-offer this triggers lives inside the same folded panel as
+  // the deck filter, even though the A2 level button itself is above the fold.
+  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: 'A2' }).click();
 
@@ -575,6 +595,7 @@ test('A5c: choosing a deck from the custom-deck manager while a session is activ
     );
   });
   await prepareResumableMixedSession(page);
+  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: /Manage Decks|Менеджер колод/ }).click();
   await page.getByRole('button', { name: /Practice|Практика/ }).first().click();
@@ -588,12 +609,13 @@ test('A5c: choosing a deck from the custom-deck manager while a session is activ
   await page.getByTestId('practice-switch-session-accept').click();
 
   await expect(page.locator('.lexicon-practice-stage')).toBeVisible();
-  // The custom deck has exactly one word with no cloze content, so `ensureDeckCustomSetCoverage`
-  // gives it 7 practicable modes (flashcards/stress/classify/paradigm/synonym/paronym/heritage) —
-  // a mixed-mode session over ONE such word plans exactly 7 mode-cards. That number is wildly
-  // different from a full-level session (hundreds of due/new cards) — proof the pool is the
-  // accepted deck, not the full corpus.
-  await expect(page.getByTestId('practice-session-progress')).toContainText('0/7');
+  // The custom deck has exactly one word that resolves to no Atlas/cloze content, so the
+  // P0-3 mode-claim honesty fix in `ensureDeckCustomSetCoverage` only claims the one mode it
+  // can actually deliver (flashcards) rather than promising modes with nothing behind them.
+  // A mixed-mode session over ONE such word plans exactly 1 mode-card — wildly different from
+  // a full-level session (hundreds of due/new cards) — proof the pool is the accepted deck,
+  // not the full corpus.
+  await expect(page.getByTestId('practice-session-progress')).toContainText('0/1');
 
   const snapshot = await readMixedSessionSnapshot(page);
   expect(snapshot?.deckId).toBe('e2e-custom-deck');
@@ -603,6 +625,7 @@ test('A5b: declining the switch offer reverts the selection and leaves the sessi
   await context.clearCookies();
   await page.addInitScript(() => window.localStorage.setItem('lu-chrome-locale', 'uk'));
   await prepareResumableMixedSession(page);
+  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: 'A2' }).click();
   await expect(page.getByTestId('practice-switch-session-offer')).toBeVisible();
@@ -696,6 +719,7 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
   // Before selecting the custom deck, the estimate reports the full-level soft-CEFR scope.
   await expect(estimate).toContainText('8 нових');
 
+  await openSecondaryTools(page);
   await page.getByRole('button', { name: /E2E Scope Deck/ }).click();
 
   // F1-F3 (PR #5837) scoped the two SESSION-start paths to the chosen deck via
@@ -795,6 +819,7 @@ test('A8a: an Atlas-only custom-deck key gets its gloss and route while a true o
   }, [catDeck, orphanDeck] as const);
 
   await page.goto('/words-of-the-day/practice/');
+  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: /E2E D10 Cat Deck/ }).click();
   await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Cat Deck');
@@ -861,6 +886,7 @@ test('A8: two different custom decks show different daily-zone sets, each drawn 
   );
 
   await page.goto('/words-of-the-day/practice/');
+  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: /E2E D10 Alpha Deck/ }).click();
   await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Alpha Deck');
@@ -887,6 +913,7 @@ test('A9a: a deck-scoped daily set is stable within a day and rotates across day
   async function selectDeckAndReadWords(clockTime: string): Promise<string[]> {
     await page.clock.setFixedTime(new Date(clockTime));
     await page.goto('/words-of-the-day/practice/');
+    await openSecondaryTools(page);
     await page.getByRole('button', { name: /E2E D10 Rotation Deck/ }).click();
     await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Rotation Deck');
     return readDailyDeckWords(page);

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -22,7 +22,6 @@ import {
   itemIdPresentInDeck,
   computeSessionScope,
   computeTodayRingDenominator,
-  countDueReviewCards,
   czNorm,
   isPracticeNewCard,
   isPracticeSessionResumable,
@@ -300,13 +299,17 @@ function ensureDeckCustomSetCoverage(
       const matchedClozeIds = clozeByLemma.get(keyLower) ?? [];
       const hasCloze = matchedClozeIds.length > 0;
 
+      // Learner-layout P0-3 / Opus P0-2: an unmatched custom-deck key has no resolved
+      // practice-core content — claiming the full mode list here promised exercises
+      // (e.g. a "5" on the Heritage card) that the active session then couldn't
+      // deliver, landing the learner in an instant empty-mode dead end. Only claim
+      // the modes this key actually resolves content for; other modes appear once
+      // real shard data resolves them (same honesty rule as the built shards).
       newIndexItems.push({
         lemmaId: atlas?.slug ?? key,
         lemma: atlas?.lemma ?? cleanKey,
         cefr: atlas?.cefr ?? null,
-        modes: hasCloze
-          ? ['flashcards', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage']
-          : ['flashcards', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage'],
+        modes: hasCloze ? ['flashcards', 'cloze'] : ['flashcards'],
         hasCloze,
         clozeIds: matchedClozeIds,
         newOrder: orderCounter++,
@@ -627,6 +630,13 @@ function visiblePracticeMode(mode: PracticeModeFilter): VisiblePracticeModeFilte
   return mode in MODE_META ? (mode as VisiblePracticeModeFilter) : 'mixed';
 }
 
+/** P0-3: the mode count must be part of the card's accessible name, not aria-hidden. */
+function modeCountAccessibleSuffix(count: number, chromeLocale: 'en' | 'uk'): string {
+  return chromeLocale === 'uk'
+    ? `${count} ${uaPlural(count, { one: 'вправа', few: 'вправи', many: 'вправ' })}`
+    : `${count} ${count === 1 ? 'exercise' : 'exercises'}`;
+}
+
 const HERITAGE_COLORS: Record<string, string> = {
   native: 'var(--lu-teal)',
   inherited: 'var(--lu-teal)',
@@ -809,17 +819,34 @@ function heritageTagColor(heritage: string | null): string | undefined {
   return HERITAGE_COLORS[heritage.toLowerCase()] ?? 'var(--lu-text-muted)';
 }
 
+/** P0-4: heritage on the flashcard back must be a text chip, not color-only. */
+const HERITAGE_LABEL_KEYS: Record<string, ChromeKey> = {
+  native: 'practice.heritageNative',
+  inherited: 'practice.heritageInherited',
+  borrowed: 'practice.heritageBorrowed',
+  loanword: 'practice.heritageBorrowed',
+  calque: 'practice.heritageCalque',
+  avoid: 'practice.heritageAvoid',
+};
+
+function heritageLabelText(heritage: string | null, chromeLocale: 'en' | 'uk'): string | undefined {
+  if (!heritage) return undefined;
+  const key = HERITAGE_LABEL_KEYS[heritage.toLowerCase()];
+  return key ? CHROME_STRINGS[chromeLocale][key] : undefined;
+}
+
 function displayPracticeForm(value: string, learnerLevel: CefrLevel): string {
   return learnerLevel === 'A1' ? value : stripStressMarks(value);
 }
 
-function cardData(entry: PracticeLexeme, learnerLevel: CefrLevel) {
+function cardData(entry: PracticeLexeme, learnerLevel: CefrLevel, chromeLocale: 'en' | 'uk') {
   return {
     front: displayPracticeForm(entry.lemma, learnerLevel),
     back: entry.gloss,
     subtitle: entry.ipa ?? entry.pos ?? undefined,
     tag: entry.cefr ?? undefined,
     tagColor: heritageTagColor(entry.heritage),
+    heritageLabel: heritageLabelText(entry.heritage, chromeLocale),
   };
 }
 
@@ -1471,6 +1498,12 @@ function LexiconPracticeIsland({
   const [clozeInput, setClozeInput] = useState('');
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
+  // Opus P0-6: a case-miss used to clear the input and loop forever with no lock —
+  // a learner who knew the word but not the case could cycle its paradigm
+  // indefinitely. Cap case-misses so the second one locks and reveals via the
+  // existing PracticeFormRail path, same as any other locked cloze result.
+  const [clozeCaseMissCount, setClozeCaseMissCount] = useState(0);
+  const clozeCaseMissOutcomeRef = useRef<CompletionOutcome | null>(null);
   const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
   const [paronymFeedback, setParonymFeedback] = useState<ParonymFeedback | null>(null);
   const [stressSelectedPosition, setStressSelectedPosition] = useState<number | null>(null);
@@ -1645,6 +1678,8 @@ function LexiconPracticeIsland({
     setClozeInput('');
     setClozeFeedback(null);
     setClozeAttemptRecorded(false);
+    setClozeCaseMissCount(0);
+    clozeCaseMissOutcomeRef.current = null;
     setHeritageFeedback(null);
     setParonymFeedback(null);
     setStressSelectedPosition(null);
@@ -2084,6 +2119,14 @@ function LexiconPracticeIsland({
     }
     return counts;
   }, [deckLemmaKeySet, indexForStats]);
+  // P0-3: a mode is only disabled once the index has actually loaded and confirms
+  // zero content — not during the transient pre-load tick where every count is 0.
+  // A real custom deck's synthesized items (`ensureDeckCustomSetCoverage`) only exist
+  // on the full `deck` built by `ensureDeck()` — the lightweight idle `dueIndex` never
+  // carries them — so for a custom deck, wait for `deck` itself rather than trusting
+  // a `dueIndex`-only count of 0 that would otherwise disable every mode forever.
+  const isCustomDeckSelected = selectedDeckFilter !== 'all' && selectedDeckFilter !== 'virtual_teacher_lesson';
+  const modeDataLoaded = isCustomDeckSelected ? deck !== null : deck !== null || dueIndex !== null;
 
   const sessionPoolConstraints = useMemo(
     () =>
@@ -3109,15 +3152,26 @@ function LexiconPracticeIsland({
 
     if (caseMiss) {
       if (!clozeAttemptRecorded) {
-        recordReview(selection, 'hard');
+        clozeCaseMissOutcomeRef.current = recordReview(selection, 'hard');
         setClozeAttemptRecorded(true);
       }
-      setClozeInput('');
+      const nextCaseMissCount = clozeCaseMissCount + 1;
+      setClozeCaseMissCount(nextCaseMissCount);
+      const exhausted = nextCaseMissCount >= 2;
+      // Keep the typed value (select it, don't clear it) — a chip tap that put the
+      // right lemma in the box must not be destroyed on the first case-miss.
       setClozeFeedback({
         kind: 'case-miss',
         textUk: `→ Правильне слово. Тепер постав його ${casePhraseAccusative(cloze.caseRule.caseLabel)}: ${cloze.caseRule.feedback}`,
         textEn: `→ Correct word. Now put it in the ${translateGrammarTerm(cloze.caseRule.caseLabel)}: ${cloze.caseRule.feedback}`,
       });
+      if (exhausted) {
+        setAnswerLocked(true);
+        if (clozeCaseMissOutcomeRef.current) {
+          pendingOutcomeRef.current = clozeCaseMissOutcomeRef.current;
+          setPendingOutcome(clozeCaseMissOutcomeRef.current);
+        }
+      }
       return;
     }
 
@@ -3143,10 +3197,6 @@ function LexiconPracticeIsland({
     setAnswerLocked(true);
   }
 
-  const dueReviews = useMemo(
-    () => (indexForStats.length ? countDueReviewCards(indexForStats, new Date()) : 0),
-    [completedToday, dailyNewCount, indexForStats, revision],
-  );
   const homeScope = useMemo(
     () =>
       indexForStats.length
@@ -3215,6 +3265,58 @@ function LexiconPracticeIsland({
     setHistory([]);
     setDeck(null);
     setClozeLoaded(false);
+  }
+
+  // P0-2: every active-phase empty state gets the same three-part block instead of
+  // a text-only dead end — what happened, the single best next action as a primary
+  // button, and (where it makes sense) up to two real-content secondary modes.
+  function renderPracticeEmptyState(
+    messageKey: ChromeKey,
+    testId: string,
+    secondaryModes: VisiblePracticeModeFilter[] = [],
+  ) {
+    const primaryIsFlashcards = messageKey === 'practice.clozePreparing' && (modeCounts.flashcards ?? 0) > 0;
+    return (
+      <div className="practice-empty-state" data-testid={testId}>
+        <p className="lexicon-practice-muted">
+          <PracticeChromeLabel k={messageKey} />
+        </p>
+        <button
+          type="button"
+          className="btn btn-accent practice-empty-primary"
+          data-testid={`${testId}-primary`}
+          onClick={() => {
+            if (primaryIsFlashcards) {
+              void startFocusMode('flashcards');
+            } else {
+              finishPractice();
+            }
+          }}
+        >
+          <PracticeChromeLabel k={primaryIsFlashcards ? 'practice.startFlashcardsCta' : 'practice.backToModes'} />
+        </button>
+        {secondaryModes.length > 0 ? (
+          <div className="practice-empty-secondary">
+            {secondaryModes
+              .filter((secondaryMode) => (modeCounts[secondaryMode] ?? 0) > 0)
+              .map((secondaryMode) => {
+                const meta = MODE_META[secondaryMode];
+                const count = modeCounts[secondaryMode] ?? 0;
+                return (
+                  <button
+                    key={secondaryMode}
+                    type="button"
+                    className="btn practice-empty-secondary-btn"
+                    onClick={() => void startFocusMode(secondaryMode)}
+                  >
+                    <ChromeDual uk={`${meta.title} · ${count}`} en={`${meta.en} · ${count}`} />
+                  </button>
+                );
+              })}
+          </div>
+        ) : null}
+      </div>
+    );
   }
 
   return (
@@ -3294,110 +3396,6 @@ function LexiconPracticeIsland({
             </div>
           )}
 
-          {/* Google Drive Sync Bar */}
-          <div className="k3-drive-sync-bar" style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', margin: '0.75rem 0 1rem 0' }}>
-            <button
-              type="button"
-              className="btn btn-sm"
-              style={{ background: 'var(--lu-accent-blue, #2563eb)', color: '#fff', borderRadius: '8px', padding: '0.4rem 0.8rem', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}
-              onClick={handleGoogleDriveSync}
-              disabled={isDriveSyncing}
-            >
-              <span>☁️</span>
-              <span>{isDriveSyncing ? 'Синхронізація...' : 'Увійти та синхронізувати з Google Drive'}</span>
-            </button>
-            {driveSyncMsg ? <span style={{ fontSize: '0.85rem', color: 'var(--lu-text-muted)' }}>{driveSyncMsg}</span> : null}
-          </div>
-
-          {/* Custom Decks & Special Deck Filter Bar */}
-          <div className="k3-deck-filter-bar" style={{ margin: '1rem 0', padding: '0.75rem 1rem', background: 'var(--lu-bg-card, rgba(255,255,255,0.05))', borderRadius: '12px', border: '1px solid var(--lu-border, rgba(255,255,255,0.1))' }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
-              <span style={{ fontWeight: 'bold', fontSize: '0.95rem' }}>
-                {chromeLocale === 'uk' ? '📚 Колоди та добірки слів' : '📚 Word Decks & Collections'}
-              </span>
-              <button
-                type="button"
-                className="btn btn-sm btn-accent"
-                onClick={() => setShowCreateModal(true)}
-                style={{ fontSize: '0.8rem', padding: '0.25rem 0.6rem' }}
-              >
-                ⚙️ {chromeLocale === 'uk' ? 'Менеджер колод / Імпорт' : 'Manage Decks / Import'}
-              </button>
-            </div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-              <button
-                type="button"
-                className={`btn btn-sm ${selectedDeckFilter === 'all' ? 'btn-primary shadow-md' : 'btn-ghost'}`}
-                onClick={() => requestDeckSwitch('all')}
-                style={selectedDeckFilter === 'all' ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
-              >
-                {selectedDeckFilter === 'all' ? '✓ ' : ''}🌐 {chromeLocale === 'uk' ? `Всі слова (${learnerLevel})` : `All Words (${learnerLevel})`}
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm ${selectedDeckFilter === 'virtual_teacher_lesson' ? 'btn-primary shadow-md' : 'btn-ghost'}`}
-                onClick={() => requestDeckSwitch('virtual_teacher_lesson')}
-                style={selectedDeckFilter === 'virtual_teacher_lesson' ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
-              >
-                {selectedDeckFilter === 'virtual_teacher_lesson' ? '✓ ' : ''}🎓 {chromeLocale === 'uk' ? 'Відібрана добірка' : 'Curated Deck'}
-              </button>
-              {customSets.map((set) => (
-                <button
-                  key={set.id}
-                  type="button"
-                  className={`btn btn-sm ${selectedDeckFilter === set.id ? 'btn-primary shadow-md' : 'btn-ghost'}`}
-                  onClick={() => requestDeckSwitch(set.id)}
-                  style={selectedDeckFilter === set.id ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
-                >
-                  {selectedDeckFilter === set.id ? '✓ ' : ''}⭐ {set.title} ({set.lemma_keys.length})
-                </button>
-              ))}
-            </div>
-            {pendingDeckSwitch ? (
-              <div className="k3-switch-offer" data-testid="practice-switch-session-offer" role="status">
-                <span><ChromeText k="practice.switchSessionOffer" /></span>
-                <div className="k3-switch-offer-actions">
-                  <button
-                    type="button"
-                    className="btn btn-sm btn-accent"
-                    data-testid="practice-switch-session-accept"
-                    onClick={acceptDeckSwitch}
-                  >
-                    <ChromeText k="practice.switchSessionAccept" />
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn-sm"
-                    data-testid="practice-switch-session-decline"
-                    onClick={declineDeckSwitch}
-                  >
-                    <ChromeText k="practice.switchSessionDecline" />
-                  </button>
-                </div>
-              </div>
-            ) : null}
-          </div>
-
-          {/* Custom Deck Manager & Document Importer Modal */}
-          {showCreateModal ? (
-            <LexiconCustomDeckManager
-              chromeLocale={chromeLocale}
-              activeDeckFilter={selectedDeckFilter}
-              shardBaseUrl={shardBaseUrl}
-              onSelectDeckFilter={(id) => {
-                // F2 (PR #5837 review): route through the same guarded switch flow as the
-                // deck-filter chips — the manager must offer a fresh session too, not
-                // silently swap the deck under an active/resumable one.
-                setCustomSets(readLocalCustomSets());
-                requestDeckSwitch(id);
-              }}
-              onClose={() => {
-                setShowCreateModal(false);
-                setCustomSets(readLocalCustomSets());
-              }}
-            />
-          ) : null}
-
           <div className="k3-practice-dashboard">
             <div className="k3-hero" data-testid="practice-dashboard-hero">
               <h1><ChromeText k="practice.heroTitle" /></h1>
@@ -3436,7 +3434,7 @@ function LexiconPracticeIsland({
 
             <div className="k3-stats" data-testid="practice-dashboard-stats" role="group" aria-label={CHROME_STRINGS[chromeLocale]['practice.stats']}>
               <div className="k3-stat">
-                <span className="k3-stat-value">{dueReviews}</span>
+                <span className="k3-stat-value">{dailyRows.pendingDue.length}</span>
                 <span className="k3-stat-label"><ChromeText k="practice.statusDue" /></span>
               </div>
               <div className="k3-stat">
@@ -3603,7 +3601,7 @@ function LexiconPracticeIsland({
                 {MODE_CARD_ORDER.map((practiceMode) => {
                   const meta = MODE_META[practiceMode];
                   const modeCount = modeCounts[practiceMode] ?? 0;
-                  const modeEmpty = practiceMode !== 'mixed' && modeCount === 0;
+                  const modeEmpty = practiceMode !== 'mixed' && modeDataLoaded && modeCount === 0;
                   return (
                     <button
                       key={practiceMode}
@@ -3613,6 +3611,8 @@ function LexiconPracticeIsland({
                       data-accent={meta.accent}
                       data-mode-count={modeCount}
                       data-mode-empty={modeEmpty ? 'true' : undefined}
+                      disabled={modeEmpty}
+                      aria-disabled={modeEmpty}
                       aria-describedby="mode-detail-line"
                       onMouseEnter={() => setHoveredMode(practiceMode)}
                       onMouseLeave={() => setHoveredMode(null)}
@@ -3622,12 +3622,22 @@ function LexiconPracticeIsland({
                     >
                       <span className="k3-mode-title">{chromeLocale === 'uk' ? meta.title : meta.en}</span>
                       <span className="k3-mode-step">{chromeLocale === 'uk' ? meta.step : meta.stepEn}</span>
+                      <span className="k3-mode-desc">
+                        {chromeLocale === 'uk' ? meta.description : meta.descriptionEn}
+                      </span>
+                      {modeEmpty ? (
+                        <span className="k3-mode-empty-note">
+                          <ChromeText k="practice.modeNoExercises" />
+                        </span>
+                      ) : null}
                       <span
                         className="k3-mode-count"
-                        aria-hidden="true"
                         data-testid={`practice-mode-count-${practiceMode}`}
                       >
-                        {modeCount}
+                        <span aria-hidden="true">{modeCount}</span>
+                        <span className="sr-only">
+                          {modeCountAccessibleSuffix(modeCount, chromeLocale)}
+                        </span>
                       </span>
                     </button>
                   );
@@ -3636,6 +3646,120 @@ function LexiconPracticeIsland({
             </div>
             </div>
           </div>
+
+          {/*
+           * Opus P0-1: account sync and deck management are power-user actions, not
+           * the first thing a learner should be asked to decide. They used to render
+           * above the whole dashboard, pushing the primary Start/Resume CTA down and
+           * putting the HARD-1/HARD-2 above-the-fold gates at risk. Folded here,
+           * below the mode grid, behind the same disclosure pattern the page already
+           * uses for secondary material.
+           */}
+          <details className="k3-practice-sources" data-testid="practice-secondary-tools">
+            <summary><ChromeText k="practice.secondaryToolsTitle" /></summary>
+            <div className="k3-practice-sources-content">
+              <div className="k3-drive-sync-bar" style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  style={{ background: 'var(--lu-accent-blue, #2563eb)', color: '#fff', borderRadius: '8px', padding: '0.4rem 0.8rem', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}
+                  onClick={handleGoogleDriveSync}
+                  disabled={isDriveSyncing}
+                >
+                  <span>☁️</span>
+                  <span>{isDriveSyncing ? 'Синхронізація...' : 'Увійти та синхронізувати з Google Drive'}</span>
+                </button>
+                {driveSyncMsg ? <span style={{ fontSize: '0.85rem', color: 'var(--lu-text-muted)' }}>{driveSyncMsg}</span> : null}
+              </div>
+
+              <div className="k3-deck-filter-bar" style={{ margin: '1rem 0 0', padding: '0.75rem 1rem', background: 'var(--lu-bg-card, rgba(255,255,255,0.05))', borderRadius: '12px', border: '1px solid var(--lu-border, rgba(255,255,255,0.1))' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+                  <span style={{ fontWeight: 'bold', fontSize: '0.95rem' }}>
+                    {chromeLocale === 'uk' ? '📚 Колоди та добірки слів' : '📚 Word Decks & Collections'}
+                  </span>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-accent"
+                    onClick={() => setShowCreateModal(true)}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.6rem' }}
+                  >
+                    ⚙️ {chromeLocale === 'uk' ? 'Менеджер колод / Імпорт' : 'Manage Decks / Import'}
+                  </button>
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                  <button
+                    type="button"
+                    className={`btn btn-sm ${selectedDeckFilter === 'all' ? 'btn-primary shadow-md' : 'btn-ghost'}`}
+                    onClick={() => requestDeckSwitch('all')}
+                    style={selectedDeckFilter === 'all' ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
+                  >
+                    {selectedDeckFilter === 'all' ? '✓ ' : ''}🌐 {chromeLocale === 'uk' ? `Всі слова (${learnerLevel})` : `All Words (${learnerLevel})`}
+                  </button>
+                  <button
+                    type="button"
+                    className={`btn btn-sm ${selectedDeckFilter === 'virtual_teacher_lesson' ? 'btn-primary shadow-md' : 'btn-ghost'}`}
+                    onClick={() => requestDeckSwitch('virtual_teacher_lesson')}
+                    style={selectedDeckFilter === 'virtual_teacher_lesson' ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
+                  >
+                    {selectedDeckFilter === 'virtual_teacher_lesson' ? '✓ ' : ''}🎓 {chromeLocale === 'uk' ? 'Відібрана добірка' : 'Curated Deck'}
+                  </button>
+                  {customSets.map((set) => (
+                    <button
+                      key={set.id}
+                      type="button"
+                      className={`btn btn-sm ${selectedDeckFilter === set.id ? 'btn-primary shadow-md' : 'btn-ghost'}`}
+                      onClick={() => requestDeckSwitch(set.id)}
+                      style={selectedDeckFilter === set.id ? { border: '2px solid #3b82f6', fontWeight: 800 } : {}}
+                    >
+                      {selectedDeckFilter === set.id ? '✓ ' : ''}⭐ {set.title} ({set.lemma_keys.length})
+                    </button>
+                  ))}
+                </div>
+                {pendingDeckSwitch ? (
+                  <div className="k3-switch-offer" data-testid="practice-switch-session-offer" role="status">
+                    <span><ChromeText k="practice.switchSessionOffer" /></span>
+                    <div className="k3-switch-offer-actions">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-accent"
+                        data-testid="practice-switch-session-accept"
+                        onClick={acceptDeckSwitch}
+                      >
+                        <ChromeText k="practice.switchSessionAccept" />
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm"
+                        data-testid="practice-switch-session-decline"
+                        onClick={declineDeckSwitch}
+                      >
+                        <ChromeText k="practice.switchSessionDecline" />
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              {showCreateModal ? (
+                <LexiconCustomDeckManager
+                  chromeLocale={chromeLocale}
+                  activeDeckFilter={selectedDeckFilter}
+                  shardBaseUrl={shardBaseUrl}
+                  onSelectDeckFilter={(id) => {
+                    // F2 (PR #5837 review): route through the same guarded switch flow as the
+                    // deck-filter chips — the manager must offer a fresh session too, not
+                    // silently swap the deck under an active/resumable one.
+                    setCustomSets(readLocalCustomSets());
+                    requestDeckSwitch(id);
+                  }}
+                  onClose={() => {
+                    setShowCreateModal(false);
+                    setCustomSets(readLocalCustomSets());
+                  }}
+                />
+              ) : null}
+            </div>
+          </details>
         </>
       )}
       {loading && (
@@ -3699,11 +3823,8 @@ function LexiconPracticeIsland({
             ) : null}
           </div>
 
-          {deck && deck.index.length === 0 && (
-            <p className="lexicon-practice-muted">
-              <PracticeChromeLabel k="practice.noCards" />
-            </p>
-          )}
+          {deck && deck.index.length === 0 &&
+            renderPracticeEmptyState('practice.noCards', 'practice-no-cards')}
 
           {deck && deck.index.length > 0 && (
             <div className="lexicon-practice-stage" ref={stageRef} tabIndex={-1}>
@@ -3731,27 +3852,20 @@ function LexiconPracticeIsland({
                     onMatchingComplete={handleMatchingComplete}
                     onMatchingMatch={handleMatchingMatch}
                     onClozeSubmit={submitCloze}
+                    onBackToModes={finishPractice}
                     showEnglishSubtitles={showEnglishSubtitles}
                     chromeLocale={chromeLocale}
                     learnerLevel={learnerLevel}
                   />
                 </>
               ) : mode === 'cloze' && deck.cloze.length === 0 ? (
-                <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
-                  <PracticeChromeLabel k="practice.clozePreparing" />
-                </p>
+                renderPracticeEmptyState('practice.clozePreparing', 'practice-cloze-empty', ['matching', 'choice'])
               ) : mode === 'heritage' && (deck.heritage?.length ?? 0) === 0 ? (
-                <p className="lexicon-practice-muted" data-testid="practice-heritage-empty">
-                  <PracticeChromeLabel k="practice.heritagePreparing" />
-                </p>
+                renderPracticeEmptyState('practice.heritagePreparing', 'practice-heritage-empty', ['flashcards', 'choice'])
               ) : mode === 'paronym' && (deck.paronym?.length ?? 0) === 0 ? (
-                <p className="lexicon-practice-muted" data-testid="practice-paronym-empty">
-                  <PracticeChromeLabel k="practice.paronymPreparing" />
-                </p>
+                renderPracticeEmptyState('practice.paronymPreparing', 'practice-paronym-empty', ['flashcards', 'choice'])
               ) : (
-                <p className="lexicon-practice-muted">
-                  <PracticeChromeLabel k="practice.allCaughtUp" />
-                </p>
+                renderPracticeEmptyState('practice.allCaughtUp', 'practice-all-caught-up')
               )}
             </div>
           )}
@@ -3795,6 +3909,7 @@ function PracticeItem({
   onMatchingComplete,
   onMatchingMatch,
   onClozeSubmit,
+  onBackToModes,
   showEnglishSubtitles,
   chromeLocale,
   learnerLevel,
@@ -3819,6 +3934,8 @@ function PracticeItem({
   onMatchingComplete(): void;
   onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
+  /** P0-2: option-build failures (empty matching/choice pools) get a real exit, not just prose. */
+  onBackToModes(): void;
   showEnglishSubtitles: boolean;
   chromeLocale: 'en' | 'uk';
   learnerLevel: CefrLevel;
@@ -3834,7 +3951,7 @@ function PracticeItem({
     );
     return (
       <PracticeFlashcard
-        card={cardData(selection.lemma, learnerLevel)}
+        card={cardData(selection.lemma, learnerLevel, chromeLocale)}
         ratingLabels={RATING_LABELS}
         intervalPreviews={intervalPreviews}
         onRate={onFlashcardRating}
@@ -4027,9 +4144,18 @@ function PracticeItem({
   if (selection.mode === 'matching') {
     if (!pairs.length) {
       return (
-        <p className="lexicon-practice-muted">
-          <PracticeChromeLabel k="practice.noMatchCards" />
-        </p>
+        <div className="practice-empty-state" data-testid="practice-match-empty">
+          <p className="lexicon-practice-muted">
+            <PracticeChromeLabel k="practice.noMatchCards" />
+          </p>
+          <button
+            type="button"
+            className="btn btn-accent practice-empty-primary"
+            onClick={onBackToModes}
+          >
+            <PracticeChromeLabel k="practice.backToModes" />
+          </button>
+        </div>
       );
     }
     const matchedCount = matchedPairIndexesRef.current.size;
@@ -4067,9 +4193,18 @@ function PracticeItem({
   const options = orderedChoiceOptions(selection, deck, selection.choicePolarity, sessionSeed, learnerLevel);
   if (!options.length) {
     return (
-      <p className="lexicon-practice-muted">
-        <PracticeChromeLabel k="practice.noChoiceCards" />
-      </p>
+      <div className="practice-empty-state" data-testid="practice-choice-empty">
+        <p className="lexicon-practice-muted">
+          <PracticeChromeLabel k="practice.noChoiceCards" />
+        </p>
+        <button
+          type="button"
+          className="btn btn-accent practice-empty-primary"
+          onClick={onBackToModes}
+        >
+          <PracticeChromeLabel k="practice.backToModes" />
+        </button>
+      </div>
     );
   }
   const prompt = choicePrompt(selection, learnerLevel);
@@ -4361,6 +4496,15 @@ function PracticeCloze({
   learnerLevel: CefrLevel;
   chromeLocale: 'en' | 'uk';
 }) {
+  const clozeInputRef = useRef<HTMLInputElement | null>(null);
+  // Opus P0-6: a case-miss keeps the typed value (it is not cleared) — select it
+  // instead so the next keystroke replaces it cleanly, rather than requiring a
+  // manual clear before the learner can try the correct case.
+  useEffect(() => {
+    if (feedback?.kind === 'case-miss' && !answerLocked) {
+      clozeInputRef.current?.select();
+    }
+  }, [feedback, answerLocked]);
   const cloze = selection.cloze;
   if (!cloze) return null;
   const [before, after] = clozeParts(cloze).map((part) => displayPracticeForm(part, learnerLevel));
@@ -4439,6 +4583,7 @@ function PracticeCloze({
         }}
       >
         <input
+          ref={clozeInputRef}
           className="cz-input"
           value={input}
           disabled={answerLocked}

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -225,13 +225,16 @@ export default function PracticeDailyDeck({
           <ChromeText k={detailsOpen ? 'practice.hideWords' : 'practice.showWords'} />
           <span className="daily-deck-counters">
             <span className="counter due">
-              {rows.pendingDue.length}
+              <span aria-hidden="true">{STATUS_META.due.glyph}</span> {rows.pendingDue.length}{' '}
+              <ChromeText k={STATUS_META.due.labelKey} />
             </span>
             <span className="counter new">
-              {rows.pendingNew.length}
+              <span aria-hidden="true">{STATUS_META.new.glyph}</span> {rows.pendingNew.length}{' '}
+              <ChromeText k={STATUS_META.new.labelKey} />
             </span>
             <span className="counter done">
-              {rows.done.length}
+              <span aria-hidden="true">{STATUS_META.done.glyph}</span> {rows.done.length}{' '}
+              <ChromeText k={STATUS_META.done.labelKey} />
             </span>
           </span>
         </summary>

--- a/site/src/components/PracticeFlashcard.tsx
+++ b/site/src/components/PracticeFlashcard.tsx
@@ -9,6 +9,8 @@ export interface PracticeFlashcardData {
   subtitle?: string;
   tag?: string;
   tagColor?: string;
+  /** P0-4: heritage as a text chip on the back — color stays a secondary channel. */
+  heritageLabel?: string;
 }
 
 interface PracticeFlashcardProps {
@@ -39,6 +41,10 @@ export default function PracticeFlashcard({
 
   const tapLabel = CHROME_STRINGS[chromeLocale]['practice.tapToFlip'];
   const rateRecallLabel = CHROME_STRINGS[chromeLocale]['practice.rateRecall'];
+  const flipHint = CHROME_STRINGS[chromeLocale]['practice.flipHint'];
+  const rateAfterFlipHint = CHROME_STRINGS[chromeLocale]['practice.rateAfterFlipHint'];
+  const keyShortcutWord = CHROME_STRINGS[chromeLocale]['practice.keyShortcutWord'];
+  const intervalPrefix = CHROME_STRINGS[chromeLocale]['practice.intervalPrefix'];
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -119,10 +125,31 @@ export default function PracticeFlashcard({
                 {card.tag}
               </span>
             )}
+            {!flipped && <span className="flashcard-flip-hint">{flipHint}</span>}
           </div>
           <div className="flashcard-back">
             <span className="flashcard-word">{card.back}</span>
             {card.subtitle && <span className="flashcard-subtitle">{card.subtitle}</span>}
+            {(card.tag || card.heritageLabel) && (
+              <span className="flashcard-back-tags">
+                {card.tag && (
+                  <span
+                    className="flashcard-tag"
+                    style={card.tagColor ? { background: card.tagColor, color: 'white' } : undefined}
+                  >
+                    {card.tag}
+                  </span>
+                )}
+                {card.heritageLabel && (
+                  <span
+                    className="flashcard-heritage-chip"
+                    style={card.tagColor ? { borderColor: card.tagColor } : undefined}
+                  >
+                    {card.heritageLabel}
+                  </span>
+                )}
+              </span>
+            )}
           </div>
         </div>
       </div>
@@ -133,6 +160,7 @@ export default function PracticeFlashcard({
         data-revealed={flipped ? 'true' : 'false'}
         data-locked={rated ? 'true' : 'false'}
       >
+        {!flipped && <p className="rating-bar-hint">{rateAfterFlipHint}</p>}
         {RATING_ORDER.map((rating, index) => (
           <button
             type="button"
@@ -144,11 +172,17 @@ export default function PracticeFlashcard({
             aria-disabled={!flipped || rated}
             onClick={() => handleRate(rating)}
           >
-            <span className="rk">{index + 1}</span>
+            <span className="rk" aria-label={`${keyShortcutWord} ${index + 1}`}>
+              {index + 1}
+            </span>
             <span className="rt" lang={chromeLocale}>
               {ratingLabels[rating][chromeLocale]}
             </span>
-            {flipped ? <span className="ri">‹{intervalPreviews[rating]}›</span> : null}
+            {flipped ? (
+              <span className="ri">
+                {intervalPrefix} {intervalPreviews[rating]}
+              </span>
+            ) : null}
           </button>
         ))}
       </div>

--- a/site/src/components/PracticeStress.tsx
+++ b/site/src/components/PracticeStress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { type PracticeStressItem, stripStressMarks } from '../lib/lexicon/srs';
 
 export interface PracticeStressProps {
@@ -35,6 +35,25 @@ export default function PracticeStress({
   const codePoints = Array.from(cleanUnstressed);
   const isCorrect = selectedPosition === item.stressIndex;
 
+  // P0-5: Digit-1..n is a redundant accelerator, matching the choice/classify
+  // pattern — the nucleus array is already in left-to-right reading order.
+  useEffect(() => {
+    if (answerLocked || item.nuclei.length === 0) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.('button, a, input, textarea, select, [role="button"]')) return;
+      const digit = Number.parseInt(event.key, 10);
+      if (!Number.isFinite(digit) || digit < 1 || digit > item.nuclei.length) return;
+      const nucleus = item.nuclei[digit - 1];
+      if (!nucleus) return;
+      event.preventDefault();
+      onSelect(nucleus.index);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [answerLocked, item.nuclei, onSelect]);
+
   return (
     <div className="practice-stress" data-testid="practice-stress" data-locked={answerLocked}>
       <p className="practice-stress-word" lang="uk" aria-label={item.stressed}>
@@ -60,8 +79,10 @@ export default function PracticeStress({
                 data-position={position}
                 disabled={answerLocked}
                 aria-pressed={selected}
+                aria-keyshortcuts={String(nucleus.nucleusIndex + 1)}
                 onClick={() => onSelect(position)}
               >
+                <span className="stress-vowel-key" aria-hidden="true">{nucleus.nucleusIndex + 1}</span>
                 {char}
               </button>
             );

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -331,6 +331,21 @@ const en = {
   'practice.poolMiss': 'This word is not in the practice pool yet.',
   'practice.progress': 'Progress',
 
+  // Learner layout P0 fixes (#6317/#6320) — visible helpers, honest empties, hit targets
+  'practice.backToModes': 'Back to modes',
+  'practice.startFlashcardsCta': 'Start flashcards',
+  'practice.heritageNative': 'native',
+  'practice.heritageInherited': 'inherited',
+  'practice.heritageBorrowed': 'borrowed',
+  'practice.heritageCalque': 'calque',
+  'practice.heritageAvoid': 'avoid',
+  'practice.flipHint': 'Tap the card to see the meaning',
+  'practice.rateAfterFlipHint': 'Flip the card first',
+  'practice.keyShortcutWord': 'key',
+  'practice.intervalPrefix': 'in',
+  'practice.modeNoExercises': 'No exercises yet',
+  'practice.secondaryToolsTitle': 'Sync & decks',
+
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Practice this word →',
   'atlas.practiceUnavailable': 'Not in the practice pool yet',
@@ -633,6 +648,21 @@ const uk: Record<ChromeKey, string> = {
   'practice.loadErrorReload': 'Не вдалося завантажити практику. Спробуйте оновити сторінку.',
   'practice.poolMiss': 'Це слово ще не в тренажері.',
   'practice.progress': 'Прогрес',
+
+  // Learner layout P0 fixes (#6317/#6320) — visible helpers, honest empties, hit targets
+  'practice.backToModes': 'Повернутись до режимів',
+  'practice.startFlashcardsCta': 'Почати флешкартки',
+  'practice.heritageNative': 'питоме',
+  'practice.heritageInherited': 'успадковане',
+  'practice.heritageBorrowed': 'запозичене',
+  'practice.heritageCalque': 'калька',
+  'practice.heritageAvoid': 'уникай',
+  'practice.flipHint': 'Торкніться картки, щоб побачити значення',
+  'practice.rateAfterFlipHint': 'Спочатку переверніть картку',
+  'practice.keyShortcutWord': 'клавіша',
+  'practice.intervalPrefix': 'через',
+  'practice.modeNoExercises': 'Немає вправ',
+  'practice.secondaryToolsTitle': 'Синхронізація та колоди',
 
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Практикувати це слово →',

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -104,7 +104,8 @@ const frontmatter = {
   }
 
   :global(.lexicon-practice button) {
-    min-height: 44px;
+    /* P0-8: raised from the 44px AA floor to the 48px target-size floor. */
+    min-height: 48px;
     border: 1px solid var(--lu-border);
     border-radius: 6px;
     background: var(--lu-surface);
@@ -249,6 +250,36 @@ const frontmatter = {
 
   :global(.lexicon-practice-warning) {
     color: var(--lu-state-wrong-fg);
+  }
+
+  :global(.lexicon-practice .sr-only) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* P0-2: every active-phase empty state gets the same shape — one sentence,
+     a primary next-action button, and (where honest) real-count secondary modes. */
+  :global(.practice-empty-state) {
+    display: grid;
+    gap: 0.75rem;
+    justify-items: start;
+  }
+
+  :global(.practice-empty-primary) {
+    width: 100%;
+  }
+
+  :global(.practice-empty-secondary) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   @media (max-width: 760px) {
@@ -431,11 +462,49 @@ const frontmatter = {
     text-align: center;
   }
 
+  :global(.flashcard-flip-hint) {
+    display: block;
+    margin-top: 0.6rem;
+    color: var(--lu-text-muted);
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+
+  :global(.flashcard-back-tags) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    margin-top: 0.35rem;
+  }
+
+  :global(.flashcard-heritage-chip) {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.55rem;
+    border: 2px solid rgba(255, 255, 255, 0.7);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: inherit;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.01em;
+  }
+
   :global(.rating-bar) {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0.6rem;
     margin-top: 1.3rem;
+  }
+
+  :global(.rating-bar-hint) {
+    grid-column: 1 / -1;
+    margin: 0 0 0.2rem;
+    color: var(--lu-text-muted);
+    font-size: 0.85rem;
+    font-weight: 700;
   }
 
   :global(.rate-btn) {
@@ -463,23 +532,45 @@ const frontmatter = {
     font-weight: 900;
   }
 
-  :global(.rate-btn[data-rate="again"]:hover) {
+  /*
+   * Opus P0-5: these four colors used to exist on :hover only, so at rest (and on
+   * touch, where there is no hover) Again/Hard/Good/Easy were visually identical
+   * grey boxes. The border color is now a base-state channel; hover/focus only
+   * add the stronger tint on top of it.
+   */
+  :global(.rate-btn[data-rate="again"]) {
     border-color: var(--lu-red);
+  }
+
+  :global(.rate-btn[data-rate="hard"]) {
+    border-color: var(--lu-orange);
+  }
+
+  :global(.rate-btn[data-rate="good"]) {
+    border-color: var(--lu-green);
+  }
+
+  :global(.rate-btn[data-rate="easy"]) {
+    border-color: var(--lu-blue);
+  }
+
+  :global(.rate-btn[data-rate="again"]:hover),
+  :global(.rate-btn[data-rate="again"]:focus-visible) {
     background: var(--lu-red-light);
   }
 
-  :global(.rate-btn[data-rate="hard"]:hover) {
-    border-color: var(--lu-orange);
+  :global(.rate-btn[data-rate="hard"]:hover),
+  :global(.rate-btn[data-rate="hard"]:focus-visible) {
     background: var(--lu-orange-light);
   }
 
-  :global(.rate-btn[data-rate="good"]:hover) {
-    border-color: var(--lu-green);
+  :global(.rate-btn[data-rate="good"]:hover),
+  :global(.rate-btn[data-rate="good"]:focus-visible) {
     background: var(--lu-green-light);
   }
 
-  :global(.rate-btn[data-rate="easy"]:hover) {
-    border-color: var(--lu-blue);
+  :global(.rate-btn[data-rate="easy"]:hover),
+  :global(.rate-btn[data-rate="easy"]:focus-visible) {
     background: var(--lu-blue-light);
   }
 
@@ -889,7 +980,7 @@ const frontmatter = {
   }
 
   :global(.lexicon-weak-chip) {
-    min-height: 40px;
+    min-height: 48px;
     padding: 0.35rem 0.85rem;
     border: 1px solid var(--lu-orange, #c2410c);
     border-radius: 999px;
@@ -1300,7 +1391,7 @@ const frontmatter = {
     gap: 0.5rem;
   }
   :global(.k3-switch-offer-actions button) {
-    min-height: 40px;
+    min-height: 48px;
     padding: 0 0.85rem;
   }
 
@@ -1380,6 +1471,7 @@ const frontmatter = {
   :global(.daily-deck-reroll) {
     display: inline-flex;
     align-items: center;
+    min-height: 48px;
     gap: 0.35rem;
     padding: 0.35rem 0.7rem;
     border: 1px solid var(--lu-border);
@@ -1465,18 +1557,20 @@ const frontmatter = {
   }
   :global(.daily-deck-counters) {
     display: flex;
-    gap: 0.5rem;
+    flex-wrap: wrap;
+    gap: 0.4rem;
   }
   :global(.daily-deck-counters .counter) {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.25rem;
     min-width: 1.5rem;
     height: 1.5rem;
-    padding: 0 0.35rem;
+    padding: 0 0.55rem;
     border-radius: 999px;
-    font-size: 0.78rem;
+    font-size: 0.72rem;
     font-weight: 900;
+    white-space: nowrap;
   }
   :global(.daily-deck-counters .counter.due) {
     background: var(--lu-yellow-dark);
@@ -1628,6 +1722,11 @@ const frontmatter = {
   }
   :global(.k3-mode-card[data-mode-empty='true']) {
     opacity: 0.55;
+    cursor: not-allowed;
+  }
+  :global(.k3-mode-card:disabled:hover) {
+    border-color: var(--lu-border);
+    box-shadow: none;
   }
   :global(.k3-mode-title) {
     font-size: 1rem;
@@ -1639,6 +1738,24 @@ const frontmatter = {
     font-weight: 900;
     letter-spacing: 0.04em;
     text-transform: uppercase;
+  }
+  /* P0-1: the description now lives on every card, not only the shared hover line. */
+  :global(.k3-mode-desc) {
+    margin: 0.15rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.35;
+    text-transform: none;
+  }
+  /* P0-3: an explicit, honest "no exercises yet" state instead of a silent tap-and-fail. */
+  :global(.k3-mode-empty-note) {
+    margin: 0.15rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
   }
   :global(.k3-mode-count) {
     position: absolute;
@@ -1759,16 +1876,27 @@ const frontmatter = {
   }
 
   :global(.stress-vowel) {
-    min-width: 2.2rem;
-    min-height: 2.6rem;
-    padding: 0 0.35rem;
+    position: relative;
+    min-width: 48px;
+    min-height: 48px;
+    padding: 0.2rem 0.5rem;
     border: 2px solid var(--lu-border);
     border-radius: 8px;
     background: var(--lu-surface);
     color: var(--lu-primary);
     font: inherit;
+    font-size: 1.35em;
     font-weight: 900;
     cursor: pointer;
+  }
+
+  :global(.stress-vowel-key) {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    color: var(--lu-text-muted);
+    font-size: 0.65rem;
+    font-weight: 900;
   }
 
   :global(.stress-vowel:hover:not(:disabled)) {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1526,6 +1526,11 @@ describe('LexiconPractice', () => {
     const user = userEvent.setup();
     const { container } = render(<LexiconPractice />);
     await user.click(await screen.findByRole('button', { name: /Коти з Атласу: сесія/ }));
+    // P0-3: the flashcards card is disabled until its count resolves — the Atlas
+    // prefix-shard lookup for this custom-deck key is itself async.
+    await waitFor(() =>
+      expect(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')).not.toBeDisabled(),
+    );
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
     await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
@@ -1578,6 +1583,9 @@ describe('LexiconPractice', () => {
     const user = userEvent.setup();
     const { container } = render(<LexiconPractice />);
     await user.click(await screen.findByRole('button', { name: /Довгий атласний глос/ }));
+    await waitFor(() =>
+      expect(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')).not.toBeDisabled(),
+    );
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
     await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
@@ -1620,6 +1628,9 @@ describe('LexiconPractice', () => {
     const user = userEvent.setup();
     const { container } = render(<LexiconPractice />);
     await user.click(await screen.findByRole('button', { name: /Справжній сирота/ }));
+    await waitFor(() =>
+      expect(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')).not.toBeDisabled(),
+    );
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
     await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
@@ -2465,7 +2476,9 @@ describe('LexiconPractice', () => {
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
     expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
-    expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toHaveValue('');
+    // Opus P0-6: a case-miss keeps the typed/chosen value (selected, not cleared) so a
+    // chip tap is not destroyed — the learner can still see and correct what they typed.
+    expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toHaveValue('книга');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
 
     await waitFor(() => {
@@ -2664,15 +2677,17 @@ describe('LexiconPractice', () => {
     document.documentElement.dataset.chromeLocale = "uk";
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "B1");
     render(<LexiconPractice />);
-    expect(screen.getByText(/Чергуйте картки/)).toBeInTheDocument();
+    // P0-1: the Mixed description now also lives on its own card, not only the
+    // shared hover line — both carry the same text, so at least one must match.
+    expect(screen.getAllByText(/Чергуйте картки/).length).toBeGreaterThan(0);
 
     await act(async () => {
       document.documentElement.dataset.chromeLocale = "en";
     });
     await waitFor(() => {
       expect(
-        screen.getByText(/Rotate flashcards, matching, choice/),
-      ).toBeInTheDocument();
+        screen.getAllByText(/Rotate flashcards, matching, choice/).length,
+      ).toBeGreaterThan(0);
     });
   });
 
@@ -2770,7 +2785,9 @@ describe('LexiconPractice', () => {
     );
     await user.click(container.querySelector('[data-activity="flashcard"]')!);
     const good = container.querySelector('[data-rate="good"] .ri');
-    expect(good?.textContent).toMatch(/‹.+›/);
+    // P0-6: a bare `‹4d›` decoded nothing — the preview now carries a locale-aware
+    // "in"/"через" prefix so the interval reads as a sentence, not a cryptic glyph.
+    expect(good?.textContent).toMatch(/^(in|через) .+/);
   });
 
   test('wrong answer dwells: feedback stays and never auto-advances', async () => {


### PR DESCRIPTION
## Summary

Implements the K3 P0 list (`docs/practice/learner-layout-ux-p0.md`) plus the Opus critique items (`docs/practice/learner-layout-ux-opus.md`) still live in code. Not a redesign — targeted layout/affordance fixes inside the existing K3 structure.

- **P0-1** — mode descriptions render on every card, not only the shared hover line.
- **P0-2** — every active-phase empty state gets a real primary next-action button + honest-count secondary modes instead of a text-only dead end.
- **P0-3** — zero-count mode cards are `disabled` with an explicit "no exercises yet" state; count badge is no longer `aria-hidden`. Also fixes Opus P0-2's root cause (custom-deck keys no longer claim the full 8-mode list).
- **P0-4** — heritage renders as a text chip on the flashcard back (color stays secondary).
- **P0-5** — stress vowel targets raised to ≥48px with visible digit badges + accelerators.
- **P0-6** — flashcards get a visible flip hint + "flip first" rating hint; interval previews get a locale-aware prefix. Also fixes Opus P0-5 (rating colors were hover-only).
- **P0-7** — daily-deck collapsed counters are glyph + number + label, not bare colored numbers.
- **P0-8** — secondary controls raised to ≥48px.
- **Opus P0-1** — Drive sync + deck management folded behind a closed-by-default disclosure below the mode grid (was rendering above the dashboard, out of scope, risking the HARD-1/HARD-2 fold gates).
- **Opus P0-6** — cloze case-miss capped at two attempts, then locks and reveals via the existing PracticeFormRail; typed value is selected instead of cleared.
- **Opus P0-7** — Due stat tile now shares the same daily-snapshot basis as New/Done.

Fixed a real regression the P0-3 disable logic introduced along the way: mode cards were disabled during the transient pre-load tick, and permanently for custom decks (the lightweight idle `dueIndex` never carries `ensureDeckCustomSetCoverage`'s synthesized items). Gated `modeEmpty` on a `modeDataLoaded` flag that accounts for both.

## Residual (honestly listed, not in this PR)

- Opus P1 items (mode-detail truncation, dead today-ring code, storage-warning recovery copy, etc.)
- The "Скоро" vs "Немає вправ" distinction for planned-but-unshipped modes — always shows "Немає вправ" now.
- Flip hint hides per-card rather than session-wide (once-per-session would need a parent-lifted flag).
- **HARD-1/HARD-2 e2e viewport gates were not re-run live** — no browser available in this sparse worktree. Please verify before merge.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (same pre-existing baseline errors, confirmed via git-stash diff)
- [x] `npx eslint` on all changed files — no new errors (same pre-existing baseline, confirmed via git-stash diff)
- [x] `npx vitest run tests/unit/LexiconPractice.test.tsx tests/unit/k3-chrome-locale.test.ts tests/unit/lexicon-srs.test.ts tests/unit/practice-chrome-copy.test.ts tests/unit/practice-locale-purity.test.ts tests/unit/weak-areas.test.ts` — 217/217 passing (updated 3 tests whose assertions encoded the old, now-intentionally-changed behavior)
- [x] `.venv/bin/pytest tests/test_lesson_schema.py tests/test_prompt_substitution.py` — 17/17 passing after lesson-schema regeneration
- [x] `.venv/bin/ruff check` on schema generator/tests — clean
- [ ] Playwright HARD-1/HARD-2 (`e2e/atlas-practice.spec.ts`) — not run, no browser in this worktree

Linked: #4700 #6132 #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)