### PR TITLE
test(atlas): stabilize A7 CEFR fixture

### DIFF
--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -731,6 +731,17 @@ test('A6b: dashboard session estimate narrows to the selected custom deck before
 test('A7: word cards render the level exactly once', async ({ page, context }) => {
   await context.clearCookies();
   await page.addInitScript(() => window.localStorage.setItem('lu-learner-level', 'A1'));
+  // Learner level is soft guidance: the real date-seeded pool may legitimately
+  // put an A2+ word first. Freeze this assertion's input so it tests duplicate
+  // CEFR rendering rather than today's selection order.
+  await page.route('**/lexicon/daily-pool.json', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { lemma: 'слово', slug: 'a7-level-once', gloss: 'word', cefr: 'A1' },
+      ]),
+    }),
+  );
   await page.goto('/words-of-the-day/practice/');
 
   // Wait for the real daily deck (not the loading placeholder's bare "—" card).


### PR DESCRIPTION
## Summary

- freeze the A7 daily-pool input to one A1 fixture
- preserve soft-CEFR production selection and the exact-one rendering assertion
- keep the repair entirely inside the E2E test boundary

## Verification

- `npm run build`
- focused Playwright A7: 1 passed
- full atlas-practice spec: A7 and 31 other cases passed; the independent pre-existing #4694 fallback test failed locally and is not touched by this PR
- `git diff --check`
- OPSEC and commit-trailer checks

Fixes #6347

X-Agent: codex/6347-atlas-a7-time-stable