### PR TITLE
fix(cf): retire shielded formal review-pr and lu-review temps

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -21,7 +21,7 @@ that skill). Do not reintroduce claims Sol rejected (see §Plane modes).
 | **Seat onboarding contract** | Task-oriented ownership matrix (discuss / delegate / fleet-comms / ACPX / Buzz deferred), Kimi routes, smoke | `docs/runbooks/agent-seat-onboarding.md` |
 | **`drive-epic` skill** | Method playbook (orient → topology → route → dispatch → settle → CF → merge → handoff) | `agents_extensions/shared/skills/drive-epic/SKILL.md` |
 | **Epic roster runbook** | Operator seat routing (which model drives which epic) | `docs/runbooks/epic-orchestrator-roster.md` |
-| **Live routing data** | Caps, ladders, formal CF pins, **live plane mode** | `/api/rules` model-assignment + `scripts/config/model_catalog.yaml` + `scripts/config/fleet_communications.yaml` + `plane-status` |
+| **Live routing data** | Caps, ladders, reviewer seats, **live plane mode** | `/api/rules` model-assignment + `scripts/config/model_catalog.yaml` + `scripts/config/fleet_communications.yaml` + `plane-status` |
 | **Launchers** | Lease claim + dual-aware pointer (not a second design) | interactive `start-*.sh`, provider `start-*-driver.sh` |
 
 **Golden rule (from drive-epic):** rules + skill teach **method**; roster/caps/modes are
@@ -34,7 +34,7 @@ at the **onboarding contract** for ownership and experimental ACPX scope; this r
 | Half | Status | Surfaces |
 | --- | --- | --- |
 | **Session stream / lease** | Live | `claim_session_supervisor_env`, `SESSION_STREAM_*`, stream tail/digest, canary mint (hook-less seats) |
-| **Message plane + CF-comms** | Authority | `scripts.fleet_comms`, `review-pr`, `publish-review-verdict` |
+| **Message plane + CF-comms** | Authority | `scripts.fleet_comms`; PR CF via direct `ask-*` + PR comment (sealed `review-pr` RETIRED) |
 
 Launchers already claim leases. Drivers must **also** speak the message-plane + CF half.
 
@@ -52,7 +52,7 @@ only for an explicit rollback or compatibility probe.
 | --- | --- |
 | `authority` mode | Fleet-comms is the durable source of truth; legacy stores are read-only migration/projection sources |
 | `dual_write` mode | Compatibility soak/rollback mode, not normal operation |
-| ACP | Provider transport only; durable queues, retries, conversations, artifacts, receipts, and formal jobs belong to fleet-comms |
+| ACP | Provider transport only; durable queues, retries, conversations, artifacts, and receipts belong to fleet-comms |
 | Who may roll back authority / retention apply / eligibility | **Infra/harness lane** with present-tense operator/advisor approval |
 
 Do not create new authoritative bridge, channel, broker, or diary writes. Historical
@@ -74,12 +74,14 @@ cold-prompts; silent plane flips; “for now” cutovers.
 .venv/bin/python -m agents_extensions.shared.session_streams tail --stream epic:<N> --limit 20
 .venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
 
-# Cross-family PR review — DIRECT by default (operator order 2026-08-06):
-# ONE round. The requester asks a cross-family lane for verdict + findings at the
-# current head, then posts them on the PR (gh pr comment / gh pr review).
+# Cross-family PR review — DIRECT only (operator 2026-08-06; sealed formal RETIRED 2026-08-07):
+# ONE round. Ask a cross-family lane for verdict + findings at the current head,
+# then post on the PR (gh pr comment / gh pr review). Merge when CI is green.
+# Then reap worktrees + temps (drive-epic §7a / reap_worktrees.py --apply).
 printf '%s\n' "Cross-family review of PR #<N> at head <SHA>: verdict + findings." | \
