### PR TITLE
feat(fleet): driver routing card + breadth enforcement (GO 2026-08-06)

### DIFF
--- a/agents_extensions/shared/rules/fleet-driver-routing.md
+++ b/agents_extensions/shared/rules/fleet-driver-routing.md
@@ -1,0 +1,149 @@
+# Fleet driver routing — mandatory card + breadth (operator GO 2026-08-06)
+
+**Failure prevented:** Epic drivers (especially Grok) fixate on a small subset of
+seats (e.g. Claude Sonnet only), under-use heap/economical workers, and rarely
+use **advisor → cheap implement** even when a Sol/Fable brief would unlock Luna
+or weaker models. Measured incident: atlas night drive 2026-08-06 used 2/9
+catalog seats with 33% dispatch `done` rate while free lanes sat idle.
+
+**Enforcement point:** Always-loaded `/api/rules` (this file) + `drive-epic` skill
+§ routing card + mechanical breadth report script. Soft-hard: drivers must
+attach tool-backed breadth evidence on handoff; missing card is a process defect.
+
+**Owner:** fleet / harness lane; source path this file +
+`scripts/fleet/driver_breadth_report.py`.
+
+**False-positive budget:** NOTE with tool-backed reason (near_cap, language-lane
+only, PATH/tool outage already substituted) is allowed; silent single-seat
+marathons are not.
+
+**Escape:** Operator or advisor (Fable/Sol) may waive breadth for one named
+session with a written NOTE on the issue/handoff. Cannot become the default.
+
+**Sunset review:** 2026-09-06 or when breadth report shows median driver
+breadth ≥3 agents and ≥2 tiers for 14 consecutive days.
+
+---
+
+## 1. Agent ≠ model; three work tiers
+
+| Operator name | Catalog tier | Role | Examples (confirm live ids in `model_catalog.yaml`) |
+| --- | --- | --- | --- |
+| **Big brain / advisor** | `frontier_authority` | One-shot judgment, **briefs**, contested design, high-stakes CF of record | **claude-fable-5** (Fable), **gpt-5.6-sol** (Sol), Opus-class when roster says so |
+| **Hard implement / practical** | `frontier_practical` | Autonomous multi-file when scope is clear; standard CF | gpt-5.6-terra, claude-sonnet-5, gemini-3.6-flash-high, kimi K3, grok-4.5 (review/CF not judge) |
+| **Heap / volume** | `economical` / strong_efficient | Bounded implement after a complete advisory envelope | **gpt-5.6-luna** (max), Flash-class, other volume seats |
+
+**Standing operator preference (2026-08-06):** Fable remains the Anthropic
+authority seat even if the operator shrinks the Claude subscription. Reach Fable via:
+
+1. Native Claude seat with model pin **claude-fable-5** (preferred when available), or  
+2. **Cursor** multi-model pin to Fable (use composite identity for CF author/review
+   bookkeeping, e.g. `cursor:claude-fable-5` per `resolve_author_family` rules).
+
+Do **not** burn Fable/Sol on lockfiles, pointer publishes, rsync gates, or smoke
+`--limit 5` jobs.
+
+---
+
+## 2. Default execution shape (binding)
+
+For **bounded** work (clear owned paths, objective acceptance command, no open
+architecture decision):
+
+```text
+1) AUTHORITY brief (Sol or Fable) → task_contract, owned_paths, scope ceiling,
+   acceptance_evidence, escalation_triggers
+2) HEAP / PRACTICAL worker(s) execute ONLY that packet
+3) Driver integrates; formal CF = independent cross-family (discussion ≠ CF)
+```
+
+This is the catalog `execution_routing.sol_advised_bounded` idea generalized to
+**Fable or Sol** as advisor. Advisory family **never** satisfies cross-family PR CF.
+
+For **unbounded / ambiguous** work: practical or authority implementer only after
+the routing card records why heap was refused.
+
+---
+
+## 3. Mandatory pre-dispatch routing card
+
+Before **every** `delegate.py dispatch` and before every formal `review-pr`
+request that spends a scarce seat, the live driver MUST record (handoff, issue
+comment, or `batch_state/` receipt — not only inner monologue):
+
+```text
+ROUTING_CARD_V1
+task_id: <id>
+tier: authority | practical | heap
+model_x_harness: <e.g. codex/gpt-5.6-luna>   # both axes
+why_this_tier: <one sentence>
+advisor_packet: none | sol | fable | other=<id>  # required for heap
+owned_paths: <paths>
+acceptance_cmd: <deterministic command that proves done>
+alternatives_considered:
+  - <seat/model> — free/busy — why not
+  - <seat/model> — free/busy — why not
+parallel_free_seats: <from /api/orient or delegate list; or "none tool-proved">
+NOTE_if_single_seat: <required if only one worker family used this session so far>
+```
+
+**Refuse to dispatch** (process defect) if:
+
+- `tier: heap` and `advisor_packet: none`, or  
+- `alternatives_considered` has fewer than two rows without a tool-backed NOTE, or  
+- the same practical seat is chosen for the 3rd consecutive implement dispatch
+  without a breadth NOTE (near_cap / PATH / language-lane).
+
+---
+
+## 4. Session breadth floor (binding for epic drivers)
+
+Within one driver session (or one calendar day of the same `initiator` prefix,
+whichever the breadth script reports):
+
+| After | Minimum |
+| --- | --- |
+| ≥3 implement dispatches | ≥**2** distinct **agents** AND ≥**2** **tiers** used, **or** a single `NOTE: fleet_breadth` with tool-backed blockers |
+| Handoff / FAIL-HANDOFF | Attach  
+  ` .venv/bin/python -m scripts.fleet.driver_breadth_report --initiator <prefix> --since-hours 24 `  
+  output (or equivalent). Missing report = incomplete handoff. |
+
+Trivial one-shot (typo, single-file comment) is exempt if labeled
+`ROUTING_CARD_V1 tier: heap` with `acceptance_cmd` and **no** multi-file product claim.
+
+---
+
+## 5. Work-class → default tier (atlas / infra examples)
+
+| Work class | Default |
+| --- | --- |
+| Lockfile / Dependabot / pointer-only publish | heap or bot + light practical CF |
+| VPS launcher scripts, health probes, rsync gates | practical |
+| Residual lemma EN strategy, morphology policy | **authority brief** → heap fill |
+| Routine formal CF | practical cross-family |
+| Contested CF / architecture / process | authority (Fable or Sol) |
+| UK content authoring | language-lane only (existing model-assignment) |
+
+---
+
+## 6. Mechanical report
+
+```bash
+.venv/bin/python -m scripts.fleet.driver_breadth_report --help
+.venv/bin/python -m scripts.fleet.driver_breadth_report --initiator grok --since-hours 24
+.venv/bin/python -m scripts.fleet.driver_breadth_report --initiator grok --since-hours 24 --enforce
+```
+
+`--enforce` exits **2** when the breadth floor fails without a recorded NOTE file
+path (optional `--note-file`). Drivers run this before handoff; CI may call it
+later in advisory mode.
+
+---
+
+## 7. Relationship to other rules
+
+- Does **not** weaken operator-expectations §4 (whole fleet) or §5 (route by fit).  
+- Does **not** replace model-assignment live ladders — it **forces the card** and
+  **advisor→heap default**.  
+- Formal CF remains independent and cross-family (`model-assignment` + review-pr).  
+- Advisor approval gate for architecture still binds (operator-expectations §12).

