### PR TITLE
fix(launcher): Claude driver Opus 5 xhigh; interactive keeps TUI model

### DIFF
--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -26,7 +26,8 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 | **hramatka** (teacher lesson service) | Grok 4.5 · Fable if judgment-heavy | `./start-grok-driver.sh --epic hramatka` |
 | **folk** (curriculum track) | Grok 4.5 † | `./start-grok-driver.sh --epic folk` |
 | **bio** (curriculum track) | Grok 4.5 | `./start-grok-driver.sh --epic bio` |
-| **any epic** — incident · architecture cutover · contested review | Fable 5 (default Anthropic) | `./start-claude-driver.sh --epic <epic>` |
+| **any epic** — incident · architecture cutover · contested review | Opus 5 @ xhigh (default Anthropic) | `./start-claude-driver.sh --epic <epic>` |
+| **any epic** — Fable alternate | Fable 5 | `./start-claude-driver.sh --epic <epic> --model claude-fable-5` |
 | **any epic** — routine Anthropic alternate | Sonnet-5 | `./start-claude-driver.sh --epic <epic> --model claude-sonnet-5` |
 
 **Driver launcher convention:** `./start-<provider>-driver.sh --epic <epic>` where `<provider>` ∈
@@ -37,14 +38,12 @@ process starts. Codex additionally performs its transport-health probe during
 adapter preflight, before it claims the lease; a degraded probe refuses the
 launch without acquiring a lane.
 
-**Fable 5 is the DEFAULT Anthropic driver seat** (operator decision 2026-07-28).
-`./start-claude-driver.sh --epic <epic>` pins Fable by default; pass
-`--model claude-sonnet-5` for the supported routine alternate. Opus 5 is not an
-orchestrator seat. Fable is reserved for the rare
-hardest-judgment session (live incident, architecture cutover, contested verdict) in the
-SUMMONED cadence — 1-2 short scheduled sessions/day, dispatch-heavy, never a resident
-polling loop (see model-assignment.md § Orchestration operating pattern). It prints a
-reserved-seat notice on launch so the cost is never spent by habit. Both Anthropic wrappers
+**Opus 5 @ xhigh is the DEFAULT Anthropic driver seat** (operator decision 2026-08-03).
+`./start-claude-driver.sh --epic <epic>` pins Opus 5 with `--effort xhigh` by default;
+pass `--model claude-fable-5` or `--model claude-sonnet-5` for supported alternates
+(and `--effort …` after `--epic` to override effort). Keep the SUMMONED cadence —
+1-2 short scheduled sessions/day, dispatch-heavy, never a resident polling loop
+(see model-assignment.md § Orchestration operating pattern). Both Anthropic wrappers
 resolve to the same `claude-<lane>` handoff slot, so the stream lease still allows only one
 Anthropic driver per lane. The legacy `scripts/start-bio-driver.sh` runs Claude + the
 `curriculum-track-orchestrator` agent-def if you specifically want that agent.

--- a/scripts/launchers/claude.sh
+++ b/scripts/launchers/claude.sh
@@ -28,7 +28,12 @@ launcher_adapter_canary() {
   return 0
 }
 launcher_adapter_exec() {
-  local cmd=(claude --model "$LC_MODEL")
+  local cmd=(claude)
+  # Only pin --model when the caller asked for one; otherwise Claude Code keeps
+  # whatever model is selected in the TUI / user settings.
+  if [ -n "${LC_MODEL:-}" ]; then
+    cmd+=(--model "$LC_MODEL")
+  fi
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
   launcher_exec_command "${cmd[@]}"

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -134,7 +134,9 @@ launcher_clear_foreign_route_state() {
 launcher_defaults() {
   case "$LC_PROVIDER" in
     claude)
-      LC_MODEL="${LAUNCHER_MODEL:-claude-fable-5}"
+      # Interactive leaves the TUI model alone unless --model / LAUNCHER_MODEL
+      # is set. Driver wrappers pin their own default via LAUNCHER_MODEL.
+      LC_MODEL="${LAUNCHER_MODEL:-}"
       LC_HARNESS="${LAUNCHER_HARNESS:-claude-code}"
       ;;
     codex)
@@ -254,11 +256,12 @@ launcher_parse() {
 }
 
 launcher_normalize_model() {
-  # D1 makes Fable the default and retains `--model sonnet` as the deliberate
-  # alternate choice. Certify against the explicit roster identifiers.
+  # Interactive omits --model unless asked; driver pins Opus 5 via
+  # start-claude-driver.sh. Short aliases normalize to roster identifiers.
   case "$LC_PROVIDER:$LC_MODEL" in
     claude:fable) LC_MODEL='claude-fable-5' ;;
     claude:sonnet) LC_MODEL='claude-sonnet-5' ;;
