### PR TITLE
Fix formal reviewer model overrides

### DIFF
--- a/agents_extensions/shared/memory/MEMORY.md
+++ b/agents_extensions/shared/memory/MEMORY.md
@@ -57,7 +57,7 @@ Compound decisions = ONE table + ONE recommendation, NEVER N parallel sign-off q
 
 ## #0H — CF REVIEW MANDATORY ON EVERY PR; THEN MERGE (2026-07-27)
 **Independent cross-family (CF) formal review is ALWAYS mandatory before merge.** No exceptions for “small,” docs-only, launcher, or infra PRs. Discussion / self-review / same-family review ≠ the gate.
-- Request immediately after `gh pr create`: `.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm --from <author-family>` (default codex sealed path). **agy / kimi / grok are NOT formal_review_eligible reviewers** — never self-seal.
+- Request immediately after `gh pr create`: `.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm|grok --initiator <orchestrator/task> --author-model <model> --author-family <family>`. Omit `--reviewer` for deterministic automatic selection. **agy / kimi are NOT formal_review_eligible reviewers** — never self-seal; native Grok is eligible, while Cursor Grok is not.
 - Closeout incomplete until CF is requested (and settled). Failure encoded: 2026-07-27 Grok shipped #5875 without `review-pr`; operator had to ask.
 - After CF pass + green blocking CI: `gh pr merge N --auto --squash --delete-branch` (action bias — don’t leave PRs limbo). Hold only for CF fail or blocking CI.
 

--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -75,14 +75,18 @@ cold-prompts; silent plane flips; “for now” cutovers.
 .venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
 
 # Formal cross-family CF — PR number is REQUIRED and positional
-.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer codex|claude|glm
+.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer codex|claude|glm|grok
 .venv/bin/python -m scripts.ai_agent_bridge publish-review-verdict ...
 ```
 
-- **agy | kimi | grok** remain `formal_review_eligible: false` until isolation proofs
-  (#5555–#5557). They **request** CF via `review-pr`; they do not self-seal.
-- Escalate hard/non-routine CF with Sol / Fable (`--model gpt-5.6-sol` or `claude-fable-5`
-  `--effort xhigh`) per model-assignment.
+- **agy | kimi** remain `formal_review_eligible: false` until their isolation
+  proofs (#5555–#5556). They **request** CF via `review-pr`; they do not self-seal.
+  Native Grok passed its exact-head isolation proof and is eligible; Cursor
+  Grok remains a non-formal availability fallback.
+- Escalate hard/non-routine CF with Sol (`--reviewer codex --model gpt-5.6-sol`,
+  provider-default ACP effort) or Fable (`--reviewer claude --model claude-fable-5
+  --effort high`) per model-assignment. Every explicit pin also requires
+  `--override-reason` and still passes the normal hard gates.
 
 ## Standalone TUI/UI contract
 

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -160,7 +160,7 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
 
   | Seat | Default (loop) | Escalate (deep) | Notes |
   | --- | --- | --- | --- |
-  | **claude** | `claude-fable-5` @ high | **`gpt-5.6-sol` @ xhigh** | Escalation is CROSS-FAMILY: Claude is a target, not an escalator. Other lanes escalate **to** Claude (`claude-fable-5` @ xhigh) or to Sol — pick by CodexBar headroom. Fable drives in the SUMMONED cadence only (see § Orchestration operating pattern) |
+  | **claude** | `claude-fable-5` @ high | **`gpt-5.6-sol` @ xhigh** | Escalation is CROSS-FAMILY: Claude is a target, not an escalator. Other formal-review lanes may explicitly select Fable at the sealed participant's fixed `high` effort, or select Sol at the Codex ACP provider default — pick by CodexBar headroom. Fable drives in the SUMMONED cadence only (see § Orchestration operating pattern) |
   | **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | Named alternate for harness / infra / devops; never co-owns a live lease |
   | **grok** | `grok-4.5` @ high | same SKU (no higher pin yet) | Cursor **explicit** `grok-4.5` = availability fallback, not quality escalate |
   | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | Flash loop; Pro deep single-shot |
@@ -210,9 +210,11 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
   Claude, Codex, GLM, and native Grok use the parent-owned exact-head sealed
   ACP path. The canonical KimiCC K3 adapter is implemented but remains
   fail-closed until its authenticated sealed canary passes. AGY remains
-  ineligible because its text-only wrapper cannot consume that MCP. Authority CF escalate:
-  `review-pr <N> --model gpt-5.6-sol --effort xhigh` or
-  `review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh`.
+  ineligible because its text-only wrapper cannot consume that MCP. Authority CF
+  model pins (both require `--override-reason`) are:
+  `review-pr <N> --reviewer codex --model gpt-5.6-sol` (the one-shot Codex ACP
+  route owns its provider-default effort) or
+  `review-pr <N> --reviewer claude --model claude-fable-5 --effort high`.
 
   <!-- fleet-roster-projection:begin formal_review_eligible -->
   | endpoint | formal_review_eligible |

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -152,8 +152,10 @@ family; never self-review, never same-family). Route it:
 .venv/bin/python -m scripts.ai_agent_bridge publish-review-verdict ...                             # publish the sealed verdict
 ```
 Pick the reviewer family from the served reviewer-seat rule; the writer's family is
-never eligible. For a hard / non-routine change, escalate the seat with
-`--model gpt-5.6-sol` (or `claude-fable-5`) `--effort xhigh`. Read the review CONTENT
+never eligible. For a hard / non-routine change, explicitly pin either
+`--reviewer codex --model gpt-5.6-sol` (provider-default Codex ACP effort) or
+`--reviewer claude --model claude-fable-5 --effort high`; include a concrete
+`--override-reason`. Read the review CONTENT
 (not just pass/fail), apply the deltas, re-probe gate-driving data yourself before
 trusting "verified". A review request is not a passive notification: after invoking
 `review-pr <PR_NUMBER>`, the requester owns its request state and must explicitly poll

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -167,14 +167,21 @@ brief includes the commit, push, and PR checklist. If `--brief-file`
 is omitted, the wrapper builds `/tmp/dispatch-fix-<task-id>.md` from
 `gh issue view <issue> --json title,body`.
 
-`.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR> [--reviewer auto|codex|glm|claude]`
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR> [--reviewer auto|codex|claude|glm|grok] [--model MODEL]`
 is the **canonical formal PR review entry** (Sol fleet-comms Phase 0–3):
 
 - **Pointer-only** prompt (PR URL + checklist + mandatory read-only contract).
 - Hard size caps — refuse fat pasted diffs/inventory YAML.
-- Default `--reviewer auto` → **Codex sealed `--review --pr`** (#5285 isolation).
-- Claude dark + local: `--reviewer glm` or `--reviewer auto --no-claude-available`
-  (GLM-5.2 is **LOCAL-ONLY** / China egress — never CI).
+- Default `--reviewer auto` uses the deterministic suitability-first scheduler;
+  no provider is an unconditional default.
+- A reviewer alias selects its practical default. Add a formally eligible
+  same-route model plus `--override-reason` for an exceptional operator pin,
+  for example `--reviewer claude --model claude-fable-5` or
+  `--reviewer codex --model gpt-5.6-sol`.
+- `agy` and `kimi` remain recognized request identities but fail closed until
+  their catalog endpoints satisfy sealed-review eligibility. GLM-5.2 is
+  **LOCAL-ONLY** / China egress and requires the matching egress policy.
+- `--no-claude-available` is a deprecated compatibility hint and never routes.
 - Do **not** identify the reviewer as “Hermes”; record model + family + harness.
 
 Formal reviews stay thin in both directions (Phase 4–5). Do not paste a review

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -31,7 +31,7 @@
 seal PRs. Formal CF:
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR_NUMBER> --reviewer codex|claude|glm
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR_NUMBER> --reviewer codex|claude|glm|grok
 .venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict ...
 ```
 