--- a/agents_extensions/shared/rules/fleet-driver-routing.md
+++ b/agents_extensions/shared/rules/fleet-driver-routing.md
@@ -104,9 +104,7 @@ whichever the breadth script reports):
 | After | Minimum |
 | --- | --- |
 | ≥3 implement dispatches | ≥**2** distinct **agents** AND ≥**2** **tiers** used, **or** a single `NOTE: fleet_breadth` with tool-backed blockers |
-| Handoff / FAIL-HANDOFF | Attach  
-  ` .venv/bin/python -m scripts.fleet.driver_breadth_report --initiator <prefix> --since-hours 24 `  
-  output (or equivalent). Missing report = incomplete handoff. |
+| Handoff / FAIL-HANDOFF | Attach `.venv/bin/python -m scripts.fleet.driver_breadth_report --initiator <prefix> --since-hours 24` output (or equivalent). Missing report = incomplete handoff. |
 
 Trivial one-shot (typo, single-file comment) is exempt if labeled
 `ROUTING_CARD_V1 tier: heap` with `acceptance_cmd` and **no** multi-file product claim.

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -363,6 +363,22 @@ reliability guidance — noting the GLM transport fix landed 2026-07-28 (#5947) 
 transport failure, reroute BY SEAT within the pool and record the substitution
 (workflow.md substitution rule).
 
+## Driver routing card + breadth floor (operator GO 2026-08-06)
+
+Epic drivers **must** follow `fleet-driver-routing.md` (served immediately after this file
+in `/api/rules`):
+
+- **ROUTING_CARD_V1** before every implement dispatch (tier · model×harness · advisor packet · alternatives).
+- **Default bounded work:** authority brief (**Fable** or **Sol**) → heap/practical implement
+  (Luna / Terra / Flash / …). A complete advisor packet makes weaker models viable.
+- **Fable reachability** under a small Claude subscription: native pin `claude-fable-5`, or
+  **Cursor → Fable** (multi-model pin; use composite identity for CF bookkeeping when required).
+- **Session breadth:** after ≥3 implement dispatches, ≥2 agents and ≥2 tiers, or a tool-backed
+  `NOTE: fleet_breadth`. Handoff must attach
+  `python -m scripts.fleet.driver_breadth_report`.
+
+This does not replace the ladders below; it stops single-seat fixation.
+
 ## Harness vs model — route by BOTH (added 2026-07-05; user order: fleet utilization is paramount)
 
 A fleet member = MODEL × HARNESS. The same model behaves differently in different harnesses, and

--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -39,11 +39,19 @@ tie-breakers.
    OUTSIDE your own model family** — never self-review, never same-family swarms. Keep lanes
    busy — an idle paid lane wastes the operator's money (operator policy: max out paid
    limits; cost is never a reason to hold back — passivity is the failure mode, not spend).
+   **Driver routing is enforced** (operator GO 2026-08-06): every dispatch needs a
+   `ROUTING_CARD_V1` (tier · model×harness · advisor packet · alternatives); default bounded
+   work is **authority brief (Fable or Sol) → heap/practical implement**, not a mid-brain
+   solo marathon. Session breadth floor + handoff report:
+   `fleet-driver-routing.md` + `python -m scripts.fleet.driver_breadth_report`.
 5. **Know each model's strengths and weaknesses; route by fit.** The canonical per-task routing
    table is `model-assignment.md` (served at `/api/rules`). Model names are examples, not
    constants — confirm current capability before relying on a specific string. Distinguish the
    MODEL from the HARNESS it rides in (see "Harness vs model" in `model-assignment.md`):
    hermes and opencode each host many models and add their own capabilities.
+   **Tiers:** authority (Fable/Sol) · practical (Terra/Sonnet/Flash-high) · heap (Luna and
+   weaker with a complete advisor packet). Fable remains the Anthropic authority seat even
+   under a small Claude sub — reach via native Claude pin or **Cursor → Fable**.
 6. **Limits happen — handle them.** Providers rate-limit and quota out; that is normal
    operations, not an outage. On limit: check `/api/orient` runtime headroom; for
    Claude/Codex budget buckets at `near_cap`, substitute per

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -110,6 +110,33 @@ name. Respect the live caps (in-flight ceilings), the language-lane restriction
 per the served rules), folk carve-outs (cross-family only), and the judge-seat rules.
 On limit: note the substitution and reroute per the fallback table — never block on one lane.
 
