### PR TITLE
fix(practice): preserve relation density and school POS

### DIFF
--- a/docs/practice/density-anti-collapse.md
+++ b/docs/practice/density-anti-collapse.md
@@ -1,0 +1,41 @@
+# Practice density anti-collapse policy (#6338)
+
+Practice density means faithfully carrying approved distinctions through the
+learner-visible deck. It does not mean increasing a count by merging categories,
+inventing a lexeme, or weakening an exercise gate.
+
+## Closed school categories stay separate
+
+The POS classify and POS-comparable option path use one shared closed mapping:
+іменник, прикметник, числівник, займенник, дієслово, прислівник, прийменник,
+сполучник, частка, and вигук. `preposition`, `conjunction`, and `particle`
+remain three separate buckets. No `function` bucket or «службове слово» answer
+may replace them for convenience.
+
+The mapping accepts deliberate source aliases and fails closed on ambiguous or
+unknown multi-POS signals. It is not a licence to turn every manifest label
+into a school category. `phrase` remains an explicit homogeneous-option
+contract for sourced identity clozes, never a POS classify answer.
+
+## Relation coverage is measured at emission
+
+An approved relation pair counts only after both legs survive Atlas and
+practice-admission checks, an authored frame validates, and the public item
+passes the production builder. Use the named relation residual ledger for
+antonym and homonym gaps, and the paronym residual audit for paronym gaps.
+Do not fill a residual by inventing a lexeme, assigning CEFR without evidence,
+or accepting a malformed frame.
+
+Synonym availability is separately floored at B1 by default; A1/A2 absence
+under that rule is a named placement residual, not evidence that the approved
+pair was silently discarded. The only A2 route is the existing curator-backed
+both-leg-A2 exception; there is no A1 exception.
+
+## Change checklist
+
+- Use the shared POS mapping; retain all ten school labels separately.
+- Keep an unknown or multi-POS source out of same-POS distractor selection.
+- Preserve existing source, VESUM, admission, frame, and option validators.
+- Produce a named residual ledger before claiming a curated relation is absent.
+- Report actual emitted items separately from approved, selected, and
+  floor-delayed pairs.

--- a/docs/practice/relation-residual-taxonomy.md
+++ b/docs/practice/relation-residual-taxonomy.md
@@ -62,7 +62,7 @@ review without changing the deck:
 
 ```bash
 .venv/bin/python -m scripts.audit.generate_practice_deck \
-  --nominate-a2-synonyms --atlas-db <atlas-db> \
+  --nominate-a2 --atlas-db <atlas-db> \
   --vesum-db <vesum-db> --synonym-verdicts <synonym-verdicts>
 ```
 