+    claude:opus|claude:opus-5) LC_MODEL='claude-opus-5' ;;
   esac
 }
 
@@ -324,7 +327,7 @@ launcher_validate_driver_certification() {
   [ "$LC_MODE" = "driver" ] || return 0
   [ "$LC_GOVERNOR" = "0" ] || return 0
   case "$LC_PROVIDER:$LC_MODEL" in
-    claude:claude-fable-5|claude:claude-sonnet-5|codex:gpt-5.6-terra|codex:gpt-5.6-sol|gemini:gemini-3.6-flash-high|gemini:gemini-3.1-pro-high|grok:grok-4.5)
+    claude:claude-opus-5|claude:claude-fable-5|claude:claude-sonnet-5|codex:gpt-5.6-terra|codex:gpt-5.6-sol|gemini:gemini-3.6-flash-high|gemini:gemini-3.1-pro-high|grok:grok-4.5)
       return 0
       ;;
     *)

--- a/start-claude-driver.sh
+++ b/start-claude-driver.sh
@@ -4,19 +4,36 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$ROOT/scripts/lib/launcher_core.sh"
 
 # Default Anthropic driver seat: Opus 5 @ xhigh. Override with --model /
-# LAUNCHER_MODEL, or with --effort after --epic (forwarded to `claude`).
+# LAUNCHER_MODEL, or with --effort (any position; normalized after the
+# selector so launcher_core can forward it to `claude`).
 export LAUNCHER_MODEL="${LAUNCHER_MODEL:-claude-opus-5}"
 
-has_effort=0
-for arg in "$@"; do
-  case "$arg" in
-    --effort|--effort=*) has_effort=1 ;;
+effort_value="xhigh"
+args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --effort)
+      if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
+        echo "Error: --effort requires a value; run --help." >&2
+        exit 2
+      fi
+      effort_value="$2"
+      shift 2
+      ;;
+    --effort=*)
+      effort_value="${1#*=}"
+      if [ -z "$effort_value" ]; then
+        echo "Error: --effort requires a value; run --help." >&2
+        exit 2
+      fi
+      shift
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
   esac
 done
-
-args=("$@")
-if [ "$has_effort" = 0 ]; then
-  args+=(--effort xhigh)
-fi
+args+=(--effort "$effort_value")
 
 launcher_main claude driver "${args[@]}"

--- a/start-claude-driver.sh
+++ b/start-claude-driver.sh
@@ -2,4 +2,21 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$ROOT/scripts/lib/launcher_core.sh"
-launcher_main claude driver "$@"
+
+# Default Anthropic driver seat: Opus 5 @ xhigh. Override with --model /
+# LAUNCHER_MODEL, or with --effort after --epic (forwarded to `claude`).
+export LAUNCHER_MODEL="${LAUNCHER_MODEL:-claude-opus-5}"
+
+has_effort=0
+for arg in "$@"; do
+  case "$arg" in
+    --effort|--effort=*) has_effort=1 ;;
+  esac
+done
+
+args=("$@")
+if [ "$has_effort" = 0 ]; then
+  args+=(--effort xhigh)
+fi
+
+launcher_main claude driver "${args[@]}"

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -121,7 +121,8 @@ def test_dry_run_does_not_require_a_provider_binary(tmp_path: Path) -> None:
     result = run_launcher("start-claude.sh", env={"PATH": provider_free_path})
     assert result.returncode == 0, result.stderr
     assert "LAUNCHER_DRY_RUN=1: would require binary claude" in result.stdout
