### PR TITLE
feat(open-model-data): bind steward-cleared rule-author rows

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_rule_author_source_rows_v1.schema.json",
+  "title": "Phase 3 steward-bound rule-author source rows v1",
+  "description": "Private exact UA-GEC rows for the rule-author packet compiler and a text-free public receipt.",
+  "type": "object",
+  "additionalProperties": false,
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "sourceRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family_id", "unit_id", "unit_sha256", "source_locator", "source_text", "corrected_text", "source_record", "span_start", "span_end", "source_sha256", "candidate_signals", "heldout", "ua_eval", "public_canary_neighbour"],
+      "properties": {
+        "family_id": {"const": "ua_gec"},
+        "unit_id": {"type": "string", "minLength": 1},
+        "unit_sha256": {"$ref": "#/$defs/sha256"},
+        "source_locator": {"$ref": "#/$defs/frozenLocator"},
+        "source_text": {"type": "string", "minLength": 1},
+        "corrected_text": {"type": "string"},
+        "source_record": {"$ref": "#/$defs/uaGecRecord"},
+        "span_start": {"const": 0},
+        "span_end": {"type": "integer", "minimum": 1},
+        "source_sha256": {"$ref": "#/$defs/sha256"},
+        "candidate_signals": {"const": []},
+        "heldout": {"const": false},
+        "ua_eval": {"const": false},
+        "public_canary_neighbour": {"const": false}
+      }
+    },
+    "frozenLocator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "table", "primary_key_fields", "primary_key_sha256"],
+      "properties": {
+        "kind": {"const": "sqlite_row"},
+        "table": {"const": "ua_gec_errors"},
+        "primary_key_fields": {"const": ["id"]},
+        "primary_key_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "uaGecRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "error", "correct", "error_type", "doc_id", "annotator_id", "partition", "is_native", "source_lang"],
+      "properties": {
+        "id": {"type": "integer", "minimum": 1},
+        "error": {"type": "string", "minLength": 1},
+        "correct": {"type": "string"},
+        "error_type": {"type": "string", "minLength": 1},
+        "doc_id": {"type": "string", "minLength": 1},
+        "annotator_id": {"type": "string", "minLength": 1},
+        "partition": {"type": "string", "pattern": ".+/train$"},
+        "is_native": {"type": "integer"},
+        "source_lang": {"type": "string", "minLength": 1}
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "text_free", "implementation_version", "role_binding", "rule_author_binding", "input_bindings", "exclusions", "aggregates", "source_rows_sha256", "receipt_sha256"],
+      "properties": {
+        "schema_version": {"const": "phase3_rule_author_source_rows_receipt_v1"},
+        "text_free": {"const": true},
+        "implementation_version": {"const": "phase3_rule_author_source_rows_v1"},
+        "role_binding": {"$ref": "#/$defs/roleBinding"},
+        "rule_author_binding": {"$ref": "#/$defs/ruleAuthorBinding"},
+        "input_bindings": {"$ref": "#/$defs/inputBindings"},
+        "exclusions": {"type": "object", "additionalProperties": false, "required": ["heldout_excluded", "ua_eval_exclusion_enforced", "public_canary_exclusion_enforced", "complement_inference_used", "all_rows_train", "clearance_source_row_set_equal"], "properties": {"heldout_excluded": {"const": true}, "ua_eval_exclusion_enforced": {"const": true}, "public_canary_exclusion_enforced": {"const": true}, "complement_inference_used": {"const": false}, "all_rows_train": {"const": true}, "clearance_source_row_set_equal": {"const": true}}},
+        "aggregates": {"type": "object", "additionalProperties": false, "required": ["source_row_count"], "properties": {"source_row_count": {"type": "integer", "minimum": 0}}},
+        "source_rows_sha256": {"$ref": "#/$defs/sha256"},
+        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "roleBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["role_id", "seat_id", "controller_identity_id", "attestation_task_id", "artifact_task_id"],
+      "properties": {"role_id": {"const": "heldout_steward"}, "seat_id": {"const": "seat_heldout_steward"}, "controller_identity_id": {"const": "controller_phase3_heldout_steward_cursor_runtime_01"}, "attestation_task_id": {"const": "phase3-role-heldout-steward-cursor-v2"}, "artifact_task_id": {"const": "phase3-heldout-partition-seal-cursor-v1"}}
+    },
+    "ruleAuthorBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["role_id", "controller_identity_id", "task_id"],
+      "properties": {"role_id": {"const": "rule_author_extractor"}, "controller_identity_id": {"const": "controller_phase3_rule_author_agy_runtime_01"}, "task_id": {"const": "phase3-role-rule-author-agy-v3"}}
+    },
+    "inputBindings": {
+      "type": "object", "additionalProperties": false,
+      "required": ["combined_contract_sha256", "source_universe_receipt_sha256", "ua_gec_ledger_sha256", "sources_db_sha256", "evaluation_contract_sha256", "coverage_contract_sha256", "role_contract_sha256", "near_duplicate_policy_sha256", "near_duplicate_policy_fingerprint_sha256", "author_clearance_receipt_sha256", "author_clearance_file_sha256", "partition_public_receipt_body_sha256", "partition_public_receipt_file_sha256", "compiler_script_sha256", "compiler_schema_sha256", "adapter_script_sha256", "adapter_schema_sha256"],
+      "properties": {"combined_contract_sha256": {"$ref": "#/$defs/sha256"}, "source_universe_receipt_sha256": {"$ref": "#/$defs/sha256"}, "ua_gec_ledger_sha256": {"$ref": "#/$defs/sha256"}, "sources_db_sha256": {"$ref": "#/$defs/sha256"}, "evaluation_contract_sha256": {"$ref": "#/$defs/sha256"}, "coverage_contract_sha256": {"$ref": "#/$defs/sha256"}, "role_contract_sha256": {"$ref": "#/$defs/sha256"}, "near_duplicate_policy_sha256": {"$ref": "#/$defs/sha256"}, "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"}, "author_clearance_receipt_sha256": {"$ref": "#/$defs/sha256"}, "author_clearance_file_sha256": {"$ref": "#/$defs/sha256"}, "partition_public_receipt_body_sha256": {"$ref": "#/$defs/sha256"}, "partition_public_receipt_file_sha256": {"$ref": "#/$defs/sha256"}, "compiler_script_sha256": {"$ref": "#/$defs/sha256"}, "compiler_schema_sha256": {"$ref": "#/$defs/sha256"}, "adapter_script_sha256": {"$ref": "#/$defs/sha256"}, "adapter_schema_sha256": {"$ref": "#/$defs/sha256"}}
+    }
+  }
+}

