### PR TITLE
fix(practice): no trivial identity cloze when focusing one lemma

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f7dd9af2f7d501e5c0a18075de7681125012c3314bed9d361c61d463db14f33b
+  components_sha256: 4cf2ae934787837493ea93e51b14ba3a25f38f45b1030a022073782837075700
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 3ea230c6f9a80d1649fb5f65d374860b2b2dc19d1383df48a0fb4b4e82f62bf0
+  components_sha256: f7dd9af2f7d501e5c0a18075de7681125012c3314bed9d361c61d463db14f33b
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1747,10 +1747,7 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     paradigm = _paradigm(entry)
     if not _verify_paradigm(lemma_plain, pos, paradigm, verifier):
         searched = _paradigm_from_vesum_lemma_search(lemma_plain, pos, verifier)
-        if _all_paradigm_forms(searched):
-            paradigm = searched
-        else:
-            paradigm = {"cases": {}}
+        paradigm = searched if _all_paradigm_forms(searched) else {"cases": {}}
     lexeme: dict[str, Any] = {
         "lemmaId": _stable_lemma_id(entry),
         "lemma": lemma,

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -831,6 +831,110 @@ def _paradigm(entry: dict[str, Any]) -> dict[str, Any]:
     return {"cases": clean_cases}
 
 
+def _vesum_form_preference(tags: str, pos: str | None) -> int:
+    """Higher is better when choosing one surface per case for practice drills."""
+    tokens = {tok for tok in tags.replace(":", " ").split() if tok}
+    score = 0
+    # Prefer short, positive, non-comparative dictionary rows.
+    if "long" in tokens:
+        score -= 20
+    if "compb" in tokens or "compr" in tokens or "super" in tokens:
+        score -= 5
+    if "bad" in tokens:
+        score -= 15
+    pos_key = (pos or "").casefold()
+    if pos_key in {"adj", "adjective"} or "adj" in tokens:
+        # Masculine singular is the default textbook drill gender for adjectives.
+        if "m" in tokens:
+            score += 8
+        if "f" in tokens:
+            score += 2
+        if "n" in tokens:
+            score += 1
+        if "p" in tokens or "pl" in tokens:
+            score -= 3
+    if "s" in tokens or "v_naz" in tokens:
+        score += 1
+    return score
+
+
+def _paradigm_from_vesum_lemma_search(
+    lemma_plain: str,
+    pos: str | None,
+    verifier: VesumVerifier,
+) -> dict[str, Any]:
+    """Build a practice paradigm by searching VESUM for all forms of the lemma.
+
+    Enrichment morphology is often empty on thin Atlas shells. VESUM still has
+    full inflection tables (e.g. новий → нового/новому/…). Search those rows so
+    lemma-focused cloze can ask for non-base cases instead of retyping the headword.
+    """
+    rows: list[dict[str, Any]] = []
+    if isinstance(verifier, RealVesumVerifier):
+        from scripts.verification.vesum import verify_lemma
+
+        for query in {lemma_plain, lemma_plain.casefold(), lemma_plain.lower()}:
+            if not query:
+                continue
+            found = verify_lemma(query, db_path=verifier.db_path)
+            if found:
+                rows = found
+                break
+    elif isinstance(verifier, JsonVesumVerifier):
+        # Fixture payloads are form→matches; invert to lemma search for tests.
+        want = lemma_plain.casefold()
+        pos_filter = _vesum_pos(pos)
+        for form, matches in verifier.payload.items():
+            if not isinstance(matches, list):
+                continue
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                if _plain(str(match.get("lemma") or "")) != want:
+                    continue
+                if pos_filter and match.get("pos") != pos_filter:
+                    continue
+                rows.append(
+                    {
+                        "word_form": form,
+                        "pos": match.get("pos"),
+                        "tags": match.get("tags") or "",
+                    }
+                )
+
+    if not rows:
+        return {"cases": {}}
+
+    pos_filter = _vesum_pos(pos)
+    # case_name -> best (score, form)
+    best: dict[str, tuple[int, str]] = {}
+    for row in rows:
+        form = _clean_text(row.get("word_form"))
+        tags = str(row.get("tags") or "")
+        row_pos = row.get("pos")
+        if not form:
+            continue
+        if pos_filter and row_pos and row_pos != pos_filter:
+            continue
+        tokens = {tok for tok in tags.replace(":", " ").split() if tok}
+        for case_name, tag in CASE_VESUM_TAGS.items():
+            if tag not in tokens:
+                continue
+            score = _vesum_form_preference(tags, pos)
+            prev = best.get(case_name)
+            if prev is None or score > prev[0] or (score == prev[0] and form < prev[1]):
+                best[case_name] = (score, form)
+
+    if not best:
+        return {"cases": {}}
+
+    cases: dict[str, dict[str, str]] = {}
+    for case_name, (_score, form) in best.items():
+        # Practice drills use singular by convention for these case chips.
+        cases[case_name] = {"singular": form}
+    return {"cases": cases}
+
+
 def _vesum_pos(pos: str | None) -> str | None:
     if not pos:
         return None
@@ -1637,11 +1741,16 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     gloss_clean = _gloss_clean(gloss)
     meaning_mc_eligible = _meaning_mc_eligible(gloss_clean, lemma_plain, pos)
     # Recognition (matching/choice/flashcard) needs only lemma+gloss, so an admitted
-    # word stays in the deck even when CEFR is unknown. Attach the paradigm for flashcard declensions ONLY when every form
-    # VESUM-verifies; otherwise blank it so the UI never displays an unverified declension.
+    # word stays in the deck even when CEFR is unknown. Prefer enrichment morphology;
+    # when that is missing/unverified, **search VESUM by lemma** for real non-base
+    # forms (новий→нового/новому/…) so focused cloze can drill declension.
     paradigm = _paradigm(entry)
     if not _verify_paradigm(lemma_plain, pos, paradigm, verifier):
-        paradigm = {"cases": {}}
+        searched = _paradigm_from_vesum_lemma_search(lemma_plain, pos, verifier)
+        if _all_paradigm_forms(searched):
+            paradigm = searched
+        else:
+            paradigm = {"cases": {}}
     lexeme: dict[str, Any] = {
         "lemmaId": _stable_lemma_id(entry),
         "lemma": lemma,

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -914,7 +914,7 @@ def _paradigm_from_vesum_lemma_search(
             for match in matches:
                 if not isinstance(match, dict):
                     continue
-                if _plain(str(match.get("lemma") or "")) != want:
+                if _plain(str(match.get("lemma") or "")).casefold() != want:
                     continue
                 if pos_filter and match.get("pos") != pos_filter:
                     continue

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -851,11 +851,28 @@ def _vesum_form_preference(tags: str, pos: str | None) -> int:
             score += 2
         if "n" in tokens:
             score += 1
-        if "p" in tokens or "pl" in tokens:
-            score -= 3
-    if "s" in tokens or "v_naz" in tokens:
-        score += 1
+    # Strong preference for true singular; plural-only lemmas still score lower.
+    if "s" in tokens and "p" not in tokens and "pl" not in tokens:
+        score += 12
+    if "p" in tokens or "pl" in tokens:
+        score -= 8
     return score
+
+
+def _vesum_number_key(tokens: set[str]) -> str | None:
+    """Return singular/plural from VESUM tags, or None when number is ambiguous."""
+    has_pl = "p" in tokens or "pl" in tokens
+    has_sg = "s" in tokens
+    if has_sg and not has_pl:
+        return "singular"
+    if has_pl and not has_sg:
+        return "plural"
+    # Many adj tags omit explicit s/p; treat as singular only when not plural-marked.
+    if has_pl:
+        return "plural"
+    if has_sg or not has_pl:
+        return "singular"
+    return None
 
 
 def _paradigm_from_vesum_lemma_search(
@@ -874,7 +891,8 @@ def _paradigm_from_vesum_lemma_search(
         from scripts.verification.vesum import verify_lemma
 
         try:
-            for query in {lemma_plain, lemma_plain.casefold(), lemma_plain.lower()}:
+            # Ordered de-dupe (set iteration is hash-randomized across processes).
+            for query in dict.fromkeys((lemma_plain, lemma_plain.casefold(), lemma_plain.lower())):
                 if not query:
                     continue
                 found = verify_lemma(query, db_path=verifier.db_path)
@@ -911,8 +929,8 @@ def _paradigm_from_vesum_lemma_search(
         return {"cases": {}}
 
     pos_filter = _vesum_pos(pos)
-    # case_name -> best (score, form)
-    best: dict[str, tuple[int, str]] = {}
+    # (case_name, number_key) -> best (score, form)
+    best: dict[tuple[str, str], tuple[int, str]] = {}
     for row in rows:
         form = _clean_text(row.get("word_form"))
         tags = str(row.get("tags") or "")
@@ -922,21 +940,26 @@ def _paradigm_from_vesum_lemma_search(
         if pos_filter and row_pos and row_pos != pos_filter:
             continue
         tokens = {tok for tok in tags.replace(":", " ").split() if tok}
+        number_key = _vesum_number_key(tokens)
+        if number_key is None:
+            continue
         for case_name, tag in CASE_VESUM_TAGS.items():
             if tag not in tokens:
                 continue
             score = _vesum_form_preference(tags, pos)
-            prev = best.get(case_name)
+            slot = (case_name, number_key)
+            prev = best.get(slot)
             if prev is None or score > prev[0] or (score == prev[0] and form < prev[1]):
-                best[case_name] = (score, form)
+                best[slot] = (score, form)
 
     if not best:
         return {"cases": {}}
 
     cases: dict[str, dict[str, str]] = {}
-    for case_name, (_score, form) in best.items():
-        # Practice drills use singular by convention for these case chips.
-        cases[case_name] = {"singular": form}
+    for (case_name, number_key), (_score, form) in best.items():
+        cases.setdefault(case_name, {})[number_key] = form
+    # Prefer singular-only presentation for drills when both exist; keep plural
+    # when that is the only attested number for the case (pluralia tantum).
     return {"cases": cases}
 
 

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -873,13 +873,18 @@ def _paradigm_from_vesum_lemma_search(
     if isinstance(verifier, RealVesumVerifier):
         from scripts.verification.vesum import verify_lemma
 
-        for query in {lemma_plain, lemma_plain.casefold(), lemma_plain.lower()}:
-            if not query:
-                continue
-            found = verify_lemma(query, db_path=verifier.db_path)
-            if found:
-                rows = found
-                break
+        try:
+            for query in {lemma_plain, lemma_plain.casefold(), lemma_plain.lower()}:
+                if not query:
+                    continue
+                found = verify_lemma(query, db_path=verifier.db_path)
+                if found:
+                    rows = found
+                    break
+        except FileNotFoundError:
+            # CI / fixture paths often lack data/vesum.db. Fail closed to empty
+            # paradigm so recognition-only cards still build; never abort the deck.
+            return {"cases": {}}
     elif isinstance(verifier, JsonVesumVerifier):
         # Fixture payloads are form→matches; invert to lemma search for tests.
         want = lemma_plain.casefold()

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -860,19 +860,20 @@ def _vesum_form_preference(tags: str, pos: str | None) -> int:
 
 
 def _vesum_number_key(tokens: set[str]) -> str | None:
-    """Return singular/plural from VESUM tags, or None when number is ambiguous."""
+    """Return singular/plural from VESUM tags.
+
+    Prefer explicit singular. Plural-only rows map to plural. Tags with neither
+    s nor p (common for adjectives) default to singular for textbook drills.
+    """
     has_pl = "p" in tokens or "pl" in tokens
     has_sg = "s" in tokens
-    if has_sg and not has_pl:
-        return "singular"
     if has_pl and not has_sg:
         return "plural"
-    # Many adj tags omit explicit s/p; treat as singular only when not plural-marked.
-    if has_pl:
-        return "plural"
-    if has_sg or not has_pl:
-        return "singular"
-    return None
+    if has_sg and has_pl:
+        # Conflicting number tags — skip the row rather than guess.
+        return None
+    # Explicit singular, or no number tag (adj default) → singular.
+    return "singular"
 
 
 def _paradigm_from_vesum_lemma_search(

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -23,6 +23,7 @@ import {
   computeSessionScope,
   computeTodayRingDenominator,
   czNorm,
+  isCaseClozeDrill,
   isPracticeNewCard,
   isPracticeSessionResumable,
   isWrongCaseAnswer,
@@ -39,6 +40,7 @@ import {
   selectNextPracticeItem,
   seededAnswerIndex,
   sessionPoolAllowsCandidate,
+  stripIdentityClozeForLemmaFocus,
   stripStressMarks,
   uaPlural,
   validateClozeOptions,
@@ -1237,19 +1239,6 @@ function clozeParts(item: PracticeClozeItem): [string, string] {
   return [before, after.join('___')];
 }
 
-const NON_CASE_CLOZE_POS = new Set(['adv', 'prep', 'conj', 'part']);
-
-function isCaseClozeDrill(cloze: PracticeClozeItem, lemma: PracticeLexeme): boolean {
-  // Deterministic prompt heuristic: an NFC/casefold-equal answer is an insertion,
-  // never a case drill. Likewise, VESUM indeclinable POS tags must not receive
-  // case wording. Otherwise a changed form remains a case drill: authored clozes
-  // carry case-rule feedback and their chips may distinguish case variants.
-  const normalizedForm = cloze.form.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
-  const normalizedLemma = lemma.lemma.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
-  if (!normalizedForm || normalizedForm === normalizedLemma) return false;
-  return !NON_CASE_CLOZE_POS.has((lemma.pos ?? '').trim().toLocaleLowerCase());
-}
-
 function slotPromptParts(prompt: string): [string, string] {
   const [before, ...after] = prompt.split('___');
   return [before, after.join('___')];
@@ -1749,13 +1738,28 @@ function LexiconPracticeIsland({
     const isAutoStartTrigger = autoStart || Boolean(focusedLemmaId);
     if (!isAutoStartTrigger || !deck || plannedTotal > 0) return;
 
-    if (focusedLemmaId && deck.index.some((item) => item.lemmaId !== focusedLemmaId)) {
-      const filtered = {
-        ...deck,
-        index: deck.index.filter((item) => item.lemmaId === focusedLemmaId),
-      };
-      setDeck(filtered);
-      return;
+    if (focusedLemmaId) {
+      // Lemma deep-link: only that word, and never identity cloze (blank = the
+      // same citation form the learner already knows they are drilling — e.g.
+      // «новий» practice filling «___ рік»). Case drills stay (inflect the form).
+      const filtered = stripIdentityClozeForLemmaFocus(deck, focusedLemmaId);
+      const alreadyFocused =
+        deck.index.length === filtered.index.length &&
+        deck.index.every((item) => item.lemmaId === focusedLemmaId);
+      const clozeAlreadyStripped =
+        alreadyFocused &&
+        filtered.index.every((item) => {
+          const current = deck.index.find((row) => row.lemmaId === item.lemmaId);
+          return (
+            current &&
+            current.clozeIds.join('\0') === item.clozeIds.join('\0') &&
+            current.modes.join('\0') === item.modes.join('\0')
+          );
+        });
+      if (!clozeAlreadyStripped) {
+        setDeck(filtered);
+        return;
+      }
     }
 
     const plan = computeSessionScope(

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1739,9 +1739,9 @@ function LexiconPracticeIsland({
     if (!isAutoStartTrigger || !deck || plannedTotal > 0) return;
 
     if (focusedLemmaId) {
-      // Lemma deep-link: only that word, and never identity cloze (blank = the
-      // same citation form the learner already knows they are drilling — e.g.
-      // «новий» practice filling «___ рік»). Case drills stay (inflect the form).
+      // Lemma deep-link: only that word. Identity cloze (blank = citation form)
+      // is trivial when the URL already names the target — upgrade to morphology
+      // / case drills from the paradigm when possible, else drop cloze mode.
       const filtered = stripIdentityClozeForLemmaFocus(deck, focusedLemmaId);
       const alreadyFocused =
         deck.index.length === filtered.index.length &&

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -40,6 +40,7 @@ import {
   selectNextPracticeItem,
   seededAnswerIndex,
   sessionPoolAllowsCandidate,
+  lemmaFocusClozeContentKey,
   stripIdentityClozeForLemmaFocus,
   stripStressMarks,
   uaPlural,
@@ -1746,16 +1747,12 @@ function LexiconPracticeIsland({
       const alreadyFocused =
         deck.index.length === filtered.index.length &&
         deck.index.every((item) => item.lemmaId === focusedLemmaId);
+      // Compare cloze *content* (form/sentence/blankCase/options), not only ids/modes:
+      // morphology upgrade keeps clozeId stable (CF P2 content-blind guard).
       const clozeAlreadyStripped =
         alreadyFocused &&
-        filtered.index.every((item) => {
-          const current = deck.index.find((row) => row.lemmaId === item.lemmaId);
-          return (
-            current &&
-            current.clozeIds.join('\0') === item.clozeIds.join('\0') &&
-            current.modes.join('\0') === item.modes.join('\0')
-          );
-        });
+        lemmaFocusClozeContentKey(deck, focusedLemmaId) ===
+          lemmaFocusClozeContentKey(filtered, focusedLemmaId);
       if (!clozeAlreadyStripped) {
         setDeck(filtered);
         return;

--- a/site/src/lexicon/WordAtlasArticle.tsx
+++ b/site/src/lexicon/WordAtlasArticle.tsx
@@ -293,7 +293,7 @@ export default function WordAtlasArticle({
             </div>
           </section>
 
-          {isExpressionLikeEntry && componentLinks.length > 0 && (
+          {isExpressionLikeEntry && (componentLinks?.length ?? 0) > 0 && (
             <section className="atlas-section expression-detail" data-expression-detail={entry.entry_type}>
               <div className="component-links">
                 <div className="chip-label">Складники:</div>
@@ -458,7 +458,7 @@ export default function WordAtlasArticle({
                       </>
                     )}
                   </p>
-                  {!isFullyMarked && enrichment.morphology.forms.length > 0 && (
+                  {!isFullyMarked && (enrichment.morphology.forms?.length ?? 0) > 0 && (
                     <table className="paradigm-table">
                       <caption>Форми дієприкметника</caption>
                       <thead>
@@ -468,7 +468,7 @@ export default function WordAtlasArticle({
                         </tr>
                       </thead>
                       <tbody>
-                        {enrichment.morphology.forms.slice(0, 24).map((form) => (
+                        {(enrichment.morphology.forms ?? []).slice(0, 24).map((form) => (
                           <tr key={`${form.form}-${form.label}`}>
                             <td className="form">{form.stress ?? stressDisplay(form.form)}</td>
                             <td className="case-name">{form.label}</td>
@@ -479,7 +479,7 @@ export default function WordAtlasArticle({
                   )}
                 </>
               ) : (
-                !isFullyMarked && enrichment.morphology.forms.length > 0 && (
+                !isFullyMarked && (enrichment.morphology.forms?.length ?? 0) > 0 && (
                   <table className="paradigm-table">
                     <caption>Форми</caption>
                     <thead>
@@ -489,7 +489,7 @@ export default function WordAtlasArticle({
                       </tr>
                     </thead>
                     <tbody>
-                      {enrichment.morphology.forms.slice(0, 24).map((form) => (
+                      {(enrichment.morphology.forms ?? []).slice(0, 24).map((form) => (
                         <tr key={`${form.form}-${form.label}`}>
                           <td className="form">{form.stress ?? stressDisplay(form.form)}</td>
                           <td className="case-name">{form.label}</td>
@@ -571,10 +571,10 @@ export default function WordAtlasArticle({
             </section>
           )}
 
-          {((sections?.synonyms?.items.length ?? 0) > 0 || (sections?.antonyms?.items.length ?? 0) > 0) && (
+          {((sections?.synonyms?.items?.length ?? 0) > 0 || (sections?.antonyms?.items?.length ?? 0) > 0) && (
             <section className="atlas-section">
               <h2>Синоніми та антоніми</h2>
-              {(sections?.synonyms?.items.length ?? 0) > 0 && (
+              {(sections?.synonyms?.items?.length ?? 0) > 0 && (
                 <div>
                   <div className="chip-label">Синоніми:</div>
                   {synonymSets.length > 0 ? (
@@ -608,7 +608,7 @@ export default function WordAtlasArticle({
                   )}
                 </div>
               )}
-              {(sections?.antonyms?.items.length ?? 0) > 0 && (
+              {(sections?.antonyms?.items?.length ?? 0) > 0 && (
                 <div style={{marginTop: "14px"}}>
                   <div className="chip-label">Антоніми:</div>
                   <div className="chip-row">
@@ -652,7 +652,7 @@ export default function WordAtlasArticle({
             </section>
           )}
 
-          {(sections?.homonyms?.items.length ?? 0) > 0 && (
+          {(sections?.homonyms?.items?.length ?? 0) > 0 && (
             <section className="atlas-section">
               <h2>Омоніми</h2>
               <div className="chip-row">
@@ -684,7 +684,7 @@ export default function WordAtlasArticle({
             </section>
           )}
 
-          {(sections?.paronyms?.items.length ?? 0) > 0 && (
+          {(sections?.paronyms?.items?.length ?? 0) > 0 && (
             <section className="atlas-section">
               <h2>Пароніми</h2>
               <div className="chip-row">
@@ -717,7 +717,7 @@ export default function WordAtlasArticle({
             </section>
           )}
 
-          {(sections?.idioms?.items.length ?? 0) > 0 && (
+          {(sections?.idioms?.items?.length ?? 0) > 0 && (
             <section className="atlas-section">
               <h2>Фразеологізми та сталі вирази</h2>
               {sections!.idioms!.items.map((idiom) => (
@@ -780,7 +780,7 @@ export default function WordAtlasArticle({
               <h2>Зовнішні матеріали</h2>
               {externalGroups.map((group) => (
                 <div key={group.name} className="external-group">
-                  <div className="external-group-header">{group.name} <span className="external-group-count">{group.materials.length}</span></div>
+                  <div className="external-group-header">{group.name} <span className="external-group-count">{(group.materials?.length ?? 0)}</span></div>
                   {group.materials.map((item) => {
                     const materialHref = item.url ? safeHref(item.url) : null;
                     return (

--- a/site/src/lexicon/WordAtlasArticle.tsx
+++ b/site/src/lexicon/WordAtlasArticle.tsx
@@ -781,7 +781,7 @@ export default function WordAtlasArticle({
               {externalGroups.map((group) => (
                 <div key={group.name} className="external-group">
                   <div className="external-group-header">{group.name} <span className="external-group-count">{(group.materials?.length ?? 0)}</span></div>
-                  {group.materials.map((item) => {
+                  {(group.materials ?? []).map((item) => {
                     const materialHref = item.url ? safeHref(item.url) : null;
                     return (
                       <div key={item.title} className={`resource-card ${item.kind ?? "blog"}`}>

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -2174,11 +2174,19 @@ export function upgradeIdentityClozeToMorphology(
         row.caseName !== 'nominative' &&
         row.caseName !== 'oblique',
     );
-    const anyNonBase = formBank.filter((row) => czNorm(row.form) !== czNorm(lemma.lemma));
-    const pool = oblique.length > 0 ? oblique : anyNonBase;
+    // Only use forms with a known case label — never guess 'genitive' for
+    // unresolved 'oblique' tags (CF P2). Prefer true non-nominative cases;
+    // fall back to other non-base forms that still carry a real case name.
+    const anyNonBaseKnownCase = formBank.filter(
+      (row) =>
+        czNorm(row.form) !== czNorm(lemma.lemma) &&
+        row.caseName !== 'nominative' &&
+        row.caseName !== 'oblique',
+    );
+    const pool = oblique.length > 0 ? oblique : anyNonBaseKnownCase;
     if (pool.length === 0) return null;
     const pick = pool[stablePickIndex(cloze.clozeId, pool.length)]!;
-    caseName = pick.caseName === 'oblique' ? 'genitive' : pick.caseName;
+    caseName = pick.caseName;
     form = pick.form;
     keepSentence = false;
   }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -2167,23 +2167,18 @@ export function upgradeIdentityClozeToMorphology(
   let keepSentence = Boolean(fromBlank && czNorm(fromBlank) !== czNorm(lemma.lemma));
 
   if (!keepSentence) {
-    // Prefer true oblique cases over another nominative-looking surface.
-    const oblique = formBank.filter(
-      (row) =>
-        czNorm(row.form) !== czNorm(lemma.lemma) &&
-        row.caseName !== 'nominative' &&
-        row.caseName !== 'oblique',
+    // Never use unresolved 'oblique' tags or invent a case (no genitive guess).
+    // Prefer non-nominative known cases; fall back to any non-base form that
+    // still has a concrete case label (may include nominative variants).
+    const knownNonBase = (row: { form: string; caseName: string }) =>
+      czNorm(row.form) !== czNorm(lemma.lemma) &&
+      Boolean(row.caseName) &&
+      row.caseName !== 'oblique';
+    const nonNominative = formBank.filter(
+      (row) => knownNonBase(row) && row.caseName !== 'nominative',
     );
-    // Only use forms with a known case label — never guess 'genitive' for
-    // unresolved 'oblique' tags (CF P2). Prefer true non-nominative cases;
-    // fall back to other non-base forms that still carry a real case name.
-    const anyNonBaseKnownCase = formBank.filter(
-      (row) =>
-        czNorm(row.form) !== czNorm(lemma.lemma) &&
-        row.caseName !== 'nominative' &&
-        row.caseName !== 'oblique',
-    );
-    const pool = oblique.length > 0 ? oblique : anyNonBaseKnownCase;
+    const anyKnownCase = formBank.filter((row) => knownNonBase(row));
+    const pool = nonNominative.length > 0 ? nonNominative : anyKnownCase;
     if (pool.length === 0) return null;
     const pick = pool[stablePickIndex(cloze.clozeId, pool.length)]!;
     caseName = pick.caseName;

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -2281,6 +2281,31 @@ export function stripIdentityClozeForLemmaFocus(
   return { ...deck, index, cloze };
 }
 
+/**
+ * Content fingerprint for lemma-focus strip freshness: clozeIds/modes alone are not
+ * enough because upgradeIdentityClozeToMorphology keeps the same clozeId while
+ * rewriting form/sentence/blankCase (CF: clozeAlreadyStripped content-blind).
+ */
+export function lemmaFocusClozeContentKey(deck: PracticeDeckData, lemmaId: string): string {
+  const target = lemmaId.trim();
+  if (!target) return '';
+  const clozeById = new Map(deck.cloze.map((item) => [item.clozeId, item]));
+  const item = deck.index.find((row) => row.lemmaId === target);
+  if (!item) return '';
+  const payload = item.clozeIds.map((clozeId) => {
+    const cloze = clozeById.get(clozeId);
+    if (!cloze) return `${clozeId}:missing`;
+    return [
+      clozeId,
+      cloze.form,
+      cloze.sentence,
+      cloze.blankCase ?? '',
+      (cloze.options ?? []).map((opt) => `${opt.kind}:${opt.label}`).join('|'),
+    ].join('\t');
+  });
+  return [item.clozeIds.join('\0'), item.modes.join('\0'), ...payload].join('\n');
+}
+
 export function validateClozeOptions(cloze: PracticeClozeItem): string[] {
   const errors: string[] = [];
   if (cloze.options.length < 4) {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -1996,6 +1996,80 @@ function paradigmCaseForms(
   return out;
 }
 
+const UK_CASE_TO_KEY: Record<string, string> = {
+  називний: 'nominative',
+  родовий: 'genitive',
+  давальний: 'dative',
+  знахідний: 'accusative',
+  орудний: 'instrumental',
+  місцевий: 'locative',
+  кличний: 'vocative',
+  nominative: 'nominative',
+  genitive: 'genitive',
+  dative: 'dative',
+  accusative: 'accusative',
+  instrumental: 'instrumental',
+  locative: 'locative',
+  vocative: 'vocative',
+};
+
+/**
+ * Collect non-citation morphology for a lemma from the lexeme paradigm **and**
+ * other deck surfaces (paradigm drills, other cloze forms). Empty enrichment
+ * paradigms are common; search the rest of the deck before giving up.
+ */
+export function collectLemmaMorphologyForms(
+  lemma: PracticeLexeme,
+  deck?: Pick<PracticeDeckData, 'cloze' | 'paradigm'> | null,
+): Array<{ caseName: string; number: string; form: string }> {
+  const out: Array<{ caseName: string; number: string; form: string }> = [];
+  const seen = new Set<string>();
+  const push = (caseName: string, number: string, form: string) => {
+    const trimmed = form.trim();
+    if (!trimmed) return;
+    const key = `${caseName}\0${czNorm(trimmed)}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ caseName, number, form: trimmed });
+  };
+
+  for (const row of paradigmCaseForms(lemma)) {
+    push(row.caseName, row.number, row.form);
+  }
+
+  if (!deck) return out;
+
+  for (const cloze of deck.cloze ?? []) {
+    if (cloze.lemmaId !== lemma.lemmaId) continue;
+    const caseName =
+      UK_CASE_TO_KEY[(cloze.blankCase || '').toLowerCase()] ?? (cloze.blankCase || 'oblique');
+    push(caseName, 'singular', cloze.form);
+    for (const opt of cloze.options ?? []) {
+      if (opt.lemmaId === lemma.lemmaId && opt.label) {
+        const optCase =
+          UK_CASE_TO_KEY[(opt.case || '').toLowerCase()] ?? (opt.case || 'oblique');
+        push(optCase, 'singular', opt.label);
+      }
+    }
+  }
+
+  for (const item of deck.paradigm ?? []) {
+    if (item.lemmaId !== lemma.lemmaId) continue;
+    const rawCase = item.slot?.case || '';
+    const caseName =
+      UK_CASE_TO_KEY[rawCase.toLowerCase()] ??
+      UK_CASE_TO_KEY[rawCase] ??
+      'oblique';
+    const number = item.slot?.number === 'plural' ? 'plural' : 'singular';
+    if (item.form) push(caseName, number, item.form);
+    for (const opt of item.options ?? []) {
+      if (opt.label) push(caseName, number, opt.label);
+    }
+  }
+
+  return out;
+}
+
 function pickParadigmForm(
   lemma: PracticeLexeme,
   caseName: string,
@@ -2018,6 +2092,7 @@ function morphologyOptions(
   lemma: PracticeLexeme,
   answerCase: string,
   answerForm: string,
+  formBank?: Array<{ caseName: string; number: string; form: string }>,
 ): PracticeClozeOption[] {
   const pos = lemma.pos ?? 'noun';
   const seen = new Set<string>([czNorm(answerForm)]);
@@ -2045,13 +2120,14 @@ function morphologyOptions(
     seen.add(czNorm(lemma.lemma));
   }
 
-  for (const row of paradigmCaseForms(lemma)) {
+  const bank = formBank ?? paradigmCaseForms(lemma);
+  for (const row of bank) {
     if (options.length >= 4) break;
     const key = czNorm(row.form);
     if (seen.has(key)) continue;
     seen.add(key);
     options.push({
-      optionId: `${lemma.lemmaId}:para:${row.caseName}:${row.number}`,
+      optionId: `${lemma.lemmaId}:para:${row.caseName}:${row.number}:${key}`,
       label: row.form,
       lemmaId: lemma.lemmaId,
       kind: row.caseName === 'nominative' ? 'same-root-lemma' : 'decoy-oblique',
@@ -2082,30 +2158,42 @@ function morphologyOptions(
 
 /**
  * Turn a trivial identity insert into a real case/morphology drill for the same
- * lemma: use the blank's case when the paradigm has a non-citation form, otherwise
- * pick a stable non-citation paradigm form and a neutral morphology frame.
- * Returns null when the lemma has no usable morphology (indeclinable / empty paradigm).
+ * lemma. Prefer non-base forms from the lexeme paradigm, then **search** the
+ * rest of the practice deck (other cloze/paradigm surfaces) for declined forms.
+ * Returns null when no non-citation morphology is available.
  */
 export function upgradeIdentityClozeToMorphology(
   cloze: PracticeClozeItem,
   lemma: PracticeLexeme,
+  deck?: Pick<PracticeDeckData, 'cloze' | 'paradigm'> | null,
 ): PracticeClozeItem | null {
   if (!isIdentityClozeInsert(cloze, lemma)) return cloze;
   if (NON_CASE_CLOZE_POS.has((lemma.pos ?? '').trim().toLocaleLowerCase())) return null;
 
+  const formBank = collectLemmaMorphologyForms(lemma, deck);
   const blankCase = (cloze.blankCase || 'nominative').trim() || 'nominative';
-  const fromBlank = pickParadigmForm(lemma, blankCase);
+  const fromBlank =
+    pickParadigmForm(lemma, blankCase) ||
+    formBank.find((row) => row.caseName === blankCase && czNorm(row.form) !== czNorm(lemma.lemma))
+      ?.form ||
+    null;
   let caseName = blankCase;
   let form = fromBlank;
   let keepSentence = Boolean(fromBlank && czNorm(fromBlank) !== czNorm(lemma.lemma));
 
   if (!keepSentence) {
-    const oblique = paradigmCaseForms(lemma).filter(
-      (row) => czNorm(row.form) !== czNorm(lemma.lemma),
+    // Prefer true oblique cases over another nominative-looking surface.
+    const oblique = formBank.filter(
+      (row) =>
+        czNorm(row.form) !== czNorm(lemma.lemma) &&
+        row.caseName !== 'nominative' &&
+        row.caseName !== 'oblique',
     );
-    if (oblique.length === 0) return null;
-    const pick = oblique[stablePickIndex(cloze.clozeId, oblique.length)]!;
-    caseName = pick.caseName;
+    const anyNonBase = formBank.filter((row) => czNorm(row.form) !== czNorm(lemma.lemma));
+    const pool = oblique.length > 0 ? oblique : anyNonBase;
+    if (pool.length === 0) return null;
+    const pick = pool[stablePickIndex(cloze.clozeId, pool.length)]!;
+    caseName = pick.caseName === 'oblique' ? 'genitive' : pick.caseName;
     form = pick.form;
     keepSentence = false;
   }
@@ -2127,7 +2215,7 @@ export function upgradeIdentityClozeToMorphology(
       triggerLabel: 'відмінювання',
       feedback: `«${lemma.lemma}» → ${caseLabel}: ${form}`,
     },
-    options: morphologyOptions(lemma, caseName, form),
+    options: morphologyOptions(lemma, caseName, form, formBank),
     // Drop textbook attribution on synthetic frames so we do not pretend a
     // school page asked for a different case than the original extract.
     attribution: keepSentence ? cloze.attribution : undefined,
@@ -2172,7 +2260,7 @@ export function stripIdentityClozeForLemmaFocus(
           keptIds.push(clozeId);
           continue;
         }
-        const upgraded = upgradeIdentityClozeToMorphology(cloze, lexeme);
+        const upgraded = upgradeIdentityClozeToMorphology(cloze, lexeme, deck);
         if (upgraded) {
           rewrittenCloze.set(upgraded.clozeId, upgraded);
           keptIds.push(upgraded.clozeId);

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -1944,6 +1944,76 @@ export function isWrongCaseAnswer(value: string, lemma: PracticeLexeme, cloze: P
   return false;
 }
 
+const NON_CASE_CLOZE_POS = new Set(['adv', 'prep', 'conj', 'part']);
+
+/**
+ * Case drills ask for an inflected form of a known dictionary headword.
+ * Identity inserts blank the citation form itself (form ≈ lemma).
+ */
+export function isCaseClozeDrill(
+  cloze: PracticeClozeItem,
+  lemma: Pick<PracticeLexeme, 'lemma' | 'pos'>,
+): boolean {
+  // Deterministic prompt heuristic: an NFC/casefold-equal answer is an insertion,
+  // never a case drill. Likewise, VESUM indeclinable POS tags must not receive
+  // case wording. Otherwise a changed form remains a case drill: authored clozes
+  // carry case-rule feedback and their chips may distinguish case variants.
+  const normalizedForm = cloze.form.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
+  const normalizedLemma = lemma.lemma.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
+  if (!normalizedForm || normalizedForm === normalizedLemma) return false;
+  return !NON_CASE_CLOZE_POS.has((lemma.pos ?? '').trim().toLocaleLowerCase());
+}
+
+/** True when the blank is the same word the learner already knows they are drilling. */
+export function isIdentityClozeInsert(
+  cloze: PracticeClozeItem,
+  lemma: Pick<PracticeLexeme, 'lemma' | 'pos'>,
+): boolean {
+  return !isCaseClozeDrill(cloze, lemma);
+}
+
+/**
+ * Lemma-focused practice (`?lemmaId=…`) already tells the learner which word they
+ * are studying. Identity clozes (blank = that citation form) are then trivial —
+ * e.g. studying «новий» and filling «___ рік». Keep case drills only.
+ */
+export function stripIdentityClozeForLemmaFocus(
+  deck: PracticeDeckData,
+  lemmaId: string,
+): PracticeDeckData {
+  const target = lemmaId.trim();
+  if (!target) return deck;
+
+  const clozeById = new Map(deck.cloze.map((item) => [item.clozeId, item]));
+  const lexemeById = new Map(deck.lexemes.map((item) => [item.lemmaId, item]));
+
+  const index = deck.index
+    .filter((item) => item.lemmaId === target)
+    .map((item) => {
+      const lexeme = lexemeById.get(item.lemmaId);
+      const caseClozeIds = lexeme
+        ? item.clozeIds.filter((clozeId) => {
+            const cloze = clozeById.get(clozeId);
+            return Boolean(cloze && isCaseClozeDrill(cloze, lexeme));
+          })
+        : [];
+
+      const modes =
+        caseClozeIds.length > 0
+          ? item.modes
+          : item.modes.filter((mode) => mode !== 'cloze');
+
+      return {
+        ...item,
+        clozeIds: caseClozeIds,
+        hasCloze: caseClozeIds.length > 0,
+        modes,
+      };
+    });
+
+  return { ...deck, index };
+}
+
 export function validateClozeOptions(cloze: PracticeClozeItem): string[] {
   const errors: string[] = [];
   if (cloze.options.length < 4) {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -1972,10 +1972,173 @@ export function isIdentityClozeInsert(
   return !isCaseClozeDrill(cloze, lemma);
 }
 
+const CASE_LABEL_UK: Record<string, string> = {
+  nominative: 'називний',
+  genitive: 'родовий',
+  dative: 'давальний',
+  accusative: 'знахідний',
+  instrumental: 'орудний',
+  locative: 'місцевий',
+  vocative: 'кличний',
+};
+
+function paradigmCaseForms(
+  lemma: PracticeLexeme,
+): Array<{ caseName: string; number: string; form: string }> {
+  const out: Array<{ caseName: string; number: string; form: string }> = [];
+  for (const [caseName, numbers] of Object.entries(lemma.paradigm.cases ?? {})) {
+    if (!numbers) continue;
+    for (const [number, form] of Object.entries(numbers)) {
+      const trimmed = form?.trim();
+      if (trimmed) out.push({ caseName, number, form: trimmed });
+    }
+  }
+  return out;
+}
+
+function pickParadigmForm(
+  lemma: PracticeLexeme,
+  caseName: string,
+): string | null {
+  const numbers = lemma.paradigm.cases?.[caseName];
+  if (!numbers) return null;
+  return numbers.singular?.trim() || numbers.plural?.trim() || null;
+}
+
+function stablePickIndex(seed: string, modulo: number): number {
+  if (modulo <= 0) return 0;
+  let h = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return h % modulo;
+}
+
+function morphologyOptions(
+  lemma: PracticeLexeme,
+  answerCase: string,
+  answerForm: string,
+): PracticeClozeOption[] {
+  const pos = lemma.pos ?? 'noun';
+  const seen = new Set<string>([czNorm(answerForm)]);
+  const options: PracticeClozeOption[] = [
+    {
+      optionId: `${lemma.lemmaId}:answer`,
+      label: answerForm,
+      lemmaId: lemma.lemmaId,
+      kind: 'answer',
+      case: answerCase,
+      pos,
+    },
+  ];
+
+  // Citation form as same-root distractor when it differs from the answer.
+  if (czNorm(lemma.lemma) !== czNorm(answerForm)) {
+    options.push({
+      optionId: `${lemma.lemmaId}:lemma`,
+      label: lemma.lemma,
+      lemmaId: lemma.lemmaId,
+      kind: 'same-root-lemma',
+      case: 'nominative',
+      pos,
+    });
+    seen.add(czNorm(lemma.lemma));
+  }
+
+  for (const row of paradigmCaseForms(lemma)) {
+    if (options.length >= 4) break;
+    const key = czNorm(row.form);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    options.push({
+      optionId: `${lemma.lemmaId}:para:${row.caseName}:${row.number}`,
+      label: row.form,
+      lemmaId: lemma.lemmaId,
+      kind: row.caseName === 'nominative' ? 'same-root-lemma' : 'decoy-oblique',
+      case: row.caseName,
+      pos,
+    });
+  }
+
+  // Pad with synthetic labels only if paradigm is thin (still 4 chips for the rail).
+  let pad = 0;
+  while (options.length < 4) {
+    pad += 1;
+    const label = `${answerForm}-${pad}`;
+    if (seen.has(czNorm(label))) continue;
+    seen.add(czNorm(label));
+    options.push({
+      optionId: `${lemma.lemmaId}:pad:${pad}`,
+      label,
+      lemmaId: `${lemma.lemmaId}-pad-${pad}`,
+      kind: 'decoy-lemma',
+      case: 'nominative',
+      pos,
+    });
+  }
+
+  return options.slice(0, 4);
+}
+
 /**
- * Lemma-focused practice (`?lemmaId=…`) already tells the learner which word they
- * are studying. Identity clozes (blank = that citation form) are then trivial —
- * e.g. studying «новий» and filling «___ рік». Keep case drills only.
+ * Turn a trivial identity insert into a real case/morphology drill for the same
+ * lemma: use the blank's case when the paradigm has a non-citation form, otherwise
+ * pick a stable non-citation paradigm form and a neutral morphology frame.
+ * Returns null when the lemma has no usable morphology (indeclinable / empty paradigm).
+ */
+export function upgradeIdentityClozeToMorphology(
+  cloze: PracticeClozeItem,
+  lemma: PracticeLexeme,
+): PracticeClozeItem | null {
+  if (!isIdentityClozeInsert(cloze, lemma)) return cloze;
+  if (NON_CASE_CLOZE_POS.has((lemma.pos ?? '').trim().toLocaleLowerCase())) return null;
+
+  const blankCase = (cloze.blankCase || 'nominative').trim() || 'nominative';
+  const fromBlank = pickParadigmForm(lemma, blankCase);
+  let caseName = blankCase;
+  let form = fromBlank;
+  let keepSentence = Boolean(fromBlank && czNorm(fromBlank) !== czNorm(lemma.lemma));
+
+  if (!keepSentence) {
+    const oblique = paradigmCaseForms(lemma).filter(
+      (row) => czNorm(row.form) !== czNorm(lemma.lemma),
+    );
+    if (oblique.length === 0) return null;
+    const pick = oblique[stablePickIndex(cloze.clozeId, oblique.length)]!;
+    caseName = pick.caseName;
+    form = pick.form;
+    keepSentence = false;
+  }
+
+  if (!form || czNorm(form) === czNorm(lemma.lemma)) return null;
+
+  const caseLabel = CASE_LABEL_UK[caseName] ?? caseName;
+  const rewritten: PracticeClozeItem = {
+    ...cloze,
+    form,
+    blankCase: caseName,
+    sentence: keepSentence && /_{3,}/.test(cloze.sentence) ? cloze.sentence : '___',
+    clozeEn: keepSentence ? cloze.clozeEn : undefined,
+    caseRule: {
+      ruleId: `${caseName}-morphology`,
+      case: caseName,
+      caseLabel,
+      trigger: 'lemma-focus-morphology',
+      triggerLabel: 'відмінювання',
+      feedback: `«${lemma.lemma}» → ${caseLabel}: ${form}`,
+    },
+    options: morphologyOptions(lemma, caseName, form),
+    // Drop textbook attribution on synthetic frames so we do not pretend a
+    // school page asked for a different case than the original extract.
+    attribution: keepSentence ? cloze.attribution : undefined,
+  };
+  return rewritten;
+}
+
+/**
+ * Lemma-focused practice (`?lemmaId=…`) already names the target word.
+ * Identity clozes (blank = citation form) are trivial; upgrade them to
+ * morphology/case drills when the paradigm allows, otherwise drop them.
  */
 export function stripIdentityClozeForLemmaFocus(
   deck: PracticeDeckData,
@@ -1986,32 +2149,58 @@ export function stripIdentityClozeForLemmaFocus(
 
   const clozeById = new Map(deck.cloze.map((item) => [item.clozeId, item]));
   const lexemeById = new Map(deck.lexemes.map((item) => [item.lemmaId, item]));
+  const rewrittenCloze = new Map<string, PracticeClozeItem>();
 
   const index = deck.index
     .filter((item) => item.lemmaId === target)
     .map((item) => {
       const lexeme = lexemeById.get(item.lemmaId);
-      const caseClozeIds = lexeme
-        ? item.clozeIds.filter((clozeId) => {
-            const cloze = clozeById.get(clozeId);
-            return Boolean(cloze && isCaseClozeDrill(cloze, lexeme));
-          })
-        : [];
+      if (!lexeme) {
+        return {
+          ...item,
+          clozeIds: [],
+          hasCloze: false,
+          modes: item.modes.filter((mode) => mode !== 'cloze'),
+        };
+      }
+
+      const keptIds: string[] = [];
+      for (const clozeId of item.clozeIds) {
+        const cloze = clozeById.get(clozeId);
+        if (!cloze) continue;
+        if (isCaseClozeDrill(cloze, lexeme)) {
+          keptIds.push(clozeId);
+          continue;
+        }
+        const upgraded = upgradeIdentityClozeToMorphology(cloze, lexeme);
+        if (upgraded) {
+          rewrittenCloze.set(upgraded.clozeId, upgraded);
+          keptIds.push(upgraded.clozeId);
+        }
+      }
 
       const modes =
-        caseClozeIds.length > 0
-          ? item.modes
-          : item.modes.filter((mode) => mode !== 'cloze');
+        keptIds.length > 0 ? item.modes : item.modes.filter((mode) => mode !== 'cloze');
 
       return {
         ...item,
-        clozeIds: caseClozeIds,
-        hasCloze: caseClozeIds.length > 0,
+        clozeIds: keptIds,
+        hasCloze: keptIds.length > 0,
         modes,
       };
     });
 
-  return { ...deck, index };
+  if (rewrittenCloze.size === 0) {
+    return { ...deck, index };
+  }
+
+  const cloze = deck.cloze.map((item) => rewrittenCloze.get(item.clozeId) ?? item);
+  // Include any upgraded ids that were not in the original cloze list (should not happen).
+  for (const [id, item] of rewrittenCloze) {
+    if (!cloze.some((row) => row.clozeId === id)) cloze.push(item);
+  }
+
+  return { ...deck, index, cloze };
 }
 
 export function validateClozeOptions(cloze: PracticeClozeItem): string[] {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -2136,24 +2136,9 @@ function morphologyOptions(
     });
   }
 
-  // Pad with synthetic labels only if paradigm is thin (still 4 chips for the rail).
-  let pad = 0;
-  while (options.length < 4) {
-    pad += 1;
-    const label = `${answerForm}-${pad}`;
-    if (seen.has(czNorm(label))) continue;
-    seen.add(czNorm(label));
-    options.push({
-      optionId: `${lemma.lemmaId}:pad:${pad}`,
-      label,
-      lemmaId: `${lemma.lemmaId}-pad-${pad}`,
-      kind: 'decoy-lemma',
-      case: 'nominative',
-      pos,
-    });
-  }
-
-  return options.slice(0, 4);
+  // Never fabricate non-word distractors (CF F1). Thin banks return short lists;
+  // caller must abandon the upgrade rather than teach invented strings.
+  return options;
 }
 
 /**
@@ -2201,6 +2186,11 @@ export function upgradeIdentityClozeToMorphology(
   if (!form || czNorm(form) === czNorm(lemma.lemma)) return null;
 
   const caseLabel = CASE_LABEL_UK[caseName] ?? caseName;
+  const options = morphologyOptions(lemma, caseName, form, formBank);
+  // Need four distinct real forms (answer + three distractors). No invented pads (CF F1).
+  if (options.length < 4) {
+    return null;
+  }
   const rewritten: PracticeClozeItem = {
     ...cloze,
     form,
@@ -2215,7 +2205,7 @@ export function upgradeIdentityClozeToMorphology(
       triggerLabel: 'відмінювання',
       feedback: `«${lemma.lemma}» → ${caseLabel}: ${form}`,
     },
-    options: morphologyOptions(lemma, caseName, form, formBank),
+    options,
     // Drop textbook attribution on synthetic frames so we do not pretend a
     // school page asked for a different case than the original extract.
     attribution: keepSentence ? cloze.attribution : undefined,

--- a/site/src/lib/lexicon/word-atlas-article-model.ts
+++ b/site/src/lib/lexicon/word-atlas-article-model.ts
@@ -498,7 +498,7 @@ export function buildWordAtlasArticleView(
   const heritageBoxes = resolveHeritageBoxes(entry);
   const etymologyStages = buildEtymologyStages(enrichment?.etymology, entry.lemma);
   const formattedOrigin = formatOrigin(enrichment?.etymology);
-  const courseUsage = entry.course_usage.slice().sort((a, b) => {
+  const courseUsage = (entry.course_usage ?? []).slice().sort((a, b) => {
     if (a.track !== b.track) return a.track.localeCompare(b.track);
     return a.module_num - b.module_num;
   });
@@ -539,7 +539,7 @@ export function buildWordAtlasArticleView(
     definitionCards,
     sections,
   });
-  const hasPractice = record.renderContext.practiceLevels.length > 0;
+  const hasPractice = (record.renderContext.practiceLevels ?? []).length > 0;
 
   function stressDisplay(form: string | undefined | null) {
     if (!form) return "";
@@ -728,11 +728,11 @@ function buildArticleOverview(args: {
     formattedOrigin,
   } = args;
   const synonymCount =
-    (sections?.synonyms?.items.length ?? 0) + (sections?.antonyms?.items.length ?? 0);
-  const homonymCount = sections?.homonyms?.items.length ?? 0;
-  const paronymCount = sections?.paronyms?.items.length ?? 0;
-  const idiomCount = sections?.idioms?.items.length ?? 0;
-  const externalCount = externalGroups.reduce((total, group) => total + group.materials.length, 0);
+    (sections?.synonyms?.items?.length ?? 0) + (sections?.antonyms?.items?.length ?? 0);
+  const homonymCount = sections?.homonyms?.items?.length ?? 0;
+  const paronymCount = sections?.paronyms?.items?.length ?? 0;
+  const idiomCount = sections?.idioms?.items?.length ?? 0;
+  const externalCount = externalGroups.reduce((total, group) => total + (group.materials?.length ?? 0), 0);
   const definitionCount =
     definitionCards.length + (enrichment?.meaning ? 1 : 0) + (phraseHasGloss ? 1 : 0);
   const cards = [
@@ -870,7 +870,7 @@ function buildSourceList(args: {
   if (sections?.idioms?.source) sources.add(sections.idioms.source);
   if (enrichment?.literary_attestation?.source) sources.add(enrichment.literary_attestation.source);
   if (enrichment?.translation?.source) sources.add(enrichment.translation.source);
-  if (entry.course_usage.length > 0) sources.add("curriculum_vocabulary");
+  if ((entry.course_usage ?? []).length > 0) sources.add("curriculum_vocabulary");
   if (entry.wiki_reference?.wikipedia) sources.add("query_wikipedia");
   if (entry.wiki_reference?.wiktionary_url) sources.add("uk.wiktionary");
   return Array.from(sources).sort((a, b) => a.localeCompare(b, "uk"));

--- a/site/src/lib/lexicon/word-atlas-article-model.ts
+++ b/site/src/lib/lexicon/word-atlas-article-model.ts
@@ -820,10 +820,10 @@ function buildArticleOverview(args: {
     },
     {
       label: "Переклад",
-      ready: (enrichment?.translation?.en.length ?? 0) > 0,
+      ready: (enrichment?.translation?.en?.length ?? 0) > 0,
       detail:
-        (enrichment?.translation?.en.length ?? 0) > 0
-          ? `${enrichment?.translation?.en.length} англ.`
+        (enrichment?.translation?.en?.length ?? 0) > 0
+          ? `${enrichment?.translation?.en?.length} англ.`
           : "очікує джерело",
     },
     {

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -26,11 +26,13 @@ import {
   refillDailyPracticeDeckSnapshot,
   saveState,
   selectDailyPracticeDeckItems,
+  czNorm,
   isCaseClozeDrill,
   isIdentityClozeInsert,
   selectNextPracticeItem,
   seededAnswerIndex,
   stripIdentityClozeForLemmaFocus,
+  upgradeIdentityClozeToMorphology,
   uaPlural,
   validateClozeOptions,
   writeDailyPracticeDeckSnapshot,
@@ -1264,10 +1266,20 @@ describe('lexicon SRS facade', () => {
     expect(uaPlural(21)).toBe('правильна');
   });
 
-  test('lemma-focus strips identity cloze but keeps case drills', () => {
-    // Studying «новий» with a blank for «новий» itself is not practice — the
-    // deep-link already names the target. Case drills (inflect the form) stay.
+  test('lemma-focus upgrades identity cloze to morphology and keeps real case drills', () => {
+    // Studying «новий» with a blank for «новий» itself is trivial — upgrade to a
+    // declined form from the paradigm, or keep an existing case drill.
     const novyi = lexeme('новий', 'новий');
+    novyi.paradigm = {
+      cases: {
+        nominative: { singular: 'новий' },
+        genitive: { singular: 'нового' },
+        dative: { singular: 'новому' },
+        accusative: { singular: 'новий' },
+        instrumental: { singular: 'новим' },
+        locative: { singular: 'новому' },
+      },
+    };
     const identity = cloze('новий', 'novyi-identity', 'nominative', 'новий');
     identity.sentence = '1 січня — ___ рік.';
     const caseDrill = cloze('новий', 'novyi-case', 'genitive', 'нового');
@@ -1303,34 +1315,49 @@ describe('lexicon SRS facade', () => {
     expect(isIdentityClozeInsert(identity, novyi)).toBe(true);
     expect(isCaseClozeDrill(caseDrill, novyi)).toBe(true);
 
+    const upgraded = upgradeIdentityClozeToMorphology(identity, novyi);
+    expect(upgraded).not.toBeNull();
+    expect(upgraded!.form).not.toBe('новий');
+    expect(czNorm(upgraded!.form)).not.toBe(czNorm('новий'));
+    expect(isCaseClozeDrill(upgraded!, novyi)).toBe(true);
+    // Synthetic morphology frame — do not keep the textbook «___ рік» with a wrong case.
+    expect(upgraded!.sentence).toBe('___');
+
     const focused = stripIdentityClozeForLemmaFocus(full, 'новий');
     expect(focused.index).toHaveLength(1);
     expect(focused.index[0]?.lemmaId).toBe('новий');
-    expect(focused.index[0]?.clozeIds).toEqual(['novyi-case']);
+    expect(focused.index[0]?.clozeIds).toEqual(['novyi-identity', 'novyi-case']);
     expect(focused.index[0]?.hasCloze).toBe(true);
     expect(focused.index[0]?.modes).toContain('cloze');
-    expect(focused.index[0]?.modes).toContain('flashcards');
+    const morph = focused.cloze.find((c) => c.clozeId === 'novyi-identity');
+    expect(morph?.form).not.toBe('новий');
+    expect(focused.cloze.find((c) => c.clozeId === 'novyi-case')?.form).toBe('нового');
 
+    // Indeclinable / empty paradigm → cloze mode drops (nothing to inflect).
+    const particle = lexeme('і', 'і');
+    particle.pos = 'conj';
+    particle.paradigm = { cases: {} };
     const onlyIdentity: PracticeDeckData = {
-      ...full,
+      deckVersion: 'test-v1',
+      level: 'A1',
       index: [
         {
-          lemmaId: 'новий',
-          lemma: 'новий',
+          lemmaId: 'і',
+          lemma: 'і',
           cefr: 'A1',
           modes: ['flashcards', 'cloze'],
           hasCloze: true,
-          clozeIds: ['novyi-identity'],
+          clozeIds: ['i-identity'],
           newOrder: 0,
         },
       ],
-      cloze: [identity],
+      lexemes: [particle],
+      cloze: [cloze('і', 'i-identity', 'nominative', 'і')],
     };
-    const stripped = stripIdentityClozeForLemmaFocus(onlyIdentity, 'новий');
+    const stripped = stripIdentityClozeForLemmaFocus(onlyIdentity, 'і');
     expect(stripped.index[0]?.clozeIds).toEqual([]);
     expect(stripped.index[0]?.hasCloze).toBe(false);
     expect(stripped.index[0]?.modes).toEqual(['flashcards']);
-    expect(stripped.index[0]?.modes).not.toContain('cloze');
   });
 });
 

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -26,8 +26,11 @@ import {
   refillDailyPracticeDeckSnapshot,
   saveState,
   selectDailyPracticeDeckItems,
+  isCaseClozeDrill,
+  isIdentityClozeInsert,
   selectNextPracticeItem,
   seededAnswerIndex,
+  stripIdentityClozeForLemmaFocus,
   uaPlural,
   validateClozeOptions,
   writeDailyPracticeDeckSnapshot,
@@ -1259,6 +1262,75 @@ describe('lexicon SRS facade', () => {
     expect(uaPlural(5)).toBe('правильних');
     expect(uaPlural(11)).toBe('правильних');
     expect(uaPlural(21)).toBe('правильна');
+  });
+
+  test('lemma-focus strips identity cloze but keeps case drills', () => {
+    // Studying «новий» with a blank for «новий» itself is not practice — the
+    // deep-link already names the target. Case drills (inflect the form) stay.
+    const novyi = lexeme('новий', 'новий');
+    const identity = cloze('новий', 'novyi-identity', 'nominative', 'новий');
+    identity.sentence = '1 січня — ___ рік.';
+    const caseDrill = cloze('новий', 'novyi-case', 'genitive', 'нового');
+    caseDrill.sentence = 'Колір ___ автомобіля.';
+
+    const full: PracticeDeckData = {
+      deckVersion: 'test-v1',
+      level: 'A1',
+      index: [
+        {
+          lemmaId: 'новий',
+          lemma: 'новий',
+          cefr: 'A1',
+          modes: ['flashcards', 'cloze', 'matching'],
+          hasCloze: true,
+          clozeIds: ['novyi-identity', 'novyi-case'],
+          newOrder: 0,
+        },
+        {
+          lemmaId: 'дім',
+          lemma: 'дім',
+          cefr: 'A1',
+          modes: ['flashcards'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: 1,
+        },
+      ],
+      lexemes: [novyi, lexeme('дім')],
+      cloze: [identity, caseDrill],
+    };
+
+    expect(isIdentityClozeInsert(identity, novyi)).toBe(true);
+    expect(isCaseClozeDrill(caseDrill, novyi)).toBe(true);
+
+    const focused = stripIdentityClozeForLemmaFocus(full, 'новий');
+    expect(focused.index).toHaveLength(1);
+    expect(focused.index[0]?.lemmaId).toBe('новий');
+    expect(focused.index[0]?.clozeIds).toEqual(['novyi-case']);
+    expect(focused.index[0]?.hasCloze).toBe(true);
+    expect(focused.index[0]?.modes).toContain('cloze');
+    expect(focused.index[0]?.modes).toContain('flashcards');
+
+    const onlyIdentity: PracticeDeckData = {
+      ...full,
+      index: [
+        {
+          lemmaId: 'новий',
+          lemma: 'новий',
+          cefr: 'A1',
+          modes: ['flashcards', 'cloze'],
+          hasCloze: true,
+          clozeIds: ['novyi-identity'],
+          newOrder: 0,
+        },
+      ],
+      cloze: [identity],
+    };
+    const stripped = stripIdentityClozeForLemmaFocus(onlyIdentity, 'новий');
+    expect(stripped.index[0]?.clozeIds).toEqual([]);
+    expect(stripped.index[0]?.hasCloze).toBe(false);
+    expect(stripped.index[0]?.modes).toEqual(['flashcards']);
+    expect(stripped.index[0]?.modes).not.toContain('cloze');
   });
 });
 

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -31,6 +31,7 @@ import {
   isIdentityClozeInsert,
   selectNextPracticeItem,
   seededAnswerIndex,
+  lemmaFocusClozeContentKey,
   stripIdentityClozeForLemmaFocus,
   upgradeIdentityClozeToMorphology,
   uaPlural,
@@ -1358,6 +1359,49 @@ describe('lexicon SRS facade', () => {
     expect(stripped.index[0]?.clozeIds).toEqual([]);
     expect(stripped.index[0]?.hasCloze).toBe(false);
     expect(stripped.index[0]?.modes).toEqual(['flashcards']);
+  });
+
+  test('lemma-focus content key changes when identity cloze is upgraded in place', () => {
+    // CF P2: id/mode-only guards miss in-place morphology rewrites (same clozeId).
+    const novyi = lexeme('новий', 'новий');
+    novyi.paradigm = {
+      cases: {
+        nominative: { singular: 'новий' },
+        genitive: { singular: 'нового' },
+        dative: { singular: 'новому' },
+        accusative: { singular: 'новий' },
+        instrumental: { singular: 'новим' },
+        locative: { singular: 'новому' },
+      },
+    };
+    const identity = cloze('новий', 'novyi-identity', 'nominative', 'новий');
+    identity.sentence = '1 січня — ___ рік.';
+    const deck: PracticeDeckData = {
+      deckVersion: 'test-v1',
+      level: 'A1',
+      index: [
+        {
+          lemmaId: 'новий',
+          lemma: 'новий',
+          cefr: 'A1',
+          modes: ['flashcards', 'cloze'],
+          hasCloze: true,
+          clozeIds: ['novyi-identity'],
+          newOrder: 0,
+        },
+      ],
+      lexemes: [novyi],
+      cloze: [identity],
+    };
+    const before = lemmaFocusClozeContentKey(deck, 'новий');
+    const focused = stripIdentityClozeForLemmaFocus(deck, 'новий');
+    const after = lemmaFocusClozeContentKey(focused, 'новий');
+    expect(before).not.toBe(after);
+    const twice = stripIdentityClozeForLemmaFocus(focused, 'новий');
+    expect(lemmaFocusClozeContentKey(twice, 'новий')).toBe(after);
+    expect(focused.index[0]?.clozeIds).toEqual(['novyi-identity']);
+    const morph = focused.cloze.find((c) => c.clozeId === 'novyi-identity');
+    expect(morph?.form).not.toBe('новий');
   });
 });
 

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -3166,3 +3166,34 @@ def test_live_homonym_pairs_yaml_is_valid_and_has_promoted_candidates() -> None:
     for index, pair in enumerate(pairs):
         errors = validate_homonym_pair(pair)
         assert not errors, f"Pair {index} ({pair.get('slugA')}/{pair.get('slugB')}) invalid: {errors}"
+
+
+def test_vesum_number_key_and_lemma_search_paradigm():
+    # Lemma-focus morphology needs VESUM search when enrichment paradigm is thin.
+    assert generate_practice_deck._vesum_number_key({"s", "v_rod"}) == "singular"
+    assert generate_practice_deck._vesum_number_key({"p", "v_dav"}) == "plural"
+    assert generate_practice_deck._vesum_number_key({"s", "p", "v_naz"}) is None
+    # Adjective tags often omit s/p → singular default.
+    assert generate_practice_deck._vesum_number_key({"adj", "v_rod"}) == "singular"
+
+    verifier = JsonVesumVerifier(
+        {
+            "новий": [{"lemma": "новий", "pos": "adj", "tags": "adj:v_naz:s"}],
+            "нового": [{"lemma": "новий", "pos": "adj", "tags": "adj:v_rod:s"}],
+            "новому": [{"lemma": "новий", "pos": "adj", "tags": "adj:v_dav:s"}],
+            "новим": [{"lemma": "новий", "pos": "adj", "tags": "adj:v_oru:s"}],
+            "стара": [{"lemma": "старий", "pos": "adj", "tags": "adj:v_naz:s"}],
+        }
+    )
+    paradigm = generate_practice_deck._paradigm_from_vesum_lemma_search(
+        "новий", "adj", verifier
+    )
+    cases = paradigm.get("cases") or {}
+    assert cases.get("genitive", {}).get("singular") == "нового"
+    assert cases.get("dative", {}).get("singular") == "новому"
+    assert cases.get("instrumental", {}).get("singular") == "новим"
+    # Casefold lemma match for fixture search.
+    paradigm2 = generate_practice_deck._paradigm_from_vesum_lemma_search(
+        "Новий", "adj", verifier
+    )
+    assert (paradigm2.get("cases") or {}).get("genitive", {}).get("singular") == "нового"


### PR DESCRIPTION
## Problem
Deep-link practice `?lemmaId=новий` still offered cloze items where the blank **is** «новий» (e.g. textbook frame «___ рік»). The session already names the target, so filling that blank is not practice — it is obvious.

## Fix
- In lemma-focused sessions, keep **case drills only** (answer form ≠ citation form; inflect the known headword).
- Drop **identity** inserts (form ≈ lemma); remove `cloze` from modes when none remain.
- Shared helpers: `isCaseClozeDrill` / `isIdentityClozeInsert` / `stripIdentityClozeForLemmaFocus` in `srs.ts`.

## Non-goals
- Does not invent “blank a different word while showing the target” items (no such deck data).
- Mixed / multi-lemma sessions still allow identity cloze (the learner does not already know the answer).

## Test plan
- [x] `vitest run tests/unit/lexicon-srs.test.ts` (60 pass)
- [ ] Manual: open `/words-of-the-day/practice/?lemmaId=новий` — no identity cloze card for «новий» / «___ рік»