### PR TITLE
fix(routing): raise CodexBar refresh timeout to a realistic CLI floor

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -250,10 +250,13 @@ def _compute_review_routing_budget() -> dict[str, Any]:
         and agents[lane].get("status") in {"unknown", "unavailable"}
     )
     if unavailable:
-        # CodexBar provider probes can serialize internally. Retry missing
-        # lanes one at a time so they do not time out behind one another.
+        # Retry missing lanes one at a time rather than one more all-lane
+        # refresh. Uses the shared realistic timeout floor (25s default,
+        # CODEXBAR_REFRESH_TIMEOUT_S) — the prior 5.0s override was still
+        # shorter than the claude lane's live-measured ~17s CLI latency and
+        # reproduced the same false-'unavailable' misclassification.
         for lane in unavailable:
-            refresh_provider_usage_data((lane,), timeout_s=5.0)
+            refresh_provider_usage_data((lane,))
         # The retry populated this process's last-known-good cache; do not
         # launch a second all-provider refresh while projecting it.
         budget = compute_routing_budget(fresh_codexbar=False)

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -6,6 +6,7 @@ Provides background-threaded asynchronous caching of provider dashboard metrics.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import threading
 import time
@@ -19,6 +20,21 @@ from scripts.api.state_helpers import cache_get_with_age, cache_set
 WEEKLY_WINDOW_MINUTES = 10080
 # Reject monthly/long windows when no exact weekly window exists (e.g. 43200 min).
 WEEKLY_WINDOW_TOLERANCE_MINUTES = 5040
