### PR TITLE
docs(hramatka): queue contract PR-1 — private #349 SSOT, public #4542 charter-only

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -76,6 +76,19 @@ with `scripts/ai_agent_bridge/inbox_watch.sh --stop "$SESSION_HANDOFF_AGENT"`; i
 crashed process leaves a stale pidfile, the operating system releases its advisory lock
 and the next watcher replaces the recorded pid safely.
 
+### 0c. Hramatka epic — dual-repo queue (epic #4542 only)
+
+If `SESSION_EPIC` is Hramatka (public #4542), the priority/ownership queue is
+private BOARD `learn-ukrainian-infra-private#349`, not the public epic body. Cold-start
+read order: **private #349 → private open PRs → public PRs linked from #4542 only.**
+Public #4542 is charter + bare pointer — never generate or mirror a public checklist
+from the private board (leak + dual-write). GitHub issue/PR state in either repo
+remains the factual SSOT for open/closed; #349 is the priority queue, not a duplicate
+status feed. Operator-only host mutation (private #360, #212) is **ESCALATE**, not
+solo action, on missing GO. If #349 and any other queue view disagree, **#349 wins** —
+correct the other view the same session. Full contract:
+`docs/runbooks/hramatka-driver-queue.md`.
+
 ### 1. Read topology + metrics (don't hold state — query it)
 ```bash
 .venv/bin/python -m scripts.fleet_comms metrics        # efficiency metrics (no content)

--- a/docs/runbooks/hramatka-driver-queue.md
+++ b/docs/runbooks/hramatka-driver-queue.md
@@ -1,0 +1,51 @@
+# Hramatka Driver Queue Contract
+
+Cold-start queue contract for anyone driving the Hramatka epic (public
+[#4542](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4542))
+across the public/private repo split. Authority: the 2026-08-07 stream-hygiene
+consult (`batch_state/hramatka-drive/CONSULT-VERDICT-stream-hygiene-2026-08-07.md`,
+gitignored local evidence; ACP conversation
+`conversation_7b6241377cd44c7ea5265da5c85efb5c`, claude/codex/agy/kimi converged
+spine, PR-1 of a 4-PR package). This is PR-1 of that package: **docs/rules only.**
+No `stream_fence` / `post_task_reap` / `hygiene_check` code — that is PR-2 through
+PR-4 of the same package.
+
+## Queue roles
+
+| Queue | Role |
+| --- | --- |
+| Private BOARD [learn-ukrainian-infra-private#349](https://github.com/learn-ukrainian/learn-ukrainian-infra-private/issues/349) | **Planning/priority queue.** Ownership + ordering for active Hramatka work. |
+| Public [#4542](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4542) | **Charter + bare pointer.** Narrative/authorization record, not a live operational checklist. Never auto-generate or mirror a public checklist from the private board — leak + dual-write, explicitly rejected by the consult. |
+| GitHub issue/PR state (either repo) | Factual SSOT for what is actually open or closed. #349 is the priority queue, not a duplicate status feed — an item can be closed on GitHub while still ranked on #349, and the reverse. |
+
+## Cold-start read order
+
+1. Private #349 (priority/ownership)
+2. Private open PRs
+3. Public PRs linked from #4542 only
+
+Do not treat #4542's own body text as a live queue snapshot — read it for
+charter/authorization context only.
+
+## Operator-only items — track/escalate, never action solo
+
+Private [#360](https://github.com/learn-ukrainian/learn-ukrainian-infra-private/issues/360)
+and [#212](https://github.com/learn-ukrainian/learn-ukrainian-infra-private/issues/212)
+require host mutation. A driver without an explicit operator GO for the specific
+mutation must **ESCALATE** — track the item and surface it, do not action it.
+This is not a bare refuse: the item stays visible and owned, it does not drop
+out of the queue.
+
+## Same-session correction rule
+
+If #349 and any other view of the queue (a cached handoff note, a stale reading
+of #4542, an out-of-date driver's own memory) disagree, **#349 wins**. Correct
+the other view in the same session — do not carry the disagreement forward or
+defer the fix to a later PR.
+
+## What this contract does not change
+
+- No `stream_fence`, `post_task_reap`, or `hygiene_check` code ships here.
+- No product/teacher-facing features.
+- No private-repo secrets or private task titles are mirrored here beyond bare
+  issue numbers.


### PR DESCRIPTION
## Outcome
Docs/rules-only PR-1 of the Hramatka stream-hygiene package (see consult verdict below). Cold-started hramatka drivers now have a written queue contract instead of tribal knowledge.

1. Public **#4542** rewritten: dropped its stale live checklist (private #243/#244/#242/#240/#241/#239/#210 were all CLOSED/MERGED while listed as open checkboxes) — replaced with charter + a bare pointer to private BOARD #349.
2. Private **BOARD #349** is now written down as the planning/priority queue; GitHub issue/PR state in either repo stays the factual SSOT for open/closed.
3. New `docs/runbooks/hramatka-driver-queue.md`: cold-start read order (private #349 → private open PRs → public PRs linked from #4542 only), operator-only escalate list (private #360, #212 — host mutation needs an explicit GO), same-session "#349 wins" correction rule.
4. `agents_extensions/shared/skills/drive-epic/SKILL.md` §0c: short pointer for any driver on epic #4542 to the contract above.

## Authority
`batch_state/hramatka-drive/CONSULT-VERDICT-stream-hygiene-2026-08-07.md` (gitignored local evidence) — ACP conversation `conversation_7b6241377cd44c7ea5265da5c85efb5c`, claude/codex/agy/kimi converged spine, 2 rounds. This is PR-1 of the agreed 4-PR implementation order; PR-2 (scope gate) through PR-4 (hygiene gate) are code and out of scope here.

## Evidence
- `gh issue view 4542 --json body -q .body | grep -c '^\- \[ \]'` → `0` (zero checkbox lines in the new body).
- `gh issue view 243/244/242 --repo learn-ukrainian/learn-ukrainian-infra-private --json state` → all `CLOSED` while the old #4542 body listed them as open `- [ ]` items (the bug this PR fixes).
- `gh issue view 349 --repo learn-ukrainian/learn-ukrainian-infra-private --json state,title` → `OPEN`, "BOARD: the ordered path to a teacher using hramatka" (confirms #349 exists and is the right target).

## Non-goals
No `stream_fence` / `post_task_reap` / `hygiene_check` code, no product/teacher features, no private task titles beyond bare issue numbers, no linter/`.python-version` changes.

Not merging this myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
