### PR TITLE
feat(hooks): audit tooling + Grok thin post-compact (measured)

### DIFF
--- a/agents_extensions/shared/hooks/context-monitor.sh
+++ b/agents_extensions/shared/hooks/context-monitor.sh
@@ -22,6 +22,16 @@ if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UK_PIPELINE" ] || [ -n "$GEM
   exit 0
 fi
 
+# Grok TUI: Claude PostToolUse context-monitor is high-frequency noise and was
+# never designed for Grok compaction (hook audit 2026-08-06). Skip unless
+# explicitly re-enabled.
+if [ -n "${GROK_AGENT:-}" ] || [ "${SESSION_HANDOFF_AGENT:-}" = "grok" ] \
+  || [ "${SESSION_HANDOFF_AGENT:-}" = "grok-build" ]; then
+  if [ "${GROK_CONTEXT_MONITOR:-}" != "1" ]; then
+    exit 0
+  fi
+fi
+
 command -v jq >/dev/null 2>&1 || exit 0
 
 INPUT=$(cat)

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -33,6 +33,24 @@ emit_context() {
   fi
 }
 
+# Grok (native TUI / build): skip the Claude curriculum in_progress scan entirely
+# (hook audit 2026-08-06). Epic-bound Grok still gets a short reminder; native
+# compaction remains authoritative. Do not run multi-second find/grep over curriculum/.
+if [ -n "${GROK_AGENT:-}" ] || [ "${SESSION_HANDOFF_AGENT:-}" = "grok" ] \
+  || [ "${SESSION_HANDOFF_AGENT:-}" = "grok-build" ]; then
+  _grok_ctx="KEY REMINDERS (Grok post-compact, thin path):
+  - Fleet driver: dispatch with ROUTING_CARD_V1; default bounded work = Fable/Sol brief → heap/practical.
+  - Heavy atlas compute on VPS (atlas-runner), not the Mac.
+  - Tool-backed claims only; breadth report before handoff.
+  - Epic=${SESSION_EPIC:-none}"
+  if [ -n "${SESSION_EPIC:-}" ]; then
+    _grok_ctx="${_grok_ctx}
+  - Continue from file handoff / fleet-comms for epic ${SESSION_EPIC}; do not re-scan curriculum state."
+  fi
+  emit_context "$_grok_ctx"
+  exit 0
+fi
+
 # Ordinary Codex tasks use the runtime's native remote compaction and need no
 # repository-authored context replay. A launcher-bound fleet driver is the
 # exception: hydrate only its exact stream and point at the durable shadow

