### PR TITLE
fix(process): mandatory post-merge cleanup (disk/ENOSPC)

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -131,6 +131,13 @@ Every epic driver session (any harness) MUST:
      (do not invent `<model>_lane`).
 7. Provider drivers inject the **`drive-epic`** binding after their lease and
    provider canary. Interactive launchers never claim a driver lease.
+8. **Post-merge cleanup is mandatory** (operator 2026-08-07). A squash-merge is not
+   done until worktree + branch + CF/review temp residue for that PR are reaped and
+   `df -h /` + `git worktree list` prove no zombie. Order and paths: `drive-epic` skill
+   §7a (worktree before branch; ACP `runtime-review-<PR>*`; `/tmp/lu-cf-clean` /
+   `/tmp/lu-review-*` / `/tmp/lu-pr*` — chmod then rm for read-only sealed snaps). Do
+   not start another formal `review-pr` while disk is near full without reaping first.
+   Session chat promises do not bind; this rule and §7a do.
 
 ## Operator launch surface (#5632)
 

--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -28,9 +28,18 @@ tie-breakers.
    scratch directory (like `batch_state/`).
    `core.bare=true` on primary is a **bug** to heal (`git config core.bare false` +
    `extensions.worktreeConfig=true`), never an intentional mode. PRs for everything — no
-   direct commits to main. After merge: delete branch local + remote, remove worktree. Close
-   issues when acceptance criteria are met, with tool-backed evidence. `X-Agent` trailer on
-   every commit. Session start/end: sweep worktrees, branches, open PRs — a dangling ref
+   direct commits to main. **After merge, cleanup is mandatory before the next formal
+   review or large dispatch** (operator 2026-08-07; ENOSPC is the known failure): (1)
+   confirm MERGED, (2) `git worktree remove --force` for that PR's dispatch worktree
+   **before** deleting the local branch, (3) delete local + remote branch +
+   `git fetch --prune` + `git worktree prune`, (4) reap finished CF residue for that PR
+   when no process holds it — `.worktrees/dispatch/acp/runtime-review-<PR>*`,
+   `/tmp/lu-cf-clean/`, `/tmp/lu-review-*`, `/tmp/lu-pr*` (read-only sealed snaps need
+   `chmod -R u+w` then `rm -rf`), task runtime tmp, stray worktree `.venv`, (5) prove
+   with `df -h /` and `git worktree list` (no zombie path for that PR). A squash-merge
+   alone is not done. Full checklist: `drive-epic` skill §7a. Close issues when
+   acceptance criteria are met, with tool-backed evidence. `X-Agent` trailer on every
+   commit. Session start/end: sweep worktrees, branches, open PRs — a dangling ref
    reads as unfinished work to the rest of the fleet.
 4. **Utilize the whole fleet — together you are stronger.** Substantive design/decisions get
    ≥1 other agent BEFORE committing; solo only for trivial work. Two distinct duties, don't

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -220,10 +220,46 @@ review gate passes AND blocking CI is green:**
 gh pr merge --auto --squash --delete-branch
 ```
 Never arm on a **draft** and never merge ahead of the review verdict. Blocking CI red →
-never `--admin`-bypass. After merge: delete remote branch, `git worktree remove --force`
-(worktree BEFORE local branch), sweep stale refs. A track/infra driver **self-merges its
-own lane's PR** after the cross-family gate + green CI (lane model — there is no promoting
-orchestrator). Flag another lane's PR with `needs=merge` rather than merging it.
+never `--admin`-bypass. A track/infra driver **self-merges its own lane's PR** after the
+cross-family gate + green CI (lane model — there is no promoting orchestrator). Flag
+another lane's PR with `needs=merge` rather than merging it.
+
+### 7a. Post-merge cleanup is mandatory (binding — operator 2026-08-07)
+
+**A squash-merge is not done until cleanup proves free of that PR's residue.** Chat
+promises do not bind; this section does. Leaving worktrees / ACP review runtimes /
+`/tmp` formal-review snaps after merge is a process defect (ENOSPC / disk full is the
+known failure mode). Do not start the next formal `review-pr` or large dispatch until
+cleanup for the just-merged PR is complete.
+
+**Order after `gh pr view <N>` shows `MERGED` (or auto-merge lands):**
+
+1. **Confirm** — `gh pr view <N> --json state,mergedAt,mergeCommit` (quote SHA when
+   handoff needs it).
+2. **Worktree first** — `git worktree remove --force .worktrees/dispatch/<agent>/<task>`
+   (and any other worktree still on that PR branch). Never leave a branch checked out
+   that blocks branch delete.
+3. **Branches** — delete local branch if present; ensure remote is gone
+   (`--delete-branch` on merge, else `git push origin --delete <branch>`); `git fetch
+   --prune`; `git worktree prune`.
+4. **Review / CF residue for that PR** (reap only when no live process holds the path):
+   - `.worktrees/dispatch/acp/runtime-review-<PR>*` — `git worktree unlock` if locked,
+     then `remove --force` (or `rm -rf` if already unregistered)
+   - `/tmp/lu-cf-clean/`, `/tmp/lu-review-*`, `/tmp/lu-pr*` tied to that PR or finished
+     formal snapshots — sealed snaps are often **read-only**: `chmod -R u+w` then
+     `rm -rf`
+   - runtime tmp under `$TMPDIR/learn-ukrainian/<task-id>*` if present
+   - stray worktree `.venv` if a worker created one
+5. **Optional sweeper** — not a substitute for step 4:
+   ```bash
+   .venv/bin/python -c "from scripts.review.isolation import sweep_review_temp_orphans; print(sweep_review_temp_orphans())"
+   ```
+6. **Prove** — `df -h /` and `git worktree list` must show no zombie path for that PR.
+   Record free space in the file handoff when disk was tight this session.
+
+**Do not** treat `gh pr merge --auto --squash --delete-branch` alone as closeout. **Do
+not** leave locked ACP review worktrees for finished reviews. **Do not** run another
+formal snapshot provision while disk is near full without reaping first.
 
 ### 8. Handoff — dual-write, cutover-aware (see §Fleet-comms state below)
 End the session on your seat's handoff signal (canary FAIL-HANDOFF for grok/gemini/kimi;


### PR DESCRIPTION
## Summary
- Bind post-merge cleanup so drivers cannot treat squash-merge as done without reaping worktrees, branches, and CF/review temp residue.
- Surfaces: `drive-epic` skill §7a (full checklist), `operator-expectations` §3 (served first at `/api/rules`), `fleet-comms-coordination` TUI contract item 8.

## Why
Operator: chat promises do not control seats; only skills/rules do. Leftover ACP review runtimes and `/tmp/lu-cf-clean` sealed snaps filled the disk (ENOSPC) during formal CF.

## Test plan
- [ ] Read §7a in drive-epic and item 8 in fleet-comms-coordination after merge
- [ ] Confirm `/api/rules` serves updated operator-expectations after agents_extensions deploy (if deploy is required for live serve)
- [ ] No product/code behavior change