--- a/docs/practice/relation-residual-taxonomy.md
+++ b/docs/practice/relation-residual-taxonomy.md
@@ -1,0 +1,71 @@
+# Antonym and homonym residual taxonomy (#6338)
+
+Curated antonym and homonym pairs are not coverage merely because they occur
+in a YAML file. A pair is emitted only when both source legs, its authored
+frame, and its resulting item satisfy the production builder. The audit below
+uses that same selector and builder; it does not create lexemes, assign CEFR,
+or relax a frame to improve a count.
+
+```bash
+.venv/bin/python -m scripts.audit.relation_residual_audit \
+  --relation antonym --vesum-db <vesum-db> --out <antonym-residual.json>
+.venv/bin/python -m scripts.audit.relation_residual_audit \
+  --relation homonym --vesum-db <vesum-db> --out <homonym-residual.json>
+```
+
+The `summary` is a stable count view. The optional `--out` file is the named
+per-pair ledger used to decide follow-up work; it is local evidence and must
+not be committed as a generated practice artifact.
+
+## Pair outcomes
+
+| Outcome | Meaning | Honest next action |
+| --- | --- | --- |
+| `pair_invalid` | Required pair fields, citations, or frames are malformed. | Repair the curated source record with evidence. |
+| `no_valid_frames` | The pair has no frame that passes the production frame validator. | Author or review a source-backed frame; do not emit a bare pair. |
+| `missing_leg` | At least one leg cannot enter the selected practice pool. | Read its leg status; never invent or force-admit it. |
+| `frame_answer_unresolved` | Both legs were selected, but no generated frame item survived production validation. | Correct the authored frame or its source evidence. |
+| `emitted` | At least one public item passed the same builder and validators as a deck build. | Count it as actual emitted coverage. |
+
+## Leg statuses
+
+`missing_leg` carries `legA` and `legB`, so a follow-up can distinguish these
+causes instead of treating all missing pairs as one opaque number:
+
+| Status | Meaning | Boundary |
+| --- | --- | --- |
+| `missing_from_atlas` | No matching Atlas entry exists. | Atlas intake, not practice generation. |
+| `not_lexeme_entry` | The matched Atlas row is not an eligible lexeme record. | Preserve the record type; do not coerce it to a lexeme. |
+| `ineligible` | The entry failed an existing practice-admission gate. The report keeps its exact `reason`. | Resolve the cited gate with source evidence; do not flip admission. |
+| `eligible_not_selected` | The row is eligible but absent from this selected pool. | Inspect pool configuration and priority evidence. |
+| `selected` | The leg reached the pool. `cefr_status` says `anchored` or `uses_b1_fallback`. | Continue to the frame/item outcome; do not call this emitted coverage. |
+
+`uses_b1_fallback` is a named CEFR residual. It records the existing curated
+relation fallback rather than silently presenting an unanchored leg as a
+curriculum placement. A missing curriculum anchor remains an `ineligible`
+reason when the admission gate rejects it.
+
+## Synonym placement residual
+
+The synonym mode has a separate, intentional placement floor. An approved
+synonym pair is not an A1 card, and it is B1+ by default even if both legs are
+already present at A1 or A2. This is a delivery policy for meaning-sensitive
+contrast, not a failed relation emission.
+
+The named residual is therefore `below_b1_floor`: the pair is approved and
+otherwise buildable, but is unavailable in A1/A2 because its availability is
+floored at B1. It must not be counted as a missing pair or as an A1/A2
+generation defect. A pair may move only to A2 when both legs are A2 and the
+curated verdict has a valid `a2Exception: true` plus curator. A1 remains
+outside that exception path. The nomination command reports candidates for
+review without changing the deck:
+
+```bash
+.venv/bin/python -m scripts.audit.generate_practice_deck \
+  --nominate-a2-synonyms --atlas-db <atlas-db> \
+  --vesum-db <vesum-db> --synonym-verdicts <synonym-verdicts>
+```
+
+An invalid exception flag drops only the exception and keeps the approved pair
+at the B1+ floor. That is fail-closed placement, not a reason to lower the
+floor or manufacture A1/A2 cards.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1099,6 +1099,9 @@ def _eligible_decoys(
     number: str,
 ) -> list[tuple[dict[str, Any], str]]:
     answer_head = _headword(answer["gloss"])
+    answer_bucket = _option_pos_bucket(answer.get("pos"))
+    if not answer_bucket:
+        return []
     candidates: list[tuple[dict[str, Any], str]] = []
     for lexeme in lexemes:
         if lexeme["lemmaId"] == answer["lemmaId"]:
