### PR TITLE
feat(fleet): add Hramatka scope gate

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -89,6 +89,9 @@ solo action, on missing GO. If #349 and any other queue view disagree, **#349 wi
 correct the other view the same session. Full contract:
 `docs/runbooks/hramatka-driver-queue.md`.
 
+Before a new dispatch, scope, or PR, run `scripts.fleet.hramatka_scope_gate`
+as specified in that runbook; only `ALLOW` permits the new action.
+
 ### 1. Read topology + metrics (don't hold state — query it)
 ```bash
 .venv/bin/python -m scripts.fleet_comms metrics        # efficiency metrics (no content)

--- a/docs/runbooks/hramatka-driver-queue.md
+++ b/docs/runbooks/hramatka-driver-queue.md
@@ -6,9 +6,8 @@ across the public/private repo split. Authority: the 2026-08-07 stream-hygiene
 consult (`batch_state/hramatka-drive/CONSULT-VERDICT-stream-hygiene-2026-08-07.md`,
 gitignored local evidence; ACP conversation
 `conversation_7b6241377cd44c7ea5265da5c85efb5c`, claude/codex/agy/kimi converged
-spine, PR-1 of a 4-PR package). This is PR-1 of that package: **docs/rules only.**
-No `stream_fence` / `post_task_reap` / `hygiene_check` code — that is PR-2 through
-PR-4 of the same package.
+spine, PR-1 of a 4-PR package). PR-2 adds the Hramatka-only scope gate below;
+`post_task_reap` and `hygiene_check` remain separate PR-3/PR-4 work.
 
 ## Queue roles
 
@@ -26,6 +25,35 @@ PR-4 of the same package.
 
 Do not treat #4542's own body text as a live queue snapshot — read it for
 charter/authorization context only.
+
+## New-scope gate
+
+Before a Hramatka driver starts a **new dispatch**, **new scope**, or **new PR**,
+run the mechanical gate with a repo-qualified issue target:
+
+```bash
+.venv/bin/python -m scripts.fleet.hramatka_scope_gate \
+  --action new_dispatch \
+  --issue-repo learn-ukrainian/learn-ukrainian.github.io \
+  --issue 4542
+```
+
+It emits JSON with exactly one of `ALLOW`, `ROUTE`, `HOLD`, or `ESCALATE`; only
+`ALLOW` exits zero. `ROUTE` always names its destination, such as
+`infra-harness epic #4707`; `HOLD` means stop the new action; `ESCALATE` means
+surface the item to the operator. The gate is deliberately not applied to
+cleanup, review, escalation, or unblocking the driver's own already-open PR.
+
+Public work must have exact stream membership through Hramatka epic #4542.
+Private work must be tracked by private board #349, carry the exact `hramatka`
+label, or use an explicit `stream:hramatka` body tag. Ordinary mentions of
+Hramatka and any 50%/majority heuristic are not membership evidence. A private
+API failure is `UNKNOWN` and therefore `HOLD` for every new-scope action; it
+never becomes an implicit allow. The gate has no environment-variable bypass.
+
+Private #360 and #212 remain `ESCALATE` because they are operator-only host
+mutation work. This PR intentionally does not add a self-asserted GO/override
+flag: a verified operator authorization belongs in its own audited workflow.
 
 ## Operator-only items — track/escalate, never action solo
 
@@ -45,7 +73,7 @@ defer the fix to a later PR.
 
 ## What this contract does not change
 
-- No `stream_fence`, `post_task_reap`, or `hygiene_check` code ships here.
+- No `post_task_reap` or `hygiene_check` code ships here.
 - No product/teacher-facing features.
 - No private-repo secrets or private task titles are mirrored here beyond bare
   issue numbers.