-    assert "would exec claude --model claude-fable-5" in result.stdout
+    assert "would exec claude " in result.stdout
+    assert "would exec claude --model" not in result.stdout
 
 
 def test_codex_driver_preserves_transport_probe_and_lease_guard() -> None:

--- a/tests/test_start_claude_profiles.py
+++ b/tests/test_start_claude_profiles.py
@@ -27,13 +27,14 @@ def _stub_claude(tmp_path: Path) -> Path:
     return bin_dir
 
 
-def test_claude_default_is_fable_and_sonnet_remains_explicit() -> None:
+def test_claude_interactive_keeps_tui_model_unless_explicit() -> None:
     default = run_launcher("start-claude.sh")
     fable = run_launcher("start-claude.sh", "--model", "fable")
     sonnet = run_launcher("start-claude.sh", "--model", "sonnet")
     assert default.returncode == sonnet.returncode == 0
     assert fable.returncode == 0
-    assert "would exec claude --model claude-fable-5" in default.stdout
+    assert "would exec claude --model" not in default.stdout
+    assert "would exec claude " in default.stdout
     assert "would exec claude --model claude-fable-5" in fable.stdout
     assert "would exec claude --model claude-sonnet-5" in sonnet.stdout
 
@@ -46,12 +47,19 @@ def test_claude_rejects_models_outside_native_profile(model: str) -> None:
 
 
 def test_certified_claude_driver_models_are_revalidated() -> None:
-    for model in ("fable", "sonnet"):
+    for model in ("opus", "fable", "sonnet"):
         result = run_launcher("start-claude-driver.sh", "--epic", "devops", "--model", model)
         assert result.returncode == 0, result.stderr
         assert "would claim lease" in result.stdout
     untrusted = run_launcher("start-claude-driver.sh", "--epic", "devops", "--model", "claude-haiku-5")
     assert untrusted.returncode == 4
+
+
+def test_claude_driver_defaults_to_opus_xhigh() -> None:
+    result = run_launcher("start-claude-driver.sh", "--epic", "devops")
+    assert result.returncode == 0, result.stderr
+    assert "would exec claude --model claude-opus-5" in result.stdout
+    assert "--effort xhigh" in result.stdout
 
 
 def test_native_claude_clears_foreign_route_and_capacity_overrides(tmp_path: Path) -> None:

--- a/tests/test_start_claude_profiles.py
+++ b/tests/test_start_claude_profiles.py
@@ -62,6 +62,22 @@ def test_claude_driver_defaults_to_opus_xhigh() -> None:
     assert "--effort xhigh" in result.stdout
 
 
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ("--effort", "high", "--epic", "devops"),
+        ("--effort=high", "--epic", "devops"),
+        ("--epic", "devops", "--effort", "high"),
+    ),
+)
+def test_claude_driver_accepts_effort_before_or_after_epic(argv: tuple[str, ...]) -> None:
+    result = run_launcher("start-claude-driver.sh", *argv)
+    assert result.returncode == 0, result.stderr
+    assert "would exec claude --model claude-opus-5" in result.stdout
+    assert "--effort high" in result.stdout
+    assert "--effort xhigh" not in result.stdout
+
+
 def test_native_claude_clears_foreign_route_and_capacity_overrides(tmp_path: Path) -> None:
     bin_dir = _stub_claude(tmp_path)
     result = run_launcher(


### PR DESCRIPTION
## Summary
- `start-claude-driver.sh` defaults to `claude-opus-5` with `--effort xhigh` (Fable/Sonnet remain explicit alternates).
- `start-claude.sh` no longer forces `--model`, so Claude Code keeps the TUI-selected model unless `--model` / `LAUNCHER_MODEL` is set.
- Certifies `claude-opus-5` for the Claude driver seat and updates the epic-orchestrator roster.

## Test plan
- [x] `LAUNCHER_DRY_RUN=1 ./start-claude-driver.sh --epic devops` → `claude --model claude-opus-5 --effort xhigh`
- [x] `LAUNCHER_DRY_RUN=1 ./start-claude.sh` → `claude` with no `--model`
- [x] `pytest tests/test_start_claude_profiles.py tests/test_launcher_contract.py` (56 passed)


Made with [Cursor](https://cursor.com)