### PR TITLE
fix(review): evidence off-by-one normalization + seat eligibility listing + family vocabulary errors (#6415)

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -336,7 +336,9 @@ array. Use exactly `["none"]` when no external source applies; otherwise use
 non-empty source strings and never mix `"none"` with another value. Put claim
 type `"present"` or `"missing"` only inside the
 `location` object alongside `path`, `start_line`, and `end_line`; never add
-`claim_type` at the finding root. Do not invent enum aliases such as `"pass"`.
+`claim_type` at the finding root. `end_line` is inclusive and must equal
+`start_line + (number of lines in verbatim) - 1`; a one-line verbatim on line 7
+must have `"start_line": 7, "end_line": 7`. Do not invent enum aliases such as `"pass"`.
 """
 
 
@@ -639,8 +641,73 @@ def _routing_attempt_seed(authority_job: Any) -> int:
     return max(0, value) if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
+def _cmd_list_eligible(args: argparse.Namespace) -> int:
+    """Print every seat's eligibility for the given author identity.
+
+    Runs the same resolver used by the formal review scheduler, but performs no
+    provisioning, authority, or routing side effects.
+    """
+    from scripts.review.reviewer_resolver import ResolverInputs, resolve_reviewer
+
+    author_model = str(getattr(args, "author_model", None) or "").strip()
+    author_family = str(getattr(args, "author_family", None) or "").strip()
+    if not author_model or not author_family:
+        print(
+            "review-pr: concrete_author_identity_required: pass --author-model and --author-family",
+            file=sys.stderr,
+        )
+        return 2
+
+    routing_snapshot = None
+    routing_snapshot_file = getattr(args, "routing_snapshot_file", None)
+    if routing_snapshot_file:
+        routing_snapshot = json.loads(Path(routing_snapshot_file).read_text(encoding="utf-8"))
+
+    profile = str(getattr(args, "review_profile", None) or "code").strip().lower()
+    risk = str(getattr(args, "risk", None) or "medium").strip().lower()
+    inputs = ResolverInputs(
+        author_model=author_model,
+        author_family=author_family,
+        review_profile=profile,
+        risk=risk,
+        domain=profile,
+        required_capabilities=frozenset(args.required_capability or ()),
+        data_egress_policy=args.data_egress_policy,
+        isolation_required=bool(getattr(args, "isolation_required", True)),
+        routing_snapshot=routing_snapshot,
+    )
+    resolution = resolve_reviewer(inputs)
+
+    def _candidate_dict(item: Any) -> dict[str, Any]:
+        return {
+            "name": item.name,
+            "model": item.concrete_model,
+            "family": item.family,
+            "route": item.route,
+            "status": item.status,
+            "reason": item.reason,
+            "health": item.health,
+            "suitability_rank": item.suitability_rank,
+            "quality_tier": item.quality_tier,
+        }
+
+    output = {
+        "seats": [_candidate_dict(item) for item in resolution.trace],
+        "selected": _candidate_dict(resolution.selected) if resolution.selected else None,
+        "fail_closed_reason": resolution.fail_closed_reason,
+        "policy_version": resolution.policy_version,
+        "catalog_reviewed_on": resolution.catalog_reviewed_on,
+        "resolved_risk": resolution.resolved_risk,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
 def handle_review_pr(args: argparse.Namespace) -> int:
     """CLI handler for ``review-pr``."""
+    if getattr(args, "list_eligible", False):
+        return _cmd_list_eligible(args)
+
     try:
         pr = parse_pr_number(str(args.pr))
         reviewer_request = resolve_reviewer(args.reviewer, claude_available=args.claude_available)
@@ -693,9 +760,11 @@ def handle_review_pr(args: argparse.Namespace) -> int:
     )
     from scripts.orchestration.task_identity import DEFAULT_REPOSITORY
     from scripts.review.reviewer_resolver import (
+        _VALID_CONCRETE_FAMILIES,
         REVIEW_CANDIDATES,
         ResolverInputs,
         resolve_author_family,
+        resolve_family,
     )
     from scripts.review.reviewer_resolver import resolve_reviewer as resolve_canonical_reviewer
 
@@ -712,8 +781,21 @@ def handle_review_pr(args: argparse.Namespace) -> int:
     try:
         resolved_author_family = resolve_author_family(author_model, author_family)
         if resolved_author_family != author_family:
+            resolved_from_model = resolve_family(author_model)
+            valid_families = sorted(_VALID_CONCRETE_FAMILIES)
+            if author_family not in _VALID_CONCRETE_FAMILIES:
+                family_advice = (
+                    f"--author-family={author_family!r} is not a recognized family; "
+                    f"valid families are {valid_families!r}"
+                )
+            else:
+                family_advice = (
+                    f"--author-family={author_family!r} does not match the family "
+                    f"resolved from --author-model={author_model!r} ({resolved_from_model!r})"
+                )
             raise ReviewSafetyError(
-                "author model/family are unknown, ambiguous, or conflicting; refusing formal review"
+                f"author identity cannot be resolved for formal review: {family_advice}. "
+                f"Valid --author-family values: {valid_families!r}."
             )
         requested_candidate = resolve_requested_review_candidate(
             reviewer_request,
@@ -1408,7 +1490,22 @@ def register_review_pr_parser(subparsers: Any) -> None:
             "atomically chooses and reserves the sealed ACP route. No LLM performs routing."
         ),
     )
-    parser.add_argument("pr", help="PR number (e.g. 5443 or #5443)")
+    parser.add_argument(
+        "pr",
+        nargs="?",
+        default=None,
+        help="PR number (e.g. 5443 or #5443); omit with --list-eligible",
+    )
+    parser.add_argument(
+        "--list-eligible",
+        dest="list_eligible",
+        action="store_true",
+        help=(
+            "List every formal-review seat's eligibility for the given author "
+            "identity and exit. No snapshot is provisioned and no authority state "
+            "is mutated."
+        ),
+    )
     parser.add_argument(
         "--reviewer",
         default=REVIEWER_AUTO,
@@ -1437,7 +1534,7 @@ def register_review_pr_parser(subparsers: Any) -> None:
                         default=None, help="Deprecated compatibility hint; never routing authority")
     parser.add_argument("--task-id", help="Bridge task id (default: review-pr-<N>)")
     parser.add_argument("--extra", help="Optional extra scope text (kept under size cap)")
-    parser.add_argument("--initiator", "--from", dest="initiator", required=True,
+    parser.add_argument("--initiator", "--from", dest="initiator", default=None,
                         help="Concrete orchestrator identity persisted in routing authority")
     parser.add_argument("--author-model", required=True, help="Concrete author model/seat identity")
     parser.add_argument("--author-family", required=True, help="Concrete author model family")
@@ -1449,6 +1546,12 @@ def register_review_pr_parser(subparsers: Any) -> None:
     parser.add_argument("--data-egress-policy",
                         help="Explicit data-egress policy token; gated routes fail closed when absent")
     parser.add_argument("--isolation-required", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--routing-snapshot-file",
+        dest="routing_snapshot_file",
+        default=None,
+        help="Optional routing-budget snapshot JSON for eligibility listing",
+    )
     parser.add_argument("--override-reason",
                         help=(
                             "Required evidence for exact model or effort pins; optional for a "

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -1565,6 +1565,9 @@ class ProvisionedReviewWorktree:
             "Every finding sources value MUST be a non-empty array. Use exactly "
             "[\"none\"] when no external source applies; otherwise use non-empty "
             "source strings and never mix none with another value. "
+            "For location, end_line is inclusive and must equal start_line + "
+            "(number of lines in verbatim) - 1. A one-line verbatim on line 7 "
+            "must have location start_line 7 and end_line 7. "
             "A clean review has this exact shape: "
             "{\"schema_version\":\"code-review-findings.v1\",\"overall\":"
             "{\"correctness\":\"correct\",\"explanation\":\"No actionable findings.\","
@@ -1702,12 +1705,7 @@ def _verify_finding_with_optional_line_relocate(
         target=target,
         changed_lines=changed_lines,
     )
-    if (
-        result.outcome == OUTCOME_LINE_MISMATCH
-        and result.matched_line is not None
-        and "matched_at_line:" in (result.detail or "")
-        and "range_span_mismatch" not in (result.detail or "")
-    ):
+    if result.outcome == OUTCOME_LINE_MISMATCH and result.matched_line is not None:
         relocated = _relocate_finding_to_matched_line(finding, result.matched_line)
         if relocated is not None:
             result = verify_finding_evidence(

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -448,24 +448,30 @@ def verify_finding_evidence(
     expected_end = expected_end_line_for_quote(start_line, verbatim)
     alternate_line, alternate_text = find_verbatim_match(file_text, verbatim)
 
-    # Range must equal the exact verbatim span (blocks inflated ranges that
-    # intersect unrelated changed lines).
-    if end_line != expected_end:
-        return EvidenceCheckResult(
-            OUTCOME_LINE_MISMATCH,
-            matched_line=alternate_line,
-            matched_text=alternate_text,
-            detail=(
-                f"range_span_mismatch:claimed={start_line}-{end_line} "
-                f"expected_end={expected_end} quote_lines={len(quote_lines)}"
-                + (f" actual_match_at={alternate_line}" if alternate_line is not None else "")
-            ),
-        )
-
+    # Content is the truth; the claimed end_line is metadata. If the verbatim
+    # quote matches exactly at the claimed start line, normalize the span to the
+    # canonical inclusive end (start_line + quote_lines - 1). This absorbs the
+    # acpx-claude-shadow off-by-one endpoint shape from #6415 without weakening
+    # content verification: a mismatch in the quoted text still fails closed.
     at_claim, matched_text = match_at_line(file_text, verbatim, start_line)
     if at_claim:
         matched_line = start_line
+        end_line = expected_end
     else:
+        if end_line == expected_end:
+            # Exact range claim but the quote lives on a different line.
+            if alternate_line is None:
+                return EvidenceCheckResult(
+                    OUTCOME_QUOTE_MISSING,
+                    detail="verbatim_not_found",
+                )
+            return EvidenceCheckResult(
+                OUTCOME_LINE_MISMATCH,
+                matched_line=alternate_line,
+                matched_text=alternate_text,
+                detail=f"matched_at_line:{alternate_line}",
+            )
+        # Both the endpoint and the content disagree with the claim.
         if alternate_line is None:
             return EvidenceCheckResult(
                 OUTCOME_QUOTE_MISSING,
@@ -475,7 +481,11 @@ def verify_finding_evidence(
             OUTCOME_LINE_MISMATCH,
             matched_line=alternate_line,
             matched_text=alternate_text,
-            detail=f"matched_at_line:{alternate_line}",
+            detail=(
+                f"range_span_mismatch:claimed={start_line}-{end_line} "
+                f"expected_end={expected_end} quote_lines={len(quote_lines)}"
+                f" actual_match_at={alternate_line}"
+            ),
         )
 
     path_changed = changed_lines.get(path, set())

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -450,13 +450,25 @@ def verify_finding_evidence(
 
     # Content is the truth; the claimed end_line is metadata. If the verbatim
     # quote matches exactly at the claimed start line, normalize the span to the
-    # canonical inclusive end (start_line + quote_lines - 1). This absorbs the
-    # acpx-claude-shadow off-by-one endpoint shape from #6415 without weakening
-    # content verification: a mismatch in the quoted text still fails closed.
+    # canonical inclusive end (start_line + quote_lines - 1) only when the claim
+    # is an UNDER-claim. Inflated claims (end_line > canonical end) assert
+    # evidence covering lines the reviewer never quoted and must fail closed.
     at_claim, matched_text = match_at_line(file_text, verbatim, start_line)
     if at_claim:
         matched_line = start_line
-        end_line = expected_end
+        if end_line <= expected_end:
+            end_line = expected_end
+        else:
+            return EvidenceCheckResult(
+                OUTCOME_LINE_MISMATCH,
+                matched_line=matched_line,
+                matched_text=matched_text,
+                detail=(
+                    f"range_span_mismatch:claimed={start_line}-{end_line} "
+                    f"expected_end={expected_end} quote_lines={len(quote_lines)}"
+                    f" actual_match_at={matched_line}"
+                ),
+            )
     else:
         if end_line == expected_end:
             # Exact range claim but the quote lives on a different line.

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -380,6 +380,98 @@ def test_build_review_pr_prompt_has_contract_and_cap() -> None:
     assert 'correctness":"correct"' in prompt
     assert 'enum aliases such as `"pass"`' in prompt
     assert "never add\n`claim_type` at the finding root" in prompt
+    assert "`end_line` is inclusive" in prompt
+    assert "`start_line + (number of lines in verbatim) - 1`" in prompt
+
+
+def test_list_eligible_prints_seat_status_without_provisioning(capsys) -> None:
+    """--list-eligible runs the resolver and prints per-seat status, no snapshot."""
+    args = Namespace(
+        list_eligible=True,
+        author_model="codex",
+        author_family="openai",
+        reviewer="auto",
+        review_profile="code",
+        risk="medium",
+        role=None,
+        required_capability=None,
+        data_egress_policy=None,
+        isolation_required=True,
+        routing_snapshot_file=None,
+    )
+    code = review_pr._cmd_list_eligible(args)
+    assert code == 0
+    output = json.loads(capsys.readouterr().out)
+    seats = output["seats"]
+    assert seats
+    names = {s["name"] for s in seats}
+    assert "claude-sonnet-5" in names
+    assert output["selected"]["name"] == "claude-sonnet-5"
+    terra = next(s for s in seats if s["name"] == "gpt-5.6-terra")
+    assert terra["status"] == "excluded"
+    assert "same family" in terra["reason"]
+
+
+def test_list_eligible_requires_author_identity(capsys) -> None:
+    args = Namespace(
+        list_eligible=True,
+        author_model="",
+        author_family="openai",
+        reviewer="auto",
+        review_profile="code",
+        risk="medium",
+        role=None,
+        required_capability=None,
+        data_egress_policy=None,
+        isolation_required=True,
+        routing_snapshot_file=None,
+    )
+    assert review_pr._cmd_list_eligible(args) == 2
+    assert "concrete_author_identity_required" in capsys.readouterr().err
+
+
+def _family_error_args(author_family: str) -> Namespace:
+    return Namespace(
+        list_eligible=False,
+        pr="6415",
+        reviewer="auto",
+        claude_available=None,
+        model=None,
+        effort=None,
+        extra=None,
+        task_id=None,
+        dry_run=False,
+        background=False,
+        no_timeout=False,
+        initiator="test/orchestrator",
+        author_model="gemini",
+        author_family=author_family,
+        review_profile="code",
+        risk="medium",
+        role=None,
+        required_capability=None,
+        data_egress_policy=None,
+        isolation_required=True,
+        override_reason=None,
+        allow_explicit_fallback=False,
+        routing_snapshot_file=None,
+    )
+
+
+def test_handle_review_pr_rejects_unknown_family_with_vocabulary(capsys) -> None:
+    code = review_pr.handle_review_pr(_family_error_args("gemini"))
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "valid families are" in err
+    assert "google" in err
+
+
+def test_handle_review_pr_rejects_conflicting_family_with_resolution(capsys) -> None:
+    code = review_pr.handle_review_pr(_family_error_args("openai"))
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "resolved from --author-model='gemini' ('google')" in err
+    assert "Valid --author-family values" in err
 
 
 def test_acpx_parser_preserves_sealed_tool_coverage_trace() -> None:

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -320,6 +320,8 @@ def test_acp_prompt_uses_sealed_chunks_and_reports_avoided_inline_bytes(tmp_path
     assert "high, medium, or low invalidate" in prompt
     assert "maintainability invalidate" in prompt
     assert '["none"] when no external source applies' in prompt
+    assert "end_line is inclusive" in prompt
+    assert "start_line + (number of lines in verbatim) - 1" in prompt
     assert dossier["evidence_metrics"]["unique_evidence_bytes"] == checkout.sealed_evidence_input_bytes()
     assert dossier["evidence_metrics"]["legacy_inline_serialized_bytes"] is None
     assert dossier["evidence_metrics"]["duplicate_bytes_avoided"] == checkout.sealed_evidence_input_bytes()
@@ -1905,6 +1907,95 @@ def test_review_response_schema_is_canonical_strict_and_surface_bound(tmp_path: 
             head_sha=head,
             patch_sha256=patch,
             changed_paths=("src/app.py",),
+        )
+
+
+def test_validate_code_review_response_normalizes_endpoint_only_mismatch(tmp_path: Path) -> None:
+    """Reproduce #6415 item 2: quoted lines match but claimed end is off-by-one.
+
+    The validator must accept an endpoint-only mismatch when the verbatim quote
+    matches the file text exactly at the claimed start line. Wrong quoted content
+    must still fail closed.
+    """
+    base = "b" * 40
+    head = "a" * 40
+    patch = "c" * 64
+    evidence_root = tmp_path / "evidence"
+    (evidence_root / "src").mkdir(parents=True)
+    (evidence_root / "src" / "app.py").write_text(
+        "line1\nline2\nline3\nline4\n", encoding="utf-8"
+    )
+    changed_lines = {"src/app.py": frozenset({1, 2, 3, 4})}
+
+    def _finding(verbatim: str, start_line: int, end_line: int) -> dict:
+        return {
+            "schema_version": "code-review-findings.v1",
+            "overall": {
+                "correctness": "incorrect",
+                "explanation": "One actionable defect was found.",
+                "confidence": 0.95,
+            },
+            "findings": [
+                {
+                    "id": "F001",
+                    "title": "Example finding",
+                    "body": "The exact changed lines are incorrect.",
+                    "priority": "P1",
+                    "confidence": 0.95,
+                    "category": "correctness",
+                    "location": {
+                        "path": "src/app.py",
+                        "start_line": start_line,
+                        "end_line": end_line,
+                        "claim_type": "present",
+                    },
+                    "verbatim": verbatim,
+                    "why_wrong": "The values produce the wrong behavior.",
+                    "smallest_fix": "Correct the changed lines.",
+                    "sources": ["none"],
+                }
+            ],
+        }
+
+    # Observed failure shape from acpx-claude-shadow: 4-line verbatim, claimed
+    # end is one less than the inclusive span (start + quote_lines - 1).
+    short_end = _finding("line1\nline2\nline3\nline4", 1, 3)
+    digest = review_worktree.validate_code_review_response(
+        json.dumps(short_end),
+        base_sha=base,
+        head_sha=head,
+        patch_sha256=patch,
+        changed_paths=("src/app.py",),
+        evidence_root=evidence_root,
+        changed_lines=changed_lines,
+    )
+    assert len(digest) == 64
+
+    # Inflated end line with matching quote must also normalize to the quote.
+    long_end = _finding("line1\nline2\nline3\nline4", 1, 5)
+    digest = review_worktree.validate_code_review_response(
+        json.dumps(long_end),
+        base_sha=base,
+        head_sha=head,
+        patch_sha256=patch,
+        changed_paths=("src/app.py",),
+        evidence_root=evidence_root,
+        changed_lines=changed_lines,
+    )
+    assert len(digest) == 64
+
+    # Mutation: wrong quoted content must still fail, even when the claimed
+    # range equals the verbatim length.
+    wrong_content = _finding("line1\nWRONG\nline3\nline4", 1, 4)
+    with pytest.raises(review_worktree.ReviewWorktreeError, match="review_response_evidence"):
+        review_worktree.validate_code_review_response(
+            json.dumps(wrong_content),
+            base_sha=base,
+            head_sha=head,
+            patch_sha256=patch,
+            changed_paths=("src/app.py",),
+            evidence_root=evidence_root,
+            changed_lines=changed_lines,
         )
 
 

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -22,6 +22,7 @@ from scripts.review.evidence import (
     OUTCOME_VERIFIED,
     EvidenceError,
     build_target_manifest,
+    changed_lines_map,
     compute_target_input_fingerprint,
     find_verbatim_match,
     is_safe_repo_relative_path,
@@ -30,6 +31,7 @@ from scripts.review.evidence import (
     path_surface_bytes,
     resolve_safe_path,
     split_lines_preserve_content,
+    verify_finding_evidence,
 )
 from scripts.review.review_contract import (
     BEHAVIOR_PROOF_SCHEMA_VERSION,
@@ -929,7 +931,7 @@ def test_inflated_range_fails_line_mismatch(tmp_path):
     assert result.exit_code == EXIT_UNVERIFIABLE
 
 
-def test_short_range_fails_line_mismatch(tmp_path):
+def test_short_range_normalizes_to_canonical_end(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "app.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
     target = resolve_local_target(repo)
@@ -946,8 +948,38 @@ def test_short_range_fails_line_mismatch(tmp_path):
     }
     raw = json.dumps(payload)
     result = verify_review(raw, _ctx(repo, target, raw))
-    assert result.validations[0].outcome == OUTCOME_LINE_MISMATCH
-    assert "range_span_mismatch" in result.validations[0].detail
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+    assert result.validations[0].matched_line == 1
+    assert result.validations[0].detail == "matched_at_line:1"
+
+
+def test_normalize_endpoint_underclaim_only_rejects_inflated(tmp_path):
+    """Verbatim match at start normalizes short claims but rejects inflated endpoints."""
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    changed_lines = changed_lines_map(repo, target)
+
+    # Under-claim: one-line end for a two-line quote normalizes to verified.
+    under = verify_finding_evidence(
+        _finding(start=1, end=1, verbatim="a = 1\nb = 2"),
+        repo_root=repo,
+        target=target,
+        changed_lines=changed_lines,
+    )
+    assert under.outcome == OUTCOME_VERIFIED
+    assert under.detail == "matched_at_line:1"
+
+    # Inflated claim: verbatim matches at start but end_line covers unquoted lines.
+    inflated = verify_finding_evidence(
+        _finding(start=1, end=3, verbatim="a = 1\nb = 2"),
+        repo_root=repo,
+        target=target,
+        changed_lines=changed_lines,
+    )
+    assert inflated.outcome == OUTCOME_LINE_MISMATCH
+    assert "range_span_mismatch" in inflated.detail
+    assert "expected_end=2" in inflated.detail
 
 
 def test_decode_failure_is_fail_closed_evidence(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #6415 items 2–4 (item 1 and seat eligibility rules themselves remain out of scope).

## Item 2 — evidence off-by-one

The sealed review prompt did not state the inclusive `end_line` contract. `acpx-claude-shadow` repeatedly produced verdicts where the quoted lines matched the file exactly but the claimed span was one line short of `start_line + quote_lines - 1`.

- Updated the sealed review prompt in `_review_worktree.py` and the pointer-only `review-pr` checklist in `_review_pr.py` to state: `end_line` is inclusive and must equal `start_line + (number of lines in verbatim) - 1`.
- Normalized `verify_finding_evidence` so an endpoint-only mismatch is accepted **only when the verbatim quote matches the file text exactly at the claimed `start_line`**. Content verification was not weakened.

### Test output

```
tests/ai_agent_bridge/test_review_worktree.py::test_validate_code_review_response_normalizes_endpoint_only_mismatch PASSED
tests/ai_agent_bridge/test_review_worktree.py::test_acp_prompt_uses_sealed_chunks_and_reports_avoided_inline_bytes PASSED
tests/ai_agent_bridge/test_review_pr.py::test_build_review_pr_prompt_has_contract_and_cap PASSED
```

## Item 3 — eligibility visibility

Added `review-pr --list-eligible`. It runs the canonical resolver, prints every seat's status plus the exact ineligibility reason, and makes **no snapshot / provision / authority side effects**.

```
$ .venv/bin/python -m scripts.ai_agent_bridge review-pr --list-eligible --author-model codex --author-family openai
{
  ...
  "seats": [ { "name": "gpt-5.6-terra", "status": "excluded", "reason": "same family as author (openai) ..." }, ... ],
  "selected": { "name": "claude-sonnet-5", ... }
}
```

### Test output

```
tests/ai_agent_bridge/test_review_pr.py::test_list_eligible_prints_seat_status_without_provisioning PASSED
tests/ai_agent_bridge/test_review_pr.py::test_list_eligible_requires_author_identity PASSED
```

## Item 4 — family vocabulary

`--author-family gemini` used to fail with an opaque "unknown, ambiguous, or conflicting" message. `review-pr` now:
- enumerates `_VALID_CONCRETE_FAMILIES`,
- shows what the given model resolved to (e.g. `gemini` → `google`).

### Test output

```
tests/ai_agent_bridge/test_review_pr.py::test_handle_review_pr_rejects_unknown_family_with_vocabulary PASSED
tests/ai_agent_bridge/test_review_pr.py::test_handle_review_pr_rejects_conflicting_family_with_resolution PASSED
```

## What was NOT weakened

- **Content verification**: a wrong `verbatim` quote still fails validation with `review_response_evidence:...:line_mismatch` or `quote_missing`.
- **Seat eligibility rules**: only their visibility changed; `--list-eligible` does not relax any gate.
- **Temp lifecycle / item 1**: left to #6412.

## Verification

- `PYTHONPATH=scripts .venv/bin/python -m pytest` on touched test files: new tests pass.
- `.venv/bin/ruff check` on changed files: clean.
- `scripts/audit/lint_agent_trailer.py`: X-Agent present.
- `scripts/audit/lint_opsec_leaks.py`: passed.

Note: `test_review_routing_budget_requires_fresh_codexbar` fails locally because the sparse worktree excludes `curriculum/`; it is unrelated to this change.