--- a/scripts/fleet/hramatka_scope_gate.py
+++ b/scripts/fleet/hramatka_scope_gate.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Fail-closed scope gate for new Hramatka driver work.
+
+The gate is intentionally wired to Hramatka only, while its decision function
+accepts a configuration and stream registry so a later, separately approved
+rollout can reuse the shape without copying policy. It never reads an
+environment-variable bypass and never mutates GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from scripts.orchestration import issue_stream_audit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_REPOSITORY = "learn-ukrainian/learn-ukrainian.github.io"
+PRIVATE_REPOSITORY = "learn-ukrainian/learn-ukrainian-infra-private"
+HRAMATKA_STREAM = "hramatka"
+HRAMATKA_EPIC = 4542
+HRAMATKA_PRIVATE_BOARD = 349
+GH_TIMEOUT_SECONDS = 15.0
+
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_BODY_STREAM_TAG_RE = re.compile(r"(?im)^\s*(?:<!--\s*)?stream\s*[:=]\s*([a-z0-9][a-z0-9-]*)\s*(?:-->)?\s*$")
+
+GATED_ACTIONS = frozenset({"new_dispatch", "new_scope", "new_pr"})
+EXEMPT_ACTIONS = frozenset({"cleanup", "review", "escalate", "unblock_own_open_pr"})
+ALL_ACTIONS = GATED_ACTIONS | EXEMPT_ACTIONS
+
+
+class Outcome(StrEnum):
+    """The only operational dispositions this gate can emit."""
+
+    ALLOW = "ALLOW"
+    ROUTE = "ROUTE"
+    HOLD = "HOLD"
+    ESCALATE = "ESCALATE"
+
+
+@dataclass(frozen=True)
+class IssueRef:
+    """A repo-qualified GitHub issue identifier."""
+
+    repository: str
+    number: int
+
+    def __post_init__(self) -> None:
+        if not _REPOSITORY_RE.fullmatch(self.repository):
+            raise ValueError("repository must be a qualified owner/name identifier")
+        if not isinstance(self.number, int) or isinstance(self.number, bool) or self.number <= 0:
+            raise ValueError("issue number must be a positive integer")
+
+    def display(self) -> str:
+        return f"{self.repository}#{self.number}"
+
+
+@dataclass(frozen=True)
+class ScopeGateConfig:
+    """Hramatka-specific policy inputs, kept explicit for later reuse."""
+
+    stream_name: str
+    public_repository: str
+    public_epic: int
+    private_repository: str
+    private_board: IssueRef
+    operator_only_issues: frozenset[IssueRef]
+
+
+HRAMATKA_SCOPE_GATE = ScopeGateConfig(
+    stream_name=HRAMATKA_STREAM,
+    public_repository=PUBLIC_REPOSITORY,
+    public_epic=HRAMATKA_EPIC,
+    private_repository=PRIVATE_REPOSITORY,
+    private_board=IssueRef(PRIVATE_REPOSITORY, HRAMATKA_PRIVATE_BOARD),
+    operator_only_issues=frozenset(
+        {
+            IssueRef(PRIVATE_REPOSITORY, 360),
+            IssueRef(PRIVATE_REPOSITORY, 212),
+        }
+    ),
+)
+
+
+@dataclass(frozen=True)
+class IssueObservation:
+    """The minimal, non-title GitHub state needed for a scope decision."""
+
+    labels: frozenset[str]
+    body: str
+    parent_number: int | None
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """A machine-readable, non-mutating scope-gate result."""
+
+    outcome: Outcome
+    reason: str
+    destination: str | None = None
+
+    def as_json(self) -> dict[str, str]:
+        payload = {"outcome": self.outcome.value, "reason": self.reason}
+        if self.destination is not None:
+            payload["destination"] = self.destination
+        return payload
+
+
+class IssueLookupUnavailable(RuntimeError):
+    """GitHub did not return a trusted issue observation."""
+
+
+IssueReader = Callable[[IssueRef], IssueObservation]
+
+
+def load_stream_registry(repo_root: Path = REPO_ROOT) -> dict[str, list[int]]:
+    """Read the canonical stream-to-epic registry without making a network call."""
+
+    return issue_stream_audit.load_registry(repo_root / "scripts" / "config" / "issue_streams.yaml")
+
+
+def _gh_issue_observation(issue: IssueRef) -> IssueObservation:
+    """Read one repo-qualified issue through GitHub GraphQL.
+
+    GitHub failures are deliberately normalized to ``IssueLookupUnavailable``:
+    callers must not accidentally distinguish a private API outage from a
+    trusted observation and allow fresh work.
+    """
+
+    owner, name = issue.repository.split("/", 1)
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "repository(owner:$owner,name:$name){issue(number:$number){"
+        "number body labels(first:100){nodes{name}} parent{number}"
+        "}}}"
+    )
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={issue.number}",
+                "-f",
+                f"query={query}",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise IssueLookupUnavailable("GitHub issue authority is unavailable") from exc
+    if proc.returncode != 0:
+        raise IssueLookupUnavailable("GitHub issue authority is unavailable")
+
+    try:
+        payload = json.loads(proc.stdout)
+        node = payload["data"]["repository"]["issue"]
+        if not isinstance(node, Mapping) or node.get("number") != issue.number:
+            raise ValueError("issue response does not identify the requested issue")
+        body = node.get("body")
+        labels_doc = node.get("labels")
+        parent_doc = node.get("parent")
+        label_nodes = labels_doc.get("nodes") if isinstance(labels_doc, Mapping) else None
+        if not isinstance(body, str) or not isinstance(label_nodes, list):
+            raise ValueError("issue response has an invalid shape")
+        labels = frozenset(
+            label["name"] for label in label_nodes if isinstance(label, Mapping) and isinstance(label.get("name"), str)
+        )
+        if len(labels) != len(label_nodes):
+            raise ValueError("issue response contains an invalid label")
+        parent_number = parent_doc.get("number") if isinstance(parent_doc, Mapping) else None
+        if parent_number is not None and (
+            not isinstance(parent_number, int) or isinstance(parent_number, bool) or parent_number <= 0
+        ):
+            raise ValueError("issue response contains an invalid parent")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise IssueLookupUnavailable("GitHub issue authority is unavailable") from exc
+    return IssueObservation(labels=labels, body=body, parent_number=parent_number)
+
+
+def _stream_destinations(stream_registry: Mapping[str, Sequence[int]]) -> dict[str, int]:
+    """Map each stream to one canonical epic for named routing messages."""
+
+    destinations: dict[str, int] = {}
+    for stream, epics in stream_registry.items():
+        if not isinstance(stream, str) or not stream:
+            raise ValueError("stream registry contains an invalid stream name")
+        if not isinstance(epics, Sequence) or isinstance(epics, (str, bytes)):
+            raise ValueError("stream registry contains invalid epics")
+        numbers = [epic for epic in epics if isinstance(epic, int) and not isinstance(epic, bool) and epic > 0]
+        if len(numbers) != len(epics) or not numbers:
+            raise ValueError("stream registry contains invalid epics")
+        destinations[stream] = min(numbers)
+    return destinations
+
+
+def _epic_to_stream(stream_registry: Mapping[str, Sequence[int]]) -> dict[int, str]:
+    """Map every configured epic to exactly one stream."""
+
+    epics: dict[int, str] = {}
+    for stream, numbers in stream_registry.items():
+        for number in numbers:
+            previous = epics.setdefault(number, stream)
+            if previous != stream:
+                raise ValueError(f"epic #{number} belongs to more than one stream")
+    return epics
+
+
+def _destination_for_stream(stream: str, destinations: Mapping[str, int]) -> str:
+    return f"{stream} epic #{destinations[stream]}"
+
+
+def _stream_from_private_tags(
+    issue: IssueRef,
+    observation: IssueObservation,
+    *,
+    config: ScopeGateConfig,
+    destinations: Mapping[str, int],
+) -> set[str]:
+    """Read explicit private stream tags only; prose mentions never count."""
+
+    streams: set[str] = set()
+    if issue == config.private_board or observation.parent_number == config.private_board.number:
+        streams.add(config.stream_name)
+
+    for raw_label in observation.labels:
+        label = raw_label.casefold().strip()
+        if label == config.stream_name:
+            streams.add(config.stream_name)
+            continue
+        for prefix in ("stream:", "stream/"):
+            if label.startswith(prefix):
+                candidate = label.removeprefix(prefix)
+                if candidate in destinations:
+                    streams.add(candidate)
+                break
+
+    for match in _BODY_STREAM_TAG_RE.finditer(observation.body):
+        candidate = match.group(1).casefold()
+        if candidate in destinations:
+            streams.add(candidate)
+    return streams
+
+
+def _route_unassigned_private(config: ScopeGateConfig) -> GateDecision:
+    return GateDecision(
+        outcome=Outcome.ROUTE,
+        reason="private issue has no exact Hramatka label, board tracking, or stream tag",
+        destination=f"private Hramatka board #{config.private_board.number} triage",
+    )
+
+
+def _gate_public_issue(
+    issue: IssueRef,
+    observation: IssueObservation,
+    *,
+    config: ScopeGateConfig,
+    destinations: Mapping[str, int],
+    epic_streams: Mapping[int, str],
+) -> GateDecision:
+    # Only exact membership is evidence. A title/body/label mention of Hramatka
+    # cannot override native stream ownership or become a percentage heuristic.
+    membership_epic = observation.parent_number or issue.number
+    stream = epic_streams.get(membership_epic)
+    if stream == config.stream_name:
+        return GateDecision(
+            outcome=Outcome.ALLOW,
+            reason=f"public issue is linked to {config.stream_name} epic #{config.public_epic}",
+        )
+    if stream is not None:
+        return GateDecision(
+            outcome=Outcome.ROUTE,
+            reason=f"public issue belongs to {stream} through epic #{membership_epic}",
+            destination=_destination_for_stream(stream, destinations),
+        )
+    return GateDecision(
+        outcome=Outcome.ROUTE,
+        reason="public issue has no exact stream membership",
+        destination="stream triage (link the issue to exactly one stream epic)",
+    )
+
+
+def _gate_private_issue(
+    issue: IssueRef,
+    observation: IssueObservation,
+    *,
+    config: ScopeGateConfig,
+    destinations: Mapping[str, int],
+) -> GateDecision:
+    streams = _stream_from_private_tags(issue, observation, config=config, destinations=destinations)
+    if len(streams) > 1:
+        return GateDecision(
+            outcome=Outcome.HOLD,
+            reason="private issue has conflicting explicit stream membership",
+        )
+    if streams == {config.stream_name}:
+        return GateDecision(
+            outcome=Outcome.ALLOW,
+            reason="private issue is explicitly tracked by the Hramatka board, label, or stream tag",
+        )
+    if streams:
+        stream = next(iter(streams))
+        return GateDecision(
+            outcome=Outcome.ROUTE,
+            reason=f"private issue is explicitly tagged for {stream}",
+            destination=_destination_for_stream(stream, destinations),
+        )
+    return _route_unassigned_private(config)
+
+
+def evaluate_scope(
+    *,
+    action: str,
+    issue: IssueRef,
+    observation: IssueObservation | None,
+    stream_registry: Mapping[str, Sequence[int]],
+    config: ScopeGateConfig = HRAMATKA_SCOPE_GATE,
+) -> GateDecision:
+    """Classify one already-observed issue without a network call.
+
+    ``observation=None`` represents an unavailable authority, not a negative
+    lookup. New work therefore holds rather than slipping through as ALLOW.
+    """
+
+    if action not in ALL_ACTIONS:
+        raise ValueError(f"unsupported action: {action}")
+    if issue.repository not in {config.public_repository, config.private_repository}:
+        raise ValueError("issue repository is not configured for the Hramatka scope gate")
+    if action in EXEMPT_ACTIONS:
+        return GateDecision(
+            outcome=Outcome.ALLOW,
+            reason=f"{action} does not create new Hramatka scope",
+        )
+    if issue in config.operator_only_issues:
+        return GateDecision(
+            outcome=Outcome.ESCALATE,
+            reason=f"{issue.display()} is operator-only host mutation work and needs verified operator GO",
+        )
+    if issue.repository == config.public_repository and issue.number == config.public_epic:
+        return GateDecision(
+            outcome=Outcome.ALLOW,
+            reason=f"public issue is the configured Hramatka epic #{config.public_epic}",
+        )
+    if observation is None:
+        repository_kind = "private" if issue.repository == config.private_repository else "public"
+        return GateDecision(
+            outcome=Outcome.HOLD,
+            reason=f"{repository_kind} issue authority is UNKNOWN; new Hramatka work is fail-closed",
+        )
+
+    destinations = _stream_destinations(stream_registry)
+    if config.stream_name not in destinations or config.public_epic not in stream_registry[config.stream_name]:
+        raise ValueError("stream registry does not match the configured Hramatka epic")
+    if issue.repository == config.public_repository:
+        return _gate_public_issue(
+            issue,
+            observation,
+            config=config,
+            destinations=destinations,
+            epic_streams=_epic_to_stream(stream_registry),
+        )
+    return _gate_private_issue(issue, observation, config=config, destinations=destinations)
+
+
+def decide_scope(
+    *,
+    action: str,
+    issue: IssueRef,
+    stream_registry: Mapping[str, Sequence[int]],
+    reader: IssueReader = _gh_issue_observation,
+    config: ScopeGateConfig = HRAMATKA_SCOPE_GATE,
+) -> GateDecision:
+    """Read authority only when the action needs a new-scope decision."""
+
+    if action not in ALL_ACTIONS:
+        raise ValueError(f"unsupported action: {action}")
+    if issue.repository not in {config.public_repository, config.private_repository}:
+        raise ValueError("issue repository is not configured for the Hramatka scope gate")
+    if action in EXEMPT_ACTIONS or issue in config.operator_only_issues:
+        return evaluate_scope(
+            action=action,
+            issue=issue,
+            observation=None,
+            stream_registry=stream_registry,
+            config=config,
+        )
+    if issue.repository == config.public_repository and issue.number == config.public_epic:
+        return evaluate_scope(
+            action=action,
+            issue=issue,
+            observation=None,
+            stream_registry=stream_registry,
+            config=config,
+        )
+    try:
+        observation = reader(issue)
+    except IssueLookupUnavailable:
+        observation = None
+    return evaluate_scope(
+        action=action,
+        issue=issue,
+        observation=observation,
+        stream_registry=stream_registry,
+        config=config,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--action", required=True, choices=sorted(ALL_ACTIONS))
+    parser.add_argument("--issue-repo", required=True, help="Qualified owner/name repository")
+    parser.add_argument("--issue", required=True, type=int, help="Positive issue number in --issue-repo")
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    reader: IssueReader = _gh_issue_observation,
+    stream_registry: Mapping[str, Sequence[int]] | None = None,
+    config: ScopeGateConfig = HRAMATKA_SCOPE_GATE,
+) -> int:
+    """Run the CLI, returning 0 only for a permitted new-scope decision."""
+
+    args = _parser().parse_args(argv)
+    try:
+        issue = IssueRef(args.issue_repo, args.issue)
+        registry = stream_registry if stream_registry is not None else load_stream_registry()
+        decision = decide_scope(
+            action=args.action,
+            issue=issue,
+            stream_registry=registry,
+            reader=reader,
+            config=config,
+        )
+    except (OSError, ValueError) as exc:
+        _parser().error(str(exc))
+        return 2  # pragma: no cover - argparse always raises SystemExit
+    print(json.dumps(decision.as_json(), ensure_ascii=False, sort_keys=True))
+    return 0 if decision.outcome is Outcome.ALLOW else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through main()
+    raise SystemExit(main())

