### PR TITLE
feat(open-model-data): bind source freezes to merged main

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_source_universe_freeze_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_source_universe_freeze_v1.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_source_universe_freeze_v1.schema.json",
+  "title": "Phase 3 source-universe freeze receipt v1",
+  "description": "A text-free receipt for the complete Phase 3 source-universe freeze; it does not certify coverage readiness.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "text_free",
+    "merged_main_sha",
+    "freezer",
+    "coverage_contract_sha256",
+    "input_sha256",
+    "pdf_editions",
+    "other_normative_style_inventory",
+    "families",
+    "status",
+    "blocking_requirements",
+    "artifact_manifest"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_source_universe_freeze_v1"},
+    "text_free": {"const": true},
+    "merged_main_sha": {"$ref": "#/$defs/git_sha"},
+    "freezer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation_version", "script_path", "script_sha256"],
+      "properties": {
+        "implementation_version": {"const": "phase3_source_universe_freezer_v2"},
+        "script_path": {"const": "scripts/projects/open_model_data/phase3_source_universe.py"},
+        "script_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "coverage_contract_sha256": {"$ref": "#/$defs/sha256"},
+    "input_sha256": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sources_db",
+        "vesum_db",
+        "calque_module",
+        "r2u_cache",
+        "pravopys_2019_pdf",
+        "pravopys_2026_pdf"
+      ],
+      "properties": {
+        "sources_db": {"$ref": "#/$defs/sha256"},
+        "vesum_db": {"$ref": "#/$defs/sha256"},
+        "calque_module": {"$ref": "#/$defs/sha256"},
+        "r2u_cache": {"$ref": "#/$defs/sha256"},
+        "pravopys_2019_pdf": {"$ref": "#/$defs/sha256"},
+        "pravopys_2026_pdf": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "pdf_editions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pravopys_2019_complete", "pravopys_2026_complete"],
+      "properties": {
+        "pravopys_2019_complete": {"$ref": "#/$defs/pravopys_2019_edition"},
+        "pravopys_2026_complete": {"$ref": "#/$defs/pravopys_2026_edition"}
+      }
+    },
+    "other_normative_style_inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_tables",
+        "additional_family_count",
+        "zero_additional_family_inventory"
+      ],
+      "properties": {
+        "candidate_tables": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "additional_family_count": {"type": "integer", "minimum": 0},
+        "zero_additional_family_inventory": {"type": "boolean"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"zero_additional_family_inventory": {"const": true}}, "required": ["zero_additional_family_inventory"]},
+          "then": {"properties": {"additional_family_count": {"const": 0}, "candidate_tables": {"maxItems": 0}}},
+          "else": {"properties": {"additional_family_count": {"minimum": 1}, "candidate_tables": {"minItems": 1}}}
+        }
+      ]
+    },
+    "families": {
+      "type": "array",
+      "minItems": 21,
+      "maxItems": 21,
+      "items": {"$ref": "#/$defs/family_receipt"},
+      "allOf": [
+        {"contains": {"properties": {"family_id": {"const": "lexical_balla_en_uk"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_dmklinger_uk_en"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_esum_cognate_forms"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_esum_etymology"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_frazeolohichnyi"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_grinchenko"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_puls_cefr"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_sum11"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_ukrajinet"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_wiktionary"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "antonenko_style_guide"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "ua_gec"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "school_textbooks"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_ulif"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "antonenko_textbook_representation"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_vesum"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "calque_inventory"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "lexical_r2u"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "pravopys_2019_complete"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "pravopys_2026_complete"}}, "required": ["family_id"]}},
+        {"contains": {"properties": {"family_id": {"const": "other_normative_style_inventory"}}, "required": ["family_id"]}}
+      ]
+    },
+    "status": {"const": "SOURCE_UNIVERSE_FROZEN_NOT_COVERAGE_READY"},
+    "blocking_requirements": {
+      "const": [
+        "source_unit_dispositions_and_dual_population_audits",
+        "textbook_nonhit_audit",
+        "pravopys_2019_2026_delta_coverage_and_audit",
+        "lexical_used_subset_census"
+      ]
+    },
+    "artifact_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_count",
+        "payload_file_count",
+        "payloads",
+        "payload_manifest_sha256",
+        "receipt_file"
+      ],
+      "properties": {
+        "artifact_count": {"const": 10},
+        "payload_file_count": {"const": 9},
+        "payloads": {
+          "type": "array",
+          "minItems": 9,
+          "maxItems": 9,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/payload"}
+        },
+        "payload_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "receipt_file": {"const": "source-universe-freeze-receipt.json"}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "git_sha": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "https_locator": {"type": "string", "pattern": "^https://[^\\s]+$"},
+    "retrieved_at": {"type": "string", "format": "date-time", "pattern": "Z$"},
+    "family_id": {
+      "enum": [
+        "lexical_balla_en_uk",
+        "lexical_dmklinger_uk_en",
+        "lexical_esum_cognate_forms",
+        "lexical_esum_etymology",
+        "lexical_frazeolohichnyi",
+        "lexical_grinchenko",
+        "lexical_puls_cefr",
+        "lexical_sum11",
+        "lexical_ukrajinet",
+        "lexical_wiktionary",
+        "antonenko_style_guide",
+        "ua_gec",
+        "school_textbooks",
+        "lexical_ulif",
+        "antonenko_textbook_representation",
+        "lexical_vesum",
+        "calque_inventory",
+        "lexical_r2u",
+        "pravopys_2019_complete",
+        "pravopys_2026_complete",
+        "other_normative_style_inventory"
+      ]
+    },
+    "ledger_family_id": {
+      "enum": [
+        "antonenko_style_guide",
+        "antonenko_textbook_representation",
+        "calque_inventory",
+        "ua_gec",
+        "school_textbooks",
+        "pravopys_2019_complete",
+        "pravopys_2026_complete",
+        "other_normative_style_inventory"
+      ]
+    },
+    "lexical_family_id": {
+      "enum": [
+        "lexical_balla_en_uk",
+        "lexical_dmklinger_uk_en",
+        "lexical_esum_cognate_forms",
+        "lexical_esum_etymology",
+        "lexical_frazeolohichnyi",
+        "lexical_grinchenko",
+        "lexical_puls_cefr",
+        "lexical_sum11",
+        "lexical_ukrajinet",
+        "lexical_wiktionary",
+        "lexical_ulif",
+        "lexical_vesum",
+        "lexical_r2u"
+      ]
+    },
+    "ledger_family_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family_id", "unit_count", "ledger_sha256", "ledger_file"],
+      "properties": {
+        "family_id": {"$ref": "#/$defs/ledger_family_id"},
+        "unit_count": {"type": "integer", "minimum": 0},
+        "ledger_sha256": {"$ref": "#/$defs/sha256"},
+        "ledger_file": {"type": "string", "pattern": "^[^/\\\\]+\\.units\\.jsonl$"}
+      }
+    },
+    "lexical_structural_family_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "family_id",
+        "unit_count",
+        "structural_receipt_file",
+        "structural_receipt_sha256",
+        "structural_universe_sha256"
+      ],
+      "properties": {
+        "family_id": {"$ref": "#/$defs/lexical_family_id"},
+        "unit_count": {"type": "integer", "minimum": 0},
+        "structural_receipt_file": {"const": "lexical_structural_freeze_v1.json"},
+        "structural_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "structural_universe_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "family_receipt": {
+      "oneOf": [
+        {"$ref": "#/$defs/ledger_family_receipt"},
+        {"$ref": "#/$defs/lexical_structural_family_receipt"}
+      ]
+    },
+    "pravopys_2019_edition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "edition_identity",
+        "input_sha256",
+        "official_download_locator",
+        "retrieval_locator",
+        "retrieved_at",
+        "page_count_extracted",
+        "stable_grain",
+        "paragraph_count",
+        "source_text_committed",
+        "rights_provenance_classification"
+      ],
+      "properties": {
+        "edition_identity": {"const": "pravopys_2019_complete"},
+        "input_sha256": {"$ref": "#/$defs/sha256"},
+        "official_download_locator": {"$ref": "#/$defs/https_locator"},
+        "retrieval_locator": {"$ref": "#/$defs/https_locator"},
+        "retrieved_at": {"$ref": "#/$defs/retrieved_at"},
+        "page_count_extracted": {"type": "integer", "minimum": 1},
+        "stable_grain": {"const": "pdf_numbered_hierarchy"},
+        "paragraph_count": {"type": "integer", "minimum": 1},
+        "source_text_committed": {"const": false},
+        "rights_provenance_classification": {"const": "rights_limited_locator_only"}
+      }
+    },
+    "pravopys_2026_edition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "edition_identity",
+        "input_sha256",
+        "official_decision_locator",
+        "official_download_locator",
+        "retrieval_locator",
+        "retrieved_at",
+        "page_count_extracted",
+        "stable_grain",
+        "paragraph_count",
+        "source_text_committed",
+        "rights_provenance_classification"
+      ],
+      "properties": {
+        "edition_identity": {"const": "pravopys_2026_complete"},
+        "input_sha256": {"$ref": "#/$defs/sha256"},
+        "official_decision_locator": {"$ref": "#/$defs/https_locator"},
+        "official_download_locator": {"$ref": "#/$defs/https_locator"},
+        "retrieval_locator": {"$ref": "#/$defs/https_locator"},
+        "retrieved_at": {"$ref": "#/$defs/retrieved_at"},
+        "page_count_extracted": {"type": "integer", "minimum": 1},
+        "stable_grain": {"const": "pdf_numbered_hierarchy"},
+        "paragraph_count": {"type": "integer", "minimum": 1},
+        "source_text_committed": {"const": false},
+        "rights_provenance_classification": {"const": "rights_limited_locator_only"}
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "byte_count"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "pattern": "^[^/\\\\][^\\\\]*$"},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "byte_count": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/scripts/projects/open_model_data/phase3_source_universe.py
+++ b/scripts/projects/open_model_data/phase3_source_universe.py
@@ -40,6 +40,9 @@ PRAVOPYS_2026_OFFICIAL_DOWNLOAD_LOCATOR = (
 )
 RIGHTS_PROVENANCE_CLASSIFICATION = "rights_limited_locator_only"
 ISO_8601_UTC = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+GIT_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+FREEZER_IMPLEMENTATION_VERSION = "phase3_source_universe_freezer_v2"
