### PR TITLE
fix(practice): A1–A2 use English learner glosses, not UK dictionary defs

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -634,6 +634,56 @@ def _is_english_learner_gloss(label: str) -> bool:
     return latin_letters > cyrillic_letters
 
 
+def _english_translation_gloss(entry: dict[str, Any]) -> str | None:
+    """First short English sense from enrichment.translation.en, if any."""
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return None
+    translation = enrichment.get("translation")
+    if not isinstance(translation, dict):
+        return None
+    en = translation.get("en")
+    candidates: list[str] = []
+    if isinstance(en, str):
+        candidates.append(en)
+    elif isinstance(en, list):
+        candidates.extend(str(item) for item in en if item)
+    cleaned: list[str] = []
+    for raw in candidates:
+        # Drop parenthetical dictionary expansions: "fairy tale (folktale)" → "fairy tale"
+        head = re.split(r"[;(]", raw, maxsplit=1)[0]
+        clean = _gloss_clean(head)
+        if clean and _is_english_learner_gloss(clean):
+            cleaned.append(clean)
+    if not cleaned:
+        return None
+    # Prefer short multi-word learner senses ("fairy tale") over a single academic
+    # first gloss ("fable") when both are offered.
+    multi = [
+        sense
+        for sense in cleaned
+        if 1 < _meaning_label_word_count(sense) <= 4 and not _meaning_label_is_phrase(sense)
+    ]
+    return multi[0] if multi else cleaned[0]
+
+
+def _practice_display_gloss(entry: dict[str, Any], level: str | None, fallback: str) -> str:
+    """Learner-facing gloss for flashcards / recognition.
+
+    A1 always prefers English scaffolding when available.
+    A1–A2 never keep a long Ukrainian dictionary definition when English exists —
+    Wiktionary-style «розповідний твір про вигаданих осіб…» is not an A2 gloss.
+    """
+    en = _english_translation_gloss(entry)
+    if not en:
+        return fallback
+    if level == "A1":
+        return en
+    if level in {"A1", "A2"} and not _is_english_learner_gloss(_gloss_clean(fallback)):
+        return en
+    return fallback
+
+
 def _romanize_ukrainian_plain(value: str) -> str:
     return "".join(_UKRAINIAN_ROMANIZATION.get(char, char) for char in value.casefold())
 
@@ -1574,10 +1624,11 @@ def validate_option_sets(cloze_items: list[dict[str, Any]]) -> list[str]:
 
 def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, Any] | None:
     lemma = _clean_text(entry.get("lemma"))
-    gloss = _clean_text(entry.get("gloss"))
+    raw_gloss = _clean_text(entry.get("gloss"))
     level = _cefr_level(entry)
-    if not lemma or not gloss:
+    if not lemma or not raw_gloss:
         return None
+    gloss = _practice_display_gloss(entry, level, raw_gloss)
     lemma_plain = _plain(lemma)
     pos = _clean_text(entry.get("pos"))
     gloss_clean = _gloss_clean(gloss)

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -650,8 +650,11 @@ def _english_translation_gloss(entry: dict[str, Any]) -> str | None:
         candidates.extend(str(item) for item in en if item)
     cleaned: list[str] = []
     for raw in candidates:
-        # Drop parenthetical dictionary expansions: "fairy tale (folktale)" → "fairy tale"
-        head = re.split(r"[;(]", raw, maxsplit=1)[0]
+        text = re.sub(r"\s+", " ", str(raw)).strip()
+        # Strip leading qualifiers: "(dated) fairy tale" → "fairy tale"
+        text = re.sub(r"^\([^)]*\)\s*", "", text).strip()
+        # Drop trailing dictionary expansions: "fairy tale (folktale)" → "fairy tale"
+        head = re.split(r"[;(]", text, maxsplit=1)[0]
         clean = _gloss_clean(head)
         if clean and _is_english_learner_gloss(clean):
             cleaned.append(clean)
@@ -679,7 +682,7 @@ def _practice_display_gloss(entry: dict[str, Any], level: str | None, fallback: 
         return fallback
     if level == "A1":
         return en
-    if level in {"A1", "A2"} and not _is_english_learner_gloss(_gloss_clean(fallback)):
+    if level == "A2" and not _is_english_learner_gloss(_gloss_clean(fallback)):
         return en
     return fallback
 

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1273,6 +1273,32 @@ def test_meaning_mc_eligibility_marks_clean_and_messy_glosses() -> None:
     assert index_items["borshch"]["modes"] == ["flashcards"]
 
 
+def test_a2_replaces_ukrainian_dictionary_gloss_with_english_translation() -> None:
+    """Wiktionary-style UK definitions are not A1/A2 learner glosses (e.g. «казка»)."""
+    verifier = JsonVesumVerifier({})
+    entry = {
+        "lemma": "казка",
+        "url_slug": "казка",
+        "gloss": "розповідний твір про вигаданих осіб і події, переважно за участю фантастичних сил",
+        "pos": "noun",
+        "primary_source": "atlas",
+        "cefr": "A2",
+        "enrichment": {
+            "translation": {
+                "en": [
+                    "fable (fictitious narration to enforce some useful truth or precept)",
+                    "fairy tale (folktale)",
+                ],
+                "source": "dmklinger",
+            }
+        },
+    }
+    lexeme = _build_lexeme(entry, verifier)
+    assert lexeme is not None
+    assert lexeme["glossClean"] == "fairy tale"
+    assert "розповідний" not in lexeme["gloss"]
+
+
 def test_meaning_mc_eligibility_requires_a_latin_majority_gloss() -> None:
     assert _meaning_mc_eligible("justice", "справедливість", "noun") is True
     assert _meaning_mc_eligible("сукупність прав", "право", "noun") is False

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1298,6 +1298,19 @@ def test_a2_replaces_ukrainian_dictionary_gloss_with_english_translation() -> No
     assert lexeme["glossClean"] == "fairy tale"
     assert "розповідний" not in lexeme["gloss"]
 
+    dated = {
+        **entry,
+        "enrichment": {
+            "translation": {
+                "en": ["(dated) fairy tale (folktale)"],
+                "source": "dmklinger",
+            }
+        },
+    }
+    dated_lexeme = _build_lexeme(dated, verifier)
+    assert dated_lexeme is not None
+    assert dated_lexeme["glossClean"] == "fairy tale"
+
 
 def test_meaning_mc_eligibility_requires_a_latin_majority_gloss() -> None:
     assert _meaning_mc_eligible("justice", "справедливість", "noun") is True


### PR DESCRIPTION
## Summary

A2 practice was showing dictionary Ukrainian definitions on cards (e.g. **казка** → *розповідний твір про вигаданих осіб і події…*). That is not an A1/A2 gloss.

- Prefer `enrichment.translation.en` for **A1** always when present.
- Prefer English for **A1–A2** when the primary gloss is not Latin-majority learner English (SUM/Wiktionary UA definitions).
- Prefer short multi-word English senses (`fairy tale`) over a lone academic first sense (`fable`).

Factory-only; live deck updates after next `generate_practice_deck` + publish.

## Test plan

- [x] Unit: A2 казка → `fairy tale`, no «розповідний»
- [x] Existing meaning-MC eligibility tests still pass

Refs #6338