### PR TITLE
fix(practice): resolve apostrophe-lemma paronym legs, audit residual

### DIFF
--- a/data/lexicon/paronym_pairs.yaml
+++ b/data/lexicon/paronym_pairs.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
-description: 'Curated paronym pairs for the §9.9 confusable-pair drill (#4506). 103
-  driver-adjudicated pairs: baseline seeds and promoted miyklas approved candidate
-  pairs (#6138, #6132, #4387). Learner-facing text is Ukrainian only. Distinction_gloss_uk
-  is natural Ukrainian. Citations trace to adjudication and source module seeds. Fail-closed:
-  curated only, no pool mining.'
+description: 'Curated paronym pairs for the §9.9 confusable-pair drill (#4506). 102
+  driver-adjudicated pairs (103 authored - 1 dedup, #6338): baseline seeds and
+  promoted miyklas approved candidate pairs (#6138, #6132, #4387). Learner-facing
+  text is Ukrainian only. Distinction_gloss_uk is natural Ukrainian. Citations trace
+  to adjudication and source module seeds. Fail-closed: curated only, no pool mining.'
 pairs:
 - slugA: адресант
   slugB: адресат
@@ -319,24 +319,6 @@ pairs:
   - sentence_with_slot: Він скористався ___, щоб знайти будинок.
     answer_form: адресою
     confusable_form: адресом
-    origin: authored-codex-4506-2026-07-19
-- slugA: пам’ятка
-  slugB: пам’ятник
-  distinction_gloss_uk: Пам’ятка — предмет або місце культурної й історичної цінності;
-    пам’ятник — споруда чи скульптура на честь когось або чогось.
-  citations:
-  - 'worksheet: 5-klas-ukrmova-litvinova-2022_s0049 — пам’ятка/пам’ятник'
-  - paronym_candidates_grinchyshyn.json — пам’ятка/пам’ятник
-  curator: codex-4506-2026-07-19
-  notes: public Atlas url_slugs confirmed; accusative noun frames avoid gender giveaways
-  frames:
-  - sentence_with_slot: Місто охороняє ___ археології.
-    answer_form: пам'ятку
-    confusable_form: пам'ятник
-    origin: authored-codex-4506-2026-07-19
-  - sentence_with_slot: На площі встановили ___ на честь поета.
-    answer_form: пам'ятник
-    confusable_form: пам'ятку
     origin: authored-codex-4506-2026-07-19
 - slugA: вдача
   slugB: удача
@@ -1472,10 +1454,12 @@ pairs:
     origin: authored-paronym-frame
 - slugA: пам'ятка
   slugB: пам'ятник
-  distinction_gloss_uk: Пам'ятка — предме давнини, інструкція чи культурний об'єкт;
+  distinction_gloss_uk: Пам'ятка — предмет давнини, інструкція чи культурний об'єкт;
     пам'ятник — монументальна споруда/скульптура на честь особи.
   citations:
   - miyklas.com.ua
+  - "worksheet: 5-klas-ukrmova-litvinova-2022_s0049 — пам'ятка/пам'ятник"
+  - paronym_candidates_grinchyshyn.json — пам'ятка/пам'ятник
   curator: miyklas-reviewed
   frames:
   - sentence_with_slot: Софія Київська — це видатна архітектурна ___ XI століття.

--- a/docs/practice/paronym-residual-taxonomy.md
+++ b/docs/practice/paronym-residual-taxonomy.md
@@ -1,0 +1,115 @@
+# Paronym pair residual taxonomy (#6338)
+
+Run date: 2026-08-04
+
+Scope: `data/lexicon/paronym_pairs.yaml` against a locally hydrated
+`data/atlas.db` (built from the `atlas-manifest` release, 17,387 approved
+public articles) and a locally built VESUM shadow (`scripts/rag/build_vesum_shadow.py`,
+brown-uk/dict_uk v6.8.0, ~7M forms — same source pinned by `scripts/config/vesum_source.lock.json`).
+Reproduce with:
+
+```
+.venv/bin/python -m scripts.audit.paronym_residual_audit --vesum-db <db> --out <path>
+```
+
+## Before / after this change
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Pairs in `paronym_pairs.yaml` | 103 | 102 |
+| Pairs with both legs in practice | 17 | 18 |
+| Emitted `paronym` items | 34 | 36 |
+| Residual pairs (≥1 leg missing) | 86 | 84 |
+
+The 103→102 drop is a dedup, not a loss: `пам'ятка`/`пам'ятник` was authored
+twice under two different apostrophe characters (curly `'` at the old line
+323, straight `'` at line 1473 — only the straight form matches the Atlas
+lemma spelling). The surviving entry keeps both citation sets.
+
+## What actually blocked the 17→18 pairs that changed side
+
+`пам'ятка`/`пам'ятник` is the one pair this change admits, and it was never a
+missing-lexeme problem: both legs already had approved Atlas articles, CEFR
+(A2/A1), and passed `is_practice_eligible`. The paronym emit loop resolved a
+pair's `slugA`/`slugB` only through `slug_to_lex`/`lexemes_by_id`, which are
+keyed by `lemmaId` — the hyphen-slugified `url_slug` (`пам'ятка` → `пам-ятка`).
+`slugA`/`slugB` carry the lemma *spelling*, not the URL slug, so any
+apostrophe-bearing pair could never resolve. `by_plain_lemma` (a
+lemma-normalized map `_select_practice_lexemes` already returns and that the
+homonym/synonym frame-selection code already consults) is the existing
+fallback for exactly this; the paronym loop was the one relation-pair loop
+not using it. Fixed in `scripts/audit/generate_practice_deck.py`.
+
+Grepping all 102 pairs for non-plain-Cyrillic characters in `slugA`/`slugB`
+found exactly 3 legs with apostrophes: `пам'ятка`, `пам'ятник` (now fixed),
+and `об'єм` (pair 51 — genuinely absent from Atlas under any spelling, stays
+residual). No other pair leg carries a character that could hit the same
+lookup gap.
+
+## Residual (84 pairs, 127 distinct blocked legs)
+
+The two blocking reasons are mutually exclusive per leg but a pair can carry
+one of each on its two legs:
+
+| Blocking pattern | Pairs |
+| --- | ---: |
+| Only missing-from-Atlas leg(s) | 34 |
+| Only ineligible (Atlas article exists, blocked below) leg(s) | 30 |
+| Both | 20 |
+| **Total residual** | **84** |
+
+### 69 legs: no Atlas article at any spelling — out of scope (no invented lexemes)
+
+These lemmas have no `article_payloads` row in `data/atlas.db` under any
+apostrophe/casing variant checked. Admitting them would mean creating new
+Atlas headwords, which is Atlas-intake work (#4387-adjacent), not a practice
+admission — explicitly out of scope for this change ("do not invent
+lexemes"):
+
+`абрис, авторитарний, авторитетний, блискучий, будівельник, будівничий, взять,
+виголошувати, вимисел, віла, віршований, геройський, героїчний, годувальниця,
+годівниця, громадянський, гірницький, гірничий, дистанція, досвідчений,
+дощовитий, змерзнути, знаменитий, знаменний, зумовлювати, контингент,
+континент, корисливий, лепський, лікарський, музикальний, нервуватися,
+об'єм, обумовлювати, орфей, пальне, передовий, писемність, письменність,
+поверховий, постановка, присідати, проголошувати, програмний, програмований,
+програмовий, прогресивний, пусто, путати, півтораста, регресивний,
+свідоцтво, свідчення, сердешний, серцевий, сніговий, тактичний, тактовний,
+туристичний, туристський, уповноваження, установка, хрещений, хутровий,
+хутряний, чисельний, численний, іммігрант, інстанція`
+
+### 58 legs: Atlas article exists but is `source_inventory_grow`, not yet CEFR-anchored
+
+All 58 have an approved public Atlas article (`primary_source ==
+"source_inventory_grow"`) but fail `is_practice_eligible` on
+`practice_ineligibility_reason == "surface_not_admitted"` — and, checked
+directly, every one of them *also* has no `course_usage` and no CEFR
+(`missing_curriculum_anchor` would fire next even if the surface flag were
+flipped). The only wired admission path for `source_inventory_grow` rows
+(`--practice-seed` → `merge_practice_seed_entries`) requires the Atlas entry
+to already carry a CEFR level and a source-backed example sentence with
+provenance before it will flip `surface_admission.practice`; neither exists
+here. Assigning a CEFR level is a curriculum decision (VESUM/PULS/course-fit
+judgment), not a mechanical admission, so these stay in residual rather than
+being force-admitted:
+
+`абонент, адрес, багатир, барва, блудити, богатир, будівник, бювет, вдача,
+виборний, виборчий, вислів, вклад, воєнний, відпуск, вілла, віршовий,
+вітровий, гривна, густо, доля, домисел, дощовий, дружний, емігрант, ефектний,
+задача, замерзнути, кампанія, кепський, корифей, кювет, лискучий, людний,
+людяний, лічити, мимохідь, мимохіть, музичний, нотація, обрис, обсяг,
+ожеледь, паливо, передній, плутати, поверхневий, привід, сопілка, спілка,
+степінь, ступінь, талан, талант, трупа, удача, хресний, їда`
+
+## Follow-up (not this change)
+
+- CEFR-anchoring the 58 `source_inventory_grow` paronym legs (with a
+  source-backed example per the existing `--practice-seed` contract) would be
+  the highest-leverage next step — it alone gates ~30 pairs.
+- The remaining 69 lemmas need Atlas intake before they can be practice
+  candidates at all.
+- Antonym/homonym pairs share the same `slug_to_lex`/`lexemes_by_id`-only
+  resolution (`generate_practice_deck.py`, antonym ~4082, homonym ~4128) and
+  likely have the same apostrophe-leg gap and a comparable
+  Atlas/CEFR-anchoring residual. Out of scope here per #6338; noted for a
+  follow-up ticket.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -4020,8 +4020,13 @@ def build_practice_shards(
             continue
         slug_a = _clean_text(pair.get("slugA"))
         slug_b = _clean_text(pair.get("slugB"))
-        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a)
-        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b)
+        # slugA/slugB carry the lemma spelling, not the URL slug: an apostrophe
+        # lemma's lemmaId is hyphen-slugified (e.g. "пам'ятка" -> "пам-ятка"),
+        # so a raw slug_to_lex/lexemes_by_id lookup never matches it. Fall back
+        # to the plain-lemma map antonym/homonym resolution never needed but
+        # synonym/homonym frame selection already relies on (#6338).
+        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a) or by_plain_lemma.get(_plain(slug_a))
+        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b) or by_plain_lemma.get(_plain(slug_b))
         if not lex_a or not lex_b:
             print(
                 f"WARN: paronym_pair[{index}] {slug_a}/{slug_b} not in practice lexemes; emitted 0 items",

--- a/scripts/audit/paronym_residual_audit.py
+++ b/scripts/audit/paronym_residual_audit.py
@@ -1,0 +1,170 @@
+"""Tool-prove why curated paronym pairs (#6338) do not emit a practice item.
+
+Reuses the production selection path from ``generate_practice_deck`` (same
+entries, same eligibility gate, same priority-key wiring) instead of
+re-deriving membership rules, so the residual counts match a real build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit.generate_practice_deck import (
+    BuildConfig,
+    RealVesumVerifier,
+    _clean_text,
+    _plain,
+    _practice_priority_keys,
+    _select_practice_lexemes,
+    _valid_paronym_frames,
+    read_atlas_db,
+    read_paronym_pairs,
+    validate_paronym_pair,
+)
+from scripts.audit.lexeme_filter import is_lexeme_entry, practice_ineligibility_reason
+
+
+def _entry_lookup(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        for key in (_clean_text(entry.get("url_slug")), _clean_text(entry.get("lemma"))):
+            if key and key not in by_key:
+                by_key[key] = entry
+    return by_key
+
+
+def _leg_status(
+    slug: str,
+    entry_by_key: dict[str, dict[str, Any]],
+    lexemes_by_slug: dict[str, dict[str, Any]],
+    by_plain_lemma: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    entry = entry_by_key.get(slug)
+    if entry is None:
+        return {"slug": slug, "status": "missing_from_atlas"}
+    if not is_lexeme_entry(entry):
+        return {"slug": slug, "status": "not_lexeme_entry"}
+    reason = practice_ineligibility_reason(entry)
+    if reason is not None:
+        return {"slug": slug, "status": "ineligible", "reason": reason}
+    # Mirrors the production paronym resolution in generate_practice_deck.py:
+    # slug_to_lex/lexemes_by_id (url_slug/lemmaId), then by_plain_lemma (#6338).
+    if (
+        slug not in lexemes_by_slug
+        and _clean_text(entry.get("lemma")) not in lexemes_by_slug
+        and _plain(slug) not in by_plain_lemma
+    ):
+        return {"slug": slug, "status": "eligible_not_selected"}
+    return {"slug": slug, "status": "selected"}
+
+
+def classify_pairs(
+    pairs: list[dict[str, Any]],
+    entries: list[dict[str, Any]],
+    verifier: RealVesumVerifier,
+) -> list[dict[str, Any]]:
+    config = BuildConfig()
+    priority_keys = _practice_priority_keys([], None, pairs, None)
+    _lexemes_by_entry, all_lexemes, by_plain_lemma, lexemes_by_id = _select_practice_lexemes(
+        entries, verifier, config, priority_keys
+    )
+    lexemes_by_slug: dict[str, dict[str, Any]] = {}
+    for lexeme in all_lexemes:
+        slug = _clean_text(lexeme.get("url_slug")) or _clean_text(lexeme.get("slug")) or lexeme.get("lemmaId")
+        if slug:
+            lexemes_by_slug[slug] = lexeme
+    lexemes_by_slug.update(lexemes_by_id)
+
+    entry_by_key = _entry_lookup(entries)
+
+    results: list[dict[str, Any]] = []
+    for index, pair in enumerate(pairs):
+        row: dict[str, Any] = {"index": index, "slugA": pair.get("slugA"), "slugB": pair.get("slugB")}
+        pair_errors = validate_paronym_pair(pair)
+        if pair_errors:
+            row["outcome"] = "pair_invalid"
+            row["errors"] = pair_errors
+            results.append(row)
+            continue
+        frames = _valid_paronym_frames(pair)
+        if not frames:
+            row["outcome"] = "no_valid_frames"
+            results.append(row)
+            continue
+
+        slug_a = _clean_text(pair.get("slugA"))
+        slug_b = _clean_text(pair.get("slugB"))
+        leg_a = _leg_status(slug_a, entry_by_key, lexemes_by_slug, by_plain_lemma)
+        leg_b = _leg_status(slug_b, entry_by_key, lexemes_by_slug, by_plain_lemma)
+        row["legA"] = leg_a
+        row["legB"] = leg_b
+        if leg_a["status"] == "selected" and leg_b["status"] == "selected":
+            row["outcome"] = "should_emit"
+        else:
+            row["outcome"] = "missing_leg"
+        results.append(row)
+    return results
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
+    outcome_counts = Counter(row["outcome"] for row in results)
+    leg_reason_counts: Counter[str] = Counter()
+    missing_from_atlas: list[str] = []
+    ineligible_by_reason: dict[str, list[str]] = {}
+    eligible_not_selected: list[str] = []
+    for row in results:
+        for leg_key in ("legA", "legB"):
+            leg = row.get(leg_key)
+            if not leg or leg["status"] == "selected":
+                continue
+            leg_reason_counts[leg["status"]] += 1
+            if leg["status"] == "missing_from_atlas":
+                missing_from_atlas.append(leg["slug"])
+            elif leg["status"] == "ineligible":
+                ineligible_by_reason.setdefault(leg["reason"], []).append(leg["slug"])
+            elif leg["status"] == "eligible_not_selected":
+                eligible_not_selected.append(leg["slug"])
+    return {
+        "pairs_total": len(results),
+        "outcome_counts": dict(outcome_counts),
+        "leg_reason_counts": dict(leg_reason_counts),
+        "missing_from_atlas": sorted(set(missing_from_atlas)),
+        "ineligible_by_reason": {k: sorted(set(v)) for k, v in ineligible_by_reason.items()},
+        "eligible_not_selected": sorted(set(eligible_not_selected)),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--atlas-db", type=Path, default=Path("data/atlas.db"))
+    parser.add_argument("--paronym-pairs", type=Path, default=Path("data/lexicon/paronym_pairs.yaml"))
+    parser.add_argument("--vesum-db", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=None, help="Write full per-pair JSON here")
+    args = parser.parse_args(argv)
+
+    entries = read_atlas_db(args.atlas_db)
+    pairs = read_paronym_pairs(args.paronym_pairs)
+    verifier = RealVesumVerifier(args.vesum_db)
+
+    results = classify_pairs(pairs, entries, verifier)
+    summary = summarize(results)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if args.out:
+        args.out.write_text(
+            json.dumps({"summary": summary, "pairs": results}, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -2613,6 +2613,34 @@ def test_paronym_pairs_emit_items_both_directions_and_validate(capsys: pytest.Ca
         assert validate_paronym_item(it) == []
 
 
+def test_paronym_apostrophe_slug_resolves_via_plain_lemma_fallback(capsys: pytest.CaptureFixture[str]) -> None:
+    # #6338: an apostrophe lemma's lemmaId is hyphen-slugified (matching a
+    # real url_slug, e.g. "пам-ятка"), so slugA/slugB carrying the apostrophe
+    # spelling must resolve through by_plain_lemma, not slug_to_lex/lexemes_by_id.
+    entries = [
+        {"lemmaId": "пам-ятка", "lemma": "пам'ятка", "gloss": "landmark", "pos": "noun", "cefr": "A2", "url_slug": "пам-ятка", "primary_source": "course_vocab", "course_usage": [{"track": "a2"}]},
+        {"lemmaId": "пам-ятник", "lemma": "пам'ятник", "gloss": "monument", "pos": "noun", "cefr": "A1", "url_slug": "пам-ятник", "primary_source": "course_vocab", "course_usage": [{"track": "a1"}]},
+    ]
+    pair = {
+        "slugA": "пам'ятка",
+        "slugB": "пам'ятник",
+        "distinction_gloss_uk": "Пам'ятка — предмет давнини; пам'ятник — споруда на честь особи.",
+        "citations": ["fixture-test"],
+        "frames": [
+            {"sentence_with_slot": "Це видатна архітектурна ___.", "answer_form": "пам'ятка", "confusable_form": "пам'ятник", "origin": "t"},
+            {"sentence_with_slot": "На площі встановили ___.", "answer_form": "пам'ятник", "confusable_form": "пам'ятку", "origin": "t2"},
+        ],
+    }
+    allowlist = ReviewedSourceAllowlist.from_payload([])
+    verifier = JsonVesumVerifier({})
+    shards = build_practice_shards(entries, allowlist, verifier, [], BuildConfig(target=10), paronym_pairs=[pair])
+    a1_items = shards.get("A1", {}).get("paronym", {}).get("paronym", [])
+    a2_items = shards.get("A2", {}).get("paronym", {}).get("paronym", [])
+    assert len(a1_items) + len(a2_items) >= 1, "apostrophe-lemma paronym pair should resolve and emit"
+    err = capsys.readouterr().err
+    assert "not in practice lexemes" not in err
+
+
 def test_paronym_builder_copies_optional_curated_prompt_en() -> None:
     lex_a = {"lemmaId": "бігати", "lemma": "бігати", "cefr": "B1"}
     lex_b = {"lemmaId": "бігти", "lemma": "бігти", "cefr": "B1"}
@@ -2670,7 +2698,9 @@ def test_live_paronym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
     live_path = Path("data/lexicon/paronym_pairs.yaml")
     assert live_path.exists()
     pairs = read_paronym_pairs(live_path)
-    assert len(pairs) == 103, f"Expected 103 paronym pairs (55 baseline + 48 promoted), got {len(pairs)}"
+    # 103 authored - 1 dedup (пам'ятка/пам'ятник was authored twice under two
+    # different apostrophe characters; #6338 merged the two into one entry).
+    assert len(pairs) == 102, f"Expected 102 paronym pairs (103 authored - 1 dedup, #6338), got {len(pairs)}"
     seen_pairs: set[tuple[str, str]] = set()
     for index, pair in enumerate(pairs):
         errors = validate_paronym_pair(pair)


### PR DESCRIPTION
## Summary

Refs #6338, #6132, #4387.

- **Bug fix**: the paronym emit loop in `generate_practice_deck.py` resolved
  `slugA`/`slugB` only via `slug_to_lex`/`lexemes_by_id`, which are keyed by
  `lemmaId` — the hyphen-slugified `url_slug`. Any pair leg with an
  apostrophe lemma (e.g. `пам'ятка` → `lemmaId` `пам-ятка`) could never
  match, even with a valid Atlas article, CEFR, and eligibility. Added the
  `by_plain_lemma` fallback the homonym/synonym resolution already uses.
- **Data fix**: `data/lexicon/paronym_pairs.yaml` had `пам'ятка`/`пам'ятник`
  authored twice under two different apostrophe characters (curly vs
  straight). Merged into one entry (both citation sets kept), fixed an
  adjacent gloss typo. 103 → 102 pairs.
- **New tool**: `scripts/audit/paronym_residual_audit.py` reuses the real
  production selection path (same entries, same eligibility gate, same
  priority-key wiring) to classify exactly why each pair does or doesn't
  emit, instead of re-deriving membership rules.
- **Residual doc**: `docs/practice/paronym-residual-taxonomy.md` — of the 84
  still-blocked pairs, 69 lemmas have no Atlas article at all (out of scope:
  no invented lexemes), 58 have an approved article but no CEFR/course
  anchor yet (a curriculum decision, not a mechanical admission — the only
  wired admission path for these requires a CEFR level and a sourced example
  sentence neither has).

Measured against a locally hydrated `atlas.db` (17,387 approved public
articles from the `atlas-manifest` release) and a locally built VESUM shadow
(brown-uk/dict_uk v6.8.0, matching `scripts/config/vesum_source.lock.json`):

| Metric | Before | After |
| --- | ---: | ---: |
| Pairs in `paronym_pairs.yaml` | 103 | 102 |
| Pairs with both legs in practice | 17 | 18 |
| Emitted `paronym` items | 34 | 36 |
| Residual pairs (documented, not force-admitted) | 86 | 84 |

Antonym/homonym pairs share the same `slug_to_lex`/`lexemes_by_id`-only
resolution and likely have the same apostrophe-leg gap — out of scope here
per the dispatch brief, noted as a follow-up in the residual doc.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_generate_practice_deck.py -q` — 119 passed (includes a new regression test for the apostrophe/`by_plain_lemma` fallback and the updated 103→102 live-pairs-count assertion)
- [x] `.venv/bin/python -m pytest tests/test_publish_practice_deck.py tests/test_extract_grinchyshyn_paronym_candidates.py -q` — 14 passed
- [x] `.venv/bin/ruff check` on all touched files — clean
- [x] `data/lexicon/paronym_pairs.yaml` YAML-parses to 102 pairs
- [x] Full `generate_practice_deck.py` build against hydrated `atlas.db` + VESUM shadow, before/after diff confirms 34 → 36 paronym items

🤖 Generated with [Claude Code](https://claude.com/claude-code)