-  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - --task-id review-<N> --review
-# Formal sealed path (review-pr / publish-review-verdict) is OPT-IN, high-risk code only.
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - --task-id review-<N> --type review
+# SHIELDED formal path (review-pr / lu-review snaps / shielded-reviews) is RETIRED —
+# do not run it. CLI fails closed unless LU_FORMAL_SHIELDED_CF=1 (unit tests only).
 ```
 
 ### Routing observability contract
@@ -100,14 +102,9 @@ job/reservation state. The dashboard is read-only: its filters, search,
 details, and load-more controls never select, retry, cancel, reclaim, or reroute
 work.
 
-- **agy | kimi** remain `formal_review_eligible: false` until their isolation
-  proofs (#5555–#5556). They **request** CF via `review-pr`; they do not self-seal.
-  Native Grok passed its exact-head isolation proof and is eligible; Cursor
-  Grok remains a non-formal availability fallback.
-- Escalate hard/non-routine CF with Sol (`--reviewer codex --model gpt-5.6-sol`,
-  provider-default ACP effort) or Fable (`--reviewer claude --model claude-fable-5
-  --effort high`) per model-assignment. Every explicit pin also requires
-  `--override-reason` and still passes the normal hard gates.
+- Cross-family review is **direct only** (`ask-<lane>` + post verdict on the PR).
+  Shielded formal `review-pr` / eligibility pins are RETIRED (operator 2026-08-07).
+  Route the reviewer seat by model-assignment (outside the author's family).
 
 ## Standalone TUI/UI contract
 
@@ -118,10 +115,11 @@ Every epic driver session (any harness) MUST:
 3. Use fleet-comms for durable coordination, queues, messages, conversations, artifacts,
    retries, dead letters, receipts, formal jobs, and session continuity. In authority
    mode, never create a new legacy bridge/channel/broker/file coordination write.
-4. Review of record = ONE cross-family round posted on the PR at the current head.
-   Direct ask + posted verdict is the default gate (operator order 2026-08-06); the
-   formal sealed path (`review-pr` / `publish-review-verdict`) is opt-in for
-   high-risk code only. Discussion and same-family chat are still not the gate.
+4. Review of record = ONE cross-family round posted on the PR at the current head
+   (direct ask + posted verdict). **Shielded formal CF (`review-pr`, sealed MCP,
+   multi-GB `lu-review-*` / `shielded-reviews` clones) is RETIRED** (operator
+   2026-08-07) — disk and process harm outweighed isolation benefit. Discussion
+   and same-family chat are still not the gate.
 5. Treat launcher-claimed stream leases as held — do not open/resume the lease yourself.
 6. **Session health by seat:**
    - **grok / gemini / kimi:** canary mint/score
@@ -132,12 +130,11 @@ Every epic driver session (any harness) MUST:
 7. Provider drivers inject the **`drive-epic`** binding after their lease and
    provider canary. Interactive launchers never claim a driver lease.
 8. **Post-merge cleanup is mandatory** (operator 2026-08-07). A squash-merge is not
-   done until worktree + branch + CF/review temp residue for that PR are reaped and
-   `df -h /` + `git worktree list` prove no zombie. Order and paths: `drive-epic` skill
-   §7a (worktree before branch; ACP `runtime-review-<PR>*`; `/tmp/lu-cf-clean` /
-   `/tmp/lu-review-*` / `/tmp/lu-pr*` — chmod then rm for read-only sealed snaps). Do
-   not start another formal `review-pr` while disk is near full without reaping first.
-   Session chat promises do not bind; this rule and §7a do.
+   done until worktree + branch + any temp residue for that PR are reaped and
+   `df -h /` + `git worktree list` prove no zombie. Prefer
+   `scripts/orchestration/reap_worktrees.py --apply` (also sweeps review temps
+   under `$TMPDIR` and `$TMPDIR/shielded-reviews`). Do not create formal sealed
+   review trees. Session chat promises do not bind; this rule and §7a do.
 
 ## Operator launch surface (#5632)
 
@@ -169,33 +166,32 @@ Supported fleet seats cold-start through:
    max-only) vs explicit KimiCC (K3 defaults `high`), rollback, and no-auth
    fresh-agent smoke.
 
-Discussion is never formal CF. Formal CF remains `review-pr` /
-`publish-review-verdict` only. ACP is structured provider transport; fleet-comms
-owns the durable record and publication state.
+Discussion is never the review of record. **Shielded formal CF (`review-pr` /
+`publish-review-verdict` / sealed `lu-review-*`) is RETIRED** (operator 2026-08-07).
+Review of record = one direct cross-family `ask-*` + posted PR verdict. ACP is
+structured provider transport for ordinary `ask-*` / `discuss`; fleet-comms owns
+durable coordination state.
 
-### Formal CF thrash ban (operator 2026-08-06)
+### CF thrash ban (operator 2026-08-06; formal path retired 2026-08-07)
 
 Agents MUST NOT:
 
-1. Push **empty commits** whose only purpose is CF reseal / authority-key reset.
-2. Re-run `review-pr` when this head already has sealed **APPROVED** (idempotent stop).
-3. Re-run `review-pr` when the tip tree is unchanged since an APPROVED ancestor
-   (empty reseals void exact-head binding without product change).
-4. Spend formal CF while **GitHub Actions** is in outage/degraded (check githubstatus).
+1. Push **empty commits** whose only purpose is re-triggering review / CI reseal.
+2. Re-request the same cross-family review when the PR head already has an
+   explicit APPROVED verdict for that SHA (idempotent stop).
+3. Burn another review seat when the tip tree is unchanged and no product delta
+   landed.
+4. Spend scarce review seats while **GitHub Actions** is in outage/degraded
+   (check githubstatus) unless the operator overrides.
 
-`review-pr` enforces (2)–(4) fail-closed. Rule (2) — exact-head already sealed
-**APPROVED** — is a HARD idempotent stop and is **never** overridable, including by
-`--allow-cf-thrash`. The override flag applies only to (3) empty-tree-tip reseals and
-(4) the GitHub Actions outage guard, operator-only with `--override-reason …`. Never
-auto-reset branches. (Python fail-closed enforcement is unchanged — this section only
-clarifies which guards the flag reaches.)
+Never auto-reset branches for review thrash. Do not reintroduce sealed formal CF.
 
 ## ACP provider transport
 
 For normal **read-only inter-agent communication**, ACP is the only provider
-transport. Fleet launchers make ordinary `ask-*`, 2–6 participant `discuss`, and
-sealed formal-review calls use the durable ACP controller for enabled routes:
-Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool, AGY, GLM, and DeepSeek. The direct
+transport. Fleet launchers make ordinary `ask-*` and 2–6 participant `discuss`
+calls use the durable ACP controller for enabled routes: Codex, Grok, Claude,
+Kimi, KimiCC K3, Cursor, Pool, AGY, GLM, and DeepSeek. The direct
 `.venv/bin/python -m scripts.fleet_comms acp-discuss` surface remains available
 to operators. Selection starts no process at cold start and does not change
 `delegate.py`. The default is two rounds and the hard maximum is three.

--- a/agents_extensions/shared/rules/fleet-driver-routing.md
+++ b/agents_extensions/shared/rules/fleet-driver-routing.md
@@ -67,7 +67,7 @@ the routing card records why heap was refused.
 
 ## 3. Mandatory pre-dispatch routing card
 
-Before **every** `delegate.py dispatch` and before every formal `review-pr`
+Before **every** `delegate.py dispatch` and before every cross-family review
 request that spends a scarce seat, the live driver MUST record (handoff, issue
 comment, or `batch_state/` receipt — not only inner monologue):
 
@@ -143,5 +143,6 @@ later in advisory mode.
 - Does **not** weaken operator-expectations §4 (whole fleet) or §5 (route by fit).  
 - Does **not** replace model-assignment live ladders — it **forces the card** and
   **advisor→heap default**.  
-- Formal CF remains independent and cross-family (`model-assignment` + review-pr).  
+- Cross-family review remains independent (`model-assignment` + direct `ask-*`);
+  shielded formal `review-pr` is retired.  
 - Advisor approval gate for architecture still binds (operator-expectations §12).

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -212,14 +212,11 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
 
   The review of record is ONE direct cross-family round (operator order
   2026-08-06): plain `ask-<lane>` with the diff reference, verdict + findings
-  posted on the PR at the current head by the requester. The **formal sealed
-  path** (`review-pr`) is OPT-IN for high-risk code only. When it is used:
-  Claude, Codex, GLM, and native Grok use the parent-owned exact-head sealed
-  ACP path; the canonical KimiCC K3 adapter remains fail-closed until its
-  authenticated sealed canary passes; AGY remains sealed-ineligible (text-only
-  wrapper). Sealed authority CF model pins (both require `--override-reason`):
-  `review-pr <N> --reviewer codex --model gpt-5.6-sol` or
-  `review-pr <N> --reviewer claude --model claude-fable-5 --effort high`.
+  posted on the PR at the current head by the requester. **Shielded formal CF
+  (`review-pr`, sealed multi-GB `lu-review-*` / `shielded-reviews` isolation) is
+  RETIRED (operator 2026-08-07)** — fail-closed in the CLI. Do not reintroduce
+  it. Lightweight agent review + green CI + merge + worktree/temp cleanup is
+  the path.
 
   <!-- fleet-roster-projection:begin formal_review_eligible -->
   | endpoint | formal_review_eligible |
@@ -502,25 +499,23 @@ The same table lives in `memory/MEMORY.md` rule #M0; this file is the deploy-rul
 
 </critical>
 
-## PR cross-family review (direct by default — operator order 2026-08-06)
+## PR cross-family review (direct only — operator 2026-08-06; sealed formal RETIRED 2026-08-07)
 
-Default review of record: ONE direct round via plain `ask-<lane>` (reference the
-branch/diff for the reviewer to fetch; do not paste huge diffs inline), verdict +
-findings posted on the PR at the current head by the requester.
-
-The sealed path below is **OPT-IN for high-risk code only**:
+Review of record: ONE direct round via plain `ask-<lane>` (reference the branch/diff
+for the reviewer to fetch; do not paste huge diffs inline), verdict + findings posted
+on the PR at the current head by the requester. Then merge when CI is green and reap
+the worktree (`reap_worktrees.py --apply` / `drive-epic` §7a).
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>
-# pins: codex→gpt-5.6-terra@high · --reviewer claude→claude-sonnet-5@high · --reviewer glm→glm-5.2
-# after sealed review returns a short verdict file:
-.venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict \
-  --pr <N> --verdict-file /tmp/verdict.txt --model <model> --family <family> --harness <harness>
+printf '%s\n' "Cross-family review of PR #<N> at head <SHA>: VERDICT + findings." | \
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - \
+    --task-id review-<N> --type review
 ```
 
