### PR TITLE
fix(reviews): authorize one result-invalid substitute

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -381,7 +382,19 @@ def _routing_trace(resolution: Any) -> dict[str, Any]:
     }
 
 
-def _semantic_request_matches(reservation: Any, request: Any) -> bool:
+def _semantic_request_matches(
+    reservation: Any,
+    request: Any,
+    *,
+    authorization_envelope: Mapping[str, Any] | None,
+) -> bool:
+    envelope = authorization_envelope
+    if not isinstance(envelope, Mapping):
+        envelope = {
+            "required_capabilities": ["code_review", "sealed_evidence"],
+            "data_egress_policy": None,
+            "isolation_required": True,
+        }
     return all(
         (
             reservation.author_model == request.author_model,
@@ -392,6 +405,9 @@ def _semantic_request_matches(reservation: Any, request: Any) -> bool:
             reservation.route_mode == request.route_mode,
             reservation.requested_reviewer == request.requested_reviewer,
             reservation.estimated_input_bytes == request.estimated_input_bytes,
+            envelope.get("required_capabilities") == list(request.required_capabilities),
+            envelope.get("data_egress_policy") == request.data_egress_policy,
+            envelope.get("isolation_required") == request.isolation_required,
         )
     )
 
@@ -618,6 +634,9 @@ def handle_review_pr(args: argparse.Namespace) -> int:
             route_mode=route_mode,
             estimated_input_bytes=estimated_input_bytes,
             requested_reviewer=requested_candidate,
+            required_capabilities=tuple(sorted(required_capabilities)),
+            data_egress_policy=getattr(args, "data_egress_policy", None),
+            isolation_required=bool(getattr(args, "isolation_required", True)),
         )
         with RoutingReservationLedger() as routing_ledger, AuthorityService() as authority:
             authority_job = authority.enqueue_formal_review(
@@ -638,7 +657,28 @@ def handle_review_pr(args: argparse.Namespace) -> int:
             replayed = authority_job.state == "complete"
             if authority_job.state == "complete":
                 routing_reservation = routing_ledger.completed_replay(authority_key)
-                if routing_reservation is None or not _semantic_request_matches(routing_reservation, routing_request):
+                reserved_decision = (
+                    next(
+                        (
+                            item
+                            for item in routing_ledger.decisions(routing_reservation.reservation_id)
+                            if item.event_type == "reserved"
+                        ),
+                        None,
+                    )
+                    if routing_reservation is not None
+                    else None
+                )
+                authorization_envelope = (
+                    reserved_decision.evidence.get("authorization_envelope")
+                    if reserved_decision is not None
+                    else None
+                )
+                if routing_reservation is None or not _semantic_request_matches(
+                    routing_reservation,
+                    routing_request,
+                    authorization_envelope=authorization_envelope,
+                ):
                     print("review-pr: completed exact-head result lacks a matching routing authority receipt", file=sys.stderr)
                     return 1
                 replay = authority.read_job_result(authority_job.job_id)
@@ -655,7 +695,8 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         "in_flight": {},
                         "diagnostics": {"stale": True, "routing_budget_error": type(exc).__name__},
                     }
-                if authority_job.state in {"failed", "expired"}:
+                substitution_pending = authority_job.state == "failed" and requested_candidate is not None
+                if authority_job.state in {"failed", "expired"} and not substitution_pending:
                     authority_job = authority.retry_job(authority_job.job_id)
                 elif authority_job.state == "dead_lettered":
                     authority_job = authority.redrive_job(authority_job.job_id)
@@ -768,6 +809,32 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         routing_request,
                         idempotency_key=f"{authority_key}:routing:{reservation_attempt}",
                     )
+                    if substitution_pending:
+                        prior = routing_ledger.latest_for_authority_key(authority_key)
+                        if prior is None:
+                            print("review-pr: failed formal job has no prior routing attempt", file=sys.stderr)
+                            return 1
+                        substitution_evidence = {
+                            "reason": override_reason,
+                            "data_egress_policy": getattr(args, "data_egress_policy", None),
+                        }
+                        try:
+                            routing_reservation = authority.authorize_formal_review_substitution(
+                                authority_job_id=authority_job.job_id,
+                                review_id=formal_job.review_id,
+                                current_head_sha=checkout.sha,
+                                expected_snapshot_artifact_id=str(formal_job.snapshot_artifact_id or ""),
+                                routing_request=attempt_request,
+                                selector=select_inside_authority,
+                                substitution_evidence=substitution_evidence,
+                                ttl_seconds=timeout + 30,
+                            )
+                        except Exception as exc:
+                            print(f"review-pr: formal reviewer substitution refused: {exc}", file=sys.stderr)
+                            return 1
+                        authority_job = authority.get_job(authority_job.job_id)
+                        substitution_pending = False
+
                     try:
                         lease = authority.claim_job(
                             authority_job.job_id,
@@ -784,11 +851,12 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         )
                         return 1
                     try:
-                        routing_reservation = routing_ledger.reserve_selection(
-                            attempt_request,
-                            select_inside_authority,
-                            ttl_seconds=timeout + 30,
-                        )
+                        if routing_reservation is None:
+                            routing_reservation = routing_ledger.reserve_selection(
+                                attempt_request,
+                                select_inside_authority,
+                                ttl_seconds=timeout + 30,
+                            )
                     except RoutingReservationUnavailable as exc:
                         _finish_authority_job_once(
                             authority,

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -810,10 +810,6 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         idempotency_key=f"{authority_key}:routing:{reservation_attempt}",
                     )
                     if substitution_pending:
-                        prior = routing_ledger.latest_for_authority_key(authority_key)
-                        if prior is None:
-                            print("review-pr: failed formal job has no prior routing attempt", file=sys.stderr)
-                            return 1
                         substitution_evidence = {
                             "reason": override_reason,
                             "data_egress_policy": getattr(args, "data_egress_policy", None),
@@ -909,7 +905,25 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                         extra=args.extra,
                     )
                     sealed_prompt = prompt + evidence
-                    routing_ledger.mark_started(routing_reservation.reservation_id)
+                    started_reservation = routing_ledger.mark_started(routing_reservation.reservation_id)
+                    if started_reservation.status != "running":
+                        _finish_authority_job_once(
+                            authority,
+                            authority_job.job_id,
+                            worker_id=worker_id,
+                            fence_token=lease.fence_token,
+                            state="failed",
+                            result=json.dumps(
+                                {
+                                    "failure_classification": "routing_reservation_not_active",
+                                    "reservation_status": started_reservation.status,
+                                },
+                                sort_keys=True,
+                            ).encode("utf-8"),
+                        )
+                        print("review-pr: routing reservation is no longer active; provider was not invoked", file=sys.stderr)
+                        return 1
+                    routing_reservation = started_reservation
                     previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
                     os.environ["LU_ACPX_TRANSPORT"] = "active"
                     invocation_error: BaseException | None = None

--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -1298,6 +1298,150 @@ class AuthorityService:
         except FormalReviewJobsError as exc:
             raise AuthorityServiceError("sealed_verdict_rejected") from exc
 