--- a/docs/best-practices/hook-audit.md
+++ b/docs/best-practices/hook-audit.md
@@ -1,0 +1,103 @@
+# Harness hook audit (2026-08-06)
+
+**Owner:** fleet / harness  
+**Operator GO:** side project while atlas continues  
+**Status:** tooling + Grok/Claude split + measured optimizations landed this PR  
+
+## Failure mode
+
+Epic drivers (Grok TUI especially) appeared “slow” and machines ran hot. Investigation
+showed **hooks are not the main thermal source** (formal CF + desktop apps dominate CPU),
+but the **Claude project hook graph is fat** and **Grok inherits it by default** via
+compat scanning of `.claude/settings.json`.
+
+## Surfaces
+
+| Surface | Role | Cost class |
+| --- | --- | --- |
+| `agents_extensions/shared/hooks/*` | Shared scripts | Source of truth for policy |
+| `.claude/settings.json` (deploy copy) | Claude Code wiring | **Fat** PreToolUse Bash ×7 + PostToolUse ×4 |
+| `agents_extensions/codex/hooks.json` | Codex lifecycle | SessionStart + serialized pre-tool policy |
+| Grok native `~/.grok/hooks` | Optional thin Grok hooks | Empty by default |
+| Grok Claude-compat | Merges project Claude hooks when trusted | **On by default** — main footgun |
+
+## Keep / drop matrix
+
+| Hook / class | Keep for Claude | Keep for Grok | Notes |
+| --- | --- | --- | --- |
+| `guard-primary-checkout-write` | yes | yes (if any Grok hooks) | Safety |
+| `guard-secret-print` | yes | yes | Safety |
+| `guard-pr-merge` / `guard-admin-merge` | yes (Bash) | optional | gh merge path |
+| `guard-branch-switch-in-main` | yes | optional | |
+| `enforce-venv` / `heal-core-bare` | yes | optional | cheap |
+| `session-setup` | yes (Claude) | thin or skip if no epic | ~1s cold |
+| `post-compact` full scan | yes (Claude epic) | **skip** when Grok + no `SESSION_EPIC` | ~2s → ~0 |
+| `context-monitor` every tool | yes (Claude) | **skip** for Grok unless `GROK_CONTEXT_MONITOR=1` | high frequency |
+| `stamp-pytest` every PostToolUse | keep fire-and-forget | skip for Grok | |
+| Entire CLI hooks | no-op if missing | no-op | still spawn shell — OK |
+| Auto-audit FileChanged curriculum | Claude only | off | |
+
+## Grok profile (enforced recommendation)
+
+```toml
+# ~/.grok/config.toml  (apply with scripts/hooks/apply_grok_hook_profile.py --apply)
+[compat.claude]
+hooks = false
+```
+
+Then restart Grok. Project trust remains for MCP; Claude seats keep their own stack.
+
+Helper:
+
+```bash
+.venv/bin/python -m scripts.hooks.apply_grok_hook_profile          # dry-run
+.venv/bin/python -m scripts.hooks.apply_grok_hook_profile --apply   # write
+```
+
+## Instrumentation
+
+```bash
+export HOOK_TIMING=1
+export HOOK_TIMING_LOG=batch_state/hook-timing.jsonl   # optional
+# wrap any hook:
+./scripts/hooks/run_hook_timed.sh path/to/hook.sh
+# or:
+.venv/bin/python -m scripts.hooks.hook_timing wrap -- bash path/to/hook.sh
+```
+
+## Measure harness
+
+```bash
+.venv/bin/python -m scripts.hooks.measure_hook_stack --repeats 3 \
+  --out batch_state/hook-audit-measure.json
+```
+
+Reports median ms per hook and the **Claude Bash PreToolUse tax** (sum of the 7 guards).
+
+## Measured results (2026-08-06, this machine)
+
+### Stack inventory (`measure_hook_stack`, worktree + primary venv)
+
+| Hook | Median ms (after PR) |
+| --- | ---: |
+| session-setup.sh | ~560–1000 (varies with load) |
+| Claude Bash PreToolUse tax (7 guards sum) | **~162** |
+| codex_hook_entry pre-tool-use | ~84 |
+| Individual guards | ~19–37 each |
+
+### Grok-targeted optimizations (fair compare: `SESSION_EPIC=atlas`, primary `CLAUDE_PROJECT_DIR`)
+
+| Path | Before (ms) | After (ms) | Result |
+| --- | ---: | ---: | --- |
+| **post-compact** (Grok + epic) | **1213** | **6** | **~199× faster** (~1.2 s saved per compact) |
+| **context-monitor** (Grok) | **7.4** | **2.8** | early skip |
+
+These are the high-frequency / high-spike fixes. Disabling Claude-compat hooks for Grok
+(`apply_grok_hook_profile --apply`) removes the **~162 ms/Bash** PreTool tax entirely for
+the Grok seat (Claude seats unchanged).
+
+## Related
+
+- Runbook: `docs/runbooks/grok-hook-profile.md`
+- Guardrail lifecycle: always-load rules unchanged; this is harness-local + docs + opt-in timing
+- Atlas remains the primary epic objective; this is a side PR

