### PR TITLE
fix(orchestration): reap dead-PID worktrees + shielded CF temps

### DIFF
--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -324,7 +324,7 @@ def _dispatch_task_id(repo_root: Path, info: WorktreeInfo) -> str | None:
     return relative.parts[1] if len(relative.parts) == 2 else None
 
 
-def _task_record_status(repo_root: Path, task_id: str | None) -> str | None:
+def _task_record(repo_root: Path, task_id: str | None) -> dict[str, Any] | None:
     if not task_id:
         return None
     task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
@@ -332,8 +332,38 @@ def _task_record_status(repo_root: Path, task_id: str | None) -> str | None:
         payload = json.loads(task_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    status = payload.get("status") if isinstance(payload, dict) else None
+    return payload if isinstance(payload, dict) else None
+
+
+def _task_record_status(repo_root: Path, task_id: str | None) -> str | None:
+    payload = _task_record(repo_root, task_id)
+    if payload is None:
+        return None
+    status = payload.get("status")
     return str(status) if status else None
+
+
+def _task_pid_alive(payload: dict[str, Any] | None) -> bool:
+    """Return True only when task JSON names a live process."""
+    if not payload:
+        return False
+    raw_pid = payload.get("pid")
+    if raw_pid is None:
+        return False
+    try:
+        pid = int(raw_pid)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but not signalable by this user — treat as live.
+        return True
+    return True
 
 
 def _activity_reason(
@@ -346,9 +376,16 @@ def _activity_reason(
     task_id = _dispatch_task_id(repo_root, info)
     if task_id and active_ids is not None and task_id in active_ids:
         return f"active dispatch task-id={task_id}"
-    task_status = _task_record_status(repo_root, task_id)
+    task_payload = _task_record(repo_root, task_id)
+    task_status = None
+    if task_payload is not None:
+        raw_status = task_payload.get("status")
+        task_status = str(raw_status) if raw_status else None
+    # Stale "running" rows with a dead worker PID must not block reaping forever
+    # (observed: multi-hour dispatch workers left status=running after exit).
     if task_status in {"queued", "starting", "running", "needs_finalize"}:
-        return f"non-terminal dispatch task-id={task_id} status={task_status}"
+        if _task_pid_alive(task_payload):
+            return f"non-terminal dispatch task-id={task_id} status={task_status}"
     if live_cwds is not None:
         worktree = info.path.resolve()
         for cwd in live_cwds:
@@ -500,22 +537,50 @@ def _qualifying_reason(
             if age_hours is not None and age_hours > 24.0:
                 return f"detached HEAD ancestor of origin/main; age {age_hours:.1f}h > 24h"
 
-    # Class A: settled-dispatch, no PR
+    # Class A: settled dispatch worktree (clean, worker gone).
+    # Open PRs live on the remote — a clean worktree matching origin/<branch>
+    # is safe to drop for disk recovery without closing the PR.
     if is_dispatch_candidate and clean is True:
         task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
         if task_file.exists():
             try:
                 task_data = json.loads(task_file.read_text(encoding="utf-8"))
+                if not isinstance(task_data, dict):
+                    return None
                 task_status = task_data.get("status")
-                if task_status in ("done", "failed", "no_deliverable") and (
-                    active_ids is not None and task_id not in active_ids
-                ):
+                pid_alive = _task_pid_alive(task_data)
+                terminal = task_status in ("done", "failed", "no_deliverable")
+                stuck_dead = (
+                    task_status in ("queued", "starting", "running", "needs_finalize")
+                    and not pid_alive
+                )
+                # Fail closed when Monitor active-task probe is unavailable.
+                settled = (
+                    (terminal or stuck_dead)
+                    and active_ids is not None
+                    and task_id not in active_ids
+                )
+                if settled and not pid_alive:
                     if info.branch:
                         prs, pr_error = _query_pr_states(repo_root, info.branch)
-                        if pr_error is None and not any(pr.state == "OPEN" for pr in prs):
-                            return f"settled dispatch task-id={task_id} status={task_status}"
+                        if pr_error is not None:
+                            return None
+                        open_prs = [pr for pr in prs if pr.state == "OPEN"]
+                        if not open_prs:
+                            return (
+                                f"settled dispatch task-id={task_id} "
+                                f"status={task_status}"
+                            )
+                        if _origin_matches_head(info.path, info.branch):
+                            return (
+                                f"settled dispatch task-id={task_id} "
+                                f"status={task_status}; open PR remains on remote"
+                            )
                     else:
-                        return f"settled dispatch task-id={task_id} status={task_status}"
+                        return (
+                            f"settled dispatch task-id={task_id} "
+                            f"status={task_status}"
+                        )
             except Exception:
                 pass
 
@@ -1063,6 +1128,22 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps([_result_payload(result) for result in results], indent=2))
     else:
         print(format_text_results(results, apply=apply))
+    # Always sweep formal CF temp roots (including $TMPDIR/shielded-reviews)
+    # when applying — worktree reaps alone left multi-GB lu-review snaps.
+    if apply:
+        try:
+            from scripts.review.isolation import sweep_review_temp_orphans
+
+            sweep = sweep_review_temp_orphans()
+            print(
+                "review_temp_sweep: "
+                f"roots_reaped={sweep.get('roots_reaped', 0)} "
+                f"bytes_freed={sweep.get('bytes_freed', 0)} "
+                f"errors={sweep.get('errors', 0)}",
+                file=sys.stderr,
+            )
+        except Exception as exc:  # noqa: BLE001 — never fail worktree reap on sweep
+            print(f"review_temp_sweep: skipped ({exc})", file=sys.stderr)
     return 1 if any(result.action == "error" for result in results) else 0
 
 

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -200,10 +200,23 @@ def is_under_worktrees(repo_root: Path, path: Path) -> bool:
 
 
 def _worktree_clean(path: Path) -> bool | None:
-    proc = _run(["git", "status", "--porcelain"], cwd=path)
+    """Return True when the worktree has no meaningful dirty files.
+
+    Dispatch workers often leave an untracked ``.venv`` (or nested site
+    venv) which must not block reaping multi-hundred-MB trees.
+    """
+    proc = _run(["git", "status", "--porcelain", "-uall"], cwd=path)
     if proc.returncode != 0:
         return None
-    return not bool((proc.stdout or "").strip())
+    ignored_prefixes = (".venv/", ".venv", "node_modules/", "node_modules")
+    for raw in (proc.stdout or "").splitlines():
+        if len(raw) < 4:
+            continue
+        rel = raw[3:].strip().strip('"')
+        if rel in ignored_prefixes or rel.startswith((".venv/", "node_modules/")):
+            continue
+        return False
+    return True
 
 
 def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequestState], str | None]:

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -383,9 +383,11 @@ def _activity_reason(
         task_status = str(raw_status) if raw_status else None
     # Stale "running" rows with a dead worker PID must not block reaping forever
     # (observed: multi-hour dispatch workers left status=running after exit).
-    if task_status in {"queued", "starting", "running", "needs_finalize"}:
-        if _task_pid_alive(task_payload):
-            return f"non-terminal dispatch task-id={task_id} status={task_status}"
+    if (
+        task_status in {"queued", "starting", "running", "needs_finalize"}
+        and _task_pid_alive(task_payload)
+    ):
+        return f"non-terminal dispatch task-id={task_id} status={task_status}"
     if live_cwds is not None:
         worktree = info.path.resolve()
         for cwd in live_cwds:
@@ -1142,7 +1144,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"errors={sweep.get('errors', 0)}",
                 file=sys.stderr,
             )
-        except Exception as exc:  # noqa: BLE001 — never fail worktree reap on sweep
+        except Exception as exc:
             print(f"review_temp_sweep: skipped ({exc})", file=sys.stderr)
     return 1 if any(result.action == "error" for result in results) else 0
 

--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -59,7 +59,10 @@ REVIEW_TEMP_ROOT_PREFIXES = (
     "lu-review-view-",
     "lu-review-write-",
 )
-REVIEW_TEMP_ORPHAN_MAX_AGE_S = 48 * 60 * 60
+# Multi-GB formal-review snaps must not sit for days after aborted CF.
+# Six hours is long enough for a healthy review; shorter than the old 48h
+# fail-open that left shielded-reviews full until manual intervention.
+REVIEW_TEMP_ORPHAN_MAX_AGE_S = 6 * 60 * 60
 REVIEW_TEMP_ROOT_MARKER_NAME = ".lu-review-root"
 REVIEW_TEMP_ROOT_MANIFEST_NAME = ".lu-review-root.json"
 LU_REVIEW_TEMP_MIN_FREE_GB = 10.0
@@ -359,15 +362,27 @@ def _review_temp_root_bytes(root: Path) -> int:
 
 
 def _review_temp_orphan_candidates(tmp_root: Path) -> tuple[Path, ...]:
-    """Return only direct review-owned roots under loose and task TMPDIRs."""
+    """Return only direct review-owned roots under loose and task TMPDIRs.
+
+    Also scans ``$TMPDIR/shielded-reviews/`` (formal CF isolation root). Earlier
+    sweeps only looked at ``$TMPDIR/lu-*`` and ``$TMPDIR/learn-ukrainian/*``,
+    so multi-GB ``lu-review-snap-*`` trees under ``shielded-reviews`` never
+    reaped after aborted formal reviews.
+    """
     candidates: list[Path] = []
     parent_sets = [tmp_root]
-    namespace = tmp_root / "learn-ukrainian"
-    try:
-        namespace_stat = namespace.lstat()
-    except FileNotFoundError:
-        namespace_stat = None
-    if namespace_stat is not None and not stat.S_ISLNK(namespace_stat.st_mode) and stat.S_ISDIR(namespace_stat.st_mode):
+    for extra_name in ("learn-ukrainian", "shielded-reviews"):
+        namespace = tmp_root / extra_name
+        try:
+            namespace_stat = namespace.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(namespace_stat.st_mode) or not stat.S_ISDIR(namespace_stat.st_mode):
+            continue
+        if extra_name == "shielded-reviews":
+            # Snaps live as direct children of shielded-reviews.
+            parent_sets.append(namespace)
+            continue
         try:
             for path in namespace.iterdir():
                 path_stat = path.lstat()

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -365,14 +365,16 @@ def test_class_a_fail_safe_skips(
     results = rw.reap_worktrees(repo_root=repo, apply=True)
     assert result_for(results, worktree_path).action == "skipped"
 
-    # Re-create task file for remaining cases
-    task_file.write_text(json.dumps({"status": "running"}), encoding="utf-8")
+    # Re-create task file for remaining cases — live worker PID required
+    task_file.write_text(
+        json.dumps({"status": "running", "pid": os.getpid()}), encoding="utf-8"
+    )
 
-    # Case 4: task status is not done/failed
+    # Case 4: task status is not done/failed and worker PID is live
     results = rw.reap_worktrees(repo_root=repo, apply=True)
     assert result_for(results, worktree_path).action == "skipped"
 
-    # Set status back to done
+    # Set status back to done (no live pid)
     task_file.write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     # Case 5: dirty tree
@@ -383,10 +385,19 @@ def test_class_a_fail_safe_skips(
     # Clean up dirty file
     (worktree_path / "dirty.txt").unlink()
 
-    # Case 6: branch has open PR
+    # Case 6: open PR but worktree not matching origin tip → keep
+    monkeypatch.setattr(rw, "_origin_matches_head", lambda _path, _branch: False)
     patch_gh(monkeypatch, {"codex/5102-raisa-fail": [{"number": 42, "state": "OPEN"}]})
     results = rw.reap_worktrees(repo_root=repo, apply=True)
     assert result_for(results, worktree_path).action == "skipped"
+
+    # Case 7: open PR + clean tip already on origin → free local worktree
+    monkeypatch.setattr(rw, "_origin_matches_head", lambda _path, _branch: True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert "open PR remains on remote" in (result.reason or "")
+    assert not worktree_path.exists()
 
 
 def test_class_b_detached_head_removed(

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -207,24 +207,27 @@ def test_review_temp_orphan_sweep_reaps_only_old_loose_and_task_roots(
 
     loose_old = tmp_path / "lu-review-git-old"
     task_old = tmp_path / "learn-ukrainian" / "task" / "lu-review-view-old"
+    shielded_old = tmp_path / "shielded-reviews" / "lu-review-snap-old"
     loose_young = tmp_path / "lu-review-write-young"
     unrelated = tmp_path / "not-review"
-    for root in (loose_old, task_old, loose_young, unrelated):
+    for root in (loose_old, task_old, shielded_old, loose_young, unrelated):
         root.mkdir(parents=True)
         (root / "payload").write_text(root.name, encoding="utf-8")
     now = time.time()
     old = now - isolation.REVIEW_TEMP_ORPHAN_MAX_AGE_S - 1
     os.utime(loose_old, (old, old))
     os.utime(task_old, (old, old))
+    os.utime(shielded_old, (old, old))
     monkeypatch.setattr(isolation.tempfile, "gettempdir", lambda: str(tmp_path))
     monkeypatch.delenv("LU_RUNTIME_TMP_BASE_ROOT", raising=False)
 
     result = sweep_review_temp_orphans(now=now)
 
-    assert result["roots_reaped"] == 2
+    assert result["roots_reaped"] == 3
     assert result["errors"] == 0
     assert not loose_old.exists()
     assert not task_old.exists()
+    assert not shielded_old.exists()
     assert loose_young.exists()
     assert unrelated.exists()
 


### PR DESCRIPTION
## Summary
- Sweep `$TMPDIR/shielded-reviews` for orphan `lu-review-*` (was invisible to the old temp sweeper).
- Shorten review-temp orphan age 48h → 6h.
- Reaper ignores stale `status=running` when worker PID is dead.
- Reaper frees clean settled dispatch worktrees even if an open PR remains on remote (HEAD matches origin).
- `--apply` also runs `sweep_review_temp_orphans`.

## Why
Disk filled to 97% from formal CF snaps under `shielded-reviews` and multi-hundred-MB worktrees that never reaped after workers finished / open PRs.

## Test
`pytest tests/orchestration/test_reap_worktrees.py tests/test_review_isolation.py::test_review_temp_orphan_sweep...` — 27 passed.

X-Agent: grok/reaper-temp-hygiene