@@ -862,10 +862,14 @@ When a worker leaves commits without a PR, or dies with `status=running` and a d
 Formal CF and auto-merge stay with the orchestrator.
 
 ### Formal CF budget rotation (Codex-authored PRs)
-Legal sealed reviewers remain `codex|claude|glm` only (`formal_review_eligible`; do **not** invent
-eligibility for kimi/agy/grok). For **Codex/Luna-authored** PRs, rotate **Claude vs GLM** using
-live routing-budget / CodexBar rem% — do not default-stack every PR on GLM when Claude has
-headroom, and do not burn a near-empty GLM seat on trivial PRs.
+Current sealed reviewer routes are `codex|claude|glm|grok`; the canonical
+`review_scheduler.endpoints` catalog remains authoritative. `agy` and
+`kimi` are recognized request identities but are not yet formally eligible.
+For **Codex/Luna-authored** PRs, use the deterministic routing budget rather
+than default-stacking one provider. An explicit `--model` may select another
+formally eligible model on the requested native route, but still requires
+`--override-reason` and passes every family, capability, isolation, health,
+and circuit gate.
 
 ### Parallel fleet utilization
 While one lane codes owned paths, free lanes should take **disjoint** non-CF work (recon, residual

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -120,9 +120,15 @@ input and transcripts. It does **not** satisfy independent cross-family review.
 Formal CF uses:
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR_NUMBER> --reviewer codex|claude|glm
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <PR_NUMBER> --reviewer codex|claude|glm|grok
 .venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict ...
 ```
+
+Reviewer aliases keep practical defaults. A present operator may select a
+different formally eligible model on that native route with `--model` plus
+`--override-reason` (for example Claude/Fable or Codex/Sol). Recognized AGY
+and Kimi request identities remain fail-closed until their catalog endpoints
+are formally eligible.
 
 Same-family helper output, design panels, and channel chat never seal a PR.
 

--- a/docs/runbooks/agy-formal-cf-isolation.md
+++ b/docs/runbooks/agy-formal-cf-isolation.md
@@ -32,7 +32,8 @@ AGY **is** an orchestrator seat for fleet-comms (#5512):
 | Deep escalate | `gemini-3.1-pro-high` @ high | Optional, not default loop |
 | Sealed formal CF *reviewer* | — | **Blocked** until isolation proof (#5555) |
 
-When AGY orchestrates, it **requests** CF via `review-pr` (codex|claude|glm). It must not treat `ask-agy --review` as sealed formal CF.
+When AGY orchestrates, it **requests** CF via `review-pr`
+(codex|claude|glm|grok). It must not treat `ask-agy --review` as sealed formal CF.
 
 ## Live lane (non-formal / orchestrator)
 

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -70,7 +70,7 @@ lint: #5642 / `scripts/lint/lint_fleet_roster.py`.
 
 | Seat | Default (loop) | Escalate (deep) | Sealed formal CF as *reviewer* |
 | --- | --- | --- | --- |
-| **claude** | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** | yes (`review-pr --reviewer claude`) |
+| **claude** | `claude-fable-5` @ high | **`gpt-5.6-sol` @ xhigh** (cross-family) | yes (`review-pr --reviewer claude`; Sonnet default, Fable explicit) |
 | **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | yes (`review-pr --reviewer codex`) |
 | **grok** | `grok-4.5` @ high | same SKU (Cursor = avail. fallback) | yes (`review-pr --reviewer grok`) |
 | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | no until #5555 — still *requests* CF |
@@ -145,7 +145,8 @@ Practical seats @ **high** — not Sol/Fable on routine PRs:
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> \
   --initiator codex/orchestrator \
   --author-model gpt-5.6-sol --author-family openai \
-  --reviewer claude --override-reason "operator-requested Anthropic dissent"
+  --reviewer claude --model claude-fable-5 --effort high \
+  --override-reason "operator-requested Fable dissent"
 
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ...  # default Laguna S 2.1
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ... --model poolside/poolside/laguna-xs-2.1  # XS 2.1 light

--- a/docs/runbooks/grok-formal-cf-isolation.md
+++ b/docs/runbooks/grok-formal-cf-isolation.md
@@ -1,36 +1,36 @@
 # Grok sealed formal CF isolation (#5557)
 
-## Status (2026-07-23 — v1 residual Option C)
+## Status (2026-08-04 — sealed ACP route live)
 
-Design spikes closed **Option C fail-closed residual**. For **fleet-comms v1 (#5512)**,
-Grok is a live **orchestrator / implement** seat and is **not** a sealed formal CF reviewer.
+The earlier Option C residual has been superseded. Grok is a live
+**orchestrator / implement** seat and an eligible sealed formal CF reviewer
+through the hash-pinned ACP profile. The model catalog remains the authority.
 
 | Capability | Native Grok CLI | Formal CF sealed path |
 | --- | --- | --- |
-| OAuth / session auth staged without tool-visible credentials | **Fails** — native OAuth store cannot be hidden from required Read/Grep/Glob tools while still authenticating | Fail-closed |
-| Auth never staged into model-read scope | **Proven** (tests: `test_grok_oauth_store_is_never_staged_*`) | Correct refusal, not a silent leak |
-| Sealed snapshot cwd + OS sandbox | Not reached for `engine=grok` | Hard raise before launch |
-| `review-pr --reviewer grok` | **Not implemented** (reviewers: `auto\|codex\|glm\|claude` only) | Use substitute seats |
-| Registry `formal_review_eligible` | `false` for `grok` | **v1 complete residual** |
-| Wire #5621 / enable #5622 | Residual closeout | Reopen only with Option A/B proof |
-| Cursor explicit `grok-4.5` | Live for **orchestrator / implement / advisory** when native dark | **Not** sealed formal CF |
+| Authentication | Cached native selector; ambient API-key selectors scrubbed | Auth material is not staged into the sealed snapshot |
+| Sealed evidence | Parent-owned MCP plus hash-pinned `acpx-grok-sealed-review.md` | Only the sealed review tools are exposed |
+| Sealed snapshot cwd + OS sandbox | Active through ACPX confinement | No primary-checkout or general filesystem access |
+| `review-pr --reviewer grok` | Implemented | Same reservation, authority, and publication path |
+| Registry `formal_review_eligible` | `true` for native `grok-4.5` | Catalog endpoint is authoritative |
+| Cursor explicit `grok-4.5` | Live for **orchestrator / implement / advisory** when native dark | Still **not** sealed formal CF |
 
 **Proof command:**
 
 ```bash
-.venv/bin/python -m pytest tests/test_review_isolation.py -k 'grok_isolated or oauth_store_is_never_staged' -q
+.venv/bin/python -m pytest \
+  tests/agent_runtime/test_acpx_adapter.py \
+  tests/ai_agent_bridge/test_review_pr.py \
+  -k 'grok and sealed' -q
 ```
 
-## Written decision (stream #5512)
+## Current decision (stream #5512)
 
-**Option C for now (fail-closed residual), not permanent wontfix.**
-
-1. Inventory + fail-closed tests landed via **#5582** (merged).
-2. Until OAuth can be scoped/proxied so tools only see the sealed snapshot (options A/B on #5557), **do not** flip `formal_review_eligible`.
-3. **Do not** treat Cursor-pinned `grok-4.5` as sealed formal CF — it is the native-dark **orchestrator/implement** fallback only (`model_catalog` `orchestrator_seats.grok` / `grok-4.5-cursor-fallback` review ladder for *resolve-reviewer* when native is unhealthy is still subject to isolation if used as formal launch).
-4. Substitute formal CF path remains the product default (below).
-
-Revisit when: Grok CLI gains a review-only credential profile, or a proxy can mint tool-scoped tokens that cannot read host OAuth stores / primary checkout.
+The native Grok ACP route is eligible only when the runtime selects its
+hash-pinned sealed-review profile and validates the parent-owned MCP config.
+The ordinary no-tool profile remains unchanged for non-review conversations.
+Cursor-pinned `grok-4.5` remains a native-dark implementation/advisory
+fallback and is not an interchangeable formal-review route.
 
 ## Live lane (non-formal)
 
@@ -46,14 +46,18 @@ Revisit when: Grok CLI gains a review-only credential profile, or a proxy can mi
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>              # codex / gpt-5.6-terra @ high
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude  # claude-sonnet-5 @ high
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer glm     # LOCAL-ONLY
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer grok    # grok-4.5 @ high
 ```
 
-## Flip criteria (do not skip)
+## Invariants
 
-1. Proven separation: auth works for the engine **without** tools reading host OAuth / ambient project credentials.
-2. `prepare_isolated_review_launch(engine="grok")` positive path + negative tests (no auth in model-read scope; no primary checkout).
-3. `review-pr --reviewer grok` **or** sealed transport registration with receipt fields (model, family=xai, harness, effort).
-4. Real smoke formal CF on a non-Grok-authored PR (cross-family).
-5. Then flip `formal_review_eligible: true` and enablement PR CF'd by a **non-Grok** family.
+1. Grok review calls use the sealed profile only when a validated sealed MCP
+   config is present; ordinary ACP calls keep the no-tool profile.
+2. Ambient API-key selectors, primary-checkout access, terminal access, and
+   arbitrary filesystem access remain denied.
+3. The reservation and published verdict record the concrete model, xAI
+   family, native Grok participant, source, and exact reviewed head.
+4. Any loss of sealed-tool coverage or catalog eligibility fails closed before
+   publication; it never silently falls back to Cursor.
 
 Parent: #5557 · stream #4707 · product #5512.

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -276,7 +276,9 @@ _CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT = (
     "Use ToolSearch only to load mcp__sealed_review__read_required, then call that "
     "reader from the requested cursor until eof=true. Do not call ReportFindings or "
     "any other built-in or MCP tool. Return the requested canonical JSON object as "
-    "the final assistant message with no prose, markdown, or trailing text."
+    "the final assistant message with no prose, markdown, or trailing text. Each "
+    "finding must contain exactly the requested canonical keys; do not add provider "
+    "annotations such as verbatim_note, even when null."
 )
 
 

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -273,10 +273,10 @@ AGENTS: dict[str, AgentEntry] = {
         "resume_policy": "bridge_only",
     },
     "acpx-codex-shadow": {
-        # Experimental read-only shadow transport (#6027). Direct-only: never
-        # returned by ``available_agents()`` (cli_available False), never a
-        # dispatch/routing/review/failover candidate. The bounded pilot is the
-        # sole public runner surface permitted to invoke this marked seat.
+        # Direct-only ACP transport (#6027): never returned by
+        # ``available_agents()`` and never a general dispatch or failover
+        # candidate. Only the runner-owned communication controller and its
+        # parent-sealed formal-review executable may invoke this seat.
         "adapter": "scripts.agent_runtime.adapters.acpx:AcpxAdapter",
         # ACPX resolves its own agent default when no --model is supplied;
         # this direct-only seat must not advertise an invented catalog model.
@@ -288,14 +288,13 @@ AGENTS: dict[str, AgentEntry] = {
         "resume_policy": "never",
     },
     "acpx-grok-shadow": {
-        # Second experimental read-only shadow transport (#6043). Direct-only:
-        # never returned by ``available_agents()`` (cli_available False), never
-        # a dispatch/routing/review/failover candidate. The bounded pilot is
-        # the sole public runner surface permitted to invoke this marked seat.
-        # Fixed
-        # effective model/effort live inside the custom --agent command; do
-        # not advertise a catalog model here. Not a new coordination plane —
-        # native Grok remains authoritative.
+        # Direct-only ACP transport (#6043): never returned by
+        # ``available_agents()`` and never a general dispatch or failover
+        # candidate. Only the runner-owned communication controller and its
+        # hash-pinned, parent-sealed formal-review executable may invoke it.
+        # Fixed effective model/effort live inside the custom --agent command;
+        # do not advertise a catalog model here. Native Grok remains the
+        # provider authority; this registry name is not a coordination plane.
         "adapter": "scripts.agent_runtime.adapters.acpx:AcpxGrokShadowAdapter",
         "default_model": None,
         "cost_tier": "unknown",

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -725,9 +725,15 @@ def handle_review_pr(args: argparse.Namespace) -> int:
     operator_override_reason = (
         str(getattr(args, "override_reason", None) or "").strip() or None
     )
+    if requested_effort is not None and requested_candidate is None:
+        print(
+            "review-pr: --effort requires an explicit eligible --reviewer or --model "
+            "so transport capability is validated before routing",
+            file=sys.stderr,
+        )
+        return 2
     if (
-        requested_candidate is not None
-        and (explicit_model is not None or requested_effort is not None)
+        (explicit_model is not None or requested_effort is not None)
         and operator_override_reason is None
     ):
         print(
@@ -1420,8 +1426,8 @@ def register_review_pr_parser(subparsers: Any) -> None:
         "--effort",
         default=None,
         help=(
-            "Optional exact ACP effort pin; it must match the selected participant's "
-            "registered transport capability"
+            "Optional exact ACP effort pin; requires an explicit eligible reviewer or "
+            "model and must match that participant's registered transport capability"
         ),
     )
     parser.add_argument("--claude-available", dest="claude_available", action=argparse.BooleanOptionalAction,

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -456,9 +456,16 @@ def resolve_requested_review_candidate(
             f"model_not_formal_review_eligible: {model!r} has no canonical candidate on {scope}; "
             f"eligible models: {eligible_models!r}"
         )
+    if requested_route is None:
+        ambiguity_advice = "add --reviewer to select the native route"
+    else:
+        ambiguity_advice = (
+            f"route {requested_route!r} defines duplicate canonical candidates for this model; "
+            "disambiguate scripts/config/model_catalog.yaml"
+        )
     raise ReviewSafetyError(
         f"ambiguous_formal_review_model: {model!r} maps to candidates {sorted(matches)!r} on {scope}; "
-        "add --reviewer to select the native route"
+        f"{ambiguity_advice}"
     )
 
 

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -127,6 +127,43 @@ def _canonical_review_response_text(response: str) -> str:
     return stripped
 
 
+def _normalize_known_null_review_annotations(response: str) -> str:
+    """Remove only known null provider annotations from finding objects.
+
+    The canonical schema remains strict: non-null annotations, unrelated extra
+    fields, duplicate JSON keys, and malformed responses are returned unchanged
+    so the normal validator can reject them.
+    """
+
+    def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate JSON key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        payload = json.loads(response, object_pairs_hook=_reject_duplicate_keys)
+    except (json.JSONDecodeError, ValueError):
+        return response
+    if not isinstance(payload, dict) or not isinstance(payload.get("findings"), list):
+        return response
+
+    changed = False
+    for finding in payload["findings"]:
+        if (
+            isinstance(finding, dict)
+            and "verbatim_note" in finding
+            and finding["verbatim_note"] is None
+        ):
+            del finding["verbatim_note"]
+            changed = True
+    if not changed:
+        return response
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
 def _finish_authority_job_once(
     authority: Any,
     job_id: str,
@@ -290,10 +327,11 @@ has exactly this shape (replace the explanation, not the field types):
 `{{"schema_version":"code-review-findings.v1","overall":{{"correctness":"correct","explanation":"No actionable findings.","confidence":0.95}},"findings":[]}}`
 Each finding object has exactly these fields: `id`, `title`, `body`, `priority`,
 `confidence`, `category`, `location`, `verbatim`, `why_wrong`, `smallest_fix`,
-and `sources`. Every `sources` value MUST be a non-empty array. Use exactly
-`["none"]` when no external source applies; otherwise use non-empty source
-strings and never mix `"none"` with another value. Put claim type `"present"`
-or `"missing"` only inside the
+and `sources`. Do not add provider annotations such as `verbatim_note`, even
+when their value would be null. Every `sources` value MUST be a non-empty
+array. Use exactly `["none"]` when no external source applies; otherwise use
+non-empty source strings and never mix `"none"` with another value. Put claim
+type `"present"` or `"missing"` only inside the
 `location` object alongside `path`, `start_line`, and `end_line`; never add
 `claim_type` at the finding root. Do not invent enum aliases such as `"pass"`.
 """
@@ -676,11 +714,23 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         print(f"review-pr: {exc}", file=sys.stderr)
         return 2
     route_mode = "explicit" if requested_candidate is not None else "auto"
-    override_reason = str(getattr(args, "override_reason", None) or "").strip() or None
-    if requested_candidate is not None and override_reason is None:
-        print("review-pr: explicit reviewer/model pin requires --override-reason", file=sys.stderr)
-        return 2
     requested_effort = str(getattr(args, "effort", None) or "").strip() or None
+    operator_override_reason = (
+        str(getattr(args, "override_reason", None) or "").strip() or None
+    )
+    if (
+        requested_candidate is not None
+        and (explicit_model is not None or requested_effort is not None)
+        and operator_override_reason is None
+    ):
+        print(
+            "review-pr: explicit model/effort pin requires --override-reason",
+            file=sys.stderr,
+        )
+        return 2
+    override_reason = operator_override_reason
+    if requested_candidate is not None and override_reason is None:
+        override_reason = f"explicit reviewer route {reviewer_request!r} requested"
     if requested_candidate is not None and requested_effort is not None:
         participant = REVIEW_CANDIDATES[requested_candidate].participant
         supported_effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
@@ -1172,7 +1222,9 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     )
                 print("review-pr: ACP reviewer failed without bridge retry", file=sys.stderr)
                 return 1
-            canonical_response = _canonical_review_response_text(raw_response)
+            canonical_response = _normalize_known_null_review_annotations(
+                _canonical_review_response_text(raw_response)
+            )
             try:
                 validate_code_review_response(
                     canonical_response,
@@ -1382,7 +1434,10 @@ def register_review_pr_parser(subparsers: Any) -> None:
                         help="Explicit data-egress policy token; gated routes fail closed when absent")
     parser.add_argument("--isolation-required", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--override-reason",
-                        help="Required evidence for every exceptional explicit reviewer/model pin")
+                        help=(
+                            "Required evidence for exact model or effort pins; optional for a "
+                            "reviewer alias selecting its practical default"
+                        ))
     parser.add_argument("--allow-explicit-fallback", action="store_true",
                         help="Permit an explicit pin to fail over after a retryable transport failure")
     parser.add_argument("--background", action="store_true")

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -4,9 +4,10 @@ Pointer-only: no embedded diffs or inventory YAML. Prefer sealed Codex
 ``--review --pr`` isolation (#5285). Claude-dark local default for
 opencode-family reviewers is GLM-5.2 (LOCAL-ONLY — never CI).
 
-Formal CF model + effort pins (operator 2026-07-21): practical seats @ high
-— Terra / Sonnet 5 / GLM, with pinned AGY as a quota substitution — not Sol/Fable on routine PRs. Authority seats
-remain on the critical review ladder only (see model_catalog.yaml).
+Formal CF defaults (operator 2026-07-21) use practical seats.  Explicit
+operator pins may select another formally eligible model on the requested
+native reviewer route; they still pass every hard gate and never change the
+automatic ladder (see model_catalog.yaml).
 """
 
 from __future__ import annotations
@@ -348,6 +349,81 @@ def formal_cf_pin(reviewer: str) -> tuple[str, str]:
     return model, effort
 
 
+def resolve_requested_review_candidate(
+    reviewer_request: str,
+    explicit_model: str | None,
+    candidates: Mapping[str, Any],
+) -> str | None:
+    """Resolve one explicit request without confusing a route with its default.
+
+    ``--reviewer`` names a semantic/native route, while ``--model`` may select
+    any formally eligible canonical candidate on that route.  The default
+    candidate remains authoritative when no model is supplied.  Model-only
+    requests consider formally eligible candidates only, which disambiguates
+    an attested native route from a non-formal fallback carrying the same model.
+    """
+    model = (explicit_model or "").strip() or None
+    default_name = None
+    requested_route = None
+    if reviewer_request != REVIEWER_AUTO:
+        default_name = EXPLICIT_REVIEWER_CANDIDATE[reviewer_request]
+        try:
+            requested_route = candidates[default_name].route
+        except (KeyError, AttributeError) as exc:
+            raise ReviewSafetyError(
+                f"reviewer_catalog_mismatch: default candidate {default_name!r} "
+                f"for reviewer {reviewer_request!r} is unavailable"
+            ) from exc
+        if not candidates[default_name].formal_review_eligible:
+            reason = candidates[default_name].formal_review_exclusion_reason or "sealed endpoint is not eligible"
+            raise ReviewSafetyError(
+                f"reviewer_not_formal_review_eligible: {reviewer_request!r} cannot satisfy "
+                f"the formal review gate: {reason}"
+            )
+        if model is None:
+            return default_name
+    elif model is None:
+        return None
+
+    matches = [
+        candidate.name
+        for candidate in candidates.values()
+        if candidate.concrete_model == model
+        and candidate.formal_review_eligible
+        and (requested_route is None or candidate.route == requested_route)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+
+    if requested_route is None:
+        scope = "the formal-review catalog"
+        eligible_models = sorted(
+            {
+                candidate.concrete_model
+                for candidate in candidates.values()
+                if candidate.formal_review_eligible
+            }
+        )
+    else:
+        scope = f"reviewer {reviewer_request!r} route {requested_route!r}"
+        eligible_models = sorted(
+            {
+                candidate.concrete_model
+                for candidate in candidates.values()
+                if candidate.formal_review_eligible and candidate.route == requested_route
+            }
+        )
+    if not matches:
+        raise ReviewSafetyError(
+            f"model_not_formal_review_eligible: {model!r} has no canonical candidate on {scope}; "
+            f"eligible models: {eligible_models!r}"
+        )
+    raise ReviewSafetyError(
+        f"ambiguous_formal_review_model: {model!r} maps to candidates {sorted(matches)!r} on {scope}; "
+        "add --reviewer to select the native route"
+    )
+
+
 def _headroom_band(record: dict[str, Any]) -> str:
     status = str(record.get("status") or "unknown")
     remaining = record.get("remaining_pct")
@@ -537,16 +613,6 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         return 2
 
     task_id = args.task_id or f"review-pr-{pr}"
-    if args.dry_run:
-        dry_model = getattr(args, "model", None) or (
-            "deterministic-scheduler" if reviewer_request == REVIEWER_AUTO else FORMAL_CF_MODEL[reviewer_request]
-        )
-        print(
-            f"review-pr dry-run pr={pr} reviewer_request={reviewer_request} "
-            f"model={dry_model} task_id={task_id} initiator={initiator} "
-            f"author={author_model}/{author_family}"
-        )
-        return 0
     if args.background:
         print(
             "review-pr: background bridge workers are retired; enqueue the formal job "
@@ -587,33 +653,56 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         verify_clean_review_evidence_reads,
     )
 
-    resolved_author_family = resolve_author_family(author_model, author_family)
-    if resolved_author_family != author_family:
-        print(
-            "review-pr: author model/family are unknown, ambiguous, or conflicting; refusing formal review",
-            file=sys.stderr,
-        )
-        return 2
-    requested_candidate = None
-    if reviewer_request != REVIEWER_AUTO:
-        requested_candidate = EXPLICIT_REVIEWER_CANDIDATE[reviewer_request]
     explicit_model = str(getattr(args, "model", None) or "").strip() or None
-    if explicit_model:
-        matches = [candidate.name for candidate in REVIEW_CANDIDATES.values() if candidate.concrete_model == explicit_model]
-        if requested_candidate is not None:
-            valid_model_pin = REVIEW_CANDIDATES[requested_candidate].concrete_model == explicit_model
-        else:
-            valid_model_pin = len(matches) == 1
-            if valid_model_pin:
-                requested_candidate = matches[0]
-        if not valid_model_pin:
-            print("review-pr: --model must identify exactly the explicitly requested canonical candidate", file=sys.stderr)
-            return 2
+    try:
+        resolved_author_family = resolve_author_family(author_model, author_family)
+        if resolved_author_family != author_family:
+            raise ReviewSafetyError(
+                "author model/family are unknown, ambiguous, or conflicting; refusing formal review"
+            )
+        requested_candidate = resolve_requested_review_candidate(
+            reviewer_request,
+            explicit_model,
+            REVIEW_CANDIDATES,
+        )
+    except ReviewSafetyError as exc:
+        print(f"review-pr: {exc}", file=sys.stderr)
+        return 2
     route_mode = "explicit" if requested_candidate is not None else "auto"
     override_reason = str(getattr(args, "override_reason", None) or "").strip() or None
     if requested_candidate is not None and override_reason is None:
         print("review-pr: explicit reviewer/model pin requires --override-reason", file=sys.stderr)
         return 2
+    requested_effort = str(getattr(args, "effort", None) or "").strip() or None
+    if requested_candidate is not None and requested_effort is not None:
+        participant = REVIEW_CANDIDATES[requested_candidate].participant
+        supported_effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
+        if requested_effort != supported_effort:
+            print(
+                f"review-pr: participant {participant!r} supports ACP effort pin "
+                f"{supported_effort!r}, not {requested_effort!r}; omit --effort when "
+                "the participant has no registered ACP effort pin",
+                file=sys.stderr,
+            )
+            return 2
+    if args.dry_run:
+        dry_model = (
+            REVIEW_CANDIDATES[requested_candidate].concrete_model
+            if requested_candidate is not None
+            else "deterministic-scheduler"
+        )
+        dry_effort = (
+            ACPX_PARTICIPANT_EFFORTS.get(REVIEW_CANDIDATES[requested_candidate].participant)
+            if requested_candidate is not None
+            else None
+        )
+        print(
+            f"review-pr dry-run pr={pr} reviewer_request={reviewer_request} "
+            f"candidate={requested_candidate or 'deterministic-scheduler'} "
+            f"model={dry_model} effort={dry_effort or 'provider_default'} "
+            f"task_id={task_id} initiator={initiator} author={author_model}/{author_family}"
+        )
+        return 0
     profile = str(getattr(args, "review_profile", None) or "code").strip().lower()
     risk = str(getattr(args, "risk", None) or "medium").strip().lower()
     requested_role = str(getattr(args, "role", None) or "").strip() or None
@@ -909,7 +998,6 @@ def handle_review_pr(args: argparse.Namespace) -> int:
                     participant = REVIEW_CANDIDATES[routing_reservation.resolved_candidate].participant
                     model = routing_reservation.resolved_model
                     effort = ACPX_PARTICIPANT_EFFORTS.get(participant)
-                    requested_effort = str(getattr(args, "effort", None) or "").strip() or None
                     if requested_effort is not None and requested_effort != effort:
                         _settle_routing_reservation_once(
                             routing_ledger,
@@ -1249,21 +1337,25 @@ def register_review_pr_parser(subparsers: Any) -> None:
     parser.add_argument(
         "--reviewer",
         default=REVIEWER_AUTO,
-        help="auto|codex|glm|claude|agy|grok|kimi (explicit routes are exceptional pins)",
+        help=(
+            "auto|codex|glm|claude|agy|grok|kimi (recognized semantic routes; "
+            "current sealed eligibility comes from model_catalog.yaml)"
+        ),
     )
     parser.add_argument(
         "--model",
         default=None,
         help=(
-            "Exceptional exact canonical model pin; must agree with --reviewer and "
-            "requires --override-reason"
+            "Exceptional exact canonical model pin; selects one formally eligible "
+            "candidate on --reviewer's native route and requires --override-reason"
         ),
     )
     parser.add_argument(
         "--effort",
         default=None,
         help=(
-            "Override formal CF effort pin (default: high; authority escalate: xhigh)"
+            "Optional exact ACP effort pin; it must match the selected participant's "
+            "registered transport capability"
         ),
     )
     parser.add_argument("--claude-available", dest="claude_available", action=argparse.BooleanOptionalAction,

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -613,6 +613,13 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         return 2
 
     task_id = args.task_id or f"review-pr-{pr}"
+    if args.no_timeout:
+        print(
+            "review-pr: --no-timeout is unsafe for leased formal reviews; "
+            "use the bounded 30-minute review lease and retry on expiry",
+            file=sys.stderr,
+        )
+        return 2
     if args.background:
         print(
             "review-pr: background bridge workers are retired; enqueue the formal job "
@@ -724,7 +731,7 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         evidence_metrics = _evidence_metrics(evidence)
         estimated_input_bytes = checkout.sealed_evidence_input_bytes()
         active_input_bytes = estimated_input_bytes
-        timeout = 86400 if args.no_timeout else 1800
+        timeout = 1800
         worker_id = f"review-pr-acp:{os.getpid()}"
         authority_key = _formal_review_authority_key(
             DEFAULT_REPOSITORY,
@@ -1379,7 +1386,11 @@ def register_review_pr_parser(subparsers: Any) -> None:
     parser.add_argument("--allow-explicit-fallback", action="store_true",
                         help="Permit an explicit pin to fail over after a retryable transport failure")
     parser.add_argument("--background", action="store_true")
-    parser.add_argument("--no-timeout", action="store_true")
+    parser.add_argument(
+        "--no-timeout",
+        action="store_true",
+        help="Unsupported for leased formal reviews; fails before authority or provider work",
+    )
     parser.add_argument("--dry-run", action="store_true")
     # Post-reply finalize is a separate CLI so review-pr stays pointer-only:
     #   .venv/bin/python -m scripts.fleet_comms formal-job accept \

--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -25,7 +25,10 @@ formal_review_eligibility_source: scripts/config/model_catalog.yaml#review_sched
 #   pool volume → Laguna S 2.1 (laguna-s-2.1); also XS 2.1 / M.1 in catalog
 #   grok dark → Cursor explicit grok-4.5
 #   agy → gemini-3.6-flash-high @ high (orchestrator seat; text-only ACP wrapper is not a formal-review route)
-# Authority Sol/Fable only on critical resolve-reviewer ladder.
+# Automatic authority Sol/Fable selection stays on the critical ladder.
+# An explicit operator pin may select either model at another risk while every
+# formal eligibility, isolation, family, capability, health, and circuit gate
+# remains enforced.
 #
 # Orchestrator seats for this stream (model_catalog.orchestrator_seats):
 #   claude(claude-fable-5 @ high, SUMMONED cadence — grok drives daily; operator 2026-07-26)

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -799,16 +799,17 @@ formal_cf_defaults:
   codex:
     model_id: gpt-5.6-terra
     effort: high
-    # Authority escalate for critical / hard CF (review-pr --model gpt-5.6-sol --effort xhigh)
+    # Authority model for critical / hard CF. The one-shot Codex ACP participant
+    # does not expose reasoning effort, so review-pr pins the model only.
     escalate_model_id: gpt-5.6-sol
-    escalate_effort: xhigh
+    escalate_effort: provider_default
   claude:
     model_id: claude-sonnet-5
     effort: high
-    # Others escalate TO Claude: Fable 5 @ xhigh is the Anthropic advisor/authority
-    # seat. Opus 5 advisory consultations are non-binding and separate from formal CF.
+    # The sealed Claude ACP participant supports Sonnet and Fable at its fixed
+    # high effort. Opus 5 advisory consultations remain non-binding and separate.
     escalate_model_id: claude-fable-5
-    escalate_effort: xhigh
+    escalate_effort: high
   glm:
     model_id: glm-5.2
     effort: high

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -759,6 +759,30 @@ def resolve_reviewer(
             fail_closed_reason=(f"unsupported review risk {inputs.risk!r}; expected one of {sorted(VALID_RISKS)}"),
         )
     active_ladder = ladder if ladder is not None else REVIEW_LADDERS[risk]
+    if inputs.pinned_candidate:
+        pinned_definition = REVIEW_CANDIDATES.get(inputs.pinned_candidate)
+        if pinned_definition is None:
+            return ReviewerResolution(
+                selected=None,
+                advisory=(),
+                trace=(),
+                substitution_note=None,
+                policy_version=_SCHEDULER_POLICY_VERSION,
+                catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+                resolved_risk=risk,
+                fail_closed_reason=f"unknown explicit reviewer pin {inputs.pinned_candidate!r}",
+            )
+        if all(
+            candidate.name != pinned_definition.name
+            for rung in active_ladder
+            for candidate in rung
+        ):
+            # Ladders express automatic preference, not an allowlist.  An
+            # operator-requested canonical pin may name another catalogued
+            # candidate, but it still goes through every hard eligibility,
+            # suitability, isolation, capability, family, health, and circuit
+            # gate below before it can be selected.
+            active_ladder = (*active_ladder, (pinned_definition,))
     try:
         normalize_routing_snapshot(inputs.routing_snapshot)
     except ValueError as exc:

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1847,7 +1847,8 @@ def test_claude_sealed_review_turn_budget_is_derived_from_required_chunks(tmp_pa
     assert AcpxClaudeShadowAdapter()._max_turns(str(config_path)) == 10
 
 
-def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch):
+@pytest.mark.parametrize("model", ["claude-sonnet-5", "claude-fable-5"])
+def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch, model):
     _stub_binary(monkeypatch, tmp_path)
     monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
     sealed_config = str(tmp_path / "sealed-config.json")
@@ -1867,7 +1868,7 @@ def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch
             prompt="review the sealed exact head",
             mode="read-only",
             cwd=tmp_path,
-            model="claude-sonnet-5",
+            model=model,
             task_id="t-claude-review",
             session_id=None,
             tool_config={
@@ -1882,6 +1883,7 @@ def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch
     pairs = list(zip(plan.cmd, plan.cmd[1:], strict=False))
     allowed = "mcp__sealed_review__read_required"
     assert ("--allowed-tools", allowed) in pairs
+    assert ("--model", model) in pairs
     assert ("--max-turns", "9") in pairs
     assert ("--system-prompt", acpx_module._CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT) in pairs
     assert "Do not call ReportFindings" in acpx_module._CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT
@@ -1891,6 +1893,7 @@ def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch
         "sealed_review__read_required",
     ]
     assert policy["defaultAction"] == "deny"
+    assert plan.metadata["model"] == model
 
 
 def test_claude_sealed_review_turn_budget_rejects_intermediate_symlink_escape(

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -1887,6 +1887,7 @@ def test_claude_sealed_review_exposes_only_required_stream(tmp_path, monkeypatch
     assert ("--max-turns", "9") in pairs
     assert ("--system-prompt", acpx_module._CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT) in pairs
     assert "Do not call ReportFindings" in acpx_module._CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT
+    assert "verbatim_note" in acpx_module._CLAUDE_SEALED_REVIEW_SYSTEM_PROMPT
     policy = json.loads(plan.cmd[plan.cmd.index("--permission-policy") + 1])
     assert policy["autoApprove"] == [
         allowed,

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -206,6 +206,28 @@ def test_review_pr_dry_run_requires_override_reason_for_explicit_fable(capsys):
     assert "requires --override-reason" in capsys.readouterr().err
 
 
+def test_review_pr_refuses_effort_only_auto_route_before_provider_spawn(capsys):
+    class Args:
+        pr = "6349"
+        reviewer = "auto"
+        claude_available = None
+        model = None
+        effort = "high"
+        extra = None
+        task_id = None
+        dry_run = False
+        from_llm = "codex"
+        background = False
+        no_timeout = False
+        initiator = "codex/6349-reviewer-model-flexibility"
+        author_model = "gpt-5.6-sol"
+        author_family = "openai"
+        override_reason = "operator requested high effort"
+
+    assert handle_review_pr(Args()) == 2
+    assert "requires an explicit eligible --reviewer or --model" in capsys.readouterr().err
+
+
 def test_review_pr_refuses_unbounded_lease_before_provider_spawn(capsys):
     class Args:
         pr = "6349"

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -163,3 +163,24 @@ def test_review_pr_dry_run_requires_override_reason_for_explicit_fable(capsys):
 
     assert handle_review_pr(Args()) == 2
     assert "requires --override-reason" in capsys.readouterr().err
+
+
+def test_review_pr_refuses_unbounded_lease_before_provider_spawn(capsys):
+    class Args:
+        pr = "6349"
+        reviewer = "auto"
+        claude_available = None
+        model = None
+        effort = None
+        extra = None
+        task_id = None
+        dry_run = False
+        from_llm = "codex"
+        background = False
+        no_timeout = True
+        initiator = "codex/6349-reviewer-model-flexibility"
+        author_model = "gpt-5.6-sol"
+        author_family = "openai"
+
+    assert handle_review_pr(Args()) == 2
+    assert "--no-timeout is unsafe for leased formal reviews" in capsys.readouterr().err

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -11,6 +11,7 @@ from scripts.agent_runtime.adapters.acpx import (
 from scripts.ai_agent_bridge._review_pr import (
     FORMAL_CF_EFFORT,
     FORMAL_CF_MODEL,
+    _normalize_known_null_review_annotations,
     formal_cf_pin,
     handle_review_pr,
     resolve_requested_review_candidate,
@@ -143,6 +144,30 @@ def test_review_pr_dry_run_accepts_fable_on_claude_route(capsys):
     assert "model=claude-fable-5 effort=high" in out
 
 
+def test_review_pr_dry_run_accepts_bare_reviewer_default_without_override(capsys):
+    class Args:
+        pr = "6349"
+        reviewer = "claude"
+        claude_available = None
+        model = None
+        effort = None
+        extra = None
+        task_id = None
+        dry_run = True
+        from_llm = "codex"
+        background = False
+        no_timeout = False
+        initiator = "codex/6349-reviewer-model-flexibility"
+        author_model = "gpt-5.6-sol"
+        author_family = "openai"
+        override_reason = None
+
+    assert handle_review_pr(Args()) == 0
+    out = capsys.readouterr().out
+    assert "candidate=claude-sonnet-5" in out
+    assert "model=claude-sonnet-5 effort=high" in out
+
+
 def test_review_pr_dry_run_requires_override_reason_for_explicit_fable(capsys):
     class Args:
         pr = "6349"
@@ -184,3 +209,27 @@ def test_review_pr_refuses_unbounded_lease_before_provider_spawn(capsys):
 
     assert handle_review_pr(Args()) == 2
     assert "--no-timeout is unsafe for leased formal reviews" in capsys.readouterr().err
+
+
+def test_known_null_review_annotation_is_removed_without_relaxing_schema():
+    response = (
+        '{"schema_version":"code-review-findings.v1","overall":{},'
+        '"findings":[{"id":"F1","verbatim_note":null}]}'
+    )
+
+    normalized = _normalize_known_null_review_annotations(response)
+
+    assert '"verbatim_note"' not in normalized
+    assert '"id":"F1"' in normalized
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        '{"findings":[{"verbatim_note":"meaningful"}]}',
+        '{"findings":[{"unknown_note":null}]}',
+        '{"findings":[],"findings":[]}',
+    ],
+)
+def test_review_annotation_normalization_preserves_strict_rejections(response: str):
+    assert _normalize_known_null_review_annotations(response) == response

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from scripts.agent_runtime.adapters.acpx import (
@@ -86,6 +88,20 @@ def test_explicit_model_refuses_wrong_route_and_ineligible_endpoint():
         resolve_requested_review_candidate("claude", "gpt-5.6-sol", REVIEW_CANDIDATES)
     with pytest.raises(ReviewSafetyError, match="reviewer_not_formal_review_eligible"):
         resolve_requested_review_candidate("agy", "gemini-3.6-flash-high", REVIEW_CANDIDATES)
+
+
+def test_same_route_model_ambiguity_reports_catalog_repair_not_reviewer_advice():
+    candidates = dict(REVIEW_CANDIDATES)
+    candidates["claude-fable-clone"] = replace(
+        REVIEW_CANDIDATES["claude-fable-5"],
+        name="claude-fable-clone",
+    )
+
+    with pytest.raises(ReviewSafetyError) as exc_info:
+        resolve_requested_review_candidate("claude", "claude-fable-5", candidates)
+
+    assert "defines duplicate canonical candidates" in str(exc_info.value)
+    assert "add --reviewer" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize("reviewer", ["agy", "kimi"])

--- a/tests/ai_agent_bridge/test_review_pr_pins.py
+++ b/tests/ai_agent_bridge/test_review_pr_pins.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.agent_runtime.adapters.acpx import (
     ACPX_PARTICIPANT_EFFORTS,
     ACPX_SUPPORTED_PARTICIPANTS,
@@ -11,8 +13,11 @@ from scripts.ai_agent_bridge._review_pr import (
     FORMAL_CF_MODEL,
     formal_cf_pin,
     handle_review_pr,
+    resolve_requested_review_candidate,
     resolve_reviewer,
 )
+from scripts.ai_agent_bridge._review_safety import ReviewSafetyError
+from scripts.review.reviewer_resolver import REVIEW_CANDIDATES
 
 
 def test_auto_remains_semantic_until_the_deterministic_scheduler_runs():
@@ -38,6 +43,56 @@ def test_formal_cross_family_pins_match_enabled_acp_routes():
         assert ACPX_PARTICIPANT_EFFORTS[reviewer] == effort
 
 
+@pytest.mark.parametrize(
+    ("reviewer", "model", "candidate"),
+    [
+        ("claude", "claude-sonnet-5", "claude-sonnet-5"),
+        ("claude", "claude-fable-5", "claude-fable-5"),
+        ("codex", "gpt-5.6-terra", "gpt-5.6-terra"),
+        ("codex", "gpt-5.6-sol", "openai_frontier"),
+        ("glm", "glm-5.2", "glm-5.2"),
+        ("grok", "grok-4.5", "grok-4.5"),
+    ],
+)
+def test_explicit_model_selects_every_formally_eligible_native_route(
+    reviewer: str,
+    model: str,
+    candidate: str,
+):
+    assert resolve_requested_review_candidate(reviewer, model, REVIEW_CANDIDATES) == candidate
+
+
+def test_explicit_reviewer_without_model_preserves_practical_default():
+    assert (
+        resolve_requested_review_candidate("claude", None, REVIEW_CANDIDATES)
+        == "claude-sonnet-5"
+    )
+
+
+def test_model_only_pin_ignores_non_formal_fallback_with_same_model():
+    assert (
+        resolve_requested_review_candidate("auto", "claude-fable-5", REVIEW_CANDIDATES)
+        == "claude-fable-5"
+    )
+    assert (
+        resolve_requested_review_candidate("auto", "grok-4.5", REVIEW_CANDIDATES)
+        == "grok-4.5"
+    )
+
+
+def test_explicit_model_refuses_wrong_route_and_ineligible_endpoint():
+    with pytest.raises(ReviewSafetyError, match="model_not_formal_review_eligible"):
+        resolve_requested_review_candidate("claude", "gpt-5.6-sol", REVIEW_CANDIDATES)
+    with pytest.raises(ReviewSafetyError, match="reviewer_not_formal_review_eligible"):
+        resolve_requested_review_candidate("agy", "gemini-3.6-flash-high", REVIEW_CANDIDATES)
+
+
+@pytest.mark.parametrize("reviewer", ["agy", "kimi"])
+def test_ineligible_reviewer_default_refuses_before_provider_spawn(reviewer: str):
+    with pytest.raises(ReviewSafetyError, match="reviewer_not_formal_review_eligible"):
+        resolve_requested_review_candidate(reviewer, None, REVIEW_CANDIDATES)
+
+
 def test_review_pr_dry_run_emits_model_and_effort(capsys):
     class Args:
         pr = "5594"
@@ -61,3 +116,50 @@ def test_review_pr_dry_run_emits_model_and_effort(capsys):
     assert "reviewer_request=auto" in out
     assert "model=deterministic-scheduler" in out
     assert "initiator=grok/orchestrator" in out
+
+
+def test_review_pr_dry_run_accepts_fable_on_claude_route(capsys):
+    class Args:
+        pr = "6349"
+        reviewer = "claude"
+        claude_available = None
+        model = "claude-fable-5"
+        effort = "high"
+        extra = None
+        task_id = None
+        dry_run = True
+        from_llm = "codex"
+        background = False
+        no_timeout = False
+        initiator = "codex/6349-reviewer-model-flexibility"
+        author_model = "gpt-5.6-sol"
+        author_family = "openai"
+        override_reason = "operator requested Fable"
+
+    assert handle_review_pr(Args()) == 0
+    out = capsys.readouterr().out
+    assert "reviewer_request=claude" in out
+    assert "candidate=claude-fable-5" in out
+    assert "model=claude-fable-5 effort=high" in out
+
+
+def test_review_pr_dry_run_requires_override_reason_for_explicit_fable(capsys):
+    class Args:
+        pr = "6349"
+        reviewer = "claude"
+        claude_available = None
+        model = "claude-fable-5"
+        effort = None
+        extra = None
+        task_id = None
+        dry_run = True
+        from_llm = "codex"
+        background = False
+        no_timeout = False
+        initiator = "codex/6349-reviewer-model-flexibility"
+        author_model = "gpt-5.6-sol"
+        author_family = "openai"
+        override_reason = None
+
+    assert handle_review_pr(Args()) == 2
+    assert "requires --override-reason" in capsys.readouterr().err

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -306,9 +306,7 @@ def test_orchestrator_escalate_pins_parallel_sol_fable_pro():
     # formal-CF review seat whose authority escalate is still Sol.
     fc = load_model_catalog()["formal_cf_defaults"]
     assert fc["codex"]["escalate_model_id"] == "gpt-5.6-sol"
-    assert fc["codex"]["escalate_effort"] == "provider_default"
     assert fc["claude"]["escalate_model_id"] == "claude-fable-5"
-    assert fc["claude"]["escalate_effort"] == "high"
 
 
 def test_practical_ladders_exclude_authority_seats():

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -306,7 +306,9 @@ def test_orchestrator_escalate_pins_parallel_sol_fable_pro():
     # formal-CF review seat whose authority escalate is still Sol.
     fc = load_model_catalog()["formal_cf_defaults"]
     assert fc["codex"]["escalate_model_id"] == "gpt-5.6-sol"
+    assert fc["codex"]["escalate_effort"] == "provider_default"
     assert fc["claude"]["escalate_model_id"] == "claude-fable-5"
+    assert fc["claude"]["escalate_effort"] == "high"
 
 
 def test_practical_ladders_exclude_authority_seats():

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -734,6 +734,48 @@ def test_explicit_pin_requires_reason_and_cannot_bypass_formal_transport_gate():
     assert "hard eligibility" in unsafe.fail_closed_reason
 
 
+def test_explicit_pin_may_override_ladder_preference_but_not_hard_gates():
+    fable = REVIEW_CANDIDATES["claude-fable-5"]
+    selected = resolve_reviewer(
+        ResolverInputs(
+            author_model="gpt-5.6-terra",
+            author_family="openai",
+            risk="medium",
+            pinned_candidate=fable.name,
+            pressure_override_reason="operator requested Fable dissent",
+        )
+    )
+    assert selected.selected is not None
+    assert selected.selected.name == "claude-fable-5"
+    assert "explicit pressure override" in selected.substitution_note
+
+    same_family = resolve_reviewer(
+        ResolverInputs(
+            author_model="claude-sonnet-5",
+            author_family="anthropic",
+            risk="medium",
+            pinned_candidate=fable.name,
+            pressure_override_reason="operator requested Fable dissent",
+        )
+    )
+    assert same_family.selected is None
+    assert "hard eligibility" in same_family.fail_closed_reason
+    assert next(item for item in same_family.trace if item.name == fable.name).status == "excluded"
+
+
+def test_unknown_explicit_pin_fails_closed_before_candidate_walk():
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="gpt-5.6-terra",
+            pinned_candidate="not-a-catalog-candidate",
+            pressure_override_reason="test",
+        )
+    )
+    assert resolution.selected is None
+    assert resolution.trace == ()
+    assert "unknown explicit reviewer pin" in resolution.fail_closed_reason
+
+
 def test_formal_k3_participant_identity_is_explicit():
     k3 = REVIEW_CANDIDATES["kimi-k3"]
     assert k3.route == "kimicc"


### PR DESCRIPTION
## Summary

- separate semantic reviewer routes from exact model selection, so Claude can run Sonnet or Fable and Codex can run Terra or Sol without changing automatic routing preferences
- preserve every hard family, capability, isolation, health, quota, and circuit gate for explicit pins
- keep bare reviewer aliases ceremony-free while requiring an auditable reason for exact model or effort pins
- reject effort-only automatic routing and unbounded formal-review leases before authority, reservation, or provider work
- normalize only the known Fable verbatim_note:null decoration while retaining strict rejection of non-null, unknown, duplicate-key, or malformed evidence
- align runtime registry, catalog, binding fleet rules, onboarding, and Grok formal-review documentation with live ACP eligibility

## Root cause

review-pr preselected each reviewer alias practical default before checking --model, making formally eligible sibling models unreachable. Documentation and runtime metadata had also drifted across Grok eligibility, Fable effort, and Codex provider-default effort. Authenticated Fable review then exposed three additional edge cases: orphan-prone no-timeout leases, same-route ambiguity guidance, and effort-only auto routing that validated too late.

## Verification

- 519 integrated local tests passed across review-pr, lifecycle/replay, resolver, catalog, ACP adapters, transport cutover, fleet contracts, roster lint, and runtime registry
- Ruff, compilation, YAML parsing, fleet-roster projection, diff, trailer, scope, and OPSEC checks passed
- authenticated exact-head Fable review approved head 8855c603bf7a7772fb886f1beed6ebee0db12147
- review receipt review_631e2780fb1040dca7c64e368176258e records model claude-fable-5, ACP transport, full sealed manifest+patch coverage, and APPROVED
- one GitHub pytest shard initially failed before pytest because Hugging Face returned HTTP 429 after an invalid 198-byte Stanza cache restore; failed-job rerun requested

Fixes #6349