### PR TITLE
fix(security): bump root js-yaml to 4.3.1 (Dependabot #251)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-plugin-jsdoc": "^61.5.0",
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.2.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "markdownlint-cli2": "^0.20.0",
         "prettier": "^3.7.4",
         "puppeteer": "^24.32.0",
@@ -8350,9 +8350,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "eslint-plugin-jsdoc": "^61.5.0",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.2.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "markdownlint-cli2": "^0.20.0",
     "prettier": "^3.7.4",
     "puppeteer": "^24.32.0",
@@ -123,7 +123,7 @@
   },
   "overrides": {
     "uuid": "11.1.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "brace-expansion@1": "1.1.16",
     "brace-expansion@2": "2.1.2",
     "markdown-it": ">=14.2.0",


### PR DESCRIPTION
## Summary
- Root `package-lock.json` still resolved **js-yaml@4.3.0** (high: CVE-2026-59870 / Dependabot alert #251).
- `site/` was fixed in #6441; root toolchain was not.
- Pin `js-yaml` to `^4.3.1` in root `package.json` (devDependency + overrides) and refresh the lock to **4.3.1**.

## Test plan
- [x] lock shows `node_modules/js-yaml` → 4.3.1
- [ ] CI green
- [ ] Dependabot alert #251 auto-closes after scan