--- a/docs/runbooks/grok-hook-profile.md
+++ b/docs/runbooks/grok-hook-profile.md
@@ -1,0 +1,53 @@
+# Grok hook profile runbook
+
+## Why
+
+Grok Build discovers hooks from multiple places. By default it also scans **Claude Code**
+project settings (`.claude/settings.json`). This repo’s Claude settings attach a **large**
+PreToolUse/PostToolUse graph optimized for Claude epic driving — not for Grok TUI latency.
+
+## Recommended profile (operator 2026-08-06)
+
+1. **Disable Claude-compat hooks for Grok** (does not affect Claude CLI seats).
+2. Keep safety where needed via thin native Grok hooks later if required.
+3. Restart Grok after config change.
+
+### Apply
+
+```bash
+# from repo root
+.venv/bin/python -m scripts.hooks.apply_grok_hook_profile           # dry-run
+.venv/bin/python -m scripts.hooks.apply_grok_hook_profile --apply    # write ~/.grok/config.toml
+```
+
+Manual equivalent — append to `~/.grok/config.toml`:
+
+```toml
+[compat.claude]
+hooks = false
+```
+
+### Verify
+
+- `/hooks` (or Ctrl+L → Hooks) should no longer list the full Claude PreToolUse stack.
+- SessionStart should not run the full Claude `session-setup` path unless you re-enable compat.
+
+## Shared script optimizations (all harnesses)
+
+These are **safe for Claude** and help Grok if compat hooks remain on:
+
+| Change | Behavior |
+| --- | --- |
+| `post-compact.sh` | Exits immediately when `GROK_AGENT` / `SESSION_HANDOFF_AGENT=grok` and no `SESSION_EPIC` |
+| `context-monitor.sh` | Skips for Grok unless `GROK_CONTEXT_MONITOR=1` |
+
+## Measure
+
+```bash
+.venv/bin/python -m scripts.hooks.measure_hook_stack --repeats 3
+# compare post-compact vs post-compact+GROK_SESSION medians in the JSON report
+```
+
+## Rollback
+
+Remove or set `hooks = true` under `[compat.claude]`, restart Grok.

