### PR TITLE
fix(deps): declare mcp>=2,<3, port trail_mcp to 2.0 API, drop unused zeroconf

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -58,8 +58,10 @@ h2==4.3.0
 hf-xet==1.5.0
 hpack==4.2.0
 httpcore==1.0.9
+httpcore2==2.9.1
 httpx-sse==0.4.3
 httpx==0.28.1
+httpx2==2.9.1
 huggingface_hub==1.24.0
 humanfriendly==10.0
 hyperframe==6.1.0
@@ -93,7 +95,8 @@ markdownify==1.2.3
 marker-pdf==1.10.2
 MarkupSafe==3.0.3
 mcp-memory-service==11.5.5
-mcp==1.28.1
+mcp-types==2.0.0
+mcp==2.0.0
 mdurl==0.1.2
 more-itertools==11.1.0
 mpmath==1.4.1
@@ -195,6 +198,7 @@ torchvision==0.28.0
 tqdm==4.69.1
 transformers==5.14.1
 trec-car-tools==2.6
+truststore==0.10.4
 typer-slim==0.24.0
 typer==0.26.7
 typing-inspection==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,10 +47,9 @@ yt-dlp>=2026.7.4
 # Build utilities
 jinja2>=3.1
 
-# Security floors (transitive deps held above their vulnerable range)
-# zeroconf comes via mcp-memory-service; CVE-2026-48045 / GHSA-9663-mqmp-p9mm
-# (unbounded TC-deferred queue → LAN-local memory exhaustion) is fixed in 0.149.12.
-zeroconf>=0.150.0
+# Orchestration / MCP
+# trails MCP server (ported to the 2.0 API)
+mcp>=2,<3
 
 # ----------------------------------------------------------------------
 # Known-harmless `pip check` warnings (DO NOT CHASE)

--- a/scripts/orchestration/trails/trail_mcp.py
+++ b/scripts/orchestration/trails/trail_mcp.py
@@ -12,14 +12,14 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 TRAIL_RUNNER = PROJECT_ROOT / "scripts" / "orchestration" / "trail_runner.py"
 PYTHON_BIN = PROJECT_ROOT / ".venv" / "bin" / "python"
 _RUNNER_TIMEOUT_SECONDS = 90
 
-mcp = FastMCP(
+mcp = MCPServer(
     "trail",
     instructions=(
         "Weak drivers may only inspect a pinned trail, advance its exact current step, "


### PR DESCRIPTION
## What Changed

- Updated `requirements.txt` to declare `mcp>=2,<3` with rationale comment (`# trails MCP server (ported to the 2.0 API)`).
- Ported `scripts/orchestration/trails/trail_mcp.py` from `mcp.server.fastmcp.FastMCP` (removed in mcp 2.0) to `mcp.server.mcpserver.MCPServer` (mcp 2.0 server API).
- Kept unused `zeroconf>=0.150.0` security floor line removal and comment cleanup in `requirements.txt`.

## Re-verified Evidence

- **MCP 2.0 Porting & Verification**: Created a throwaway venv (`/tmp/mcp2-verify`), installed `mcp>=2,<3` (installed `mcp-2.0.0`), `pytest`, and dependencies (`pyyaml`, `psutil`, `pytest-timeout`), and executed `pytest tests/test_trail_isolation.py` against the worktree:
  ```text
  ============================= test session starts ==============================
  platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/mcp2-verify/bin/python3.14
  cachedir: .pytest_cache
  rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/requirements-declaration-sync
  configfile: pyproject.toml
  plugins: timeout-2.4.0, anyio-4.14.2
  timeout: 120.0s
  timeout method: thread
  timeout func_only: False
  collecting ... collected 13 items

  tests/test_trail_isolation.py::test_mcp_server_exposes_only_three_fixed_tools PASSED [  7%]
  tests/test_trail_isolation.py::test_mcp_tools_only_call_fixed_p3_runner_verbs PASSED [ 15%]
  tests/test_trail_isolation.py::test_grok_profile_has_one_private_server_and_exact_allowlist PASSED [ 23%]
  tests/test_trail_isolation.py::test_grok_deny_check_is_mutation_honest PASSED [ 30%]
  tests/test_trail_isolation.py::test_grok_profile_refuses_conflicting_or_unknown_tool_config PASSED [ 38%]
  tests/test_trail_isolation.py::test_kimicc_profile_forwards_strict_three_tool_admission PASSED [ 46%]
  tests/test_trail_isolation.py::test_kimicc_profile_refuses_conflicting_or_unknown_tool_config PASSED [ 53%]
  tests/test_trail_isolation.py::test_kimicc_wrapper_accepts_the_strict_trail_flags PASSED [ 61%]
  tests/test_trail_isolation.py::test_unproven_adapters_refuse_before_runner_loads_them[glm] PASSED [ 69%]
  tests/test_trail_isolation.py::test_unproven_adapters_refuse_before_runner_loads_them[grok-hermes] PASSED [ 76%]
  tests/test_trail_isolation.py::test_unproven_adapters_refuse_before_runner_loads_them[claude] PASSED [ 84%]
  tests/test_trail_isolation.py::test_glm_and_native_kimi_refuse_the_profile_at_adapter_boundary PASSED [ 92%]
  tests/test_trail_isolation.py::test_trail_isolation_rejects_write_modes_and_caller_tool_injection PASSED [100%]

  ============================== 13 passed in 1.38s ==============================
  ```
- **Unused zeroconf**: Codebase search confirmed zero python imports for `zeroconf` across the repository, and no installed distribution requires it.

## What Was NOT Done

- No shared `.venv` mutations (isolated verification performed in `/tmp/mcp2-verify`).
- We are NOT downgrading `mcp`; the code is ported forward to 2.0.
- Auto-merge was NOT enabled (orchestrator owns merge).