### PR TITLE
fix(practice): cloze must not spoil dictionary-form answers

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b617e9a50a9eda2c5aac5b1c55365d578c4d727f74936cf402282c490270a03e
+  components_sha256: 3ea230c6f9a80d1649fb5f65d374860b2b2dc19d1383df48a0fb4b4e82f62bf0
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -4516,15 +4516,19 @@ function PracticeCloze({
   const [before, after] = clozeParts(cloze).map((part) => displayPracticeForm(part, learnerLevel));
   const caseDrill = isCaseClozeDrill(cloze, selection.lemma);
   const displayLemma = displayPracticeForm(selection.lemma.lemma, learnerLevel);
+  // Case drills name the dictionary form on purpose (inflect it).
+  // Non-case / dictionary-form inserts must NOT name the answer — that turns
+  // a real blank (e.g. textbook inventory with ___) into a giveaway.
   const clozePrompt = caseDrill
     ? {
       uk: `Поставте слово „${displayLemma}” у правильному відмінку.`,
       en: `Put the word „${displayLemma}” in the correct case.`,
     }
     : {
-      uk: `Вставте слово „${displayLemma}” у пропуск.`,
-      en: `Fill in the blank with the word „${displayLemma}”.`,
+      uk: 'Вставте пропущене слово.',
+      en: 'Fill in the missing word.',
     };
+
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2548,9 +2548,10 @@ describe('LexiconPractice', () => {
     render(<LexiconPractice initialDeck={indeclinableClozeDeck()} autoStart initialMode="cloze" />);
 
     const task = screen.getByTestId('practice-cloze').querySelector('.cz-task');
-    expect(task).toHaveTextContent('Fill in the blank with the word „згодом”.');
+    expect(task).toHaveTextContent('Fill in the missing word.');
+    expect(task).not.toHaveTextContent('згодом');
     expect(task).not.toHaveTextContent('correct case');
-    expect(screen.getByLabelText('Вставте слово „згодом” у пропуск.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Вставте пропущене слово.')).toBeInTheDocument();
   });
 
   test('cloze shows a usable sentence English before feedback for A1', () => {


### PR DESCRIPTION
## Summary

Non-case cloze tasks were saying **Fill in the blank with the word „старший”** while the sentence already had a real `___` blank. That turns textbook inventory into a giveaway.

- **Case drills** still name the lemma (“put *word* in the correct case”) — intentional.
- **Dictionary-form inserts** now use neutral copy: *Вставте пропущене слово.* / *Fill in the missing word.*

## Test plan

- [x] Unit: neutral prompt for form===lemma adverb cloze
- [ ] CI + cross-family CF

Refs #6338