+
+# Live-measured 2026-08-04: `codexbar usage --json --provider claude` took
+# ~17s end-to-end twice in a row (its own dashboard-fetch latency, not a
+# hang) while codex returned in ~2s. The prior 2.0s refresh timeout
+# guaranteed a false 'unavailable' classification for the claude lane on
+# every fresh-refresh call — Monitor/routing then painted a healthy lane as
+# capacity-unknown (routing-budget false-red). This floor covers both
+# refresh_provider_usage_data() callers: the explicit fresh-refresh path
+# (state_router.compute_routing_budget(fresh_codexbar=True)) and the
+# background refresh thread (trigger_background_refresh). Neither blocks an
+# HTTP response thread past its own asyncio.to_thread call, so there is no
+# reason for the background path to run a shorter, more failure-prone
+# timeout than the explicit one — the prior 2.0s/5.0s split was itself the
+# bug, not a deliberate tradeoff.
+DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S = 25.0
 
 PROVIDER_TO_LANE = {
     "codex": "codex",
@@ -97,13 +113,38 @@ def _with_observation_metadata(
     return result
 
 
-def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 2.0) -> dict[str, dict[str, Any]]:
+def _codexbar_refresh_timeout_s() -> float:
+    """Per-provider CLI timeout floor for a blocking CodexBar refresh.
+
+    Override via CODEXBAR_REFRESH_TIMEOUT_S (e.g. a slower box, or CI).
+    Read fresh on every call so tests can monkeypatch the env var per-case.
+    """
+    raw = os.environ.get("CODEXBAR_REFRESH_TIMEOUT_S")
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            value = None
+        if value is not None and value > 0:
+            return value
+    return DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S
+
+
+def refresh_provider_usage_data(
+    providers: Iterable[str], *, timeout_s: float | None = None
+) -> dict[str, dict[str, Any]]:
     """Synchronously refresh selected providers in parallel for an explicit caller.
 
     The regular API path intentionally remains cache-only and non-blocking. This
     helper is reserved for callers, such as the dispatch budget guard, which
     explicitly need a bounded fresh verdict before acting.
+
+    timeout_s defaults to _codexbar_refresh_timeout_s() (CODEXBAR_REFRESH_TIMEOUT_S,
+    25.0s) — a real CLI call, not a hang. Callers should only override this when
+    they have their own measured reason to.
     """
+    if timeout_s is None:
+        timeout_s = _codexbar_refresh_timeout_s()
     unique_providers = tuple(dict.fromkeys(providers))
     if not unique_providers:
         return {}
@@ -543,8 +584,12 @@ def trigger_background_refresh() -> None:
 def _run_all_refreshes() -> None:
     # The background path must not serially spend six long CLI timeouts. Its
     # bounded probes are parallel and failed probes cannot poison LKG data.
+    # Runs on a daemon thread, so it does not block any HTTP response —
+    # it shares the same realistic timeout floor as the explicit fresh-refresh
+    # path (see _codexbar_refresh_timeout_s) rather than the prior 2.0s, which
+    # never let the claude lane's ~17s CLI probe complete.
     providers = ["claude", "codex", "cursor", "gemini", "grok", "kimi"]
-    refresh_provider_usage_data(providers, timeout_s=2.0)
+    refresh_provider_usage_data(providers)
 
 
 def get_provider_usage_data(provider: str) -> dict[str, Any]:

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -351,12 +351,13 @@ def test_review_routing_budget_requires_fresh_codexbar(monkeypatch) -> None:
     monkeypatch.setattr(
         codexbar_usage,
         "refresh_provider_usage_data",
-        lambda providers, *, timeout_s: refreshed.append((tuple(providers), timeout_s)) or {},
+        lambda providers, *, timeout_s=None: refreshed.append((tuple(providers), timeout_s)) or {},
     )
 
     assert review_pr._compute_review_routing_budget()["agents"]["kimi"]["status"] == "cool"
     assert observed == [True, False]
-    assert refreshed == [(('kimi',), 5.0)]
+    # Production uses the shared floor (25s default / env) — no hard-coded 5.0s override.
+    assert refreshed == [(("kimi",), None)]
 
 
 def test_build_review_pr_prompt_has_contract_and_cap() -> None:

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -879,3 +879,89 @@ def test_cache_miss_starts_background_refresh_without_waiting(monkeypatch):
     assert entered.wait(timeout=0.5)
     assert elapsed < 0.2
     assert result["freshness"] == "unavailable"
+
+
+def test_default_refresh_timeout_floor_matches_real_cli_latency(monkeypatch):
+    """Regression: the prior 2.0s default never let the claude lane's CLI
+    probe complete (live-measured 2026-08-04: `codexbar usage --json
+    --provider claude` took ~17s twice in a row, its own dashboard-fetch
+    latency, not a hang), which painted a healthy lane as capacity-unavailable
+    — the routing-budget false-red this dispatch fixes."""
+    monkeypatch.delenv("CODEXBAR_REFRESH_TIMEOUT_S", raising=False)
+    assert (
+        codexbar_usage_mod._codexbar_refresh_timeout_s()
+        == codexbar_usage_mod.DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S
+    )
+    # Comfortable margin above the live-measured ~17s worst case.
+    assert codexbar_usage_mod.DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S >= 20.0
+
+
+def test_refresh_timeout_env_override(monkeypatch):
+    """CODEXBAR_REFRESH_TIMEOUT_S lets a slower box or CI raise/lower the floor."""
+    monkeypatch.setenv("CODEXBAR_REFRESH_TIMEOUT_S", "9.5")
+    assert codexbar_usage_mod._codexbar_refresh_timeout_s() == 9.5
+
+    # Malformed or non-positive overrides fall back to the safe default
+    # rather than passing a bad value to subprocess.run(timeout=...).
+    monkeypatch.setenv("CODEXBAR_REFRESH_TIMEOUT_S", "not-a-number")
+    assert (
+        codexbar_usage_mod._codexbar_refresh_timeout_s()
+        == codexbar_usage_mod.DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S
+    )
+
+    monkeypatch.setenv("CODEXBAR_REFRESH_TIMEOUT_S", "-5")
+    assert (
+        codexbar_usage_mod._codexbar_refresh_timeout_s()
+        == codexbar_usage_mod.DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S
+    )
+
+
+def test_refresh_provider_usage_data_defaults_to_realistic_timeout(monkeypatch):
+    """The blocking fresh-refresh path (state_router fresh_codexbar=True) must
+    pass the realistic default down to the CLI subprocess timeout, not the
+    prior 2.0s that starved slow lanes like claude."""
+    monkeypatch.delenv("CODEXBAR_REFRESH_TIMEOUT_S", raising=False)
+    seen_timeouts = []
+
+    def fake_fetch(provider, *, timeout_s):
+        seen_timeouts.append(timeout_s)
+        return _normalize_provider_data(provider, json.loads(CODEX_FIXTURE)[0])
+
+    monkeypatch.setattr(codexbar_usage_mod, "fetch_codexbar_usage", fake_fetch)
+    codexbar_usage_mod.refresh_provider_usage_data(["codex"])
+    assert seen_timeouts == [codexbar_usage_mod.DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S]
+
+
+def test_background_refresh_no_longer_hardcodes_two_second_timeout(monkeypatch):
+    """_run_all_refreshes previously hardcoded timeout_s=2.0 directly, even
+    though it runs on a non-blocking daemon thread with no reason to use a
+    shorter timeout than the explicit fresh-refresh path."""
+    captured = {}
+
+    def fake_refresh(providers, *, timeout_s=None):
+        captured["timeout_s"] = timeout_s
+        captured["providers"] = tuple(providers)
+        return {}
+
+    monkeypatch.setattr(codexbar_usage_mod, "refresh_provider_usage_data", fake_refresh)
+    codexbar_usage_mod._run_all_refreshes()
+    # No override passed -> refresh_provider_usage_data resolves the shared
+    # realistic default itself, instead of the caller hardcoding 2.0.
+    assert captured["timeout_s"] is None
+    assert "claude" in captured["providers"]
+
+
+def test_timeout_failure_kind_maps_to_fail_open_reviewer_status():
+    """Ties this fix to the existing fail-open classification (reviewer_resolver
+    operator note 2026-08-03: 'red probe must not ban CF lanes'): a CLI timeout
+    must produce status='unavailable', which reviewer_resolver treats as missing
+    evidence, never as a dead/unhealthy lane."""
+    from scripts.review.reviewer_resolver import _HEALTH_ALIASES
+
+    timeout_result = codexbar_usage_mod._normalize_provider_error(
+        "claude",
+        {"kind": "timeout", "code": "TIMEOUT", "message": "CodexBar CLI timed out after 25.0s"},
+    )
+    assert timeout_result["status"] == "unavailable"
+    assert timeout_result["error_kind"] == "timeout"
+    assert _HEALTH_ALIASES[timeout_result["status"]] is None  # fail-open, not "unhealthy"


### PR DESCRIPTION
## Problem
`refresh_provider_usage_data(..., timeout_s=2.0)` (and its callers' hardcoded 2.0s/5.0s overrides) timed out under real CLI latency — live-measured 2026-08-04, `codexbar usage --json --provider claude` took ~17s end-to-end twice in a row (dashboard-fetch latency, not a hang) while codex returned in ~2s. The 2s cap guaranteed the claude lane was classified `unavailable` on every fresh-refresh call, painting a healthy lane as capacity-unknown — the Monitor/routing-budget false-red this fixes. No existing issue matched; related to the open infra epic #4707.

## Fix
- Raise the refresh timeout to a realistic, env-overridable floor: `DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S = 25.0`, override via `CODEXBAR_REFRESH_TIMEOUT_S`.
- `refresh_provider_usage_data()` now resolves this default itself (`timeout_s: float | None = None`) instead of baking in `2.0`.
- Both callers that previously hardcoded a shorter timeout now just inherit the shared default: the background thread (`_run_all_refreshes`, was `2.0`) and `_review_pr.py`'s per-lane retry (was `5.0`). Neither call blocks an HTTP response thread past its own `asyncio.to_thread` call, so there was no reason for either to run a shorter, more failure-prone timeout than the explicit fresh-refresh path — the prior split was the bug, not a deliberate tradeoff.
- `reviewer_resolver.py` already fail-opens an `unavailable` CodexBar status (operator note 2026-08-03: "red probe must not ban CF lanes") rather than treating it as a dead/unhealthy lane — so a timeout was never hard-red at the reviewer-routing layer, only at the CLI-probe layer. Added a regression test tying the two together end-to-end.

## Tests
5 new cases in `tests/test_codexbar_usage.py`:
- default timeout floor (`_codexbar_refresh_timeout_s()` == 25.0, comfortably above the live-measured ~17s worst case)
- `CODEXBAR_REFRESH_TIMEOUT_S` env override (valid / malformed / non-positive → falls back safely)
- `refresh_provider_usage_data()` passes the resolved default down to the CLI subprocess timeout
- `_run_all_refreshes()` no longer hardcodes `2.0`
- a `timeout`-kind failure's `status='unavailable'` maps through reviewer_resolver's `_HEALTH_ALIASES` to fail-open (`None`), never `"unhealthy"`

```
$ LEARN_UK_REPO_ROOT=<primary-checkout> .venv/bin/python -m pytest tests/test_codexbar_usage.py tests/test_review_reviewer_resolver.py tests/api/test_routing_budget_endpoint.py -q
94 passed in 0.92s
```
(`LEARN_UK_REPO_ROOT` points pytest collection at a full checkout for `curriculum.yaml`, which this sparse dispatch worktree doesn't carry — unrelated to this change; confirmed the same import error exists on `git stash`.)

`.venv/bin/ruff check scripts/api/codexbar_usage.py scripts/ai_agent_bridge/_review_pr.py tests/test_codexbar_usage.py` → all checks passed.

X-Agent: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)