### PR TITLE
fix(eval): privatize invalid HF result receipt

### DIFF
--- a/data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.disposition.json
+++ b/data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.disposition.json
@@ -1,7 +1,8 @@
 {
-  "schema_version": "ua_open_weight_eval_run_disposition.v1",
+  "schema_version": "ua_open_weight_eval_run_disposition.v2",
   "issue": 6273,
   "recorded_on": "2026-08-03",
+  "last_updated_on": "2026-08-04",
   "run_config_sha256": "38d6ee4757a26e4f45b1e6860319821b8eacac9ad28548e4962550ad93661972",
   "status": "invalid_semantic_output",
   "evaluation_valid": false,
@@ -26,13 +27,41 @@
     "reserved_marker_violation_rows": 4000,
     "introduced_control_violation_rows": 1830
   },
-  "public_artifact": {
+  "retained_artifact": {
     "repository": "krisztiankoos/ua-open-weight-eval-results",
+    "repository_type": "huggingface_dataset",
+    "visibility": "private",
+    "visibility_changed_on": "2026-08-04",
+    "repository_deleted": false,
     "invalid_revision": "6d294b175820777ae382e36ec6a781c5f9032728",
     "package_sha256": "f5710a3fe9aabeac29d5e6a00b7858657fc6880172b9222b9cc0db0bee86917a",
     "corrective_card_revision": "152e04defc7faecadfa994a9f8f07fea6c5adb0e",
     "corrective_readme_sha256": "e5b0a2d2acdfe561b530a3911137e3ae870ab066baa776bd95d449650160dec2",
-    "preservation_policy": "retain immutable bytes as an invalid runtime failure receipt; do not cite metrics as model results"
+    "preservation_policy": "retain the invalid runtime-failure bytes privately; do not cite metrics as model results",
+    "visibility_receipt": {
+      "verified_on": "2026-08-04",
+      "authenticated_repo_info_private": true,
+      "anonymous_http_status": 401,
+      "content_revision_preserved": true
+    }
+  },
+  "public_transparency": {
+    "incident_record": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/main/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md",
+    "disposition_file": "data/projects/ua_open_weight_eval/runs/gemma4_qat_q4_0_hf_jobs_v1.disposition.json",
+    "retained_evidence": [
+      "invalid_revision",
+      "package_sha256",
+      "corrective_card_revision",
+      "corrective_readme_sha256",
+      "canary.responses_sha256",
+      "full.responses_sha256"
+    ]
+  },
+  "publication_policy": {
+    "scope": "future_hugging_face_result_repositories",
+    "required_gate": "actual_saved_outputs_pass_source_aware_response_integrity",
+    "required_verification_schema": "ua_open_weight_eval_results_verification.v2",
+    "failure_action": "keep result repository private and publish only the incident explanation and hashes on GitHub"
   },
   "replacement_run": {
     "authorized": false,

--- a/docs/projects/ua-open-weight-eval/HF_INVALID_RESULT_CARD.md
+++ b/docs/projects/ua-open-weight-eval/HF_INVALID_RESULT_CARD.md
@@ -33,6 +33,10 @@ configs:
 > **Do not use this dataset as a Gemma 4 baseline and do not cite its metrics
 > as evidence of Ukrainian-language quality.**
 
+This Hugging Face repository was made private on 2026-08-04 without deleting
+its files or history. The public transparency record is the GitHub incident
+report and its retained hashes, not this invalid result payload.
+
 The provider jobs completed and the files were structurally valid, but the
 saved responses were runtime-corrupted. A source-aware replay on 2026-08-03
 found:
@@ -49,7 +53,7 @@ source is not treated as newly introduced corruption. The gate makes no
 linguistic judgment about Ukrainian, quoted Russian, surzhyk, historical
 language, or regional language.
 
-The original payload is preserved for transparency as a failure receipt. Its
+The original payload is preserved privately as a failure receipt. Its
 historical revision is `6d294b175820777ae382e36ec6a781c5f9032728`; its
 historical package SHA-256 is
 `f5710a3fe9aabeac29d5e6a00b7858657fc6880172b9222b9cc0db0bee86917a`.
@@ -67,12 +71,16 @@ source-aware gate are maintained in the
 > **Не використовуйте цей набір як базову оцінку Gemma 4 і не цитуйте його
 > метрики як доказ якості української мови.**
 
+Репозиторій Hugging Face зроблено приватним 4 серпня 2026 року без видалення
+файлів чи історії. Публічними доказами залишаються опис інциденту та хеші на
+GitHub, а не цей недійсний пакет результатів.
+
 Завдання провайдера завершилися, але збережені відповіді були пошкоджені
 середовищем виконання. Усі 100 відповідей canary і всі 4 000 відповідей
 повного запуску містять нові службові маркери моделі. Майже всі відповіді
 `preserve`/`abstain` також не відтворили джерело дослівно.
 
-Початкові файли збережено для прозорості лише як квитанцію про помилку. Вони не
+Початкові файли збережено приватно лише як квитанцію про помилку. Вони не
 дають надійних висновків про українську мову Gemma 4. Сам незмінний набір
 UA Open-Weight Eval v0.1.0 не визнано недійсним; недійсною є лише ця комбінація
 моделі, середовища виконання та відповідей. Повторний запуск не дозволено.

--- a/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md
+++ b/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md
@@ -6,8 +6,8 @@
 > rows introduced reserved model markers. Of the preserve/abstain rows, 98/98
 > in the canary and 3,961/3,961 in the full run failed the exact-copy contract.
 > This run says nothing reliable about Gemma 4's Ukrainian ability. Its bytes
-> remain available only as a transparent runtime-failure receipt. No rerun is
-> authorized.
+> are retained privately as a runtime-failure receipt; this public incident
+> record retains their hashes. No rerun is authorized.
 
 Issue [#6273](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6273)
 authorized one evaluation-only attempt on Hugging Face Jobs. It did not train,
@@ -221,8 +221,10 @@ bucket-mount remedy is disproven and must not be retried. See the official
 [Jobs persistence guidance](https://huggingface.co/docs/hub/en/jobs-manage).
 
 Raw generations, parse failures, private checkpoints, and provider logs remain
-private. The complete final parsed responses are public because they are needed
-to reproduce all fourteen deterministic reports.
+private. The invalid final parsed responses were initially published for report
+reproduction, then made private on 2026-08-04. Their public availability did
+not add valid evaluation evidence; the incident record and immutable hashes are
+sufficient for transparency.
 
 ## Free preparation and verification
 
@@ -249,10 +251,12 @@ by both the CPU preflight and any authorized GPU launch. `verify-transport`
 then re-downloads the staged files and verifies their exact set, sizes, and
 hashes before a provider job is submitted.
 
-## Invalid public artifact boundary
+## Private invalid artifact boundary
 
-The retained public dataset contains the historical bytes listed below, but its
-current card labels them an invalid runtime-failure receipt:
+The retained Hugging Face dataset is private as of 2026-08-04 and contains the
+historical bytes listed below. It was not deleted, and the visibility change
+preserved corrective revision
+`152e04defc7faecadfa994a9f8f07fea6c5adb0e`:
 
 - `README.md` — Hugging Face card, limitations, and English/Ukrainian reproduction;
 - `responses.jsonl` — complete parsed actions and output text, without raw generations;
@@ -265,9 +269,20 @@ current card labels them an invalid runtime-failure receipt:
 The package excludes weights, model derivatives, source cases, source-only
 request packets, raw generations, checkpoints, provider logs, failed-attempt
 traces, private corpus material, and any aggregate Ukrainian-quality score.
-The original revision remains immutable evidence. The corrective card revision
-is verified by a fresh anonymous, token-free download; every non-card payload
-file must retain its original hash.
+The original revision and package SHA-256 remain public in this incident record
+and the disposition file. Before the visibility change, a fresh anonymous,
+token-free download verified the corrective card revision and every unchanged
+non-card payload hash. After the change, authenticated repository metadata
+reported `private: true`, an anonymous request returned HTTP 401, and the
+content revision remained unchanged.
+
+No future Hugging Face result repository may be made public merely because its
+provider job, shape, hashes, metrics, runtime, or cost receipts validate. The
+exact saved responses must first pass the source-aware integrity gate, and
+`verify-results` must return
+`ua_open_weight_eval_results_verification.v2` with
+`publication_eligible: true`. A semantic failure keeps the result repository
+private while GitHub retains the public incident explanation and hashes.
 
 ## Українською
 
@@ -279,6 +294,7 @@ file must retain its original hash.
 квитанцію про помилку середовища виконання; повторний запуск не дозволено.
 
 Підсумок містить окремі звіти за чотирнадцятьма напрямами. Єдиного показника
-«якості української» немає. Повні розібрані відповіді публікуються для
-відтворюваності, але сирі генерації, приватні контрольні точки, журнали
-провайдера та ваги моделі не публікуються.
+«якості української» немає. Недійсні розібрані відповіді збережено приватно;
+публічними на GitHub залишаються опис інциденту та хеші. Майбутній репозиторій
+результатів можна оприлюднити лише після семантичної перевірки фактично
+збережених відповідей.

--- a/docs/projects/ua-open-weight-eval/README.md
+++ b/docs/projects/ua-open-weight-eval/README.md
@@ -135,7 +135,9 @@ Publication is eligible only when this command returns verification schema
 actual 4,000 saved responses with zero violations. Transport completion,
 provider status, file shape, manifests, hashes, metrics, runtime, or cost are
 not substitutes. A failure keeps the result repository private; GitHub retains
-the public incident explanation and hashes.
+the public incident explanation and hashes. A verification exception or CLI
+exit code `2` produces no v2 eligibility receipt and therefore means
+publication is ineligible; it is not an infrastructure-only warning to ignore.
 
 ## Українською
 
@@ -157,6 +159,14 @@ the public incident explanation and hashes.
 непрозорі послідовні ідентифікатори без міток категорій. Модель працює з ним
 локально, а команда `score` детерміновано оцінює збережені відповіді. Набір і
 його похідні заборонено додавати до навчальних представлень Foundry.
+
+Перед оприлюдненням майбутнього репозиторію результатів Hugging Face виконайте
+команду `verify-results` для точних підготовлених файлів. Оприлюднення дозволено
+лише тоді, коли схема перевірки
+`ua_open_weight_eval_results_verification.v2` повертає `status: passed`,
+`publication_eligible: true` і квитанцію `semantic_validation` для всіх 4 000
+фактично збережених відповідей без жодного порушення. Виняток перевірки або код
+завершення `2` означає, що репозиторій результатів має залишатися приватним.
 
 ## Acceptance contract
 

--- a/docs/projects/ua-open-weight-eval/README.md
+++ b/docs/projects/ua-open-weight-eval/README.md
@@ -7,19 +7,22 @@ proposal. It needs no paid annotator, closed API, or model judge.
 
 ## Release and adoption status
 
-> **Gemma 4 HF result correction (2026-08-03):** the published HF Jobs output
-> is invalid runtime evidence, not a model baseline. All canary and full-run
-> rows fail the corrected source-aware integrity gate. Do not cite its metrics
-> as Gemma 4 Ukrainian results. This does not invalidate the frozen evaluation
-> suite itself; it invalidates only that runner/output pairing. See the
+> **Gemma 4 HF result correction (updated 2026-08-04):** the HF Jobs output is
+> invalid runtime evidence, not a model baseline. All canary and full-run rows
+> fail the corrected source-aware integrity gate. Its Hugging Face result
+> repository is retained privately, while the incident explanation and hashes
+> remain public on GitHub. Do not cite its metrics as Gemma 4 Ukrainian
+> results. This does not invalidate the frozen evaluation suite itself; it
+> invalidates only that runner/output pairing. See the
 > [incident record](HF_JOBS_BASELINE.md).
 
 The repository implementation shipped in PR #6268. The public package uses the
 non-colliding tag `ua-open-weight-eval-v0.1.0`; its generated
 `PUBLICATION_MANIFEST.json` and `SHA256SUMS` define the canonical released
-bytes. The GitHub release is public. The attempted Gemma 4 QAT Q4_0 HF Jobs run
-is retained as an invalid failure receipt tracked in issue #6273. Independent
-external adoption remains a separate, currently unproven fact.
+bytes. The GitHub release remains public. The attempted Gemma 4 QAT Q4_0 HF
+Jobs run is retained privately as an invalid failure receipt tracked in
+issue #6273. Independent external adoption remains a separate, currently
+unproven fact.
 The exact bounded execution contract is in the
 [HF Jobs baseline runbook](HF_JOBS_BASELINE.md). An adapter, local fixture, or
 our own completed run does not demonstrate independent adoption.
@@ -115,6 +118,24 @@ The command rejects missing or extra files and includes no model weights,
 provider output, private corpus, VESUM data, literary/textbook corpus content,
 or pending v0.2 material. The staged directory is the complete Hugging Face
 dataset-repository payload; upload remains an explicit operator approval gate.
+
+Result repositories have a separate fail-closed publication gate. Before any
+future Hugging Face result repository is made public, run `verify-results` on
+the exact staged result bytes:
+
+```bash
+.venv/bin/python -m scripts.projects.ua_open_weight_eval.hf_jobs_baseline \
+  verify-results \
+  --root batch_state/ua-open-weight-eval-results
+```
+
+Publication is eligible only when this command returns verification schema
+`ua_open_weight_eval_results_verification.v2`, `status: passed`,
+`publication_eligible: true`, and a `semantic_validation` receipt covering the
+actual 4,000 saved responses with zero violations. Transport completion,
+provider status, file shape, manifests, hashes, metrics, runtime, or cost are
+not substitutes. A failure keeps the result repository private; GitHub retains
+the public incident explanation and hashes.
 
 ## Українською
 

--- a/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
+++ b/docs/strategy/UKRAINIAN_OPEN_MODEL_DATA_INFRASTRUCTURE_NORTH_STAR.md
@@ -58,9 +58,10 @@ and evidence over owning or producing model weights. Foundry implementation
 completion stops before model download, accelerator rental, optimizer
 execution, adapter production, or weight upload. The later #6273 Gemma 4
 Hugging Face Jobs attempt completed structurally but failed source-aware output
-integrity and is retained only as an invalid runtime-failure receipt. It does
-not authorize a rerun or training. The accepted boundary between public
-evaluation gold, private product data, and training data remains intact.
+integrity and is retained privately only as an invalid runtime-failure receipt;
+the incident explanation and hashes remain public on GitHub. It does not
+authorize a rerun or training. The accepted boundary between public evaluation
+gold, private product data, and training data remains intact.
 
 ## Solo-operator execution model
 

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -184,6 +184,7 @@ def load_disposition(path: Path = DISPOSITION_PATH) -> dict[str, Any]:
         "run disposition schema drift",
     )
     _require(disposition.get("issue") == 6273, "run disposition issue drift")
+    _require(disposition.get("last_updated_on") == "2026-08-04", "run disposition update date drift")
     _require(disposition.get("run_config_sha256") == sha256_file(CONFIG_PATH), "run disposition config drift")
     _require(disposition.get("status") == "invalid_semantic_output", "run disposition status drift")
     _require(disposition.get("evaluation_valid") is False, "invalid run cannot be evaluation-valid")
@@ -197,7 +198,25 @@ def load_disposition(path: Path = DISPOSITION_PATH) -> dict[str, Any]:
         "retained artifact identity drift",
     )
     _require(retained.get("visibility") == "private", "invalid result repository must remain private")
+    _require(retained.get("visibility_changed_on") == "2026-08-04", "artifact visibility date drift")
     _require(retained.get("repository_deleted") is False, "invalid result repository must be retained")
+    for field in ("invalid_revision", "corrective_card_revision"):
+        _require(
+            re.fullmatch(r"[0-9a-f]{40}", str(retained.get(field, ""))) is not None,
+            f"retained artifact {field} is not a commit revision",
+        )
+    for field in ("package_sha256", "corrective_readme_sha256"):
+        _require(
+            re.fullmatch(r"[0-9a-f]{64}", str(retained.get(field, ""))) is not None,
+            f"retained artifact {field} is not a SHA-256",
+        )
+    for stage in ("canary", "full"):
+        stage_receipt = disposition.get(stage)
+        _require(isinstance(stage_receipt, dict), f"{stage} disposition receipt is missing")
+        _require(
+            re.fullmatch(r"[0-9a-f]{64}", str(stage_receipt.get("responses_sha256", ""))) is not None,
+            f"{stage} response evidence is not a SHA-256",
+        )
     visibility_receipt = retained.get("visibility_receipt")
     _require(isinstance(visibility_receipt, dict), "artifact visibility receipt is missing")
     _require(

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -180,7 +180,7 @@ def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:
 def load_disposition(path: Path = DISPOSITION_PATH) -> dict[str, Any]:
     disposition = read_json(path)
     _require(
-        disposition.get("schema_version") == "ua_open_weight_eval_run_disposition.v1",
+        disposition.get("schema_version") == "ua_open_weight_eval_run_disposition.v2",
         "run disposition schema drift",
     )
     _require(disposition.get("issue") == 6273, "run disposition issue drift")
@@ -189,6 +189,55 @@ def load_disposition(path: Path = DISPOSITION_PATH) -> dict[str, Any]:
     _require(disposition.get("evaluation_valid") is False, "invalid run cannot be evaluation-valid")
     _require(disposition.get("scoreable") is False, "invalid run cannot be scoreable")
     _require(disposition.get("rerun_authorized") is False, "incident correction cannot authorize a rerun")
+    retained = disposition.get("retained_artifact")
+    _require(isinstance(retained, dict), "retained artifact disposition is missing")
+    _require(
+        retained.get("repository") == "krisztiankoos/ua-open-weight-eval-results"
+        and retained.get("repository_type") == "huggingface_dataset",
+        "retained artifact identity drift",
+    )
+    _require(retained.get("visibility") == "private", "invalid result repository must remain private")
+    _require(retained.get("repository_deleted") is False, "invalid result repository must be retained")
+    visibility_receipt = retained.get("visibility_receipt")
+    _require(isinstance(visibility_receipt, dict), "artifact visibility receipt is missing")
+    _require(
+        visibility_receipt.get("authenticated_repo_info_private") is True
+        and visibility_receipt.get("anonymous_http_status") == 401
+        and visibility_receipt.get("content_revision_preserved") is True,
+        "private artifact retention is not verified",
+    )
+    transparency = disposition.get("public_transparency")
+    _require(isinstance(transparency, dict), "public incident evidence is missing")
+    _require(
+        transparency.get("incident_record")
+        == "https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/main/docs/projects/ua-open-weight-eval/HF_JOBS_BASELINE.md",
+        "public incident record drift",
+    )
+    _require(
+        set(transparency.get("retained_evidence", []))
+        == {
+            "invalid_revision",
+            "package_sha256",
+            "corrective_card_revision",
+            "corrective_readme_sha256",
+            "canary.responses_sha256",
+            "full.responses_sha256",
+        },
+        "public incident hash evidence drift",
+    )
+    policy = disposition.get("publication_policy")
+    _require(isinstance(policy, dict), "result publication policy is missing")
+    _require(
+        policy.get("scope") == "future_hugging_face_result_repositories"
+        and policy.get("required_gate") == "actual_saved_outputs_pass_source_aware_response_integrity"
+        and policy.get("required_verification_schema") == "ua_open_weight_eval_results_verification.v2",
+        "result publication semantic gate drift",
+    )
+    _require(
+        policy.get("failure_action")
+        == "keep result repository private and publish only the incident explanation and hashes on GitHub",
+        "result publication failure policy drift",
+    )
     return disposition
 
 
@@ -1228,7 +1277,15 @@ def verify_results_package(root: Path) -> dict[str, Any]:
     _require(report["scoring"]["global_quality_score"] is None, "global score must remain null")
     _require(report["scoring"]["global_score_prohibited"] is True, "global score policy drift")
     integrity = verify_response_integrity(root / "responses.jsonl")
+    _require(integrity["status"] == "passed", "response semantic validation did not pass")
     _require(integrity["checked_rows"] == 4000, "response integrity count drift")
+    for field in (
+        "violation_rows",
+        "copy_contract_violation_rows",
+        "reserved_marker_violation_rows",
+        "introduced_control_violation_rows",
+    ):
+        _require(integrity[field] == 0, f"response semantic validation has nonzero {field}")
     _require(len(report["tracks"]) == 14, "track count drift")
     responses = suite_cli.read_jsonl(root / "responses.jsonl")
     _require(len(responses) == 4001, "response completeness drift")
@@ -1244,8 +1301,10 @@ def verify_results_package(root: Path) -> dict[str, Any]:
         text = path.read_text(encoding="utf-8", errors="ignore")
         _require("/Users/" not in text and "HF_TOKEN=" not in text, f"private path or token leaked in {path.name}")
     return {
-        "schema_version": "ua_open_weight_eval_results_verification.v1",
+        "schema_version": "ua_open_weight_eval_results_verification.v2",
         "status": "passed",
+        "publication_eligible": True,
+        "semantic_validation": integrity,
         "files": len(PUBLIC_FILES),
         "responses": 4000,
         "tracks": 14,

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -93,6 +93,7 @@ def test_invalid_run_disposition_requires_private_retention_and_semantic_publica
     assert retained["visibility"] == "private"
     assert retained["repository_deleted"] is False
     assert retained["visibility_receipt"]["authenticated_repo_info_private"] is True
+    assert retained["visibility_receipt"]["anonymous_http_status"] == 401
     assert retained["visibility_receipt"]["content_revision_preserved"] is True
     assert disposition["public_transparency"]["incident_record"].startswith("https://github.com/")
     assert disposition["publication_policy"] == {
@@ -108,6 +109,12 @@ def test_invalid_run_disposition_requires_private_retention_and_semantic_publica
     drifted = tmp_path / "disposition.json"
     drifted.write_text(json.dumps(disposition), encoding="utf-8")
     with pytest.raises(hf_jobs_baseline.BaselineError, match="must remain private"):
+        hf_jobs_baseline.load_disposition(drifted)
+
+    hash_drift = hf_jobs_baseline.load_disposition()
+    hash_drift["full"]["responses_sha256"] = None
+    drifted.write_text(json.dumps(hash_drift), encoding="utf-8")
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="full response evidence is not a SHA-256"):
         hf_jobs_baseline.load_disposition(drifted)
 
 
@@ -937,7 +944,10 @@ def _complete_responses(config: dict) -> list[dict]:
     return rows
 
 
-def test_results_package_includes_complete_responses_but_not_private_generations(tmp_path: Path) -> None:
+def test_results_package_includes_complete_responses_but_not_private_generations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     config = hf_jobs_baseline.load_config()
     responses = tmp_path / "responses.jsonl"
     _write_jsonl(responses, _complete_responses(config))
@@ -1043,6 +1053,12 @@ def test_results_package_includes_complete_responses_but_not_private_generations
             output_dir=invalid_output,
         )
     assert not invalid_output.exists()
+
+    nonzero_integrity = {**result["semantic_validation"], "violation_rows": 1}
+    with monkeypatch.context() as scoped:
+        scoped.setattr(hf_jobs_baseline, "verify_response_integrity", lambda _: nonzero_integrity)
+        with pytest.raises(hf_jobs_baseline.BaselineError, match="nonzero violation_rows"):
+            hf_jobs_baseline.verify_results_package(output)
 
     (output / "report.json").write_text("{}\n", encoding="utf-8")
     with pytest.raises(

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -85,6 +85,32 @@ def test_config_freezes_official_qat_artifact_runtime_and_budget() -> None:
     }
 
 
+def test_invalid_run_disposition_requires_private_retention_and_semantic_publication_gate(
+    tmp_path: Path,
+) -> None:
+    disposition = hf_jobs_baseline.load_disposition()
+    retained = disposition["retained_artifact"]
+    assert retained["visibility"] == "private"
+    assert retained["repository_deleted"] is False
+    assert retained["visibility_receipt"]["authenticated_repo_info_private"] is True
+    assert retained["visibility_receipt"]["content_revision_preserved"] is True
+    assert disposition["public_transparency"]["incident_record"].startswith("https://github.com/")
+    assert disposition["publication_policy"] == {
+        "scope": "future_hugging_face_result_repositories",
+        "required_gate": "actual_saved_outputs_pass_source_aware_response_integrity",
+        "required_verification_schema": "ua_open_weight_eval_results_verification.v2",
+        "failure_action": (
+            "keep result repository private and publish only the incident explanation and hashes on GitHub"
+        ),
+    }
+
+    disposition["retained_artifact"]["visibility"] = "public"
+    drifted = tmp_path / "disposition.json"
+    drifted.write_text(json.dumps(disposition), encoding="utf-8")
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="must remain private"):
+        hf_jobs_baseline.load_disposition(drifted)
+
+
 def test_balanced_canary_is_deterministic_category_balanced_and_track_covering() -> None:
     config = hf_jobs_baseline.load_config()
     cases = suite_cli.read_jsonl(suite_cli.CASES_PATH)
@@ -972,6 +998,12 @@ def test_results_package_includes_complete_responses_but_not_private_generations
         output_dir=output,
     )
     assert result["status"] == "passed"
+    assert result["schema_version"] == "ua_open_weight_eval_results_verification.v2"
+    assert result["publication_eligible"] is True
+    assert result["semantic_validation"]["status"] == "passed"
+    assert result["semantic_validation"]["checked_rows"] == 4000
+    assert result["semantic_validation"]["violation_rows"] == 0
+    assert result["semantic_validation"]["responses_sha256"] == hf_jobs_baseline.sha256_file(responses)
     assert result["responses"] == 4000
     public_receipt = json.loads((output / "run_receipt.public.json").read_text(encoding="utf-8"))
     assert public_receipt["environment"]["launch_client"] == {


### PR DESCRIPTION
## Outcome

- made `krisztiankoos/ua-open-weight-eval-results` private without deleting the repository or changing revision `152e04defc7faecadfa994a9f8f07fea6c5adb0e`
- retained the public GitHub incident explanation and immutable hashes in the v2 disposition
- kept the frozen UA Open-Weight Eval v0.1.0 GitHub release public and byte-verified
- made result-package verification emit publication eligibility only after all 4,000 actual saved responses pass source-aware integrity with zero violations

## External receipts

- authenticated Hugging Face metadata: `private: true`, repository preserved, content revision unchanged
- anonymous Hugging Face request after the change: HTTP 401
- anonymous frozen-suite `SHA256SUMS` download: HTTP 200

## Verification

- `pytest tests/test_ua_open_weight_eval_hf_jobs.py -q`: 25 passed
- `suite_cli verify`: 4,000 cases; frozen cases hash `2164d7ba31322bf3cfbed8045ad3a5b6e759395175b2c1ab11172b9c0f1237db`
- Ruff check and format check: passed
- Python compilation: passed
- markdownlint-cli2 on four changed docs: 0 errors
- JSON parse, `git diff --check`, staged OPSEC lint, and X-Agent trailer lint: passed

## Review routing

- pre-commit Anthropic consultation failed before returning a review: `Reached maximum number of turns (1)`
- Gemini 3.6 Flash High substituted for panel input, inspected the exact diff, and reported no P0-P3 findings
- this panel input does not satisfy the independent formal PR review gate

Follow-up to #6318 and incident #6273.