--- a/tests/test_hramatka_scope_gate.py
+++ b/tests/test_hramatka_scope_gate.py
@@ -1,0 +1,343 @@
+"""Hermetic policy tests for the Hramatka new-scope gate."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from scripts.fleet import hramatka_scope_gate as gate
+
+PUBLIC = gate.PUBLIC_REPOSITORY
+PRIVATE = gate.PRIVATE_REPOSITORY
+REGISTRY = {
+    "hramatka": [4542],
+    "infra-harness": [4707],
+    "devops": [5703],
+}
+
+
+def _issue(repository: str, number: int) -> gate.IssueRef:
+    return gate.IssueRef(repository, number)
+
+
+def _observation(
+    *,
+    labels: set[str] | None = None,
+    body: str = "",
+    parent_number: int | None = None,
+) -> gate.IssueObservation:
+    return gate.IssueObservation(
+        labels=frozenset(labels or set()),
+        body=body,
+        parent_number=parent_number,
+    )
+
+
+def _reader(observation: gate.IssueObservation) -> gate.IssueReader:
+    return lambda _issue_ref: observation
+
+
+def _unavailable(_issue_ref: gate.IssueRef) -> gate.IssueObservation:
+    raise gate.IssueLookupUnavailable("fixture unavailable")
+
+
+def test_constants_pin_the_approved_hramatka_scope() -> None:
+    config = gate.HRAMATKA_SCOPE_GATE
+
+    assert config.stream_name == "hramatka"
+    assert config.public_epic == 4542
+    assert config.private_board == _issue(PRIVATE, 349)
+    assert config.operator_only_issues == {_issue(PRIVATE, 360), _issue(PRIVATE, 212)}
+
+
+def test_configured_public_epic_allows_without_api_lookup() -> None:
+    def must_not_run(_issue_ref: gate.IssueRef) -> gate.IssueObservation:
+        pytest.fail("the configured public epic is already exact membership")
+
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PUBLIC, 4542),
+        stream_registry=REGISTRY,
+        reader=must_not_run,
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+    assert decision.destination is None
+
+
+def test_public_native_child_of_hramatka_epic_allows() -> None:
+    decision = gate.decide_scope(
+        action="new_scope",
+        issue=_issue(PUBLIC, 6001),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation(parent_number=4542)),
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+
+
+def test_secondary_configured_hramatka_epic_is_still_exact_membership() -> None:
+    registry = {**REGISTRY, "hramatka": [4542, 6999]}
+
+    decision = gate.decide_scope(
+        action="new_scope",
+        issue=_issue(PUBLIC, 6005),
+        stream_registry=registry,
+        reader=_reader(_observation(parent_number=6999)),
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+
+
+def test_public_other_stream_routes_to_named_epic() -> None:
+    decision = gate.decide_scope(
+        action="new_pr",
+        issue=_issue(PUBLIC, 6002),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation(parent_number=4707)),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+    assert decision.destination == "infra-harness epic #4707"
+
+
+def test_primary_membership_beats_a_hramatka_word_mention() -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PUBLIC, 6003),
+        stream_registry=REGISTRY,
+        reader=_reader(
+            _observation(
+                labels={"hramatka"},
+                body="Hramatka is mentioned here.",
+                parent_number=4707,
+            )
+        ),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+    assert decision.destination == "infra-harness epic #4707"
+
+
+def test_unassigned_public_issue_routes_to_stream_triage() -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PUBLIC, 6004),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation()),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+    assert decision.destination == "stream triage (link the issue to exactly one stream epic)"
+
+
+@pytest.mark.parametrize(
+    "observation",
+    [
+        _observation(labels={"hramatka"}),
+        _observation(labels={"stream:hramatka"}),
+        _observation(body="<!-- stream:hramatka -->"),
+        _observation(parent_number=349),
+    ],
+)
+def test_explicit_private_hramatka_tracking_allows(observation: gate.IssueObservation) -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PRIVATE, 6101),
+        stream_registry=REGISTRY,
+        reader=_reader(observation),
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+
+
+def test_private_board_itself_is_explicit_hramatka_tracking() -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PRIVATE, 349),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation()),
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+
+
+def test_private_other_stream_tag_routes_to_named_destination() -> None:
+    decision = gate.decide_scope(
+        action="new_scope",
+        issue=_issue(PRIVATE, 6102),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation(body="stream: infra-harness")),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+    assert decision.destination == "infra-harness epic #4707"
+
+
+def test_untagged_private_issue_routes_to_private_board_triage() -> None:
+    decision = gate.decide_scope(
+        action="new_pr",
+        issue=_issue(PRIVATE, 6103),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation()),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+    assert decision.destination == "private Hramatka board #349 triage"
+
+
+def test_conflicting_private_stream_tags_hold() -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PRIVATE, 6104),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation(labels={"hramatka", "stream:infra-harness"})),
+    )
+
+    assert decision.outcome is gate.Outcome.HOLD
+
+
+@pytest.mark.parametrize("action", sorted(gate.GATED_ACTIONS))
+def test_private_api_unavailable_holds_every_new_scope_action(action: str) -> None:
+    decision = gate.decide_scope(
+        action=action,
+        issue=_issue(PRIVATE, 349),
+        stream_registry=REGISTRY,
+        reader=_unavailable,
+    )
+
+    assert decision.outcome is gate.Outcome.HOLD
+    assert "UNKNOWN" in decision.reason
+
+
+@pytest.mark.parametrize("number", [360, 212])
+def test_operator_only_private_host_mutation_escalates_without_lookup(number: int) -> None:
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PRIVATE, number),
+        stream_registry=REGISTRY,
+        reader=_unavailable,
+    )
+
+    assert decision.outcome is gate.Outcome.ESCALATE
+    assert "operator-only" in decision.reason
+
+
+@pytest.mark.parametrize("action", sorted(gate.EXEMPT_ACTIONS))
+def test_non_scope_actions_are_exempt_without_api_lookup(action: str) -> None:
+    decision = gate.decide_scope(
+        action=action,
+        issue=_issue(PRIVATE, 6106),
+        stream_registry=REGISTRY,
+        reader=_unavailable,
+    )
+
+    assert decision.outcome is gate.Outcome.ALLOW
+
+
+def test_environment_variable_cannot_bypass_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALLOW_HRAMATKA_SCOPE_GATE", "1")
+
+    decision = gate.decide_scope(
+        action="new_dispatch",
+        issue=_issue(PUBLIC, 6107),
+        stream_registry=REGISTRY,
+        reader=_reader(_observation(parent_number=4707)),
+    )
+
+    assert decision.outcome is gate.Outcome.ROUTE
+
+
+def test_issue_refs_reject_unqualified_or_nonpositive_identifiers() -> None:
+    with pytest.raises(ValueError, match="qualified"):
+        gate.IssueRef("4542", 4542)
+    with pytest.raises(ValueError, match="positive"):
+        gate.IssueRef(PUBLIC, 0)
+
+
+def test_gh_reader_uses_the_repo_qualified_graphql_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "number": 349,
+                                "body": "<!-- stream:hramatka -->",
+                                "labels": {"nodes": [{"name": "hramatka"}]},
+                                "parent": None,
+                            }
+                        }
+                    }
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(gate.subprocess, "run", fake_run)
+
+    observation = gate._gh_issue_observation(_issue(PRIVATE, 349))
+
+    assert observation == _observation(labels={"hramatka"}, body="<!-- stream:hramatka -->")
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command[:3] == ["gh", "api", "graphql"]
+    assert f"owner={PRIVATE.split('/', 1)[0]}" in command
+    assert f"name={PRIVATE.split('/', 1)[1]}" in command
+    assert "number=349" in command
+    assert kwargs["cwd"] == gate.REPO_ROOT
+
+
+def test_gh_reader_hides_private_api_errors_and_treats_malformed_output_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def nonzero_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="private issue title: sensitive")
+
+    monkeypatch.setattr(gate.subprocess, "run", nonzero_run)
+    with pytest.raises(gate.IssueLookupUnavailable) as nonzero_error:
+        gate._gh_issue_observation(_issue(PRIVATE, 349))
+    assert "sensitive" not in str(nonzero_error.value)
+
+    def malformed_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="not json", stderr="")
+
+    monkeypatch.setattr(gate.subprocess, "run", malformed_run)
+    with pytest.raises(gate.IssueLookupUnavailable):
+        gate._gh_issue_observation(_issue(PRIVATE, 349))
+
+
+def test_cli_emits_only_json_and_nonzero_for_a_route(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = gate.main(
+        ["--action", "new_dispatch", "--issue-repo", PUBLIC, "--issue", "6108"],
+        reader=_reader(_observation(parent_number=4707)),
+        stream_registry=REGISTRY,
+    )
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "destination": "infra-harness epic #4707",
+        "outcome": "ROUTE",
+        "reason": "public issue belongs to infra-harness through epic #4707",
+    }
+
+
+def test_cli_allows_configured_epic_and_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = gate.main(
+        ["--action", "new_dispatch", "--issue-repo", PUBLIC, "--issue", "4542"],
+        reader=_unavailable,
+        stream_registry=REGISTRY,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "ALLOW"
+    assert "destination" not in payload


### PR DESCRIPTION
## Summary

- Add a Hramatka-only scope gate for new dispatches, scopes, and PRs.
- Return ALLOW, ROUTE, HOLD, or ESCALATE from exact public membership/private explicit tracking; route named destinations and fail closed on unknown private authority.
- Document the gate and point drive-epic §0c to it. No reaper or hygiene check is included.

## Validation

- `.venv/bin/python -m pytest tests/test_hramatka_scope_gate.py tests/test_issue_stream_audit.py -q` (73 passed)
- `.venv/bin/ruff check scripts/fleet/hramatka_scope_gate.py tests/test_hramatka_scope_gate.py`
- Runbook Markdown lint, skill metadata lint, OPSEC diff scan, and CLI smoke all passed.

## Sparse checkout note

`npm run agents:deploy` could not reach sync because this dispatch worktree omits the required `curriculum/` tree; it stops at the existing prompt-lint active-track check. No generated deployed copies were edited manually.

No merge requested.