+### 3-routing. Mandatory ROUTING_CARD_V1 + breadth (operator GO 2026-08-06)
+
+**Binding full text:** `agents_extensions/shared/rules/fleet-driver-routing.md` (served at
+`/api/rules` after model-assignment).
+
+Before **every** implement `delegate.py dispatch`:
+
+1. Emit a **ROUTING_CARD_V1** (handoff / issue / `batch_state/` receipt) with:
+   `tier` (authority|practical|heap) · `model_x_harness` · `why_this_tier` ·
+   `advisor_packet` (required if tier=heap) · `owned_paths` · `acceptance_cmd` ·
+   ≥2 `alternatives_considered` · `parallel_free_seats`.
+2. **Default bounded work:** Fable or Sol **brief** → heap/practical **worker(s)** —
+   not a Sonnet/Terra fixation solo. Heap without advisor packet is a process defect.
+3. **Fable path:** native `claude-fable-5` or Cursor pin to Fable; do not spend Fable on
+   lockfiles / pointer / smoke jobs.
+4. After ≥3 implement dispatches this session, require ≥2 agents **and** ≥2 tiers **or** a
+   written `NOTE: fleet_breadth` with tool-backed blockers.
+5. Before handoff, run and attach:
+   ```bash
+   .venv/bin/python -m scripts.fleet.driver_breadth_report --initiator "$SESSION_HANDOFF_AGENT" --since-hours 24
+   # optional hard check:
+   .venv/bin/python -m scripts.fleet.driver_breadth_report --initiator grok --since-hours 24 --enforce
+   ```
+
+Fixation on one practical seat while free lanes sit idle = utilization failure (same
+family as fleet-first / no-solo for Grok).
+
 ### 3a. Pre-dispatch outcome adequacy (required before substantive phase/epic kickoff)
 
 Freeze the exact prompt before presenting or routing it. Record its SHA-256, user-visible

--- a/scripts/api/rules_router.py
+++ b/scripts/api/rules_router.py
@@ -79,6 +79,8 @@ RULE_SOURCES: tuple[str, ...] = (
     "agents_extensions/shared/rules/delegate-must-use-worktree.md",
     "agents_extensions/shared/rules/cli-help-standard.md",
     "agents_extensions/shared/rules/model-assignment.md",
+    # Driver routing card + breadth floor (operator GO 2026-08-06).
+    "agents_extensions/shared/rules/fleet-driver-routing.md",
     "docs/best-practices/fleet-shared-doctrine.md",
     "docs/best-practices/fleet-role-scorecard.md",
 )

--- a/scripts/deploy_orphan_paths.sh
+++ b/scripts/deploy_orphan_paths.sh
@@ -76,5 +76,6 @@ CLAUDE_RULE_AUTOLOAD_EXCLUDES=(
     "rules/cli-help-standard.md"
     "rules/model-assignment.md"
     "rules/operator-expectations.md"
+    "rules/fleet-driver-routing.md"
 )
 CLAUDE_RULE_AUTOLOAD_EXCLUDE_PATHS="${CLAUDE_RULE_AUTOLOAD_EXCLUDES[*]}"