+FREEZER_SCRIPT_PATH = "scripts/projects/open_model_data/phase3_source_universe.py"
 
 SOURCES_FAMILIES = {
     "lexical_balla_en_uk": "balla_en_uk",
@@ -72,6 +75,19 @@ HEADING_MARKER = re.compile(
 # A contents leader is a long trailing run, or a three-mark run followed by a page
 # number; unlike ordinary ``(...)`` title punctuation, the shorter form needs digits.
 TOC_LEADER = re.compile(r"(?:[.…]{3,}\s*\d+|[.…]{4,})\s*$")
+PAYLOAD_FILES = frozenset({
+    "antonenko_style_guide.units.jsonl",
+    "antonenko_textbook_representation.units.jsonl",
+    "calque_inventory.units.jsonl",
+    "lexical_structural_freeze_v1.json",
+    "other_normative_style_inventory.units.jsonl",
+    "pravopys_2019_complete.units.jsonl",
+    "pravopys_2026_complete.units.jsonl",
+    "school_textbooks.units.jsonl",
+    "ua_gec.units.jsonl",
+})
+RECEIPT_FILE = "source-universe-freeze-receipt.json"
+EXPECTED_OUTPUT_FILES = frozenset({*PAYLOAD_FILES, RECEIPT_FILE})
 
 
 class FreezeError(ValueError):
@@ -92,6 +108,34 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _verify_merged_main_binding(merged_main_sha: str) -> dict[str, str]:
+    """Bind the freezer executable to the exact current origin/main commit."""
+    require(GIT_SHA40.fullmatch(merged_main_sha) is not None, "merged-main SHA must be 40 lowercase hex characters")
+    try:
+        remote_head = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "origin/main"],
+            check=False,
+            capture_output=True,
+        )
+        merged_script = subprocess.run(
+            ["git", "-C", str(ROOT), "show", f"{merged_main_sha}:{FREEZER_SCRIPT_PATH}"],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise FreezeError(f"unable to verify merged-main binding: {exc}") from exc
+    require(remote_head.returncode == 0, "unable to resolve origin/main for freeze binding")
+    require(remote_head.stdout.decode("ascii").strip() == merged_main_sha, "freeze SHA is not the current origin/main head")
+    require(merged_script.returncode == 0, "freezer implementation is absent from the merged-main SHA")
+    current_script = ROOT / FREEZER_SCRIPT_PATH
+    require(merged_script.stdout == current_script.read_bytes(), "running freezer bytes differ from merged-main freezer bytes")
+    return {
+        "implementation_version": FREEZER_IMPLEMENTATION_VERSION,
+        "script_path": FREEZER_SCRIPT_PATH,
+        "script_sha256": sha256_file(current_script),
+    }
 
 
 def require(condition: bool, message: str) -> None:
@@ -563,10 +607,15 @@ def freeze(
     r2u_cache: Path,
     output_dir: Path,
     pdftotext: Path,
+    merged_main_sha: str,
 ) -> dict[str, Any]:
     """Validate every family first, then atomically publish text-free ledgers."""
     for path, label in ((coverage_contract, "coverage contract"), (sources_db, "sources database"), (vesum_db, "VESUM database"), (pravopys_2019_pdf, "2019 PDF"), (pravopys_2026_pdf, "2026 PDF"), (calque_module, "calque module"), (r2u_cache, "R2U cache")):
         require(path.is_file(), f"missing {label}: {path}")
+    freezer_binding = _verify_merged_main_binding(merged_main_sha)
+    if output_dir.exists():
+        unexpected = {path.name for path in output_dir.iterdir()} - EXPECTED_OUTPUT_FILES
+        require(not unexpected, f"output directory contains stale or unexpected files: {sorted(unexpected)}")
     contract = _read_json(coverage_contract)
     families = _expected_families(contract)
     source_hash, vesum_hash = sha256_file(sources_db), sha256_file(vesum_db)
@@ -630,15 +679,39 @@ def freeze(
                 "structural_universe_sha256": summary["ordered_rolling_sha256"],
             })
         require({item["family_id"] for item in receipt_families} == set(families), "not every mandatory source family was frozen")