+    def authorize_formal_review_substitution(
+        self,
+        *,
+        authority_job_id: str,
+        review_id: str,
+        current_head_sha: str,
+        expected_snapshot_artifact_id: str,
+        routing_request: Any,
+        selector: Any,
+        substitution_evidence: Mapping[str, Any],
+        ttl_seconds: int,
+        now: str | None = None,
+    ) -> Any:
+        """Atomically requeue one failed formal review and reserve its substitute."""
+        from scripts.fleet_comms.routing_reservations import RoutingReservationLedger
+
+        jid = _nonempty(authority_job_id, field="authority_job_id")
+        rid = _nonempty(review_id, field="review_id")
+        head = _nonempty(current_head_sha, field="current_head_sha").lower()
+        snapshot = _nonempty(expected_snapshot_artifact_id, field="expected_snapshot_artifact_id")
+        now_value = self._now_string(now)
+        with self._write_transaction():
+            job = self._require_job_tx(jid)
+            if str(job["job_kind"]) != "formal_review" or str(job["subject_id"]) != rid:
+                raise AuthorityServiceError("substitution_authority_job_mismatch")
+            if str(job["idempotency_key"]) != str(routing_request.authority_key):
+                raise AuthorityServiceError("substitution_authority_key_mismatch")
+            review = self._conn.execute(
+                "SELECT snapshot_artifact_id, sealed_verdict_artifact_id FROM formal_review_jobs WHERE review_id = ?",
+                (rid,),
+            ).fetchone()
+            if review is None or str(review["snapshot_artifact_id"] or "") != snapshot:
+                raise AuthorityServiceError("substitution_snapshot_drift")
+            if review["sealed_verdict_artifact_id"] is not None:
+                raise AuthorityServiceError("substitution_verdict_already_accepted")
+            published = self._conn.execute(
+                "SELECT 1 FROM github_publications WHERE review_id = ? LIMIT 1", (rid,)
+            ).fetchone()
+            if published is not None:
+                raise AuthorityServiceError("substitution_verdict_already_published")
+            self._require_formal_snapshot_seal_tx(rid, current_head_sha=head)
+            ledger = RoutingReservationLedger(store=self.store)
+            reason = _nonempty(
+                str(substitution_evidence.get("reason") or ""),
+                field="substitution_reason",
+            )
+            egress = substitution_evidence.get("data_egress_policy")
+            if egress is not None and not isinstance(egress, str):
+                raise AuthorityServiceError("substitution_egress_policy_invalid")
+            if egress != routing_request.data_egress_policy:
+                raise AuthorityServiceError("substitution_egress_policy_mismatch")
+            job_state = str(job["state"])
+            if job_state in {"queued", "running"}:
+                existing = ledger.latest_for_authority_key(routing_request.authority_key)
+                decision = (
+                    next(
+                        (
+                            item
+                            for item in ledger.decisions(existing.reservation_id)
+                            if item.event_type == "authorized_substitution"
+                        ),
+                        None,
+                    )
+                    if existing is not None
+                    else None
+                )
+                if (
+                    existing is None
+                    or existing.idempotency_key != routing_request.idempotency_key
+                    or decision is None
+                    or decision.evidence.get("review_id") != rid
+                    or decision.evidence.get("authority_job_id") != jid
+                    or decision.evidence.get("authority_key") != routing_request.authority_key
+                    or decision.evidence.get("reason") != reason
+                    or decision.evidence.get("requested_data_egress_policy") != egress
+                    or decision.evidence.get("new_requested_reviewer")
+                    != routing_request.requested_reviewer
+                ):
+                    raise AuthorityServiceError("substitution_authority_job_not_failed")
+                return ledger.reserve_selection(
+                    routing_request,
+                    selector,
+                    ttl_seconds=ttl_seconds,
+                    now=now_value,
+                    substitution=decision.evidence,
+                )
+            if job_state != "failed":
+                raise AuthorityServiceError("substitution_authority_job_not_failed")
+            prior = ledger.latest_for_authority_key(routing_request.authority_key)
+            if prior is None:
+                raise AuthorityServiceError("substitution_prior_reservation_missing")
+            prior_reserved = next(
+                (
+                    decision
+                    for decision in ledger.decisions(prior.reservation_id)
+                    if decision.event_type == "reserved"
+                ),
+                None,
+            )
+            prior_envelope = (
+                prior_reserved.evidence.get("authorization_envelope")
+                if prior_reserved is not None
+                else None
+            )
+            prior_envelope_source = "persisted"
+            if not isinstance(prior_envelope, Mapping):
+                prior_envelope = {
+                    "required_capabilities": ["code_review", "sealed_evidence"],
+                    "data_egress_policy": None,
+                    "isolation_required": True,
+                }
+                prior_envelope_source = "formal-review-default-contract-before-6342"
+            evidence = {
+                "prior_reservation_id": prior.reservation_id,
+                "prior_failure_classification": prior.failure_classification,
+                "review_id": rid,
+                "authority_job_id": jid,
+                "authority_key": routing_request.authority_key,
+                "reason": reason,
+                "prior_authorization_envelope_source": prior_envelope_source,
+                "prior_data_egress_policy": prior_envelope.get("data_egress_policy"),
+                "requested_data_egress_policy": egress,
+                "prior_resolved_candidate": prior.resolved_candidate,
+                "new_requested_reviewer": routing_request.requested_reviewer,
+            }
+            reservation = ledger.reserve_selection(
+                routing_request,
+                selector,
+                ttl_seconds=ttl_seconds,
+                now=now_value,
+                substitution=evidence,
+            )
+            self._conn.execute(
+                """UPDATE authority_jobs SET state = 'queued', result_artifact_id = NULL,
+                   terminal_sha256 = NULL, lease_owner = NULL, lease_expires_at = NULL,
+                   updated_at = ?, completed_at = NULL WHERE job_id = ?""",
+                (now_value, jid),
+            )
+            self._append_job_event_tx(
+                jid, int(job["fence_token"]), "substitution_authorized", "queued",
+                {"reservation_id": reservation.reservation_id, "review_id": rid},
+            )
+            return reservation
+
     # ------------------------------------------------------------------
     # Historical migration seam (no live-state caller is invoked here)
 

--- a/scripts/fleet_comms/routing_reservations.py
+++ b/scripts/fleet_comms/routing_reservations.py
@@ -62,6 +62,9 @@ class RoutingReservationRequest:
     route_mode: RouteMode
     estimated_input_bytes: int
     requested_reviewer: str | None = None
+    required_capabilities: tuple[str, ...] = ()
+    data_egress_policy: str | None = None
+    isolation_required: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -298,6 +301,7 @@ class RoutingReservationLedger:
         *,
         ttl_seconds: int = 300,
         now: str | None = None,
+        substitution: Mapping[str, Any] | None = None,
     ) -> RoutingReservation:
         """Replay or atomically select and admit a route.
 
@@ -308,6 +312,7 @@ class RoutingReservationLedger:
         req, request_sha, semantic_sha = self._validate_request(request)
         ttl = _positive_int(ttl_seconds, "ttl_seconds")
         current, current_iso = _now(now)
+        substitution_data = _mapping(substitution, field="substitution")
         with self._write_transaction():
             self._recover_expired_tx(current_iso)
             idempotent = self._conn.execute(
@@ -318,6 +323,14 @@ class RoutingReservationLedger:
             if idempotent is not None:
                 if str(idempotent["request_sha256"]) != request_sha:
                     raise RoutingReservationError("idempotency_key_reused_with_different_request")
+                if substitution_data:
+                    decision = self._conn.execute(
+                        """SELECT evidence_json FROM routing_reservation_decisions
+                           WHERE reservation_id = ? AND event_type = 'authorized_substitution'""",
+                        (str(idempotent["reservation_id"]),),
+                    ).fetchone()
+                    if decision is None or json.loads(str(decision["evidence_json"])) != substitution_data:
+                        raise RoutingReservationError("substitution_idempotency_conflict")
                 return self._reservation_from_row(idempotent)
 
             latest = self._conn.execute(
@@ -326,7 +339,14 @@ class RoutingReservationLedger:
                    ORDER BY attempt DESC LIMIT 1""",
                 (req.authority_key,),
             ).fetchone()
-            if latest is not None and str(latest["semantic_sha256"]) != semantic_sha:
+            if latest is not None and substitution_data:
+                self._validate_substitution_tx(
+                    latest,
+                    req,
+                    substitution_data,
+                    created_at=current_iso,
+                )
+            elif latest is not None and str(latest["semantic_sha256"]) != semantic_sha:
                 raise RoutingReservationError("authority_key_semantic_conflict")
             if latest is not None and str(latest["status"]) in _ACTIVE_STATUSES:
                 # A distinct initiator joins the same exact-head decision rather
@@ -337,6 +357,13 @@ class RoutingReservationLedger:
             if selection is None:
                 raise RoutingReservationUnavailable("no_policy_approved_route")
             selected = self._validate_selection(selection)
+            if substitution_data:
+                if selected.candidate != req.requested_reviewer:
+                    raise RoutingReservationError("substitution_selected_reviewer_mismatch")
+                if selected.family == req.author_family:
+                    raise RoutingReservationError("substitution_same_family")
+                if selected.candidate == str(latest["resolved_candidate"]):
+                    raise RoutingReservationError("substitution_reviewer_unchanged")
             circuit = self._circuit_state(self._circuit_key(selected.quota_bucket, selected.credential_bucket))
             if circuit is not None and circuit.open_until is not None and circuit.open_until > current_iso:
                 raise RoutingReservationUnavailable("credential_bucket_circuit_open")
@@ -414,9 +441,22 @@ class RoutingReservationLedger:
                     "policy_version": selected.policy_version,
                     "route_mode": req.route_mode,
                     "trace": selected.trace,
+                    "authorization_envelope": {
+                        "required_capabilities": list(req.required_capabilities),
+                        "data_egress_policy": req.data_egress_policy,
+                        "isolation_required": req.isolation_required,
+                    },
                 },
                 created_at=current_iso,
             )
+            if substitution_data:
+                self._append_decision_tx(
+                    reservation_id,
+                    "authorized_substitution",
+                    "reserved",
+                    substitution_data,
+                    current_iso,
+                )
             return self._get_reservation_tx(reservation_id)
 
     def reserve(
@@ -573,11 +613,19 @@ class RoutingReservationLedger:
         ).fetchone()
         return self._reservation_from_row(row) if row is not None else None
 