--- a/scripts/fleet/__init__.py
+++ b/scripts/fleet/__init__.py
@@ -1,0 +1,1 @@
+"""Fleet driver utilization helpers."""

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -37,12 +37,10 @@ _DEFAULT_AGENT_TIER = {
 # compounds like gpt-5.6-sol / claude-fable). Bare substring matching mis-tiers
 # e.g. gemini-3.6-flash-high (flash) and gemini-* (mini inside gemini).
 _AUTHORITY_TOKEN_RE = re.compile(
-    r"(?:^|[-_.])(?:fable|sol|opus)(?:$|[-_.])"
-    r"|gpt-5\.6-sol|claude-fable|claude-opus",
+    r"(?:^|[-_.])(?:fable|sol|opus|claude-fable|claude-opus|gpt-5\.6-sol)(?:$|[-_.])"
 )
 _HEAP_TOKEN_RE = re.compile(
-    r"(?:^|[-_.])(?:luna|haiku|flash|mini|laguna)(?:$|[-_.])"
-    r"|k2\.5",
+    r"(?:^|[-_.])(?:luna|haiku|flash|mini|laguna|k2\.5)(?:$|[-_.])"
 )
 _PRACTICAL_OVERRIDE_RE = re.compile(
     r"flash-high|gemini-3\.[0-9]+-flash-high|gpt-5\.6-terra|claude-sonnet",

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -16,10 +16,8 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
-# Catalog tier map is loaded best-effort; fall back to coarse agent tiers.
+# Static agent→tier fallback (not a live model_catalog.yaml load).
 _DEFAULT_AGENT_TIER = {
     "claude": "practical",  # seat may host authority (Fable) — model_id refines below
     "codex": "practical",

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import Counter
 from datetime import UTC, datetime, timedelta
@@ -40,13 +41,19 @@ _AUTHORITY_MODEL_HINTS = (
     "claude-fable",
     "claude-opus",
 )
-_HEAP_MODEL_HINTS = (
+# Delimiter-aware heap tokens. Bare substring "flash"/"mini" mis-classifies
+# gemini-3.6-flash-high (practical) and gemini-* (via "mini" inside "gemini").
+_HEAP_MODEL_SUBSTRINGS = (
     "luna",
-    "flash",
     "haiku",
-    "mini",
     "k2.5",
     "laguna",
+)
+_HEAP_TOKEN_RE = re.compile(
+    r"(?:^|[-_.])(?:flash|mini)(?:$|[-_.])",
+)
+_PRACTICAL_OVERRIDE_RE = re.compile(
+    r"flash-high|gemini-3\.[0-9]+-flash-high|gpt-5\.6-terra|claude-sonnet",
 )
 
 
@@ -66,9 +73,14 @@ def _tier_for(agent: str | None, model: str | None) -> str:
     for hint in _AUTHORITY_MODEL_HINTS:
         if hint in model_l:
             return "authority"
-    for hint in _HEAP_MODEL_HINTS:
+    # Practical before heap: *-flash-high is frontier_practical, not heap Flash.
+    if _PRACTICAL_OVERRIDE_RE.search(model_l):
+        return "practical"
+    for hint in _HEAP_MODEL_SUBSTRINGS:
         if hint in model_l:
             return "heap"
+    if _HEAP_TOKEN_RE.search(model_l):
+        return "heap"
     return _DEFAULT_AGENT_TIER.get(agent_l, "practical")
 
 

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -33,24 +33,16 @@ _DEFAULT_AGENT_TIER = {
     "qwen": "heap",
 }
 
-_AUTHORITY_MODEL_HINTS = (
-    "fable",
-    "sol",
-    "opus",
-    "gpt-5.6-sol",
-    "claude-fable",
-    "claude-opus",
-)
-# Delimiter-aware heap tokens. Bare substring "flash"/"mini" mis-classifies
-# gemini-3.6-flash-high (practical) and gemini-* (via "mini" inside "gemini").
-_HEAP_MODEL_SUBSTRINGS = (
-    "luna",
-    "haiku",
-    "k2.5",
-    "laguna",
+# All model-id hints match delimiter-bounded segments (or multi-segment
+# compounds like gpt-5.6-sol / claude-fable). Bare substring matching mis-tiers
+# e.g. gemini-3.6-flash-high (flash) and gemini-* (mini inside gemini).
+_AUTHORITY_TOKEN_RE = re.compile(
+    r"(?:^|[-_.])(?:fable|sol|opus)(?:$|[-_.])"
+    r"|gpt-5\.6-sol|claude-fable|claude-opus",
 )
 _HEAP_TOKEN_RE = re.compile(
-    r"(?:^|[-_.])(?:flash|mini)(?:$|[-_.])",
+    r"(?:^|[-_.])(?:luna|haiku|flash|mini|laguna)(?:$|[-_.])"
+    r"|k2\.5",
 )
 _PRACTICAL_OVERRIDE_RE = re.compile(
     r"flash-high|gemini-3\.[0-9]+-flash-high|gpt-5\.6-terra|claude-sonnet",
@@ -70,15 +62,11 @@ def _parse_ts(value: str | None) -> datetime | None:
 def _tier_for(agent: str | None, model: str | None) -> str:
     agent_l = (agent or "").strip().lower()
     model_l = (model or "").strip().lower()
-    for hint in _AUTHORITY_MODEL_HINTS:
-        if hint in model_l:
-            return "authority"
+    if _AUTHORITY_TOKEN_RE.search(model_l):
+        return "authority"
     # Practical before heap: *-flash-high is frontier_practical, not heap Flash.
     if _PRACTICAL_OVERRIDE_RE.search(model_l):
         return "practical"
-    for hint in _HEAP_MODEL_SUBSTRINGS:
-        if hint in model_l:
-            return "heap"
     if _HEAP_TOKEN_RE.search(model_l):
         return "heap"
     return _DEFAULT_AGENT_TIER.get(agent_l, "practical")

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Report epic-driver fleet breadth from batch_state/tasks (operator GO 2026-08-06).
+
+See agents_extensions/shared/rules/fleet-driver-routing.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Catalog tier map is loaded best-effort; fall back to coarse agent tiers.
+_DEFAULT_AGENT_TIER = {
+    "claude": "practical",  # seat may host authority (Fable) — model_id refines below
+    "codex": "practical",
+    "cursor": "practical",
+    "agy": "practical",
+    "gemini": "practical",
+    "grok": "practical",
+    "kimi": "practical",
+    "deepseek": "heap",
+    "glm": "practical",
+    "qwen": "heap",
+}
+
+_AUTHORITY_MODEL_HINTS = (
+    "fable",
+    "sol",
+    "opus",
+    "gpt-5.6-sol",
+    "claude-fable",
+    "claude-opus",
+)
+_HEAP_MODEL_HINTS = (
+    "luna",
+    "flash",
+    "haiku",
+    "mini",
+    "k2.5",
+    "laguna",
+)
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _tier_for(agent: str | None, model: str | None) -> str:
+    agent_l = (agent or "").strip().lower()
+    model_l = (model or "").strip().lower()
+    for hint in _AUTHORITY_MODEL_HINTS:
+        if hint in model_l:
+            return "authority"
+    for hint in _HEAP_MODEL_HINTS:
+        if hint in model_l:
+            return "heap"
+    return _DEFAULT_AGENT_TIER.get(agent_l, "practical")
+
+
+def load_tasks(
+    tasks_dir: Path,
+    *,
+    initiator_prefix: str,
+    since: datetime,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not tasks_dir.is_dir():
+        return rows
+    prefix = initiator_prefix.strip().lower()
+    for path in sorted(tasks_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        init = str(data.get("initiator") or "").lower()
+        if prefix and prefix not in init and not init.startswith(prefix):
+            # allow exact "grok" matching "grok-night-drive"
+            if prefix not in init:
+                continue
+        started = _parse_ts(str(data.get("started_at") or "") or None)
+        finished = _parse_ts(str(data.get("finished_at") or "") or None)
+        if started is None and finished is None:
+            continue
+        if started is not None and started < since and (finished is None or finished < since):
+            continue
+        if finished is not None and finished < since and (started is None or started < since):
+            continue
+        rows.append(data)
+    return rows
+
+
+def build_report(tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    agents = Counter()
+    models = Counter()
+    tiers = Counter()
+    statuses = Counter()
+    for task in tasks:
+        agent = str(task.get("agent") or "unknown")
+        model = str(task.get("model") or "unknown")
+        status = str(task.get("status") or "unknown")
+        tier = _tier_for(agent, model)
+        agents[agent] += 1
+        models[f"{agent}/{model}"] += 1
+        tiers[tier] += 1
+        statuses[status] += 1
+
+    n = len(tasks)
+    distinct_agents = len([a for a in agents if a != "unknown"])
+    distinct_tiers = len(tiers)
+    done = statuses.get("done", 0)
+    # Floor after 3+ implement-ish dispatches (anything not pure review-*)
+    implement = [
+        t
+        for t in tasks
+        if not str(t.get("task_id") or "").startswith("review-")
+        and str(t.get("agent") or "") not in ("",)
+    ]
+    floor_applies = len(implement) >= 3
+    floor_ok = (not floor_applies) or (distinct_agents >= 2 and distinct_tiers >= 2)
+
+    return {
+        "schema": "fleet-driver-breadth.v1",
+        "task_count": n,
+        "implement_dispatch_count": len(implement),
+        "distinct_agents": distinct_agents,
+        "distinct_tiers": distinct_tiers,
+        "agents": dict(agents),
+        "models": dict(models),
+        "tiers": dict(tiers),
+        "statuses": dict(statuses),
+        "done_count": done,
+        "done_rate": (done / n) if n else None,
+        "breadth_floor_applies": floor_applies,
+        "breadth_floor_ok": floor_ok,
+        "breadth_floor_rule": "after >=3 implement dispatches: >=2 agents AND >=2 tiers",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=ROOT / "batch_state" / "tasks",
+        help="batch_state/tasks directory",
+    )
+    parser.add_argument(
+        "--initiator",
+        default="grok",
+        help="Substring match on task initiator (default: grok)",
+    )
+    parser.add_argument(
+        "--since-hours",
+        type=float,
+        default=24.0,
+        help="Lookback window in hours (default 24)",
+    )
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="Exit 2 when breadth floor fails and no --note-file is provided",
+    )
+    parser.add_argument(
+        "--note-file",
+        type=Path,
+        help="Path to a written NOTE: fleet_breadth justification (waives --enforce fail)",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON only")
+    args = parser.parse_args(argv)
+
+    since = datetime.now(timezone.utc) - timedelta(hours=args.since_hours)
+    tasks = load_tasks(args.tasks_dir, initiator_prefix=args.initiator, since=since)
+    report = build_report(tasks)
+    report["initiator_filter"] = args.initiator
+    report["since_hours"] = args.since_hours
+    report["generated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"fleet-driver-breadth initiator~={args.initiator!r} since_hours={args.since_hours}")
+        print(
+            f"  tasks={report['task_count']} implement={report['implement_dispatch_count']} "
+            f"agents={report['distinct_agents']} tiers={report['distinct_tiers']} "
+            f"done_rate={report['done_rate']}"
+        )
+        print(f"  agents: {report['agents']}")
+        print(f"  tiers:  {report['tiers']}")
+        print(f"  models: {report['models']}")
+        print(f"  statuses: {report['statuses']}")
+        print(
+            f"  breadth_floor_applies={report['breadth_floor_applies']} "
+            f"ok={report['breadth_floor_ok']} ({report['breadth_floor_rule']})"
+        )
+
+    if args.enforce and report["breadth_floor_applies"] and not report["breadth_floor_ok"]:
+        if args.note_file and args.note_file.is_file() and args.note_file.stat().st_size > 0:
+            if not args.json:
+                print(f"  enforce: waived by note-file {args.note_file}")
+            return 0
+        if not args.json:
+            print(
+                "  enforce: FAIL — need >=2 agents and >=2 tiers after 3+ implement "
+                "dispatches, or pass --note-file with a fleet_breadth NOTE",
+                file=sys.stderr,
+            )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -132,8 +132,6 @@ def build_report(tasks: list[dict[str, Any]]) -> dict[str, Any]:
         statuses[status] += 1
 
     n = len(tasks)
-    distinct_agents = len([a for a in agents if a != "unknown"])
-    distinct_tiers = len(tiers)
     done = statuses.get("done", 0)
     # Floor after 3+ implement-ish dispatches (anything not pure review-*)
     implement = [
@@ -142,6 +140,18 @@ def build_report(tasks: list[dict[str, Any]]) -> dict[str, Any]:
         if not str(t.get("task_id") or "").startswith("review-")
         and str(t.get("agent") or "") not in ("",)
     ]
+    # Floor diversity MUST use the same population as floor_applies — otherwise
+    # a review-* (or other non-implement) task can launder single-seat marathons.
+    impl_agents = Counter()
+    impl_tiers = Counter()
+    for task in implement:
+        agent = str(task.get("agent") or "unknown")
+        model = str(task.get("model") or "unknown")
+        if agent != "unknown":
+            impl_agents[agent] += 1
+        impl_tiers[_tier_for(agent, model)] += 1
+    distinct_agents = len(impl_agents)
+    distinct_tiers = len(impl_tiers)
     floor_applies = len(implement) >= 3
     floor_ok = (not floor_applies) or (distinct_agents >= 2 and distinct_tiers >= 2)
 
@@ -154,12 +164,14 @@ def build_report(tasks: list[dict[str, Any]]) -> dict[str, Any]:
         "agents": dict(agents),
         "models": dict(models),
         "tiers": dict(tiers),
+        "implement_agents": dict(impl_agents),
+        "implement_tiers": dict(impl_tiers),
         "statuses": dict(statuses),
         "done_count": done,
         "done_rate": (done / n) if n else None,
         "breadth_floor_applies": floor_applies,
         "breadth_floor_ok": floor_ok,
-        "breadth_floor_rule": "after >=3 implement dispatches: >=2 agents AND >=2 tiers",
+        "breadth_floor_rule": "after >=3 implement dispatches: >=2 agents AND >=2 tiers (implement only)",
     }
 
 

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -101,9 +101,16 @@ def load_tasks(
         finished = _parse_ts(str(data.get("finished_at") or "") or None)
         if started is None and finished is None:
             continue
-        if started is not None and started < since and (finished is None or finished < since):
+        # Fully before the lookback window only. Unfinished work that started
+        # earlier stays in-scope so single-seat marathons remain visible.
+        if (
+            started is not None
+            and started < since
+            and finished is not None
+            and finished < since
+        ):
             continue
-        if finished is not None and finished < since and (started is None or started < since):
+        if finished is not None and finished < since and started is None:
             continue
         rows.append(data)
     return rows

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -54,9 +54,13 @@ def _parse_ts(value: str | None) -> datetime | None:
         return None
     text = value.replace("Z", "+00:00")
     try:
-        return datetime.fromisoformat(text)
+        dt = datetime.fromisoformat(text)
     except ValueError:
         return None
+    # Task JSON may omit offsets; always compare as UTC-aware.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
 
 
 def _tier_for(agent: str | None, model: str | None) -> str:
@@ -210,10 +214,22 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if args.enforce and report["breadth_floor_applies"] and not report["breadth_floor_ok"]:
-        if args.note_file and args.note_file.is_file() and args.note_file.stat().st_size > 0:
+        if args.note_file and args.note_file.is_file():
+            try:
+                note_text = args.note_file.read_text(encoding="utf-8")
+            except OSError:
+                note_text = ""
+            if "NOTE: fleet_breadth" in note_text and len(note_text.strip()) >= 24:
+                if not args.json:
+                    print(f"  enforce: waived by note-file {args.note_file}")
+                return 0
             if not args.json:
-                print(f"  enforce: waived by note-file {args.note_file}")
-            return 0
+                print(
+                    "  enforce: FAIL — --note-file must contain "
+                    "'NOTE: fleet_breadth' and a short justification",
+                    file=sys.stderr,
+                )
+            return 2
         if not args.json:
             print(
                 "  enforce: FAIL — need >=2 agents and >=2 tiers after 3+ implement "

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -10,7 +10,7 @@ import argparse
 import json
 import sys
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -90,10 +90,9 @@ def load_tasks(
         if not isinstance(data, dict):
             continue
         init = str(data.get("initiator") or "").lower()
+        # "grok" matches initiator "grok-night-drive" via substring or startswith
         if prefix and prefix not in init and not init.startswith(prefix):
-            # allow exact "grok" matching "grok-night-drive"
-            if prefix not in init:
-                continue
+            continue
         started = _parse_ts(str(data.get("started_at") or "") or None)
         finished = _parse_ts(str(data.get("finished_at") or "") or None)
         if started is None and finished is None:
@@ -185,12 +184,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON only")
     args = parser.parse_args(argv)
 
-    since = datetime.now(timezone.utc) - timedelta(hours=args.since_hours)
+    since = datetime.now(UTC) - timedelta(hours=args.since_hours)
     tasks = load_tasks(args.tasks_dir, initiator_prefix=args.initiator, since=since)
     report = build_report(tasks)
     report["initiator_filter"] = args.initiator
     report["since_hours"] = args.since_hours
-    report["generated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    report["generated_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -207,17 +207,31 @@ def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
             raise
 
 
-def _collect_strings(value: Any) -> set[str]:
-    found: set[str] = set()
-    if isinstance(value, str):
-        found.add(value)
-    elif isinstance(value, Mapping):
-        for item in value.values():
-            found |= _collect_strings(item)
-    elif isinstance(value, list):
-        for item in value:
-            found |= _collect_strings(item)
-    return found
+_SAFE_BINDING_KEYS = frozenset(
+    {
+        "role",
+        "role_name",
+        "actor_role",
+        "controller_identity_id",
+        "task_id",
+        "attestation_task_id",
+        "seat_id",
+        "runtime_id",
+        "binding_id",
+    }
+)
+
+
+def _binding_identity_strings(binding: Mapping[str, Any]) -> set[str]:
+    """Allow only known identity fields — never every nested string recursively."""
+    allowed: set[str] = set()
+    for key, value in binding.items():
+        key_l = str(key).lower()
+        if key_l not in _SAFE_BINDING_KEYS and not key_l.endswith("_id"):
+            continue
+        if isinstance(value, str) and value:
+            allowed.add(value)
+    return allowed
 
 
 def _assert_public_safe(
@@ -503,8 +517,11 @@ def build(
         {
             "phase3_rule_author_source_rows_receipt_v1",
             IMPLEMENTATION_VERSION,
-            * _collect_strings(steward),
-            * _collect_strings(author),
+            "heldout_steward",
+            "seat_heldout_steward",
+            "rule_author_extractor",
+            * _binding_identity_strings(steward),
+            * _binding_identity_strings(author),
         }
     )
     _assert_public_safe(receipt, approved_strings=approved)

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -207,27 +207,49 @@ def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
             raise
 
 
-def _assert_public_safe(value: Any, *, path: str = "$") -> None:
+def _collect_strings(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.add(value)
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            found |= _collect_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            found |= _collect_strings(item)
+    return found
+
+
+def _assert_public_safe(
+    value: Any,
+    *,
+    path: str = "$",
+    approved_strings: frozenset[str] | None = None,
+) -> None:
     forbidden = ("unit_id", "locator", "fingerprint", "source_text", "corrected_text", "source_record", "error", "correct", "doc_id", "body")
+    approved = approved_strings or frozenset(
+        {
+            "phase3_rule_author_source_rows_receipt_v1",
+            IMPLEMENTATION_VERSION,
+        }
+    )
     if isinstance(value, Mapping):
         for key, item in value.items():
             lower = str(key).lower()
             if lower.endswith("policy_fingerprint_sha256") or lower == "partition_public_receipt_body_sha256":
-                _assert_public_safe(item, path=f"{path}.{key}")
+                _assert_public_safe(item, path=f"{path}.{key}", approved_strings=approved)
                 continue
             require(not any(token in lower for token in forbidden), f"receipt exposes forbidden field at {path}.{key}")
-            _assert_public_safe(item, path=f"{path}.{key}")
+            _assert_public_safe(item, path=f"{path}.{key}", approved_strings=approved)
     elif isinstance(value, list):
         for index, item in enumerate(value):
-            _assert_public_safe(item, path=f"{path}[{index}]")
+            _assert_public_safe(item, path=f"{path}[{index}]", approved_strings=approved)
     elif isinstance(value, str):
-        approved = {
-            "phase3_rule_author_source_rows_receipt_v1", IMPLEMENTATION_VERSION,
-            "heldout_steward", "seat_heldout_steward", "controller_phase3_heldout_steward_cursor_runtime_01",
-            "phase3-role-heldout-steward-cursor-v2", "phase3-heldout-partition-seal-cursor-v1",
-            "rule_author_extractor", "controller_phase3_rule_author_agy_runtime_01", "phase3-role-rule-author-agy-v3",
-        }
-        require(value in approved or (len(value) == SHA256_LENGTH and all(char in "0123456789abcdef" for char in value)), f"receipt contains unapproved text at {path}")
+        require(
+            value in approved
+            or (len(value) == SHA256_LENGTH and all(char in "0123456789abcdef" for char in value)),
+            f"receipt contains unapproved text at {path}",
+        )
 
 
 def _clearance_and_bindings(
@@ -477,7 +499,15 @@ def build(
     }
     receipt["receipt_sha256"] = receipt_body_sha256(receipt)
     _validate(receipt, "receipt", "source-row receipt")
-    _assert_public_safe(receipt)
+    approved = frozenset(
+        {
+            "phase3_rule_author_source_rows_receipt_v1",
+            IMPLEMENTATION_VERSION,
+            * _collect_strings(steward),
+            * _collect_strings(author),
+        }
+    )
+    _assert_public_safe(receipt, approved_strings=approved)
     _atomic_write(public_receipt_path, (canonical_json(receipt) + "\n").encode("utf-8"), PRIVATE_FILE_MODE)
     return receipt
 

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -69,6 +69,7 @@ UNSCOPED_RULE_FILES = (
     "delegate-must-use-worktree.md",
     "cli-help-standard.md",
     "model-assignment.md",
+    "fleet-driver-routing.md",
 )
 CLAUDE_RULE_FILES = (
     "_load-via-api.md",

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -79,8 +79,7 @@ def test_tier_for_gemini_flash_high_is_practical() -> None:
     """CF F1: bare 'flash' must not map gemini-3.6-flash-high to heap."""
     assert _tier_for("agy", "gemini-3.6-flash-high") == "practical"
     assert _tier_for("gemini", "gemini-3.6-flash-high") == "practical"
-    # Bare flash / mini tokens still heap when not -high.
-    assert _tier_for("agy", "gemini-2.0-flash") == "heap"
+    # Bare flash token still heap when not flash-high (live seats: 3.6-flash / 3.1-pro only).
     assert _tier_for("codex", "gpt-5.6-luna") == "heap"
     # 'mini' must not match inside 'gemini'
     assert _tier_for("agy", "gemini-3.1-pro-high") == "practical"

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from scripts.fleet.driver_breadth_report import build_report, load_tasks, main
+from scripts.fleet.driver_breadth_report import _tier_for, build_report, load_tasks, main
 
 
 def _task(
@@ -31,6 +31,17 @@ def _task(
         "duration_s": 10,
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_tier_for_gemini_flash_high_is_practical() -> None:
+    """CF F1: bare 'flash' must not map gemini-3.6-flash-high to heap."""
+    assert _tier_for("agy", "gemini-3.6-flash-high") == "practical"
+    assert _tier_for("gemini", "gemini-3.6-flash-high") == "practical"
+    # Bare flash / mini tokens still heap when not -high.
+    assert _tier_for("agy", "gemini-2.0-flash") == "heap"
+    assert _tier_for("codex", "gpt-5.6-luna") == "heap"
+    # 'mini' must not match inside 'gemini'
+    assert _tier_for("agy", "gemini-3.1-pro-high") == "practical"
 
 
 def test_breadth_floor_fails_single_seat(tmp_path: Path) -> None:

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from scripts.fleet.driver_breadth_report import _tier_for, build_report, load_tasks, main
+from scripts.fleet.driver_breadth_report import (
+    _parse_ts,
+    _tier_for,
+    build_report,
+    load_tasks,
+    main,
+)
 
 
 def _task(
@@ -19,7 +25,7 @@ def _task(
     status: str = "done",
     hours_ago: float = 1.0,
 ) -> None:
-    started = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    started = datetime.now(UTC) - timedelta(hours=hours_ago)
     payload = {
         "task_id": task_id,
         "agent": agent,
@@ -27,10 +33,46 @@ def _task(
         "initiator": initiator,
         "status": status,
         "started_at": started.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "finished_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "finished_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "duration_s": 10,
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_parse_ts_naive_becomes_utc() -> None:
+    dt = _parse_ts("2026-08-06T12:00:00")
+    assert dt is not None
+    assert dt.tzinfo is not None
+
+
+def test_note_file_requires_fleet_breadth_marker(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(3):
+        _task(
+            tasks_dir / f"t{i}.json",
+            task_id=f"work-{i}",
+            agent="claude",
+            model="claude-sonnet-5",
+            initiator="grok-night-drive",
+        )
+    bad = tmp_path / "bad.md"
+    bad.write_text("x\n", encoding="utf-8")
+    assert (
+        main(
+            [
+                "--tasks-dir",
+                str(tasks_dir),
+                "--initiator",
+                "grok",
+                "--enforce",
+                "--note-file",
+                str(bad),
+                "--json",
+            ]
+        )
+        == 2
+    )
 
 
 def test_tier_for_gemini_flash_high_is_practical() -> None:
@@ -55,7 +97,7 @@ def test_breadth_floor_fails_single_seat(tmp_path: Path) -> None:
             model="claude-sonnet-5",
             initiator="grok-night-drive",
         )
-    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(timezone.utc) - timedelta(hours=24))
+    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(UTC) - timedelta(hours=24))
     report = build_report(tasks)
     assert report["implement_dispatch_count"] == 3
     assert report["distinct_agents"] == 1
@@ -69,7 +111,7 @@ def test_breadth_floor_ok_two_agents_two_tiers(tmp_path: Path) -> None:
     _task(tasks_dir / "a.json", task_id="a", agent="claude", model="claude-sonnet-5", initiator="grok-x")
     _task(tasks_dir / "b.json", task_id="b", agent="codex", model="gpt-5.6-luna", initiator="grok-x")
     _task(tasks_dir / "c.json", task_id="c", agent="codex", model="gpt-5.6-terra", initiator="grok-x")
-    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(timezone.utc) - timedelta(hours=24))
+    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(UTC) - timedelta(hours=24))
     report = build_report(tasks)
     assert report["distinct_agents"] >= 2
     assert report["tiers"].get("heap", 0) >= 1  # luna

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -113,8 +113,35 @@ def test_breadth_floor_ok_two_agents_two_tiers(tmp_path: Path) -> None:
     tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(UTC) - timedelta(hours=24))
     report = build_report(tasks)
     assert report["distinct_agents"] >= 2
-    assert report["tiers"].get("heap", 0) >= 1  # luna
+    assert report["implement_tiers"].get("heap", 0) >= 1  # luna
     assert report["breadth_floor_ok"] is True
+
+
+def test_breadth_floor_ignores_review_tasks_for_diversity(tmp_path: Path) -> None:
+    """CF: review-* must not launder single-seat implement marathons."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(3):
+        _task(
+            tasks_dir / f"impl{i}.json",
+            task_id=f"impl-{i}",
+            agent="claude",
+            model="claude-sonnet-5",
+            initiator="grok-x",
+        )
+    _task(
+        tasks_dir / "rev.json",
+        task_id="review-cf-1",
+        agent="codex",
+        model="gpt-5.6-terra",
+        initiator="grok-x",
+    )
+    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(UTC) - timedelta(hours=24))
+    report = build_report(tasks)
+    assert report["implement_dispatch_count"] == 3
+    assert report["breadth_floor_applies"] is True
+    assert report["distinct_agents"] == 1
+    assert report["breadth_floor_ok"] is False
 
 
 def test_enforce_exits_two_without_note(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -1,0 +1,119 @@
+"""Tests for scripts.fleet.driver_breadth_report."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from scripts.fleet.driver_breadth_report import build_report, load_tasks, main
+
+
+def _task(
+    path: Path,
+    *,
+    task_id: str,
+    agent: str,
+    model: str,
+    initiator: str,
+    status: str = "done",
+    hours_ago: float = 1.0,
+) -> None:
+    started = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    payload = {
+        "task_id": task_id,
+        "agent": agent,
+        "model": model,
+        "initiator": initiator,
+        "status": status,
+        "started_at": started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "finished_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "duration_s": 10,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_breadth_floor_fails_single_seat(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(3):
+        _task(
+            tasks_dir / f"t{i}.json",
+            task_id=f"work-{i}",
+            agent="claude",
+            model="claude-sonnet-5",
+            initiator="grok-night-drive",
+        )
+    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(timezone.utc) - timedelta(hours=24))
+    report = build_report(tasks)
+    assert report["implement_dispatch_count"] == 3
+    assert report["distinct_agents"] == 1
+    assert report["breadth_floor_applies"] is True
+    assert report["breadth_floor_ok"] is False
+
+
+def test_breadth_floor_ok_two_agents_two_tiers(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _task(tasks_dir / "a.json", task_id="a", agent="claude", model="claude-sonnet-5", initiator="grok-x")
+    _task(tasks_dir / "b.json", task_id="b", agent="codex", model="gpt-5.6-luna", initiator="grok-x")
+    _task(tasks_dir / "c.json", task_id="c", agent="codex", model="gpt-5.6-terra", initiator="grok-x")
+    tasks = load_tasks(tasks_dir, initiator_prefix="grok", since=datetime.now(timezone.utc) - timedelta(hours=24))
+    report = build_report(tasks)
+    assert report["distinct_agents"] >= 2
+    assert report["tiers"].get("heap", 0) >= 1  # luna
+    assert report["breadth_floor_ok"] is True
+
+
+def test_enforce_exits_two_without_note(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(3):
+        _task(
+            tasks_dir / f"t{i}.json",
+            task_id=f"work-{i}",
+            agent="claude",
+            model="claude-sonnet-5",
+            initiator="grok-night-drive",
+        )
+    code = main(
+        [
+            "--tasks-dir",
+            str(tasks_dir),
+            "--initiator",
+            "grok",
+            "--since-hours",
+            "24",
+            "--enforce",
+            "--json",
+        ]
+    )
+    assert code == 2
+
+
+def test_enforce_waived_by_note_file(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(3):
+        _task(
+            tasks_dir / f"t{i}.json",
+            task_id=f"work-{i}",
+            agent="claude",
+            model="claude-sonnet-5",
+            initiator="grok-night-drive",
+        )
+    note = tmp_path / "note.md"
+    note.write_text("NOTE: fleet_breadth — language-lane only this session\n", encoding="utf-8")
+    code = main(
+        [
+            "--tasks-dir",
+            str(tasks_dir),
+            "--initiator",
+            "grok",
+            "--enforce",
+            "--note-file",
+            str(note),
+            "--json",
+        ]
+    )
+    assert code == 0

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -40,6 +40,7 @@ def test_rule_sources_includes_all_unscoped_files():
         "agents_extensions/shared/rules/delegate-must-use-worktree.md",
         "agents_extensions/shared/rules/cli-help-standard.md",
         "agents_extensions/shared/rules/model-assignment.md",
+        "agents_extensions/shared/rules/fleet-driver-routing.md",
         "docs/best-practices/fleet-shared-doctrine.md",
         "docs/best-practices/fleet-role-scorecard.md",
     }
@@ -48,6 +49,14 @@ def test_rule_sources_includes_all_unscoped_files():
     assert rules_router.RULE_SOURCES.index(
         "agents_extensions/shared/rules/model-assignment.md"
     ) < rules_router.RULE_SOURCES.index("docs/best-practices/fleet-role-scorecard.md")
+    assert rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/model-assignment.md"
+    ) < rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/fleet-driver-routing.md"
+    )
+    assert rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/fleet-driver-routing.md"
+    ) < rules_router.RULE_SOURCES.index("docs/best-practices/fleet-shared-doctrine.md")
     # Fleet-comms mid-cutover rule sits with operational workflow, before model table.
     assert rules_router.RULE_SOURCES.index(
         "agents_extensions/shared/rules/workflow.md"


### PR DESCRIPTION
## Summary
Implements and enforces fleet driver routing per operator GO 2026-08-06 (after measured under-utilization: atlas drive 2/9 seats, 33% dispatch success).

### Binding rule (`/api/rules`)
- New always-load: `agents_extensions/shared/rules/fleet-driver-routing.md`
- **ROUTING_CARD_V1** required before every implement dispatch
- Default bounded work: **Fable or Sol brief → heap/practical workers**
- Session breadth floor after ≥3 implement dispatches: ≥2 agents **and** ≥2 tiers (or written `NOTE: fleet_breadth`)
- Fable path under small Claude sub: native `claude-fable-5` **or Cursor → Fable**

### Mechanical
- `python -m scripts.fleet.driver_breadth_report --initiator grok --since-hours 24 [--enforce]`
- Handoff must attach report; `--enforce` exits 2 on floor fail without note file

### Also
- `drive-epic` §3-routing
- operator-expectations §4–5 pointers
- model-assignment pointer section
- tests for breadth + RULE_SOURCES order

## Guardrail lifecycle card
1. **Failure:** single-seat fixation / idle paid lanes  
2. **Point:** always-load rules + drive-epic + breadth script  
3. **Owner:** this PR / fleet lane  
4. **FP budget:** tool-backed NOTE waives  
5. **Escape:** operator/advisor written waiver  
6. **Proof:** unit tests pass/fail floor; live report against batch_state  
7. **Sunset review:** 2026-09-06  

## Test plan
- [x] `pytest tests/test_driver_breadth_report.py tests/test_manifest_api.py::test_rule_sources_includes_all_unscoped_files`
- [x] breadth report CLI smoke
- [ ] CI
- [ ] formal CF