+        payload_files = sorted(
+            (
+                {"path": target.name, "sha256": sha256_file(temporary), "byte_count": temporary.stat().st_size}
+                for temporary, target in staged
+            ),
+            key=lambda item: str(item["path"]),
+        )
+        require({str(item["path"]) for item in payload_files} == PAYLOAD_FILES, "source-freeze payload file set changed")
         receipt = {
             "schema_version": "phase3_source_universe_freeze_v1", "text_free": True,
+            "status": "SOURCE_UNIVERSE_FROZEN_NOT_COVERAGE_READY",
+            "merged_main_sha": merged_main_sha,
+            "freezer": freezer_binding,
             "coverage_contract_sha256": sha256_file(coverage_contract),
             "input_sha256": {"sources_db": source_hash, "vesum_db": vesum_hash, "calque_module": sha256_file(calque_module), "r2u_cache": sha256_file(r2u_cache), "pravopys_2019_pdf": pdf2019["input_sha256"], "pravopys_2026_pdf": pdf2026["input_sha256"]},
             "pdf_editions": {"pravopys_2019_complete": pdf2019, "pravopys_2026_complete": pdf2026},
             "other_normative_style_inventory": discovery, "families": receipt_families,
+            "blocking_requirements": [
+                "source_unit_dispositions_and_dual_population_audits",
+                "textbook_nonhit_audit",
+                "pravopys_2019_2026_delta_coverage_and_audit",
+                "lexical_used_subset_census",
+            ],
+            "artifact_manifest": {
+                "artifact_count": len(EXPECTED_OUTPUT_FILES),
+                "payload_file_count": len(payload_files),
+                "payloads": payload_files,
+                "payload_manifest_sha256": _unit_hash(payload_files),
+                "receipt_file": RECEIPT_FILE,
+            },
         }
         receipt_bytes = (canonical_json(receipt) + "\n").encode("utf-8")
