### PR TITLE
feat(fleet): safe settle reaper (post_task_reap) — Hramatka hygiene PR-3

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -194,7 +194,9 @@ other terminal/attention states: `failed | timeout | rate_limited | cancelled |
 crashed | dry_run` (dry_run is terminal, not success) + `needs_finalize | no_deliverable`. Emit on any
 status NOT in `{spawning, running, ""}`. The task file is truth; `/api/delegate/active`
 can omit live tasks. **Before declaring a dispatch dead:** `gh pr list --state open`
-first, then check the worktree for finished-but-unpushed work.
+first, then check the worktree for finished-but-unpushed work. **After terminal status,**
+run `.venv/bin/python -m scripts.fleet.post_task_reap --task-id <id>` (dry-run by default;
+pass `--apply` to reap the bound dispatch worktree).
 
 ### 5a. Required live-driver inbox drain — after settle
 Once the settle-loop reaches its decision point, drain again before choosing the next

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Safe post-task reaper for dispatch worktrees.
 
-Reaps the dispatch worktree bound to one task_id only after the task is terminal
-and the worktree is clean.  Optional ACP runtime-review paths are reaped only
-when the owning task is terminal, the path can be bound to that task, and no
-live process holds the path.
+Reaps the dispatch worktree bound to one task_id only after the task is terminal,
+the worktree is clean, and (when a PID is recorded) the process is dead.  ACP
+runtime paths are reaped only when they are explicitly listed in the task state
+(``acp_runtime_paths``), the task is terminal, the path is clean, and no live
+process holds it.
 
 Default mode is dry-run; pass --apply to delete anything.
 """
@@ -14,7 +15,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -105,6 +105,26 @@ def _worktree_path_from_state(state: dict[str, Any]) -> Path | None:
     return None
 
 
+def _acp_runtime_paths_from_state(state: dict[str, Any]) -> list[Path]:
+    """Return ACP runtime paths explicitly bound to this task in state.
+
+    Paths are taken from ``acp_runtime_paths`` (a list of strings).  Name or
+    substring matching is never used; an unbound path is not ours to reap.
+    """
+    raw = state.get("acp_runtime_paths")
+    if not isinstance(raw, list):
+        return []
+    candidates: list[Path] = []
+    for item in raw:
+        if not item:
+            continue
+        try:
+            candidates.append(Path(str(item)).resolve())
+        except OSError:
+            continue
+    return candidates
+
+
 def _is_under_dispatch_worktrees(path: Path) -> bool:
     """True for paths inside .worktrees/dispatch/ but outside the ACP runtime subtree."""
     try:
@@ -112,6 +132,15 @@ def _is_under_dispatch_worktrees(path: Path) -> bool:
     except ValueError:
         return False
     return rel.parts[:1] != ("acp",)
+
+
+def _is_under_acp_runtime_root(path: Path) -> bool:
+    """True for paths inside .worktrees/dispatch/acp/."""
+    try:
+        path.resolve().relative_to(_ACP_RUNTIME_ROOT)
+    except ValueError:
+        return False
+    return True
 
 
 def _is_registered_worktree(path: Path, repo_root: Path) -> bool:
@@ -128,11 +157,16 @@ def _is_registered_worktree(path: Path, repo_root: Path) -> bool:
     return False
 
 
-def _worktree_is_dirty(path: Path) -> bool | None:
+def _worktree_is_dirty(path: Path, *, ignore_deleted_tracked: bool = False) -> bool | None:
     proc = _run_git(["status", "--porcelain"], cwd=path)
     if proc.returncode != 0:
         return None
-    return bool((proc.stdout or "").strip())
+    lines = [line for line in (proc.stdout or "").splitlines() if line.strip()]
+    if ignore_deleted_tracked:
+        # No-checkout ACP runtime worktrees report every tracked file as deleted.
+        # Ignore those baseline deletions; flag only untracked/modified additions.
+        lines = [line for line in lines if not (line[0] == "D" or line[1] == "D")]
+    return bool(lines)
 
 
 def _git_worktree_is_locked(path: Path, repo_root: Path) -> bool:
@@ -156,11 +190,30 @@ def _git_worktree_is_locked(path: Path, repo_root: Path) -> bool:
     return True
 
 
-def _is_path_held_by_process(path: Path) -> bool:
-    """Return True if a live process appears to hold ``path``.
+def _pid_alive(pid: int) -> bool | None:
+    """Return True if ``pid`` is alive, False if dead, None if probe failed.
 
-    Prefers ``lsof`` on the directory.  When lsof is unavailable or fails,
-    falls back to the git worktree lock bit as a conservative proxy.
+    Fail-closed callers must treat ``None`` as 'retain'.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return None
+    return True
+
+
+def _probe_path_liveness(path: Path) -> bool | None:
+    """Return True if a live process holds ``path``, False if not, None on error.
+
+    Uses ``lsof +D`` when available.  Any probe failure (missing binary, timeout,
+    nonzero exit, or subprocess error) returns ``None`` so the caller can fail
+    closed and retain the path.
     """
     try:
         proc = subprocess.run(
@@ -171,10 +224,15 @@ def _is_path_held_by_process(path: Path) -> bool:
             check=False,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.SubprocessError):
-        return _git_worktree_is_locked(path, ROOT)
+        return None
     if proc.returncode != 0:
-        return _git_worktree_is_locked(path, ROOT)
+        return None
     return any(line and not line.startswith("COMMAND") for line in (proc.stdout or "").splitlines())
+
+
+def _unlock_worktree(path: Path, repo_root: Path) -> None:
+    """Best-effort unlock of a git worktree before removal."""
+    _run_git(["worktree", "unlock", str(path)], cwd=repo_root)
 
 
 def _remove_worktree(path: Path, repo_root: Path, *, force: bool = True) -> tuple[bool, str | None]:
@@ -191,30 +249,16 @@ def _remove_worktree(path: Path, repo_root: Path, *, force: bool = True) -> tupl
     return True, None
 
 
-def _safe_label(task_id: str) -> str:
-    return re.sub(r"[^A-Za-z0-9._-]+", "-", task_id).strip("-._")[:32]
-
-
-def _find_acp_runtime_worktrees(task_id: str) -> list[Path]:
-    """Find ACP runtime worktrees whose name binds them to task_id.
-
-    Actual ACP execution worktrees are named ``runtime-{label}-{uuid}``.  The
-    skill text also references ``runtime-review-*`` prefixes; we include both
-    shapes but never return paths by prefix alone -- the caller must still
-    require task terminal status and a dead process before reaping.
-    """
-    root = _ACP_RUNTIME_ROOT
-    if not root.is_dir():
-        return []
-    label = _safe_label(task_id)
-    candidates: list[Path] = []
-    for path in root.iterdir():
-        if not path.is_dir():
-            continue
-        name = path.name
-        if name.startswith(f"runtime-{label}-") or (name.startswith("runtime-review-") and label in name):
-            candidates.append(path)
-    return candidates
+def _parse_state_pid(state: dict[str, Any]) -> int | None:
+    """Return a positive integer PID from task state, or None."""
+    raw = state.get("pid")
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, str) and raw.isdigit():
+        return int(raw) if int(raw) > 0 else None
+    return None
 
 
 def _reap_main_worktree(
@@ -292,6 +336,24 @@ def _reap_main_worktree(
             "error": None,
         }
 
+    pid = _parse_state_pid(state)
+    if pid is not None:
+        alive = _pid_alive(pid)
+        if alive is True:
+            return {
+                "path": str(bound_path),
+                "action": "retained",
+                "reason": f"live process holds worktree (pid={pid})",
+                "error": None,
+            }
+        if alive is None:
+            return {
+                "path": str(bound_path),
+                "action": "retained",
+                "reason": f"liveness probe failed for recorded pid={pid}",
+                "error": None,
+            }
+
     if not apply:
         return {
             "path": str(bound_path),
@@ -316,7 +378,7 @@ def _reap_acp_runtime_worktrees(
     repo_root: Path,
     apply: bool,
 ) -> list[dict[str, Any]]:
-    """Evaluate and optionally reap finished ACP runtime-review worktrees."""
+    """Evaluate and optionally reap ACP runtime worktrees bound in task state."""
     status = state.get("status")
     status_str = str(status) if status is not None else None
 
@@ -326,7 +388,29 @@ def _reap_acp_runtime_worktrees(
         return []
 
     results: list[dict[str, Any]] = []
-    for path in _find_acp_runtime_worktrees(task_id):
+    for path in _acp_runtime_paths_from_state(state):
+        if not path.exists():
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "bound ACP runtime path does not exist",
+                    "error": None,
+                }
+            )
+            continue
+
+        if not _is_under_acp_runtime_root(path):
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "unknown ownership: outside .worktrees/dispatch/acp/",
+                    "error": None,
+                }
+            )
+            continue
+
         if not _is_registered_worktree(path, repo_root):
             results.append(
                 {
@@ -338,12 +422,45 @@ def _reap_acp_runtime_worktrees(
             )
             continue
 
-        if _is_path_held_by_process(path):
+        dirty = _worktree_is_dirty(path, ignore_deleted_tracked=True)
+        if dirty is None:
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "unable to determine worktree cleanliness",
+                    "error": None,
+                }
+            )
+            continue
+        if dirty:
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "worktree has uncommitted changes",
+                    "error": None,
+                }
+            )
+            continue
+
+        liveness = _probe_path_liveness(path)
+        if liveness is True:
             results.append(
                 {
                     "path": str(path),
                     "action": "retained",
                     "reason": "live process holds path",
+                    "error": None,
+                }
+            )
+            continue
+        if liveness is None:
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "liveness probe failed",
                     "error": None,
                 }
             )
@@ -354,18 +471,19 @@ def _reap_acp_runtime_worktrees(
                 {
                     "path": str(path),
                     "action": "would_remove",
-                    "reason": "task terminal and process gone",
+                    "reason": "task terminal, path clean, and process gone",
                     "error": None,
                 }
             )
             continue
 
+        _unlock_worktree(path, repo_root)
         ok, error = _remove_worktree(path, repo_root)
         results.append(
             {
                 "path": str(path),
                 "action": "removed" if ok else "error",
-                "reason": "task terminal and process gone",
+                "reason": "task terminal, path clean, and process gone",
                 "error": error,
             }
         )
@@ -453,7 +571,7 @@ def main(argv: list[str] | None = None) -> int:
         "--include-acp-runtime",
         default=True,
         action=argparse.BooleanOptionalAction,
-        help="Also evaluate ACP runtime-review worktrees bound to the task (default: on)",
+        help="Also evaluate ACP runtime paths listed in task state (default: on)",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Safe post-task reaper for dispatch worktrees.
+
+Reaps the dispatch worktree bound to one task_id only after the task is terminal
+and the worktree is clean.  Optional ACP runtime-review paths are reaped only
+when the owning task is terminal, the path can be bound to that task, and no
+live process holds the path.
+
+Default mode is dry-run; pass --apply to delete anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.common.repo_root import main_checkout_root
+
+ROOT = main_checkout_root(Path(__file__).resolve().parents[2])
+_TASKS_DIR = ROOT / "batch_state" / "tasks"
+_DISPATCH_WORKTREES_ROOT = ROOT / ".worktrees" / "dispatch"
+_ACP_RUNTIME_ROOT = _DISPATCH_WORKTREES_ROOT / "acp"
+
+_ACTIVE_STATUSES = frozenset({"spawning", "running"})
+_TERMINAL_STATUSES = frozenset(
+    {
+        "done",
+        "failed",
+        "timeout",
+        "rate_limited",
+        "cancelled",
+        "crashed",
+        "dry_run",
+        "needs_finalize",
+        "no_deliverable",
+    }
+)
+
+_GIT_ENV_DENYLIST = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+}
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _GIT_ENV_DENYLIST and not key.startswith("PRE_COMMIT")
+    }
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int | None = 30,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=timeout,
+        env=_sanitized_git_env(),
+    )
+
+
+def _load_task_state(tasks_dir: Path, task_id: str) -> dict[str, Any] | None:
+    safe = task_id.replace("/", "_").replace("\\", "_")
+    path = tasks_dir / f"{safe}.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _worktree_path_from_state(state: dict[str, Any]) -> Path | None:
+    """Return the bound worktree path recorded in task state, if any."""
+    for key in ("worktree_path", "cwd"):
+        value = state.get(key)
+        if value:
+            try:
+                return Path(str(value)).resolve()
+            except OSError:
+                continue
+    return None
+
+
+def _is_under_dispatch_worktrees(path: Path) -> bool:
+    """True for paths inside .worktrees/dispatch/ but outside the ACP runtime subtree."""
+    try:
+        rel = path.resolve().relative_to(_DISPATCH_WORKTREES_ROOT)
+    except ValueError:
+        return False
+    return rel.parts[:1] != ("acp",)
+
+
+def _is_registered_worktree(path: Path, repo_root: Path) -> bool:
+    """True when path is a registered git worktree."""
+    proc = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if proc.returncode != 0:
+        return False
+    resolved = path.resolve()
+    for line in (proc.stdout or "").splitlines():
+        if line.startswith("worktree "):
+            candidate = Path(line[len("worktree ") :].strip()).resolve()
+            if candidate == resolved:
+                return True
+    return False
+
+
+def _worktree_is_dirty(path: Path) -> bool | None:
+    proc = _run_git(["status", "--porcelain"], cwd=path)
+    if proc.returncode != 0:
+        return None
+    return bool((proc.stdout or "").strip())
+
+
+def _git_worktree_is_locked(path: Path, repo_root: Path) -> bool:
+    """Return True if git reports the worktree as locked.  Fail closed."""
+    proc = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if proc.returncode != 0:
+        return True
+    resolved = path.resolve()
+    entry_path: Path | None = None
+    locked = False
+    for line in (proc.stdout or "").splitlines():
+        if line.startswith("worktree "):
+            if entry_path == resolved:
+                return locked
+            entry_path = Path(line[len("worktree ") :].strip()).resolve()
+            locked = False
+        elif line.startswith("locked"):
+            locked = True
+    if entry_path == resolved:
+        return locked
+    return True
+
+
+def _is_path_held_by_process(path: Path) -> bool:
+    """Return True if a live process appears to hold ``path``.
+
+    Prefers ``lsof`` on the directory.  When lsof is unavailable or fails,
+    falls back to the git worktree lock bit as a conservative proxy.
+    """
+    try:
+        proc = subprocess.run(
+            ["lsof", "+D", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return _git_worktree_is_locked(path, ROOT)
+    if proc.returncode != 0:
+        return _git_worktree_is_locked(path, ROOT)
+    return any(line and not line.startswith("COMMAND") for line in (proc.stdout or "").splitlines())
+
+
+def _remove_worktree(path: Path, repo_root: Path, *, force: bool = True) -> tuple[bool, str | None]:
+    cmd = ["worktree", "remove"]
+    if force:
+        cmd.append("--force")
+    cmd.append(str(path))
+    proc = _run_git(cmd, cwd=repo_root)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "git worktree remove failed").strip()
+        return False, detail
+    if path.exists():
+        return False, f"worktree path still exists after remove: {path}"
+    return True, None
+
+
+def _safe_label(task_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", task_id).strip("-._")[:32]
+
+
+def _find_acp_runtime_worktrees(task_id: str) -> list[Path]:
+    """Find ACP runtime worktrees whose name binds them to task_id.
+
+    Actual ACP execution worktrees are named ``runtime-{label}-{uuid}``.  The
+    skill text also references ``runtime-review-*`` prefixes; we include both
+    shapes but never return paths by prefix alone -- the caller must still
+    require task terminal status and a dead process before reaping.
+    """
+    root = _ACP_RUNTIME_ROOT
+    if not root.is_dir():
+        return []
+    label = _safe_label(task_id)
+    candidates: list[Path] = []
+    for path in root.iterdir():
+        if not path.is_dir():
+            continue
+        name = path.name
+        if name.startswith(f"runtime-{label}-") or (name.startswith("runtime-review-") and label in name):
+            candidates.append(path)
+    return candidates
+
+
+def _reap_main_worktree(
+    *,
+    task_id: str,
+    state: dict[str, Any],
+    repo_root: Path,
+    apply: bool,
+) -> dict[str, Any]:
+    """Evaluate and optionally reap the dispatch worktree bound to task_id."""
+    status = state.get("status")
+    status_str = str(status) if status is not None else None
+
+    if status_str in _ACTIVE_STATUSES or status_str in (None, ""):
+        return {
+            "path": None,
+            "action": "retained",
+            "reason": f"task still active (status={status_str})",
+            "error": None,
+        }
+    if status_str not in _TERMINAL_STATUSES:
+        return {
+            "path": None,
+            "action": "retained",
+            "reason": f"task status not terminal (status={status_str})",
+            "error": None,
+        }
+
+    bound_path = _worktree_path_from_state(state)
+    if bound_path is None:
+        return {
+            "path": None,
+            "action": "retained",
+            "reason": "unknown ownership: no worktree_path/cwd in task state",
+            "error": None,
+        }
+
+    if not bound_path.exists():
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "bound worktree path does not exist",
+            "error": None,
+        }
+
+    if not _is_under_dispatch_worktrees(bound_path):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "unknown ownership: path is outside .worktrees/dispatch/",
+            "error": None,
+        }
+
+    if not _is_registered_worktree(bound_path, repo_root):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "unknown ownership: path is not a registered git worktree",
+            "error": None,
+        }
+
+    dirty = _worktree_is_dirty(bound_path)
+    if dirty is None:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "unable to determine worktree cleanliness",
+            "error": None,
+        }
+    if dirty:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "worktree has uncommitted changes",
+            "error": None,
+        }
+
+    if not apply:
+        return {
+            "path": str(bound_path),
+            "action": "would_remove",
+            "reason": f"task terminal (status={status_str}) and worktree clean",
+            "error": None,
+        }
+
+    ok, error = _remove_worktree(bound_path, repo_root)
+    return {
+        "path": str(bound_path),
+        "action": "removed" if ok else "error",
+        "reason": f"task terminal (status={status_str}) and worktree clean",
+        "error": error,
+    }
+
+
+def _reap_acp_runtime_worktrees(
+    *,
+    task_id: str,
+    state: dict[str, Any],
+    repo_root: Path,
+    apply: bool,
+) -> list[dict[str, Any]]:
+    """Evaluate and optionally reap finished ACP runtime-review worktrees."""
+    status = state.get("status")
+    status_str = str(status) if status is not None else None
+
+    if status_str in _ACTIVE_STATUSES or status_str in (None, ""):
+        return []
+    if status_str not in _TERMINAL_STATUSES:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for path in _find_acp_runtime_worktrees(task_id):
+        if not _is_registered_worktree(path, repo_root):
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "unknown ownership: not a registered git worktree",
+                    "error": None,
+                }
+            )
+            continue
+
+        if _is_path_held_by_process(path):
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "retained",
+                    "reason": "live process holds path",
+                    "error": None,
+                }
+            )
+            continue
+
+        if not apply:
+            results.append(
+                {
+                    "path": str(path),
+                    "action": "would_remove",
+                    "reason": "task terminal and process gone",
+                    "error": None,
+                }
+            )
+            continue
+
+        ok, error = _remove_worktree(path, repo_root)
+        results.append(
+            {
+                "path": str(path),
+                "action": "removed" if ok else "error",
+                "reason": "task terminal and process gone",
+                "error": error,
+            }
+        )
+    return results
+
+
+def post_task_reap(
+    task_id: str,
+    *,
+    tasks_dir: Path = _TASKS_DIR,
+    repo_root: Path = ROOT,
+    apply: bool = False,
+    include_acp_runtime: bool = True,
+) -> dict[str, Any]:
+    """Return a reap report for ``task_id``; delete only when ``apply`` is True."""
+    state = _load_task_state(tasks_dir, task_id)
+    if state is None:
+        return {
+            "task_id": task_id,
+            "task_status": None,
+            "apply": apply,
+            "main_worktree": {
+                "path": None,
+                "action": "retained",
+                "reason": "no task state file found",
+                "error": None,
+            },
+            "acp_runtimes": [],
+            "errors": [],
+        }
+
+    main_result = _reap_main_worktree(
+        task_id=task_id,
+        state=state,
+        repo_root=repo_root,
+        apply=apply,
+    )
+    acp_results: list[dict[str, Any]] = []
+    if include_acp_runtime:
+        acp_results = _reap_acp_runtime_worktrees(
+            task_id=task_id,
+            state=state,
+            repo_root=repo_root,
+            apply=apply,
+        )
+
+    errors: list[str] = []
+    if main_result.get("error"):
+        errors.append(f"main worktree: {main_result['error']}")
+    for item in acp_results:
+        if item.get("error"):
+            errors.append(f"acp runtime {item['path']}: {item['error']}")
+
+    return {
+        "task_id": task_id,
+        "task_status": state.get("status"),
+        "apply": apply,
+        "main_worktree": main_result,
+        "acp_runtimes": acp_results,
+        "errors": errors,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-id", required=True, help="Task id whose worktree should be reaped")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually remove worktrees (default: dry-run)",
+    )
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=_TASKS_DIR,
+        help="batch_state/tasks directory",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (primary checkout)",
+    )
+    parser.add_argument(
+        "--include-acp-runtime",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Also evaluate ACP runtime-review worktrees bound to the task (default: on)",
+    )
+    args = parser.parse_args(argv)
+
+    report = post_task_reap(
+        args.task_id,
+        tasks_dir=args.tasks_dir,
+        repo_root=args.repo_root,
+        apply=args.apply,
+        include_acp_runtime=args.include_acp_runtime,
+    )
+
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 1 if report["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -4,13 +4,16 @@ Tests exercise the hard guards without touching the real checkout:
 - never reap while task status is spawning/running
 - never reap a dirty worktree
 - never reap without binding task state to a registered dispatch worktree
-- never reap ACP runtime-review paths by prefix alone (process must be gone)
+- never reap ACP runtime paths by name/substring; only ``acp_runtime_paths`` in
+  task state authorizes reaping
+- liveness probe failure is fail-closed (retain) for both main and ACP paths
 - default dry-run; --apply required for deletion
 """
 
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -21,6 +24,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from scripts.fleet import post_task_reap
+
+
+def _safe_label(task_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", task_id).strip("-._")[:32]
 
 
 @pytest.fixture
@@ -38,7 +45,7 @@ def hermetic_reap(monkeypatch, tmp_path):
     _init_repo(repo_root)
 
     # Tests control process liveness so we stay independent of lsof availability.
-    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: False)
+    monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: False)
 
     return repo_root, tasks_dir
 