--- a/scripts/hooks/__init__.py
+++ b/scripts/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Hook audit, timing, and harness profile helpers."""

--- a/scripts/hooks/apply_grok_hook_profile.py
+++ b/scripts/hooks/apply_grok_hook_profile.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Idempotently set Grok harness hook profile (operator hook audit 2026-08-06).
+
+Default action: disable Claude-compat hooks so Grok does not inherit the fat
+`.claude/settings.json` PreToolUse stack. Writes `~/.grok/config.toml` unless
+`--config` is passed. Dry-run by default; pass `--apply` to write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CONFIG = Path.home() / ".grok" / "config.toml"
+
+SNIPPET = """
+# Hook audit 2026-08-06 — Grok must not inherit Claude's fat project hooks.
+# Thin Grok guards (if any) live under ~/.grok/hooks/ or <project>/.grok/hooks/.
+# See docs/best-practices/hook-audit.md and docs/runbooks/grok-hook-profile.md
+[compat.claude]
+hooks = false
+""".lstrip()
+
+
+def ensure_compat_claude_hooks_false(text: str) -> tuple[str, bool]:
+    """Return (new_text, changed)."""
+    # Already correct
+    if re.search(
+        r"(?ms)^\[compat\.claude\][^\[]*^hooks\s*=\s*false\s*$",
+        text,
+    ):
+        return text, False
+    # Section exists with hooks = true → flip
+    if re.search(r"(?ms)^\[compat\.claude\]", text):
+        new = re.sub(
+            r"(?ms)(^\[compat\.claude\][^\[]*?^hooks\s*=\s*)\w+",
+            r"\1false",
+            text,
+            count=1,
+        )
+        if new != text:
+            return new, True
+        # section without hooks key
+        new = re.sub(
+            r"(?ms)(^\[compat\.claude\]\s*\n)",
+            r"\1hooks = false\n",
+            text,
+            count=1,
+        )
+        return new, new != text
+    # Append
+    body = text.rstrip() + ("\n\n" if text.strip() else "") + SNIPPET
+    if not body.endswith("\n"):
+        body += "\n"
+    return body, True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes (default is dry-run)",
+    )
+    args = parser.parse_args(argv)
+    path: Path = args.config
+    if not path.exists():
+        text = ""
+    else:
+        text = path.read_text(encoding="utf-8")
+    new_text, changed = ensure_compat_claude_hooks_false(text)
+    if not changed:
+        print(f"ok: {path} already has [compat.claude] hooks = false")
+        return 0
+    if not args.apply:
+        print(f"dry-run: would update {path}")
+        print("--- proposed tail ---")
+        print(SNIPPET if not text.strip() else "(patch existing [compat.claude] or append block)")
+        print("re-run with --apply to write")
+        return 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_text, encoding="utf-8")
+    print(f"applied: {path}  ([compat.claude] hooks = false)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/apply_grok_hook_profile.py
+++ b/scripts/hooks/apply_grok_hook_profile.py
@@ -25,24 +25,29 @@ hooks = false
 
 
 def ensure_compat_claude_hooks_false(text: str) -> tuple[str, bool]:
-    """Return (new_text, changed)."""
-    # Already correct
+    """Return (new_text, changed).
+
+    Idempotent even when ``hooks = false`` has trailing whitespace or an inline
+    TOML comment. Never inserts a second ``hooks`` key into an existing section.
+    """
+    # Already correct: value is false (optional spaces / inline comment after).
     if re.search(
-        r"(?ms)^\[compat\.claude\][^\[]*^hooks\s*=\s*false\s*$",
+        r"(?ms)^\[compat\.claude\][^\[]*^hooks\s*=\s*false\s*(?:#.*)?$",
         text,
     ):
         return text, False
-    # Section exists with hooks = true → flip
+    # Section exists
     if re.search(r"(?ms)^\[compat\.claude\]", text):
-        new = re.sub(
-            r"(?ms)(^\[compat\.claude\][^\[]*?^hooks\s*=\s*)\w+",
-            r"\1false",
-            text,
-            count=1,
-        )
-        if new != text:
-            return new, True
-        # section without hooks key
+        # Existing hooks key (any value) → set value token to false, keep rest of line.
+        if re.search(r"(?ms)^\[compat\.claude\][^\[]*^hooks\s*=", text):
+            new = re.sub(
+                r"(?ms)(^\[compat\.claude\][^\[]*?^hooks\s*=\s*)\S+",
+                r"\1false",
+                text,
+                count=1,
+            )
+            return new, new != text
+        # Section without hooks key
         new = re.sub(
             r"(?ms)(^\[compat\.claude\]\s*\n)",
             r"\1hooks = false\n",

--- a/scripts/hooks/apply_grok_hook_profile.py
+++ b/scripts/hooks/apply_grok_hook_profile.py
@@ -67,10 +67,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     path: Path = args.config
-    if not path.exists():
-        text = ""
-    else:
-        text = path.read_text(encoding="utf-8")
+    text = "" if not path.exists() else path.read_text(encoding="utf-8")
     new_text, changed = ensure_compat_claude_hooks_false(text)
     if not changed:
         print(f"ok: {path} already has [compat.claude] hooks = false")

--- a/scripts/hooks/hook_timing.py
+++ b/scripts/hooks/hook_timing.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Append one JSONL timing row for a harness hook invocation.
+
+Enable with HOOK_TIMING=1 (or HOOK_TIMING=always). Default log path:
+  batch_state/hook-timing.jsonl  (gitignored runtime)
+
+Does not modify tool stdin/stdout contracts beyond passing them through when
+used as a wrapper (see run_hook_timed.sh).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOG = ROOT / "batch_state" / "hook-timing.jsonl"
+
+
+def timing_enabled() -> bool:
+    val = (os.environ.get("HOOK_TIMING") or "").strip().lower()
+    return val in {"1", "true", "yes", "always", "on", "force"}
+
+
+def log_path() -> Path:
+    raw = (os.environ.get("HOOK_TIMING_LOG") or "").strip()
+    return Path(raw) if raw else DEFAULT_LOG
+
+
+def append_row(row: dict[str, Any], path: Path | None = None, *, force: bool = False) -> None:
+    if not force and not timing_enabled():
+        return
+    dest = path or log_path()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        **row,
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+    }
+    with dest.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def run_wrapped(argv: list[str]) -> int:
+    """Run argv as the real hook; log wall ms. stdin is forwarded."""
+    if not argv:
+        print("run_wrapped: missing command", file=sys.stderr)
+        return 2
+    event = os.environ.get("HOOK_EVENT_NAME") or os.environ.get("hook_event_name") or ""
+    matcher = os.environ.get("HOOK_MATCHER") or ""
+    tool = os.environ.get("HOOK_TOOL_NAME") or ""
+    stdin = sys.stdin.buffer.read()
+    t0 = time.perf_counter()
+    proc = subprocess.run(argv, input=stdin, capture_output=True)
+    ms = (time.perf_counter() - t0) * 1000.0
+    # preserve hook contract: stdout/stderr pass-through
+    if proc.stdout:
+        sys.stdout.buffer.write(proc.stdout)
+    if proc.stderr:
+        sys.stderr.buffer.write(proc.stderr)
+    append_row(
+        {
+            "event": event or "unknown",
+            "matcher": matcher or None,
+            "tool_name": tool or None,
+            "command": argv[0],
+            "argv_tail": argv[1:6],
+            "ms": round(ms, 2),
+            "rc": proc.returncode,
+            "stdout_bytes": len(proc.stdout or b""),
+            "stderr_bytes": len(proc.stderr or b""),
+            "harness": os.environ.get("SESSION_HANDOFF_AGENT")
+            or os.environ.get("GROK_AGENT")
+            or os.environ.get("CLAUDE_CODE")
+            or "unknown",
+        }
+    )
+    return int(proc.returncode)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    log_p = sub.add_parser("log", help="Append one timing row (no subprocess)")
+    log_p.add_argument("--event", required=True)
+    log_p.add_argument("--ms", type=float, required=True)
+    log_p.add_argument("--rc", type=int, default=0)
+    log_p.add_argument("--matcher", default="")
+    log_p.add_argument("--command", default="")
+    log_p.add_argument("--tool-name", default="")
+
+    wrap_p = sub.add_parser("wrap", help="Run command and log timing")
+    wrap_p.add_argument("command", nargs=argparse.REMAINDER, help="Command after --")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "log":
+        append_row(
+            {
+                "event": args.event,
+                "matcher": args.matcher or None,
+                "tool_name": args.tool_name or None,
+                "command": args.command or None,
+                "ms": args.ms,
+                "rc": args.rc,
+            },
+            force=True,
+        )
+        return 0
+    if args.cmd == "wrap":
+        cmd = list(args.command)
+        if cmd and cmd[0] == "--":
+            cmd = cmd[1:]
+        os.environ.setdefault("HOOK_TIMING", "1")
+        return run_wrapped(cmd)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/hook_timing.py
+++ b/scripts/hooks/hook_timing.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +41,7 @@ def append_row(row: dict[str, Any], path: Path | None = None, *, force: bool = F
     dest.parent.mkdir(parents=True, exist_ok=True)
     row = {
         **row,
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
     }
     with dest.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
@@ -52,7 +52,7 @@ def run_wrapped(argv: list[str]) -> int:
     if not argv:
         print("run_wrapped: missing command", file=sys.stderr)
         return 2
-    event = os.environ.get("HOOK_EVENT_NAME") or os.environ.get("hook_event_name") or ""
+    event = os.environ.get("HOOK_EVENT_NAME") or ""
     matcher = os.environ.get("HOOK_MATCHER") or ""
     tool = os.environ.get("HOOK_TOOL_NAME") or ""
     stdin = sys.stdin.buffer.read()

--- a/scripts/hooks/measure_hook_stack.py
+++ b/scripts/hooks/measure_hook_stack.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Measure shared harness hook wall times and emit a JSON report.
+
+Used for the hook audit (operator 2026-08-06). Safe: empty/`{}` payloads only;
+hooks are invoked with CLAUDE_PROJECT_DIR set; no network required for local guards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _python_bin() -> str:
+    """Prefer this checkout's venv; walk parents for layout-A worktrees."""
+    for parent in [ROOT, *ROOT.parents]:
+        cand = parent / ".venv" / "bin" / "python"
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return str(cand)
+    return sys.executable
+
+
+PYTHON = _python_bin()
+
+# (name, argv, stdin_bytes|None, env_extra)
+STACK: list[tuple[str, list[str], bytes | None, dict[str, str]]] = [
+    (
+        "session-setup.sh",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/session-setup.sh")],
+        None,
+        {},
+    ),
+    (
+        "post-compact.sh",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/post-compact.sh")],
+        b"{}",
+        {},
+    ),
+    (
+        "post-compact.sh+GROK_SESSION",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/post-compact.sh")],
+        b"{}",
+        {"SESSION_HANDOFF_AGENT": "grok", "GROK_AGENT": "1"},
+    ),
+    (
+        "enforce-venv.sh",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/enforce-venv.sh")],
+        b"{}",
+        {},
+    ),
+    (
+        "heal-core-bare.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/heal-core-bare.py")],
+        None,
+        {},
+    ),
+    (
+        "guard-primary-checkout-write.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/guard-primary-checkout-write.py")],
+        b"{}",
+        {},
+    ),
+    (
+        "guard-pr-merge.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/guard-pr-merge.py")],
+        b"{}",
+        {},
+    ),
+    (
+        "guard-secret-print.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/guard-secret-print.py")],
+        b"{}",
+        {},
+    ),
+    (
+        "guard-branch-switch-in-main.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/guard-branch-switch-in-main.py")],
+        b"{}",
+        {},
+    ),
+    (
+        "guard-admin-merge.py",
+        [PYTHON, str(ROOT / "agents_extensions/shared/hooks/guard-admin-merge.py")],
+        b"{}",
+        {},
+    ),
+    (
+        "context-monitor.sh",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/context-monitor.sh")],
+        b'{"session_id":"","transcript_path":""}',
+        {},
+    ),
+    (
+        "context-monitor.sh+GROK_AGENT",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/context-monitor.sh")],
+        b'{"session_id":"x","transcript_path":"/nonexistent"}',
+        {"GROK_AGENT": "1", "SESSION_HANDOFF_AGENT": "grok"},
+    ),
+    (
+        "tool-timing.sh",
+        ["bash", str(ROOT / "agents_extensions/shared/hooks/tool-timing.sh")],
+        b'{"tool_name":"Bash","duration_ms":1,"hook_event_name":"PostToolUse"}',
+        {},
+    ),
+    (
+        "codex_hook_entry pre-tool-use",
+        ["bash", str(ROOT / "scripts/agent_runtime/codex_hook_entry.sh"), "pre-tool-use"],
+        b"{}",
+        {},
+    ),
+]
+
+
+def _time_one(
+    name: str,
+    argv: list[str],
+    stdin: bytes | None,
+    env_extra: dict[str, str],
+    *,
+    repeats: int,
+) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(ROOT)
+    env.update(env_extra)
+    samples: list[float] = []
+    last_rc = 0
+    for _ in range(max(1, repeats)):
+        t0 = time.perf_counter()
+        proc = subprocess.run(argv, input=stdin, capture_output=True, env=env, cwd=ROOT)
+        samples.append((time.perf_counter() - t0) * 1000.0)
+        last_rc = int(proc.returncode)
+    return {
+        "name": name,
+        "ms_median": round(statistics.median(samples), 2),
+        "ms_mean": round(statistics.fmean(samples), 2),
+        "ms_min": round(min(samples), 2),
+        "ms_max": round(max(samples), 2),
+        "samples": [round(s, 2) for s in samples],
+        "rc": last_rc,
+        "argv0": argv[0],
+    }
+
+
+def estimate_bash_pretool_tax(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Sum of typical PreToolUse Bash guards (Claude settings stack)."""
+    names = {
+        "enforce-venv.sh",
+        "heal-core-bare.py",
+        "guard-branch-switch-in-main.py",
+        "guard-admin-merge.py",
+        "guard-pr-merge.py",
+        "guard-secret-print.py",
+        "guard-primary-checkout-write.py",
+    }
+    by_name = {r["name"]: r for r in rows}
+    parts = []
+    total = 0.0
+    for n in sorted(names):
+        if n in by_name:
+            parts.append({"name": n, "ms_median": by_name[n]["ms_median"]})
+            total += float(by_name[n]["ms_median"])
+    return {"components": parts, "ms_median_sum": round(total, 2)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repeats", type=int, default=3, help="Samples per hook (default 3)")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=ROOT / "batch_state" / "hook-audit-measure.json",
+        help="Write JSON report here",
+    )
+    parser.add_argument("--json-stdout", action="store_true")
+    args = parser.parse_args(argv)
+
+    rows = [
+        _time_one(name, argv, stdin, env_extra, repeats=args.repeats)
+        for name, argv, stdin, env_extra in STACK
+    ]
+    bash_tax = estimate_bash_pretool_tax(rows)
+    report = {
+        "schema": "hook-stack-measure.v1",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": str(ROOT),
+        "repeats": args.repeats,
+        "hooks": rows,
+        "estimates": {
+            "claude_bash_pretool_median_sum_ms": bash_tax["ms_median_sum"],
+            "claude_bash_pretool_components": bash_tax["components"],
+            "session_start_median_ms": next(
+                (r["ms_median"] for r in rows if r["name"] == "session-setup.sh"), None
+            ),
+            "post_compact_median_ms": next(
+                (r["ms_median"] for r in rows if r["name"] == "post-compact.sh"), None
+            ),
+            "post_compact_grok_median_ms": next(
+                (r["ms_median"] for r in rows if r["name"] == "post-compact.sh+GROK_SESSION"),
+                None,
+            ),
+        },
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    if args.json_stdout:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(f"wrote {args.out}")
+        print(
+            f"session-setup median={report['estimates']['session_start_median_ms']} ms  "
+            f"post-compact={report['estimates']['post_compact_median_ms']} ms  "
+            f"post-compact+grok={report['estimates']['post_compact_grok_median_ms']} ms  "
+            f"bash_pretool_sum={report['estimates']['claude_bash_pretool_median_sum_ms']} ms"
+        )
+        for r in sorted(rows, key=lambda x: -x["ms_median"])[:8]:
+            print(f"  {r['ms_median']:8.1f} ms  {r['name']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/measure_hook_stack.py
+++ b/scripts/hooks/measure_hook_stack.py
@@ -14,7 +14,7 @@ import statistics
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -193,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
     bash_tax = estimate_bash_pretool_tax(rows)
     report = {
         "schema": "hook-stack-measure.v1",
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "repo": str(ROOT),
         "repeats": args.repeats,
         "hooks": rows,

--- a/scripts/hooks/run_hook_timed.sh
+++ b/scripts/hooks/run_hook_timed.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Opt-in wrapper: HOOK_TIMING=1 logs wall-ms to batch_state/hook-timing.jsonl
+# while preserving the underlying hook's stdin/stdout/stderr/rc.
+#
+# Usage (Claude settings command field):
+#   HOOK_EVENT_NAME=PreToolUse HOOK_MATCHER=Bash \
+#     $CLAUDE_PROJECT_DIR/scripts/hooks/run_hook_timed.sh \
+#     $CLAUDE_PROJECT_DIR/.claude/hooks/enforce-venv.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHON="${ROOT}/.venv/bin/python"
+if [ ! -x "$PYTHON" ]; then
+  exec "$@"
+fi
+if [ "${HOOK_TIMING:-}" = "1" ] || [ "${HOOK_TIMING:-}" = "true" ] || [ "${HOOK_TIMING:-}" = "always" ]; then
+  exec "$PYTHON" -m scripts.hooks.hook_timing wrap -- "$@"
+fi
+exec "$@"

--- a/scripts/hooks/run_hook_timed.sh
+++ b/scripts/hooks/run_hook_timed.sh
@@ -13,6 +13,8 @@ if [ ! -x "$PYTHON" ]; then
   exec "$@"
 fi
 if [ "${HOOK_TIMING:-}" = "1" ] || [ "${HOOK_TIMING:-}" = "true" ] || [ "${HOOK_TIMING:-}" = "always" ]; then
+  # -m resolution uses cwd, not the interpreter path — pin to repo root.
+  cd "$ROOT" || exit 1
   exec "$PYTHON" -m scripts.hooks.hook_timing wrap -- "$@"
 fi
 exec "$@"

--- a/tests/test_hook_timing_and_profile.py
+++ b/tests/test_hook_timing_and_profile.py
@@ -1,0 +1,58 @@
+"""Tests for hook timing logger and Grok hook profile applicator."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from scripts.hooks.apply_grok_hook_profile import ensure_compat_claude_hooks_false
+from scripts.hooks.hook_timing import append_row, main as timing_main
+
+
+def test_append_row_force(tmp_path: Path, monkeypatch) -> None:
+    log = tmp_path / "t.jsonl"
+    monkeypatch.delenv("HOOK_TIMING", raising=False)
+    append_row({"event": "PreToolUse", "ms": 12.5, "rc": 0}, path=log, force=True)
+    lines = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["event"] == "PreToolUse"
+    assert row["ms"] == 12.5
+    assert "ts" in row
+
+
+def test_timing_log_cli(tmp_path: Path, monkeypatch) -> None:
+    log = tmp_path / "cli.jsonl"
+    monkeypatch.setenv("HOOK_TIMING_LOG", str(log))
+    assert (
+        timing_main(
+            ["log", "--event", "SessionStart", "--ms", "100.5", "--rc", "0", "--command", "x"]
+        )
+        == 0
+    )
+    row = json.loads(log.read_text(encoding="utf-8").strip())
+    assert row["event"] == "SessionStart"
+    assert row["ms"] == 100.5
+
+
+def test_ensure_compat_appends() -> None:
+    text, changed = ensure_compat_claude_hooks_false("")
+    assert changed
+    assert "[compat.claude]" in text
+    assert "hooks = false" in text
+
+
+def test_ensure_compat_idempotent() -> None:
+    base = "[compat.claude]\nhooks = false\n"
+    text, changed = ensure_compat_claude_hooks_false(base)
+    assert changed is False
+    assert text == base
+
+
+def test_ensure_compat_flips_true() -> None:
+    base = "[models]\ndefault = \"grok-4.5\"\n\n[compat.claude]\nhooks = true\n"
+    text, changed = ensure_compat_claude_hooks_false(base)
+    assert changed
+    assert "hooks = false" in text
+    assert "hooks = true" not in text

--- a/tests/test_hook_timing_and_profile.py
+++ b/tests/test_hook_timing_and_profile.py
@@ -50,9 +50,28 @@ def test_ensure_compat_idempotent() -> None:
     assert text == base
 
 
+def test_ensure_compat_idempotent_with_inline_comment() -> None:
+    """Trailing inline comments must not trigger a second hooks key (CF F1)."""
+    base = "[compat.claude]\nhooks = false  # operator note\n"
+    text, changed = ensure_compat_claude_hooks_false(base)
+    assert changed is False
+    assert text == base
+    assert text.count("hooks") == 1
+
+
 def test_ensure_compat_flips_true() -> None:
     base = "[models]\ndefault = \"grok-4.5\"\n\n[compat.claude]\nhooks = true\n"
     text, changed = ensure_compat_claude_hooks_false(base)
     assert changed
     assert "hooks = false" in text
     assert "hooks = true" not in text
+
+
+def test_ensure_compat_flips_true_keeps_inline_comment() -> None:
+    base = "[compat.claude]\nhooks = true  # was on\n"
+    text, changed = ensure_compat_claude_hooks_false(base)
+    assert changed
+    assert "hooks = false" in text
+    assert "hooks = true" not in text
+    assert text.count("hooks") == 1
+    assert "# was on" in text

--- a/tests/test_hook_timing_and_profile.py
+++ b/tests/test_hook_timing_and_profile.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 from scripts.hooks.apply_grok_hook_profile import ensure_compat_claude_hooks_false
-from scripts.hooks.hook_timing import append_row, main as timing_main
+from scripts.hooks.hook_timing import append_row
+from scripts.hooks.hook_timing import main as timing_main
 
 
 def test_append_row_force(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Hook audit side project (atlas remains primary). Implements the full recommendation set: inventory/docs, opt-in timing, measure harness, Grok/Claude hook split profile, and two high-impact shared-script optimizations with **measured** before/after.

## Changes
| Area | What |
| --- | --- |
| Docs | `docs/best-practices/hook-audit.md`, `docs/runbooks/grok-hook-profile.md` |
| Timing | `scripts.hooks.hook_timing` + `run_hook_timed.sh` (`HOOK_TIMING=1`) |
| Measure | `python -m scripts.hooks.measure_hook_stack` |
| Grok profile | `python -m scripts.hooks.apply_grok_hook_profile [--apply]` → `[compat.claude] hooks=false` |
| Optimizations | `post-compact.sh` Grok thin path; `context-monitor.sh` Grok skip |

## Measurements (this machine, fair env `SESSION_EPIC=atlas` + Grok)

| Metric | Before | After |
| --- | ---: | ---: |
| post-compact (Grok) | **1213 ms** | **6 ms** (~199×) |
| context-monitor (Grok) | 7.4 ms | 2.8 ms |
| Claude Bash PreTool sum (7 guards) | — | **~162 ms** (still paid if Claude-compat hooks left on) |

## Operator action after merge
```bash
.venv/bin/python -m scripts.hooks.apply_grok_hook_profile --apply
# restart Grok TUI
```

## Test plan
- [x] `pytest tests/test_hook_timing_and_profile.py`
- [x] measure_hook_stack + before/after post-compact
- [ ] CI
- [ ] formal CF