+    def latest_for_authority_key(self, authority_key: str) -> RoutingReservation | None:
+        row = self._conn.execute(
+            """SELECT * FROM routing_reservations WHERE authority_key = ?
+               ORDER BY attempt DESC LIMIT 1""",
+            (_required(authority_key, "authority_key"),),
+        ).fetchone()
+        return self._reservation_from_row(row) if row is not None else None
+
     def decisions(self, reservation_id: str) -> tuple[RoutingReservationDecision, ...]:
         rid = _required(reservation_id, "reservation_id")
         rows = self._conn.execute(
             """SELECT * FROM routing_reservation_decisions
-               WHERE reservation_id = ? ORDER BY created_at, decision_id""",
+               WHERE reservation_id = ? ORDER BY created_at, rowid""",
             (rid,),
         ).fetchall()
         return tuple(self._decision_from_row(row) for row in rows)
@@ -618,6 +666,9 @@ class RoutingReservationLedger:
                 if request.requested_reviewer is not None
                 else None
             ),
+            required_capabilities=tuple(sorted({_required(item, "required_capability") for item in request.required_capabilities})),
+            data_egress_policy=(_required(request.data_egress_policy, "data_egress_policy") if request.data_egress_policy is not None else None),
+            isolation_required=bool(request.isolation_required),
         )
         semantic_payload = {
             "author_family": normalized.author_family,
@@ -629,12 +680,87 @@ class RoutingReservationLedger:
             "requested_risk": normalized.requested_risk,
             "requested_role": normalized.requested_role,
             "route_mode": normalized.route_mode,
+            "required_capabilities": normalized.required_capabilities,
+            "data_egress_policy": normalized.data_egress_policy,
+            "isolation_required": normalized.isolation_required,
         }
         semantic_sha = hashlib.sha256(_canonical_json(semantic_payload).encode("utf-8")).hexdigest()
         request_sha = hashlib.sha256(
             _canonical_json({**semantic_payload, "initiator": normalized.initiator}).encode("utf-8")
         ).hexdigest()
         return normalized, request_sha, semantic_sha
+
+    def _validate_substitution_tx(
+        self,
+        latest: sqlite3.Row,
+        request: RoutingReservationRequest,
+        evidence: Mapping[str, Any],
+        *,
+        created_at: str,
+    ) -> None:
+        """Allow the one explicit post-result-invalid compensation edge only."""
+        prior_id = _required(str(evidence.get("prior_reservation_id") or ""), "prior_reservation_id")
+        reason = _required(str(evidence.get("reason") or ""), "substitution_reason")
+        if len(reason) > 500:
+            raise RoutingReservationError("substitution_reason_too_long")
+        existing = self._conn.execute(
+            """SELECT 1 FROM routing_reservation_decisions d
+               JOIN routing_reservations r ON r.reservation_id = d.reservation_id
+               WHERE r.authority_key = ? AND d.event_type = 'authorized_substitution' LIMIT 1""",
+            (request.authority_key,),
+        ).fetchone()
+        if existing is not None:
+            raise RoutingReservationError("substitution_already_authorized")
+        if prior_id != str(latest["reservation_id"]):
+            raise RoutingReservationError("substitution_prior_not_latest")
+        if str(latest["status"]) != "failed" or str(latest["failure_classification"] or "") != "result_invalid":
+            raise RoutingReservationError("substitution_prior_not_result_invalid")
+        if request.route_mode != "explicit" or request.requested_reviewer is None:
+            raise RoutingReservationError("substitution_explicit_reviewer_required")
+        for field in (
+            "author_model", "author_family", "requested_role", "requested_profile",
+            "requested_risk", "estimated_input_bytes",
+        ):
+            if str(latest[field]) != str(getattr(request, field)):
+                raise RoutingReservationError("substitution_authorization_envelope_drift")
+        prior = self._conn.execute(
+            "SELECT evidence_json FROM routing_reservation_decisions WHERE reservation_id = ? AND event_type = 'reserved'",
+            (prior_id,),
+        ).fetchone()
+        envelope = json.loads(str(prior["evidence_json"])).get("authorization_envelope") if prior else None
+        if not isinstance(envelope, dict):
+            legacy_envelope = {
+                "required_capabilities": ["code_review", "sealed_evidence"],
+                "data_egress_policy": None,
+                "isolation_required": True,
+            }
+            if (
+                list(request.required_capabilities)
+                != legacy_envelope["required_capabilities"]
+                or request.data_egress_policy is not None
+                or request.isolation_required is not True
+            ):
+                raise RoutingReservationError(
+                    "substitution_legacy_authorization_envelope_unavailable"
+                )
+            envelope = legacy_envelope
+            self._append_decision_tx(
+                prior_id,
+                "legacy_authorization_envelope_reconstructed",
+                "failed",
+                {
+                    "authorization_envelope": legacy_envelope,
+                    "source": "formal-review-default-contract-before-6342",
+                    "substitution_reason": reason,
+                },
+                created_at,
+            )
+        if (
+            envelope.get("required_capabilities") != list(request.required_capabilities)
+            or envelope.get("data_egress_policy") != request.data_egress_policy
+            or envelope.get("isolation_required") != request.isolation_required
+        ):
+            raise RoutingReservationError("substitution_authorization_envelope_drift")
 
     def _validate_selection(self, selection: RoutingSelection) -> RoutingSelection:
         if not isinstance(selection, RoutingSelection):
@@ -911,17 +1037,32 @@ class RoutingReservationLedger:
             self.ledger = ledger
 
         def __enter__(self) -> None:
-            self.ledger._conn.execute("BEGIN IMMEDIATE")
+            self.nested = self.ledger._conn.in_transaction
+            if self.nested:
+                self.ledger._conn.execute("SAVEPOINT routing_reservation_write")
+            else:
+                self.ledger._conn.execute("BEGIN IMMEDIATE")
 
         def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
             if exc_type is None:
                 try:
-                    self.ledger._conn.commit()
+                    if self.nested:
+                        self.ledger._conn.execute("RELEASE SAVEPOINT routing_reservation_write")
+                    else:
+                        self.ledger._conn.commit()
                 except Exception:
-                    self.ledger._conn.rollback()
+                    if self.nested:
+                        self.ledger._conn.execute("ROLLBACK TO SAVEPOINT routing_reservation_write")
+                        self.ledger._conn.execute("RELEASE SAVEPOINT routing_reservation_write")
+                    else:
+                        self.ledger._conn.rollback()
                     raise
             else:
-                self.ledger._conn.rollback()
+                if self.nested:
+                    self.ledger._conn.execute("ROLLBACK TO SAVEPOINT routing_reservation_write")
+                    self.ledger._conn.execute("RELEASE SAVEPOINT routing_reservation_write")
+                else:
+                    self.ledger._conn.rollback()
             return False
 
     def _write_transaction(self) -> _WriteTransaction:

--- a/scripts/fleet_comms/routing_reservations.py
+++ b/scripts/fleet_comms/routing_reservations.py
@@ -324,6 +324,8 @@ class RoutingReservationLedger:
                 if str(idempotent["request_sha256"]) != request_sha:
                     raise RoutingReservationError("idempotency_key_reused_with_different_request")
                 if substitution_data:
+                    if str(idempotent["status"]) not in _ACTIVE_STATUSES:
+                        raise RoutingReservationError("substitution_idempotent_replay_not_active")
                     decision = self._conn.execute(
                         """SELECT evidence_json FROM routing_reservation_decisions
                            WHERE reservation_id = ? AND event_type = 'authorized_substitution'""",
@@ -339,6 +341,8 @@ class RoutingReservationLedger:
                    ORDER BY attempt DESC LIMIT 1""",
                 (req.authority_key,),
             ).fetchone()
+            if latest is None and substitution_data:
+                raise RoutingReservationError("substitution_prior_reservation_missing")
             if latest is not None and substitution_data:
                 self._validate_substitution_tx(
                     latest,
@@ -346,7 +350,7 @@ class RoutingReservationLedger:
                     substitution_data,
                     created_at=current_iso,
                 )
-            elif latest is not None and str(latest["semantic_sha256"]) != semantic_sha:
+            elif latest is not None and str(latest["semantic_sha256"]) != semantic_sha and not self._is_legacy_default_envelope_match(latest, req):
                 raise RoutingReservationError("authority_key_semantic_conflict")
             if latest is not None and str(latest["status"]) in _ACTIVE_STATUSES:
                 # A distinct initiator joins the same exact-head decision rather
@@ -761,6 +765,40 @@ class RoutingReservationLedger:
             or envelope.get("isolation_required") != request.isolation_required
         ):
             raise RoutingReservationError("substitution_authorization_envelope_drift")