@@ -1107,7 +1110,7 @@ def _eligible_decoys(
         # level-bounded cloze option set without inventing a placement.
         if not lexeme.get("cefr") or not answer.get("cefr"):
             continue
-        if lexeme.get("pos") != answer.get("pos"):
+        if _option_pos_bucket(lexeme.get("pos")) != answer_bucket:
             continue
         if CEFR_RANK[lexeme["cefr"]] > CEFR_RANK[answer["cefr"]]:
             continue
@@ -1122,40 +1125,20 @@ def _eligible_decoys(
 
 
 def _option_pos_bucket(pos: Any) -> str:
-    """Map manifest POS variants into a safe option-comparison bucket."""
-    value = _clean_text(pos)
-    if not value:
-        return ""
-    normalized = value.casefold()
-    # The hydrated manifest uses these standard shorthand/form labels for
-    # lexical categories already represented by the broader buckets below.
-    # Keep this list deliberately narrow: semantic labels such as
-    # ``predicative`` and ``sequence word`` remain separate until their
-    # exercise contract is reviewed.
-    if normalized in {
-        "imperative",
-        "infinitive",
-    }:
-        return "verb"
-    if normalized == "intj":
-        return "interjection"
-    if normalized == "numr":
-        return "numeral"
-    if "pronoun" in normalized or normalized in {"pron", "negative pronoun"}:
-        return "pronoun"
-    if "adverb" in normalized or normalized == "adv":
-        return "adverb"
-    if "noun" in normalized or normalized in {"propn", "proper noun"}:
-        return "noun"
-    if "verb" in normalized or normalized in {"passive", "participle", "gerund"}:
-        return "verb"
-    if "adject" in normalized or normalized in {"adj", "adjective"}:
-        return "adjective"
-    if "numeral" in normalized or normalized in {"num", "number"}:
-        return "numeral"
-    if normalized in {"preposition", "prep", "conjunction", "conj", "particle", "part"}:
-        return "function"
-    return normalized
+    """Return one closed school-POS bucket suitable for a cloze option set.
+
+    Classify and distractor selection intentionally share ``_POS_BUCKET_ALIASES``:
+    there are ten school categories, not an eleventh ``function`` catch-all.
+    Ambiguous and unknown signals cannot safely seed a same-POS option set.
+    ``phrase`` is the one explicit non-school option contract; it remains
+    separate from the ten school categories and can never become a classify
+    answer.
+    """
+    buckets = _normalize_pos_buckets(pos)
+    if len(buckets) == 1:
+        return buckets[0]
+    text = _clean_text(pos)
+    return text.casefold() if text and text.casefold() in _OPTION_ONLY_POS_BUCKETS else ""
 
 
 def _eligible_dictionary_decoys(
@@ -1172,6 +1155,8 @@ def _eligible_dictionary_decoys(
     lemma.
     """
     answer_bucket = _option_pos_bucket(answer.get("pos"))
+    if not answer_bucket:
+        return []
     answer_head = _headword(answer["gloss"])
     answer_label = _plain(answer["lemma"])
     candidates: list[tuple[dict[str, Any], str]] = []
@@ -1240,7 +1225,7 @@ def _option(
         "lemmaId": lemma_id,
         "kind": kind,
         "case": case_name,
-        "pos": pos or "",
+        "pos": _option_pos_bucket(pos),
     }
 
 
@@ -1540,10 +1525,13 @@ def validate_option_set(cloze: dict[str, Any]) -> list[str]:
     if blank_case != "nominative" and (oblique_count < 2 or oblique_distractor_count < 1):
         errors.append("option set must contain at least two oblique-looking forms")
     pos_values = {
-        str(option.get("pos") or "")
+        _option_pos_bucket(option.get("pos"))
         for option in options
-        if isinstance(option, dict) and option.get("pos")
+        if isinstance(option, dict) and "pos" in option
     }
+    if "" in pos_values:
+        errors.append("option set contains an unknown or multi-POS category")
+        pos_values.discard("")
     if len(pos_values) > 1:
         errors.append("option set must stay within one POS bucket")
     root_counts: dict[str, int] = {}
@@ -1863,10 +1851,10 @@ def _morph_labels(morphology: dict[str, Any]) -> list[str]:
 
 
 _POS_BUCKET_ALIASES: dict[str, tuple[str, ...]] = {
-    "noun": ("іменник", "noun", "abbreviation", "proper noun", "plural noun"),
+    "noun": ("іменник", "noun", "abbreviation", "proper noun", "plural noun", "propn"),
     "adjective": ("прикметник", "adj", "adjective"),
-    "numeral": ("числівник", "num", "numr", "numeral"),
-    "pronoun": ("займенник", "pronoun", "pron"),
+    "numeral": ("числівник", "num", "numr", "numeral", "number"),
+    "pronoun": ("займенник", "pronoun", "pron", "negative pronoun"),
     "verb": ("дієслово", "verb", "infinitive", "imperative"),
     "adverb": ("прислівник", "присл", "adv", "adverb"),
     "preposition": (
@@ -1888,6 +1876,12 @@ _POS_BUCKET_ALIASES: dict[str, tuple[str, ...]] = {
     ),
     "interjection": ("вигук", "interjection", "interj", "intj"),
 }
+
+# A phrase is not a school POS and must never appear as a classify answer.  It
+# is, however, an established homogeneous-option contract for sourced
+# identity clozes.  Keep it explicit rather than smuggling arbitrary unknown
+# labels into the school taxonomy.
+_OPTION_ONLY_POS_BUCKETS = frozenset({"phrase"})
 
 
 def _normalize_pos_buckets(value: Any) -> list[str]:
@@ -4237,8 +4231,8 @@ def build_practice_shards(
             continue
         slug_a = _clean_text(pair.get("slugA"))
         slug_b = _clean_text(pair.get("slugB"))
-        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a)
-        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b)
+        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a) or by_plain_lemma.get(_plain(slug_a))
+        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b) or by_plain_lemma.get(_plain(slug_b))
         if not lex_a or not lex_b:
             print(
                 f"WARN: antonym_pair[{index}] {slug_a}/{slug_b} not in practice lexemes; emitted 0 items",
@@ -4297,8 +4291,8 @@ def build_practice_shards(
             continue
         slug_a = _clean_text(pair.get("slugA"))
         slug_b = _clean_text(pair.get("slugB"))
-        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a)
-        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b)
+        lex_a = slug_to_lex.get(slug_a) or lexemes_by_id.get(slug_a) or by_plain_lemma.get(_plain(slug_a))
+        lex_b = slug_to_lex.get(slug_b) or lexemes_by_id.get(slug_b) or by_plain_lemma.get(_plain(slug_b))
         if not lex_a or not lex_b:
             print(
                 f"WARN: homonym_pair[{index}] {slug_a}/{slug_b} not in practice lexemes; emitted 0 items",

--- a/scripts/audit/relation_residual_audit.py
+++ b/scripts/audit/relation_residual_audit.py
@@ -1,0 +1,215 @@
+"""Explain curated antonym or homonym practice residuals (#6338).
+
+The audit imports the production selector, validators, frame filters, and item
+builders. It therefore measures the same candidate pool and emit gate as a
+real practice build; it never invents a lexeme or a CEFR placement to improve
+coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit.generate_practice_deck import (
+    BuildConfig,
+    RealVesumVerifier,
+    _build_antonym_items,
+    _build_homonym_items,
+    _clean_text,
+    _plain,
+    _practice_priority_keys,
+    _select_practice_lexemes,
+    _strip_antonym_option_metadata,
+    _strip_homonym_option_metadata,
+    _valid_antonym_frames,
+    _valid_homonym_frames,
+    read_antonym_pairs,
+    read_atlas_db,
+    read_homonym_pairs,
+    validate_antonym_item,
+    validate_antonym_pair,
+    validate_homonym_item,
+    validate_homonym_pair,
+)
+from scripts.audit.lexeme_filter import is_lexeme_entry, practice_ineligibility_reason
+
+RelationBuilder = Callable[..., list[dict[str, Any]]]
+RelationValidator = Callable[[dict[str, Any]], list[str]]
+FrameSelector = Callable[[dict[str, Any]], list[dict[str, Any]]]
+
+
+def _relation_parts(
+    relation: str,
+) -> tuple[Callable[[Path], list[dict[str, Any]]], RelationValidator, FrameSelector, RelationBuilder, Callable[[dict[str, Any]], dict[str, Any]], Callable[[dict[str, Any], bool], list[str]]]:
+    if relation == "antonym":
+        return (
+            read_antonym_pairs,
+            validate_antonym_pair,
+            _valid_antonym_frames,
+            _build_antonym_items,
+            _strip_antonym_option_metadata,
+            lambda item, internal: validate_antonym_item(item, internal_options=internal),
+        )
+    return (
+        read_homonym_pairs,
+        validate_homonym_pair,
+        _valid_homonym_frames,
+        _build_homonym_items,
+        _strip_homonym_option_metadata,
+        lambda item, internal: validate_homonym_item(item, internal_options=internal),
+    )
+
+
+def _entry_lookup(entries: list[dict[str, Any]]) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    by_plain: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        for key in (_clean_text(entry.get("url_slug")), _clean_text(entry.get("lemma"))):
+            if key:
+                by_key.setdefault(key, entry)
+                by_plain.setdefault(_plain(key), entry)
+    return by_key, by_plain
+
+
+def _leg_status(
+    slug: str,
+    entry_by_key: dict[str, dict[str, Any]],
+    entry_by_plain: dict[str, dict[str, Any]],
+    lexemes_by_id: dict[str, dict[str, Any]],
+    by_plain_lemma: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    entry = entry_by_key.get(slug) or entry_by_plain.get(_plain(slug))
+    if entry is None:
+        return {"slug": slug, "status": "missing_from_atlas"}, None
+    if not is_lexeme_entry(entry):
+        return {"slug": slug, "status": "not_lexeme_entry"}, None
+    if reason := practice_ineligibility_reason(entry):
+        return {"slug": slug, "status": "ineligible", "reason": reason}, None
+    lexeme = lexemes_by_id.get(slug) or by_plain_lemma.get(_plain(slug))
+    if lexeme is None:
+        return {"slug": slug, "status": "eligible_not_selected"}, None
+    return {
+        "slug": slug,
+        "status": "selected",
+        "cefr": lexeme.get("cefr"),
+        "cefr_status": "anchored" if lexeme.get("cefr") else "uses_b1_fallback",
+    }, lexeme
+
+
+def classify_pairs(
+    relation: str,
+    pairs: list[dict[str, Any]],
+    entries: list[dict[str, Any]],
+    verifier: RealVesumVerifier,
+) -> list[dict[str, Any]]:
+    """Classify pair residuals through the production selection and item emitters."""
+    _reader, validator, frame_selector, builder, strip_options, item_validator = _relation_parts(relation)
+    priority_keys = _practice_priority_keys(
+        [],
+        None,
+        None,
+        None,
+        antonym_pairs=pairs if relation == "antonym" else None,
+        homonym_pairs=pairs if relation == "homonym" else None,
+    )
+    _by_entry, all_lexemes, by_plain_lemma, lexemes_by_id = _select_practice_lexemes(
+        entries, verifier, BuildConfig(), priority_keys
+    )
+    for lexeme in all_lexemes:
+        slug = _clean_text(lexeme.get("url_slug")) or _clean_text(lexeme.get("slug"))
+        if slug:
+            lexemes_by_id.setdefault(slug, lexeme)
+    entry_by_key, entry_by_plain = _entry_lookup(entries)
+
+    results: list[dict[str, Any]] = []
+    for index, pair in enumerate(pairs):
+        row: dict[str, Any] = {"index": index, "slugA": pair.get("slugA"), "slugB": pair.get("slugB")}
+        if errors := validator(pair):
+            row.update(outcome="pair_invalid", errors=errors)
+            results.append(row)
+            continue
+        if not frame_selector(pair):
+            row["outcome"] = "no_valid_frames"
+            results.append(row)
+            continue
+
+        slug_a = _clean_text(pair.get("slugA"))
+        slug_b = _clean_text(pair.get("slugB"))
+        leg_a, lex_a = _leg_status(slug_a, entry_by_key, entry_by_plain, lexemes_by_id, by_plain_lemma)
+        leg_b, lex_b = _leg_status(slug_b, entry_by_key, entry_by_plain, lexemes_by_id, by_plain_lemma)
+        row.update(legA=leg_a, legB=leg_b)
+        if not lex_a or not lex_b:
+            row["outcome"] = "missing_leg"
+            results.append(row)
+            continue
+
+        internal_items = builder(pair, lex_a, lex_b, "relation-residual-audit", verifier=verifier, public_options=False)
+        public_items = [strip_options(item) for item in internal_items]
+        valid_items = [
+            item
+            for internal, item in zip(internal_items, public_items, strict=True)
+            if not item_validator(internal, True) and not item_validator(item, False)
+        ]
+        if not valid_items:
+            row["outcome"] = "frame_answer_unresolved"
+        else:
+            row.update(outcome="emitted", emitted_items=len(valid_items))
+        results.append(row)
+    return results
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
+    outcome_counts = Counter(row["outcome"] for row in results)
+    leg_status_counts: Counter[str] = Counter()
+    ineligible_by_reason: Counter[str] = Counter()
+    cefr_status_counts: Counter[str] = Counter()
+    for row in results:
+        for leg_key in ("legA", "legB"):
+            leg = row.get(leg_key)
+            if not isinstance(leg, dict):
+                continue
+            leg_status_counts[str(leg["status"])] += 1
+            if leg["status"] == "ineligible":
+                ineligible_by_reason[str(leg.get("reason"))] += 1
+            if leg["status"] == "selected":
+                cefr_status_counts[str(leg["cefr_status"])] += 1
+    return {
+        "pairs_total": len(results),
+        "outcome_counts": dict(sorted(outcome_counts.items())),
+        "leg_status_counts": dict(sorted(leg_status_counts.items())),
+        "ineligible_by_reason": dict(sorted(ineligible_by_reason.items())),
+        "selected_cefr_status_counts": dict(sorted(cefr_status_counts.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--relation", choices=("antonym", "homonym"), required=True)
+    parser.add_argument("--atlas-db", type=Path, default=Path("data/atlas.db"))
+    parser.add_argument("--pairs", type=Path)
+    parser.add_argument("--vesum-db", type=Path, required=True)
+    parser.add_argument("--out", type=Path, help="Write full pair classifications here")
+    args = parser.parse_args(argv)
+
+    reader, *_rest = _relation_parts(args.relation)
+    pairs_path = args.pairs or Path(f"data/lexicon/{args.relation}_pairs.yaml")
+    results = classify_pairs(args.relation, reader(pairs_path), read_atlas_db(args.atlas_db), RealVesumVerifier(args.vesum_db))
+    summary = summarize(results)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if args.out:
+        args.out.write_text(json.dumps({"summary": summary, "pairs": results}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -2259,8 +2259,16 @@ def test_inventory_identity_decoys_render_normalized_lemmas_at_source_case() -> 
 @pytest.mark.parametrize(
     ("manifest_pos", "expected_bucket"),
     [
+        ("noun", "noun"),
+        ("adjective", "adjective"),
+        ("numeral", "numeral"),
+        ("pronoun", "pronoun"),
         ("infinitive", "verb"),
         ("imperative", "verb"),
+        ("adverb", "adverb"),
+        ("preposition", "preposition"),
+        ("conjunction", "conjunction"),
+        ("particle", "particle"),
         ("numr", "numeral"),
         ("intj", "interjection"),
     ],
@@ -2269,6 +2277,51 @@ def test_option_pos_bucket_normalizes_unambiguous_manifest_aliases(
     manifest_pos: str, expected_bucket: str
 ) -> None:
     assert generate_practice_deck._option_pos_bucket(manifest_pos) == expected_bucket
+
+
+def test_option_pos_bucket_uses_the_same_closed_school_set_as_classify() -> None:
+    assert {
+        generate_practice_deck._option_pos_bucket(alias)
+        for aliases in generate_practice_deck._POS_BUCKET_ALIASES.values()
+        for alias in aliases
+    } == set(generate_practice_deck.CLASSIFY_LABELS["pos"])
+    assert generate_practice_deck._option_pos_bucket("predicative") == ""
+    assert generate_practice_deck._option_pos_bucket("noun/verb") == ""
+
+
+def test_validate_option_set_rejects_unknown_or_multi_pos_option() -> None:
+    errors = validate_option_set(
+        {
+            "options": [
+                {"label": "один", "pos": "noun", "kind": "answer"},
+                {"label": "два", "pos": "noun/verb", "kind": "decoy"},
+                {"label": "три", "pos": "noun", "kind": "decoy"},
+                {"label": "чотири", "pos": "noun", "kind": "decoy"},
+            ]
+        }
+    )
+
+    assert "option set contains an unknown or multi-POS category" in errors
+
+
+def test_dictionary_decoys_do_not_mash_school_function_categories() -> None:
+    answer = {
+        "lemmaId": "bez",
+        "lemma": "без",
+        "gloss": "without",
+        "pos": "preposition",
+        "cefr": "A1",
+    }
+    lexemes = [
+        answer,
+        {"lemmaId": "do", "lemma": "до", "gloss": "to", "pos": "prep", "cefr": "A1"},
+        {"lemmaId": "i", "lemma": "і", "gloss": "and", "pos": "conjunction", "cefr": "A1"},
+        {"lemmaId": "ne", "lemma": "не", "gloss": "not", "pos": "particle", "cefr": "A1"},
+    ]
+
+    decoys = generate_practice_deck._eligible_dictionary_decoys(answer, lexemes)
+
+    assert [(lexeme["lemmaId"], label) for lexeme, label in decoys] == [("do", "до")]
 
 
 def test_sentence_inventory_identity_cloze_scales_across_levels_and_pos(

--- a/tests/test_relation_residual_audit.py
+++ b/tests/test_relation_residual_audit.py
@@ -1,0 +1,79 @@
+"""Regression tests for named antonym/homonym residual reporting (#6338)."""
+
+from __future__ import annotations
+
+from scripts.audit import relation_residual_audit as residual
+
+
+def test_leg_statuses_keep_atlas_and_selection_failures_distinct() -> None:
+    entries = [
+        {
+            "url_slug": "selected",
+            "lemma": "selected",
+            "gloss": "selected",
+            "enrichment": {"cefr": {"level": "A2"}},
+        },
+        {"url_slug": "not-lexeme", "lemma": "not-lexeme", "pos": "grammar term"},
+        {
+            "url_slug": "not-selected",
+            "lemma": "not-selected",
+            "gloss": "not selected",
+            "enrichment": {"cefr": {"level": "A2"}},
+        },
+    ]
+    entry_by_key, entry_by_plain = residual._entry_lookup(entries)
+    selected = {"selected": {"lemma": "selected", "cefr": "A2"}}
+
+    missing, _ = residual._leg_status(
+        "missing", entry_by_key, entry_by_plain, selected, selected
+    )
+    not_lexeme, _ = residual._leg_status(
+        "not-lexeme", entry_by_key, entry_by_plain, selected, selected
+    )
+    not_selected, _ = residual._leg_status(
+        "not-selected", entry_by_key, entry_by_plain, selected, selected
+    )
+    selected_leg, selected_lexeme = residual._leg_status(
+        "selected", entry_by_key, entry_by_plain, selected, selected
+    )
+
+    assert missing == {"slug": "missing", "status": "missing_from_atlas"}
+    assert not_lexeme == {"slug": "not-lexeme", "status": "not_lexeme_entry"}
+    assert not_selected == {"slug": "not-selected", "status": "eligible_not_selected"}
+    assert selected_leg == {
+        "slug": "selected",
+        "status": "selected",
+        "cefr": "A2",
+        "cefr_status": "anchored",
+    }
+    assert selected_lexeme == selected["selected"]
+
+
+def test_summarize_reports_named_frame_and_cefr_residuals() -> None:
+    summary = residual.summarize(
+        [
+            {"outcome": "missing_leg", "legA": {"status": "missing_from_atlas"}},
+            {
+                "outcome": "frame_answer_unresolved",
+                "legA": {"status": "selected", "cefr_status": "uses_b1_fallback"},
+                "legB": {"status": "ineligible", "reason": "missing_curriculum_anchor"},
+            },
+            {"outcome": "no_valid_frames"},
+        ]
+    )
+
+    assert summary == {
+        "pairs_total": 3,
+        "outcome_counts": {
+            "frame_answer_unresolved": 1,
+            "missing_leg": 1,
+            "no_valid_frames": 1,
+        },
+        "leg_status_counts": {
+            "ineligible": 1,
+            "missing_from_atlas": 1,
+            "selected": 1,
+        },
+        "ineligible_by_reason": {"missing_curriculum_anchor": 1},
+        "selected_cefr_status_counts": {"uses_b1_fallback": 1},
+    }


### PR DESCRIPTION
## What changed

- keeps all ten school POS categories distinct for practice-option selection, including separate preposition, conjunction, and particle buckets
- adds production-path antonym/homonym residual auditing and named residual documentation
- records the synonym B1 availability floor separately from failed pair emission

## Validation

- `.venv/bin/python -m pytest -q tests/test_generate_practice_deck.py tests/test_relation_residual_audit.py` (145 passed)
- `.venv/bin/python -m ruff check scripts/audit/generate_practice_deck.py scripts/audit/relation_residual_audit.py tests/test_generate_practice_deck.py tests/test_relation_residual_audit.py`
- `npx --no-install markdownlint-cli2 docs/practice/relation-residual-taxonomy.md docs/practice/density-anti-collapse.md`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main...HEAD`

## Cross-family input

AGY review identified and this branch fixes the fail-closed validation gap for normalized empty POS values. The requested `gemini-3.1-pro-high` route was unavailable because ACP binds AGY to `gemini-3.6-flash-high`; that registered fallback completed the read-only review.

Relates to #6338, #6132, and #4387.