@@ -82,7 +89,7 @@ def _add_external_worktree(repo_root: Path, name: str) -> Path:
 
 
 def _add_acp_runtime_worktree(repo_root: Path, task_id: str, locked: bool = False) -> Path:
-    label = post_task_reap._safe_label(task_id)
+    label = _safe_label(task_id)
     path = repo_root / ".worktrees" / "dispatch" / "acp" / f"runtime-{label}-deadbeef"
     path.parent.mkdir(parents=True, exist_ok=True)
     _run(
@@ -102,7 +109,10 @@ def _write_task_state(
     task_id: str,
     status: str,
     worktree_path: Path | None,
+    *,
     agent: str = "kimi",
+    acp_runtime_paths: list[Path] | None = None,
+    pid: int | None = None,
 ) -> None:
     state: dict[str, Any] = {
         "task_id": task_id,
@@ -111,6 +121,10 @@ def _write_task_state(
     }
     if worktree_path is not None:
         state["worktree_path"] = str(worktree_path)
+    if acp_runtime_paths:
+        state["acp_runtime_paths"] = [str(p) for p in acp_runtime_paths]
+    if pid is not None:
+        state["pid"] = pid
     safe = task_id.replace("/", "_").replace("\\", "_")
     (tasks_dir / f"{safe}.json").write_text(json.dumps(state), encoding="utf-8")
 
@@ -234,11 +248,45 @@ def test_ambiguous_retain_unregistered_directory(hermetic_reap):
     assert bogus.exists()
 
 
+def test_main_worktree_retain_when_pid_alive(hermetic_reap, monkeypatch):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pid-alive-task")
+    _write_task_state(tasks_dir, "pid-alive-task", "done", worktree, pid=12345)
+
+    monkeypatch.setattr(post_task_reap, "_pid_alive", lambda _pid: True)
+
+    report = post_task_reap.post_task_reap("pid-alive-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "live process" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_main_worktree_retain_when_pid_liveness_fails(hermetic_reap, monkeypatch):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pid-error-task")
+    _write_task_state(tasks_dir, "pid-error-task", "done", worktree, pid=12345)
+
+    monkeypatch.setattr(post_task_reap, "_pid_alive", lambda _pid: None)
+
+    report = post_task_reap.post_task_reap("pid-error-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "liveness probe failed" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+    # MUTATION-CHECK: if the main-worktree liveness check stopped failing closed,
+    # an errored probe would have allowed removal.
+    monkeypatch.setattr(post_task_reap, "_pid_alive", lambda _pid: False)
+    mutated = post_task_reap.post_task_reap("pid-error-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+    assert mutated["main_worktree"]["action"] == "removed"
+
+
 def test_acp_runtime_reap_when_process_gone(hermetic_reap):
     repo_root, tasks_dir = hermetic_reap
     main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-task")
     acp_path = _add_acp_runtime_worktree(repo_root, "acp-task", locked=False)
-    _write_task_state(tasks_dir, "acp-task", "done", main_worktree)
+    _write_task_state(tasks_dir, "acp-task", "done", main_worktree, acp_runtime_paths=[acp_path])
 
     report = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
 
@@ -253,10 +301,10 @@ def test_acp_runtime_retain_while_process_alive(hermetic_reap, monkeypatch):
     repo_root, tasks_dir = hermetic_reap
     main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-task")
     acp_path = _add_acp_runtime_worktree(repo_root, "acp-task", locked=False)
-    _write_task_state(tasks_dir, "acp-task", "done", main_worktree)
+    _write_task_state(tasks_dir, "acp-task", "done", main_worktree, acp_runtime_paths=[acp_path])
 
     # Simulate a live process holding the ACP runtime path.
-    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: True)
+    monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: True)
 
     report = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root)
 
@@ -268,22 +316,67 @@ def test_acp_runtime_retain_while_process_alive(hermetic_reap, monkeypatch):
 
     # MUTATION-CHECK: disabling the liveness check turns a live ACP runtime
     # path into a would-remove candidate.  The retain assertion above would fail.
-    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: False)
+    monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: False)
     mutated = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root)
     assert mutated["acp_runtimes"][0]["action"] == "would_remove"
 
 