-        staged.append((_stage(output_dir / "source-universe-freeze-receipt.json", receipt_bytes), output_dir / "source-universe-freeze-receipt.json"))
+        staged.append((_stage(output_dir / RECEIPT_FILE, receipt_bytes), output_dir / RECEIPT_FILE))
         for temporary, target in staged:
             os.replace(temporary, target)
         return receipt
@@ -667,6 +740,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--r2u-cache", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--pdftotext", type=Path, required=True)
+    parser.add_argument("--merged-main-sha", required=True)
     return parser.parse_args(argv)
 
 

--- a/tests/test_open_model_phase3_source_universe.py
+++ b/tests/test_open_model_phase3_source_universe.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from jsonschema import Draft202012Validator, ValidationError
 
 from scripts.projects.open_model_data import phase3_source_universe as freezer
 
 SOURCE_TABLES = tuple(freezer.SOURCES_FAMILIES.values())
+FREEZE_SCHEMA = freezer.ROOT / "data/projects/open_model_data/contracts/phase3_source_universe_freeze_v1.schema.json"
 
 
 def _json(path: Path, value: object) -> None:
@@ -77,6 +80,15 @@ def _inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object
     monkeypatch.setattr(freezer, "EXPECTED_2026_SHA256", freezer.sha256_file(pdf2026).upper())
     monkeypatch.setattr(freezer, "EXPECTED_PARAGRAPH_COUNT", 2)
     monkeypatch.setattr(freezer, "extract_pdf_pages", lambda path, tool: ["РОЗДІЛ I\n§ 1. heading\n1. unit", "§ 2. heading\nа) unit"])
