### PR TITLE
fix(open-model-data): preserve unreported UA-GEC source language

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
@@ -52,7 +52,7 @@
         "annotator_id": {"type": "string", "minLength": 1},
         "partition": {"type": "string", "pattern": ".+/train$"},
         "is_native": {"type": "integer"},
-        "source_lang": {"type": "string", "minLength": 1}
+        "source_lang": {"type": "string"}
       }
     },
     "receipt": {

--- a/scripts/projects/open_model_data/phase3_heldout_partition.py
+++ b/scripts/projects/open_model_data/phase3_heldout_partition.py
@@ -321,7 +321,7 @@ def reconstruct_ua_gec_rows(
         require(isinstance(error_type, str) and error_type, "ua_gec error_type malformed")
         require(isinstance(annotator_id, str) and annotator_id, "ua_gec annotator_id malformed")
         require(isinstance(is_native, int), "ua_gec is_native malformed")
-        require(isinstance(source_lang, str) and source_lang, "ua_gec source_lang malformed")
+        require(isinstance(source_lang, str), "ua_gec source_lang malformed")
         source_record = freeze_mod._normal(
             {
                 "id": row_id,

--- a/scripts/projects/open_model_data/phase3_rule_author_packets.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_packets.py
@@ -412,9 +412,12 @@ def _item_from_row(row: Mapping[str, Any], clearance_sha: str, policy_sha: str) 
         isinstance(annotator, str)
         and annotator
         and isinstance(source_lang, str)
-        and source_lang
         and isinstance(is_native, int),
         "UA-GEC correction provenance is malformed",
+    )
+    require(
+        source_lang != "unknown",
+        "UA-GEC source_lang literal 'unknown' collides with packet sentinel",
     )
     frozen = {"family_id": family_id, "unit_id": unit_id, "unit_sha256": unit_sha}
     identity = {"frozen_unit": frozen, "source_sha256": supplied_sha, "start": start, "end": end}
@@ -444,7 +447,7 @@ def _item_from_row(row: Mapping[str, Any], clearance_sha: str, policy_sha: str) 
             "partition": partition,
             "annotator_identity_sha256": sha256_bytes(annotator.encode("utf-8")),
             "is_native": is_native,
-            "source_lang": source_lang,
+            "source_lang": source_lang or "unknown",
         },
         "candidate_signals": sorted(set(candidate_signals)),
         "clearance_sha256": clearance_sha,

--- a/tests/test_open_model_phase3_heldout_partition.py
+++ b/tests/test_open_model_phase3_heldout_partition.py
@@ -358,6 +358,45 @@ def test_document_identity_collapses_layers() -> None:
     assert left != heldout.document_identity_for_ua_gec("docB")
 
 
+def test_reconstruction_preserves_empty_source_lang_and_rejects_non_strings(tmp_path: Path) -> None:
+    def reconstruct(source_lang: object, index: int) -> dict[str, object]:
+        db_path = tmp_path / f"sources-{index}.db"
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                "CREATE TABLE ua_gec_errors (id INTEGER PRIMARY KEY, error TEXT, correct TEXT, error_type TEXT, "
+                "doc_id TEXT, annotator_id TEXT, partition TEXT, is_native INTEGER, source_lang TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO ua_gec_errors VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (1, "synthetic error", "synthetic correction", "G/Case", "doc", "annotator", "gec/train", 1, source_lang),
+            )
+        payload = {
+            "id": 1,
+            "error": "synthetic error",
+            "correct": "synthetic correction",
+            "error_type": "G/Case",
+            "doc_id": "doc",
+            "annotator_id": "annotator",
+            "partition": "gec/train",
+            "is_native": 1,
+            "source_lang": source_lang if isinstance(source_lang, str) else "",
+        }
+        return heldout.reconstruct_ua_gec_rows(
+            sources_db=db_path,
+            freeze_units=[_unit_for_row(1, ordinal=1, payload=payload)],
+        )[0]
+
+    empty = reconstruct("", 1)
+    assert empty["source_lang"] == ""
+    assert empty["source_record"]["source_lang"] == ""
+    assert empty["unit_sha256"] == freeze_mod._unit_hash(empty["source_record"])
+    assert reconstruct("fr-CA", 2)["source_record"]["source_lang"] == "fr-CA"
+
+    for index, invalid in enumerate((None, b"invalid"), start=3):
+        with pytest.raises(heldout.PartitionError, match="source_lang malformed"):
+            reconstruct(invalid, index)
+
+
 def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) -> None:
     root = _build_fixture_root(tmp_path)
     private = root / "batch_state/open-model-data/phase3-heldout"