--- a/scripts/projects/open_model_data/phase3_heldout_partition.py
+++ b/scripts/projects/open_model_data/phase3_heldout_partition.py
@@ -293,7 +293,8 @@ def reconstruct_ua_gec_rows(
     connection = _connect_sources(sources_db)
     try:
         rows = connection.execute(
-            'SELECT "id", "error", "correct", "doc_id", "partition" FROM "ua_gec_errors" ORDER BY "id"'
+            'SELECT "id", "error", "correct", "error_type", "doc_id", "annotator_id", '
+            '"partition", "is_native", "source_lang" FROM "ua_gec_errors" ORDER BY "id"'
         ).fetchall()
     finally:
         connection.close()
@@ -311,8 +312,30 @@ def reconstruct_ua_gec_rows(
         error = row["error"]
         correct = row["correct"]
         require(isinstance(error, str) and isinstance(correct, str), "ua_gec row text fields malformed")
+        error_type = row["error_type"]
         doc_id = row["doc_id"]
+        annotator_id = row["annotator_id"]
+        is_native = row["is_native"]
+        source_lang = row["source_lang"]
         require(isinstance(doc_id, str) and doc_id != "", "ua_gec doc_id malformed")
+        require(isinstance(error_type, str) and error_type, "ua_gec error_type malformed")
+        require(isinstance(annotator_id, str) and annotator_id, "ua_gec annotator_id malformed")
+        require(isinstance(is_native, int), "ua_gec is_native malformed")
+        require(isinstance(source_lang, str) and source_lang, "ua_gec source_lang malformed")
+        source_record = freeze_mod._normal(
+            {
+                "id": row_id,
+                "error": error,
+                "correct": correct,
+                "error_type": error_type,
+                "doc_id": doc_id,
+                "annotator_id": annotator_id,
+                "partition": str(row["partition"]),
+                "is_native": is_native,
+                "source_lang": source_lang,
+            }
+        )
+        require(unit["unit_sha256"] == freeze_mod._unit_hash(source_record), "ua_gec frozen unit hash drift")
         reconstructed.append(
             {
                 "family_id": UA_GEC_FAMILY,
@@ -328,6 +351,11 @@ def reconstruct_ua_gec_rows(
                 "partition": str(row["partition"]),
                 "error": error,
                 "correct": correct,
+                "error_type": error_type,
+                "annotator_id": annotator_id,
+                "is_native": is_native,
+                "source_lang": source_lang,
+                "source_record": source_record,
                 "locator": unit["locator"],
             }
         )

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -142,7 +142,7 @@ def _prepare_private_dir(private_dir: Path) -> Path:
     for entry in entries:
         _lstat(entry, "private source-row directory entry")
         require(entry.name == ROWS_FILENAME and entry.is_file(), "unexpected file in private source-row directory")
-        require((entry.stat().st_mode & 0o777) == PRIVATE_FILE_MODE, "private source-row file permissions too open")
+        require((entry.stat().st_mode & 0o777) == PRIVATE_FILE_MODE, "private source-row file permissions drift")
     return private_dir / ROWS_FILENAME
 
 

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Materialize explicitly cleared UA-GEC source rows for the rule-author lane.
+
+This steward-only adapter has one narrow authority: turn the exact private
+author-clearance allowlist into the private JSONL input accepted by
+``phase3_rule_author_packets --sources``.  It never derives an allowlist from
+a complement, opens a held-out seal, or makes Ukrainian classification,
+disposition, or rule decisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_heldout_partition as heldout
+from scripts.projects.open_model_data import phase3_near_duplicate as near_duplicate
+from scripts.projects.open_model_data import phase3_rule_author_packets as packets
+
+ROOT = Path(__file__).resolve().parents[3]
+DATA = ROOT / "data/projects/open_model_data"
+SCHEMA_PATH = DATA / "contracts/phase3_rule_author_source_rows_v1.schema.json"
+PACKET_SCHEMA_PATH = DATA / "contracts/phase3_rule_author_packet_bundle_v1.schema.json"
+SCRIPT_PATH = "scripts/projects/open_model_data/phase3_rule_author_source_rows.py"
+PACKET_SCRIPT_PATH = "scripts/projects/open_model_data/phase3_rule_author_packets.py"
+IMPLEMENTATION_VERSION = "phase3_rule_author_source_rows_v1"
+ROWS_FILENAME = "rule_author_source_rows_v1.jsonl"
+PRIVATE_DIR_MODE = 0o700
+PRIVATE_FILE_MODE = 0o600
+SHA256_LENGTH = 64
+
+
+class SourceRowsError(ValueError):
+    """A private source-row boundary cannot be established safely."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SourceRowsError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise SourceRowsError(f"cannot read artifact: {path}") from exc
+    return digest.hexdigest()
+
+
+def receipt_body_sha256(receipt: Mapping[str, Any]) -> str:
+    return sha256_bytes((canonical_json({key: value for key, value in receipt.items() if key != "receipt_sha256"}) + "\n").encode("utf-8"))
+
+
+def _lstat(path: Path, label: str) -> os.stat_result:
+    try:
+        result = path.lstat()
+    except OSError as exc:
+        raise SourceRowsError(f"missing {label}: {path}") from exc
+    require(not stat.S_ISLNK(result.st_mode), f"symlink is forbidden for {label}")
+    return result
+
+
+def _absolute_lexical(path: Path) -> Path:
+    """Make a path absolute without resolving a terminal or parent symlink."""
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def _reject_symlink_components(path: Path, label: str) -> None:
+    """Reject a symlink in any existing lexical component of ``path``."""
+    absolute = _absolute_lexical(path)
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        if not current.exists() and not current.is_symlink():
+            return
+        _lstat(current, label)
+
+
+def _regular_file(path: Path, label: str) -> None:
+    _reject_symlink_components(path, label)
+    result = _lstat(path, label)
+    require(stat.S_ISREG(result.st_mode), f"{label} must be a regular file")
+
+
+def read_json(path: Path, label: str = "JSON artifact") -> dict[str, Any]:
+    _regular_file(path, label)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SourceRowsError(f"cannot read {label}") from exc
+    require(isinstance(value, dict), f"{label} must be an object")
+    return value
+
+
+def _schema_validator(definition: str) -> Draft202012Validator:
+    schema = read_json(SCHEMA_PATH, "adapter schema")
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator({"$schema": schema["$schema"], "$defs": schema["$defs"], "$ref": f"#/$defs/{definition}"})
+
+
+def _validate(value: Mapping[str, Any], definition: str, label: str) -> None:
+    errors = sorted(_schema_validator(definition).iter_errors(value), key=lambda item: list(item.path))
+    if errors:
+        location = ".".join(str(part) for part in errors[0].path) or "<root>"
+        raise SourceRowsError(f"{label} schema violation at {location}: {errors[0].message}")
+
+
+def _prepare_private_dir(private_dir: Path) -> Path:
+    _reject_symlink_components(private_dir, "private source-row directory")
+    if private_dir.exists() or private_dir.is_symlink():
+        result = _lstat(private_dir, "private source-row directory")
+        require(stat.S_ISDIR(result.st_mode), "private source-row path must be a directory")
+        require((result.st_mode & 0o777) == PRIVATE_DIR_MODE, "private source-row directory permissions too open")
+    else:
+        private_dir.mkdir(parents=True, mode=PRIVATE_DIR_MODE)
+        os.chmod(private_dir, PRIVATE_DIR_MODE)
+    entries = list(private_dir.iterdir())
+    for entry in entries:
+        _lstat(entry, "private source-row directory entry")
+        require(entry.name == ROWS_FILENAME and entry.is_file(), "unexpected file in private source-row directory")
+        require((entry.stat().st_mode & 0o777) == PRIVATE_FILE_MODE, "private source-row file permissions too open")
+    return private_dir / ROWS_FILENAME
+
+
+def _prepare_public_receipt_path(path: Path) -> None:
+    """Reject symlinked receipt destinations before an atomic replacement."""
+    _reject_symlink_components(path, "public source-row receipt")
+    if path.exists() or path.is_symlink():
+        _regular_file(path, "public source-row receipt")
+    ancestor = path.parent
+    while not ancestor.exists() and ancestor != ancestor.parent:
+        ancestor = ancestor.parent
+    result = _lstat(ancestor, "public source-row receipt parent")
+    require(stat.S_ISDIR(result.st_mode), "public source-row receipt parent must be a directory")
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    if _absolute_lexical(left) == _absolute_lexical(right):
+        return True
+    try:
+        return left.exists() and right.exists() and os.path.samefile(left, right)
+    except OSError:
+        return False
+
+
+def _assert_output_paths_safe(
+    *, private_dir: Path, public_receipt_path: Path, inputs: Sequence[Path], input_directories: Sequence[Path]
+) -> None:
+    rows_path = private_dir / ROWS_FILENAME
+    private_absolute = _absolute_lexical(private_dir)
+    public_absolute = _absolute_lexical(public_receipt_path)
+    require(public_absolute != private_absolute and private_absolute not in public_absolute.parents, "public receipt may not be inside private source-row directory")
+    require(not _same_path(public_receipt_path, rows_path), "public receipt aliases private source rows")
+    for input_path in inputs:
+        require(not _same_path(rows_path, input_path), "private source rows alias an input artifact")
+        require(not _same_path(public_receipt_path, input_path), "public receipt aliases an input artifact")
+    for input_directory in input_directories:
+        directory_absolute = _absolute_lexical(input_directory)
+        for output_path, label in (
+            (private_absolute, "private source-row directory"),
+            (_absolute_lexical(rows_path), "private source rows"),
+            (public_absolute, "public receipt"),
+        ):
+            require(
+                output_path != directory_absolute and directory_absolute not in output_path.parents,
+                f"{label} may not be inside an input directory",
+            )
+
+
+def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as handle:
+        temporary = Path(handle.name)
+        try:
+            os.fchmod(handle.fileno(), mode)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            os.replace(temporary, path)
+            os.chmod(path, mode)
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+
+
+def _assert_public_safe(value: Any, *, path: str = "$") -> None:
+    forbidden = ("unit_id", "locator", "fingerprint", "source_text", "corrected_text", "source_record", "error", "correct", "doc_id", "body")
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            lower = str(key).lower()
+            if lower.endswith("policy_fingerprint_sha256") or lower == "partition_public_receipt_body_sha256":
+                _assert_public_safe(item, path=f"{path}.{key}")
+                continue
+            require(not any(token in lower for token in forbidden), f"receipt exposes forbidden field at {path}.{key}")
+            _assert_public_safe(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _assert_public_safe(item, path=f"{path}[{index}]")
+    elif isinstance(value, str):
+        approved = {
+            "phase3_rule_author_source_rows_receipt_v1", IMPLEMENTATION_VERSION,
+            "heldout_steward", "seat_heldout_steward", "controller_phase3_heldout_steward_cursor_runtime_01",
+            "phase3-role-heldout-steward-cursor-v2", "phase3-heldout-partition-seal-cursor-v1",
+            "rule_author_extractor", "controller_phase3_rule_author_agy_runtime_01", "phase3-role-rule-author-agy-v3",
+        }
+        require(value in approved or (len(value) == SHA256_LENGTH and all(char in "0123456789abcdef" for char in value)), f"receipt contains unapproved text at {path}")
+
+
+def _clearance_and_bindings(
+    *,
+    clearance_path: Path,
+    public_partition_receipt_path: Path,
+    source_universe_dir: Path,
+    sources_db: Path,
+    evaluation_path: Path,
+    coverage_path: Path,
+    role_path: Path,
+    near_duplicate_policy_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, str], str, str]:
+    clearance = read_json(clearance_path, "author clearance")
+    partition_receipt = read_json(public_partition_receipt_path, "partition public receipt")
+    _reject_symlink_components(source_universe_dir, "source-universe directory")
+    source_dir_stat = _lstat(source_universe_dir, "source-universe directory")
+    require(stat.S_ISDIR(source_dir_stat.st_mode), "source-universe path must be a directory")
+    source_freeze_receipt = source_universe_dir / packets.LEDGER_RECEIPT
+    _regular_file(source_freeze_receipt, "source-universe receipt")
+    freeze_receipt = read_json(source_freeze_receipt, "source-universe receipt")
+    families = freeze_receipt.get("families")
+    require(isinstance(families, list), "source-universe family ledgers missing")
+    ua_ledgers = [item for item in families if isinstance(item, Mapping) and item.get("family_id") == "ua_gec"]
+    require(len(ua_ledgers) == 1, "source-universe lacks one UA-GEC ledger")
+    ledger_name = ua_ledgers[0].get("ledger_file")
+    require(isinstance(ledger_name, str) and Path(ledger_name).name == ledger_name, "unsafe UA-GEC ledger path")
+    ledger_path = source_universe_dir / ledger_name
+    _regular_file(ledger_path, "frozen UA-GEC ledger")
+    ledger_sha = ua_ledgers[0].get("ledger_sha256")
+    require(isinstance(ledger_sha, str) and ledger_sha == sha256_file(ledger_path), "frozen UA-GEC ledger hash drift")
+    _regular_file(sources_db, "sources DB")
+    _regular_file(evaluation_path, "evaluation contract")
+    _regular_file(coverage_path, "coverage contract")
+    _regular_file(role_path, "role contract")
+    _regular_file(near_duplicate_policy_path, "near-duplicate policy")
+    _regular_file(ROOT / PACKET_SCRIPT_PATH, "packet compiler")
+    _regular_file(PACKET_SCHEMA_PATH, "packet compiler schema")
+
+    try:
+        near_duplicate.policy_for_governed_use(
+            "public_canary_neighbour_exclusion",
+            path=near_duplicate_policy_path,
+            expected_fingerprint=near_duplicate.PINNED_POLICY_FINGERPRINT,
+        )
+    except near_duplicate.NearDuplicatePolicyError as exc:
+        raise SourceRowsError(str(exc)) from exc
+
+    clearance_file_sha = sha256_file(clearance_path)
+    freeze_sha = sha256_file(source_freeze_receipt)
+    try:
+        packets.validate_clearance(
+            clearance,
+            clearance_sha256=clearance_file_sha,
+            receipt_sha256=freeze_sha,
+            evaluation_path=evaluation_path,
+            coverage_path=coverage_path,
+            role_path=role_path,
+        )
+    except packets.PacketCompilerError as exc:
+        raise SourceRowsError(str(exc)) from exc
+    require(partition_receipt.get("schema_version") == "phase3_heldout_public_receipt_v1", "wrong partition public receipt")
+    require(partition_receipt.get("text_free") is True, "partition public receipt is not text-free")
+    require(heldout.receipt_body_sha256(partition_receipt) == partition_receipt.get("receipt_sha256"), "partition public receipt hash drift")
+    role_contract = read_json(role_path, "role contract")
+    try:
+        expected_steward = heldout.verify_role_binding(role_contract)
+    except heldout.PartitionError as exc:
+        raise SourceRowsError(str(exc)) from exc
+    require(clearance.get("role_binding") == expected_steward, "clearance is not bound to assigned heldout steward")
+    try:
+        author = packets._derive_role_actor(role_contract, "rule_author_extractor")
+    except packets.PacketCompilerError as exc:
+        raise SourceRowsError(str(exc)) from exc
+    require(
+        author["controller_identity_id"] != expected_steward["controller_identity_id"],
+        "heldout steward and rule author identities must be distinct",
+    )
+    public_bindings = partition_receipt.get("input_bindings")
+    require(isinstance(public_bindings, Mapping), "partition public input bindings missing")
+    clearance_bindings = clearance["input_bindings"]
+    for key, actual in {
+        "combined_contract_sha256": packets.COMBINED_CONTRACT_SHA256,
+        "source_universe_receipt_sha256": freeze_sha,
+        "evaluation_contract_sha256": sha256_file(evaluation_path),
+        "coverage_contract_sha256": sha256_file(coverage_path),
+        "role_contract_sha256": sha256_file(role_path),
+        "near_duplicate_policy_fingerprint_sha256": near_duplicate.PINNED_POLICY_FINGERPRINT,
+    }.items():
+        require(clearance_bindings.get(key) == actual, f"clearance {key} binding drift")
+        require(public_bindings.get(key) == actual, f"partition public {key} binding drift")
+    require(public_bindings.get("sources_db_sha256") == sha256_file(sources_db), "sources DB binding drift")
+    for key in ("ua_eval_exclusion_manifest_sha256", "public_canary_exclusion_manifest_sha256"):
+        require(clearance_bindings.get(key) == public_bindings.get(key), f"clearance {key} binding drift")
+    artifact_hashes = partition_receipt.get("artifact_hashes")
+    require(isinstance(artifact_hashes, Mapping), "partition artifact hashes missing")
+    require(artifact_hashes.get("author_clearance_sha256") == clearance.get("receipt_sha256"), "clearance receipt binding drift")
+    for field in ("heldout_excluded", "ua_eval_exclusion_enforced", "public_canary_exclusion_enforced"):
+        require(clearance.get(field) is True, f"clearance {field} is not exactly true")
+    require(clearance.get("heldout_complement_encoded") is False, "clearance encodes a heldout complement")
+    return clearance, partition_receipt, expected_steward, author, clearance_file_sha, str(ledger_sha)
+
+
+def _row_from_reconstructed(row: Mapping[str, Any]) -> dict[str, Any]:
+    require(row.get("family_id") == "ua_gec", "reconstructed non-UA-GEC row")
+    require(row.get("split") == "train", "non-train row cannot enter source rows")
+    source_record = row.get("source_record")
+    require(isinstance(source_record, Mapping), "reconstruction lacks exact source record")
+    normalized = packets.source_universe._normal(source_record)
+    require(isinstance(normalized, Mapping), "source record normalization failed")
+    require(row.get("unit_sha256") == packets.source_universe._unit_hash(normalized), "source record unit hash drift")
+    source_text = normalized.get("error")
+    corrected_text = normalized.get("correct")
+    require(isinstance(source_text, str) and source_text and isinstance(corrected_text, str), "source text pair malformed")
+    for field in ("error_type", "annotator_id", "is_native", "source_lang"):
+        require(normalized.get(field) == row.get(field), f"reconstructed {field} drift")
+    locator = heldout.frozen_locator_binding(row["locator"])
+    output = {
+        "family_id": "ua_gec",
+        "unit_id": row["unit_id"],
+        "unit_sha256": row["unit_sha256"],
+        "source_locator": locator,
+        "source_text": source_text,
+        "corrected_text": corrected_text,
+        "source_record": normalized,
+        "span_start": 0,
+        "span_end": len(source_text),
+        "source_sha256": sha256_bytes(source_text.encode("utf-8")),
+        "candidate_signals": [],
+        "heldout": False,
+        "ua_eval": False,
+        "public_canary_neighbour": False,
+    }
+    _validate(output, "sourceRow", "source row")
+    try:
+        packets._item_from_row(output, "0" * SHA256_LENGTH, near_duplicate.PINNED_POLICY_FINGERPRINT)
+    except packets.PacketCompilerError as exc:
+        raise SourceRowsError(f"adapter output is not packet-compiler compatible: {exc}") from exc
+    return output
+
+
+def build(
+    *,
+    clearance_path: Path,
+    source_universe_dir: Path,
+    sources_db: Path,
+    public_partition_receipt_path: Path,
+    evaluation_path: Path,
+    coverage_path: Path,
+    role_path: Path,
+    near_duplicate_policy_path: Path,
+    private_dir: Path,
+    public_receipt_path: Path,
+) -> dict[str, Any]:
+    """Build exact allowlisted private rows and a text-free aggregate receipt."""
+    inputs = (
+        clearance_path,
+        source_universe_dir,
+        sources_db,
+        public_partition_receipt_path,
+        evaluation_path,
+        coverage_path,
+        role_path,
+        near_duplicate_policy_path,
+        SCHEMA_PATH,
+        PACKET_SCHEMA_PATH,
+        ROOT / PACKET_SCRIPT_PATH,
+        ROOT / SCRIPT_PATH,
+    )
+    for input_path in inputs:
+        _reject_symlink_components(input_path, "input artifact")
+    _prepare_public_receipt_path(public_receipt_path)
+    _assert_output_paths_safe(
+        private_dir=private_dir,
+        public_receipt_path=public_receipt_path,
+        inputs=inputs,
+        input_directories=(source_universe_dir,),
+    )
+    rows_path = _prepare_private_dir(private_dir)
+    clearance, partition_receipt, steward, author, clearance_file_sha, ledger_sha = _clearance_and_bindings(
+        clearance_path=clearance_path,
+        public_partition_receipt_path=public_partition_receipt_path,
+        source_universe_dir=source_universe_dir,
+        sources_db=sources_db,
+        evaluation_path=evaluation_path,
+        coverage_path=coverage_path,
+        role_path=role_path,
+        near_duplicate_policy_path=near_duplicate_policy_path,
+    )
+    freeze_units = heldout._load_freeze_ua_gec_units(source_universe_dir)
+    try:
+        reconstructed = heldout.reconstruct_ua_gec_rows(sources_db=sources_db, freeze_units=freeze_units)
+    except heldout.PartitionError as exc:
+        raise SourceRowsError(str(exc)) from exc
+    cleared = clearance.get("cleared_units")
+    require(isinstance(cleared, list), "clearance cleared units missing")
+    allowed = {(item.get("family_id"), item.get("unit_id")): item.get("unit_sha256") for item in cleared if isinstance(item, Mapping)}
+    require(len(allowed) == len(cleared), "clearance has duplicate or malformed units")
+    require(clearance.get("cleared_unit_count") == len(allowed), "clearance count drift")
+    live = {(item["family_id"], item["unit_id"]): item for item in reconstructed}
+    require(set(allowed) <= set(live), "clearance references missing frozen source unit")
+    rows: list[dict[str, Any]] = []
+    for key in sorted(allowed):
+        row = live[key]
+        require(allowed[key] == row["unit_sha256"], "clearance unit hash drift")
+        rows.append(_row_from_reconstructed(row))
+    actual = {(row["family_id"], row["unit_id"]) for row in rows}
+    require(actual == set(allowed), "source rows must equal clearance exactly; complement inference is forbidden")
+    payload = "".join(canonical_json(row) + "\n" for row in rows).encode("utf-8")
+    _atomic_write(rows_path, payload, PRIVATE_FILE_MODE)
+    require((rows_path.stat().st_mode & 0o777) == PRIVATE_FILE_MODE, "private source-row file permissions too open")
+    receipt = {
+        "schema_version": "phase3_rule_author_source_rows_receipt_v1",
+        "text_free": True,
+        "implementation_version": IMPLEMENTATION_VERSION,
+        "role_binding": steward,
+        "rule_author_binding": author,
+        "input_bindings": {
+            "combined_contract_sha256": packets.COMBINED_CONTRACT_SHA256,
+            "source_universe_receipt_sha256": sha256_file(source_universe_dir / packets.LEDGER_RECEIPT),
+            "ua_gec_ledger_sha256": ledger_sha,
+            "sources_db_sha256": sha256_file(sources_db),
+            "evaluation_contract_sha256": sha256_file(evaluation_path),
+            "coverage_contract_sha256": sha256_file(coverage_path),
+            "role_contract_sha256": sha256_file(role_path),
+            "near_duplicate_policy_sha256": sha256_file(near_duplicate_policy_path),
+            "near_duplicate_policy_fingerprint_sha256": near_duplicate.PINNED_POLICY_FINGERPRINT,
+            "author_clearance_receipt_sha256": clearance["receipt_sha256"],
+            "author_clearance_file_sha256": clearance_file_sha,
+            "partition_public_receipt_body_sha256": partition_receipt["receipt_sha256"],
+            "partition_public_receipt_file_sha256": sha256_file(public_partition_receipt_path),
+            "compiler_script_sha256": sha256_file(ROOT / PACKET_SCRIPT_PATH),
+            "compiler_schema_sha256": sha256_file(PACKET_SCHEMA_PATH),
+            "adapter_script_sha256": sha256_file(ROOT / SCRIPT_PATH),
+            "adapter_schema_sha256": sha256_file(SCHEMA_PATH),
+        },
+        "exclusions": {
+            "heldout_excluded": True,
+            "ua_eval_exclusion_enforced": True,
+            "public_canary_exclusion_enforced": True,
+            "complement_inference_used": False,
+            "all_rows_train": True,
+            "clearance_source_row_set_equal": True,
+        },
+        "aggregates": {"source_row_count": len(rows)},
+        "source_rows_sha256": sha256_bytes(payload),
+    }
+    receipt["receipt_sha256"] = receipt_body_sha256(receipt)
+    _validate(receipt, "receipt", "source-row receipt")
+    _assert_public_safe(receipt)
+    _atomic_write(public_receipt_path, (canonical_json(receipt) + "\n").encode("utf-8"), 0o644)
+    return receipt
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clearance", type=Path, required=True)
+    parser.add_argument("--source-universe", type=Path, required=True)
+    parser.add_argument("--sources-db", type=Path, required=True)
+    parser.add_argument("--partition-public-receipt", type=Path, required=True)
+    parser.add_argument("--evaluation", type=Path, required=True)
+    parser.add_argument("--coverage", type=Path, required=True)
+    parser.add_argument("--role", type=Path, required=True)
+    parser.add_argument("--near-duplicate-policy", type=Path, required=True)
+    parser.add_argument("--private-dir", type=Path, required=True)
+    parser.add_argument("--public-receipt", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        receipt = build(
+            clearance_path=args.clearance, source_universe_dir=args.source_universe,
+            sources_db=args.sources_db, public_partition_receipt_path=args.partition_public_receipt,
+            evaluation_path=args.evaluation, coverage_path=args.coverage, role_path=args.role,
+            near_duplicate_policy_path=args.near_duplicate_policy, private_dir=args.private_dir,
+            public_receipt_path=args.public_receipt,
+        )
+    except SourceRowsError as exc:
+        parser.error(str(exc))
+    sys.stdout.write(canonical_json(receipt) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -478,7 +478,7 @@ def build(
     receipt["receipt_sha256"] = receipt_body_sha256(receipt)
     _validate(receipt, "receipt", "source-row receipt")
     _assert_public_safe(receipt)
-    _atomic_write(public_receipt_path, (canonical_json(receipt) + "\n").encode("utf-8"), 0o644)
+    _atomic_write(public_receipt_path, (canonical_json(receipt) + "\n").encode("utf-8"), PRIVATE_FILE_MODE)
     return receipt
 
 

--- a/tests/test_open_model_phase3_heldout_partition.py
+++ b/tests/test_open_model_phase3_heldout_partition.py
@@ -377,6 +377,7 @@ def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) 
         schema_path=root / SCHEMA.relative_to(ROOT),
         skip_source_freeze_git_binding=True,
     )
+    public_bytes_before_reconstruction_metadata_rerun = (public / "public_receipt_v1.json").read_bytes()
     second = heldout.build_artifacts(
         root=root,
         source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
@@ -393,6 +394,7 @@ def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) 
         skip_source_freeze_git_binding=True,
     )
     assert first["public_receipt_sha256"] == second["public_receipt_sha256"]
+    assert (public / "public_receipt_v1.json").read_bytes() == public_bytes_before_reconstruction_metadata_rerun
     assert first["heldout_seal_sha256"] == second["heldout_seal_sha256"]
     assert first["author_clearance_sha256"] == second["author_clearance_sha256"]
 

--- a/tests/test_open_model_phase3_rule_author_source_rows.py
+++ b/tests/test_open_model_phase3_rule_author_source_rows.py
@@ -1,0 +1,221 @@
+"""Hermetic checks for steward-only Phase 3 rule-author source rows."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_heldout_partition as heldout
+from scripts.projects.open_model_data import phase3_rule_author_packets as packets
+from scripts.projects.open_model_data import phase3_rule_author_source_rows as rows
+from scripts.projects.open_model_data import phase3_source_universe as freeze
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rows.canonical_json(value) + "\n", encoding="utf-8")
+
+
+def _fixture(tmp_path: Path, *, include_test: bool = False) -> dict[str, Path]:
+    root = tmp_path / "synthetic"
+    data = root / "data/projects/open_model_data"
+    role = ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
+    evaluation = ROOT / "data/projects/open_model_data/evidence/correction_protection_evaluation_contract_v1.json"
+    coverage = ROOT / "data/projects/open_model_data/evidence/correction_protection_coverage_contract_v1.json"
+    policy = ROOT / "data/projects/open_model_data/evidence/correction_protection_near_duplicate_policy_v1.json"
+    for source, target in ((role, data / "role.json"), (evaluation, data / "evaluation.json"), (coverage, data / "coverage.json"), (policy, data / "policy.json")):
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+    db = root / "data/sources.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db)
+    connection.execute("CREATE TABLE ua_gec_errors (id INTEGER PRIMARY KEY, error TEXT, correct TEXT, error_type TEXT, doc_id TEXT, annotator_id TEXT, partition TEXT, is_native INTEGER, source_lang TEXT)")
+    records = [
+        (1, "synthetic train error one", "synthetic correction one", "G/Case", "train-doc", "ann-one", "gec/train", 1, "uk"),
+        (2, "synthetic train error two", "synthetic correction two", "F/Calque", "train-doc-two", "ann-two", "gec/train", 0, "ru"),
+    ]
+    if include_test:
+        records.append((3, "synthetic heldout error", "synthetic heldout correction", "G/Case", "test-doc", "ann-three", "gec/test", 1, "uk"))
+    connection.executemany("INSERT INTO ua_gec_errors VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", records)
+    connection.commit()
+    connection.close()
+    universe = data / "source-universe"
+    units = []
+    for ordinal, record in enumerate(records, 1):
+        payload = dict(zip(("id", "error", "correct", "error_type", "doc_id", "annotator_id", "partition", "is_native", "source_lang"), record, strict=True))
+        units.append({"family_id": "ua_gec", "unit_id": freeze._opaque_id("unit.ua_gec", {"table": "ua_gec_errors", "identity": {"id": record[0]}}), "unit_sha256": freeze._unit_hash(freeze._normal(payload)), "ordinal": ordinal, "locator": {"kind": "sqlite_row", "table": "ua_gec_errors", "primary_key_fields": ["id"], "primary_key_sha256": freeze._unit_hash({"id": record[0]})}})
+    ledger = universe / "ua_gec.units.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.write_text("".join(rows.canonical_json(item) + "\n" for item in units), encoding="utf-8")
+    freeze_receipt = {"schema_version": "phase3_source_universe_freeze_v1", "text_free": True, "merged_main_sha": "0" * 40, "families": [{"family_id": "ua_gec", "ledger_file": ledger.name, "ledger_sha256": rows.sha256_file(ledger)}]}
+    _write(universe / "source-universe-freeze-receipt.json", freeze_receipt)
+    steward = heldout.verify_role_binding(heldout.read_json(data / "role.json"))
+    clearance = {"schema_version": "phase3_author_clearance_receipt_v1", "text_free": True, "implementation_version": "phase3_heldout_partition_v1", "role_binding": steward, "input_bindings": {"combined_contract_sha256": packets.COMBINED_CONTRACT_SHA256, "role_contract_sha256": rows.sha256_file(data / "role.json"), "evaluation_contract_sha256": rows.sha256_file(data / "evaluation.json"), "coverage_contract_sha256": rows.sha256_file(data / "coverage.json"), "source_universe_receipt_sha256": rows.sha256_file(universe / "source-universe-freeze-receipt.json"), "near_duplicate_policy_fingerprint_sha256": packets.near_duplicate.PINNED_POLICY_FINGERPRINT, "ua_eval_exclusion_manifest_sha256": "2" * 64, "public_canary_exclusion_manifest_sha256": "3" * 64}, "cleared_units": [{key: unit[key] for key in ("family_id", "unit_id", "unit_sha256")} for unit in units], "cleared_unit_count": len(units), "heldout_excluded": True, "ua_eval_exclusion_enforced": True, "public_canary_exclusion_enforced": True, "heldout_complement_encoded": False, "fingerprints_encoded": False, "locators_encoded": False}
+    clearance["receipt_sha256"] = packets.receipt_body_sha256(clearance)
+    clearance_path = root / "private/author_clearance_v1.json"
+    _write(clearance_path, clearance)
+    public = {"schema_version": "phase3_heldout_public_receipt_v1", "text_free": True, "input_bindings": {**clearance["input_bindings"], "sources_db_sha256": rows.sha256_file(db)}, "artifact_hashes": {"author_clearance_sha256": clearance["receipt_sha256"]}}
+    public["receipt_sha256"] = heldout.receipt_body_sha256(public)
+    public_path = root / "public/partition.json"
+    _write(public_path, public)
+    return {"db": db, "universe": universe, "clearance": clearance_path, "public": public_path, "evaluation": data / "evaluation.json", "coverage": data / "coverage.json", "role": data / "role.json", "policy": data / "policy.json", "private": root / "batch_state/source-rows", "receipt": root / "public/source-rows-receipt.json"}
+
+
+def _build(paths: dict[str, Path]) -> dict[str, object]:
+    return rows.build(clearance_path=paths["clearance"], source_universe_dir=paths["universe"], sources_db=paths["db"], public_partition_receipt_path=paths["public"], evaluation_path=paths["evaluation"], coverage_path=paths["coverage"], role_path=paths["role"], near_duplicate_policy_path=paths["policy"], private_dir=paths["private"], public_receipt_path=paths["receipt"])
+
+
+def _rewrite_clearance_and_public(paths: dict[str, Path], clearance: dict[str, object]) -> None:
+    clearance["cleared_unit_count"] = len(clearance["cleared_units"])
+    clearance["receipt_sha256"] = packets.receipt_body_sha256(
+        {key: value for key, value in clearance.items() if key != "receipt_sha256"}
+    )
+    _write(paths["clearance"], clearance)
+    public = rows.read_json(paths["public"], "public")
+    public["artifact_hashes"]["author_clearance_sha256"] = clearance["receipt_sha256"]
+    public["receipt_sha256"] = heldout.receipt_body_sha256(
+        {key: value for key, value in public.items() if key != "receipt_sha256"}
+    )
+    _write(paths["public"], public)
+
+
+def test_rows_are_deterministic_private_complete_and_packet_compiler_compatible(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    first = _build(paths)
+    output = paths["private"] / rows.ROWS_FILENAME
+    first_bytes = output.read_bytes()
+    second = _build(paths)
+    assert first == second
+    assert output.read_bytes() == first_bytes
+    assert (paths["private"].stat().st_mode & 0o777) == 0o700
+    assert (output.stat().st_mode & 0o777) == 0o600
+    materialized = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert {item["source_record"]["error_type"] for item in materialized} == {"G/Case", "F/Calque"}
+    assert {item["source_record"]["annotator_id"] for item in materialized} == {"ann-one", "ann-two"}
+    assert all(item["heldout"] is False and item["ua_eval"] is False and item["public_canary_neighbour"] is False for item in materialized)
+    assert all(packets._item_from_row(item, "0" * 64, packets.near_duplicate.PINNED_POLICY_FINGERPRINT) for item in materialized)
+    schema = rows.read_json(rows.SCHEMA_PATH, "adapter schema")
+    Draft202012Validator.check_schema(schema)
+    receipt = rows.read_json(paths["receipt"], "public receipt")
+    assert receipt["text_free"] is True and "source_text" not in rows.canonical_json(receipt)
+    assert receipt["rule_author_binding"]["role_id"] == "rule_author_extractor"
+    assert receipt["rule_author_binding"]["controller_identity_id"] != receipt["role_binding"]["controller_identity_id"]
+    assert receipt["input_bindings"]["ua_gec_ledger_sha256"] == rows.sha256_file(paths["universe"] / "ua_gec.units.jsonl")
+    assert receipt["input_bindings"]["partition_public_receipt_body_sha256"] == rows.read_json(paths["public"])["receipt_sha256"]
+    assert receipt["input_bindings"]["partition_public_receipt_file_sha256"] == rows.sha256_file(paths["public"])
+    assert receipt["exclusions"]["all_rows_train"] is True
+    assert receipt["exclusions"]["clearance_source_row_set_equal"] is True
+
+
+def test_rejects_stale_db_test_injection_and_unexpected_or_symlink_private_inputs(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    with sqlite3.connect(paths["db"]) as connection:
+        connection.execute("UPDATE ua_gec_errors SET error = 'tampered' WHERE id = 1")
+    with pytest.raises(rows.SourceRowsError, match="sources DB binding drift"):
+        _build(paths)
+    paths = _fixture(tmp_path / "test")
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    clearance["cleared_units"] = [*clearance["cleared_units"], {"family_id": "ua_gec", "unit_id": "unit.ua_gec." + "0" * 64, "unit_sha256": "0" * 64}]
+    _rewrite_clearance_and_public(paths, clearance)
+    with pytest.raises(rows.SourceRowsError, match="missing frozen source unit"):
+        _build(paths)
+    paths = _fixture(tmp_path / "test-injection", include_test=True)
+    with pytest.raises(rows.SourceRowsError, match="non-train row"):
+        _build(paths)
+    paths = _fixture(tmp_path / "unexpected")
+    paths["private"].mkdir(parents=True, mode=0o700)
+    os.chmod(paths["private"], 0o700)
+    (paths["private"] / "unexpected.json").write_text("{}\n", encoding="utf-8")
+    with pytest.raises(rows.SourceRowsError, match="unexpected file"):
+        _build(paths)
+    paths = _fixture(tmp_path / "symlink")
+    paths["private"].parent.mkdir(parents=True)
+    os.symlink(paths["private"].parent, paths["private"])
+    with pytest.raises(rows.SourceRowsError, match="symlink"):
+        _build(paths)
+
+
+def test_clearance_omission_is_exact_not_a_complement(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    clearance["cleared_units"] = clearance["cleared_units"][:1]
+    _rewrite_clearance_and_public(paths, clearance)
+    receipt = _build(paths)
+    output = (paths["private"] / rows.ROWS_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert receipt["aggregates"]["source_row_count"] == 1
+    assert len(output) == 1
+
+
+@pytest.mark.parametrize("mutation, match", [
+    (lambda clearance: clearance.__setitem__("cleared_units", [*clearance["cleared_units"], clearance["cleared_units"][0]]), "duplicate"),
+    (lambda clearance: clearance.__setitem__("cleared_units", [{"family_id": "ua_gec"}]), "schema violation"),
+    (lambda clearance: clearance["cleared_units"][0].__setitem__("unit_sha256", "0" * 64), "unit hash drift"),
+])
+def test_rejects_duplicate_missing_or_wrong_hash_clearance(tmp_path: Path, mutation, match: str) -> None:
+    paths = _fixture(tmp_path)
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    mutation(clearance)
+    _rewrite_clearance_and_public(paths, clearance)
+    with pytest.raises(rows.SourceRowsError, match=match):
+        _build(paths)
+
+
+def test_rejects_stale_contract_or_partition_receipt_binding_and_permission_drift(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    paths["coverage"].write_text("{}\n", encoding="utf-8")
+    with pytest.raises(rows.SourceRowsError, match="coverage-contract binding drift"):
+        _build(paths)
+    paths = _fixture(tmp_path / "receipt")
+    public = rows.read_json(paths["public"], "public")
+    public["input_bindings"]["sources_db_sha256"] = "0" * 64
+    public["receipt_sha256"] = heldout.receipt_body_sha256({key: value for key, value in public.items() if key != "receipt_sha256"})
+    _write(paths["public"], public)
+    with pytest.raises(rows.SourceRowsError, match="sources DB binding drift"):
+        _build(paths)
+    paths = _fixture(tmp_path / "permissions")
+    _build(paths)
+    os.chmod(paths["private"] / rows.ROWS_FILENAME, 0o644)
+    with pytest.raises(rows.SourceRowsError, match="permissions too open"):
+        _build(paths)
+
+
+def test_rejects_destructive_output_aliases_and_cli_symlink_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    paths = _fixture(tmp_path)
+    public_alias = {**paths, "receipt": paths["clearance"]}
+    with pytest.raises(rows.SourceRowsError, match="public receipt aliases an input"):
+        _build(public_alias)
+    private_alias = {**paths, "receipt": paths["private"] / "receipt.json"}
+    with pytest.raises(rows.SourceRowsError, match="inside private"):
+        _build(private_alias)
+    private_in_freeze = {**paths, "private": paths["universe"] / "private-output"}
+    with pytest.raises(rows.SourceRowsError, match="private source-row directory may not be inside an input directory"):
+        _build(private_in_freeze)
+    public_in_freeze = {**paths, "receipt": paths["universe"] / "public-receipt.json"}
+    with pytest.raises(rows.SourceRowsError, match="public receipt may not be inside an input directory"):
+        _build(public_in_freeze)
+    paths["private"].mkdir(parents=True, mode=0o700)
+    os.chmod(paths["private"], 0o700)
+    aliased_clearance = paths["private"] / rows.ROWS_FILENAME
+    aliased_clearance.write_bytes(paths["clearance"].read_bytes())
+    os.chmod(aliased_clearance, 0o600)
+    rows_alias = {**paths, "clearance": aliased_clearance}
+    with pytest.raises(rows.SourceRowsError, match="private source rows alias an input"):
+        _build(rows_alias)
+    link = tmp_path / "clearance-link.json"
+    os.symlink(paths["clearance"], link)
+    with pytest.raises(SystemExit) as exc:
+        rows.main([
+            "--clearance", str(link), "--source-universe", str(paths["universe"]), "--sources-db", str(paths["db"]),
+            "--partition-public-receipt", str(paths["public"]), "--evaluation", str(paths["evaluation"]),
+            "--coverage", str(paths["coverage"]), "--role", str(paths["role"]), "--near-duplicate-policy", str(paths["policy"]),
+            "--private-dir", str(paths["private"]), "--public-receipt", str(paths["receipt"]),
+        ])
+    assert exc.value.code == 2
+    assert "symlink is forbidden" in capsys.readouterr().err

--- a/tests/test_open_model_phase3_rule_author_source_rows.py
+++ b/tests/test_open_model_phase3_rule_author_source_rows.py
@@ -181,7 +181,7 @@ def test_rejects_stale_contract_or_partition_receipt_binding_and_permission_drif
         _build(paths)
     paths = _fixture(tmp_path / "permissions")
     _build(paths)
-    os.chmod(paths["private"] / rows.ROWS_FILENAME, 0o644)
+    os.chmod(paths["private"] / rows.ROWS_FILENAME, 0o640)
     with pytest.raises(rows.SourceRowsError, match="permissions too open"):
         _build(paths)
 

--- a/tests/test_open_model_phase3_rule_author_source_rows.py
+++ b/tests/test_open_model_phase3_rule_author_source_rows.py
@@ -181,8 +181,8 @@ def test_rejects_stale_contract_or_partition_receipt_binding_and_permission_drif
         _build(paths)
     paths = _fixture(tmp_path / "permissions")
     _build(paths)
-    os.chmod(paths["private"] / rows.ROWS_FILENAME, 0o640)
-    with pytest.raises(rows.SourceRowsError, match="permissions too open"):
+    os.chmod(paths["private"] / rows.ROWS_FILENAME, 0o400)
+    with pytest.raises(rows.SourceRowsError, match="permissions drift"):
         _build(paths)
 
 


### PR DESCRIPTION
## Summary
- add a heldout-steward-only adapter that materializes the exact private UA-GEC source rows named by `author_clearance_v1.json`
- preserve frozen source-record metadata and require set equality with the explicit cleared-unit allowlist; complement inference is forbidden
- bind the compiler/schema, source freeze and exact UA-GEC ledger, sources DB, evaluation/coverage/role/near-duplicate contracts, partition public receipt, and distinct steward/rule-author identities
- emit only a text-free aggregate public receipt while enforcing 0700 directories, 0600 private/receipt files, symlink rejection, and destructive-output alias protection

## Phase 3 scope
Part of #6375 under stream epic #6321. This is boundary infrastructure only. It does not open heldout content, run the private adapter, make Ukrainian linguistic decisions, or claim ENGINE_READY/SOURCE_COVERAGE_READY/LINGUISTICALLY_VALIDATED/CONSUMER_PROVEN. Actual execution remains restricted to `controller_phase3_heldout_steward_cursor_runtime_01`; the rule author remains `controller_phase3_rule_author_agy_runtime_01`.

## Verification
- `pytest tests/test_open_model_phase3_rule_author_packets.py tests/test_open_model_phase3_rule_author_source_rows.py tests/test_open_model_phase3_heldout_partition.py tests/test_open_model_phase3_recovery_contracts.py -q` — 116 passed
- Ruff passed
- `py_compile` passed
- JSON Schema parses and validates in focused tests
- `git diff --check` passed
- OPSEC audit passed
- agent trailer audit passed

## Security disposition
CodeQL correctly flagged the original 0644 text-free receipt mode and a world-readable permission-drift test fixture. Exact head `d3b565a4c1` tightens the receipt to 0600 and uses 0640 for the intentionally invalid fixture; all tests remain green. Fresh exact-head CI and review are required.

## Safety
No private heldout or cleared source-row body was opened, executed, copied, or committed by the root. No training, paid compute, Hugging Face mutation/upload, or outreach occurred.