+    monkeypatch.setattr(
+        freezer,
+        "_verify_merged_main_binding",
+        lambda sha: {
+            "implementation_version": freezer.FREEZER_IMPLEMENTATION_VERSION,
+            "script_path": freezer.FREEZER_SCRIPT_PATH,
+            "script_sha256": "b" * 64,
+        },
+    )
     return {
         "coverage_contract": contract, "sources_db": sources, "vesum_db": vesum,
         "pravopys_2019_pdf": pdf2019, "pravopys_2026_pdf": pdf2026,
@@ -85,6 +97,7 @@ def _inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object
         "pravopys_2026_retrieved_at": "2026-08-05T22:05:39Z",
         "pravopys_2026_retrieval_locator": "https://data.commoncrawl.org/fixture-2026",
         "calque_module": module, "r2u_cache": cache, "pdftotext": tmp_path / "unused",
+        "merged_main_sha": "a" * 40,
     }
 
 
@@ -98,7 +111,7 @@ def test_freeze_writes_all_21_text_free_ledgers_deterministically(tmp_path: Path
     receipt = _freeze(inputs, first)
     _freeze(inputs, second)
     assert len(receipt["families"]) == 21
-    assert len(list(first.iterdir())) <= 12
+    assert {path.name for path in first.iterdir()} == freezer.EXPECTED_OUTPUT_FILES
     assert sorted(path.name for path in first.iterdir()) == sorted(path.name for path in second.iterdir())
     for path in first.iterdir():
         assert path.read_bytes() == (second / path.name).read_bytes()
@@ -123,6 +136,16 @@ def test_freeze_writes_all_21_text_free_ledgers_deterministically(tmp_path: Path
     }
     assert receipt["pdf_editions"]["pravopys_2026_complete"]["official_decision_locator"] == freezer.PRAVOPYS_2026_DECISION_LOCATOR
     assert receipt["pdf_editions"]["pravopys_2026_complete"]["official_download_locator"] == freezer.PRAVOPYS_2026_OFFICIAL_DOWNLOAD_LOCATOR
+    Draft202012Validator(json.loads(FREEZE_SCHEMA.read_text(encoding="utf-8"))).validate(receipt)
+    manifest = receipt["artifact_manifest"]
+    assert manifest["artifact_count"] == 10
+    assert manifest["payload_file_count"] == 9
+    assert {item["path"] for item in manifest["payloads"]} == freezer.PAYLOAD_FILES
+    assert manifest["payload_manifest_sha256"] == freezer._unit_hash(manifest["payloads"])
+    for item in manifest["payloads"]:
+        payload = first / item["path"]
+        assert item["sha256"] == freezer.sha256_file(payload)
+        assert item["byte_count"] == payload.stat().st_size
 
 
 def test_count_mismatch_fails_before_output_publication(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -134,6 +157,65 @@ def test_count_mismatch_fails_before_output_publication(tmp_path: Path, monkeypa
     with pytest.raises(freezer.FreezeError, match="frozen unit count mismatch"):
         _freeze(inputs, output)
     assert not output.exists() or not list(output.iterdir())
+
+
+def test_stale_output_file_fails_before_freeze(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = _inputs(tmp_path, monkeypatch)
+    output = tmp_path / "out"
+    output.mkdir()
+    (output / "stale.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(freezer.FreezeError, match="stale or unexpected"):
+        _freeze(inputs, output)
+
+
+def test_merged_main_binding_fails_on_noncanonical_sha() -> None:
+    with pytest.raises(freezer.FreezeError, match="40 lowercase hex"):
+        freezer._verify_merged_main_binding("A" * 40)
+
+
+def test_merged_main_binding_requires_current_remote_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        freezer.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=("b" * 40 + "\n").encode()),
+    )
+    with pytest.raises(freezer.FreezeError, match="not the current origin/main"):
+        freezer._verify_merged_main_binding("a" * 40)
+
+
+def test_merged_main_binding_requires_identical_freezer_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = iter(
+        [
+            SimpleNamespace(returncode=0, stdout=("a" * 40 + "\n").encode()),
+            SimpleNamespace(returncode=0, stdout=b"different freezer"),
+        ]
+    )
+    monkeypatch.setattr(freezer.subprocess, "run", lambda *args, **kwargs: next(calls))
+    with pytest.raises(freezer.FreezeError, match="running freezer bytes differ"):
+        freezer._verify_merged_main_binding("a" * 40)
+
+
+def test_receipt_schema_rejects_artifact_manifest_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt = _freeze(_inputs(tmp_path, monkeypatch), tmp_path / "out")
+    receipt["artifact_manifest"]["artifact_count"] = 9
+    validator = Draft202012Validator(json.loads(FREEZE_SCHEMA.read_text(encoding="utf-8")))
+    with pytest.raises(ValidationError):
+        validator.validate(receipt)
+
+
+def test_receipt_schema_rejects_wrong_family_receipt_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt = _freeze(_inputs(tmp_path, monkeypatch), tmp_path / "out")
+    lexical = next(item for item in receipt["families"] if item["family_id"] == "lexical_balla_en_uk")
+    lexical.clear()
+    lexical.update({
+        "family_id": "lexical_balla_en_uk",
+        "unit_count": 1,
+        "ledger_sha256": "a" * 64,
+        "ledger_file": "lexical_balla_en_uk.units.jsonl",
+    })
+    validator = Draft202012Validator(json.loads(FREEZE_SCHEMA.read_text(encoding="utf-8")))
+    with pytest.raises(ValidationError):
+        validator.validate(receipt)
 
 
 def test_pdf_hash_mismatch_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Part of #6375. This is a mechanical Phase 3 recovery prerequisite and cannot
complete `SOURCE_COVERAGE_READY` or Phase 3.

## Outcome

- adds a strict receipt schema for the 21-family, 10-file text-free source freeze;
- requires every production freeze to name the exact current `origin/main` SHA;
- verifies the running freezer bytes are identical to the script stored at that
  merged-main commit before reading the source databases or PDFs;
- binds all nine payload filenames, hashes, and byte counts into one deterministic
  payload-manifest hash and rejects stale/unexpected output files;
- keeps the receipt explicitly at `SOURCE_UNIVERSE_FROZEN_NOT_COVERAGE_READY` with
  disposition audits, textbook non-hit audit, Pravopys delta audit, and lexical
  used-subset census still blocking.

This PR intentionally does not contain a source-freeze receipt. After this code is
reviewed and merged, the next PR will run the freezer from that merged-main SHA and
commit the resulting 10 text-free evidence files. This avoids a circular or
unmerged-code provenance claim.

## Verification

- 121 focused and adjacent tests passed.
- receipt schema passed Draft 2020-12 meta-validation and positive/negative fixture
  validation.
- Ruff, `git diff --check`, agent-trailer lint, and staged OPSEC lint passed.

No Ukrainian linguistic decisions, source dispositions, audit seeds, training,
paid compute, model download, Hugging Face mutation, upload, outreach, or Phase 4
action occurred.