--- a/tests/test_open_model_phase3_rule_author_packets.py
+++ b/tests/test_open_model_phase3_rule_author_packets.py
@@ -280,6 +280,49 @@ def test_document_identity_uses_hash_verified_normalized_record(tmp_path: Path) 
     assert len(identities) == 1
 
 
+def test_source_lang_empty_maps_to_packet_sentinel_without_rewriting_nonempty_value(tmp_path: Path) -> None:
+    empty = _source_record(
+        1,
+        error="synthetic source span one",
+        correct="synthetic correction one",
+        error_type="F",
+    )
+    empty["source_lang"] = ""
+    nonempty = _source_record(
+        2,
+        error="synthetic source span two",
+        correct="synthetic correction two",
+        error_type="Calque",
+    )
+    nonempty["source_lang"] = "fr-CA"
+    paths = _fixture(tmp_path, records=[empty, nonempty])
+
+    bundle = _build(paths)
+    metadata_by_text = {
+        item["source_text"]: item["metadata"]["source_lang"]
+        for packet in bundle["packets"]
+        for item in packet["items"]
+    }
+    assert metadata_by_text == {
+        "synthetic source span one": "unknown",
+        "synthetic source span two": "fr-CA",
+    }
+
+
+def test_raw_unknown_source_lang_fails_closed_to_prevent_packet_sentinel_collision(tmp_path: Path) -> None:
+    record = _source_record(
+        1,
+        error="synthetic source span one",
+        correct="synthetic correction one",
+        error_type="F",
+    )
+    record["source_lang"] = "unknown"
+    paths = _fixture(tmp_path, records=[record])
+
+    with pytest.raises(packets.PacketCompilerError, match="packet sentinel"):
+        _build(paths)
+
+
 def test_clearance_is_exact_not_a_complement_and_frozen_units_cannot_drift(tmp_path: Path) -> None:
     paths = _fixture(tmp_path)
     clearance = json.loads(paths["clearance"].read_text(encoding="utf-8"))

--- a/tests/test_open_model_phase3_rule_author_source_rows.py
+++ b/tests/test_open_model_phase3_rule_author_source_rows.py
@@ -23,7 +23,12 @@ def _write(path: Path, value: object) -> None:
     path.write_text(rows.canonical_json(value) + "\n", encoding="utf-8")
 
 
-def _fixture(tmp_path: Path, *, include_test: bool = False) -> dict[str, Path]:
+def _fixture(
+    tmp_path: Path,
+    *,
+    include_test: bool = False,
+    source_langs: tuple[str, str] = ("uk", "ru"),
+) -> dict[str, Path]:
     root = tmp_path / "synthetic"
     data = root / "data/projects/open_model_data"
     role = ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
