### PR TITLE
fix(review): retain rejected formal responses

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -167,6 +167,32 @@ def _settle_routing_reservation_once(
     return True
 
 
+def _record_rejected_formal_response(
+    authority: Any,
+    review_id: str,
+    raw_response: str,
+) -> bool:
+    """Persist an invalid provider response before releasing authority state.
+
+    This capture intentionally does not turn the response into a verdict.  It
+    is a durable failed formal-review attempt even when the authority lease has
+    already become stale by the time validation finishes.
+    """
+    from scripts.fleet_comms.formal_review_jobs import (
+        FormalReviewJobsError,
+        FormalReviewJobService,
+    )
+
+    try:
+        FormalReviewJobService(store=authority.store).record_rejected_response(
+            review_id,
+            raw_response,
+        )
+    except FormalReviewJobsError:
+        return False
+    return True
+
+
 def _compute_review_routing_budget() -> dict[str, Any]:
     """Take a bounded fresh capacity snapshot for this standalone process."""
     from scripts.api.codexbar_usage import refresh_provider_usage_data
@@ -893,6 +919,18 @@ def handle_review_pr(args: argparse.Namespace) -> int:
 
             if not raw_response:
                 if not replayed:
+                    captured = _record_rejected_formal_response(
+                        authority,
+                        formal_job.review_id,
+                        raw_response,
+                    )
+                    if not captured:
+                        print(
+                            "review-pr: failed to durably capture invalid reviewer response; "
+                            "routing and authority state were left unchanged",
+                            file=sys.stderr,
+                        )
+                        return 1
                     if routing_reservation is not None:
                         _settle_routing_reservation_once(
                             routing_ledger,
@@ -932,6 +970,18 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     )
             except ReviewWorktreeError as exc:
                 if not replayed:
+                    captured = _record_rejected_formal_response(
+                        authority,
+                        formal_job.review_id,
+                        raw_response,
+                    )
+                    if not captured:
+                        print(
+                            "review-pr: failed to durably capture invalid reviewer response; "
+                            "routing and authority state were left unchanged",
+                            file=sys.stderr,
+                        )
+                        return 1
                     if routing_reservation is not None:
                         _settle_routing_reservation_once(
                             routing_ledger,

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -269,6 +269,89 @@ class FormalReviewJobService:
             created_at=created,
         )
 
+    def record_rejected_response(
+        self,
+        review_id: str,
+        raw_response: str | bytes,
+    ) -> FormalReviewAttempt:
+        """Atomically retain a non-canonical response as a failed attempt.
+
+        A response which failed formal-review validation is evidence of an
+        attempted review, not a verdict.  Persist the original bytes and its
+        failed attempt together so a subsequent authority-lease race cannot
+        erase the only durable record of the provider result.
+        """
+        job = self.get_job(review_id, include_attempts=False)
+        payload = (
+            raw_response.encode("utf-8")
+            if isinstance(raw_response, str)
+            else bytes(raw_response)
+        )
+
+        attempt_id = new_id("review-attempt")
+        created = _utc_now()
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            current = self._conn.execute(
+                "SELECT sealed_verdict_artifact_id FROM formal_review_jobs WHERE review_id = ?",
+                (job.review_id,),
+            ).fetchone()
+            if current is None:
+                raise FormalReviewJobsError(f"formal review job not found: {job.review_id}")
+            if current["sealed_verdict_artifact_id"] is not None:
+                raise FormalReviewJobsError(
+                    f"sealed_verdict_already_set: job {job.review_id} cannot record a rejected response"
+                )
+            capture = self.store.store_bytes(
+                payload,
+                producer="formal-review-jobs",
+                retention_class="rejected-review-response",
+                logical_filename=f"{job.review_id}.rejected-response.raw",
+                mime_type="text/plain; charset=utf-8",
+                commit=False,
+            )
+            row = self._conn.execute(
+                "SELECT COALESCE(MAX(attempt_number), 0) FROM formal_review_attempts WHERE review_id = ?",
+                (job.review_id,),
+            ).fetchone()
+            attempt_number = int(row[0]) + 1 if row is not None else 1
+            self._conn.execute(
+                """INSERT INTO formal_review_attempts(
+                    review_attempt_id, review_id, attempt_number,
+                    completion_state, raw_capture_artifact_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    attempt_id,
+                    job.review_id,
+                    attempt_number,
+                    CompletionState.FAILED.value,
+                    capture.artifact_id,
+                    created,
+                ),
+            )
+            self._conn.execute(
+                "UPDATE formal_review_jobs SET state = 'failed' WHERE review_id = ?",
+                (job.review_id,),
+            )
+            self._conn.commit()
+        except FormalReviewJobsError:
+            self._conn.rollback()
+            raise
+        except Exception as exc:
+            self._conn.rollback()
+            raise FormalReviewJobsError(
+                f"failed to record rejected response for {job.review_id}: {exc}"
+            ) from exc
+
+        return FormalReviewAttempt(
+            review_attempt_id=attempt_id,
+            review_id=job.review_id,
+            attempt_number=attempt_number,
+            completion_state=CompletionState.FAILED.value,
+            raw_capture_artifact_id=capture.artifact_id,
+            created_at=created,
+        )
+
     def accept_sealed_verdict(
         self,
         review_id: str,

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from argparse import Namespace
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from agent_runtime.adapters.acpx import (
@@ -14,6 +17,201 @@ from agent_runtime.adapters.acpx import (
 )
 from ai_agent_bridge import _review_pr as review_pr
 from ai_agent_bridge._review_safety import ReviewSafetyError
+
+
+def _invalid_response_args() -> Namespace:
+    return Namespace(
+        pr="6342",
+        reviewer="auto",
+        claude_available=None,
+        model=None,
+        effort=None,
+        extra=None,
+        task_id=None,
+        dry_run=False,
+        background=False,
+        no_timeout=False,
+        initiator="codex/orchestrator",
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        allow_explicit_fallback=False,
+        override_reason=None,
+        review_profile=None,
+        risk=None,
+        role=None,
+        required_capability=None,
+        data_egress_policy=None,
+        isolation_required=True,
+    )
+
+
+def _run_invalid_response_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    stale_lease: bool,
+) -> tuple[int, list[str], object]:
+    """Run one invalid response through the bridge with a real formal-job store."""
+    from agent_runtime import runner
+    from ai_agent_bridge import _review_worktree
+
+    from scripts.fleet_comms import authority as authority_module
+    from scripts.fleet_comms import routing_reservations
+    from scripts.fleet_comms.artifacts import ArtifactStore
+    from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    reservation = SimpleNamespace(
+        reservation_id="routing-reservation_fixture",
+        resolved_candidate="claude-sonnet-5",
+        resolved_route="claude",
+        resolved_model="claude-sonnet-5",
+        resolved_family="anthropic",
+        quota_bucket="claude",
+    )
+    events: list[str] = []
+
+    class FakeLedger:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def reserve_selection(self, *_args, **_kwargs):
+            return reservation
+
+        def mark_started(self, _reservation_id):
+            events.append("started")
+
+        def settle(self, _reservation_id, **_kwargs):
+            events.append("settled")
+            job = formal_jobs.list_jobs(include_attempts=True)[0]
+            assert job.state == "failed"
+            assert len(job.attempts) == 1
+            capture_id = job.attempts[0].raw_capture_artifact_id
+            assert capture_id is not None
+            assert store.read_bytes(capture_id) == b"not valid JSON"
+            return reservation
+
+    store = ArtifactStore(root=tmp_path / "fleet-comms-v1")
+    formal_jobs = FormalReviewJobService(store=store)
+
+    class FakeAuthority:
+        def __init__(self) -> None:
+            self.store = store
+            self.formal = None
+            self.job = SimpleNamespace(state="queued", job_id="authority-job_fixture", subject_id="")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_formal_review(self, **_kwargs):
+            self.formal = formal_jobs.create_job(
+                "learn-ukrainian/learn-ukrainian.github.io",
+                6342,
+                checkout.sha,
+                "cross-family-review",
+            )
+            self.job.subject_id = self.formal.review_id
+            return self.job
+
+        def require_publishable_formal_review(self, review_id, **_kwargs):
+            return formal_jobs.get_job(review_id, include_attempts=False)
+
+        def claim_job(self, *_args, **_kwargs):
+            return SimpleNamespace(fence_token=1)
+
+        def finish_job(self, *_args, **_kwargs):
+            events.append("finish")
+            assert self.formal is not None
+            recorded = formal_jobs.get_job(self.formal.review_id)
+            assert recorded.state == "failed"
+            assert recorded.sealed_verdict_artifact_id is None
+            assert len(recorded.attempts) == 1
+            capture_id = recorded.attempts[0].raw_capture_artifact_id
+            assert capture_id is not None
+            assert store.read_bytes(capture_id) == b"not valid JSON"
+            if stale_lease:
+                raise authority_module.AuthorityStaleLeaseError("terminalization_conflict")
+
+    authority = FakeAuthority()
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(
+        _review_worktree,
+        "validate_code_review_response",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            _review_worktree.ReviewWorktreeError("review_response_invalid_json")
+        ),
+    )
+    monkeypatch.setattr(review_pr, "_compute_review_routing_budget", lambda: {"agents": {}})
+    monkeypatch.setattr(routing_reservations, "RoutingReservationLedger", FakeLedger)
+    monkeypatch.setattr(authority_module, "AuthorityService", lambda: authority)
+    monkeypatch.setattr(
+        runner,
+        "invoke_inter_agent",
+        lambda *_args, **_kwargs: SimpleNamespace(ok=True, response="not valid JSON"),
+    )
+    try:
+        return review_pr.handle_review_pr(_invalid_response_args()), events, formal_jobs
+    finally:
+        # The caller inspects the service before this helper returns; its store
+        # is then closed by the test after assertions.
+        pass
+
+
+def test_invalid_json_is_captured_before_live_lease_failure_settlement(monkeypatch, tmp_path, capsys) -> None:
+    code, events, formal_jobs = _run_invalid_response_lifecycle(
+        monkeypatch,
+        tmp_path,
+        stale_lease=False,
+    )
+    try:
+        assert code == 1
+        assert events == ["started", "settled", "finish"]
+        job = formal_jobs.list_jobs(include_attempts=True)[0]
+        assert job.state == "failed"
+        assert job.sealed_verdict_artifact_id is None
+        assert job.attempts[0].completion_state == "failed"
+        assert "reviewer result invalid" in capsys.readouterr().err
+    finally:
+        formal_jobs.close()
+
+
+def test_invalid_json_is_captured_before_stale_lease_failure_settlement(monkeypatch, tmp_path, capsys) -> None:
+    code, events, formal_jobs = _run_invalid_response_lifecycle(
+        monkeypatch,
+        tmp_path,
+        stale_lease=True,
+    )
+    try:
+        assert code == 1
+        assert events == ["started", "settled", "finish"]
+        job = formal_jobs.list_jobs(include_attempts=True)[0]
+        assert job.state == "failed"
+        assert job.sealed_verdict_artifact_id is None
+        assert job.attempts[0].raw_capture_artifact_id is not None
+        assert "lease was lost while validating" in capsys.readouterr().err
+    finally:
+        formal_jobs.close()
 
 
 def test_parse_pr_number() -> None:

--- a/tests/test_fleet_comms_formal_review_jobs.py
+++ b/tests/test_fleet_comms_formal_review_jobs.py
@@ -97,6 +97,68 @@ def test_record_attempt_with_and_without_raw_capture(tmp_path: Path) -> None:
                 )
 
 
+@pytest.mark.parametrize(
+    "raw_response",
+    ["not a canonical code-review JSON response", ""],
+)
+def test_record_rejected_response_is_captured_as_failed_and_unpublishable(
+    tmp_path: Path,
+    raw_response: str,
+) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 43, HEAD, GATE)
+
+        attempt = svc.record_rejected_response(job.review_id, raw_response)
+
+        assert attempt.completion_state == CompletionState.FAILED.value
+        assert attempt.raw_capture_artifact_id is not None
+        assert svc.store.read_bytes(attempt.raw_capture_artifact_id) == raw_response.encode("utf-8")
+        recorded = svc.get_job(job.review_id)
+        assert recorded.state == "failed"
+        assert recorded.sealed_verdict_artifact_id is None
+        assert recorded.attempts == (attempt,)
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_missing"):
+            svc.load_sealed_verdict(job.review_id)
+
+
+def test_record_rejected_response_rolls_back_when_raw_capture_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 44, HEAD, GATE)
+
+        def reject_store(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("raw_capture_store_failed")
+
+        monkeypatch.setattr(svc.store, "store_bytes", reject_store)
+
+        with pytest.raises(FormalReviewJobsError, match="raw_capture_store_failed"):
+            svc.record_rejected_response(job.review_id, "invalid response")
+
+        recorded = svc.get_job(job.review_id)
+        assert recorded.state == "open"
+        assert recorded.attempts == ()
+        assert recorded.sealed_verdict_artifact_id is None
+
+
+def test_record_rejected_response_refuses_already_sealed_verdict_without_extra_binding(
+    tmp_path: Path,
+) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        before = svc.get_job(job.review_id)
+        artifact_count = svc.store.connection.execute("SELECT COUNT(*) FROM artifacts").fetchone()[0]
+
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_already_set"):
+            svc.record_rejected_response(job.review_id, "invalid response")
+
+        after = svc.get_job(job.review_id)
+        assert after.to_dict() == before.to_dict()
+        assert svc.store.connection.execute("SELECT COUNT(*) FROM artifacts").fetchone()[0] == artifact_count
+
+
 def test_list_jobs_filters_and_alias(tmp_path: Path) -> None:
     with _service(tmp_path) as svc:
         j1 = svc.create_job(REPO, 1, HEAD, GATE)


### PR DESCRIPTION
Part of #6342. This is the first, capture-only prerequisite PR; it intentionally does not close #6342 or permit a reviewer retry/substitution.

## What changed

- Atomically store an invalid or empty provider response as a raw artifact plus a failed `formal_review_attempt` before routing settlement or authority terminalization.
- Keep the rejected response separate from sealed verdicts and therefore unpublishable.
- If raw capture fails, leave the formal job, routing reservation, and authority state unchanged.
- Reject capture after a sealed verdict is already bound.

## Verification

- `41 passed`: review lifecycle, review PR, and formal-review job suites.
- Ruff, Python compilation, OPSEC, commit-trailer validation, and `git diff --check` passed.

## Explicitly out of scope

The second #6342 PR will own exact-head reviewer substitution and its authorization/state-machine guards. This PR does not alter routing admission, retry behavior, reviewer selection, evidence coverage, or publication gates.