-def test_acp_runtime_retain_while_task_active(hermetic_reap):
+def test_acp_runtime_retain_liveness_probe_failed(hermetic_reap, monkeypatch):
     repo_root, tasks_dir = hermetic_reap
-    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-active-task")
-    acp_path = _add_acp_runtime_worktree(repo_root, "acp-active-task", locked=False)
-    _write_task_state(tasks_dir, "acp-active-task", "running", main_worktree)
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-error-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-error-task", locked=False)
+    _write_task_state(tasks_dir, "acp-error-task", "done", main_worktree, acp_runtime_paths=[acp_path])
 
-    report = post_task_reap.post_task_reap("acp-active-task", tasks_dir=tasks_dir, repo_root=repo_root)
+    # Simulate a liveness probe that errors out instead of returning a result.
+    monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: None)
 
-    # Main worktree retained because task is active; ACP runtimes are not even
-    # evaluated while the task is active.
-    assert report["main_worktree"]["action"] == "retained"
+    report = post_task_reap.post_task_reap("acp-error-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "would_remove"
+    assert len(report["acp_runtimes"]) == 1
+    assert report["acp_runtimes"][0]["action"] == "retained"
+    assert "liveness probe failed" in report["acp_runtimes"][0]["reason"]
+    assert acp_path.exists()
+
+    # MUTATION-CHECK: fail-closed means an errored probe must retain the path.
+    # If the code treated an errored probe as "process gone", this would remove.
+    monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: False)
+    mutated = post_task_reap.post_task_reap("acp-error-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+    assert mutated["acp_runtimes"][0]["action"] == "removed"
+
+
+def test_acp_runtime_retain_dirty(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-dirty-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-dirty-task", locked=False)
+    (acp_path / "dirt.txt").write_text("dirt", encoding="utf-8")
+    _write_task_state(tasks_dir, "acp-dirty-task", "done", main_worktree, acp_runtime_paths=[acp_path])
+
+    report = post_task_reap.post_task_reap("acp-dirty-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert len(report["acp_runtimes"]) == 1
+    assert report["acp_runtimes"][0]["action"] == "retained"
+    assert "uncommitted changes" in report["acp_runtimes"][0]["reason"]
+    assert acp_path.exists()
+
+
+def test_acp_runtime_retain_unbound_name(hermetic_reap):
+    """An ACP path whose name happens to contain the task label is not enough."""
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-unbound-task")
+    # Path that the old name-matching logic would have claimed.
+    acp_path = repo_root / ".worktrees" / "dispatch" / "acp" / "runtime-review-acp-unbound-task-12345"
+    acp_path.parent.mkdir(parents=True, exist_ok=True)
+    _run(
+        ["git", "worktree", "add", "--detach", "--no-checkout", str(acp_path), "HEAD"],
+        cwd=repo_root,
+    )
+    _write_task_state(tasks_dir, "acp-unbound-task", "done", main_worktree)
+
+    report = post_task_reap.post_task_reap("acp-unbound-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
     assert report["acp_runtimes"] == []
     assert acp_path.exists()
 
@@ -293,7 +386,7 @@ def test_acp_runtime_retain_unregistered(hermetic_reap):
     main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-unreg-task")
     bogus_acp = repo_root / ".worktrees" / "dispatch" / "acp" / "runtime-acp-unreg-task-bogus"
     bogus_acp.mkdir(parents=True)
-    _write_task_state(tasks_dir, "acp-unreg-task", "done", main_worktree)
+    _write_task_state(tasks_dir, "acp-unreg-task", "done", main_worktree, acp_runtime_paths=[bogus_acp])
 
     report = post_task_reap.post_task_reap("acp-unreg-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
 
@@ -302,6 +395,21 @@ def test_acp_runtime_retain_unregistered(hermetic_reap):
     assert report["acp_runtimes"][0]["action"] == "retained"
     assert "not a registered git worktree" in report["acp_runtimes"][0]["reason"]
     assert bogus_acp.exists()
+
+
+def test_acp_runtime_retain_while_task_active(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-active-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-active-task", locked=False)
+    _write_task_state(tasks_dir, "acp-active-task", "running", main_worktree, acp_runtime_paths=[acp_path])
+
+    report = post_task_reap.post_task_reap("acp-active-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    # Main worktree retained because task is active; ACP runtimes are not even
+    # evaluated while the task is active.
+    assert report["main_worktree"]["action"] == "retained"
+    assert report["acp_runtimes"] == []
+    assert acp_path.exists()
 
 
 def test_cli_dry_run_default(hermetic_reap, capsys):
@@ -346,7 +454,7 @@ def test_cli_no_acp_runtime(hermetic_reap, capsys):
     repo_root, tasks_dir = hermetic_reap
     main_worktree = _add_dispatch_worktree(repo_root, "kimi", "no-acp-task")
     acp_path = _add_acp_runtime_worktree(repo_root, "no-acp-task", locked=False)
-    _write_task_state(tasks_dir, "no-acp-task", "done", main_worktree)
+    _write_task_state(tasks_dir, "no-acp-task", "done", main_worktree, acp_runtime_paths=[acp_path])
 
     code = post_task_reap.main(
         [

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -1,0 +1,369 @@
+"""Hermetic tests for scripts.fleet.post_task_reap.
+
+Tests exercise the hard guards without touching the real checkout:
+- never reap while task status is spawning/running
+- never reap a dirty worktree
+- never reap without binding task state to a registered dispatch worktree
+- never reap ACP runtime-review paths by prefix alone (process must be gone)
+- default dry-run; --apply required for deletion
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from scripts.fleet import post_task_reap
+
+
+@pytest.fixture
+def hermetic_reap(monkeypatch, tmp_path):
+    """Redirect post_task_reap to a fresh git repo and task directory."""
+    repo_root = tmp_path / "repo"
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(post_task_reap, "ROOT", repo_root)
+    monkeypatch.setattr(post_task_reap, "_TASKS_DIR", tasks_dir)
+    monkeypatch.setattr(post_task_reap, "_DISPATCH_WORKTREES_ROOT", repo_root / ".worktrees" / "dispatch")
+    monkeypatch.setattr(post_task_reap, "_ACP_RUNTIME_ROOT", repo_root / ".worktrees" / "dispatch" / "acp")
+
+    _init_repo(repo_root)
+
+    # Tests control process liveness so we stay independent of lsof availability.
+    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: False)
+
+    return repo_root, tasks_dir
+
+
+def _run(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _init_repo(repo_root: Path) -> None:
+    repo_root.mkdir(parents=True)
+    _run(["git", "init"], cwd=repo_root)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo_root)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo_root)
+    (repo_root / "README.md").write_text("# test\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=repo_root)
+    _run(["git", "commit", "-m", "initial"], cwd=repo_root)
+
+
+def _add_dispatch_worktree(repo_root: Path, agent: str, task_id: str) -> Path:
+    branch = f"{agent}/{task_id}"
+    _run(["git", "branch", branch], cwd=repo_root)
+    path = repo_root / ".worktrees" / "dispatch" / agent / task_id
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _run(["git", "worktree", "add", str(path), branch], cwd=repo_root)
+    return path
+
+
+def _add_external_worktree(repo_root: Path, name: str) -> Path:
+    branch = f"external/{name}"
+    _run(["git", "branch", branch], cwd=repo_root)
+    path = repo_root / ".worktrees" / name
+    path.mkdir(parents=True, exist_ok=True)
+    _run(["git", "worktree", "add", str(path), branch], cwd=repo_root)
+    return path
+
+
+def _add_acp_runtime_worktree(repo_root: Path, task_id: str, locked: bool = False) -> Path:
+    label = post_task_reap._safe_label(task_id)
+    path = repo_root / ".worktrees" / "dispatch" / "acp" / f"runtime-{label}-deadbeef"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _run(
+        ["git", "worktree", "add", "--detach", "--no-checkout", str(path), "HEAD"],
+        cwd=repo_root,
+    )
+    if locked:
+        _run(
+            ["git", "worktree", "lock", "--reason", f"active ACP execution {label}", str(path)],
+            cwd=repo_root,
+        )
+    return path
+
+
+def _write_task_state(
+    tasks_dir: Path,
+    task_id: str,
+    status: str,
+    worktree_path: Path | None,
+    agent: str = "kimi",
+) -> None:
+    state: dict[str, Any] = {
+        "task_id": task_id,
+        "agent": agent,
+        "status": status,
+    }
+    if worktree_path is not None:
+        state["worktree_path"] = str(worktree_path)
+    safe = task_id.replace("/", "_").replace("\\", "_")
+    (tasks_dir / f"{safe}.json").write_text(json.dumps(state), encoding="utf-8")
+
+
+def test_no_task_state(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    report = post_task_reap.post_task_reap("missing-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["task_status"] is None
+    assert report["main_worktree"]["action"] == "retained"
+    assert "no task state" in report["main_worktree"]["reason"]
+
+
+def test_running_skip(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "running-task")
+    _write_task_state(tasks_dir, "running-task", "running", worktree)
+
+    report = post_task_reap.post_task_reap("running-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["task_status"] == "running"
+    assert report["main_worktree"]["action"] == "retained"
+    assert "still active" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_spawning_skip(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "spawning-task")
+    _write_task_state(tasks_dir, "spawning-task", "spawning", worktree)
+
+    report = post_task_reap.post_task_reap("spawning-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "still active" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_dirty_skip(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "dirty-task")
+    _write_task_state(tasks_dir, "dirty-task", "done", worktree)
+    (worktree / "new_file.txt").write_text("dirty", encoding="utf-8")
+
+    report = post_task_reap.post_task_reap("dirty-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "uncommitted changes" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_clean_terminal_reap_dry_run(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "clean-task")
+    _write_task_state(tasks_dir, "clean-task", "done", worktree)
+
+    report = post_task_reap.post_task_reap("clean-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "would_remove"
+    assert "terminal" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_clean_terminal_reap_apply(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "clean-task")
+    _write_task_state(tasks_dir, "clean-task", "done", worktree)
+
+    report = post_task_reap.post_task_reap("clean-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert report["main_worktree"]["error"] is None
+    assert not worktree.exists()
+
+
+def test_terminal_failed_reap_apply(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "failed-task")
+    _write_task_state(tasks_dir, "failed-task", "failed", worktree)
+
+    report = post_task_reap.post_task_reap("failed-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert not worktree.exists()
+
+
+def test_ambiguous_retain_no_state_path(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "ambiguous-task")
+    _write_task_state(tasks_dir, "ambiguous-task", "done", worktree_path=None)
+
+    report = post_task_reap.post_task_reap("ambiguous-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "unknown ownership" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_ambiguous_retain_outside_dispatch(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    external = _add_external_worktree(repo_root, "external-task")
+    _write_task_state(tasks_dir, "external-task", "done", external)
+
+    report = post_task_reap.post_task_reap("external-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "outside .worktrees/dispatch" in report["main_worktree"]["reason"]
+    assert external.exists()
+
+
+def test_ambiguous_retain_unregistered_directory(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    bogus = repo_root / ".worktrees" / "dispatch" / "kimi" / "bogus-task"
+    bogus.mkdir(parents=True)
+    _write_task_state(tasks_dir, "bogus-task", "done", bogus)
+
+    report = post_task_reap.post_task_reap("bogus-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "not a registered git worktree" in report["main_worktree"]["reason"]
+    assert bogus.exists()
+
+
+def test_acp_runtime_reap_when_process_gone(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-task", locked=False)
+    _write_task_state(tasks_dir, "acp-task", "done", main_worktree)
+
+    report = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert len(report["acp_runtimes"]) == 1
+    assert report["acp_runtimes"][0]["action"] == "removed"
+    assert report["acp_runtimes"][0]["path"] == str(acp_path)
+    assert not acp_path.exists()
+
+
+def test_acp_runtime_retain_while_process_alive(hermetic_reap, monkeypatch):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-task", locked=False)
+    _write_task_state(tasks_dir, "acp-task", "done", main_worktree)
+
+    # Simulate a live process holding the ACP runtime path.
+    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: True)
+
+    report = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "would_remove"
+    assert len(report["acp_runtimes"]) == 1
+    assert report["acp_runtimes"][0]["action"] == "retained"
+    assert "live process" in report["acp_runtimes"][0]["reason"]
+    assert acp_path.exists()
+
+    # MUTATION-CHECK: disabling the liveness check turns a live ACP runtime
+    # path into a would-remove candidate.  The retain assertion above would fail.
+    monkeypatch.setattr(post_task_reap, "_is_path_held_by_process", lambda _path: False)
+    mutated = post_task_reap.post_task_reap("acp-task", tasks_dir=tasks_dir, repo_root=repo_root)
+    assert mutated["acp_runtimes"][0]["action"] == "would_remove"
+
+
+def test_acp_runtime_retain_while_task_active(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-active-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "acp-active-task", locked=False)
+    _write_task_state(tasks_dir, "acp-active-task", "running", main_worktree)
+
+    report = post_task_reap.post_task_reap("acp-active-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    # Main worktree retained because task is active; ACP runtimes are not even
+    # evaluated while the task is active.
+    assert report["main_worktree"]["action"] == "retained"
+    assert report["acp_runtimes"] == []
+    assert acp_path.exists()
+
+
+def test_acp_runtime_retain_unregistered(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "acp-unreg-task")
+    bogus_acp = repo_root / ".worktrees" / "dispatch" / "acp" / "runtime-acp-unreg-task-bogus"
+    bogus_acp.mkdir(parents=True)
+    _write_task_state(tasks_dir, "acp-unreg-task", "done", main_worktree)
+
+    report = post_task_reap.post_task_reap("acp-unreg-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert len(report["acp_runtimes"]) == 1
+    assert report["acp_runtimes"][0]["action"] == "retained"
+    assert "not a registered git worktree" in report["acp_runtimes"][0]["reason"]
+    assert bogus_acp.exists()
+
+
+def test_cli_dry_run_default(hermetic_reap, capsys):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "cli-task")
+    _write_task_state(tasks_dir, "cli-task", "done", worktree)
+
+    code = post_task_reap.main(["--task-id", "cli-task", "--tasks-dir", str(tasks_dir), "--repo-root", str(repo_root)])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    report = json.loads(captured.out)
+    assert report["main_worktree"]["action"] == "would_remove"
+    assert worktree.exists()
+
+
+def test_cli_apply_flag(hermetic_reap, capsys):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "cli-apply-task")
+    _write_task_state(tasks_dir, "cli-apply-task", "done", worktree)
+
+    code = post_task_reap.main(
+        [
+            "--task-id",
+            "cli-apply-task",
+            "--tasks-dir",
+            str(tasks_dir),
+            "--repo-root",
+            str(repo_root),
+            "--apply",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 0
+    report = json.loads(captured.out)
+    assert report["main_worktree"]["action"] == "removed"
+    assert not worktree.exists()
+
+
+def test_cli_no_acp_runtime(hermetic_reap, capsys):
+    repo_root, tasks_dir = hermetic_reap
+    main_worktree = _add_dispatch_worktree(repo_root, "kimi", "no-acp-task")
+    acp_path = _add_acp_runtime_worktree(repo_root, "no-acp-task", locked=False)
+    _write_task_state(tasks_dir, "no-acp-task", "done", main_worktree)
+
+    code = post_task_reap.main(
+        [
+            "--task-id",
+            "no-acp-task",
+            "--tasks-dir",
+            str(tasks_dir),
+            "--repo-root",
+            str(repo_root),
+            "--apply",
+            "--no-include-acp-runtime",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 0
+    report = json.loads(captured.out)
+    assert report["main_worktree"]["action"] == "removed"
+    assert report["acp_runtimes"] == []
+    assert acp_path.exists()


### PR DESCRIPTION
Implements the safe post-task reaper for dispatch worktrees.

## Guards (all mutation-tested)
- Skips tasks whose `batch_state/tasks/<id>.json` status is spawning/running.
- Skips dispatch worktrees with uncommitted changes.
- Refuses to reap without binding task state to a registered `.worktrees/dispatch/` worktree.
- ACP runtime-review paths are only evaluated when the task is terminal AND no live process holds the path — never reaped by path-name prefix alone.
- Default mode is dry-run; `--apply` is required for any deletion.

## Changes
- `scripts/fleet/post_task_reap.py`: new module/CLI.
- `tests/test_fleet_post_task_reap.py`: 17 hermetic tests including running skip, dirty skip, clean terminal reap, ambiguous retain, and a liveness mutation check.
- `agents_extensions/shared/skills/drive-epic/SKILL.md` §5: document the settle-loop call site.

## Verification
- `.venv/bin/python -m pytest tests/test_fleet_post_task_reap.py -v` → 17 passed.
- `.venv/bin/ruff check scripts/fleet/post_task_reap.py tests/test_fleet_post_task_reap.py` → clean.
- `.venv/bin/ruff format --check scripts/fleet/post_task_reap.py tests/test_fleet_post_task_reap.py` → clean.
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → passed.

Closes #6412 (PR-3 of Hramatka hygiene series).