+
+    def _is_legacy_default_envelope_match(
+        self,
+        latest: sqlite3.Row,
+        request: RoutingReservationRequest,
+    ) -> bool:
+        if (
+            request.required_capabilities != ("code_review", "sealed_evidence")
+            or request.data_egress_policy is not None
+            or not request.isolation_required
+        ):
+            return False
+        reserved = self._conn.execute(
+            """SELECT evidence_json FROM routing_reservation_decisions
+               WHERE reservation_id = ? AND event_type = 'reserved'""",
+            (str(latest["reservation_id"]),),
+        ).fetchone()
+        if reserved is None:
+            return False
+        reserved_evidence = json.loads(str(reserved["evidence_json"]))
+        if isinstance(reserved_evidence.get("authorization_envelope"), dict):
+            return False
+        # A pre-envelope row is accepted only when its historic semantic hash
+        # still proves the complete base identity and the current request uses
+        # the exact formal-review defaults above.
+        payload = {
+            "author_family": request.author_family, "author_model": request.author_model,
+            "authority_key": request.authority_key, "estimated_input_bytes": request.estimated_input_bytes,
+            "requested_profile": request.requested_profile, "requested_reviewer": request.requested_reviewer,
+            "requested_risk": request.requested_risk, "requested_role": request.requested_role,
+            "route_mode": request.route_mode,
+        }
+        legacy = hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+        return str(latest["semantic_sha256"]) == legacy
 
     def _validate_selection(self, selection: RoutingSelection) -> RoutingSelection:
         if not isinstance(selection, RoutingSelection):

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -96,8 +96,9 @@ def _run_invalid_response_lifecycle(
         def reserve_selection(self, *_args, **_kwargs):
             return reservation
 
-        def mark_started(self, _reservation_id):
+        def mark_started(self, reservation_id):
             events.append("started")
+            return SimpleNamespace(status="running", reservation_id=reservation_id)
 
         def settle(self, _reservation_id, **_kwargs):
             events.append("settled")

--- a/tests/ai_agent_bridge/test_review_pr_lifecycle.py
+++ b/tests/ai_agent_bridge/test_review_pr_lifecycle.py
@@ -6,6 +6,7 @@ from argparse import Namespace
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import pytest
 from ai_agent_bridge import _review_pr
 
 
@@ -264,7 +265,16 @@ def test_active_exact_head_exits_before_reservation_or_provider_call(monkeypatch
     assert "already active" in capsys.readouterr().err
 
 
-def test_refused_substitution_makes_no_provider_call_or_claim(monkeypatch, capsys, tmp_path) -> None:
+@pytest.mark.parametrize(
+    "refusal",
+    ("substitution_snapshot_drift", "substitution_reservation_expired"),
+)
+def test_refused_substitution_makes_no_provider_call_or_claim(
+    monkeypatch,
+    capsys,
+    tmp_path,
+    refusal: str,
+) -> None:
     from agent_runtime import runner
     from ai_agent_bridge import _review_worktree
 
@@ -323,7 +333,7 @@ def test_refused_substitution_makes_no_provider_call_or_claim(monkeypatch, capsy
             return formal
 
         def authorize_formal_review_substitution(self, **_kwargs):
-            raise authority_module.AuthorityServiceError("substitution_snapshot_drift")
+            raise authority_module.AuthorityServiceError(refusal)
 
         def claim_job(self, *_args, **_kwargs):
             raise AssertionError("refused substitution must not claim")
@@ -344,4 +354,114 @@ def test_refused_substitution_makes_no_provider_call_or_claim(monkeypatch, capsy
     assert _review_pr.handle_review_pr(
         _args(reviewer="glm", override_reason="operator-authorized result-invalid substitution")
     ) == 1
-    assert "formal reviewer substitution refused: substitution_snapshot_drift" in capsys.readouterr().err
+    assert f"formal reviewer substitution refused: {refusal}" in capsys.readouterr().err
+
+
+def test_expired_reservation_after_successful_substitution_never_reaches_provider(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    from agent_runtime import runner
+    from ai_agent_bridge import _review_worktree
+
+    from scripts.api import state_router
+    from scripts.fleet_comms import authority as authority_module
+    from scripts.fleet_comms import routing_reservations
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    prior = SimpleNamespace(
+        reservation_id="routing-reservation_prior",
+        failure_classification="result_invalid",
+    )
+    substitute = SimpleNamespace(
+        reservation_id="routing-reservation_substitute",
+        resolved_candidate="glm-5.2",
+        resolved_route="glm",
+        resolved_model="glm-5.2",
+        resolved_family="zhipu",
+        quota_bucket="glm-weekly",
+    )
+
+    class FakeLedger:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def latest_for_authority_key(self, _authority_key):
+            return prior
+
+        def reserve_selection(self, *_args, **_kwargs):
+            raise AssertionError("substitution reservation must already be authority-owned")
+
+        def mark_started(self, reservation_id):
+            assert reservation_id == substitute.reservation_id
+            return SimpleNamespace(status="expired")
+
+    failed_job = SimpleNamespace(state="failed", job_id="job_failed", subject_id="review_failed")
+    queued_job = SimpleNamespace(state="queued", job_id="job_failed", subject_id="review_failed")
+    formal = SimpleNamespace(review_id="review_failed", snapshot_artifact_id="artifact_fixture")
+    finish_calls: list[dict[str, object]] = []
+
+    class FakeAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_formal_review(self, **_kwargs):
+            return failed_job
+
+        def require_publishable_formal_review(self, *_args, **_kwargs):
+            return formal
+
+        def authorize_formal_review_substitution(self, **_kwargs):
+            return substitute
+
+        def get_job(self, job_id):
+            assert job_id == queued_job.job_id
+            return queued_job
+
+        def claim_job(self, job_id, _worker_id, **_kwargs):
+            assert job_id == queued_job.job_id
+            return SimpleNamespace(fence_token=7)
+
+        def finish_job(self, _job_id, **kwargs):
+            finish_calls.append(kwargs)
+
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: {"agents": {}})
+    monkeypatch.setattr(routing_reservations, "RoutingReservationLedger", FakeLedger)
+    monkeypatch.setattr(authority_module, "AuthorityService", FakeAuthority)
+    monkeypatch.setattr(
+        runner,
+        "invoke_inter_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("expired route invoked provider")),
+    )
+
+    assert _review_pr.handle_review_pr(
+        _args(reviewer="glm", override_reason="operator-authorized result-invalid substitution")
+    ) == 1
+    assert len(finish_calls) == 1
+    assert finish_calls[0]["state"] == "failed"
+    assert finish_calls[0]["fence_token"] == 7
+    assert b'"failure_classification": "routing_reservation_not_active"' in finish_calls[0]["result"]
+    assert "provider was not invoked" in capsys.readouterr().err

--- a/tests/ai_agent_bridge/test_review_pr_lifecycle.py
+++ b/tests/ai_agent_bridge/test_review_pr_lifecycle.py
@@ -9,10 +9,16 @@ from types import SimpleNamespace
 from ai_agent_bridge import _review_pr
 
 
-def _args(*, background: bool = False, dry_run: bool = False) -> Namespace:
+def _args(
+    *,
+    background: bool = False,
+    dry_run: bool = False,
+    reviewer: str = "auto",
+    override_reason: str | None = None,
+) -> Namespace:
     return Namespace(
         pr="5900",
-        reviewer="auto",
+        reviewer=reviewer,
         claude_available=None,
         model=None,
         effort=None,
@@ -24,6 +30,14 @@ def _args(*, background: bool = False, dry_run: bool = False) -> Namespace:
         initiator="codex/orchestrator",
         author_model="gpt-5.6-sol",
         author_family="openai",
+        allow_explicit_fallback=False,
+        override_reason=override_reason,
+        review_profile=None,
+        risk=None,
+        role=None,
+        required_capability=None,
+        data_egress_policy="approved",
+        isolation_required=True,
     )
 
 
@@ -38,6 +52,42 @@ def test_review_pr_dry_run_keeps_auto_unresolved_until_authority_transaction(cap
     assert "reviewer_request=auto" in output
     assert "model=deterministic-scheduler" in output
     assert "initiator=codex/orchestrator" in output
+
+
+def test_completed_replay_requires_the_original_authorization_envelope() -> None:
+    reservation = SimpleNamespace(
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        requested_role="code:medium",
+        requested_profile="code",
+        requested_risk="medium",
+        route_mode="auto",
+        requested_reviewer=None,
+        estimated_input_bytes=123,
+    )
+    request = SimpleNamespace(
+        **vars(reservation),
+        required_capabilities=("code_review", "sealed_evidence"),
+        data_egress_policy="approved",
+        isolation_required=True,
+    )
+    envelope = {
+        "required_capabilities": ["code_review", "sealed_evidence"],
+        "data_egress_policy": "approved",
+        "isolation_required": True,
+    }
+
+    assert _review_pr._semantic_request_matches(
+        reservation,
+        request,
+        authorization_envelope=envelope,
+    )
+    request.data_egress_policy = "different-policy"
+    assert not _review_pr._semantic_request_matches(
+        reservation,
+        request,
+        authorization_envelope=envelope,
+    )
 
 
 def test_completed_exact_head_replays_without_provider_call(monkeypatch, capsys, tmp_path) -> None:
@@ -90,6 +140,20 @@ def test_completed_exact_head_replays_without_provider_call(monkeypatch, capsys,
 
         def completed_replay(self, _key):
             return reservation
+
+        def decisions(self, _reservation_id):
+            return (
+                SimpleNamespace(
+                    event_type="reserved",
+                    evidence={
+                        "authorization_envelope": {
+                            "required_capabilities": ["code_review", "sealed_evidence"],
+                            "data_egress_policy": "approved",
+                            "isolation_required": True,
+                        }
+                    },
+                ),
+            )
 
     job = SimpleNamespace(state="complete", job_id="job_fixture", subject_id="review_fixture")
     formal = SimpleNamespace(review_id="review_fixture", snapshot_artifact_id="artifact_fixture")
@@ -198,3 +262,86 @@ def test_active_exact_head_exits_before_reservation_or_provider_call(monkeypatch
 
     assert _review_pr.handle_review_pr(_args()) == 1
     assert "already active" in capsys.readouterr().err
+
+
+def test_refused_substitution_makes_no_provider_call_or_claim(monkeypatch, capsys, tmp_path) -> None:
+    from agent_runtime import runner
+    from ai_agent_bridge import _review_worktree
+
+    from scripts.api import state_router
+    from scripts.fleet_comms import authority as authority_module
+    from scripts.fleet_comms import routing_reservations
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    prior = SimpleNamespace(
+        reservation_id="routing-reservation_prior",
+        failure_classification="result_invalid",
+    )
+
+    class FakeLedger:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def latest_for_authority_key(self, _authority_key):
+            return prior
+
+        def reserve_selection(self, *_args, **_kwargs):
+            raise AssertionError("refused substitution must not reserve")
+
+    job = SimpleNamespace(state="failed", job_id="job_failed", subject_id="review_failed")
+    formal = SimpleNamespace(review_id="review_failed", snapshot_artifact_id="artifact_fixture")
+
+    class FakeAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_formal_review(self, **_kwargs):
+            return job
+
+        def require_publishable_formal_review(self, *_args, **_kwargs):
+            return formal
+
+        def authorize_formal_review_substitution(self, **_kwargs):
+            raise authority_module.AuthorityServiceError("substitution_snapshot_drift")
+
+        def claim_job(self, *_args, **_kwargs):
+            raise AssertionError("refused substitution must not claim")
+
+        def retry_job(self, *_args, **_kwargs):
+            raise AssertionError("refused substitution must not requeue")
+
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: {"agents": {}})
+    monkeypatch.setattr(routing_reservations, "RoutingReservationLedger", FakeLedger)
+    monkeypatch.setattr(authority_module, "AuthorityService", FakeAuthority)
+    monkeypatch.setattr(
+        runner,
+        "invoke_inter_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("provider call after refusal")),
+    )
+
+    assert _review_pr.handle_review_pr(
+        _args(reviewer="glm", override_reason="operator-authorized result-invalid substitution")
+    ) == 1
+    assert "formal reviewer substitution refused: substitution_snapshot_drift" in capsys.readouterr().err

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -21,6 +21,7 @@ from scripts.fleet_comms.message_plane import MessagePlane, resolve_plane_mode
 from scripts.fleet_comms.migrations import MIGRATIONS, apply_migrations
 from scripts.fleet_comms.review_publisher import record_publication_receipt
 from scripts.fleet_comms.routing_reservations import (
+    RoutingReservationError,
     RoutingReservationLedger,
     RoutingReservationRequest,
     RoutingReservationUnavailable,
@@ -41,6 +42,23 @@ def _root(tmp_path: Path) -> Path:
 
 def _sha(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _historic_routing_semantic_sha(request: RoutingReservationRequest) -> str:
+    """Return the pre-#6342 request identity without envelope dimensions."""
+    payload = {
+        "author_family": request.author_family,
+        "author_model": request.author_model,
+        "authority_key": request.authority_key,
+        "estimated_input_bytes": request.estimated_input_bytes,
+        "requested_profile": request.requested_profile,
+        "requested_reviewer": request.requested_reviewer,
+        "requested_risk": request.requested_risk,
+        "requested_role": request.requested_role,
+        "route_mode": request.route_mode,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def test_authority_mode_resolves_without_changing_existing_modes() -> None:
@@ -921,6 +939,11 @@ def _failed_formal_substitution_fixture(
         )
         if legacy_envelope:
             ledger._append_decision_tx = original_append
+            ledger._conn.execute(
+                "UPDATE routing_reservations SET semantic_sha256 = ? WHERE reservation_id = ?",
+                (_historic_routing_semantic_sha(original_request), original.reservation_id),
+            )
+            ledger._conn.commit()
         ledger.settle(
             original.reservation_id,
             status="failed",
@@ -1038,6 +1061,43 @@ def test_authority_identical_substitution_replay_returns_existing_reservation(tm
             ttl_seconds=60,
             now="2035-01-01T00:00:03Z",
         ) == first
+
+
+def test_authority_refuses_replay_after_substitution_reservation_ttl_expiry(tmp_path: Path) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+        substitute = service.authorize_formal_review_substitution(
+            authority_job_id=job.job_id,
+            review_id=review.review_id,
+            current_head_sha="a" * 40,
+            expected_snapshot_artifact_id=review.snapshot_artifact_id,
+            routing_request=request,
+            selector=_substitution_selection,
+            substitution_evidence=evidence,
+            ttl_seconds=1,
+            now="2035-01-01T00:00:02Z",
+        )
+        with RoutingReservationLedger(store=service.store) as ledger:
+            expired = ledger.recover_expired(now="2035-01-01T00:00:04Z")
+            assert len(expired) == 1 and expired[0].reservation_id == substitute.reservation_id
+            assert ledger.get(substitute.reservation_id).status == "expired"
+
+        with pytest.raises(
+            RoutingReservationError,
+            match="substitution_idempotent_replay_not_active",
+        ):
+            service.authorize_formal_review_substitution(
+                authority_job_id=job.job_id,
+                review_id=review.review_id,
+                current_head_sha="a" * 40,
+                expected_snapshot_artifact_id=review.snapshot_artifact_id,
+                routing_request=request,
+                selector=_substitution_selection,
+                substitution_evidence=evidence,
+                ttl_seconds=1,
+                now="2035-01-01T00:00:04Z",
+            )
+        assert service.get_job(job.job_id).state == "queued"
 
 
 @pytest.mark.parametrize("rejection", ("sealed", "published", "head", "snapshot", "job", "review"))

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,13 @@ from scripts.fleet_comms.authority import (
 from scripts.fleet_comms.cli import main
 from scripts.fleet_comms.message_plane import MessagePlane, resolve_plane_mode
 from scripts.fleet_comms.migrations import MIGRATIONS, apply_migrations
+from scripts.fleet_comms.review_publisher import record_publication_receipt
+from scripts.fleet_comms.routing_reservations import (
+    RoutingReservationLedger,
+    RoutingReservationRequest,
+    RoutingReservationUnavailable,
+    RoutingSelection,
+)
 
 
 class _UnusedExecutor:
@@ -799,3 +807,386 @@ def test_formal_review_refuses_head_mismatch_before_verdict_publication(tmp_path
         ).fetchone()
         assert seal is not None
         assert seal["snapshot_artifact_id"] == review.snapshot_artifact_id
+
+
+def _substitution_request(authority_key: str, idempotency_key: str = "substitute") -> RoutingReservationRequest:
+    return RoutingReservationRequest(
+        authority_key=authority_key,
+        idempotency_key=idempotency_key,
+        initiator="codex/orchestrator",
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        requested_role="code:high",
+        requested_profile="code",
+        requested_risk="high",
+        route_mode="explicit",
+        estimated_input_bytes=123,
+        requested_reviewer="glm-5.2",
+        required_capabilities=("code_review", "sealed_evidence"),
+        data_egress_policy="approved",
+        isolation_required=True,
+    )
+
+
+def _substitution_selection(_context: object) -> RoutingSelection:
+    return RoutingSelection(
+        candidate="glm-5.2",
+        route="glm",
+        model="glm-5.2",
+        family="zhipu",
+        quota_bucket="glm-weekly",
+        credential_bucket="glm-key-a",
+        quota_limit=1,
+        credential_limit=1,
+        policy_version="resolver-v1",
+        quota_snapshot={"remaining": 1},
+        quota_fresh_at="2035-01-01T00:00:00Z",
+        trace={"source": "fixture"},
+    )
+
+
+def _failed_formal_substitution_fixture(
+    service: AuthorityService,
+    *,
+    legacy_envelope: bool = False,
+) -> tuple[object, object, RoutingReservationRequest, dict[str, object]]:
+    """Create the sole admissible post-result-invalid substitution boundary."""
+    head = "a" * 40
+    authority_key = "formal-review:substitution-fixture"
+    job = service.enqueue_formal_review(
+        repository="owner/repo",
+        pr_number=42,
+        head_sha=head,
+        gate_kind="cross-family-review",
+        snapshot=b'{"head":"' + head.encode("ascii") + b'"}',
+        idempotency_key=authority_key,
+    )
+    review = service.require_publishable_formal_review(job.subject_id, current_head_sha=head)
+    assert review.snapshot_artifact_id is not None
+    egress_policy = None if legacy_envelope else "approved"
+    original_request = RoutingReservationRequest(
+        authority_key=authority_key,
+        idempotency_key="original",
+        initiator="codex/orchestrator",
+        author_model="gpt-5.6-sol",
+        author_family="openai",
+        requested_role="code:high",
+        requested_profile="code",
+        requested_risk="high",
+        route_mode="auto",
+        estimated_input_bytes=123,
+        required_capabilities=("code_review", "sealed_evidence"),
+        data_egress_policy=egress_policy,
+        isolation_required=True,
+    )
+    with RoutingReservationLedger(store=service.store) as ledger:
+        original_append = ledger._append_decision_tx
+        if legacy_envelope:
+            def append_without_envelope(
+                reservation_id: str,
+                event_type: str,
+                state: str,
+                evidence: dict[str, object],
+                created_at: str,
+            ) -> None:
+                old_evidence = dict(evidence)
+                if event_type == "reserved":
+                    old_evidence.pop("authorization_envelope", None)
+                original_append(
+                    reservation_id,
+                    event_type,
+                    state,
+                    old_evidence,
+                    created_at,
+                )
+
+            ledger._append_decision_tx = append_without_envelope
+        original = ledger.reserve_selection(
+            original_request,
+            lambda _context: RoutingSelection(
+                candidate="grok-4.5",
+                route="grok",
+                model="grok-4.5",
+                family="xai",
+                quota_bucket="grok-weekly",
+                credential_bucket="grok-key-a",
+                quota_limit=1,
+                credential_limit=1,
+                policy_version="resolver-v1",
+                quota_snapshot={"remaining": 1},
+                quota_fresh_at="2035-01-01T00:00:00Z",
+                trace={"source": "fixture"},
+            ),
+            now="2035-01-01T00:00:00Z",
+        )
+        if legacy_envelope:
+            ledger._append_decision_tx = original_append
+        ledger.settle(
+            original.reservation_id,
+            status="failed",
+            failure_classification="result_invalid",
+            now="2035-01-01T00:00:01Z",
+        )
+    lease = service.claim_job(job.job_id, "fixture-worker", now="2035-01-01T00:00:00Z")
+    service.finish_job(
+        job.job_id,
+        worker_id="fixture-worker",
+        fence_token=lease.fence_token,
+        state="failed",
+        result=b'{"failure_classification":"result_invalid"}',
+        now="2035-01-01T00:00:01Z",
+    )
+    request = replace(_substitution_request(authority_key), data_egress_policy=egress_policy)
+    evidence = {
+        "prior_reservation_id": original.reservation_id,
+        "reason": "operator-authorized result-invalid substitution",
+        "review_id": review.review_id,
+        "authority_job_id": job.job_id,
+        "authority_key": authority_key,
+        "data_egress_policy": egress_policy,
+        "new_requested_reviewer": "glm-5.2",
+    }
+    return job, review, request, evidence
+
+
+def test_authority_authorizes_one_atomic_result_invalid_substitution(tmp_path: Path) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+        reservation = service.authorize_formal_review_substitution(
+            authority_job_id=job.job_id,
+            review_id=review.review_id,
+            current_head_sha="a" * 40,
+            expected_snapshot_artifact_id=review.snapshot_artifact_id,
+            routing_request=request,
+            selector=_substitution_selection,
+            substitution_evidence=evidence,
+            ttl_seconds=60,
+            now="2035-01-01T00:00:02Z",
+        )
+
+        assert reservation.attempt == 2
+        assert service.get_job(job.job_id).state == "queued"
+        with RoutingReservationLedger(store=service.store) as ledger:
+            assert [item.event_type for item in ledger.decisions(reservation.reservation_id)] == [
+                "reserved",
+                "authorized_substitution",
+            ]
+
+
+def test_authority_authorizes_the_pre_6342_formal_review_default_envelope(
+    tmp_path: Path,
+) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(
+            service,
+            legacy_envelope=True,
+        )
+        reservation = service.authorize_formal_review_substitution(
+            authority_job_id=job.job_id,
+            review_id=review.review_id,
+            current_head_sha="a" * 40,
+            expected_snapshot_artifact_id=review.snapshot_artifact_id,
+            routing_request=request,
+            selector=_substitution_selection,
+            substitution_evidence=evidence,
+            ttl_seconds=60,
+            now="2035-01-01T00:00:02Z",
+        )
+
+        assert reservation.attempt == 2
+        with RoutingReservationLedger(store=service.store) as ledger:
+            prior = next(
+                item
+                for item in ledger.decisions(evidence["prior_reservation_id"])
+                if item.event_type == "legacy_authorization_envelope_reconstructed"
+            )
+            substitute = next(
+                item
+                for item in ledger.decisions(reservation.reservation_id)
+                if item.event_type == "authorized_substitution"
+            )
+        assert prior.evidence["source"] == "formal-review-default-contract-before-6342"
+        assert (
+            substitute.evidence["prior_authorization_envelope_source"]
+            == "formal-review-default-contract-before-6342"
+        )
+        assert substitute.evidence["requested_data_egress_policy"] is None
+
+
+def test_authority_identical_substitution_replay_returns_existing_reservation(tmp_path: Path) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+        first = service.authorize_formal_review_substitution(
+            authority_job_id=job.job_id,
+            review_id=review.review_id,
+            current_head_sha="a" * 40,
+            expected_snapshot_artifact_id=review.snapshot_artifact_id,
+            routing_request=request,
+            selector=_substitution_selection,
+            substitution_evidence=evidence,
+            ttl_seconds=60,
+            now="2035-01-01T00:00:02Z",
+        )
+        assert service.authorize_formal_review_substitution(
+            authority_job_id=job.job_id,
+            review_id=review.review_id,
+            current_head_sha="a" * 40,
+            expected_snapshot_artifact_id=review.snapshot_artifact_id,
+            routing_request=request,
+            selector=_substitution_selection,
+            substitution_evidence=evidence,
+            ttl_seconds=60,
+            now="2035-01-01T00:00:03Z",
+        ) == first
+
+
+@pytest.mark.parametrize("rejection", ("sealed", "published", "head", "snapshot", "job", "review"))
+def test_authority_substitution_rejects_terminal_or_identity_drift(
+    tmp_path: Path,
+    rejection: str,
+) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+        kwargs = {
+            "authority_job_id": job.job_id,
+            "review_id": review.review_id,
+            "current_head_sha": "a" * 40,
+            "expected_snapshot_artifact_id": review.snapshot_artifact_id,
+            "routing_request": request,
+            "selector": _substitution_selection,
+            "substitution_evidence": evidence,
+            "ttl_seconds": 60,
+            "now": "2035-01-01T00:00:02Z",
+        }
+        error = ""
+        if rejection == "sealed":
+            artifact = service.store.store_bytes(b"sealed", producer="test")
+            service.store.connection.execute(
+                "UPDATE formal_review_jobs SET sealed_verdict_artifact_id = ? WHERE review_id = ?",
+                (artifact.artifact_id, review.review_id),
+            )
+            service.store.connection.commit()
+            error = "substitution_verdict_already_accepted"
+        elif rejection == "published":
+            record_publication_receipt(
+                service.store.connection,
+                review_id=review.review_id,
+                head_sha="a" * 40,
+            )
+            error = "substitution_verdict_already_published"
+        elif rejection == "head":
+            kwargs["current_head_sha"] = "b" * 40
+            error = "formal_review_head_mismatch"
+        elif rejection == "snapshot":
+            kwargs["expected_snapshot_artifact_id"] = "artifact_wrong"
+            error = "substitution_snapshot_drift"
+        elif rejection == "job":
+            other = service.enqueue_request(
+                recipient="codex",
+                body="unrelated",
+                idempotency_key="unrelated-authority-job",
+            )
+            kwargs["authority_job_id"] = other.job_id
+            error = "substitution_authority_job_mismatch"
+        else:
+            kwargs["review_id"] = "review_wrong"
+            error = "substitution_authority_job_mismatch"
+
+        with pytest.raises(AuthorityServiceError, match=error):
+            service.authorize_formal_review_substitution(**kwargs)
+        assert service.get_job(job.job_id).state == "failed"
+
+
+@pytest.mark.parametrize("selector_kind", ("none", "capacity"))
+def test_authority_substitution_refusal_rolls_back_requeue_and_reservation(
+    tmp_path: Path,
+    selector_kind: str,
+) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+
+        def no_route_selector(_context: object) -> None:
+            return None
+
+        selector = no_route_selector
+        if selector_kind == "capacity":
+            with RoutingReservationLedger(store=service.store) as ledger:
+                ledger.reserve_selection(
+                    _substitution_request("formal-review:capacity-blocker", "blocker"),
+                    _substitution_selection,
+                    now="2035-01-01T00:00:02Z",
+                )
+            selector = _substitution_selection
+        with pytest.raises(RoutingReservationUnavailable):
+            service.authorize_formal_review_substitution(
+                authority_job_id=job.job_id,
+                review_id=review.review_id,
+                current_head_sha="a" * 40,
+                expected_snapshot_artifact_id=review.snapshot_artifact_id,
+                routing_request=request,
+                selector=selector,
+                substitution_evidence=evidence,
+                ttl_seconds=60,
+                now="2035-01-01T00:00:02Z",
+            )
+
+        assert service.get_job(job.job_id).state == "failed"
+        with RoutingReservationLedger(store=service.store) as ledger:
+            attempts = [
+                item for item in (ledger.latest_for_authority_key(request.authority_key),)
+                if item is not None
+            ]
+            assert len(attempts) == 1 and attempts[0].attempt == 1
+        events = service.store.connection.execute(
+            "SELECT event_type FROM authority_job_events WHERE job_id = ? ORDER BY rowid",
+            (job.job_id,),
+        ).fetchall()
+        assert "substitution_authorized" not in [row[0] for row in events]
+
+
+def _concurrent_substitution(root: Path, job_id: str, review_id: str, snapshot: str, request: RoutingReservationRequest, evidence: dict[str, str]) -> str:
+    with AuthorityService(root=root) as service:
+        try:
+            return service.authorize_formal_review_substitution(
+                authority_job_id=job_id,
+                review_id=review_id,
+                current_head_sha="a" * 40,
+                expected_snapshot_artifact_id=snapshot,
+                routing_request=request,
+                selector=_substitution_selection,
+                substitution_evidence=evidence,
+                ttl_seconds=60,
+                now="2035-01-01T00:00:02Z",
+            ).reservation_id
+        except AuthorityServiceError as exc:
+            return str(exc)
+
+
+def test_concurrent_substitution_requests_do_not_fork_authority_or_reservation(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    with AuthorityService(root=root) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(
+            pool.map(
+                lambda _index: _concurrent_substitution(
+                    root,
+                    job.job_id,
+                    review.review_id,
+                    str(review.snapshot_artifact_id),
+                    request,
+                    evidence,
+                ),
+                range(2),
+            )
+        )
+    reservation_ids = [value for value in outcomes if value.startswith("routing-reservation_")]
+    assert reservation_ids and len(set(reservation_ids)) == 1
+    assert all(
+        value.startswith("routing-reservation_") or value == "substitution_authority_job_not_failed"
+        for value in outcomes
+    )
+    with AuthorityService(root=root) as service, RoutingReservationLedger(store=service.store) as ledger:
+        reservation = ledger.latest_for_authority_key(request.authority_key)
+        assert reservation is not None and reservation.attempt == 2
+        assert service.get_job(job.job_id).state == "queued"

--- a/tests/test_fleet_comms_routing_reservations.py
+++ b/tests/test_fleet_comms_routing_reservations.py
@@ -198,6 +198,387 @@ def test_same_authority_key_semantic_conflict_fails_closed(tmp_path: Path) -> No
             ledger.reserve_selection(changed, _selection, now="2035-01-01T00:00:01Z")
 
 
+def test_one_result_invalid_substitution_is_linked_idempotent_and_single_use(tmp_path: Path) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        first = ledger.reserve_selection(
+            _request("repo:substitution:head", "first"), _selection, now="2035-01-01T00:00:00Z"
+        )
+        ledger.settle(
+            first.reservation_id, status="failed", failure_classification="result_invalid",
+            now="2035-01-01T00:00:01Z",
+        )
+        substitute = replace(
+            _request("repo:substitution:head", "substitute"),
+            route_mode="explicit", requested_reviewer="glm-5.2",
+        )
+        evidence = {
+            "prior_reservation_id": first.reservation_id,
+            "reason": "operator-authorized invalid-result substitution",
+            "review_id": "review_fixture", "authority_job_id": "authority-job_fixture",
+            "authority_key": "repo:substitution:head", "data_egress_policy": "approved",
+        }
+        def selection(context: object) -> RoutingSelection:
+            return replace(_selection(context), candidate="glm-5.2", family="zhipu")
+
+        second = ledger.reserve_selection(substitute, selection, now="2035-01-01T00:00:02Z", substitution=evidence)
+        assert second.attempt == 2 and second.fallback_from is None
+        assert ledger.reserve_selection(substitute, selection, now="2035-01-01T00:00:03Z", substitution=evidence) == second
+        assert "authorized_substitution" in {item.event_type for item in ledger.decisions(second.reservation_id)}
+        with pytest.raises(RoutingReservationError, match="substitution_idempotency_conflict"):
+            ledger.reserve_selection(
+                substitute,
+                selection,
+                now="2035-01-01T00:00:03Z",
+                substitution={**evidence, "reason": "different operator reason"},
+            )
+        with pytest.raises(RoutingReservationError, match="substitution_already_authorized"):
+            ledger.reserve_selection(
+                replace(substitute, idempotency_key="second-substitution"), selection,
+                now="2035-01-01T00:00:04Z", substitution=evidence,
+            )
+
+
+def _failed_result_invalid_reservation(
+    ledger: RoutingReservationLedger,
+    *,
+    authority_key: str,
+) -> tuple[RoutingReservationRequest, dict[str, str]]:
+    original = replace(
+        _request(authority_key, "first"),
+        required_capabilities=("code_review", "sealed_evidence"),
+        data_egress_policy="approved",
+        isolation_required=True,
+    )
+    first = ledger.reserve_selection(original, _selection, now="2035-01-01T00:00:00Z")
+    ledger.settle(
+        first.reservation_id,
+        status="failed",
+        failure_classification="result_invalid",
+        now="2035-01-01T00:00:01Z",
+    )
+    substitute = replace(
+        original,
+        idempotency_key="substitute",
+        route_mode="explicit",
+        requested_reviewer="glm-5.2",
+    )
+    return substitute, {
+        "prior_reservation_id": first.reservation_id,
+        "reason": "operator-authorized invalid-result substitution",
+        "review_id": "review_fixture",
+        "authority_job_id": "authority-job_fixture",
+        "authority_key": authority_key,
+        "data_egress_policy": "approved",
+    }
+
+
+def _glm_selection(context: object) -> RoutingSelection:
+    return replace(_selection(context), candidate="glm-5.2", family="zhipu")
+
+
+def _legacy_failed_result_invalid_reservation(
+    ledger: RoutingReservationLedger,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    authority_key: str,
+) -> tuple[RoutingReservationRequest, dict[str, str], str]:
+    """Create a pre-#6342 reservation whose decision lacks the new envelope."""
+    original_append = ledger._append_decision_tx
+
+    def append_without_envelope(
+        reservation_id: str,
+        event_type: str,
+        state: str,
+        evidence: dict[str, object],
+        created_at: str,
+    ) -> None:
+        legacy_evidence = dict(evidence)
+        if event_type == "reserved":
+            legacy_evidence.pop("authorization_envelope", None)
+        original_append(reservation_id, event_type, state, legacy_evidence, created_at)
+
+    monkeypatch.setattr(ledger, "_append_decision_tx", append_without_envelope)
+    original = replace(
+        _request(authority_key, "legacy-first"),
+        required_capabilities=("code_review", "sealed_evidence"),
+        isolation_required=True,
+    )
+    first = ledger.reserve_selection(original, _selection, now="2035-01-01T00:00:00Z")
+    monkeypatch.setattr(ledger, "_append_decision_tx", original_append)
+    ledger.settle(
+        first.reservation_id,
+        status="failed",
+        failure_classification="result_invalid",
+        now="2035-01-01T00:00:01Z",
+    )
+    substitute = replace(
+        original,
+        idempotency_key="legacy-substitute",
+        route_mode="explicit",
+        requested_reviewer="glm-5.2",
+    )
+    evidence = {
+        "prior_reservation_id": first.reservation_id,
+        "reason": "operator-authorized legacy result-invalid substitution",
+        "review_id": "review_fixture",
+        "authority_job_id": "authority-job_fixture",
+        "authority_key": authority_key,
+    }
+    return substitute, evidence, first.reservation_id
+
+
+def test_substitution_reconstructs_only_the_legacy_formal_review_default_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence, prior_id = _legacy_failed_result_invalid_reservation(
+            ledger,
+            monkeypatch,
+            authority_key="repo:substitution:legacy-default",
+        )
+        second = ledger.reserve_selection(
+            substitute,
+            _glm_selection,
+            now="2035-01-01T00:00:02Z",
+            substitution=evidence,
+        )
+
+        assert second.attempt == 2
+        reconstruction = [
+            decision
+            for decision in ledger.decisions(prior_id)
+            if decision.event_type == "legacy_authorization_envelope_reconstructed"
+        ]
+        assert len(reconstruction) == 1
+        assert reconstruction[0].evidence == {
+            "authorization_envelope": {
+                "required_capabilities": ["code_review", "sealed_evidence"],
+                "data_egress_policy": None,
+                "isolation_required": True,
+            },
+            "source": "formal-review-default-contract-before-6342",
+            "substitution_reason": evidence["reason"],
+        }
+        assert "authorized_substitution" in {
+            decision.event_type for decision in ledger.decisions(second.reservation_id)
+        }
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        {"required_capabilities": ("code_review",)},
+        {"data_egress_policy": "local_interactive"},
+        {"isolation_required": False},
+    ),
+)
+def test_substitution_rejects_legacy_envelope_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed: dict[str, object],
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence, prior_id = _legacy_failed_result_invalid_reservation(
+            ledger,
+            monkeypatch,
+            authority_key=f"repo:substitution:legacy-reject:{next(iter(changed))}",
+        )
+        with pytest.raises(
+            RoutingReservationError,
+            match="substitution_legacy_authorization_envelope_unavailable",
+        ):
+            ledger.reserve_selection(
+                replace(substitute, **changed),
+                _glm_selection,
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+
+        assert "legacy_authorization_envelope_reconstructed" not in {
+            decision.event_type for decision in ledger.decisions(prior_id)
+        }
+
+
+def test_substitution_rolls_back_legacy_reconstruction_when_selection_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence, prior_id = _legacy_failed_result_invalid_reservation(
+            ledger,
+            monkeypatch,
+            authority_key="repo:substitution:legacy-rollback",
+        )
+        with pytest.raises(RoutingReservationUnavailable, match="no_policy_approved_route"):
+            ledger.reserve_selection(
+                substitute,
+                lambda _context: None,
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+
+        assert "legacy_authorization_envelope_reconstructed" not in {
+            decision.event_type for decision in ledger.decisions(prior_id)
+        }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("author_model", "glm-5.2"),
+        ("author_family", "zhipu"),
+        ("requested_role", "security-review"),
+        ("requested_profile", "security"),
+        ("requested_risk", "critical"),
+        ("estimated_input_bytes", 1201),
+        ("required_capabilities", ("code_review",)),
+        ("data_egress_policy", "different-approved-policy"),
+        ("isolation_required", False),
+    ),
+)
+def test_substitution_rejects_authorization_envelope_drift(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence = _failed_result_invalid_reservation(
+            ledger,
+            authority_key=f"repo:substitution:drift:{field}",
+        )
+
+        with pytest.raises(RoutingReservationError, match="substitution_authorization_envelope_drift"):
+            ledger.reserve_selection(
+                replace(substitute, **{field: value}),
+                _glm_selection,
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+
+
+def test_substitution_rejects_active_or_non_result_invalid_prior(tmp_path: Path) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        active = ledger.reserve_selection(
+            _request("repo:substitution:active", "first"),
+            _selection,
+            now="2035-01-01T00:00:00Z",
+        )
+        request = replace(
+            _request("repo:substitution:active", "substitute"),
+            route_mode="explicit",
+            requested_reviewer="glm-5.2",
+        )
+        evidence = {"prior_reservation_id": active.reservation_id, "reason": "operator-authorized"}
+        with pytest.raises(RoutingReservationError, match="substitution_prior_not_result_invalid"):
+            ledger.reserve_selection(request, _glm_selection, substitution=evidence)
+
+        ledger.settle(
+            active.reservation_id,
+            status="failed",
+            failure_classification="transport_error",
+            now="2035-01-01T00:00:01Z",
+        )
+        with pytest.raises(RoutingReservationError, match="substitution_prior_not_result_invalid"):
+            ledger.reserve_selection(request, _glm_selection, substitution=evidence)
+
+
+@pytest.mark.parametrize(
+    ("reason", "error"),
+    (
+        ("", "substitution_reason_required"),
+        ("x" * 501, "substitution_reason_too_long"),
+    ),
+)
+def test_substitution_reason_is_required_and_bounded(tmp_path: Path, reason: str, error: str) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence = _failed_result_invalid_reservation(
+            ledger,
+            authority_key=f"repo:substitution:reason:{len(reason)}",
+        )
+        with pytest.raises(RoutingReservationError, match=error):
+            ledger.reserve_selection(
+                substitute,
+                _glm_selection,
+                now="2035-01-01T00:00:02Z",
+                substitution={**evidence, "reason": reason},
+            )
+
+
+def test_substitution_rejects_stale_link_and_ineligible_selection(tmp_path: Path) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        substitute, evidence = _failed_result_invalid_reservation(
+            ledger,
+            authority_key="repo:substitution:selection",
+        )
+        with pytest.raises(RoutingReservationError, match="substitution_prior_not_latest"):
+            ledger.reserve_selection(
+                substitute,
+                _glm_selection,
+                now="2035-01-01T00:00:02Z",
+                substitution={**evidence, "prior_reservation_id": "routing-reservation_wrong"},
+            )
+        with pytest.raises(RoutingReservationError, match="substitution_selected_reviewer_mismatch"):
+            ledger.reserve_selection(
+                substitute,
+                _selection,
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+        with pytest.raises(RoutingReservationError, match="substitution_same_family"):
+            ledger.reserve_selection(
+                substitute,
+                lambda context: replace(_glm_selection(context), family="openai"),
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+        with pytest.raises(RoutingReservationError, match="substitution_reviewer_unchanged"):
+            ledger.reserve_selection(
+                replace(substitute, requested_reviewer="codex"),
+                lambda context: replace(_selection(context), family="xai"),
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+
+
+def test_substitution_selector_or_admission_failure_leaves_no_compensating_reservation(
+    tmp_path: Path,
+) -> None:
+    root = _root(tmp_path)
+    with RoutingReservationLedger(root=root) as ledger:
+        substitute, evidence = _failed_result_invalid_reservation(
+            ledger,
+            authority_key="repo:substitution:rollback",
+        )
+        prior = ledger.latest_for_authority_key(substitute.authority_key)
+        assert prior is not None
+        with pytest.raises(RoutingReservationUnavailable, match="no_policy_approved_route"):
+            ledger.reserve_selection(
+                substitute,
+                lambda _context: None,
+                now="2035-01-01T00:00:02Z",
+                substitution=evidence,
+            )
+        assert ledger.latest_for_authority_key(substitute.authority_key) == prior
+        assert "authorized_substitution" not in {
+            decision.event_type for decision in ledger.decisions(prior.reservation_id)
+        }
+
+        ledger.reserve_selection(
+            _request("repo:substitution:blocker", "blocker"),
+            _selection,
+            now="2035-01-01T00:00:02Z",
+        )
+        with pytest.raises(RoutingReservationUnavailable, match="credential_bucket_exhausted"):
+            ledger.reserve_selection(
+                substitute,
+                _glm_selection,
+                now="2035-01-01T00:00:03Z",
+                substitution=evidence,
+            )
+        assert ledger.latest_for_authority_key(substitute.authority_key) == prior
+
+
 def test_credential_admission_and_completed_bytes_are_independent_of_quota_bucket(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_fleet_comms_routing_reservations.py
+++ b/tests/test_fleet_comms_routing_reservations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -37,6 +39,35 @@ def _request(authority_key: str, idempotency_key: str, initiator: str = "codex")
         route_mode="auto",
         estimated_input_bytes=1200,
     )
+
+
+def _historic_semantic_sha(request: RoutingReservationRequest) -> str:
+    """Match the pre-#6342 identity, before the envelope fields were added."""
+    payload = {
+        "author_family": request.author_family,
+        "author_model": request.author_model,
+        "authority_key": request.authority_key,
+        "estimated_input_bytes": request.estimated_input_bytes,
+        "requested_profile": request.requested_profile,
+        "requested_reviewer": request.requested_reviewer,
+        "requested_risk": request.requested_risk,
+        "requested_role": request.requested_role,
+        "route_mode": request.route_mode,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _mark_historic_semantic_sha(
+    ledger: RoutingReservationLedger,
+    reservation_id: str,
+    request: RoutingReservationRequest,
+) -> None:
+    ledger._conn.execute(
+        "UPDATE routing_reservations SET semantic_sha256 = ? WHERE reservation_id = ?",
+        (_historic_semantic_sha(request), reservation_id),
+    )
+    ledger._conn.commit()
 
 
 def _selection(context: object) -> RoutingSelection:
@@ -305,6 +336,7 @@ def _legacy_failed_result_invalid_reservation(
     )
     first = ledger.reserve_selection(original, _selection, now="2035-01-01T00:00:00Z")
     monkeypatch.setattr(ledger, "_append_decision_tx", original_append)
+    _mark_historic_semantic_sha(ledger, first.reservation_id, original)
     ledger.settle(
         first.reservation_id,
         status="failed",
@@ -421,6 +453,95 @@ def test_substitution_rolls_back_legacy_reconstruction_when_selection_fails(
         assert "legacy_authorization_envelope_reconstructed" not in {
             decision.event_type for decision in ledger.decisions(prior_id)
         }
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        {"required_capabilities": ("code_review",)},
+        {"data_egress_policy": "local_interactive"},
+        {"isolation_required": False},
+    ),
+)
+def test_pre_envelope_active_join_and_transport_retry_keep_legacy_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed: dict[str, object],
+) -> None:
+    """Only a substitution reconstructs the old envelope; normal retries do not."""
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        original_append = ledger._append_decision_tx
+
+        def append_without_envelope(
+            reservation_id: str,
+            event_type: str,
+            state: str,
+            evidence: dict[str, object],
+            created_at: str,
+        ) -> None:
+            legacy_evidence = dict(evidence)
+            if event_type == "reserved":
+                legacy_evidence.pop("authorization_envelope", None)
+            original_append(reservation_id, event_type, state, legacy_evidence, created_at)
+
+        legacy = replace(
+            _request("repo:legacy:normal-retry", "first"),
+            required_capabilities=("code_review", "sealed_evidence"),
+            data_egress_policy=None,
+            isolation_required=True,
+        )
+        monkeypatch.setattr(ledger, "_append_decision_tx", append_without_envelope)
+        first = ledger.reserve_selection(legacy, _selection, now="2035-01-01T00:00:00Z")
+        monkeypatch.setattr(ledger, "_append_decision_tx", original_append)
+        _mark_historic_semantic_sha(ledger, first.reservation_id, legacy)
+
+        joined = ledger.reserve_selection(
+            replace(legacy, idempotency_key="join", initiator="grok"),
+            _selection,
+            now="2035-01-01T00:00:01Z",
+        )
+        assert joined.reservation_id == first.reservation_id
+        assert joined.semantic_sha256 == _historic_semantic_sha(legacy)
+        ledger.settle(
+            first.reservation_id,
+            status="failed",
+            failure_classification="transport_error",
+            now="2035-01-01T00:00:02Z",
+        )
+        retry = ledger.reserve_selection(
+            replace(legacy, idempotency_key="retry"),
+            _selection,
+            now="2035-01-01T00:00:03Z",
+        )
+        assert retry.attempt == 2
+
+        with pytest.raises(RoutingReservationError, match="authority_key_semantic_conflict"):
+            ledger.reserve_selection(
+                replace(legacy, idempotency_key="changed", **changed),
+                _selection,
+                now="2035-01-01T00:00:04Z",
+            )
+        assert "legacy_authorization_envelope_reconstructed" not in {
+            decision.event_type for decision in ledger.decisions(first.reservation_id)
+        }
+
+
+def test_substitution_without_a_prior_reservation_fails_closed_without_type_error(
+    tmp_path: Path,
+) -> None:
+    with RoutingReservationLedger(root=_root(tmp_path)) as ledger:
+        request = replace(
+            _request("repo:substitution:no-prior", "substitute"),
+            route_mode="explicit",
+            requested_reviewer="glm-5.2",
+        )
+        with pytest.raises(RoutingReservationError, match="substitution_prior_reservation_missing"):
+            ledger.reserve_selection(
+                request,
+                _glm_selection,
+                now="2035-01-01T00:00:00Z",
+                substitution={"reason": "operator-authorized substitution"},
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #6342

## What changed

- Persist the formal-review capability, egress, and isolation authorization envelope in routing decisions.
- Permit exactly one explicit cross-family replacement after a terminal result_invalid response.
- Derive review, authority-job, failure, and prior-reservation identities inside the authority transaction instead of trusting bridge input.
- Keep the original head, snapshot, author, role, profile, risk, evidence size, capabilities, egress, and isolation ceiling stable.
- Reconstruct only the pre-#6342 default formal-review envelope for historical reservations; reject any expansion.
- Requeue the authority job and reserve the replacement atomically, with idempotent replay and no double/forked substitution.
- Bind completed exact-head replay to the same authorization envelope.

## Root cause

A provider could return an invalid canonical review response after a successful transport, but the lifecycle had no durable, one-time compensation edge. Normal retry/fallback semantics were intentionally too broad, and bridge-supplied identity fields were not sufficient authority.

## Validation

- 87 focused tests passed across routing reservations, authority cutover, and review-pr lifecycle/behavior.
- Ruff, Python compilation, git diff checks, OPSEC lint, and X-Agent trailer validation passed.
- Tests cover drift, legacy-state compatibility, selector/capacity rollback, accepted/published/head/snapshot/job refusal, concurrency, idempotent replay, and zero provider calls after refusal.

No provider review call, model inference, training, upload, or paid compute was performed by this implementation.