### PR TITLE
feat(open-model-data): add textbook non-hit audit boundary

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_textbook_nonhit_bundle_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_textbook_nonhit_bundle_v1.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_textbook_nonhit_bundle_v1.schema.json",
+  "title": "Phase 3 textbook non-hit scanner bundle v1",
+  "description": "Complete source-free textbook chunk candidate/non-hit inventory and audit freeze.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "text_free", "source_bindings", "scanner", "rubric", "scanner_review", "population", "audit_contract"],
+  "properties": {
+    "schema_version": {"const": "phase3_textbook_nonhit_bundle_v1"},
+    "text_free": {"const": true},
+    "source_bindings": {"$ref": "#/$defs/source_bindings"},
+    "scanner": {"$ref": "#/$defs/scanner"},
+    "rubric": {"$ref": "#/$defs/rubric"},
+    "scanner_review": {"$ref": "#/$defs/scanner_review"},
+    "population": {"$ref": "#/$defs/population"},
+    "audit_contract": {"$ref": "#/$defs/audit_contract"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "locator": {
+      "type": "object", "additionalProperties": false,
+      "required": ["kind", "table", "primary_key_fields", "primary_key_sha256"],
+      "properties": {
+        "kind": {"const": "sqlite_row"}, "table": {"const": "textbooks"},
+        "primary_key_fields": {"const": ["id"]}, "primary_key_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "role_binding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["role_id", "controller_identity_id", "reserved_task_id"],
+      "properties": {
+        "role_id": {"type": "string", "minLength": 1},
+        "controller_identity_id": {"type": "string", "pattern": "^controller_[a-z0-9_]+$"},
+        "reserved_task_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "unit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unit_id", "unit_sha256", "locator", "tracked_file", "source_identity", "metadata_sha256", "candidate_classes"],
+      "properties": {
+        "unit_id": {"type": "string", "pattern": "^unit\\.school_textbooks\\.[a-f0-9]{64}$"},
+        "unit_sha256": {"$ref": "#/$defs/sha256"},
+        "locator": {"$ref": "#/$defs/locator"},
+        "tracked_file": {"type": "string", "minLength": 1},
+        "source_identity": {"type": "string", "minLength": 1},
+        "metadata_sha256": {"$ref": "#/$defs/sha256"},
+        "candidate_classes": {"type": "array", "uniqueItems": true, "items": {"enum": ["rule_bearing", "error_correction", "editing_exercise", "contrast", "metalinguistic_candidate"]}}
+      }
+    },
+    "source_bindings": {
+      "type": "object", "additionalProperties": false,
+      "required": ["coverage_contract_sha256", "role_contract_sha256", "source_freeze_receipt_sha256", "school_ledger_sha256", "frozen_unit_identity_sha256", "sources_db_sha256", "metadata_index_sha256", "tracked_file_total", "section_total", "section_tracked_file_total", "section_metadata_sha256"],
+      "properties": {
+        "coverage_contract_sha256": {"$ref": "#/$defs/sha256"}, "role_contract_sha256": {"$ref": "#/$defs/sha256"},
+        "source_freeze_receipt_sha256": {"$ref": "#/$defs/sha256"}, "school_ledger_sha256": {"$ref": "#/$defs/sha256"},
+        "frozen_unit_identity_sha256": {"$ref": "#/$defs/sha256"},
+        "sources_db_sha256": {"$ref": "#/$defs/sha256"}, "metadata_index_sha256": {"$ref": "#/$defs/sha256"},
+        "tracked_file_total": {"const": 168}, "section_total": {"const": 7250},
+        "section_tracked_file_total": {"type": "integer", "minimum": 1, "maximum": 168},
+        "section_metadata_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scanner": {
+      "type": "object", "additionalProperties": false,
+      "required": ["implementation_version", "script_path", "script_sha256", "candidate_classes", "classification_universe_sha256", "author"],
+      "properties": {
+        "implementation_version": {"const": "phase3_textbook_nonhit_v1"}, "script_path": {"const": "scripts/projects/open_model_data/phase3_textbook_nonhit.py"},
+        "script_sha256": {"$ref": "#/$defs/sha256"},
+        "candidate_classes": {"const": ["rule_bearing", "error_correction", "editing_exercise", "contrast", "metalinguistic_candidate"]},
+        "classification_universe_sha256": {"$ref": "#/$defs/sha256"},
+        "author": {"allOf": [{"$ref": "#/$defs/role_binding"}, {"properties": {"role_id": {"const": "rule_author_extractor"}}}]}
+      }
+    },
+    "rubric": {
+      "type": "object", "additionalProperties": false,
+      "required": ["rubric_id", "candidate_classes", "positive_fixture_ids", "negative_fixture_ids", "expected_decisions", "rubric_sha256"],
+      "properties": {
+        "rubric_id": {"type": "string", "minLength": 1},
+        "candidate_classes": {"const": ["rule_bearing", "error_correction", "editing_exercise", "contrast", "metalinguistic_candidate"]},
+        "positive_fixture_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "negative_fixture_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "expected_decisions": {"type": "object", "additionalProperties": {"type": "boolean"}},
+        "rubric_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "review_receipt": {
+      "type": "object", "additionalProperties": false,
+      "required": ["schema_version", "text_free", "scanner_author", "scanner_reviewer", "scanner", "metadata_index_sha256", "classification_universe_sha256", "rubric_sha256", "decision"],
+      "properties": {
+        "schema_version": {"const": "phase3_textbook_scanner_review_receipt_v1"}, "text_free": {"const": true},
+        "scanner_author": {"allOf": [{"$ref": "#/$defs/role_binding"}, {"properties": {"role_id": {"const": "rule_author_extractor"}}}]},
+        "scanner_reviewer": {"allOf": [{"$ref": "#/$defs/role_binding"}, {"properties": {"role_id": {"const": "ukrainian_source_reviewer"}}}]},
+        "scanner": {
+          "type": "object", "additionalProperties": false,
+          "required": ["implementation_version", "script_path", "script_sha256"],
+          "properties": {
+            "implementation_version": {"const": "phase3_textbook_nonhit_v1"},
+            "script_path": {"const": "scripts/projects/open_model_data/phase3_textbook_nonhit.py"},
+            "script_sha256": {"$ref": "#/$defs/sha256"}
+          }
+        },
+        "metadata_index_sha256": {"$ref": "#/$defs/sha256"}, "classification_universe_sha256": {"$ref": "#/$defs/sha256"},
+        "rubric_sha256": {"$ref": "#/$defs/sha256"}, "decision": {"const": "approved"}
+      }
+    },
+    "scanner_review": {
+      "type": "object", "additionalProperties": false,
+      "required": ["receipt", "receipt_sha256", "receipt_file_sha256"],
+      "properties": {
+        "receipt": {"$ref": "#/$defs/review_receipt"}, "receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "receipt_file_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "population": {
+      "type": "object", "additionalProperties": false,
+      "required": ["frozen_unit_total", "candidate_total", "nonhit_total", "all_units_sha256", "candidate_universe_sha256", "nonhit_universe_sha256", "all_units", "candidate_units", "nonhit_units"],
+      "properties": {
+        "frozen_unit_total": {"const": 54979}, "candidate_total": {"type": "integer", "minimum": 0}, "nonhit_total": {"type": "integer", "minimum": 0},
+        "all_units_sha256": {"$ref": "#/$defs/sha256"}, "candidate_universe_sha256": {"$ref": "#/$defs/sha256"}, "nonhit_universe_sha256": {"$ref": "#/$defs/sha256"},
+        "all_units": {"type": "array", "minItems": 54979, "maxItems": 54979, "items": {"$ref": "#/$defs/unit"}},
+        "candidate_units": {"type": "array", "items": {"$ref": "#/$defs/unit"}}, "nonhit_units": {"type": "array", "items": {"$ref": "#/$defs/unit"}}
+      }
+    },
+    "audit_contract": {
+      "type": "object", "additionalProperties": false,
+      "required": ["auditor_role_id", "auditor_identity_id", "auditor_task_id", "sample_formula", "sampler_version", "stratification", "sampling_without_replacement", "entropy_contract", "arbitrary_seed_forbidden", "first_containing_origin_main_squash_merge_required", "unique_canonical_tuple_seed_required", "auditor_sole_attestor_committer", "seed_choice_reroll_reuse_forbidden", "passing_sample_reuse_forbidden", "zero_misses_required", "miss_invalidates_population_and_sample"],
+      "properties": {
+        "auditor_role_id": {"const": "textbook_nonhit_auditor"}, "auditor_identity_id": {"type": "string", "pattern": "^controller_[a-z0-9_]+$"}, "auditor_task_id": {"type": "string", "minLength": 1}, "sample_formula": {"const": "min(1000,nonhit_total)"},
+        "sampler_version": {"const": "phase3_textbook_nonhit_hamilton_v1"}, "stratification": {"const": ["tracked_file", "source_identity"]},
+        "sampling_without_replacement": {"const": true}, "entropy_contract": {"const": "approved_common_anti_grinding_v1"}, "arbitrary_seed_forbidden": {"const": true},
+        "first_containing_origin_main_squash_merge_required": {"const": true}, "unique_canonical_tuple_seed_required": {"const": true},
+        "auditor_sole_attestor_committer": {"const": true}, "seed_choice_reroll_reuse_forbidden": {"const": true},
+        "passing_sample_reuse_forbidden": {"const": true}, "zero_misses_required": {"const": true}, "miss_invalidates_population_and_sample": {"const": true}
+      }
+    }
+  }
+}

--- a/scripts/projects/open_model_data/phase3_textbook_nonhit.py
+++ b/scripts/projects/open_model_data/phase3_textbook_nonhit.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python3
+"""Freeze and sample the text-free Phase 3 textbook non-hit population.
+
+This is deliberately not a linguistic scanner.  It imports classifications made
+by an authorised external lane (or neutral empty classifications), preserves the
+complete frozen chunk identity universe, and provides the deterministic audit
+draw/validation boundary.  Source text is never read or written by this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import os
+import re
+import sqlite3
+import tempfile
+import unicodedata
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
+BUNDLE_SCHEMA = CONTRACTS / "phase3_textbook_nonhit_bundle_v1.schema.json"
+COVERAGE_SCHEMA = CONTRACTS / "correction_protection_coverage_contract_v1.schema.json"
+ROLE_SCHEMA = CONTRACTS / "correction_protection_role_contract_v1.schema.json"
+SOURCE_FREEZE_SCHEMA = CONTRACTS / "phase3_source_universe_freeze_v1.schema.json"
+
+EXPECTED_UNIT_TOTAL = 54_979
+EXPECTED_TRACKED_FILE_TOTAL = 168
+EXPECTED_SECTION_TOTAL = 7_250
+SCANNER_IMPLEMENTATION_VERSION = "phase3_textbook_nonhit_v1"
+SCANNER_SCRIPT_PATH = "scripts/projects/open_model_data/phase3_textbook_nonhit.py"
+SAMPLER_VERSION = "phase3_textbook_nonhit_hamilton_v1"
+AUDITOR_ROLE_ID = "textbook_nonhit_auditor"
+SCANNER_AUTHOR_ROLE_ID = "rule_author_extractor"
+SCANNER_REVIEWER_ROLE_ID = "ukrainian_source_reviewer"
+APPROVED_ENTROPY_MODULE = "scripts.projects.open_model_data.phase3_audit_entropy"
+APPROVED_ENTROPY_VERIFIER = "verify_entropy_receipt"
+CANDIDATE_CLASSES = (
+    "rule_bearing",
+    "error_correction",
+    "editing_exercise",
+    "contrast",
+    "metalinguistic_candidate",
+)
+AUDIT_DECISIONS = ("agree", "missed_candidate", "ambiguous_eligibility")
+SHA256 = re.compile(r"^[a-f0-9]{64}$")
+FORBIDDEN_TEXT_FIELDS = frozenset({"body", "content", "excerpt", "snippet", "source_text", "text"})
+
+
+class TextbookNonhitError(ValueError):
+    """The source-free scanner audit boundary has been violated."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _hash(value: Any) -> str:
+    return sha256_bytes(canonical_json(value).encode("utf-8"))
+
+
+def _normal(value: Any) -> Any:
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, Mapping):
+        return {str(key): _normal(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normal(item) for item in value]
+    return value
+
+
+def _source_universe_unit_id(row_id: int) -> str:
+    payload = {"table": "textbooks", "identity": {"id": row_id}}
+    return f"unit.school_textbooks.{_hash(_normal(payload))}"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise TextbookNonhitError(message)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TextbookNonhitError(f"cannot read JSON input: {path}") from exc
+    require(isinstance(value, dict), f"expected JSON object: {path}")
+    return value
+
+
+def _validate_schema(value: Mapping[str, Any], schema_path: Path, label: str) -> None:
+    schema = _read_json(schema_path)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(value), key=lambda error: list(error.path))
+    if errors:
+        location = ".".join(str(part) for part in errors[0].path) or "<root>"
+        raise TextbookNonhitError(f"{label} schema violation at {location}: {errors[0].message}")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        handle = path.open(encoding="utf-8")
+    except OSError as exc:
+        raise TextbookNonhitError(f"cannot read JSONL input: {path}") from exc
+    with handle:
+        for line_number, line in enumerate(handle, start=1):
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise TextbookNonhitError(f"invalid JSONL at {path}:{line_number}") from exc
+            require(isinstance(value, dict), f"expected object at {path}:{line_number}")
+            rows.append(value)
+    return rows
+
+
+def _unit_identity(row: Mapping[str, Any]) -> dict[str, Any]:
+    require(not (FORBIDDEN_TEXT_FIELDS & set(row)), "source text is forbidden from textbook scanner artifacts")
+    required = {"unit_id", "unit_sha256", "locator"}
+    require(required <= set(row), "frozen school textbook unit lacks identity fields")
+    unit_id, unit_hash, locator = row["unit_id"], row["unit_sha256"], row["locator"]
+    require(isinstance(unit_id, str) and unit_id.startswith("unit.school_textbooks."), "invalid textbook unit_id")
+    require(isinstance(unit_hash, str) and SHA256.fullmatch(unit_hash) is not None, "invalid textbook unit_sha256")
+    require(isinstance(locator, Mapping), "invalid textbook unit locator")
+    return {"unit_id": unit_id, "unit_sha256": unit_hash, "locator": dict(locator)}
+
+
+def _load_source_units(path: Path) -> tuple[list[dict[str, Any]], str]:
+    rows = _read_jsonl(path)
+    units = [_unit_identity(row) for row in rows]
+    require(len(units) == EXPECTED_UNIT_TOTAL, f"school textbook denominator must be {EXPECTED_UNIT_TOTAL}, got {len(units)}")
+    unit_ids = [unit["unit_id"] for unit in units]
+    require(len(set(unit_ids)) == len(unit_ids), "duplicate frozen textbook unit_id")
+    identities = sorted(units, key=lambda item: str(item["unit_id"]))
+    return identities, sha256_file(path)
+
+
+def _school_family(receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+    families = receipt.get("families")
+    require(isinstance(families, list), "source freeze lacks family receipts")
+    matches = [family for family in families if isinstance(family, Mapping) and family.get("family_id") == "school_textbooks"]
+    require(len(matches) == 1, "source freeze lacks one school_textbooks receipt")
+    family = matches[0]
+    require(family.get("unit_count") == EXPECTED_UNIT_TOTAL, "source freeze textbook denominator changed")
+    require(isinstance(family.get("ledger_sha256"), str) and SHA256.fullmatch(str(family["ledger_sha256"])) is not None, "source freeze lacks textbook ledger hash")
+    return family
+
+
+def _assigned_role(roles: Mapping[str, Any], role_id: str) -> dict[str, str]:
+    seats = [seat for seat in roles.get("seats", []) if isinstance(seat, Mapping) and seat.get("role_id") == role_id]
+    require(len(seats) == 1, f"role contract lacks one {role_id} seat")
+    seat = seats[0]
+    require(seat.get("assignment_state") == "assigned_verified", f"{role_id} is not assigned")
+    require(seat.get("controller_identity_attested") is True, f"{role_id} identity is not attested")
+    identity = seat.get("controller_identity_id")
+    require(isinstance(identity, str) and identity, f"{role_id} lacks assigned identity")
+    tasks = [task for task in roles.get("task_bindings", []) if isinstance(task, Mapping) and task.get("role_id") == role_id]
+    require(len(tasks) == 1, f"role contract lacks one {role_id} task binding")
+    task = tasks[0]
+    require(task.get("controller_identity_id") == identity, f"{role_id} task identity mismatch")
+    require(task.get("status") != "reserved_not_launched", f"{role_id} task is not active")
+    task_id = task.get("reserved_task_id")
+    require(isinstance(task_id, str) and task_id, f"{role_id} task lacks identity")
+    return {"role_id": role_id, "controller_identity_id": identity, "reserved_task_id": task_id}
+
+
+def _metadata_index(
+    sources_db: Path,
+    frozen_units: Sequence[Mapping[str, Any]],
+    source_freeze: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Reconstruct frozen unit IDs using only explicit non-text DB columns."""
+    require(sources_db.is_file() and sources_db.stat().st_size > 0, "missing sources database")
+    db_sha256 = sha256_file(sources_db)
+    receipt_hash = source_freeze.get("input_sha256", {}).get("sources_db")
+    require(receipt_hash == db_sha256, "sources database does not match source freeze")
+    connection = sqlite3.connect(sources_db.resolve().as_uri() + "?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only=ON")
+    try:
+        textbook_columns = {row[1] for row in connection.execute('PRAGMA table_info("textbooks")')}
+        required = {"id", "chunk_id", "source_file", "grade", "author", "char_count", "parent_section_id", "author_uk", "subject"}
+        require(required <= textbook_columns, "textbooks lacks required non-text identity metadata")
+        rows = connection.execute(
+            'SELECT "id", "chunk_id", "source_file", "grade", "author", "char_count", '
+            '"parent_section_id", "author_uk", "subject" FROM "textbooks" ORDER BY "id"'
+        ).fetchall()
+        section_columns = {row[1] for row in connection.execute('PRAGMA table_info("textbook_sections")')}
+        section_required = {"section_id", "source_file", "grade", "section_number", "page_start", "page_end", "chunk_count"}
+        require(section_required <= section_columns, "textbook_sections lacks required non-text metadata")
+        sections = connection.execute(
+            'SELECT "section_id", "source_file", "grade", "section_number", "page_start", '
+            '"page_end", "chunk_count" FROM "textbook_sections" ORDER BY "section_id"'
+        ).fetchall()
+    finally:
+        connection.close()
+    require(len(rows) == EXPECTED_UNIT_TOTAL, f"sources DB textbook denominator must be {EXPECTED_UNIT_TOTAL}")
+    require(len(sections) == EXPECTED_SECTION_TOTAL, f"section metadata denominator must be {EXPECTED_SECTION_TOTAL}")
+    section_by_id = {row["section_id"]: row for row in sections}
+    section_records = [_normal(dict(row)) for row in sections]
+    section_hash_by_file: dict[str, str] = {}
+    grouped_sections: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in section_records:
+        grouped_sections[str(row["source_file"])].append(row)
+    for source_file, values in grouped_sections.items():
+        section_hash_by_file[source_file] = _hash(values)
+    frozen_by_id = {str(unit["unit_id"]): unit for unit in frozen_units}
+    index_rows: list[dict[str, Any]] = []
+    for row in rows:
+        row_id = row["id"]
+        require(isinstance(row_id, int), "textbook primary key is not an integer")
+        unit_id = _source_universe_unit_id(row_id)
+        require(unit_id in frozen_by_id, "sources DB textbook row is absent from frozen unit ledger")
+        source_file = row["source_file"]
+        require(isinstance(source_file, str) and source_file, "textbook row lacks tracked source_file")
+        parent = row["parent_section_id"]
+        if parent is not None:
+            require(parent in section_by_id, "textbook parent section is absent from section metadata")
+            require(section_by_id[parent]["source_file"] == source_file, "textbook parent section source mismatch")
+        source_basis = {
+            "source_file": source_file,
+            "grade": row["grade"],
+            "author": row["author"],
+            "author_uk": row["author_uk"],
+            "subject": row["subject"],
+            "section_metadata_sha256": section_hash_by_file.get(source_file),
+        }
+        metadata_basis = _normal(dict(row))
+        index_rows.append({
+            "unit_id": unit_id,
+            "tracked_file": source_file,
+            "source_identity": f"source.school_textbooks.{_hash(_normal(source_basis))}",
+            "metadata_sha256": _hash(metadata_basis),
+        })
+    index_rows.sort(key=lambda item: item["unit_id"])
+    index_ids = {row["unit_id"] for row in index_rows}
+    require(len(index_ids) == EXPECTED_UNIT_TOTAL and index_ids == set(frozen_by_id), "metadata index is not a bijection with frozen units")
+    tracked_files = {row["tracked_file"] for row in index_rows}
+    require(len(tracked_files) == EXPECTED_TRACKED_FILE_TOTAL, f"tracked textbook file total must be {EXPECTED_TRACKED_FILE_TOTAL}")
+    return {
+        "sources_db_sha256": db_sha256,
+        "metadata_index_sha256": _hash(index_rows),
+        "tracked_file_total": len(tracked_files),
+        "section_total": len(sections),
+        "section_tracked_file_total": len(grouped_sections),
+        "section_metadata_sha256": _hash(section_records),
+        "rows": index_rows,
+    }
+
+
+def validate_bindings(
+    *,
+    coverage_contract: Path,
+    role_contract: Path,
+    source_freeze_receipt: Path,
+    school_units: Path,
+    sources_db: Path,
+) -> dict[str, Any]:
+    """Validate the current contracts and full frozen textbook identity ledger."""
+    coverage = _read_json(coverage_contract)
+    roles = _read_json(role_contract)
+    receipt = _read_json(source_freeze_receipt)
+    _validate_schema(coverage, COVERAGE_SCHEMA, "coverage contract")
+    _validate_schema(roles, ROLE_SCHEMA, "role contract")
+    _validate_schema(receipt, SOURCE_FREEZE_SCHEMA, "source-universe freeze receipt")
+    require(coverage.get("text_free") is True and receipt.get("text_free") is True, "text-free contract binding missing")
+    require(coverage.get("contract_inputs") == roles.get("contract_inputs"), "coverage and role contracts bind different Phase 3 inputs")
+    families = coverage.get("mandatory_families")
+    require(isinstance(families, list), "coverage contract lacks mandatory families")
+    school = next((family for family in families if isinstance(family, Mapping) and family.get("family_id") == "school_textbooks"), None)
+    require(isinstance(school, Mapping), "coverage contract lacks school_textbooks")
+    scanner = school.get("scanner_nonhit_audit")
+    require(isinstance(scanner, Mapping), "coverage contract lacks scanner non-hit audit")
+    require(scanner.get("auditor_role_id") == AUDITOR_ROLE_ID, "wrong non-hit auditor role")
+    require(scanner.get("seed_owner_role_id") == AUDITOR_ROLE_ID, "wrong non-hit seed owner")
+    require(scanner.get("sample_formula") == "min(1000,nonhit_total)", "weakened non-hit sample formula")
+    require(scanner.get("stratification") == ["tracked_file", "source_identity"], "wrong non-hit stratification")
+    require(scanner.get("rubric_frozen_before_sampling") is True and scanner.get("zero_misses_required") is True, "weakened non-hit acceptance contract")
+    source_school = _school_family(receipt)
+    units, ledger_file_sha256 = _load_source_units(school_units)
+    require(source_school["ledger_sha256"] == ledger_file_sha256, "school unit ledger does not match frozen receipt")
+    auditor = _assigned_role(roles, AUDITOR_ROLE_ID)
+    author = _assigned_role(roles, SCANNER_AUTHOR_ROLE_ID)
+    reviewer = _assigned_role(roles, SCANNER_REVIEWER_ROLE_ID)
+    root_identity = roles.get("root", {}).get("controller_identity_id")
+    identities = {auditor["controller_identity_id"], author["controller_identity_id"], reviewer["controller_identity_id"]}
+    require(len(identities) == 3 and root_identity not in identities, "scanner author, reviewer, auditor, and root identities must be distinct")
+    metadata = _metadata_index(sources_db, units, receipt)
+    return {
+        "coverage_contract_sha256": sha256_file(coverage_contract),
+        "role_contract_sha256": sha256_file(role_contract),
+        "source_freeze_receipt_sha256": sha256_file(source_freeze_receipt),
+        "school_ledger_sha256": ledger_file_sha256,
+        "frozen_unit_identity_sha256": _hash(units),
+        "sources_db_sha256": metadata["sources_db_sha256"],
+        "metadata_index_sha256": metadata["metadata_index_sha256"],
+        "tracked_file_total": metadata["tracked_file_total"],
+        "section_total": metadata["section_total"],
+        "section_tracked_file_total": metadata["section_tracked_file_total"],
+        "section_metadata_sha256": metadata["section_metadata_sha256"],
+        "auditor": auditor,
+        "scanner_author": author,
+        "scanner_reviewer": reviewer,
+        "metadata_rows": metadata["rows"],
+        "units": units,
+    }
+
+
+def neutral_classifications(units: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return source-free neutral stubs without caller-controlled strata."""
+    rows: list[dict[str, Any]] = []
+    for unit in units:
+        unit_id = unit.get("unit_id")
+        require(isinstance(unit_id, str), "neutral stub lacks frozen unit identity")
+        rows.append({
+            "unit_id": unit_id,
+            "unit_sha256": unit.get("unit_sha256"),
+            "locator": unit.get("locator"),
+            "candidate_classes": [],
+        })
+    return rows
+
+
+def _validated_classifications(
+    units: Sequence[Mapping[str, Any]], metadata_rows: Sequence[Mapping[str, Any]],
+    classifications: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    by_id = {str(unit["unit_id"]): unit for unit in units}
+    require(len(classifications) == len(units), "classification rows must account for every frozen textbook unit")
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in classifications:
+        require(isinstance(source, Mapping), "invalid scanner classification row")
+        require(set(source) == {"unit_id", "unit_sha256", "locator", "candidate_classes"}, "classification fields must be closed and source-free")
+        unit_id = source.get("unit_id")
+        require(isinstance(unit_id, str) and unit_id in by_id, "classification references a non-frozen textbook unit")
+        require(unit_id not in seen, "duplicate scanner classification unit")
+        seen.add(unit_id)
+        expected = by_id[unit_id]
+        require(source.get("unit_sha256") == expected["unit_sha256"], "classification unit hash differs from freeze")
+        require(source.get("locator") == expected["locator"], "classification locator differs from freeze")
+        classes = source.get("candidate_classes")
+        require(isinstance(classes, list) and all(isinstance(item, str) for item in classes), "invalid candidate classes")
+        require(set(classes) <= set(CANDIDATE_CLASSES), "unknown candidate class")
+        require(len(classes) == len(set(classes)), "duplicate candidate class")
+        rows.append({
+            **expected,
+            "candidate_classes": sorted(classes),
+        })
+    require(seen == set(by_id), "classification universe is incomplete")
+    metadata = {str(row["unit_id"]): row for row in metadata_rows}
+    require(set(metadata) == set(by_id), "metadata strata are not a frozen-unit bijection")
+    return sorted(({
+        **row,
+        "tracked_file": metadata[str(row["unit_id"])]["tracked_file"],
+        "source_identity": metadata[str(row["unit_id"])]["source_identity"],
+        "metadata_sha256": metadata[str(row["unit_id"])]["metadata_sha256"],
+    } for row in rows), key=lambda item: str(item["unit_id"]))
+
+
+def _validate_rubric(rubric: Mapping[str, Any]) -> dict[str, Any]:
+    required = {"rubric_id", "candidate_classes", "positive_fixture_ids", "negative_fixture_ids", "expected_decisions"}
+    require(set(rubric) == required, "eligibility rubric fields must be closed and complete")
+    require(isinstance(rubric["rubric_id"], str) and rubric["rubric_id"], "rubric lacks identity")
+    require(rubric["candidate_classes"] == list(CANDIDATE_CLASSES), "rubric candidate classes changed")
+    positive, negative = rubric["positive_fixture_ids"], rubric["negative_fixture_ids"]
+    require(isinstance(positive, list) and isinstance(negative, list) and positive and negative, "rubric needs positive and negative fixtures")
+    require(all(isinstance(item, str) and item for item in positive + negative), "invalid rubric fixture identity")
+    require(len(set(positive)) == len(positive) and len(set(negative)) == len(negative) and not (set(positive) & set(negative)), "rubric fixture identities overlap")
+    expected = rubric["expected_decisions"]
+    require(isinstance(expected, Mapping) and set(expected) == set(positive + negative), "rubric expected decisions do not bind every fixture")
+    require(all(expected[item] is True for item in positive) and all(expected[item] is False for item in negative), "rubric fixture decisions do not match polarity")
+    return dict(rubric)
+
+
+def _validate_review_receipt(
+    receipt_path: Path,
+    *,
+    bindings: Mapping[str, Any],
+    classification_sha256: str,
+    rubric_sha256: str,
+    scanner_sha256: str,
+) -> dict[str, Any]:
+    receipt = _read_json(receipt_path)
+    required = {
+        "schema_version", "text_free", "scanner_author", "scanner_reviewer", "scanner",
+        "metadata_index_sha256", "classification_universe_sha256", "rubric_sha256", "decision",
+    }
+    require(set(receipt) == required, "scanner/rubric review receipt fields must be closed")
+    require(receipt.get("schema_version") == "phase3_textbook_scanner_review_receipt_v1", "wrong scanner review receipt schema")
+    require(receipt.get("text_free") is True and receipt.get("decision") == "approved", "scanner/rubric review is not approved")
+    require(receipt.get("scanner_author") == bindings["scanner_author"], "review receipt scanner author does not match role/task contract")
+    require(receipt.get("scanner_reviewer") == bindings["scanner_reviewer"], "review receipt reviewer does not match role/task contract")
+    scanner = receipt.get("scanner")
+    require(scanner == {
+        "implementation_version": SCANNER_IMPLEMENTATION_VERSION,
+        "script_path": SCANNER_SCRIPT_PATH,
+        "script_sha256": scanner_sha256,
+    }, "review receipt scanner identity changed")
+    require(receipt.get("metadata_index_sha256") == bindings["metadata_index_sha256"], "review receipt metadata index hash changed")
+    require(receipt.get("classification_universe_sha256") == classification_sha256, "review receipt classification hash changed")
+    require(receipt.get("rubric_sha256") == rubric_sha256, "review receipt rubric hash changed")
+    return {"receipt": receipt, "receipt_sha256": sha256_file(receipt_path)}
+
+
+def _validate_bundle_integrity(bundle: Mapping[str, Any]) -> None:
+    """Check semantic identities that JSON Schema cannot express."""
+    _validate_schema(bundle, BUNDLE_SCHEMA, "textbook non-hit bundle")
+    population = bundle["population"]
+    all_units = population["all_units"]
+    candidates = population["candidate_units"]
+    nonhits = population["nonhit_units"]
+    require(len(all_units) == EXPECTED_UNIT_TOTAL, "bundle does not retain every frozen textbook unit")
+    require(len({row["unit_id"] for row in all_units}) == EXPECTED_UNIT_TOTAL, "bundle has duplicate frozen textbook unit")
+    require(all(row["candidate_classes"] for row in candidates), "candidate universe includes non-candidate")
+    require(all(not row["candidate_classes"] for row in nonhits), "non-hit universe includes candidate")
+    all_ids = {row["unit_id"] for row in all_units}
+    candidate_ids = {row["unit_id"] for row in candidates}
+    nonhit_ids = {row["unit_id"] for row in nonhits}
+    require(candidate_ids.isdisjoint(nonhit_ids) and candidate_ids | nonhit_ids == all_ids, "candidate/non-hit universes are not a complete complement")
+    require(population["candidate_total"] == len(candidates) and population["nonhit_total"] == len(nonhits), "population totals drifted")
+    require(population["all_units_sha256"] == _hash(all_units), "all-unit population hash drifted")
+    require(population["candidate_universe_sha256"] == _hash(candidates), "candidate universe hash drifted")
+    require(population["nonhit_universe_sha256"] == _hash(nonhits), "non-hit universe hash drifted")
+    require(bundle["scanner"]["classification_universe_sha256"] == population["all_units_sha256"], "scanner classification hash drifted")
+    frozen_projection = [{key: row[key] for key in ("unit_id", "unit_sha256", "locator")} for row in all_units]
+    require(bundle["source_bindings"]["frozen_unit_identity_sha256"] == _hash(frozen_projection), "frozen unit identity binding drifted")
+    metadata_projection = [{key: row[key] for key in ("unit_id", "tracked_file", "source_identity", "metadata_sha256")} for row in all_units]
+    require(bundle["source_bindings"]["metadata_index_sha256"] == _hash(metadata_projection), "metadata index binding drifted")
+    require(len({row["tracked_file"] for row in all_units}) == EXPECTED_TRACKED_FILE_TOTAL, "tracked file population drifted")
+    rubric = dict(bundle["rubric"])
+    rubric_hash = rubric.pop("rubric_sha256")
+    _validate_rubric(rubric)
+    require(rubric_hash == _hash(rubric), "rubric hash drifted")
+    receipt = bundle["scanner_review"]["receipt"]
+    require(bundle["scanner_review"]["receipt_sha256"] == _hash(receipt), "embedded scanner review receipt hash drifted")
+    require(receipt["text_free"] is True and receipt["decision"] == "approved", "embedded scanner review is not approved")
+    require(receipt["scanner_author"] == bundle["scanner"]["author"], "scanner author/review binding drifted")
+    require(receipt["classification_universe_sha256"] == population["all_units_sha256"], "scanner review receipt classification hash drifted")
+    require(receipt["classification_universe_sha256"] == bundle["scanner"]["classification_universe_sha256"], "scanner review/scanner classification binding drifted")
+    require(receipt["metadata_index_sha256"] == bundle["source_bindings"]["metadata_index_sha256"], "scanner review receipt metadata hash drifted")
+    require(receipt["rubric_sha256"] == rubric_hash, "scanner review receipt rubric hash drifted")
+    require(receipt["scanner"] == {
+        "implementation_version": bundle["scanner"]["implementation_version"],
+        "script_path": bundle["scanner"]["script_path"],
+        "script_sha256": bundle["scanner"]["script_sha256"],
+    }, "scanner review receipt implementation identity drifted")
+    reviewer = receipt["scanner_reviewer"]
+    require(isinstance(reviewer, Mapping), "scanner review receipt lacks reviewer binding")
+    identities = {
+        bundle["scanner"]["author"]["controller_identity_id"],
+        reviewer.get("controller_identity_id"),
+        bundle["audit_contract"]["auditor_identity_id"],
+    }
+    require(None not in identities and len(identities) == 3, "scanner author, reviewer, and auditor identities overlap")
+
+
+def build_bundle(
+    *,
+    coverage_contract: Path,
+    role_contract: Path,
+    source_freeze_receipt: Path,
+    school_units: Path,
+    sources_db: Path,
+    classifications: Sequence[Mapping[str, Any]],
+    rubric: Mapping[str, Any],
+    scanner_review_receipt: Path,
+) -> dict[str, Any]:
+    """Compile a complete, immutable text-free candidate/non-hit universe."""
+    bindings = validate_bindings(
+        coverage_contract=coverage_contract, role_contract=role_contract,
+        source_freeze_receipt=source_freeze_receipt, school_units=school_units,
+        sources_db=sources_db,
+    )
+    classified = _validated_classifications(bindings["units"], bindings["metadata_rows"], classifications)
+    frozen_rubric = _validate_rubric(rubric)
+    scanner_sha256 = sha256_file(ROOT / SCANNER_SCRIPT_PATH)
+    classification_sha256 = _hash(classified)
+    rubric_sha256 = _hash(frozen_rubric)
+    review = _validate_review_receipt(
+        scanner_review_receipt,
+        bindings=bindings,
+        classification_sha256=classification_sha256,
+        rubric_sha256=rubric_sha256,
+        scanner_sha256=scanner_sha256,
+    )
+    candidates = [row for row in classified if row["candidate_classes"]]
+    nonhits = [row for row in classified if not row["candidate_classes"]]
+    require(len(candidates) + len(nonhits) == EXPECTED_UNIT_TOTAL, "candidate/non-hit complement does not equal frozen denominator")
+    bundle = {
+        "schema_version": "phase3_textbook_nonhit_bundle_v1",
+        "text_free": True,
+        "source_bindings": {key: bindings[key] for key in (
+            "coverage_contract_sha256", "role_contract_sha256", "source_freeze_receipt_sha256",
+            "school_ledger_sha256", "frozen_unit_identity_sha256",
+            "sources_db_sha256", "metadata_index_sha256", "tracked_file_total",
+            "section_total", "section_tracked_file_total",
+            "section_metadata_sha256",
+        )},
+        "scanner": {
+            "implementation_version": SCANNER_IMPLEMENTATION_VERSION,
+            "script_path": SCANNER_SCRIPT_PATH,
+            "script_sha256": scanner_sha256,
+            "candidate_classes": list(CANDIDATE_CLASSES),
+            "classification_universe_sha256": classification_sha256,
+            "author": bindings["scanner_author"],
+        },
+        "rubric": {**frozen_rubric, "rubric_sha256": rubric_sha256},
+        "scanner_review": {
+            "receipt": review["receipt"],
+            "receipt_sha256": _hash(review["receipt"]),
+            "receipt_file_sha256": review["receipt_sha256"],
+        },
+        "population": {
+            "frozen_unit_total": EXPECTED_UNIT_TOTAL,
+            "candidate_total": len(candidates),
+            "nonhit_total": len(nonhits),
+            "all_units_sha256": _hash(classified),
+            "candidate_universe_sha256": _hash(candidates),
+            "nonhit_universe_sha256": _hash(nonhits),
+            "all_units": classified,
+            "candidate_units": candidates,
+            "nonhit_units": nonhits,
+        },
+        "audit_contract": {
+            "auditor_role_id": AUDITOR_ROLE_ID,
+            "auditor_identity_id": bindings["auditor"]["controller_identity_id"],
+            "auditor_task_id": bindings["auditor"]["reserved_task_id"],
+            "sample_formula": "min(1000,nonhit_total)",
+            "sampler_version": SAMPLER_VERSION,
+            "stratification": ["tracked_file", "source_identity"],
+            "sampling_without_replacement": True,
+            "entropy_contract": "approved_common_anti_grinding_v1",
+            "arbitrary_seed_forbidden": True,
+            "first_containing_origin_main_squash_merge_required": True,
+            "unique_canonical_tuple_seed_required": True,
+            "auditor_sole_attestor_committer": True,
+            "seed_choice_reroll_reuse_forbidden": True,
+            "passing_sample_reuse_forbidden": True,
+            "zero_misses_required": True,
+            "miss_invalidates_population_and_sample": True,
+        },
+    }
+    _validate_bundle_integrity(bundle)
+    return bundle
+
+
+def hamilton_quotas(counts: Mapping[str, int], sample_n: int) -> dict[str, int]:
+    """Allocate without replacement using proportional Hamilton largest remainder."""
+    require(sample_n >= 0 and all(isinstance(value, int) and value > 0 for value in counts.values()), "invalid stratum counts")
+    total = sum(counts.values())
+    require(sample_n <= total, "sample exceeds stratum population")
+    keys = sorted(counts)
+    if sample_n == 0:
+        return {key: 0 for key in keys}
+    baseline = {key: 0 for key in keys}
+    if sample_n >= len(keys):
+        baseline = {key: 1 for key in keys}
+    remaining_n = sample_n - sum(baseline.values())
+    capacity = {key: counts[key] - baseline[key] for key in keys}
+    capacity_total = sum(capacity.values())
+    if remaining_n == 0:
+        return baseline
+    exact = {key: remaining_n * capacity[key] / capacity_total for key in keys}
+    quotas = {key: baseline[key] + int(exact[key]) for key in keys}
+    unassigned = sample_n - sum(quotas.values())
+    for key in sorted(keys, key=lambda item: (-(exact[item] - int(exact[item])), item))[:unassigned]:
+        quotas[key] += 1
+    require(all(quotas[key] <= counts[key] for key in keys), "Hamilton allocation exceeds a stratum")
+    return quotas
+
+
+def _select(rows: Sequence[Mapping[str, Any]], count: int, seed: str, namespace: str) -> list[dict[str, Any]]:
+    ranked = sorted(rows, key=lambda row: (
+        _hash({"sampler_version": SAMPLER_VERSION, "seed": seed, "namespace": namespace, "unit_id": row["unit_id"]}),
+        str(row["unit_id"]),
+    ))
+    return [dict(row) for row in ranked[:count]]
+
+
+def _verify_approved_entropy(bundle: Mapping[str, Any], entropy_receipt: Mapping[str, Any]) -> dict[str, str]:
+    """Delegate anti-grinding verification to the approved common helper only."""
+    try:
+        module = importlib.import_module(APPROVED_ENTROPY_MODULE)
+    except ImportError as exc:
+        raise TextbookNonhitError("approved common anti-grinding entropy helper is unavailable") from exc
+    verifier = getattr(module, APPROVED_ENTROPY_VERIFIER, None)
+    require(callable(verifier), "approved common anti-grinding entropy verifier is unavailable")
+    try:
+        result = verifier(
+            entropy_receipt,
+            purpose="textbook_nonhit",
+            frozen_bundle_sha256=_hash(bundle),
+            frozen_population_sha256=bundle["population"]["nonhit_universe_sha256"],
+            auditor_role_id=AUDITOR_ROLE_ID,
+            auditor_identity_id=bundle["audit_contract"]["auditor_identity_id"],
+        )
+    except Exception as exc:
+        raise TextbookNonhitError("approved common anti-grinding entropy receipt is invalid") from exc
+    require(isinstance(result, Mapping), "approved entropy verifier returned an invalid result")
+    required = {"derived_seed", "entropy_receipt_sha256", "first_containing_merge_sha", "canonical_tuple_sha256"}
+    require(set(result) == required, "approved entropy verifier result shape changed")
+    require(all(isinstance(result[key], str) and result[key] for key in required), "approved entropy verifier returned empty identity")
+    require(SHA256.fullmatch(str(result["entropy_receipt_sha256"])) is not None, "invalid entropy receipt hash")
+    require(SHA256.fullmatch(str(result["canonical_tuple_sha256"])) is not None, "invalid entropy tuple hash")
+    require(re.fullmatch(r"[a-f0-9]{40}", str(result["first_containing_merge_sha"])) is not None, "invalid entropy merge SHA")
+    return {key: str(result[key]) for key in required}
+
+
+def draw_audit_sample(bundle: Mapping[str, Any], *, entropy_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Draw one deterministic sample only after approved entropy verification."""
+    _validate_bundle_integrity(bundle)
+    entropy = _verify_approved_entropy(bundle, entropy_receipt)
+    seed = entropy["derived_seed"]
+    nonhits = bundle["population"]["nonhit_units"]
+    require(isinstance(nonhits, list), "bundle lacks non-hit universe")
+    sample_n = min(1000, len(nonhits))
+    by_file: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in nonhits:
+        by_file[row["tracked_file"]].append(row)
+    file_quotas = hamilton_quotas({key: len(value) for key, value in by_file.items()}, sample_n)
+    selected: list[dict[str, Any]] = []
+    source_quotas: dict[str, dict[str, int]] = {}
+    for tracked_file in sorted(by_file):
+        rows = by_file[tracked_file]
+        by_source: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+        for row in rows:
+            by_source[row["source_identity"]].append(row)
+        local_quotas = hamilton_quotas({key: len(value) for key, value in by_source.items()}, file_quotas[tracked_file])
+        source_quotas[tracked_file] = local_quotas
+        for source_identity in sorted(by_source):
+            selected.extend(_select(by_source[source_identity], local_quotas[source_identity], seed, f"{tracked_file}:{source_identity}"))
+    require(len(selected) == sample_n and len({row["unit_id"] for row in selected}) == sample_n, "sample is not without replacement")
+    selected.sort(key=lambda row: str(row["unit_id"]))
+    return {
+        "schema_version": "phase3_textbook_nonhit_audit_sample_v1",
+        "text_free": True,
+        "bundle_sha256": _hash(bundle),
+        "nonhit_universe_sha256": bundle["population"]["nonhit_universe_sha256"],
+        "auditor_role_id": AUDITOR_ROLE_ID,
+        "auditor_identity_id": bundle["audit_contract"]["auditor_identity_id"],
+        "auditor_task_id": bundle["audit_contract"]["auditor_task_id"],
+        "entropy_receipt_sha256": entropy["entropy_receipt_sha256"],
+        "first_containing_merge_sha": entropy["first_containing_merge_sha"],
+        "canonical_tuple_sha256": entropy["canonical_tuple_sha256"],
+        "derived_seed_sha256": _hash({"derived_seed": seed}),
+        "sampler_version": SAMPLER_VERSION,
+        "sample_n": sample_n,
+        "nonhit_total": len(nonhits),
+        "shortfall_census": sample_n == len(nonhits) and len(nonhits) < 1000,
+        "file_quotas": file_quotas,
+        "source_quotas": source_quotas,
+        "sample_units": selected,
+        "sample_sha256": _hash(selected),
+    }
+
+
+def validate_audit_results(
+    bundle: Mapping[str, Any],
+    sample: Mapping[str, Any],
+    *,
+    entropy_receipt: Mapping[str, Any],
+    decision_receipt_path: Path,
+) -> dict[str, Any]:
+    """Recompute the sample and validate one immutable auditor decision receipt."""
+    _validate_bundle_integrity(bundle)
+    recomputed = draw_audit_sample(bundle, entropy_receipt=entropy_receipt)
+    require(sample == recomputed, "sample differs from deterministic bundle/entropy recomputation")
+    decision_receipt = _read_json(decision_receipt_path)
+    required = {
+        "schema_version", "text_free", "auditor_role_id", "auditor_identity_id", "auditor_task_id",
+        "bundle_sha256", "sample_sha256", "entropy_receipt_sha256", "decisions", "decisions_sha256",
+    }
+    require(set(decision_receipt) == required, "audit decision receipt fields must be closed")
+    require(decision_receipt.get("schema_version") == "phase3_textbook_nonhit_decision_receipt_v1", "wrong audit decision receipt schema")
+    require(decision_receipt.get("text_free") is True, "audit decision receipt is not text-free")
+    require(decision_receipt.get("auditor_role_id") == AUDITOR_ROLE_ID, "audit decision role is not textbook non-hit auditor")
+    require(decision_receipt.get("auditor_identity_id") == bundle["audit_contract"]["auditor_identity_id"], "audit decision identity is not the assigned auditor")
+    require(decision_receipt.get("auditor_task_id") == bundle["audit_contract"]["auditor_task_id"], "audit decision task is not the assigned auditor task")
+    require(decision_receipt.get("bundle_sha256") == _hash(bundle), "decision receipt bundle hash changed")
+    require(decision_receipt.get("sample_sha256") == sample["sample_sha256"], "decision receipt sample hash changed")
+    require(decision_receipt.get("entropy_receipt_sha256") == sample["entropy_receipt_sha256"], "decision receipt entropy hash changed")
+    decisions = decision_receipt.get("decisions")
+    require(isinstance(decisions, list), "decision receipt lacks decisions")
+    require(decision_receipt.get("decisions_sha256") == _hash(decisions), "audit decision rows hash changed")
+    sample_units = recomputed["sample_units"]
+    require(len(decisions) == len(sample_units), "every sample unit requires one audit decision")
+    sample_ids = {row["unit_id"] for row in sample_units}
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for row in decisions:
+        require(isinstance(row, Mapping), "invalid audit decision")
+        require(set(row) == {"unit_id", "decision"}, "audit decision fields must be closed and source-free")
+        unit_id, decision = row.get("unit_id"), row.get("decision")
+        require(isinstance(unit_id, str) and unit_id in sample_ids and unit_id not in seen, "audit decision does not bind exactly one sample unit")
+        require(decision in AUDIT_DECISIONS, "unknown audit decision")
+        seen.add(unit_id)
+        normalized.append({"unit_id": unit_id, "decision": decision})
+    require(seen == sample_ids, "audit decisions omit a sample unit")
+    misses = sorted(row["unit_id"] for row in normalized if row["decision"] != "agree")
+    result = {
+        "schema_version": "phase3_textbook_nonhit_audit_result_v1",
+        "text_free": True,
+        "bundle_sha256": _hash(bundle),
+        "sample_sha256": recomputed["sample_sha256"],
+        "entropy_receipt_sha256": recomputed["entropy_receipt_sha256"],
+        "auditor_role_id": AUDITOR_ROLE_ID,
+        "auditor_identity_id": bundle["audit_contract"]["auditor_identity_id"],
+        "auditor_task_id": bundle["audit_contract"]["auditor_task_id"],
+        "decision_receipt_file_sha256": sha256_file(decision_receipt_path),
+        "decisions_sha256": decision_receipt["decisions_sha256"],
+        "decision_total": len(normalized),
+        "miss_total": len(misses),
+        "missed_unit_ids": misses,
+        "status": "PASS_ZERO_MISSES" if not misses else "INVALID_SCANNER_POPULATION_AND_SAMPLE",
+        "requires_new_scanner_hash_and_auditor_seed": bool(misses),
+        "prior_sample_reuse_forbidden": True,
+    }
+    return {**result, "result_sha256": _hash(result)}
+
+
+def write_bundle(bundle: Mapping[str, Any], output: Path) -> None:
+    """Atomically write a schema-validated text-free bundle."""
+    _validate_bundle_integrity(bundle)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", newline="\n", dir=output.parent, delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(canonical_json(bundle) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, output)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--coverage-contract", type=Path, required=True)
+    parser.add_argument("--role-contract", type=Path, required=True)
+    parser.add_argument("--source-freeze-receipt", type=Path, required=True)
+    parser.add_argument("--school-units", type=Path, required=True)
+    parser.add_argument("--sources-db", type=Path, required=True)
+    parser.add_argument("--classifications", type=Path, required=True)
+    parser.add_argument("--rubric", type=Path, required=True)
+    parser.add_argument("--scanner-review-receipt", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    bundle = build_bundle(
+        coverage_contract=args.coverage_contract, role_contract=args.role_contract,
+        source_freeze_receipt=args.source_freeze_receipt, school_units=args.school_units,
+        sources_db=args.sources_db, classifications=_read_jsonl(args.classifications),
+        rubric=_read_json(args.rubric), scanner_review_receipt=args.scanner_review_receipt,
+    )
+    write_bundle(bundle, args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_open_model_phase3_textbook_nonhit.py
+++ b/tests/test_open_model_phase3_textbook_nonhit.py
@@ -1,0 +1,240 @@
+"""Hermetic tests for the text-free textbook non-hit scanner boundary."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_textbook_nonhit as scanner
+
+
+def _json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+
+def _source_db(path: Path, total: int) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE textbooks (id INTEGER PRIMARY KEY, chunk_id TEXT, title TEXT, text TEXT, "
+            "source_file TEXT, grade TEXT, author TEXT, char_count INTEGER, parent_section_id INTEGER, "
+            "author_uk TEXT, subject TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE textbook_sections (section_id INTEGER PRIMARY KEY, source_file TEXT, grade INTEGER, "
+            "section_title TEXT, section_number TEXT, page_start INTEGER, page_end INTEGER, chunk_count INTEGER, full_text TEXT)"
+        )
+        for section_id in range(1, 5):
+            source_file = f"file-{(section_id - 1) % 3}"
+            connection.execute(
+                "INSERT INTO textbook_sections VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (section_id, source_file, 5, "forbidden section title", str(section_id), section_id, section_id, 2, "forbidden full text"),
+            )
+        for index in range(total):
+            source_file = f"file-{index % 3}"
+            parent = (index % 4) + 1 if index < 4 else None
+            # Keep parent/source identity coherent for the linked fixture rows.
+            if parent is not None:
+                source_file = f"file-{(parent - 1) % 3}"
+            connection.execute(
+                "INSERT INTO textbooks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (index + 1, f"chunk-{index}", "forbidden title", "forbidden textbook text", source_file, "5", "author", 10, parent, "author-uk", "subject"),
+            )
+
+
+def _frozen_unit(row_id: int) -> dict[str, object]:
+    return {
+        "unit_id": scanner._source_universe_unit_id(row_id),
+        "unit_sha256": f"{row_id + 100:064x}",
+        "locator": {
+            "kind": "sqlite_row", "table": "textbooks", "primary_key_fields": ["id"],
+            "primary_key_sha256": scanner._hash({"id": row_id}),
+        },
+    }
+
+
+def _fixture_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, total: int = 8) -> dict[str, object]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(scanner, "EXPECTED_UNIT_TOTAL", total)
+    monkeypatch.setattr(scanner, "EXPECTED_TRACKED_FILE_TOTAL", 3)
+    monkeypatch.setattr(scanner, "EXPECTED_SECTION_TOTAL", 4)
+    monkeypatch.setattr(scanner, "_validate_schema", lambda *args, **kwargs: None)
+    sources_db = tmp_path / "sources.db"
+    _source_db(sources_db, total)
+    units = [_frozen_unit(index + 1) for index in range(total)]
+    ledger = tmp_path / "school.units.jsonl"
+    ledger.write_text("".join(json.dumps(item, sort_keys=True) + "\n" for item in units), encoding="utf-8")
+    coverage, roles, freeze = tmp_path / "coverage.json", tmp_path / "roles.json", tmp_path / "freeze.json"
+    contract_inputs = {"original_prompt_sha256": "a" * 64, "scope_amendment_sha256": "b" * 64, "combined_contract_sha256": "c" * 64}
+    _json(coverage, {"text_free": True, "contract_inputs": contract_inputs, "mandatory_families": [{"family_id": "school_textbooks", "scanner_nonhit_audit": {"auditor_role_id": scanner.AUDITOR_ROLE_ID, "seed_owner_role_id": scanner.AUDITOR_ROLE_ID, "sample_formula": "min(1000,nonhit_total)", "stratification": ["tracked_file", "source_identity"], "rubric_frozen_before_sampling": True, "zero_misses_required": True}}]})
+    role_rows = [
+        (scanner.AUDITOR_ROLE_ID, "controller_auditor", "task-auditor"),
+        (scanner.SCANNER_AUTHOR_ROLE_ID, "controller_author", "task-author"),
+        (scanner.SCANNER_REVIEWER_ROLE_ID, "controller_reviewer", "task-reviewer"),
+    ]
+    _json(roles, {
+        "contract_inputs": contract_inputs, "root": {"controller_identity_id": "controller_root"},
+        "seats": [{"role_id": role, "assignment_state": "assigned_verified", "controller_identity_attested": True, "controller_identity_id": identity} for role, identity, _ in role_rows],
+        "task_bindings": [{"role_id": role, "controller_identity_id": identity, "reserved_task_id": task, "status": "identity_attested_pre_artifact"} for role, identity, task in role_rows],
+    })
+    _json(freeze, {
+        "text_free": True, "input_sha256": {"sources_db": scanner.sha256_file(sources_db)},
+        "families": [{"family_id": "school_textbooks", "unit_count": total, "ledger_sha256": scanner.sha256_file(ledger)}],
+    })
+    rubric = {"rubric_id": "rubric-fixture-v1", "candidate_classes": list(scanner.CANDIDATE_CLASSES), "positive_fixture_ids": ["positive-1"], "negative_fixture_ids": ["negative-1"], "expected_decisions": {"positive-1": True, "negative-1": False}}
+    classifications = scanner.neutral_classifications(units)
+    classifications[1]["candidate_classes"] = ["rule_bearing"]
+    classifications[6]["candidate_classes"] = ["contrast"]
+    inputs: dict[str, object] = {
+        "coverage_contract": coverage, "role_contract": roles, "source_freeze_receipt": freeze,
+        "school_units": ledger, "sources_db": sources_db, "classifications": classifications,
+        "rubric": rubric,
+    }
+    bindings = scanner.validate_bindings(
+        coverage_contract=coverage, role_contract=roles, source_freeze_receipt=freeze,
+        school_units=ledger, sources_db=sources_db,
+    )
+    classified = scanner._validated_classifications(units, bindings["metadata_rows"], classifications)
+    review = {
+        "schema_version": "phase3_textbook_scanner_review_receipt_v1", "text_free": True,
+        "scanner_author": bindings["scanner_author"], "scanner_reviewer": bindings["scanner_reviewer"],
+        "scanner": {"implementation_version": scanner.SCANNER_IMPLEMENTATION_VERSION, "script_path": scanner.SCANNER_SCRIPT_PATH, "script_sha256": scanner.sha256_file(scanner.ROOT / scanner.SCANNER_SCRIPT_PATH)},
+        "metadata_index_sha256": bindings["metadata_index_sha256"], "classification_universe_sha256": scanner._hash(classified),
+        "rubric_sha256": scanner._hash(rubric), "decision": "approved",
+    }
+    review_path = tmp_path / "review.json"
+    _json(review_path, review)
+    inputs["scanner_review_receipt"] = review_path
+    return inputs
+
+
+def _bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    return scanner.build_bundle(**_fixture_inputs(tmp_path, monkeypatch))
+
+
+def _entropy() -> dict[str, str]:
+    return {
+        "derived_seed": "fixed-approved-derived-seed",
+        "entropy_receipt_sha256": "a" * 64,
+        "first_containing_merge_sha": "b" * 40,
+        "canonical_tuple_sha256": "c" * 64,
+    }
+
+
+def test_build_derives_strata_and_preserves_complete_complement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = _bundle(tmp_path, monkeypatch)
+    population = bundle["population"]
+    assert population["frozen_unit_total"] == 8
+    assert len(population["candidate_units"]) == 2
+    assert len(population["nonhit_units"]) == 6
+    assert bundle["source_bindings"]["tracked_file_total"] == 3
+    assert bundle["source_bindings"]["section_total"] == 4
+    assert {row["tracked_file"] for row in population["all_units"]} == {"file-0", "file-1", "file-2"}
+    assert all(row["source_identity"].startswith("source.school_textbooks.") for row in population["all_units"])
+    assert all("text" not in row for row in population["all_units"])
+
+
+def test_metadata_and_review_tampering_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = _fixture_inputs(tmp_path, monkeypatch)
+    inputs["classifications"][0]["tracked_file"] = "caller-invented"
+    with pytest.raises(scanner.TextbookNonhitError, match="closed and source-free"):
+        scanner.build_bundle(**inputs)
+    inputs = _fixture_inputs(tmp_path / "review", monkeypatch)
+    review = json.loads(inputs["scanner_review_receipt"].read_text(encoding="utf-8"))
+    review["scanner_author"] = review["scanner_reviewer"]
+    _json(inputs["scanner_review_receipt"], review)
+    with pytest.raises(scanner.TextbookNonhitError, match="scanner author"):
+        scanner.build_bundle(**inputs)
+    inputs = _fixture_inputs(tmp_path / "db", monkeypatch)
+    with sqlite3.connect(inputs["sources_db"]) as connection:
+        connection.execute("UPDATE textbooks SET source_file='drifted' WHERE id=1")
+    with pytest.raises(scanner.TextbookNonhitError, match="sources database does not match"):
+        scanner.build_bundle(**inputs)
+
+
+def test_post_build_partition_retarget_cannot_reuse_old_review_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _bundle(tmp_path, monkeypatch)
+    population = bundle["population"]
+    moved = population["nonhit_units"].pop(0)
+    moved["candidate_classes"] = ["rule_bearing"]
+    population["candidate_units"].append(moved)
+    population["candidate_units"].sort(key=lambda row: row["unit_id"])
+    all_row = next(row for row in population["all_units"] if row["unit_id"] == moved["unit_id"])
+    all_row["candidate_classes"] = ["rule_bearing"]
+    population["candidate_total"] = len(population["candidate_units"])
+    population["nonhit_total"] = len(population["nonhit_units"])
+    population["all_units_sha256"] = scanner._hash(population["all_units"])
+    population["candidate_universe_sha256"] = scanner._hash(population["candidate_units"])
+    population["nonhit_universe_sha256"] = scanner._hash(population["nonhit_units"])
+    bundle["scanner"]["classification_universe_sha256"] = population["all_units_sha256"]
+
+    with pytest.raises(scanner.TextbookNonhitError, match="review receipt classification hash drifted"):
+        scanner.draw_audit_sample(bundle, entropy_receipt={})
+
+
+def test_entropy_fails_closed_until_approved_helper_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(scanner.importlib, "import_module", lambda name: (_ for _ in ()).throw(ImportError(name)))
+    with pytest.raises(scanner.TextbookNonhitError, match="approved common anti-grinding"):
+        scanner.draw_audit_sample(bundle, entropy_receipt={})
+
+
+def test_audit_recomputes_sample_and_binds_immutable_auditor_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(scanner, "_verify_approved_entropy", lambda *args, **kwargs: _entropy())
+    sample = scanner.draw_audit_sample(bundle, entropy_receipt={"opaque": "verified-by-common-helper"})
+    decisions = [{"unit_id": row["unit_id"], "decision": "agree"} for row in sample["sample_units"]]
+    receipt = {
+        "schema_version": "phase3_textbook_nonhit_decision_receipt_v1", "text_free": True,
+        "auditor_role_id": scanner.AUDITOR_ROLE_ID, "auditor_identity_id": "controller_auditor", "auditor_task_id": "task-auditor",
+        "bundle_sha256": scanner._hash(bundle), "sample_sha256": sample["sample_sha256"],
+        "entropy_receipt_sha256": sample["entropy_receipt_sha256"], "decisions": decisions,
+        "decisions_sha256": scanner._hash(decisions),
+    }
+    receipt_path = tmp_path / "decisions.json"
+    _json(receipt_path, receipt)
+    passed = scanner.validate_audit_results(bundle, sample, entropy_receipt={}, decision_receipt_path=receipt_path)
+    assert passed["status"] == "PASS_ZERO_MISSES"
+    assert passed["result_sha256"] == scanner._hash({key: value for key, value in passed.items() if key != "result_sha256"})
+    sample["sample_units"][0] = dict(bundle["population"]["candidate_units"][0])
+    with pytest.raises(scanner.TextbookNonhitError, match="sample differs"):
+        scanner.validate_audit_results(bundle, sample, entropy_receipt={}, decision_receipt_path=receipt_path)
+
+
+def test_nonagree_result_invalidates_population_and_requires_fresh_entropy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(scanner, "_verify_approved_entropy", lambda *args, **kwargs: _entropy())
+    sample = scanner.draw_audit_sample(bundle, entropy_receipt={})
+    decisions = [{"unit_id": row["unit_id"], "decision": "agree"} for row in sample["sample_units"]]
+    decisions[0]["decision"] = "ambiguous_eligibility"
+    receipt = {
+        "schema_version": "phase3_textbook_nonhit_decision_receipt_v1", "text_free": True,
+        "auditor_role_id": scanner.AUDITOR_ROLE_ID, "auditor_identity_id": "controller_auditor", "auditor_task_id": "task-auditor",
+        "bundle_sha256": scanner._hash(bundle), "sample_sha256": sample["sample_sha256"],
+        "entropy_receipt_sha256": sample["entropy_receipt_sha256"], "decisions": decisions,
+        "decisions_sha256": scanner._hash(decisions),
+    }
+    path = tmp_path / "miss.json"
+    _json(path, receipt)
+    failed = scanner.validate_audit_results(bundle, sample, entropy_receipt={}, decision_receipt_path=path)
+    assert failed["status"] == "INVALID_SCANNER_POPULATION_AND_SAMPLE"
+    assert failed["requires_new_scanner_hash_and_auditor_seed"] is True
+    assert failed["prior_sample_reuse_forbidden"] is True
+
+
+def test_hamilton_and_production_schema_pins_denominators() -> None:
+    assert scanner.hamilton_quotas({"a": 4, "b": 3, "c": 3}, 5) == {"a": 2, "b": 2, "c": 1}
+    schema = json.loads(scanner.BUNDLE_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    assert schema["additionalProperties"] is False
+    population = schema["$defs"]["population"]["properties"]
+    assert population["frozen_unit_total"] == {"const": 54979}
+    assert population["all_units"]["minItems"] == population["all_units"]["maxItems"] == 54979
+    source = schema["$defs"]["source_bindings"]["properties"]
+    assert source["tracked_file_total"] == {"const": 168}
+    assert source["section_total"] == {"const": 7250}


### PR DESCRIPTION
Part of #6375 and epic #6321.

Implements the deterministic, text-free school-textbook non-hit universe and independent audit boundary for the complete frozen denominator: 54,979 chunks, 168 tracked files, and 7,250 sections. It binds scanner/rubric review, reconstructs frozen unit identities from non-text database metadata, derives the exact non-hit complement, and requires the approved common auditor entropy contract plus zero-miss decisions.

This PR does not claim a scanner classification or audit pass. Production sampling remains fail-closed until the scanner classification/rubric receipt and independent textbook-auditor entropy/decisions exist.

Phase 3 status after this intermediate PR:
- ENGINE_READY: unmet
- SOURCE_COVERAGE_READY: unmet
- LINGUISTICALLY_VALIDATED: unmet
- CONSUMER_PROVEN: unmet

Verification:
- 6 focused tests passed
- Ruff and py_compile passed
- Draft 2020-12 schema validation passed
- real neutral-complement smoke reconstructed 54,979 units / 168 files / 7,250 sections
- git diff --check, staged OPSEC, protected-file checks, and X-Agent trailer passed

No Phase 4 action, training, paid compute, model download, Hugging Face mutation, upload, or outreach.