-**AGY orchestrator** (`gemini-3.6-flash-high` @ high) runs the loop and still *requests* CF with
-`review-pr` above — do not treat `ask-agy --review` as sealed formal CF until #5555 flips
-`formal_review_eligible`.
+**Shielded formal CF is RETIRED.** Do not run `review-pr` / `publish-review-verdict`
+/ sealed `lu-review-*` / `shielded-reviews` clones — the CLI fails closed (tests may
+set `LU_FORMAL_SHIELDED_CF=1` only). Cross-family still means outside the author's
+model family; discussion and same-family chat are not the gate.
 
 Bridge steers with a **warning** (not refuse) if `ask-* --review` looks like PR CF
 without a sealed target — so agent work is not discarded (#5486 warn-not-reject).

--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -28,19 +28,19 @@ tie-breakers.
    scratch directory (like `batch_state/`).
    `core.bare=true` on primary is a **bug** to heal (`git config core.bare false` +
    `extensions.worktreeConfig=true`), never an intentional mode. PRs for everything — no
-   direct commits to main. **After merge, cleanup is mandatory before the next formal
-   review or large dispatch** (operator 2026-08-07; ENOSPC is the known failure): (1)
-   confirm MERGED, (2) `git worktree remove --force` for that PR's dispatch worktree
-   **before** deleting the local branch, (3) delete local + remote branch +
-   `git fetch --prune` + `git worktree prune`, (4) reap finished CF residue for that PR
-   when no process holds it — `.worktrees/dispatch/acp/runtime-review-<PR>*`,
-   `/tmp/lu-cf-clean/`, `/tmp/lu-review-*`, `/tmp/lu-pr*` (read-only sealed snaps need
-   `chmod -R u+w` then `rm -rf`), task runtime tmp, stray worktree `.venv`, (5) prove
-   with `df -h /` and `git worktree list` (no zombie path for that PR). A squash-merge
-   alone is not done. Full checklist: `drive-epic` skill §7a. Close issues when
-   acceptance criteria are met, with tool-backed evidence. `X-Agent` trailer on every
-   commit. Session start/end: sweep worktrees, branches, open PRs — a dangling ref
-   reads as unfinished work to the rest of the fleet.
+   direct commits to main. **After merge, cleanup is mandatory before the next large
+   dispatch** (operator 2026-08-07; ENOSPC is the known failure): (1) confirm MERGED,
+   (2) `git worktree remove --force` for that PR's dispatch worktree **before**
+   deleting the local branch, (3) delete local + remote branch + `git fetch --prune`
+   + `git worktree prune`, (4) bulk reap:
+   `.venv/bin/python scripts/orchestration/reap_worktrees.py --apply` (also sweeps
+   any leftover `$TMPDIR` / `shielded-reviews` temps from the retired formal path),
+   (5) prove with `df -h /` and `git worktree list` (no zombie path for that PR). A
+   squash-merge alone is not done. Full checklist: `drive-epic` skill §7a. **Do not
+   create sealed `lu-review-*` trees** — shielded formal CF is retired. Close issues
+   when acceptance criteria are met, with tool-backed evidence. `X-Agent` trailer on
+   every commit. Session start/end: sweep worktrees, branches, open PRs — a dangling
+   ref reads as unfinished work to the rest of the fleet.
 4. **Utilize the whole fleet — together you are stronger.** Substantive design/decisions get
    ≥1 other agent BEFORE committing; solo only for trivial work. Two distinct duties, don't
    conflate them: (a) *discussion/panel input* improves the work but does NOT satisfy the

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -210,26 +210,24 @@ action. Read and apply every `unread` or `read-but-not-live-consumed` entry, the
 ```
 
 ### 6. Cross-family review gate (load-bearing — discussion ≠ review)
+
 A review of record is **independent and cross-family** (outside the author's model
-family; never self-review, never same-family). Route it:
+family; never self-review, never same-family).
+
+**Shielded formal CF is RETIRED (operator 2026-08-07).** Do **not** run
+`review-pr` / sealed `lu-review-*` / `shielded-reviews` clones — the CLI fails
+closed. Use lightweight direct review:
+
 ```bash
-# PR number is REQUIRED and positional (omitting it exits with a usage error):
-.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer <cross-family-lane>
-.venv/bin/python -m scripts.ai_agent_bridge publish-review-verdict ...                             # publish the sealed verdict
+printf '%s\n' "Cross-family review of PR #<N> at head <SHA>: VERDICT + findings." | \
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - \
+    --task-id review-<N> --type review
+# Post verdict on the PR, then merge when CI is green.
 ```
-Pick the reviewer family and capability from the served reviewer-seat rule; the writer's
-family is never eligible. For a hard / non-routine change, record the live role selection
-and concrete `--override-reason`; do not hard-wire a reviewer identity in this skill. Read the review CONTENT
-(not just pass/fail), apply the deltas, re-probe gate-driving data yourself before
-trusting "verified". A review request is not a passive notification: after invoking
-`review-pr <PR_NUMBER>`, the requester owns its request state and must explicitly poll
-it on each subsequent cycle with:
-```bash
-.venv/bin/python -m scripts.ai_agent_bridge asks --task-id review-pr-<PR_NUMBER>
-```
-Wait for that request to show `replied`; treat `sent`, `processing`, `timed-out`, or
-`failed` as its actual state and act on it. Do not assume a disconnected reply will
-surface in the live driver's context.
+
+Pick the reviewer family from the served reviewer-seat rule; the writer's family
+is never eligible. Read the review CONTENT (not just pass/fail), apply deltas,
+re-probe gate-driving data yourself.
 
 ### 7. Merge discipline
 PRs only — never commit or merge to `main` directly. **Arm auto-merge the moment the
@@ -245,39 +243,23 @@ another lane's PR with `needs=merge` rather than merging it.
 ### 7a. Post-merge cleanup is mandatory (binding — operator 2026-08-07)
 
 **A squash-merge is not done until cleanup proves free of that PR's residue.** Chat
-promises do not bind; this section does. Leaving worktrees / ACP review runtimes /
-`/tmp` formal-review snaps after merge is a process defect (ENOSPC / disk full is the
-known failure mode). Do not start the next formal `review-pr` or large dispatch until
-cleanup for the just-merged PR is complete.
+promises do not bind; this section does. Leaving dispatch worktrees or tmp residue
+after merge is a process defect (ENOSPC / disk full is the known failure mode).
 
-**Order after `gh pr view <N>` shows `MERGED` (or auto-merge lands):**
+**Order after `gh pr view <N>` shows `MERGED`:**
 
-1. **Confirm** — `gh pr view <N> --json state,mergedAt,mergeCommit` (quote SHA when
-   handoff needs it).
+1. **Confirm** merge SHA.
 2. **Worktree first** — `git worktree remove --force .worktrees/dispatch/<agent>/<task>`
-   (and any other worktree still on that PR branch). Never leave a branch checked out
-   that blocks branch delete.
-3. **Branches** — delete local branch if present; ensure remote is gone
-   (`--delete-branch` on merge, else `git push origin --delete <branch>`); `git fetch
-   --prune`; `git worktree prune`.
-4. **Review / CF residue for that PR** (reap only when no live process holds the path):
-   - `.worktrees/dispatch/acp/runtime-review-<PR>*` — `git worktree unlock` if locked,
-     then `remove --force` (or `rm -rf` if already unregistered)
-   - `/tmp/lu-cf-clean/`, `/tmp/lu-review-*`, `/tmp/lu-pr*` tied to that PR or finished
-     formal snapshots — sealed snaps are often **read-only**: `chmod -R u+w` then
-     `rm -rf`
-   - runtime tmp under `$TMPDIR/learn-ukrainian/<task-id>*` if present
-   - stray worktree `.venv` if a worker created one
-5. **Optional sweeper** — not a substitute for step 4:
+3. **Branches** — local delete + remote gone + `git fetch --prune` + `git worktree prune`
+4. **Bulk reap** (preferred):
    ```bash
-   .venv/bin/python -c "from scripts.review.isolation import sweep_review_temp_orphans; print(sweep_review_temp_orphans())"
+   .venv/bin/python scripts/orchestration/reap_worktrees.py --apply
    ```
-6. **Prove** — `df -h /` and `git worktree list` must show no zombie path for that PR.
-   Record free space in the file handoff when disk was tight this session.
+   Also sweeps orphan review temps under `$TMPDIR` and `$TMPDIR/shielded-reviews` if any
+   leftovers remain from the retired formal path.
+5. **Prove** — `df -h /` and `git worktree list` show no zombie for that PR.
 
-**Do not** treat `gh pr merge --auto --squash --delete-branch` alone as closeout. **Do
-not** leave locked ACP review worktrees for finished reviews. **Do not** run another
-formal snapshot provision while disk is near full without reaping first.
+**Do not** treat merge alone as closeout. **Do not** run sealed formal CF.
 
 ### 8. Handoff — dual-write, cutover-aware (see §Fleet-comms state below)
 End the session on your seat's handoff signal (canary FAIL-HANDOFF for grok/gemini/kimi;

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -704,10 +704,43 @@ def _cmd_list_eligible(args: argparse.Namespace) -> int:
     return 0
 
 
+# Operator 2026-08-07: shielded formal CF is retired. Multi-GB sealed clones
+# under $TMPDIR/shielded-reviews caused disk ENOSPC and process thrash for days.
+# Cross-family review remains: direct ask-* / PR comment verdicts only.
+# Unit tests may set LU_FORMAL_SHIELDED_CF=1 to exercise the old path.
+_FORMAL_SHIELDED_CF_RETIRED_MSG = """\
+review-pr: SHIELDED FORMAL CF IS RETIRED (operator 2026-08-07).
+
+Do not use sealed review-pr / lu-review snaps / shielded-reviews trees.
+Lightweight cross-family review:
+
+  printf '%s\\n' "Cross-family review of PR #<N> at head <SHA>: VERDICT + findings." | \\
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - \\
+      --task-id review-<N> --type review
+
+Then post the verdict on the PR (gh pr comment / gh pr review) and merge when CI is green.
+publish-review-verdict / formal sealed jobs are not the default gate.
+"""
+
+
+def formal_shielded_cf_enabled() -> bool:
+    """Return True only when the retired formal path is explicitly re-enabled for tests."""
+    return os.environ.get("LU_FORMAL_SHIELDED_CF", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def handle_review_pr(args: argparse.Namespace) -> int:
     """CLI handler for ``review-pr``."""
     if getattr(args, "list_eligible", False):
         return _cmd_list_eligible(args)
+
+    if not formal_shielded_cf_enabled():
+        print(_FORMAL_SHIELDED_CF_RETIRED_MSG.rstrip(), file=sys.stderr)
+        return 2
 
     try:
         pr = parse_pr_number(str(args.pr))

--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -51,10 +51,11 @@ fleet_comms_cold_clause() {
     "Use fleet-comms as communication authority when current mode=${plane_mode}; " \
     "legacy bridge/channel stores are read-only migration projections in authority mode. " \
     "Topology: \`.venv/bin/python -m scripts.fleet_comms plane-status\` (+ metrics/backlog/dead-letters). " \
-    "Formal CF: \`.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer <cross-family>\` " \
-    "then publish-review-verdict (PR number required; never self-seal). " \
-    "All normal inter-agent asks, 2–6 seat discussions, and sealed formal review provider calls use ACP; " \
+    "Cross-family CF: direct ask-<lane> for verdict+findings, post on the PR, merge when CI green " \
+    "(sealed review-pr / lu-review temps RETIRED — do not use). Never self-seal. " \
+    "All normal inter-agent asks and 2–6 seat discussions use ACP; " \
     "never fall back to bridge/provider execution. ACP transports; fleet-comms owns durable state. " \
+    "After merge: reap worktrees (\`reap_worktrees.py --apply\`). " \
     "Continuity: stream lease already claimed; write durable receipts to fleet-comms."
 }
 
@@ -66,7 +67,7 @@ fleet_comms_print_banner_line() {
   fi
   case "$plane_mode" in
     off)
-      echo "  fleet-comms: plane=off · diary authoritative · CF via review-pr · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
+      echo "  fleet-comms: plane=off · diary authoritative · CF via direct ask · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
       ;;
     shadow|dual_write)
       echo "  fleet-comms: plane=${plane_mode} (compatibility soak) · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"

--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -171,7 +171,17 @@ def create_review_temp_root(
     dir: str | os.PathLike[str] | None = None,
     context: dict[str, Any] | None = None,
 ) -> Path:
-    """Create a private review root whose cleanup identity is its sentinel."""
+    """Create a private review root whose cleanup identity is its sentinel.
+
+    Production shielded formal CF is retired (operator 2026-08-07). Creating
+    ``lu-review-*`` roots requires ``LU_FORMAL_SHIELDED_CF=1`` (unit tests only).
+    """
+    if prefix.startswith(REVIEW_TEMP_ROOT_PREFIXES) and not _formal_shielded_cf_temps_allowed():
+        raise OSError(
+            "shielded formal CF temp roots are retired; "
+            "set LU_FORMAL_SHIELDED_CF=1 only for unit tests. "
+            "Use direct ask-* cross-family review on the PR instead of review-pr."
+        )
     root = Path(tempfile.mkdtemp(prefix=prefix, dir=dir))
     try:
         _write_review_temp_root_marker(root, prefix=prefix, context=context)
@@ -182,6 +192,15 @@ def create_review_temp_root(
             shutil.rmtree(root)
         raise
     return root
+
+
+def _formal_shielded_cf_temps_allowed() -> bool:
+    return os.environ.get("LU_FORMAL_SHIELDED_CF", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def _has_review_temp_root_marker(root: Path) -> bool:

--- a/tests/ai_agent_bridge/test_formal_shielded_cf_retired.py
+++ b/tests/ai_agent_bridge/test_formal_shielded_cf_retired.py
@@ -1,0 +1,47 @@
+"""Shielded formal CF is retired in production (operator 2026-08-07)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ai_agent_bridge import _review_pr as review_pr
+from scripts.review import isolation
+
+
+def test_handle_review_pr_refuses_when_formal_disabled(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("LU_FORMAL_SHIELDED_CF", raising=False)
+    # Autouse conftest enables the flag — clear it for this production-path check.
+    monkeypatch.setenv("LU_FORMAL_SHIELDED_CF", "")
+    code = review_pr.handle_review_pr(
+        SimpleNamespace(
+            list_eligible=False,
+            pr="9999",
+            reviewer="codex",
+            initiator="test",
+            author_model="grok-4.5",
+            author_family="xai",
+        )
+    )
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "RETIRED" in captured.err
+    assert "review-pr" in captured.err
+
+
+def test_create_review_temp_root_refuses_lu_prefix_when_formal_disabled(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LU_FORMAL_SHIELDED_CF", "")
+    with pytest.raises(OSError, match="retired"):
+        isolation.create_review_temp_root(prefix="lu-review-snap-", dir=tmp_path)
+
+
+def test_create_review_temp_root_allows_when_formal_enabled_for_tests(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LU_FORMAL_SHIELDED_CF", "1")
+    root = isolation.create_review_temp_root(prefix="lu-review-snap-", dir=tmp_path)
+    assert root.is_dir()
+    isolation.remove_review_temp_tree(root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,3 +445,12 @@ Content here.
 
 Practice content.
 """
+
+
+@pytest.fixture(autouse=True)
+def _enable_formal_shielded_cf_for_unit_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit tests may still exercise isolation helpers; production CLI stays retired.
+
+    Production / drivers leave LU_FORMAL_SHIELDED_CF unset so review-pr refuses.
+    """
+    monkeypatch.setenv("LU_FORMAL_SHIELDED_CF", "1")

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -22,7 +22,7 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     assert RULE.is_file(), "missing shared rule SSOT"
     body = RULE.read_text(encoding="utf-8")
     assert "plane-status" in body
-    assert "review-pr" in body
+    assert "review-pr" in body  # named as RETIRED; must not reappear as the active gate
     assert "dual_write" in body or "dual-write" in body
     assert "competing design" in body
     # Post-#5632 Sol alignment (drive-epic skill).
@@ -32,11 +32,11 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     assert "fleet-comms is the durable source of truth" in body.lower()
     assert "legacy stores are read-only" in body.lower()
     assert "acp" in body.lower() and "provider transport" in body.lower()
-    # Direct one-round review regime (operator order 2026-08-06, PR #6423):
-    # the rule must document the direct default AND the opt-in sealed path.
+    # Direct one-round review only (operator 2026-08-06; sealed formal RETIRED 2026-08-07).
     assert "direct" in body.lower() and "one round" in body.lower().replace("-", " ")
-    assert "opt-in" in body.lower()
-    assert "review-pr" in body  # sealed path still documented (opt-in)
+    assert "retired" in body.lower()
+    assert "ask-" in body.lower()
+    assert "opt-in" not in body.lower()  # sealed formal is not opt-in; it is gone
     assert HELPER.is_file(), "missing shared launcher helper"
     helper = HELPER.read_text(encoding="utf-8")
     assert "fleet_comms_cold_clause" in helper
@@ -44,6 +44,8 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     assert "fleet-comms-coordination.md" in helper
     assert "drive-epic" in helper
     assert "authoritative" in helper
+    assert "direct ask" in helper.lower() or "ask-" in helper
+    assert "review-pr" in helper  # named as retired in the cold clause
 
 
 def test_epic_launchers_source_shared_helper_or_rule_pointer() -> None:
@@ -70,11 +72,11 @@ def test_shared_launcher_clause_onboards_authority_and_acp_layers() -> None:
         "LU_AGENT_COMM_TRANSPORT",
         "All normal inter-agent asks",
         "2–6 seat discussions",
-        "sealed formal review provider calls use ACP",
         "never fall back to bridge/provider execution",
         "fleet-comms owns durable state",
         "legacy bridge/channel stores are read-only",
         "Continuity: stream lease already claimed",
+        "RETIRED",
     ):
         assert required in helper
 

--- a/tests/test_live_driver_message_consumption.py
+++ b/tests/test_live_driver_message_consumption.py
@@ -146,4 +146,7 @@ def test_drive_epic_skill_keeps_all_required_live_inbox_boundaries():
     acknowledgement = ".venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver"
     assert text.count(inbox_command) == 4
     assert text.count(acknowledgement) == 4
-    assert ".venv/bin/python -m scripts.ai_agent_bridge asks --task-id review-pr-<PR_NUMBER>" in text
+    # Cross-family gate is direct ask-* only; sealed review-pr is retired.
+    assert "ask-" in text and "RETIRED" in text
+    assert "review-pr" in text  # named only as the retired path
+    assert "asks --task-id review-pr-" not in text


### PR DESCRIPTION
## Summary
- **Retire shielded formal CF** (operator 2026-08-07): multi-GB `lu-review-*` / `shielded-reviews` isolation filled the disk and thrash-killed drivers for days.
- `review-pr` fails closed with a direct-CF recipe unless `LU_FORMAL_SHIELDED_CF=1` (unit tests only).
- `create_review_temp_root` refuses `lu-review-*` prefixes without that env flag.
- Binding rules + `drive-epic` §6/§7a: **direct `ask-*` + PR verdict + green CI + `reap_worktrees.py --apply`** — no sealed formal path.

## Why
Drivers were not cleaning formal snaps; the path was overengineered and hindered the fleet. Cross-family review stays — lightweight only.

## Test plan
- [x] `pytest tests/ai_agent_bridge/test_formal_shielded_cf_retired.py` (3 passed)
- [x] bare `review-pr` without env prints RETIRED and exits 2
- [x] ruff on touched Python files

## Cleanup after merge
- `reap_worktrees.py --apply`
- remove this worktree