@@ -38,8 +43,8 @@ def _fixture(tmp_path: Path, *, include_test: bool = False) -> dict[str, Path]:
     connection = sqlite3.connect(db)
     connection.execute("CREATE TABLE ua_gec_errors (id INTEGER PRIMARY KEY, error TEXT, correct TEXT, error_type TEXT, doc_id TEXT, annotator_id TEXT, partition TEXT, is_native INTEGER, source_lang TEXT)")
     records = [
-        (1, "synthetic train error one", "synthetic correction one", "G/Case", "train-doc", "ann-one", "gec/train", 1, "uk"),
-        (2, "synthetic train error two", "synthetic correction two", "F/Calque", "train-doc-two", "ann-two", "gec/train", 0, "ru"),
+        (1, "synthetic train error one", "synthetic correction one", "G/Case", "train-doc", "ann-one", "gec/train", 1, source_langs[0]),
+        (2, "synthetic train error two", "synthetic correction two", "F/Calque", "train-doc-two", "ann-two", "gec/train", 0, source_langs[1]),
     ]
     if include_test:
         records.append((3, "synthetic heldout error", "synthetic heldout correction", "G/Case", "test-doc", "ann-three", "gec/test", 1, "uk"))
@@ -112,6 +117,27 @@ def test_rows_are_deterministic_private_complete_and_packet_compiler_compatible(
     assert receipt["input_bindings"]["partition_public_receipt_file_sha256"] == rows.sha256_file(paths["public"])
     assert receipt["exclusions"]["all_rows_train"] is True
     assert receipt["exclusions"]["clearance_source_row_set_equal"] is True
+
+
+def test_empty_source_lang_is_schema_valid_and_preserves_frozen_hash(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path, source_langs=("", "fr-CA"))
+    _build(paths)
+    materialized = [
+        json.loads(line)
+        for line in (paths["private"] / rows.ROWS_FILENAME).read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert {item["source_record"]["source_lang"] for item in materialized} == {"", "fr-CA"}
+    assert all(
+        item["unit_sha256"] == freeze._unit_hash(freeze._normal(item["source_record"]))
+        for item in materialized
+    )
+    schema = rows.read_json(rows.SCHEMA_PATH, "adapter schema")
+    validator = Draft202012Validator(
+        {"$schema": schema["$schema"], "$defs": schema["$defs"], "$ref": "#/$defs/sourceRow"}
+    )
+    for item in materialized:
+        validator.validate(item)
 
 
 def test_rejects_stale_db_test_injection_and_unexpected_or_symlink_private_inputs(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes part of #6375 (intermediate engine recovery; does not close the issue).
Parent stream epic: #6321.

## Outcome

Unblocks exact frozen UA-GEC reconstruction for the 4,597 of 8,937 rows whose source-language field is an empty, unreported string.

- preserves raw `source_lang=""` byte-exactly in the hash-bound source record;
- continues to reject NULL/non-string values;
- maps empty to the explicit non-linguistic sentinel `unknown` only in rule-author packet metadata;
- preserves every non-empty value byte-exactly;
- rejects a raw literal `unknown` to avoid sentinel ambiguity;
- does not change partitioning, clearance membership, denominators, query limits, evaluation, or roles.

No Ukrainian language is inferred from text, error type, annotator, or model judgment.

## Fresh reviews before implementation

- Independent Claude Ukrainian/domain review: `APPROVE`, mandatory conditions implemented (`phase3-empty-source-lang-domain-review-v1`).
- Independent Grok scope/circularity review: `APPROVE`, no denominator, leakage, or heldout-design change (`phase3-empty-source-lang-scope-review-v1`).

Both reviewers verified the binding prompt and amendment hashes.

## Phase 3 status truth

- `ENGINE_READY`: still incomplete.
- `SOURCE_COVERAGE_READY`: unmet.
- `LINGUISTICALLY_VALIDATED`: unmet.
- `CONSUMER_PROVEN`: unmet.

This intermediate PR cannot complete Phase 3.

## Verification

- focused adapter/compiler suites — 44 passed
- source-universe/freeze suites — 35 passed
- Ruff — passed
- `py_compile` — passed
- Draft 2020-12 schema validation — passed
- `git diff --check` — passed
- agent trailer lint — passed
- OPSEC diff lint — passed

## Boundaries

No model training, model download, paid compute, Hugging Face mutation, upload, outreach, Phase 4 work, or heldout-body inspection.
