### PR TITLE
docs(rules): require a four-line template for every blocker claim

### DIFF
--- a/agents_extensions/shared/rules/non-negotiable-rules.md
+++ b/agents_extensions/shared/rules/non-negotiable-rules.md
@@ -216,6 +216,59 @@ Full rule + anti-pattern catalog + per-agent enforcement: **`docs/best-practices
 
 ---
 
+## 11a. Blocker claims — the four-line template (TOP PRIORITY, advisor ruling 2026-08-05)
+
+<critical>
+
+Rule 11 governs whether a tool produced a claim. It does **not** govern whether the sentence says
+more than the tool result said — and that gap has its own failure mode.
+
+A claim of **incapacity** — "I can't", "I'm blocked", "this needs your permission", "access is
+denied" — is the worst place for that gap, for a structural reason: **a wrong fact gets caught
+downstream by gates and tests, but a wrong blocker is never tested.** Its whole function is to stop
+work and hand the problem to the operator. Nothing catches it except the operator's attention.
+
+**A refusal is a fact about one exact command string, never about a capability.**
+
+Incident that produced this rule (2026-08-05, hramatka lane): the driver ran
+`ssh -o BatchMode=yes hramatka 'hostname; uname -a'` and it **succeeded**. Later one command —
+`ssh hramatka "... sudo -n ... register_review_record ..."` — was refused by the permission
+classifier. The driver then told the operator, twice, that it needed permission "to run `ssh` to
+the hramatka host", and that this blocked a queue of six PRs. That was false. SSH was never
+blocked. The disproof was already in the same transcript when the false claim was made. No new
+evidence was needed — only the discipline to look at evidence already held.
+
+**Every blocker claim MUST carry all four lines. No line may be omitted.**
+
+```text
+BLOCKED:     <the verbatim command that was refused or failed>
+ERROR:       <the literal error / refusal text, quoted, not paraphrased>
+STILL WORKS: <output of a probe showing the surrounding capability is intact>
+ASK:         <the narrowest grant that unblocks — must match BLOCKED, not a category containing it>
+```
+
+`STILL WORKS` is the load-bearing line. It forces the discriminating test that separates "one
+`sudo` write was refused" from "ssh is blocked". In the incident above that line could not have
+been filled in honestly, which would have exposed the error before it reached the operator.
+
+**ASK must not widen.** If `BLOCKED` is one `sudo` subcommand, `ASK` is that subcommand — not
+"ssh access", not "host access", not any category containing it.
+
+**Before asserting a capability is gone, run the cheapest probe of that capability.** If a probe of
+it already succeeded earlier in the session, the claim is refuted — say so instead of asking.
+
+**Operator audit is one glance:** any missing line ⇒ reject the claim unread. A fabricated quote is
+falsifiable against the transcript in seconds.
+
+**Honest limit, stated rather than hidden:** no hook can verify that a quoted line is *accurate*.
+Enforcement makes the format mandatory; the format makes a fiction falsifiable at a glance; the
+glance is the real verifier. This reduces recurrence — it does not eliminate it, and no mechanism
+will. Treat a violation as grounds to pull the lane, not as something to argue about.
+
+</critical>
+
+---
+
 ## Enforcement
 
 Negotiating requirements down, skipping audit gates, producing under-length modules, shipping without references, leaving incomplete work, giving up before PASS, **or making verifiable claims without running the tool** = task failure.


### PR DESCRIPTION
## Why

Rule 11 (`deterministic over hallucination`) asks whether a tool produced a claim. It does not ask
whether the sentence claims **more than the tool result supports**. Incapacity claims are where that
gap costs the most, for a structural reason: a wrong fact gets caught downstream by gates and tests,
but **a wrong blocker is never tested** — its entire function is to stop work and hand the problem to
the operator.

## The incident this comes from

hramatka lane, 2026-08-05. Sequence, from the session transcript:

1. `ssh -o BatchMode=yes hramatka 'hostname; uname -a'` → **succeeded** (`hramatka` / `Linux hramatka 6.8.0-136-generic`).
2. `ssh hramatka "... sudo -n .venv/bin/python -m hramatka.ops.register_review_record ..."` → refused by the permission classifier.
3. The driver then told the operator, twice, that it needed permission *"to run `ssh` to the hramatka host"*, and that this blocked a queue of six PRs.

Step 3 is false. SSH was never blocked; exactly one command shape was. The disproof from step 1 was
already in the same transcript. No new evidence was needed — only the discipline to look at evidence
already held.

## What the rule requires

Every blocker claim carries four mandatory lines:

```text
BLOCKED:     <the verbatim command that was refused or failed>
ERROR:       <the literal error / refusal text, quoted, not paraphrased>
STILL WORKS: <output of a probe showing the surrounding capability is intact>
ASK:         <the narrowest grant that unblocks — must match BLOCKED, not a category containing it>
```

`STILL WORKS` is the load-bearing line: it forces the discriminating probe that separates "one `sudo`
write refused" from "ssh is blocked". In the incident above it could not have been filled in honestly,
which would have surfaced the error before it reached the operator.

Operator audit is one glance — any missing line, reject the claim unread.

## Honest limit, stated in the rule rather than hidden

No hook can verify that a quoted line is *accurate*. Enforcement can make the format mandatory; the
format makes a fiction falsifiable at a glance; the glance is the real verifier. This reduces
recurrence, it does not eliminate it, and the rule says so rather than implying a guarantee.

## Provenance

Advisor ruling: **Fable**, 2026-08-05, consulted on operator instruction. Fable also recommended a
`Stop` hook in `settings.json` that rejects blocker language lacking the template markers. That
touches operator harness config and is **not** in this PR.

## Verification

- `pytest tests/test_manifest_api.py tests/test_operator_contract_wiring.py tests/test_monitor_api_telemetry.py` → `37 passed in 1.82s` (these consume the rules files via `/api/rules`).
- Docs-only change to `agents_extensions/shared/rules/` — the served source of truth, not a deploy mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
