### PR TITLE
feat(open-model-data): make textbook corpus readiness explicit

### DIFF
--- a/data/textbook_curriculum_denominator.yaml
+++ b/data/textbook_curriculum_denominator.yaml
@@ -1,0 +1,4056 @@
+schema_version: textbook_curriculum_denominator_v1
+operation:
+  as_of: 2026/27
+  grades:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+  basis_policy:
+  - 'Grades 1-4: current TOP №743, Savchenko/Shyian programs.'
+  - 'Grades 5-9: current TOP №235 as updated by №1120, staged NUS cohorts.'
+  - 'Grades 10-11: current order-890 / 2011 standard material.'
+  future_transitions_not_current:
+  - The 2026 primary TOP starts for Grade 1 in September 2028.
+  - The 2024 profile standard starts on 1 September 2027.
+selection_reference:
+  path: docs/l2-uk-direct/textbook-selection.yaml
+  selected_book_count_is_inventory_only: true
+  selection_note: The 116-book selection is a local inventory selection, not the official curriculum denominator.
+requirement_classes:
+- required_common
+- required_one_of
+- profile_or_track
+- optional_elective
+- no_textbook_required_or_unresolved
+locator_registry:
+  MON_P12: https://mon.gov.ua/static-objects/mon/sites/1/zagalna%20serednya/programy-1-4-klas/2022/08/15/Typova.osvitnya.prohrama.1-4/Typova.osvitnya.prohrama.1-2.Savchenko.pdf
+  MON_P34: https://mon.gov.ua/static-objects/mon/sites/1/zagalna%20serednya/programy-1-4-klas/2022/08/15/Typova.osvitnya.prohrama.1-4/Typova.osvitnya.prohrama.3-4.Savchenko.pdf
+  MON_B235: https://mon.gov.ua/static-objects/mon/uploads/public/661/68f/f4b/66168ff4b1bbe581264698.pdf
+  MON_BFAQ: https://mon.gov.ua/news/vidpovidaiemo-na-zapytannia-shchodo-onovlenoi-typovoi-osvitnoi-prohramy-dlia-59-klasiv-nush
+  MON_U890: https://mon.gov.ua/static-objects/mon/zagalna%20serednya/typovi-programu-2-11/typova-osv-prohr-zzso-iii-stupenya-890.pdf
+  MON_UINDEX: https://mon.gov.ua/osvita-2/zagalna-serednya-osvita/osvitni-programi/navchalni-programi-dlya-10-11-klasiv
+  IMZO_ROOT: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/
+  IMZO_1_BUKVAR: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/1-klas/1-ukranska-mova-bukvar-1-klas/
+  IMZO_3_READ: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/3-klas/ukranska-mova-ta-chitannya-pdruchnik-dlya-3-klasu-zakladv-zagalno-seredno-osvti-u-2-kh-chastinakh/
+  IMZO_4: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/4-klas/
+  IMZO_6_UA: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/6-klas-n/movno-lteraturna-osvtnya-galuz/ukranska-mova/
+  IMZO_6_MATH: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/6-klas-n/matematichna-osvtnya-galuz/
+  IMZO_6_INFO: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/6-klas-n/nformatichna-osvtnya-galuz/nformatika/
+  IMZO_8_ALG: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/8-klas-old/algebra-8-klas/
+  IMZO_8_GEO: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/8-klas-old/geometrya-8-klas/
+  IMZO_10: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/10-klas/
+  IMZO_11: https://lib.imzo.gov.ua/yelektronn-vers-pdruchnikv/11-klas/
+cells:
+- cell_id: g01.ukrmova_bukvar
+  grade: 1
+  canonical_subject_id: ukrmova_bukvar
+  display_name_uk: Українська мова. Буквар
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  official_edition_catalog_locator_ids:
+  - IMZO_1_BUKVAR
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g01.ukrmova_bukvar
+    source_ids:
+    - 3028-bukvar-1-klas-zakhariichuk
+    - 3029-ukr-mova-bukvar-1-klas-bolshakova
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: 'Formal TOP cell is integrated ''Українська мова. Навчання грамоти''; IMZO names the approved textbook family
+    ''Українська мова. Буквар''. DB: 394 chunks, 4 files; present.'
+- cell_id: g02.ukrmova
+  grade: 2
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g02.ukrmova_chytannia_combined
+    source_ids:
+    - 3037-ukrmova-bolshakova-2-klas
+    - 57-ukrayinska-mova-vashulenko-dubovyk-2-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: 'TOP permits separate Ukrainian language plus Reading or an integrated course. DB identity ukrmova: 746 chunks,
+    6 files; present.'
+- cell_id: g02.chytannia
+  grade: 2
+  canonical_subject_id: chytannia
+  display_name_uk: Читання
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g02.ukrmova_chytannia_combined
+    source_ids:
+    - 3037-ukrmova-bolshakova-2-klas
+    - 57-ukrayinska-mova-vashulenko-dubovyk-2-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: No separate DB identity; normalized under ukrmova.
+- cell_id: g03.ukrmova
+  grade: 3
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_3_READ
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g03.ukrmova_lit_chytannia_combined
+    source_ids:
+    - 1504-ukrmova-ta-chytannja-sachenko-3-klas-nush
+    - 1524-ukrmova-ta-chytannya-vashulenko-3klas-nush
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: 'DB: 939 chunks, 6 files; present.'
+- cell_id: g03.lit_chytannia
+  grade: 3
+  canonical_subject_id: lit_chytannia
+  display_name_uk: Літературне читання
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_3_READ
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g03.ukrmova_lit_chytannia_combined
+    source_ids:
+    - 1504-ukrmova-ta-chytannja-sachenko-3-klas-nush
+    - 1524-ukrmova-ta-chytannya-vashulenko-3klas-nush
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: IMZO packages Ukrainian language and reading as a combined two-part volume; DB normalizes it under ukrmova.
+- cell_id: g04.ukrmova
+  grade: 4
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_4
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g04.ukrmova_lit_chytannia_combined
+    source_ids:
+    - 650-ukrayinska-mova-varzacka-4-klas
+    - 652-ukrayinska-mova-zaharychuk-4-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: 'DB: 986 chunks, 6 files; present.'
+- cell_id: g04.lit_chytannia
+  grade: 4
+  canonical_subject_id: lit_chytannia
+  display_name_uk: Літературне читання
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_4
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g04.ukrmova_lit_chytannia_combined
+    source_ids:
+    - 650-ukrayinska-mova-varzacka-4-klas
+    - 652-ukrayinska-mova-zaharychuk-4-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: IMZO catalog title is 'Українська мова та читання'; DB normalizes it under ukrmova.
+- cell_id: g01.foreign_language
+  grade: 1
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g01.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; exact edition universe not yet enumerated in the current corpus.
+- cell_id: g02.foreign_language
+  grade: 2
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g02.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; exact edition universe not yet enumerated in the current corpus.
+- cell_id: g03.foreign_language
+  grade: 3
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g03.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; exact edition universe not yet enumerated in the current corpus.
+- cell_id: g04.foreign_language
+  grade: 4
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g04.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; exact edition universe not yet enumerated in the current corpus.
+- cell_id: g01.matematyka
+  grade: 1
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g01.matematyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; primary math titles are not represented in current SQLite.
+- cell_id: g02.matematyka
+  grade: 2
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g02.matematyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; primary math titles are not represented in current SQLite.
+- cell_id: g03.matematyka
+  grade: 3
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g03.matematyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; primary math titles are not represented in current SQLite.
+- cell_id: g04.matematyka
+  grade: 4
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g04.matematyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; primary math titles are not represented in current SQLite.
+- cell_id: g01.ya_doslidzhuiu_svit
+  grade: 1
+  canonical_subject_id: ya_doslidzhuiu_svit
+  display_name_uk: Я досліджую світ
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g01.ya_doslidzhuiu_svit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official integrated course; title-level acquisition reconciliation pending.
+- cell_id: g02.ya_doslidzhuiu_svit
+  grade: 2
+  canonical_subject_id: ya_doslidzhuiu_svit
+  display_name_uk: Я досліджую світ
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g02.ya_doslidzhuiu_svit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official integrated course; title-level acquisition reconciliation pending.
+- cell_id: g03.ya_doslidzhuiu_svit
+  grade: 3
+  canonical_subject_id: ya_doslidzhuiu_svit
+  display_name_uk: Я досліджую світ
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g03.ya_doslidzhuiu_svit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official integrated course; title-level acquisition reconciliation pending.
+- cell_id: g04.ya_doslidzhuiu_svit
+  grade: 4
+  canonical_subject_id: ya_doslidzhuiu_svit
+  display_name_uk: Я досліджую світ
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g04.ya_doslidzhuiu_svit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official integrated course; title-level acquisition reconciliation pending.
+- cell_id: g01.dyzain_i_tekhnolohii
+  grade: 1
+  canonical_subject_id: dyzain_i_tekhnolohii
+  display_name_uk: Дизайн і технології
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g01.dyzain_i_tekhnolohii
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g02.dyzain_i_tekhnolohii
+  grade: 2
+  canonical_subject_id: dyzain_i_tekhnolohii
+  display_name_uk: Дизайн і технології
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g02.dyzain_i_tekhnolohii
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g03.dyzain_i_tekhnolohii
+  grade: 3
+  canonical_subject_id: dyzain_i_tekhnolohii
+  display_name_uk: Дизайн і технології
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g03.dyzain_i_tekhnolohii
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g04.dyzain_i_tekhnolohii
+  grade: 4
+  canonical_subject_id: dyzain_i_tekhnolohii
+  display_name_uk: Дизайн і технології
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g04.dyzain_i_tekhnolohii
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g03.informatyka
+  grade: 3
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_4
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g03.informatyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: TOP table has Informatics in both grades; no current DB source.
+- cell_id: g04.informatyka
+  grade: 4
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_4
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g04.informatyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: TOP table has Informatics in both grades; no current DB source.
+- cell_id: g01.mystetstvo
+  grade: 1
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g01.mystetstvo
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g02.mystetstvo
+  grade: 2
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g02.mystetstvo
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g03.mystetstvo
+  grade: 3
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g03.mystetstvo
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g04.mystetstvo
+  grade: 4
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g04.mystetstvo
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Official cell; title-level acquisition reconciliation pending.
+- cell_id: g01.fizychna_kultura
+  grade: 1
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g01.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Curricular cell confirmed; no textbook identity in current corpus.
+- cell_id: g02.fizychna_kultura
+  grade: 2
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g02.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Curricular cell confirmed; no textbook identity in current corpus.
+- cell_id: g03.fizychna_kultura
+  grade: 3
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g03.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Curricular cell confirmed; no textbook identity in current corpus.
+- cell_id: g04.fizychna_kultura
+  grade: 4
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №743; Savchenko/Shyian primary cohort
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_P12
+  - MON_P34
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g04.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: approved_primary_basis
+  evidence_note: Curricular cell confirmed; no textbook identity in current corpus.
+- cell_id: g05.ukrmova
+  grade: 5
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g05.ukrmova
+    source_ids:
+    - 1643-ukrainska-mova-avramenko-5-klas-2022
+    - 1649-ukrmova-5-klas-golub
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+- cell_id: g06.ukrmova
+  grade: 6
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g06.ukrmova
+    source_ids:
+    - 2591-ukrmova-6-klas-zabolotnyi-2023
+    - 2592-ukrmova-6-klas-avramenko
+    - 2595-ukrmova-6-klas-golub
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+- cell_id: g07.ukrmova
+  grade: 7
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g07.ukrmova
+    source_ids:
+    - 2873-ukrainska-mova-zabolotnyi-7-klas-2024
+    - 2876-ukrainska-mova-avramenko-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+- cell_id: g08.ukrmova
+  grade: 8
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g08.ukrmova
+    source_ids:
+    - 2899-ukrainska-mova-avramenko-8-klas-2025
+    - 2902-ukrainska-mova-zabolotnyi-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+- cell_id: g09.ukrmova
+  grade: 9
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g09.ukrmova
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 970-ukrmova-9klas-avramenko
+    - 1000-ukrmova-zabolotniy-9-klas-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current 2026/27 NUS source is not enumerated in the selected manifest; 2017 inventory is legacy-only and cannot satisfy this cell.
+- cell_id: g05.ukrlit
+  grade: 5
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g05.ukrlit
+    source_ids:
+    - 1685-5_ukrlit_avramenko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+  choice_group_id: g05.literature_realization
+  choice_member_id: separate
+  choice_member_requires: &id001
+  - g05.ukrlit
+  - g05.zarlit
+- cell_id: g06.ukrlit
+  grade: 6
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g06.ukrlit
+    source_ids:
+    - 2618-ukralit-6-klas-avramenko-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+  choice_group_id: g06.literature_realization
+  choice_member_id: separate
+  choice_member_requires: &id002
+  - g06.ukrlit
+  - g06.zarlit
+- cell_id: g07.ukrlit
+  grade: 7
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.ukrlit
+    source_ids:
+    - 2863-ukrainska-literatura-avramenko-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+  choice_group_id: g07.literature_realization
+  choice_member_id: separate
+  choice_member_requires: &id003
+  - g07.ukrlit
+  - g07.zarlit
+- cell_id: g08.ukrlit
+  grade: 8
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.ukrlit
+    source_ids:
+    - 2962-ukrainska-literatura-avramenko-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for every grade 5-9.
+  choice_group_id: g08.literature_realization
+  choice_member_id: separate
+  choice_member_requires: &id004
+  - g08.ukrlit
+  - g08.zarlit
+- cell_id: g09.ukrlit
+  grade: 9
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.ukrlit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 967-ukrliteratura-9-klas-avramenko-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current 2026/27 NUS source is not enumerated in the selected manifest; 2017 inventory is legacy-only and cannot satisfy this cell.
+  choice_group_id: g09.literature_realization
+  choice_member_id: separate
+  choice_member_requires: &id005
+  - g09.ukrlit
+  - g09.zarlit
+- cell_id: g05.zarlit
+  grade: 5
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g05.zarlit
+    source_ids:
+    - 1693-5_zarlit_voloschuk
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Separate identity present in DB for every grade 5-9.
+  choice_group_id: g05.literature_realization
+  choice_member_id: separate
+  choice_member_requires: *id001
+- cell_id: g06.zarlit
+  grade: 6
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g06.zarlit
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Separate identity present in DB for every grade 5-9.
+  choice_group_id: g06.literature_realization
+  choice_member_id: separate
+  choice_member_requires: *id002
+- cell_id: g07.zarlit
+  grade: 7
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.zarlit
+    source_ids:
+    - 2858-zarubizhna-literatura-voloshchuk-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Separate identity present in DB for every grade 5-9.
+  choice_group_id: g07.literature_realization
+  choice_member_id: separate
+  choice_member_requires: *id003
+- cell_id: g08.zarlit
+  grade: 8
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.zarlit
+    source_ids:
+    - 2995-zarubizhna-literatura-voloshchuk-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Separate identity present in DB for every grade 5-9.
+  choice_group_id: g08.literature_realization
+  choice_member_id: separate
+  choice_member_requires: *id004
+- cell_id: g09.zarlit
+  grade: 9
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.zarlit
+    source_ids:
+    - 3176-zarubizhna-literatura-9-klas-kovbasenko-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Separate identity present in DB for every grade 5-9.
+  choice_group_id: g09.literature_realization
+  choice_member_id: separate
+  choice_member_requires: *id005
+- cell_id: g05.literature_integrated
+  grade: 5
+  canonical_subject_id: literature_integrated
+  display_name_uk: Інтегрований курс літератур (української та зарубіжної)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.literature_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 4; no distinct current DB identity.
+  choice_group_id: g05.literature_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g05.literature_integrated
+- cell_id: g06.literature_integrated
+  grade: 6
+  canonical_subject_id: literature_integrated
+  display_name_uk: Інтегрований курс літератур (української та зарубіжної)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.literature_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 4; no distinct current DB identity.
+  choice_group_id: g06.literature_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g06.literature_integrated
+- cell_id: g07.literature_integrated
+  grade: 7
+  canonical_subject_id: literature_integrated
+  display_name_uk: Інтегрований курс літератур (української та зарубіжної)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.literature_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 4; no distinct current DB identity.
+  choice_group_id: g07.literature_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g07.literature_integrated
+- cell_id: g08.literature_integrated
+  grade: 8
+  canonical_subject_id: literature_integrated
+  display_name_uk: Інтегрований курс літератур (української та зарубіжної)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.literature_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 4; no distinct current DB identity.
+  choice_group_id: g08.literature_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g08.literature_integrated
+- cell_id: g09.literature_integrated
+  grade: 9
+  canonical_subject_id: literature_integrated
+  display_name_uk: Інтегрований курс літератур (української та зарубіжної)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.literature_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 4; no distinct current DB identity.
+  choice_group_id: g09.literature_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g09.literature_integrated
+- cell_id: g05.foreign_language
+  grade: 5
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 47; outside current tracked subject identity.
+- cell_id: g06.foreign_language
+  grade: 6
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 47; outside current tracked subject identity.
+- cell_id: g07.foreign_language
+  grade: 7
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 47; outside current tracked subject identity.
+- cell_id: g08.foreign_language
+  grade: 8
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 47; outside current tracked subject identity.
+- cell_id: g09.foreign_language
+  grade: 9
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземна мова
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 47; outside current tracked subject identity.
+- cell_id: g05.matematyka
+  grade: 5
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_MATH
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g05.matematyka
+    source_ids:
+    - 1632-matematyka-5-klas-ister-2022
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grade 5 present (305 chunks); Grade 6 PDF-only / extraction missing.
+- cell_id: g06.matematyka
+  grade: 6
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_MATH
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g06.matematyka
+    source_ids:
+    - 2590-matematyka-6-klas-ister-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grade 5 present (305 chunks); Grade 6 PDF-only / extraction missing.
+- cell_id: g07.algebra
+  grade: 7
+  canonical_subject_id: algebra
+  display_name_uk: Алгебра
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_ALG
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.algebra
+    source_ids:
+    - 2892-algebra-merzliak-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 7 and 9 present; Grade 8 extraction missing.
+  choice_group_id: g07.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: &id006
+  - g07.algebra
+  - g07.heometriya
+- cell_id: g08.algebra
+  grade: 8
+  canonical_subject_id: algebra
+  display_name_uk: Алгебра
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_ALG
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.algebra
+    source_ids:
+    - 2906-algebra-merzliak-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 7 and 9 present; Grade 8 extraction missing.
+  choice_group_id: g08.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: &id007
+  - g08.algebra
+  - g08.heometriya
+- cell_id: g09.algebra
+  grade: 9
+  canonical_subject_id: algebra
+  display_name_uk: Алгебра
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_ALG
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.algebra
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 982-algebra-merzlyak-9-klas-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; 2017 algebra inventory is retained as legacy-only evidence.
+  choice_group_id: g09.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: &id008
+  - g09.algebra
+  - g09.heometriya
+- cell_id: g07.heometriya
+  grade: 7
+  canonical_subject_id: heometriya
+  display_name_uk: Геометрія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_GEO
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.heometriya
+    source_ids:
+    - 2885-geometriia-merzliak-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 7 and 9 present; Grade 8 extraction missing.
+  choice_group_id: g07.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: *id006
+- cell_id: g08.heometriya
+  grade: 8
+  canonical_subject_id: heometriya
+  display_name_uk: Геометрія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_GEO
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.heometriya
+    source_ids:
+    - 2912-geometriia-merzliak-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 7 and 9 present; Grade 8 extraction missing.
+  choice_group_id: g08.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: *id007
+- cell_id: g09.heometriya
+  grade: 9
+  canonical_subject_id: heometriya
+  display_name_uk: Геометрія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_8_GEO
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.heometriya
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 996-geometriya-merzlyak-9-klas-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; 2017 geometry inventory is retained as legacy-only evidence.
+  choice_group_id: g09.mathematics_realization
+  choice_member_id: separate
+  choice_member_requires: *id008
+- cell_id: g07.matematyka_integrated
+  grade: 7
+  canonical_subject_id: matematyka_integrated
+  display_name_uk: Математика (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.matematyka_integrated
+    source_ids:
+    - 2879-matematyka-ister-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 52; Grade 7 normalized as matematyka, Grades 8-9 not separately resolved.
+  choice_group_id: g07.mathematics_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g07.matematyka_integrated
+- cell_id: g08.matematyka_integrated
+  grade: 8
+  canonical_subject_id: matematyka_integrated
+  display_name_uk: Математика (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.matematyka_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 52; Grade 7 normalized as matematyka, Grades 8-9 not separately resolved.
+  choice_group_id: g08.mathematics_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g08.matematyka_integrated
+- cell_id: g09.matematyka_integrated
+  grade: 9
+  canonical_subject_id: matematyka_integrated
+  display_name_uk: Математика (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.matematyka_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 52; Grade 7 normalized as matematyka, Grades 8-9 not separately resolved.
+  choice_group_id: g09.mathematics_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g09.matematyka_integrated
+- cell_id: g05.natural_5_6_one_of
+  grade: 5
+  canonical_subject_id: natural_5_6_one_of
+  display_name_uk: Пізнаємо природу | Довкілля | Природничі науки
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g05.natural_5_6_one_of
+    source_ids:
+    - 1722-piznaiemo-pryrodu-korshevnuk-5-klas-2022
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 53-54 and FAQ confirms the one-of choice. DB has pryroda in grades 5-6, but variant identity
+    is not fully resolved.
+  choice_group_id: g05.natural_science_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g05.natural_5_6_one_of
+- cell_id: g06.natural_5_6_one_of
+  grade: 6
+  canonical_subject_id: natural_5_6_one_of
+  display_name_uk: Пізнаємо природу | Довкілля | Природничі науки
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g06.natural_5_6_one_of
+    source_ids:
+    - 2651-piznaiemo-pryrodu-6-klas-korshevniuk
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 53-54 and FAQ confirms the one-of choice. DB has pryroda in grades 5-6, but variant identity
+    is not fully resolved.
+  choice_group_id: g06.natural_science_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g06.natural_5_6_one_of
+- cell_id: g07.natural_7_9_integrated
+  grade: 7
+  canonical_subject_id: natural_7_9_integrated
+  display_name_uk: Природничі науки (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.natural_7_9_integrated
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 59; no complete current DB identity.
+  choice_group_id: g07.natural_science_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g07.natural_7_9_integrated
+- cell_id: g08.natural_7_9_integrated
+  grade: 8
+  canonical_subject_id: natural_7_9_integrated
+  display_name_uk: Природничі науки (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.natural_7_9_integrated
+    source_ids:
+    - 2958-pryrodnychi-nauky-mandrenko-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 59; no complete current DB identity.
+  choice_group_id: g08.natural_science_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g08.natural_7_9_integrated
+- cell_id: g09.natural_7_9_integrated
+  grade: 9
+  canonical_subject_id: natural_7_9_integrated
+  display_name_uk: Природничі науки (інтегрований курс)
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.natural_7_9_integrated
+    source_ids:
+    - 3238-pryrodnychi-nauky-9-klas-mandrenko-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 59; no complete current DB identity.
+  choice_group_id: g09.natural_science_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g09.natural_7_9_integrated
+- cell_id: g07.biolohiya
+  grade: 7
+  canonical_subject_id: biolohiya
+  display_name_uk: Біологія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.biolohiya
+    source_ids:
+    - 2838-biologiia-zadorozhnyi-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 8-9 present; Grade 7 source has only 2 chunks and is effectively empty.
+  choice_group_id: g07.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: &id009
+  - g07.biolohiya
+  - g07.heohrafiya
+  - g07.fizyka
+  - g07.khimiya
+- cell_id: g08.biolohiya
+  grade: 8
+  canonical_subject_id: biolohiya
+  display_name_uk: Біологія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.biolohiya
+    source_ids:
+    - 2923-biologiia-anderson-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 8-9 present; Grade 7 source has only 2 chunks and is effectively empty.
+  choice_group_id: g08.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: &id010
+  - g08.biolohiya
+  - g08.heohrafiya
+  - g08.fizyka
+  - g08.khimiya
+- cell_id: g09.biolohiya
+  grade: 9
+  canonical_subject_id: biolohiya
+  display_name_uk: Біологія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.biolohiya
+    source_ids:
+    - 3152-biologiia-9-klas-zadorozhnyi-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 8-9 present; Grade 7 source has only 2 chunks and is effectively empty.
+  choice_group_id: g09.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: &id011
+  - g09.biolohiya
+  - g09.heohrafiya
+  - g09.fizyka
+  - g09.khimiya
+- cell_id: g06.heohrafiya
+  grade: 6
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g06.heohrafiya
+    source_ids:
+    - 6-klas-heohrafiya-zapotockyi-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 6-9.
+- cell_id: g07.heohrafiya
+  grade: 7
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.heohrafiya
+    source_ids:
+    - 7-klas-heohrafiya-hilberh-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 6-9.
+  choice_group_id: g07.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id009
+- cell_id: g08.heohrafiya
+  grade: 8
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.heohrafiya
+    source_ids:
+    - 8-klas-heohrafiya-hilberh-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 6-9.
+  choice_group_id: g08.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id010
+- cell_id: g09.heohrafiya
+  grade: 9
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.heohrafiya
+    source_ids:
+    - 3162-geografiia-9-klas-boiko-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 6-9.
+  choice_group_id: g09.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id011
+- cell_id: g07.fizyka
+  grade: 7
+  canonical_subject_id: fizyka
+  display_name_uk: Фізика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.fizyka
+    source_ids:
+    - 2823-fizyka-bariakhtar-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 7-9.
+  choice_group_id: g07.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id009
+- cell_id: g08.fizyka
+  grade: 8
+  canonical_subject_id: fizyka
+  display_name_uk: Фізика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.fizyka
+    source_ids:
+    - 2971-fizyka-bariakhtar-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 7-9.
+  choice_group_id: g08.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id010
+- cell_id: g09.fizyka
+  grade: 9
+  canonical_subject_id: fizyka
+  display_name_uk: Фізика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.fizyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 3115-fizyka-9-klas-bariakhtar
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; the 2022 physics inventory is retained as legacy-only evidence.
+  choice_group_id: g09.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id011
+- cell_id: g07.khimiya
+  grade: 7
+  canonical_subject_id: khimiya
+  display_name_uk: Хімія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.khimiya
+    source_ids:
+    - 2819-khimiia-grygorovych-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 7-9.
+  choice_group_id: g07.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id009
+- cell_id: g08.khimiya
+  grade: 8
+  canonical_subject_id: khimiya
+  display_name_uk: Хімія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.khimiya
+    source_ids:
+    - 2921-khimiia-grygorovych-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present in DB for grades 7-9.
+  choice_group_id: g08.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id010
+- cell_id: g09.khimiya
+  grade: 9
+  canonical_subject_id: khimiya
+  display_name_uk: Хімія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.khimiya
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 1041-himiya-9-klas-popel-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; 2017 chemistry inventory is retained as legacy-only evidence.
+  choice_group_id: g09.natural_science_realization
+  choice_member_id: separate
+  choice_member_requires: *id011
+- cell_id: g05.informatyka
+  grade: 5
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_INFO
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g05.informatyka
+    source_ids:
+    - 1660-informatyka-5-klas-ryvkind-2022
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5, 7, 8, 9 present; Grade 6 PDF-only / extraction missing.
+- cell_id: g06.informatyka
+  grade: 6
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_INFO
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g06.informatyka
+    source_ids:
+    - 2686-informatyka-6-klas-ryvkind-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5, 7, 8, 9 present; Grade 6 PDF-only / extraction missing.
+- cell_id: g07.informatyka
+  grade: 7
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_INFO
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g07.informatyka
+    source_ids:
+    - 2809-informatyka-ryvkind-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5, 7, 8, 9 present; Grade 6 PDF-only / extraction missing.
+- cell_id: g08.informatyka
+  grade: 8
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_INFO
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g08.informatyka
+    source_ids:
+    - 3011-informatyka-ryvkind-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5, 7, 8, 9 present; Grade 6 PDF-only / extraction missing.
+- cell_id: g09.informatyka
+  grade: 9
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_6_INFO
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g09.informatyka
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 1046-informatika-9-klas-ryvkind-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; 2017 informatics inventory is retained as legacy-only evidence.
+- cell_id: g05.tekhnolohiyi
+  grade: 5
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 60; no current DB identity or local acquisition mapping.
+- cell_id: g06.tekhnolohiyi
+  grade: 6
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 60; no current DB identity or local acquisition mapping.
+- cell_id: g07.tekhnolohiyi
+  grade: 7
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 60; no current DB identity or local acquisition mapping.
+- cell_id: g08.tekhnolohiyi
+  grade: 8
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 60; no current DB identity or local acquisition mapping.
+- cell_id: g09.tekhnolohiyi
+  grade: 9
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 60; no current DB identity or local acquisition mapping.
+- cell_id: g05.zdorovia_bezpeka_dobrobut
+  grade: 5
+  canonical_subject_id: zdorovia_bezpeka_dobrobut
+  display_name_uk: Здоров’я, безпека та добробут
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g05.zdorovia_bezpeka_dobrobut
+    source_ids:
+    - 1707-zdorovia-bezpeka-ta-dobrobut-voroncova-5-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5-8 present; Grade 9 is deferred, not evidence of non-teaching.
+- cell_id: g06.zdorovia_bezpeka_dobrobut
+  grade: 6
+  canonical_subject_id: zdorovia_bezpeka_dobrobut
+  display_name_uk: Здоров’я, безпека та добробут
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g06.zdorovia_bezpeka_dobrobut
+    source_ids:
+    - 2644-zdorovia-6-klas-vorontsova-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5-8 present; Grade 9 is deferred, not evidence of non-teaching.
+- cell_id: g07.zdorovia_bezpeka_dobrobut
+  grade: 7
+  canonical_subject_id: zdorovia_bezpeka_dobrobut
+  display_name_uk: Здоров’я, безпека та добробут
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g07.zdorovia_bezpeka_dobrobut
+    source_ids:
+    - 2813-zdorovia-bezpeka-ta-dobrobut-gushchyna-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5-8 present; Grade 9 is deferred, not evidence of non-teaching.
+- cell_id: g08.zdorovia_bezpeka_dobrobut
+  grade: 8
+  canonical_subject_id: zdorovia_bezpeka_dobrobut
+  display_name_uk: Здоров’я, безпека та добробут
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g08.zdorovia_bezpeka_dobrobut
+    source_ids:
+    - 2997-zdorovia-bezpeka-ta-dobrobut-vasylenko-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5-8 present; Grade 9 is deferred, not evidence of non-teaching.
+- cell_id: g09.zdorovia_bezpeka_dobrobut
+  grade: 9
+  canonical_subject_id: zdorovia_bezpeka_dobrobut
+  display_name_uk: Здоров’я, безпека та добробут
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g09.zdorovia_bezpeka_dobrobut
+    source_ids:
+    - 3181-zdorovia-9-klas-voroncova-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Grades 5-8 present; Grade 9 is deferred, not evidence of non-teaching.
+- cell_id: g05.etyka
+  grade: 5
+  canonical_subject_id: etyka
+  display_name_uk: Етика / інший курс морального спрямування
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g05.etyka
+    source_ids:
+    - 1695-etyka-5-klas-meleshchenko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially optional; etyka present in DB for grades 5-6.
+- cell_id: g06.etyka
+  grade: 6
+  canonical_subject_id: etyka
+  display_name_uk: Етика / інший курс морального спрямування
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g06.etyka
+    source_ids:
+    - 2632-etyka-6-klas-martyniuk
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially optional; etyka present in DB for grades 5-6.
+- cell_id: g08.finansova
+  grade: 8
+  canonical_subject_id: finansova
+  display_name_uk: Підприємництво і фінансова грамотність
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g08.finansova
+    source_ids:
+    - 2950-pidpryiemnyctvo-i-finansova-gramotnist-plastun-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 66; Grade 8 present; Grade 9 deferred.
+- cell_id: g09.finansova
+  grade: 9
+  canonical_subject_id: finansova
+  display_name_uk: Підприємництво і фінансова грамотність
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g09.finansova
+    source_ids:
+    - 3211-pidruchnyk-pidpryiemnyctvo-i-finansova-gramotnist-9-klas-gilberg-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 66; Grade 8 present; Grade 9 deferred.
+- cell_id: g05.vstup_istorii
+  grade: 5
+  canonical_subject_id: vstup_istorii
+  display_name_uk: Вступ до історії України та громадянської освіти
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g05.vstup_istorii
+    source_ids:
+    - 1668-vstup-do-istorii-5-klas-shchupak-2022
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present under normalized istoriya.
+  choice_group_id: g05.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g05.vstup_istorii
+- cell_id: g06.istoriya_ukr_vsesvit
+  grade: 6
+  canonical_subject_id: istoriya_ukr_vsesvit
+  display_name_uk: Історія України. Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g06.istoriya_ukr_vsesvit
+    source_ids:
+    - 2606-istoriia-6-klas-gisem-2023
+    - 2610-istoriia-6-klas-shchupak-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present under istoriya.
+  choice_group_id: g06.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g06.istoriya_ukr_vsesvit
+- cell_id: g05.history_integrated_5_6
+  grade: 5
+  canonical_subject_id: history_integrated_5_6
+  display_name_uk: Україна і світ | Досліджуємо історію і суспільство
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.history_integrated_5_6
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: FAQ says the school chooses the MNP; no distinct current DB identity.
+  choice_group_id: g05.history_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g05.history_integrated_5_6
+- cell_id: g06.history_integrated_5_6
+  grade: 6
+  canonical_subject_id: history_integrated_5_6
+  display_name_uk: Україна і світ | Досліджуємо історію і суспільство
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.history_integrated_5_6
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: FAQ says the school chooses the MNP; no distinct current DB identity.
+  choice_group_id: g06.history_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g06.history_integrated_5_6
+- cell_id: g07.history_separate
+  grade: 7
+  canonical_subject_id: history_separate
+  display_name_uk: Історія України + Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.history_separate
+    source_ids: []
+    source_groups:
+    - - 2847-istoriia-ukrainy-galimov-7-klas-2024
+    - - 2855-vsesvitnia-istoriia-ladychenko-7-klas-2024
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present under istoriya and vsesvitnia.
+  choice_group_id: g07.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g07.history_separate
+- cell_id: g08.history_separate
+  grade: 8
+  canonical_subject_id: history_separate
+  display_name_uk: Історія України + Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.history_separate
+    source_ids: []
+    source_groups:
+    - - 3014-istoriia-ukrainy-gisem-8-klas-2025
+      - 3018-istoriia-ukrainy-galimov-8-klas-2025
+      - 3020-istoriia-ukrainy-shchupak-8-klas-2025
+    - - 2976-vsesvitnia-istoriia-ladychenko-8-klas-2025
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present under istoriya and vsesvitnia.
+  choice_group_id: g08.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g08.history_separate
+- cell_id: g09.history_separate
+  grade: 9
+  canonical_subject_id: history_separate
+  display_name_uk: Історія України + Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.history_separate
+    source_ids: []
+    source_groups:
+    - - 3127-istoriia-ukrainy-9-klas-gisem
+    - - 3159-vsesvitnia-istoriia-9-klas-pometun-2026
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Present under istoriya and vsesvitnia.
+  choice_group_id: g09.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g09.history_separate
+- cell_id: g07.history_integrated_7_9
+  grade: 7
+  canonical_subject_id: history_integrated_7_9
+  display_name_uk: 'Історія: Україна і світ'
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.history_integrated_7_9
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 73; no distinct current DB identity.
+  choice_group_id: g07.history_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g07.history_integrated_7_9
+- cell_id: g08.history_integrated_7_9
+  grade: 8
+  canonical_subject_id: history_integrated_7_9
+  display_name_uk: 'Історія: Україна і світ'
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.history_integrated_7_9
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 73; no distinct current DB identity.
+  choice_group_id: g08.history_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g08.history_integrated_7_9
+- cell_id: g09.history_integrated_7_9
+  grade: 9
+  canonical_subject_id: history_integrated_7_9
+  display_name_uk: 'Історія: Україна і світ'
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.history_integrated_7_9
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 73; no distinct current DB identity.
+  choice_group_id: g09.history_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g09.history_integrated_7_9
+- cell_id: g08.hromadianska
+  grade: 8
+  canonical_subject_id: hromadianska
+  display_name_uk: Громадянська освіта
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.hromadianska
+    source_ids:
+    - 2988-gromadianska-osvita-vasylkiv-8-klas-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: 'Present in DB: 143 chunks.'
+  choice_group_id: g08.civics_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g08.hromadianska
+- cell_id: g09.pravoznavstvo
+  grade: 9
+  canonical_subject_id: pravoznavstvo
+  display_name_uk: Правознавство
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g09.pravoznavstvo
+    source_ids:
+    - 3236-pravoznavstvo-9-klas-remekh-2026
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Official MNP 75; deferred in current corpus.
+- cell_id: g05.mystetstvo_one_of
+  grade: 5
+  canonical_subject_id: mystetstvo_one_of
+  display_name_uk: Мистецтво | Музичне мистецтво | Образотворче мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g05.mystetstvo_one_of
+    source_ids:
+    - 1709-mystectstvo-rublia-5-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Integrated mystetstvo is present in every grade 5-9; separate music/visual identities are not in DB.
+  choice_group_id: g05.arts_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g05.mystetstvo_one_of
+- cell_id: g06.mystetstvo_one_of
+  grade: 6
+  canonical_subject_id: mystetstvo_one_of
+  display_name_uk: Мистецтво | Музичне мистецтво | Образотворче мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g06.mystetstvo_one_of
+    source_ids:
+    - 2687-mystetstvo-6-klas-rublia
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Integrated mystetstvo is present in every grade 5-9; separate music/visual identities are not in DB.
+  choice_group_id: g06.arts_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g06.mystetstvo_one_of
+- cell_id: g07.mystetstvo_one_of
+  grade: 7
+  canonical_subject_id: mystetstvo_one_of
+  display_name_uk: Мистецтво | Музичне мистецтво | Образотворче мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g07.mystetstvo_one_of
+    source_ids:
+    - 2804-mystectvo-masol-7-klas-2024
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Integrated mystetstvo is present in every grade 5-9; separate music/visual identities are not in DB.
+  choice_group_id: g07.arts_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g07.mystetstvo_one_of
+- cell_id: g08.mystetstvo_one_of
+  grade: 8
+  canonical_subject_id: mystetstvo_one_of
+  display_name_uk: Мистецтво | Музичне мистецтво | Образотворче мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g08.mystetstvo_one_of
+    source_ids:
+    - 8-klas-mystetstvo-komarovska-2025
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Integrated mystetstvo is present in every grade 5-9; separate music/visual identities are not in DB.
+  choice_group_id: g08.arts_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g08.mystetstvo_one_of
+- cell_id: g09.mystetstvo_one_of
+  grade: 9
+  canonical_subject_id: mystetstvo_one_of
+  display_name_uk: Мистецтво | Музичне мистецтво | Образотворче мистецтво
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g09.mystetstvo_one_of
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: legacy_only
+    legacy_inventory_source_ids:
+    - 9-klas-mystetstvo-masol-2017
+    edition_policy: current_nus_cohort
+  evidence_note: Current Grade 9 NUS source is not enumerated; the 2017 art inventory is legacy-only and separate music/visual identities are unresolved.
+  choice_group_id: g09.arts_realization
+  choice_member_id: integrated
+  choice_member_requires:
+  - g09.mystetstvo_one_of
+- cell_id: g05.fizychna_kultura
+  grade: 5
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially compulsory; no textbook identity in current corpus.
+- cell_id: g06.fizychna_kultura
+  grade: 6
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially compulsory; no textbook identity in current corpus.
+- cell_id: g07.fizychna_kultura
+  grade: 7
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially compulsory; no textbook identity in current corpus.
+- cell_id: g08.fizychna_kultura
+  grade: 8
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially compulsory; no textbook identity in current corpus.
+- cell_id: g09.fizychna_kultura
+  grade: 9
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_B235
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Officially compulsory; no textbook identity in current corpus.
+- cell_id: g05.interfield_course
+  grade: 5
+  canonical_subject_id: interfield_course
+  display_name_uk: Робототехніка | STEM | Драматургія і театр | Фізика та основи техніки | Економіка і право
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 5
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g05.interfield_course
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Not a universal denominator cell; include only when a school-selected course is evidenced.
+- cell_id: g06.interfield_course
+  grade: 6
+  canonical_subject_id: interfield_course
+  display_name_uk: Робототехніка | STEM | Драматургія і театр | Фізика та основи техніки | Економіка і право
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 6
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g06.interfield_course
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Not a universal denominator cell; include only when a school-selected course is evidenced.
+- cell_id: g07.interfield_course
+  grade: 7
+  canonical_subject_id: interfield_course
+  display_name_uk: Робототехніка | STEM | Драматургія і театр | Фізика та основи техніки | Економіка і право
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 7
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g07.interfield_course
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Not a universal denominator cell; include only when a school-selected course is evidenced.
+- cell_id: g08.interfield_course
+  grade: 8
+  canonical_subject_id: interfield_course
+  display_name_uk: Робототехніка | STEM | Драматургія і театр | Фізика та основи техніки | Економіка і право
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 8
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g08.interfield_course
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Not a universal denominator cell; include only when a school-selected course is evidenced.
+- cell_id: g09.interfield_course
+  grade: 9
+  canonical_subject_id: interfield_course
+  display_name_uk: Робототехніка | STEM | Драматургія і театр | Фізика та основи техніки | Економіка і право
+  cohort_or_effective_basis: current 2026/27; TOP №235 updated by №1120; NUS staged cohort for Grade 9
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_B235
+  - MON_BFAQ
+  official_edition_catalog_locator_ids:
+  - IMZO_ROOT
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g09.interfield_course
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_nus_cohort
+  evidence_note: Not a universal denominator cell; include only when a school-selected course is evidenced.
+- cell_id: g10.ukrmova
+  grade: 10
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g10.ukrmova
+    source_ids:
+    - 3081-ukrmova-10-klas-glazova
+    - 3082-ukrmova-10-klas-karaman
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.ukrmova
+  grade: 11
+  canonical_subject_id: ukrmova
+  display_name_uk: Українська мова
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g11.ukrmova
+    source_ids:
+    - 1238-ukrmova-11-klas-glazova
+    - 1239-ukrainska-mova-11-klas-avramenko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.ukrlit
+  grade: 10
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g10.ukrlit
+    source_ids:
+    - 392-ukrayinska-lteratura-avramenko-paharenko-10-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.ukrlit
+  grade: 11
+  canonical_subject_id: ukrlit
+  display_name_uk: Українська література
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g11.ukrlit
+    source_ids:
+    - 1237-ukrliteratura-avramenko-11klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.zarlit
+  grade: 10
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.zarlit
+    source_ids:
+    - 1147-zarubizhna-10-klas-voloschuk
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.zarlit
+  grade: 11
+  canonical_subject_id: zarlit
+  display_name_uk: Зарубіжна література
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.zarlit
+    source_ids:
+    - 1279-zarubizhna-11-klas-voloschuk
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.history_ua_world
+  grade: 10
+  canonical_subject_id: history_ua_world
+  display_name_uk: Історія України. Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g10.history_ua_world
+    source_ids: []
+    source_groups:
+    - - 3092-istoriia-ukrainy-10-klas-khlibovska
+    - - 3109-vsesvitnia-istoriia-10-klas-gisem-stan
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Separate identities present; integrated alternative requires title-level reconciliation.
+  choice_group_id: g10.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g10.history_ua_world
+- cell_id: g11.history_ua_world
+  grade: 11
+  canonical_subject_id: history_ua_world
+  display_name_uk: Історія України. Всесвітня історія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_one_of
+  official_program_locator_ids:
+  - MON_U890
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: choice_required
+  coverage:
+    coverage_unit_id: g11.history_ua_world
+    source_ids: []
+    source_groups:
+    - - 3021-istoriia-ukrainy-galimov-11-klas
+      - 3023-istoriia-ukrainy-khlibovska-11-klas-2024
+      - 3024-istoriia-ukrainy-gisem-11-klas-2024
+    - - 3027-vsesvitnia-istoriia-shchupak-11-klas-2024
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Separate identities present; integrated alternative requires title-level reconciliation.
+  choice_group_id: g11.history_realization
+  choice_member_id: separate
+  choice_member_requires:
+  - g11.history_ua_world
+- cell_id: g10.hromadianska
+  grade: 10
+  canonical_subject_id: hromadianska
+  display_name_uk: Громадянська освіта
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g10.hromadianska
+    source_ids:
+    - 10-klas-hromadianska-gisem-2018
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for Grade 10; exact 10/11 timetable row requires order-890 table extraction.
+- cell_id: g10.foreign_language
+  grade: 10
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземні мови
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g10.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; not represented in current tracked DB.
+- cell_id: g11.foreign_language
+  grade: 11
+  canonical_subject_id: foreign_language
+  display_name_uk: Іноземні мови
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g11.foreign_language
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; not represented in current tracked DB.
+- cell_id: g10.matematyka
+  grade: 10
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g10.matematyka
+    source_ids:
+    - 1153-matematyka-10-klas-merzlyak
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.matematyka
+  grade: 11
+  canonical_subject_id: matematyka
+  display_name_uk: Математика
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g11.matematyka
+    source_ids:
+    - 3065-matematyka-11-klas-nelin
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.algebra_geometry
+  grade: 10
+  canonical_subject_id: algebra_geometry
+  display_name_uk: Алгебра і геометрія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.algebra_geometry
+    source_ids: []
+    source_groups:
+    - - 1223-algebra-10-klas-ister
+    - - 1178-geometriya-10-klas-ister
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Algebra and geometry identities present in DB for both grades.
+- cell_id: g11.algebra_geometry
+  grade: 11
+  canonical_subject_id: algebra_geometry
+  display_name_uk: Алгебра і геометрія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.algebra_geometry
+    source_ids: []
+    source_groups:
+    - - 1250-algebra-ister-11-klas
+    - - 1248-geometriya-11-klas-ister
+    source_match_mode: all
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Algebra and geometry identities present in DB for both grades.
+- cell_id: g10.informatyka
+  grade: 10
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10-11.informatyka_combined
+    source_ids:
+    - 3099-informatyka-10-11-klas-rudenko-stand
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.informatyka
+  grade: 11
+  canonical_subject_id: informatyka
+  display_name_uk: Інформатика
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10-11.informatyka_combined
+    source_ids:
+    - 3099-informatyka-10-11-klas-rudenko-stand
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.zakhyst_ukrainy
+  grade: 10
+  canonical_subject_id: zakhyst_ukrainy
+  display_name_uk: Захист України
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g10.zakhyst_ukrainy
+    source_ids:
+    - 10-klas-zakhyst-fuka-2023
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.zakhyst_ukrainy
+  grade: 11
+  canonical_subject_id: zakhyst_ukrainy
+  display_name_uk: Захист України
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: required_common
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: required
+  coverage:
+    coverage_unit_id: g11.zakhyst_ukrainy
+    source_ids:
+    - 1270-zahyst-vitchyzny-11-klass-gudyma-med
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.mystetstvo
+  grade: 10
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10-11.mystetstvo_combined
+    source_ids:
+    - 3090-mystectvo-10-11-klas-nazarenko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: 'DB source 10-11-klas-mystectvo-nazarenko-2018: 311 chunks, stored under Grade 10; no separate Grade 11 source.'
+- cell_id: g11.mystetstvo
+  grade: 11
+  canonical_subject_id: mystetstvo
+  display_name_uk: Мистецтво
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10-11.mystetstvo_combined
+    source_ids:
+    - 3090-mystectvo-10-11-klas-nazarenko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: 'DB source 10-11-klas-mystectvo-nazarenko-2018: 311 chunks, stored under Grade 10; no separate Grade 11 source.'
+- cell_id: g10.tekhnolohiyi
+  grade: 10
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g10.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no current DB identity.
+- cell_id: g11.tekhnolohiyi
+  grade: 11
+  canonical_subject_id: tekhnolohiyi
+  display_name_uk: Технології
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g11.tekhnolohiyi
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no current DB identity.
+- cell_id: g10.biolohiya_ekolohiya
+  grade: 10
+  canonical_subject_id: biolohiya_ekolohiya
+  display_name_uk: Біологія і екологія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.biolohiya_ekolohiya
+    source_ids:
+    - 3113-biologiia-i-ekologiia-10-klas-zadorozhnyi-stan
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.biolohiya_ekolohiya
+  grade: 11
+  canonical_subject_id: biolohiya_ekolohiya
+  display_name_uk: Біологія і екологія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.biolohiya_ekolohiya
+    source_ids:
+    - 3111-biologiia-ekologiia-11-klas-shalamov
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.heohrafiya
+  grade: 10
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.heohrafiya
+    source_ids:
+    - 1184-geografiya-10-klas-boyko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.heohrafiya
+  grade: 11
+  canonical_subject_id: heohrafiya
+  display_name_uk: Географія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.heohrafiya
+    source_ids:
+    - 1242-geografiya-11klas-pestushko
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.fizyka_astronomiya
+  grade: 10
+  canonical_subject_id: fizyka_astronomiya
+  display_name_uk: Фізика і астрономія | Фізика | Астрономія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.fizyka_astronomiya
+    source_ids:
+    - 3079-fizyka-10-klas-bariakhtar
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Physics present in both grades; astronomy present in Grade 11; exact integrated-title mapping pending.
+- cell_id: g11.fizyka_astronomiya
+  grade: 11
+  canonical_subject_id: fizyka_astronomiya
+  display_name_uk: Фізика і астрономія | Фізика | Астрономія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.fizyka_astronomiya
+    source_ids:
+    - 1277-fizyka-i-astronomiya-11-klas-zasekina
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Physics present in both grades; astronomy present in Grade 11; exact integrated-title mapping pending.
+- cell_id: g10.khimiya
+  grade: 10
+  canonical_subject_id: khimiya
+  display_name_uk: Хімія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.khimiya
+    source_ids:
+    - 3077-khimiia-10-klas-grygorovych
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.khimiya
+  grade: 11
+  canonical_subject_id: khimiya
+  display_name_uk: Хімія
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.khimiya
+    source_ids:
+    - 3059-khimiia-11-klas-grygorovych
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.pryrodnychi_nauky
+  grade: 10
+  canonical_subject_id: pryrodnychi_nauky
+  display_name_uk: Природничі науки (4 проєкти)
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g10.pryrodnychi_nauky
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Official program family; exact project-to-edition mapping unresolved.
+- cell_id: g11.pryrodnychi_nauky
+  grade: 11
+  canonical_subject_id: pryrodnychi_nauky
+  display_name_uk: Природничі науки (4 проєкти)
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g11.pryrodnychi_nauky
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Official program family; exact project-to-edition mapping unresolved.
+- cell_id: g10.ekonomika
+  grade: 10
+  canonical_subject_id: ekonomika
+  display_name_uk: Економіка
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.ekonomika
+    source_ids:
+    - 10-klas-ekonomika-krupska-2018
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.ekonomika
+  grade: 11
+  canonical_subject_id: ekonomika
+  display_name_uk: Економіка
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.ekonomika
+    source_ids:
+    - 1318-ekonomika-krihovec-homyak-11-klas
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.pravoznavstvo
+  grade: 10
+  canonical_subject_id: pravoznavstvo
+  display_name_uk: Правознавство
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.pravoznavstvo
+    source_ids:
+    - 10-klas-pravoznavstvo-lukianchykov-2018
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g11.pravoznavstvo
+  grade: 11
+  canonical_subject_id: pravoznavstvo
+  display_name_uk: Правознавство
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.pravoznavstvo
+    source_ids:
+    - 11-klas-pravoznavstvo-narovlianskyi-2019
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Present in DB for both grades.
+- cell_id: g10.finansova
+  grade: 10
+  canonical_subject_id: finansova
+  display_name_uk: Фінансова грамотність
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g10.finansova
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially described as a selective/optional subject; no current DB identity.
+- cell_id: g11.finansova
+  grade: 11
+  canonical_subject_id: finansova
+  display_name_uk: Фінансова грамотність
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: optional_elective
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: optional
+  coverage:
+    coverage_unit_id: g11.finansova
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially described as a selective/optional subject; no current DB identity.
+- cell_id: g10.kreslennia
+  grade: 10
+  canonical_subject_id: kreslennia
+  display_name_uk: Креслення
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g10.kreslennia
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no current DB identity.
+- cell_id: g11.kreslennia
+  grade: 11
+  canonical_subject_id: kreslennia
+  display_name_uk: Креслення
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: profile_or_track
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: profile_conditional
+  coverage:
+    coverage_unit_id: g11.kreslennia
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: resolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no current DB identity.
+- cell_id: g10.fizychna_kultura
+  grade: 10
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g10.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no textbook identity in current DB.
+- cell_id: g11.fizychna_kultura
+  grade: 11
+  canonical_subject_id: fizychna_kultura
+  display_name_uk: Фізична культура
+  cohort_or_effective_basis: current 2026/27; order-890 / 2011 upper-secondary standard; 2027 profile transition is future
+  requirement_class: no_textbook_required_or_unresolved
+  official_program_locator_ids:
+  - MON_UINDEX
+  official_edition_catalog_locator_ids:
+  - IMZO_10
+  - IMZO_11
+  textbook_applicability: unresolved
+  coverage:
+    coverage_unit_id: g11.fizychna_kultura
+    source_ids: []
+    source_groups: []
+    source_match_mode: any
+    evidence_state: unresolved
+    legacy_inventory_source_ids: []
+    edition_policy: current_order_890
+  evidence_note: Officially listed; no textbook identity in current DB.

--- a/docs/l2-uk-direct/textbook-selection.yaml
+++ b/docs/l2-uk-direct/textbook-selection.yaml
@@ -1,6 +1,6 @@
 # Textbook Selection for RAG Database
 # Selected: 2026-02-26
-# Total: 115 books (42 humanities + 22 wave-1 STEM + 51 batch-3, #4593) from pidruchnyk.com.ua + Google Drive
+# Total: 116 books (115 prior selections + Grade 6 Zabolotnyi 2023 recovery) from pidruchnyk.com.ua, shkola.in.ua, and Google Drive
 # Strategy: 2 мова per grade, 1 literature (5-11), 1-2 history (5-11)
 #
 # PDF URL pattern: https://pidruchnyk.com.ua/uploads/book/{filename}.pdf
@@ -133,7 +133,18 @@ books:
     author: Голуб
     year: 2023
     slug: 2595-ukrmova-6-klas-golub
-    note: "Replaces Заболотний (SSL error)"
+    note: "Second current-edition language source"
+
+  - id: g6-mova-zabolotnyi
+    grade: 6
+    subject: ukrainska_mova
+    author: Заболотний
+    year: 2023
+    slug: 2591-ukrmova-6-klas-zabolotnyi-2023
+    canonical_source: 6-klas-ukrmova-zabolotnyi-2023
+    fallback_page_urls:
+      - "https://shkola.in.ua/2835-ukrainska-mova-6-klas-zabolotnyi.html"
+    note: "Current official edition replacing the corrupt 2020 extraction"
 
   - id: g6-lit-avramenko
     grade: 6
@@ -389,6 +400,9 @@ books:
     author: Ривкінд
     year: 2023
     slug: 2686-informatyka-6-klas-ryvkind-2023
+    canonical_source: 6-klas-informatyka-ryvkind-2023
+    fallback_page_urls:
+      - "https://shkola.in.ua/2898-informatyka-6-klas-ryvkind.html"
 
   - id: g6-matematyka-ister
     grade: 6
@@ -396,6 +410,9 @@ books:
     author: Істер
     year: 2023
     slug: 2590-matematyka-6-klas-ister-2023
+    canonical_source: 6-klas-matematyka-ister-2023
+    fallback_page_urls:
+      - "https://shkola.in.ua/2815-matematyka-6-klas-ister.html"
 
   - id: g7-algebra-merzliak
     grade: 7
@@ -445,6 +462,9 @@ books:
     author: Мерзляк
     year: 2025
     slug: 2906-algebra-merzliak-8-klas-2025
+    canonical_source: 8-klas-algebra-merzliak-2025
+    fallback_page_urls:
+      - "https://shkola.in.ua/318-alhebra-8-klas-merzliak.html"
 
   - id: g8-biolohiya-anderson
     grade: 8
@@ -466,6 +486,9 @@ books:
     author: Мерзляк
     year: 2025
     slug: 2912-geometriia-merzliak-8-klas-2025
+    canonical_source: 8-klas-heometriya-merzliak-2025
+    fallback_page_urls:
+      - "https://shkola.in.ua/338-heometriia-8-klas-merzliak.html"
 
   - id: g8-informatyka-ryvkind
     grade: 8
@@ -929,6 +952,6 @@ books:
     grade: 11
     subject: mystetstvo
     author: Назаренко
-    year: 2019
+    year: 2018
     slug: 3090-mystectvo-10-11-klas-nazarenko
     note: "combined 10(11) volume, fills mystetstvo-11 slot"

--- a/scripts/crawl/download_textbooks.py
+++ b/scripts/crawl/download_textbooks.py
@@ -9,17 +9,40 @@ Usage:
 """
 
 import argparse
+import hashlib
+import os
 import re
+import sys
+import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
 import requests
 import yaml
 from bs4 import BeautifulSoup
 
+try:
+    from scripts.wiki.textbook_subjects import (
+        AUTHOR_UK_BY_TRANSLIT,
+        normalize_subject_slug,
+        subject_for_source_file,
+    )
+except ModuleNotFoundError:
+    # Preserve the documented direct-script entry point as well as ``-m``.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from scripts.wiki.textbook_subjects import (
+        AUTHOR_UK_BY_TRANSLIT,
+        normalize_subject_slug,
+        subject_for_source_file,
+    )
+
 BASE_URL = "https://pidruchnyk.com.ua"
 SELECTION_FILE = Path("docs/l2-uk-direct/textbook-selection.yaml")
 OUTPUT_DIR = Path("data/textbooks")
+PDF_SIGNATURE = b"%PDF-"
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
 # Polite crawl delay (seconds between requests)
 CRAWL_DELAY = 2.0
@@ -33,6 +56,12 @@ HEADERS = {
 
 class TitleGuardError(Exception):
     """Raised when the fetched page's title does not match selection criteria."""
+
+    pass
+
+
+class DownloadValidationError(ValueError):
+    """Raised when a streamed response cannot be retained as a PDF."""
 
     pass
 
@@ -176,6 +205,52 @@ def check_filename_overlap(filename: str, subject: str, author: str) -> bool:
     return True
 
 
+def find_retained_book_pdfs(retained_store: Path, book: dict) -> list[Path]:
+    """Find canonical retained PDFs matching explicit book metadata.
+
+    This is filename-only and therefore does not hydrate cloud-backed file
+    contents.  Ambiguous matches are returned for the readiness audit to
+    resolve; any match prevents an automatic duplicate acquisition.
+    """
+    try:
+        grade = int(book["grade"])
+        year = int(book["year"])
+    except (KeyError, TypeError, ValueError):
+        return []
+    subject = normalize_subject_slug(str(book.get("subject") or ""))
+    author = normalize_whitespace(str(book.get("author") or ""))
+    author_tokens = {
+        latin.casefold()
+        for latin, cyrillic in AUTHOR_UK_BY_TRANSLIT.items()
+        if normalize_whitespace(cyrillic) in author
+    }
+    if not subject or not author_tokens:
+        return []
+
+    matches: list[Path] = []
+    for path in sorted(retained_store.rglob("*.pdf")):
+        stem = path.stem.casefold().replace("_", "-")
+        grade_match = re.search(r"(?:^|-)(\d{1,2})(?:-(\d{1,2}))?-klas(?:-|$)", stem)
+        if grade_match is None:
+            continue
+        first_grade = int(grade_match.group(1))
+        last_grade = int(grade_match.group(2) or first_grade)
+        if not first_grade <= grade <= last_grade:
+            continue
+        retained_subject = subject_for_source_file(stem)
+        if retained_subject != subject and not (
+            grade == 1 and subject == "ukrmova" and retained_subject == "bukvar"
+        ):
+            continue
+        if not any(re.search(rf"(?:^|-){re.escape(token)}(?:-|$)", stem) for token in author_tokens):
+            continue
+        years = {int(value) for value in re.findall(r"(?<!\d)(20\d{2})(?!\d)", stem)}
+        if years and year not in years:
+            continue
+        matches.append(path)
+    return matches
+
+
 def load_selection() -> list[dict]:
     """Load the book selection YAML."""
     with open(SELECTION_FILE) as f:
@@ -227,23 +302,33 @@ def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | Non
         filename = href.split("/")[-1]
         all_pdfs.append({"url": href, "label": text, "filename": filename})
 
-    # 2. Search for drive iframes if no pdf links found
+    # 2. Discover Google Drive mirrors in both anchors and iframes.  When a
+    # page exposes one direct PDF and one Drive copy, they are alternate
+    # transports for one logical book, not two volumes to retain separately.
+    drive_candidates: list[dict[str, str]] = []
+    seen_drive_ids: set[str] = set()
+    drive_urls = [str(tag.get("href", "")) for tag in soup.find_all("a", href=True)]
+    drive_urls.extend(
+        str(tag.get("src", "")) for tag in soup.find_all("iframe", src=True)
+    )
+    for drive_url in drive_urls:
+        drive_id = _google_drive_id(drive_url)
+        if drive_id is None or drive_id in seen_drive_ids:
+            continue
+        seen_drive_ids.add(drive_id)
+        drive_candidates.append(
+            {
+                "url": f"https://docs.google.com/uc?export=download&id={drive_id}",
+                "label": "Google Drive mirror",
+                "filename": f"{drive_id}.pdf",
+                "gdrive_id": drive_id,
+            }
+        )
+
     if not all_pdfs:
-        for iframe in soup.find_all("iframe", src=re.compile(r"drive\.google\.com")):
-            src = iframe.get("src", "")
-            match = re.search(r"/file/d/([a-zA-Z0-9_-]+)", src)
-            if not match:
-                match = re.search(r"id=([a-zA-Z0-9_-]+)", src)
-            if match:
-                drive_id = match.group(1)
-                all_pdfs.append(
-                    {
-                        "url": f"https://docs.google.com/uc?export=download&id={drive_id}",
-                        "label": "Google Drive iframe",
-                        "filename": f"{drive_id}.pdf",
-                        "gdrive_id": drive_id,
-                    }
-                )
+        all_pdfs = drive_candidates
+    elif len(all_pdfs) == 1 and drive_candidates:
+        all_pdfs[0]["alternate_downloads"] = drive_candidates
 
     if not target_year or not all_pdfs:
         return all_pdfs
@@ -271,8 +356,308 @@ def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | Non
     return filtered
 
 
-def download_pdf(url: str, dest: Path, dry_run: bool = False) -> bool:
-    """Download a PDF file. Returns True if downloaded, False if skipped."""
+def _google_drive_id(url: str) -> str | None:
+    for pattern in (r"/file/d/([a-zA-Z0-9_-]+)", r"[?&]id=([a-zA-Z0-9_-]+)"):
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _fallback_for_component(
+    fallback_pdfs: list[dict],
+    *,
+    primary_count: int,
+    component_index: int,
+) -> dict:
+    """Match a fallback volume by deterministic component position."""
+    if len(fallback_pdfs) != primary_count:
+        raise DownloadValidationError(
+            "fallback page volume count does not match the primary edition"
+        )
+    try:
+        return fallback_pdfs[component_index]
+    except IndexError as exc:
+        raise DownloadValidationError("fallback component index is out of range") from exc
+
+
+def extract_shkola_pdf_links(
+    page_url: str,
+    *,
+    author: str,
+    grade: int,
+    target_year: int | None = None,
+) -> list[dict]:
+    """Resolve Shkola's download forms without retaining the PDF response.
+
+    Shkola exposes an opaque ``vslink`` form value and returns the actual PDF
+    or Google Drive locator as an HTTP redirect.  Only the redirect is
+    resolved here; the bounded streaming downloader remains responsible for
+    fetching and validating content.
+    """
+    parsed = urlparse(page_url)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname not in {
+        "shkola.in.ua",
+        "www.shkola.in.ua",
+    }:
+        raise ValueError("Shkola resolver requires a shkola.in.ua page URL")
+
+    session = requests.Session()
+    session.headers.update(HEADERS)
+    response = session.get(page_url, timeout=30)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    title_tag = soup.find("title")
+    title_text = title_tag.get_text(strip=True) if title_tag else ""
+    title_norm = normalize_whitespace(title_text)
+    if (
+        normalize_whitespace(author) not in title_norm
+        or normalize_whitespace(f"{grade} клас") not in title_norm
+    ):
+        raise TitleGuardError(
+            f"Expected author '{author}' and '{grade} клас' in title. Got '{title_text}'"
+        )
+
+    resolved: list[dict] = []
+    for form in soup.find_all("form"):
+        button = form.find(attrs={"name": "vslink"})
+        if button is None or not button.get("value"):
+            continue
+        label = " ".join(
+            value
+            for value in (
+                button.get("title", ""),
+                button.get_text(" ", strip=True),
+            )
+            if value
+        )
+        candidate_years = {int(value) for value in re.findall(r"(?<!\d)(20\d{2})(?!\d)", label)}
+        if target_year is not None and candidate_years and target_year not in candidate_years:
+            continue
+
+        endpoint = urljoin(getattr(response, "url", page_url), form.get("action") or "")
+        redirect = session.post(
+            endpoint,
+            data={"vslink": button["value"]},
+            timeout=30,
+            stream=True,
+            allow_redirects=False,
+        )
+        try:
+            redirect.raise_for_status()
+            locator = redirect.headers.get("Location", "")
+        finally:
+            _safe_close(redirect)
+        if not locator:
+            continue
+        locator = urljoin(endpoint, locator)
+        drive_id = _google_drive_id(locator)
+        item = {
+            "url": locator,
+            "label": label or "Shkola download",
+            "filename": f"{drive_id}.pdf" if drive_id else locator.rsplit("/", 1)[-1],
+        }
+        if drive_id:
+            item["gdrive_id"] = drive_id
+        if item not in resolved:
+            resolved.append(item)
+    return resolved
+
+
+def _safe_close(response: object) -> None:
+    """Close a requests response when the response double supports it."""
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
+
+
+def _header(response: object, name: str) -> str:
+    """Read a response header from real or minimal test response objects."""
+    headers = getattr(response, "headers", {}) or {}
+    if hasattr(headers, "get"):
+        value = headers.get(name)
+        if value is not None:
+            return str(value)
+        lower_name = name.lower()
+        for key, candidate in headers.items():
+            if str(key).lower() == lower_name:
+                return str(candidate)
+    return ""
+
+
+def _validate_max_size(max_size_bytes: int | None) -> None:
+    if max_size_bytes is not None and max_size_bytes <= 0:
+        raise ValueError("max_size_bytes must be positive")
+
+
+def _declared_size(response: object) -> int | None:
+    value = _header(response, "Content-Length").strip()
+    if not value:
+        return None
+    try:
+        size = int(value)
+    except ValueError:
+        return None
+    return size if size >= 0 else None
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(DOWNLOAD_CHUNK_SIZE), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _existing_pdf_hashes(
+    retained_store: Path,
+    *,
+    size_bytes: int,
+    exclude: Path | None = None,
+) -> set[str]:
+    """Hash only retained PDFs whose byte size can match the candidate.
+
+    The retained store may be cloud-backed.  Reading every PDF would hydrate
+    the whole library locally for each acquisition; unequal sizes already
+    prove unequal content, so those files are never opened.
+    """
+    if not retained_store.exists():
+        return set()
+    excluded = exclude.resolve(strict=False) if exclude is not None else None
+    hashes: set[str] = set()
+    for path in sorted(
+        candidate for candidate in retained_store.rglob("*") if candidate.suffix.casefold() == ".pdf"
+    ):
+        if (
+            not path.is_file()
+            or path.stat().st_size != size_bytes
+            or (excluded is not None and path.resolve(strict=False) == excluded)
+        ):
+            continue
+        hashes.add(_sha256_file(path))
+    return hashes
+
+
+def resolve_retained_store(path: Path) -> Path:
+    """Resolve the configured retained store, including a Drive symlink.
+
+    The downloader never creates a repository-local fallback store.  The
+    caller must provide the existing retained location (the legacy default is
+    still accepted for CLI compatibility and is resolved before use).
+    """
+    candidate = Path(path).expanduser()
+    if not candidate.exists() or not candidate.is_dir():
+        raise ValueError(f"retained store must be an existing directory: {candidate}")
+    return candidate.resolve(strict=False)
+
+
+def _invalid_pdf_title(path: Path) -> str:
+    """Extract a bounded diagnostic title from an invalid response body."""
+    try:
+        html = path.read_bytes().decode("utf-8", errors="ignore")
+    except OSError:
+        return "No Title Found"
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.string.strip() if soup.title and soup.title.string else "No Title Found"
+    return " ".join(title.split())
+
+
+def _retain_response(
+    response: object,
+    dest: Path,
+    *,
+    retained_store: Path | None = None,
+    max_size_bytes: int | None = None,
+    invalid_detail: Callable[[Path], str] | None = None,
+) -> bool:
+    """Stream one response to a same-filesystem temp file, then retain it atomically.
+
+    The response is never written to ``dest`` until its SHA-256, size, and PDF
+    signature have passed validation.  The temporary file is removed on every
+    path, including iterator, validation, duplicate, and rename failures.
+    """
+    _validate_max_size(max_size_bytes)
+    declared_size = _declared_size(response)
+    if max_size_bytes is not None and declared_size is not None and declared_size > max_size_bytes:
+        raise DownloadValidationError(
+            f"declared response size {declared_size} exceeds limit {max_size_bytes}"
+        )
+
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=str(dest.parent),
+        prefix=f".{dest.name}.",
+        suffix=".part",
+    )
+    os.close(fd)
+    temporary = Path(temporary_name)
+    try:
+        digest = hashlib.sha256()
+        total = 0
+        first_nonempty = b""
+        with temporary.open("wb") as handle:
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                if not chunk:
+                    continue
+                if isinstance(chunk, str):
+                    raise DownloadValidationError("response yielded text instead of bytes")
+                if not first_nonempty:
+                    first_nonempty = bytes(chunk)
+                total += len(chunk)
+                if max_size_bytes is not None and total > max_size_bytes:
+                    raise DownloadValidationError(
+                        f"response size exceeds limit {max_size_bytes}"
+                    )
+                handle.write(chunk)
+                digest.update(chunk)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        if total == 0 or not first_nonempty.startswith(PDF_SIGNATURE):
+            detail = invalid_detail(temporary) if invalid_detail is not None else ""
+            suffix = f" HTML Title: {detail}" if detail else ""
+            raise DownloadValidationError(f"Downloaded payload is not a PDF.{suffix}")
+
+        retained_root = resolve_retained_store(retained_store or dest.parent)
+        if digest.hexdigest() in _existing_pdf_hashes(
+            retained_root,
+            size_bytes=total,
+            exclude=dest,
+        ):
+            print(f"  SKIP (duplicate content already retained): {dest.name}")
+            return False
+
+        # A concurrent or earlier caller may have created the canonical name
+        # while this response was streaming.  Do not replace that final file.
+        if dest.exists():
+            size_mb = dest.stat().st_size / (1024 * 1024)
+            print(f"  SKIP (exists, {size_mb:.1f} MB): {dest.name}")
+            return False
+
+        os.replace(temporary, dest)
+        size_mb = total / (1024 * 1024)
+        print(f"  OK ({size_mb:.1f} MB): {dest.name}")
+        return True
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def download_pdf(
+    url: str,
+    dest: Path,
+    dry_run: bool = False,
+    *,
+    retained_store: Path | None = None,
+    retained_root: Path | None = None,
+    max_size_bytes: int | None = None,
+) -> bool:
+    """Download one PDF with streamed validation and atomic retention.
+
+    Returns True when a new file is retained and False when the canonical name
+    or exact content is already retained.
+    """
     if dest.exists():
         size_mb = dest.stat().st_size / (1024 * 1024)
         print(f"  SKIP (exists, {size_mb:.1f} MB): {dest.name}")
@@ -285,22 +670,27 @@ def download_pdf(url: str, dest: Path, dry_run: bool = False) -> bool:
 
     print(f"  Downloading: {dest.name}...")
     resp = requests.get(url, headers=HEADERS, timeout=120, stream=True)
-    resp.raise_for_status()
-
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    total = 0
-    with open(dest, "wb") as f:
-        for chunk in resp.iter_content(chunk_size=8192):
-            if chunk:
-                f.write(chunk)
-                total += len(chunk)
-
-    size_mb = total / (1024 * 1024)
-    print(f"  OK ({size_mb:.1f} MB): {dest.name}")
-    return True
+    try:
+        resp.raise_for_status()
+        return _retain_response(
+            resp,
+            dest,
+            retained_store=retained_store or retained_root,
+            max_size_bytes=max_size_bytes,
+        )
+    finally:
+        _safe_close(resp)
 
 
-def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bool:
+def download_from_gdrive(
+    drive_id: str,
+    dest: Path,
+    dry_run: bool = False,
+    *,
+    retained_store: Path | None = None,
+    retained_root: Path | None = None,
+    max_size_bytes: int | None = None,
+) -> bool:
     """Download a file from Google Drive via uc?export=download.
 
     Handles the large-file confirmation warning if encountered.
@@ -328,12 +718,17 @@ def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bo
     # Check if we got the confirmation page
     confirm_token = None
     uuid_token = None
+    confirm_url = url
     content_type = resp.headers.get("Content-Type", "")
     if "text/html" in content_type:
         html_content = resp.text
 
         # 1. Parse HTML using BeautifulSoup
         soup = BeautifulSoup(html_content, "html.parser")
+
+        download_form = soup.find("form")
+        if download_form and download_form.get("action"):
+            confirm_url = urljoin(getattr(resp, "url", url), download_form.get("action"))
 
         # Look for input fields
         confirm_input = soup.find("input", {"name": "confirm"})
@@ -346,7 +741,7 @@ def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bo
         # 2. Look in form actions or links
         if not confirm_token or not uuid_token:
             urls_to_check = []
-            form = soup.find("form")
+            form = download_form
             if form and form.get("action"):
                 urls_to_check.append(form.get("action"))
             for a in soup.find_all("a", href=True):
@@ -386,61 +781,40 @@ def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bo
         params = {"export": "download", "id": drive_id, "confirm": confirm_token}
         if uuid_token:
             params["uuid"] = uuid_token
-        resp = session.get(url, params=params, stream=True, timeout=120)
+        _safe_close(resp)
+        resp = session.get(confirm_url, params=params, stream=True, timeout=120)
         resp.raise_for_status()
 
-    # Step 3: Write response content to file
-    dest.parent.mkdir(parents=True, exist_ok=True)
-
-    # We inspect the first chunk of the response to ensure it's a PDF
-    chunks_iter = resp.iter_content(chunk_size=8192)
     try:
-        first_chunk = next(chunks_iter)
-    except StopIteration:
-        first_chunk = b""
-
-    # A real PDF starts with %PDF- magic bytes
-    if not first_chunk.startswith(b"%PDF-"):
-        # Not a PDF. Let's read the rest of the chunks to get the full HTML content.
-        html_bytes = first_chunk
-        for chunk in chunks_iter:
-            if chunk:
-                html_bytes += chunk
-
-        # Parse title from HTML
-        html_text = html_bytes.decode("utf-8", errors="ignore")
-        soup = BeautifulSoup(html_text, "html.parser")
-        title = soup.title.string.strip() if (soup.title and soup.title.string) else "No Title Found"
-        title = " ".join(title.split())
-
-        print(f"  Google Drive returned non-PDF page. HTML Title: {title}")
-
-        # Ensure no dest file remains
-        if dest.exists():
-            dest.unlink()
-
-        raise ValueError(f"Downloaded payload is not a PDF. HTML Title: {title}")
-
-    # It's a valid PDF. Write first chunk and stream the rest.
-    total = 0
-    with open(dest, "wb") as f:
-        if first_chunk:
-            f.write(first_chunk)
-            total += len(first_chunk)
-        for chunk in chunks_iter:
-            if chunk:
-                f.write(chunk)
-                total += len(chunk)
-
-    size_mb = total / (1024 * 1024)
-    print(f"  OK ({size_mb:.1f} MB): {dest.name}")
-    return True
+        return _retain_response(
+            resp,
+            dest,
+            retained_store=retained_store or retained_root,
+            max_size_bytes=max_size_bytes,
+            invalid_detail=_invalid_pdf_title,
+        )
+    finally:
+        _safe_close(resp)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Download selected textbook PDFs")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be downloaded")
     parser.add_argument("--only", type=int, help="Only download for this grade")
+    parser.add_argument(
+        "--retained-store",
+        "--output-dir",
+        dest="retained_store",
+        type=Path,
+        default=OUTPUT_DIR,
+        help="Existing retained PDF store; symlinks (including Google Drive) are resolved before use",
+    )
+    parser.add_argument(
+        "--max-size-bytes",
+        type=int,
+        default=None,
+        help="Optional hard limit for one streamed PDF response",
+    )
     parser.add_argument(
         "--all-editions",
         action="store_true",
@@ -452,8 +826,9 @@ def main():
     if args.only:
         books = [b for b in books if b["grade"] == args.only]
 
+    retained_store = resolve_retained_store(args.retained_store)
     print(f"Selected {len(books)} books to process")
-    print(f"Output directory: {OUTPUT_DIR}")
+    print(f"Output directory: {retained_store}")
     print()
 
     total_downloaded = 0
@@ -470,6 +845,21 @@ def main():
         print(f"[{book_id}] Grade {grade} — {author}")
         print(f"{'=' * 60}")
 
+        retained_matches = find_retained_book_pdfs(retained_store, book)
+        if retained_matches:
+            print(
+                "  SKIP — retained source already matches metadata: "
+                + ", ".join(path.name for path in retained_matches)
+            )
+            total_skipped += len(retained_matches)
+            continue
+
+        canonical_source = str(book.get("canonical_source") or "").strip()
+        if not canonical_source:
+            print("  ERROR — missing canonical_source for an unretained acquisition")
+            total_failed += 1
+            continue
+
         if book.get("status") == "needs_manual_pdf" and not (book.get("slug") or book.get("gdrive_id")):
             print("  SKIP — needs manual PDF link (not yet available)")
             total_skipped += 1
@@ -478,6 +868,7 @@ def main():
         # Check for override_pdfs (manual PDF URLs when page is broken)
         override_pdfs = book.get("override_pdfs")
         gdrive_id = book.get("gdrive_id")
+        target_year = None if args.all_editions else book.get("year")
 
         if override_pdfs:
             pdfs = [{"url": url, "label": url.split("/")[-1], "filename": url.split("/")[-1]} for url in override_pdfs]
@@ -493,19 +884,29 @@ def main():
             ]
             print("  Using registry Google Drive ID")
         else:
-            target_year = None if args.all_editions else book.get("year")
+            pdfs = []
             try:
                 pdfs = extract_pdf_links(slug, author=author, grade=grade, target_year=target_year)
             except TitleGuardError:
                 # Expected-vs-actual warning printed inside extract_pdf_links
-                total_failed += 1
                 time.sleep(CRAWL_DELAY)
-                continue
             except Exception as e:
                 print(f"  ERROR fetching page: {e}")
-                total_failed += 1
                 time.sleep(CRAWL_DELAY)
-                continue
+            for fallback_page_url in book.get("fallback_page_urls", []):
+                if pdfs:
+                    break
+                try:
+                    pdfs = extract_shkola_pdf_links(
+                        fallback_page_url,
+                        author=author,
+                        grade=grade,
+                        target_year=target_year,
+                    )
+                    if pdfs:
+                        print(f"  Using Shkola fallback: {fallback_page_url}")
+                except Exception as exc:
+                    print(f"  WARNING: fallback page failed: {exc}")
 
             if not pdfs:
                 if gdrive_id:
@@ -526,7 +927,7 @@ def main():
 
         print(f"  Found {len(pdfs)} PDF(s)")
 
-        grade_dir = OUTPUT_DIR / f"grade-{grade:02d}"
+        grade_dir = retained_store / f"grade-{grade:02d}"
 
         for i, pdf_info in enumerate(pdfs):
             pdf_url = pdf_info["url"]
@@ -536,22 +937,101 @@ def main():
             check_filename_overlap(pdf_info["filename"], book["subject"], author)
 
             # Canonical naming
-            filename = f"{slug}.pdf" if len(pdfs) == 1 else f"{slug}-{i + 1}.pdf"
+            filename = (
+                f"{canonical_source}.pdf"
+                if len(pdfs) == 1
+                else f"{canonical_source}-{i + 1}.pdf"
+            )
             dest = grade_dir / filename
 
             try:
                 if pdf_gdrive_id:
-                    downloaded = download_from_gdrive(pdf_gdrive_id, dest, dry_run=args.dry_run)
+                    downloaded = download_from_gdrive(
+                        pdf_gdrive_id,
+                        dest,
+                        dry_run=args.dry_run,
+                        retained_store=retained_store,
+                        max_size_bytes=args.max_size_bytes,
+                    )
                 else:
-                    downloaded = download_pdf(pdf_url, dest, dry_run=args.dry_run)
-
-                if downloaded:
-                    total_downloaded += 1
-                else:
-                    total_skipped += 1
+                    downloaded = download_pdf(
+                        pdf_url,
+                        dest,
+                        dry_run=args.dry_run,
+                        retained_store=retained_store,
+                        max_size_bytes=args.max_size_bytes,
+                    )
             except Exception as e:
-                print(f"  ERROR downloading {filename}: {e}")
-                total_failed += 1
+                print(f"  WARNING: primary download failed for {filename}: {e}")
+                downloaded = None
+                for alternate in pdf_info.get("alternate_downloads", []):
+                    try:
+                        alternate_drive_id = alternate.get("gdrive_id")
+                        if alternate_drive_id:
+                            downloaded = download_from_gdrive(
+                                alternate_drive_id,
+                                dest,
+                                dry_run=args.dry_run,
+                                retained_store=retained_store,
+                                max_size_bytes=args.max_size_bytes,
+                            )
+                        else:
+                            downloaded = download_pdf(
+                                alternate["url"],
+                                dest,
+                                dry_run=args.dry_run,
+                                retained_store=retained_store,
+                                max_size_bytes=args.max_size_bytes,
+                            )
+                        print(f"  Used same-page mirror: {alternate['label']}")
+                        break
+                    except Exception as alternate_error:
+                        print(f"  WARNING: same-page mirror failed: {alternate_error}")
+                if downloaded is None:
+                    for fallback_page_url in book.get("fallback_page_urls", []):
+                        try:
+                            fallback_pdfs = extract_shkola_pdf_links(
+                                fallback_page_url,
+                                author=author,
+                                grade=grade,
+                                target_year=target_year,
+                            )
+                            fallback = _fallback_for_component(
+                                fallback_pdfs,
+                                primary_count=len(pdfs),
+                                component_index=i,
+                            )
+                            fallback_drive_id = fallback.get("gdrive_id")
+                            if fallback_drive_id:
+                                downloaded = download_from_gdrive(
+                                    fallback_drive_id,
+                                    dest,
+                                    dry_run=args.dry_run,
+                                    retained_store=retained_store,
+                                    max_size_bytes=args.max_size_bytes,
+                                )
+                            else:
+                                downloaded = download_pdf(
+                                    fallback["url"],
+                                    dest,
+                                    dry_run=args.dry_run,
+                                    retained_store=retained_store,
+                                    max_size_bytes=args.max_size_bytes,
+                                )
+                            print(f"  Used Shkola fallback: {fallback_page_url}")
+                            break
+                        except Exception as fallback_error:
+                            print(f"  WARNING: fallback download failed: {fallback_error}")
+                if downloaded is None:
+                    print(f"  ERROR downloading {filename}: all configured sources failed")
+                    total_failed += 1
+                    time.sleep(CRAWL_DELAY)
+                    continue
+
+            if downloaded:
+                total_downloaded += 1
+            else:
+                total_skipped += 1
 
             time.sleep(CRAWL_DELAY)
 

--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -13,7 +13,8 @@ title-probed from the source pages during wave-1 acquisition (2026-07-06).
 
 Usage:
     .venv/bin/python scripts/ingest/incremental_textbook_ingest.py \
-        --slugs 9-klas-khimiya-popel-2017 [...] [--db data/sources.db] [--dry-run]
+        --slugs 9-klas-khimiya-popel-2017 [...] \
+        [--db data/sources.db] [--chunks-root GDRIVE/textbook_chunks] [--dry-run]
     .venv/bin/python scripts/ingest/incremental_textbook_ingest.py --wave1
 """
 from __future__ import annotations
@@ -26,12 +27,23 @@ from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).resolve()
 PROJECT_ROOT = SCRIPT_PATH.parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from wiki.build_sources_db import _build_textbook_row
+from wiki.config import TEXTBOOK_CHUNKS_DIR
+from wiki.extract_sections import (
+    assign_sections,
+    build_section_groups,
+    ensure_schema,
+    load_textbook_rows,
+)
 from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
 
-CHUNKS_DIR = PROJECT_ROOT / "data" / "textbook_chunks"
+# The canonical chunk store is the Google Drive corpus mount. Keep this
+# constant patchable for local fixtures, but do not assume the absent
+# repo-local data/textbook_chunks directory is the production source.
+CHUNKS_DIR = TEXTBOOK_CHUNKS_DIR
 DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
 
 # Author map: single source of truth in wiki.textbook_subjects (PR #4650).
@@ -67,9 +79,11 @@ class IngestError(RuntimeError):
     """Deterministic ingest failure."""
 
 
-def find_jsonl(slug: str) -> Path:
+def find_jsonl(slug: str, *, chunks_root: Path | None = None) -> Path:
+    """Resolve one source JSONL under the explicit or canonical chunk root."""
     grade = int(slug.split("-")[0])
-    path = CHUNKS_DIR / f"grade-{grade:02d}" / f"{slug}.jsonl"
+    root = Path(chunks_root) if chunks_root is not None else CHUNKS_DIR
+    path = root / f"grade-{grade:02d}" / f"{slug}.jsonl"
     if not path.is_file():
         raise IngestError(f"chunk file missing: {path}")
     return path
@@ -89,8 +103,8 @@ def enrich_author_uk(entry: dict, *, slug: str) -> dict:
     return entry
 
 
-def build_rows(slug: str) -> list[tuple]:
-    jsonl_path = find_jsonl(slug)
+def build_rows(slug: str, *, chunks_root: Path | None = None) -> list[tuple]:
+    jsonl_path = find_jsonl(slug, chunks_root=chunks_root)
     grade = f"grade-{int(slug.split('-')[0]):02d}"
     rows: list[tuple] = []
     with open(jsonl_path, encoding="utf-8") as fh:
@@ -118,7 +132,108 @@ TB_SQL = """INSERT INTO textbooks
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
 
-def ingest(slugs: list[str], *, db_path: Path, dry_run: bool) -> dict[str, int]:
+SECTION_INSERT_SQL = """INSERT INTO textbook_sections
+    (source_file, grade, section_title, section_number, page_start, page_end,
+     chunk_count, full_text)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
+
+
+def _rebuild_source_sections(conn: sqlite3.Connection, slug: str) -> tuple[int, int]:
+    """Replace only one source's section rows and parent links.
+
+    The existing extraction helpers provide deterministic assignment and
+    grouping. This writer deliberately avoids ``persist_sections`` because
+    that helper clears every textbook section and every parent link in the
+    database, which is not safe for an incremental source replacement.
+    """
+    ensure_schema(conn)
+    source_rows = [row for row in load_textbook_rows(conn) if row.source_file == slug]
+    assignments = assign_sections(source_rows)
+    sections = build_section_groups(assignments)
+
+    # Null links before deleting section parents so this remains valid if a
+    # caller has enabled foreign-key enforcement on the connection.
+    conn.execute(
+        "UPDATE textbooks SET parent_section_id = NULL WHERE source_file = ?",
+        (slug,),
+    )
+    conn.execute("DELETE FROM textbook_sections WHERE source_file = ?", (slug,))
+
+    section_id_by_row_id: dict[int, int] = {}
+    for section in sections:
+        cursor = conn.execute(
+            SECTION_INSERT_SQL,
+            (
+                section.source_file,
+                section.grade,
+                section.section_title,
+                section.section_number,
+                section.page_start,
+                section.page_end,
+                section.chunk_count,
+                section.full_text,
+            ),
+        )
+        section_id = cursor.lastrowid
+        for assignment in section.rows:
+            section_id_by_row_id[assignment.row.id] = section_id
+
+    links = [
+        (section_id_by_row_id[assignment.row.id], assignment.row.id)
+        for assignment in assignments
+        if assignment.section_title is not None
+    ]
+    conn.executemany(
+        "UPDATE textbooks SET parent_section_id = ? WHERE id = ?",
+        links,
+    )
+    linked_rows = conn.execute(
+        """SELECT COUNT(*) FROM textbooks
+           WHERE source_file = ? AND parent_section_id IS NOT NULL""",
+        (slug,),
+    ).fetchone()[0]
+    total_rows = len(source_rows)
+    if linked_rows != total_rows:
+        raise IngestError(
+            f"{slug}: {total_rows - linked_rows} accepted school-textbook rows "
+            "remain unlinked from textbook_sections"
+        )
+    return len(sections), linked_rows
+
+
+def _fts_source_evidence(
+    conn: sqlite3.Connection,
+    slug: str,
+    expected_rows: int,
+) -> dict[str, object]:
+    """Return and validate the source's external-content FTS row parity."""
+    indexed_rows = conn.execute(
+        """SELECT COUNT(*) FROM textbooks_fts AS f
+           JOIN textbooks AS t ON t.id = f.rowid
+           WHERE t.source_file = ?""",
+        (slug,),
+    ).fetchone()[0]
+    evidence = {
+        "source_file": slug,
+        "expected_rows": expected_rows,
+        "indexed_rows": indexed_rows,
+        "parity": indexed_rows == expected_rows,
+    }
+    if not evidence["parity"]:
+        raise IngestError(
+            f"{slug}: textbooks/textbooks_fts parity failed "
+            f"({indexed_rows} indexed, {expected_rows} rows)"
+        )
+    return evidence
+
+
+def ingest(
+    slugs: list[str],
+    *,
+    db_path: Path,
+    dry_run: bool,
+    chunks_root: Path | None = None,
+) -> dict[str, int]:
     """Run the delete+insert+FTS-resync cycle for ``slugs``.
 
     Concurrency note (review, PR #4624): sources.db runs in WAL mode in
@@ -126,19 +241,36 @@ def ingest(slugs: list[str], *, db_path: Path, dry_run: bool) -> dict[str, int]:
     prefer running while no build/review dispatch is mid-flight.
     """
     counts: dict[str, int] = {}
-    per_slug_rows = {slug: build_rows(slug) for slug in slugs}  # fail fast, pre-tx
+    receipts: dict[str, dict[str, object]] = {}
+    per_slug_rows = {
+        slug: build_rows(slug, chunks_root=chunks_root)
+        for slug in slugs
+    }  # fail fast, pre-tx
     conn = sqlite3.connect(str(db_path), timeout=30.0)
     try:
+        conn.execute("PRAGMA foreign_keys = ON")
         conn.execute("BEGIN")
         for slug, rows in per_slug_rows.items():
             deleted = conn.execute(
                 "DELETE FROM textbooks WHERE source_file = ?", (slug,)
             ).rowcount
             conn.executemany(TB_SQL, rows)
+            section_rows, linked_rows = _rebuild_source_sections(conn, slug)
             counts[slug] = len(rows)
-            print(f"  {slug}: deleted {deleted}, inserted {len(rows)}")
+            receipts[slug] = {
+                "source_file": slug,
+                "deleted_rows": deleted,
+                "inserted_rows": len(rows),
+                "section_rows": section_rows,
+                "linked_rows": linked_rows,
+            }
+            print(f"  {slug}: deleted {deleted}, inserted {len(rows)}, "
+                  f"sections {section_rows}, links {linked_rows}")
         print("  resyncing textbooks_fts (external-content rebuild)…")
         conn.execute("INSERT INTO textbooks_fts(textbooks_fts) VALUES('rebuild')")
+        for slug, rows in per_slug_rows.items():
+            receipts[slug]["fts"] = _fts_source_evidence(conn, slug, len(rows))
+            print(f"  FTS evidence: {json.dumps(receipts[slug]['fts'], ensure_ascii=False)}")
         if dry_run:
             conn.execute("ROLLBACK")
             print("  DRY-RUN: rolled back")
@@ -151,6 +283,8 @@ def ingest(slugs: list[str], *, db_path: Path, dry_run: bool) -> dict[str, int]:
         raise
     finally:
         conn.close()
+    for _slug, receipt in receipts.items():
+        print(f"  receipt: {json.dumps(receipt, ensure_ascii=False, sort_keys=True)}")
     return counts
 
 
@@ -162,12 +296,23 @@ def main(argv: list[str] | None = None) -> int:
         "--wave1", action="store_true", help="Ingest the 22 #4593 wave-1 books"
     )
     parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument(
+        "--chunks-root",
+        type=Path,
+        default=CHUNKS_DIR,
+        help="Canonical textbook chunk directory (Google Drive mount or fixture root)",
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
     slugs = list(WAVE1_SLUGS) if args.wave1 else list(args.slugs)
     try:
-        counts = ingest(slugs, db_path=args.db, dry_run=args.dry_run)
+        counts = ingest(
+            slugs,
+            db_path=args.db,
+            dry_run=args.dry_run,
+            chunks_root=args.chunks_root,
+        )
     except (IngestError, ValueError) as exc:
         # ValueError: _build_textbook_row's strictness gates (author_uk,
         # unmapped subject) — surface cleanly instead of a traceback.

--- a/scripts/projects/open_model_data/textbook_corpus_readiness.py
+++ b/scripts/projects/open_model_data/textbook_corpus_readiness.py
@@ -1,0 +1,956 @@
+#!/usr/bin/env python3
+"""Reconcile retained textbook PDFs, chunk JSONL files, and SQLite rows.
+
+This is a read-only, text-free readiness receipt.  It recursively inventories
+the configured retained store and reports only paths relative to that store,
+file hashes, sizes, counts, and provenance metadata.  It never copies a PDF,
+opens SQLite for writing, or emits chunk text.
+
+The deterministic predicates are:
+
+* ``ready``: at least one PDF, one non-empty/available chunk JSONL, and one
+  SQLite ``textbooks`` row are present for the reconciled source, and the
+  extraction is not suspect.
+* ``pdf_without_chunks``: a PDF is present and no chunk JSONL is present.
+* ``chunks_without_pdf``: a chunk JSONL is present and no PDF is present.
+* ``chunks_not_ingested``: chunk JSONL is present but its reconciled SQLite
+  row count is zero.
+* ``db_without_chunks``: SQLite rows are present but no chunk JSONL is present.
+* ``suspect_extraction``: a chunk JSONL has zero, one, or two non-empty rows,
+  or a PDF has a known page count of at least 20 and fewer than 0.05 rows per
+  page.  This intentionally flags a 273-page PDF with two rows without any
+  network or PDF text extraction.
+* ``missing_selected_source``: a selected source has no PDF, chunk JSONL, or
+  SQLite rows after split-volume reconciliation.
+
+Split components are recognized only by a terminal ``-1``, ``-2``, ``_1``,
+``_2``, ``-part-1``/``-part-2`` (and equivalent ``part1``/``part2`` or
+``vol1``/``vol2``) suffix.  A component is grouped with a selected common
+slug only when the complete stem is that slug plus one of those suffixes;
+numeric years and other terminal numbers are not stripped.
+
+Chunk-payload hashes are SHA-256 hashes of canonical JSON for each parsed
+non-empty JSONL row (or of the stripped raw bytes for an invalid row).  Raw
+row/file occurrences remain visible in duplicate groups, while unique counts
+are reported separately so duplicates do not inflate corpus counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import unicodedata
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import yaml
+
+try:
+    from scripts.wiki.textbook_subjects import (
+        AUTHOR_UK_BY_TRANSLIT,
+        normalize_subject_slug,
+        subject_for_source_file,
+    )
+except ModuleNotFoundError:
+    # Preserve direct-script execution in addition to package execution.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+    from scripts.wiki.textbook_subjects import (
+        AUTHOR_UK_BY_TRANSLIT,
+        normalize_subject_slug,
+        subject_for_source_file,
+    )
+
+SCHEMA_VERSION = "textbook_corpus_readiness_v1"
+HASH_BLOCK_SIZE = 1024 * 1024
+SUSPECT_MAX_ROWS = 2
+SUSPECT_MIN_PAGES = 20
+SUSPECT_ROWS_PER_PAGE = 0.05
+PDF_SUFFIX = ".pdf"
+JSONL_SUFFIX = ".jsonl"
+
+_COMPONENT_RE = re.compile(
+    r"(?i)^(?P<base>.+?)(?:[-_](?:(?:part|volume|vol|p)[-_]?)?(?P<number>[12]))$"
+)
+_MOJIBAKE_RE = re.compile(
+    r"[À-ÿ]{2,}|(?:Р[°µЅ])|(?:С[Ѓ‚])|â€�"
+)
+_LOCATOR_KEYS = frozenset(
+    {
+        "url",
+        "urls",
+        "source_url",
+        "source_urls",
+        "acquisition_url",
+        "acquisition_urls",
+        "download_url",
+        "download_urls",
+        "pdf_url",
+        "pdf_urls",
+        "locator",
+        "locators",
+        "source_locator",
+        "source_locators",
+    }
+)
+_SOURCE_KEYS = (
+    "source_file",
+    "source_slug",
+    "slug",
+    "book_slug",
+    "book_id",
+    "id",
+    "name",
+    "file",
+    "filename",
+)
+_STATUS_ORDER = (
+    "ready",
+    "pdf_without_chunks",
+    "chunks_without_pdf",
+    "chunks_not_ingested",
+    "db_without_chunks",
+    "suspect_extraction",
+    "missing_selected_source",
+)
+_PREDICATES = {
+    "ready": (
+        "pdf_present and chunks_present and db_row_count > 0 and not suspect_extraction"
+    ),
+    "pdf_without_chunks": "pdf_present and not chunks_present",
+    "chunks_without_pdf": "chunks_present and not pdf_present",
+    "chunks_not_ingested": "chunks_present and db_row_count == 0",
+    "db_without_chunks": "db_row_count > 0 and not chunks_present",
+    "suspect_extraction": (
+        "any chunk file has <= 2 rows, or known_pdf_pages >= 20 and rows/pages < 0.05"
+    ),
+    "missing_selected_source": (
+        "selected and not pdf_present and not chunks_present and db_row_count == 0"
+    ),
+}
+
+
+class ReadinessError(ValueError):
+    """Raised when a readiness input cannot be read safely."""
+
+
+def canonical_json(value: Any) -> str:
+    """Return the canonical UTF-8 JSON representation used by the receipt."""
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_file(path: Path) -> str:
+    """Hash a file in bounded blocks without exposing its contents."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(HASH_BLOCK_SIZE), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _slug_key(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return "-".join("".join(char if char.isalnum() else " " for char in normalized).split())
+
+
+def _source_covers_grade(source_key: str, grade: int) -> bool:
+    match = re.search(r"(?:^|-)(\d{1,2})(?:-(\d{1,2}))?-klas(?:-|$)", source_key)
+    if match is None:
+        return False
+    first = int(match.group(1))
+    last = int(match.group(2) or first)
+    return first <= grade <= last
+
+
+def _stem(value: str) -> str:
+    text = Path(str(value or "")).name
+    for suffix in (JSONL_SUFFIX, PDF_SUFFIX):
+        if text.casefold().endswith(suffix):
+            return text[: -len(suffix)]
+    return text
+
+
+def split_component(stem: str) -> tuple[str, str]:
+    """Return ``(common_stem, component)`` using the documented suffix rule."""
+    match = _COMPONENT_RE.match(_stem(stem))
+    if not match:
+        return _stem(stem), "base"
+    return match.group("base"), f"part-{match.group('number')}"
+
+
+def _safe_source_identifier(value: str) -> str:
+    """Keep source IDs useful while preventing local mount paths from leaking."""
+    text = str(value or "").strip()
+    if not text:
+        return "<empty-source-file>"
+    if os.path.isabs(text) or text.casefold().startswith("file:"):
+        return "<local-source-file-redacted>"
+    return _stem(text)
+
+
+def _safe_locator(value: str) -> str:
+    """Retain external locators but redact local absolute paths."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if os.path.isabs(text) or text.casefold().startswith("file:"):
+        return "<local-locator-redacted>"
+    return text
+
+
+def _read_yaml_or_json(path: Path) -> Any:
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ReadinessError(f"cannot read input document: {path.name}") from exc
+
+
+def _selection_items(document: Any) -> list[Mapping[str, Any] | str]:
+    if isinstance(document, Mapping):
+        for key in ("books", "selection", "sources", "items"):
+            value = document.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, (Mapping, str))]
+        # A simple source -> locator/metadata mapping is also accepted.
+        return [dict({"slug": key}, **(value if isinstance(value, Mapping) else {})) for key, value in document.items()]
+    if isinstance(document, list):
+        return [item for item in document if isinstance(item, (Mapping, str))]
+    return []
+
+
+def _selection_source(
+    item: Mapping[str, Any] | str,
+) -> tuple[str, str, set[str], dict[str, Any]] | None:
+    if isinstance(item, str):
+        value = _stem(item)
+        return value, value, {_slug_key(value)}, {}
+    values = {key: str(item.get(key) or "").strip() for key in _SOURCE_KEYS}
+    display = next((values[key] for key in ("source_file", "slug", "book_slug", "file", "filename", "id", "name") if values[key]), "")
+    if not display:
+        return None
+    display = _stem(display)
+    aliases = {_slug_key(display)}
+    for value in values.values():
+        if value:
+            aliases.add(_slug_key(_stem(value)))
+    selection_id = _safe_source_identifier(values.get("id") or display)
+    metadata: dict[str, Any] = {}
+    with contextlib.suppress(KeyError, TypeError, ValueError):
+        metadata["grade"] = int(item["grade"])
+    with contextlib.suppress(KeyError, TypeError, ValueError):
+        metadata["year"] = int(item["year"])
+    subject = normalize_subject_slug(str(item.get("subject") or ""))
+    if subject:
+        metadata["subject"] = subject
+    author = unicodedata.normalize("NFKC", str(item.get("author") or "")).casefold().strip()
+    if author:
+        metadata["author"] = author
+        metadata["author_tokens"] = sorted(
+            latin.casefold()
+            for latin, cyrillic in AUTHOR_UK_BY_TRANSLIT.items()
+            if cyrillic.casefold() in author
+        )
+    return display, selection_id, aliases, metadata
+
+
+class _SourceIndex:
+    """Match file/DB/map identifiers to selected or discovered source groups."""
+
+    def __init__(self, items: Sequence[Mapping[str, Any] | str]) -> None:
+        self.selected: dict[str, dict[str, Any]] = {}
+        self.aliases: dict[str, str] = {}
+        for item in items:
+            parsed = _selection_source(item)
+            if parsed is None:
+                continue
+            display, selection_id, aliases, metadata = parsed
+            key = _slug_key(display)
+            selected = self.selected.setdefault(
+                key,
+                {
+                    "source": display,
+                    "selection_ids": set(),
+                    "aliases": set(),
+                    "metadata": metadata,
+                },
+            )
+            selected["selection_ids"].add(selection_id)
+            selected["aliases"].update(aliases)
+            for alias in aliases:
+                self.aliases[alias] = key
+
+    def _metadata_match(self, raw: str) -> str | None:
+        """Resolve renamed retained files by explicit selection metadata.
+
+        Acquisition-page slugs often start with a website numeric ID, while
+        retained files use canonical ``grade-subject-author-year`` names.  A
+        match is accepted only when grade, subject, and a verified author token
+        agree and exactly one selection row qualifies.  If the retained name
+        carries a four-digit year, it must also agree; an absent year is allowed
+        because a few legacy canonical names omit it.
+        """
+        raw_key = _slug_key(raw)
+        raw_subject = subject_for_source_file(raw_key)
+        raw_years = {int(value) for value in re.findall(r"(?<!\d)(20\d{2})(?!\d)", raw_key)}
+        matches: list[str] = []
+        for key, selected in self.selected.items():
+            metadata = selected.get("metadata") or {}
+            grade = metadata.get("grade")
+            subject = metadata.get("subject")
+            author_tokens = metadata.get("author_tokens") or []
+            if not grade or not subject or not author_tokens:
+                continue
+            if not _source_covers_grade(raw_key, int(grade)):
+                continue
+            if raw_subject != subject and not (
+                int(grade) == 1 and subject == "ukrmova" and raw_subject == "bukvar"
+            ):
+                continue
+            if not any(re.search(rf"(?:^|-){re.escape(token)}(?:-|$)", raw_key) for token in author_tokens):
+                continue
+            year = metadata.get("year")
+            if raw_years and year not in raw_years:
+                continue
+            matches.append(key)
+        return matches[0] if len(matches) == 1 else None
+
+    def resolve(self, value: str) -> tuple[str, str, str]:
+        raw = _stem(value)
+        raw_key = _slug_key(raw)
+        if raw_key in self.aliases:
+            selected_key = self.aliases[raw_key]
+            return selected_key, self.selected[selected_key]["source"], "base"
+
+        base, component = split_component(raw)
+        base_key = _slug_key(base)
+        if base_key in self.aliases:
+            selected_key = self.aliases[base_key]
+            return selected_key, self.selected[selected_key]["source"], component
+
+        selected_key = self._metadata_match(base)
+        if selected_key is not None:
+            return selected_key, self.selected[selected_key]["source"], component
+
+        return base_key, base, component
+
+    def ensure_discovered(self, key: str, source: str) -> dict[str, Any]:
+        # Discovered inventory sources must not become selected sources.  The
+        # selected mapping is intentionally limited to the selection input so
+        # missing_selected_source remains meaningful.
+        return self.selected.get(
+            key,
+            {"source": source, "selection_ids": set(), "aliases": set(), "metadata": {}},
+        )
+
+
+def _relative_path(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _enumerate_files(root: Path, suffix: str) -> list[Path]:
+    return sorted(
+        (path for path in root.rglob("*") if path.is_file() and path.suffix.casefold() == suffix),
+        key=lambda path: _relative_path(root, path),
+    )
+
+
+def _pdf_page_count(path: Path) -> int | None:
+    """Read page count without extracting or emitting PDF text."""
+    try:
+        from pypdf import PdfReader
+
+        count = len(PdfReader(str(path), strict=False).pages)
+        if count:
+            return count
+    except Exception:
+        pass
+
+    page_pattern = re.compile(rb"/Type\s*/Page(?:\s|/|>)")
+    count_pattern = re.compile(rb"/Count\s+(\d+)")
+    page_count = 0
+    tree_count = 0
+    tail = b""
+    try:
+        with path.open("rb") as handle:
+            for block in iter(lambda: handle.read(HASH_BLOCK_SIZE), b""):
+                data = tail + block
+                page_count += len(page_pattern.findall(data)) - len(page_pattern.findall(tail))
+                counts = [int(value) for value in count_pattern.findall(data)]
+                if counts:
+                    tree_count = max(tree_count, *counts)
+                tail = data[-64:]
+    except OSError:
+        return None
+    return page_count or tree_count or None
+
+
+def _has_mojibake(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(_MOJIBAKE_RE.search(value))
+    if isinstance(value, Mapping):
+        return any(_has_mojibake(key) or _has_mojibake(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(_has_mojibake(item) for item in value)
+    return False
+
+
+def _jsonl_stats(path: Path, relative: str) -> tuple[dict[str, Any], dict[str, list[int]]]:
+    digest = hashlib.sha256()
+    row_count = invalid_rows = mojibake_rows = total_bytes = 0
+    payload_counts: Counter[str] = Counter()
+    occurrences: dict[str, list[int]] = defaultdict(list)
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, 1):
+            digest.update(raw_line)
+            total_bytes += len(raw_line)
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            row_count += 1
+            try:
+                decoded = stripped.decode("utf-8")
+                row = json.loads(decoded)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                invalid_rows += 1
+                payload = stripped
+                mojibake_rows += int(bool(_MOJIBAKE_RE.search(stripped.decode("utf-8", errors="replace"))))
+            else:
+                payload = canonical_json(row).encode("utf-8")
+                mojibake_rows += int(_has_mojibake(row))
+            payload_hash = hashlib.sha256(payload).hexdigest()
+            payload_counts[payload_hash] += 1
+            occurrences[payload_hash].append(line_number)
+
+    stats = {
+        "path": relative,
+        "byte_size": total_bytes,
+        "sha256": digest.hexdigest(),
+        "row_count": row_count,
+        "unique_payload_count": len(payload_counts),
+        "duplicate_payload_count": row_count - len(payload_counts),
+        "invalid_row_count": invalid_rows,
+        "mojibake_rows": mojibake_rows,
+    }
+    return stats, occurrences
+
+
+def _read_db(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "available": path.is_file(),
+        "table_present": False,
+        "row_count": 0,
+        "rows_by_source": {},
+        "error": None,
+    }
+    if not path.is_file():
+        result["error"] = "database_missing"
+        return result
+
+    uri = f"file:{quote(str(path.resolve()), safe='/')}?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except (OSError, sqlite3.Error):
+        result["error"] = "database_unreadable"
+        return result
+    try:
+        table = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'textbooks'"
+        ).fetchone()
+        if table is None:
+            result["error"] = "textbooks_table_missing"
+            return result
+        result["table_present"] = True
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(textbooks)")}
+        if "source_file" in columns:
+            rows = connection.execute(
+                "SELECT source_file, COUNT(*) FROM textbooks GROUP BY source_file ORDER BY source_file"
+            ).fetchall()
+            by_source: dict[str, int] = {}
+            for source_file, count in rows:
+                key = _safe_source_identifier(str(source_file or ""))
+                by_source[key] = by_source.get(key, 0) + int(count)
+            result["rows_by_source"] = by_source
+        else:
+            total = int(connection.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0])
+            result["rows_by_source"] = {"<missing-source-file>": total} if total else {}
+        result["row_count"] = sum(result["rows_by_source"].values())
+    except sqlite3.Error:
+        result["error"] = "textbooks_table_unreadable"
+    finally:
+        connection.close()
+    return result
+
+
+def _looks_like_locator(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    return text.startswith(("http://", "https://", "ftp://"))
+
+
+def _strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from _strings(item)
+
+
+def _map_source_key(value: Mapping[str, Any], inherited: str | None) -> str | None:
+    for key in _SOURCE_KEYS:
+        candidate = value.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            return _stem(candidate)
+    return inherited
+
+
+def _extract_locators(value: Any, inherited: str | None = None) -> dict[str, list[str]]:
+    extracted: dict[str, list[str]] = defaultdict(list)
+
+    def visit(node: Any, source: str | None) -> None:
+        if isinstance(node, Mapping):
+            current = _map_source_key(node, source)
+            for key, child in node.items():
+                key_text = str(key).casefold()
+                if key_text in _LOCATOR_KEYS:
+                    for locator in _strings(child):
+                        if _looks_like_locator(locator) and current:
+                            extracted[current].append(locator.strip())
+                    continue
+                if isinstance(child, str) and _looks_like_locator(child):
+                    extracted[_stem(str(key))].append(child.strip())
+                elif isinstance(child, (Mapping, list, tuple)):
+                    visit(child, current or (_stem(str(key)) if isinstance(child, Mapping) else source))
+        elif isinstance(node, list):
+            for child in node:
+                visit(child, source)
+
+    visit(value, inherited)
+    return {key: sorted(set(values)) for key, values in sorted(extracted.items())}
+
+
+def _load_url_maps(paths: Sequence[Path]) -> tuple[list[dict[str, Any]], dict[int, dict[str, list[str]]]]:
+    metadata: list[dict[str, Any]] = []
+    maps: dict[int, dict[str, list[str]]] = {}
+    for index, path in enumerate(paths):
+        record: dict[str, Any] = {"index": index, "present": path.is_file(), "source_count": 0, "locator_count": 0}
+        if not path.is_file():
+            record["error"] = "map_missing"
+            metadata.append(record)
+            continue
+        try:
+            values = _extract_locators(_read_yaml_or_json(path))
+        except ReadinessError:
+            values = {}
+            record["error"] = "map_unreadable"
+        maps[index] = values
+        record["source_count"] = len(values)
+        record["locator_count"] = sum(len(locators) for locators in values.values())
+        metadata.append(record)
+    return metadata, maps
+
+
+def _duplicate_pdf_groups(pdf_files: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    by_hash: dict[str, list[str]] = defaultdict(list)
+    for record in pdf_files:
+        by_hash[str(record["sha256"])].append(str(record["path"]))
+    return [
+        {"sha256": digest, "count": len(paths), "paths": sorted(paths)}
+        for digest, paths in sorted(by_hash.items())
+        if len(paths) > 1
+    ]
+
+
+def _duplicate_payload_groups(occurrences: Mapping[str, list[tuple[str, int]]]) -> list[dict[str, Any]]:
+    groups: list[dict[str, Any]] = []
+    for digest, values in sorted(occurrences.items()):
+        if len(values) < 2:
+            continue
+        by_path: dict[str, list[int]] = defaultdict(list)
+        for path, line_number in values:
+            by_path[path].append(line_number)
+        groups.append(
+            {
+                "sha256": digest,
+                "count": len(values),
+                "occurrences": [
+                    {"path": path, "row_numbers": sorted(numbers)}
+                    for path, numbers in sorted(by_path.items())
+                ],
+            }
+        )
+    return groups
+
+
+def _ordered_states(states: Iterable[str]) -> list[str]:
+    order = {name: index for index, name in enumerate(_STATUS_ORDER)}
+    return sorted(set(states), key=lambda value: (order.get(value, len(order)), value))
+
+
+def _source_states(
+    *,
+    selected: bool,
+    pdf_present: bool,
+    chunks_present: bool,
+    db_rows: int,
+    suspect: bool,
+) -> tuple[str, list[str]]:
+    states: list[str] = []
+    if selected and not pdf_present and not chunks_present and db_rows == 0:
+        states.append("missing_selected_source")
+    if pdf_present and not chunks_present:
+        states.append("pdf_without_chunks")
+    if chunks_present and not pdf_present:
+        states.append("chunks_without_pdf")
+    if chunks_present and db_rows == 0:
+        states.append("chunks_not_ingested")
+    if db_rows > 0 and not chunks_present:
+        states.append("db_without_chunks")
+    if suspect:
+        states.append("suspect_extraction")
+    if pdf_present and chunks_present and db_rows > 0 and not suspect:
+        states.append("ready")
+    states = _ordered_states(states)
+    if "missing_selected_source" in states:
+        primary = "missing_selected_source"
+    elif "suspect_extraction" in states:
+        primary = "suspect_extraction"
+    elif "ready" in states:
+        primary = "ready"
+    elif states:
+        primary = states[0]
+    else:
+        primary = "untracked"
+    return primary, states
+
+
+def build_report(
+    *,
+    gdrive_root: Path,
+    db_path: Path,
+    selection_path: Path,
+    url_maps: Sequence[Path] = (),
+) -> dict[str, Any]:
+    """Build a deterministic text-free readiness report from local inputs."""
+    root = Path(gdrive_root).expanduser()
+    if not root.exists() or not root.is_dir():
+        raise ReadinessError("gdrive root is missing or not a directory")
+    root = root.resolve()
+    # The configured Drive root also contains literary and reference corpora.
+    # Restrict a normal project layout to its two textbook stores; retain the
+    # direct-root fallback for small standalone fixtures and explicit stores.
+    pdf_root = root / "textbooks" if (root / "textbooks").is_dir() else root
+    chunks_root = (
+        root / "textbook_chunks"
+        if (root / "textbook_chunks").is_dir()
+        else root
+    )
+
+    selection = _read_yaml_or_json(Path(selection_path))
+    selection_items = _selection_items(selection)
+    index = _SourceIndex(selection_items)
+    url_map_metadata, loaded_maps = _load_url_maps([Path(path) for path in url_maps])
+
+    pdf_records: list[dict[str, Any]] = []
+    jsonl_records: list[dict[str, Any]] = []
+    payload_occurrences: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    source_data: dict[str, dict[str, Any]] = {}
+
+    def source_bucket(key: str, source: str) -> dict[str, Any]:
+        bucket = source_data.setdefault(
+            key,
+            {
+                "source": source,
+                "pdfs": [],
+                "chunks": [],
+                "db_rows": 0,
+                "db_sources": [],
+                "payload_hashes": set(),
+                "components": defaultdict(
+                    lambda: {"pdfs": [], "chunks": [], "db_rows": 0, "db_sources": []}
+                ),
+            },
+        )
+        if source < bucket["source"]:
+            bucket["source"] = source
+        return bucket
+
+    for key, selected in index.selected.items():
+        source_bucket(key, selected["source"])
+
+    for path in _enumerate_files(pdf_root, PDF_SUFFIX):
+        relative = _relative_path(root, path)
+        key, source, component = index.resolve(path.stem)
+        index.ensure_discovered(key, source)
+        record = {
+            "path": relative,
+            "byte_size": path.stat().st_size,
+            "sha256": sha256_file(path),
+            "page_count": _pdf_page_count(path),
+            "source": source,
+            "component": component,
+        }
+        pdf_records.append(record)
+        bucket = source_bucket(key, source)
+        bucket["pdfs"].append(record)
+        bucket["components"][component]["pdfs"].append(record)
+
+    for path in _enumerate_files(chunks_root, JSONL_SUFFIX):
+        relative = _relative_path(root, path)
+        key, source, component = index.resolve(path.stem)
+        index.ensure_discovered(key, source)
+        stats, row_occurrences = _jsonl_stats(path, relative)
+        stats.update({"source": source, "component": component})
+        jsonl_records.append(stats)
+        bucket = source_bucket(key, source)
+        bucket["chunks"].append(stats)
+        bucket["components"][component]["chunks"].append(stats)
+        bucket["payload_hashes"].update(row_occurrences)
+        for payload_hash, row_numbers in row_occurrences.items():
+            payload_occurrences[payload_hash].extend((relative, number) for number in row_numbers)
+
+    db = _read_db(Path(db_path).expanduser())
+    if not db["available"] or db["error"] is not None or not db["table_present"]:
+        raise ReadinessError(
+            f"textbook database is not readable: {db['error'] or 'unknown_database_error'}"
+        )
+    for raw_source, row_count in sorted(db["rows_by_source"].items()):
+        key, source, component = index.resolve(raw_source)
+        index.ensure_discovered(key, source)
+        bucket = source_bucket(key, source)
+        bucket["db_rows"] += int(row_count)
+        bucket["db_sources"].append(_safe_source_identifier(raw_source))
+        bucket["components"][component]["db_rows"] += int(row_count)
+        bucket["components"][component]["db_sources"].append(_safe_source_identifier(raw_source))
+
+    locator_data: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for map_index, values in loaded_maps.items():
+        for raw_source, locators in values.items():
+            key, source, _component = index.resolve(raw_source)
+            index.ensure_discovered(key, source)
+            source_bucket(key, source)
+            for locator in locators:
+                safe = _safe_locator(locator)
+                if safe:
+                    locator_data[key].append({"map_index": map_index, "locator": safe})
+
+    sources: list[dict[str, Any]] = []
+    for key in sorted(source_data, key=lambda value: (value, source_data[value]["source"])):
+        bucket = source_data[key]
+        selected = index.selected.get(key)
+        pdfs = sorted(bucket["pdfs"], key=lambda record: record["path"])
+        chunks = sorted(bucket["chunks"], key=lambda record: record["path"])
+        db_rows = int(bucket["db_rows"])
+        total_rows = sum(int(record["row_count"]) for record in chunks)
+        page_counts = [record["page_count"] for record in pdfs if record["page_count"] is not None]
+        suspect = any(int(record["row_count"]) <= SUSPECT_MAX_ROWS for record in chunks)
+        if page_counts and total_rows:
+            suspect = suspect or any(
+                pages >= SUSPECT_MIN_PAGES and total_rows / pages < SUSPECT_ROWS_PER_PAGE
+                for pages in page_counts
+            )
+        elif page_counts and chunks and total_rows == 0:
+            suspect = True
+        primary, states = _source_states(
+            selected=selected is not None,
+            pdf_present=bool(pdfs),
+            chunks_present=bool(chunks),
+            db_rows=db_rows,
+            suspect=suspect,
+        )
+
+        components: list[dict[str, Any]] = []
+        component_data = bucket["components"]
+        for component in sorted(component_data):
+            values = component_data[component]
+            components.append(
+                {
+                    "component": component,
+                    "pdf_paths": sorted(record["path"] for record in values["pdfs"]),
+                    "chunk_paths": sorted(record["path"] for record in values["chunks"]),
+                    "db_source_files": sorted(set(values["db_sources"])),
+                    "db_row_count": int(values["db_rows"]),
+                }
+            )
+
+        locators = sorted(
+            set(
+                (int(item["map_index"]), str(item["locator"]))
+                for item in locator_data.get(key, [])
+            )
+        )
+        source_record = {
+            "source": bucket["source"],
+            "selected": selected is not None,
+            "selection_ids": sorted(selected["selection_ids"]) if selected else [],
+            "status": primary,
+            "states": states,
+            "pdf": {
+                "present": bool(pdfs),
+                "file_count": len(pdfs),
+                "byte_size": sum(int(record["byte_size"]) for record in pdfs),
+                "paths": [record["path"] for record in pdfs],
+                "page_counts": page_counts,
+            },
+            "chunks": {
+                "present": bool(chunks),
+                "file_count": len(chunks),
+                "row_count": total_rows,
+                "unique_payload_count": len(bucket["payload_hashes"]),
+                "mojibake_rows": sum(int(record["mojibake_rows"]) for record in chunks),
+                "paths": [record["path"] for record in chunks],
+            },
+            "db": {"row_count": db_rows, "source_files": sorted(set(bucket["db_sources"]))},
+            "components": components,
+            "acquisition_locators": [
+                {"map_index": map_index, "locator": locator}
+                for map_index, locator in locators
+            ],
+        }
+        sources.append(source_record)
+
+    pdf_hashes = [str(record["sha256"]) for record in pdf_records]
+    chunk_row_count = sum(int(record["row_count"]) for record in jsonl_records)
+    unique_chunk_payload_count = len(payload_occurrences)
+    mojibake_files = [record for record in jsonl_records if int(record["mojibake_rows"]) > 0]
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "predicates": dict(_PREDICATES),
+        "split_volume_rule": (
+            "terminal -1/-2, _1/_2, -part-1/-part-2, -part1/-part2, "
+            "-vol1/-vol2, -volume-1/-volume-2, or -p1/-p2 only"
+        ),
+        "selection": {
+            "selected_count": len(index.selected),
+            "selected_sources": [
+                {
+                    "source": index.selected[key]["source"],
+                    "selection_ids": sorted(index.selected[key]["selection_ids"]),
+                }
+                for key in sorted(index.selected)
+            ],
+        },
+        "url_maps": url_map_metadata,
+        "database": {
+            "available": bool(db["available"]),
+            "table_present": bool(db["table_present"]),
+            "row_count": int(db["row_count"]),
+            "source_count": len(db["rows_by_source"]),
+            "error": db["error"],
+        },
+        "counts": {
+            "pdf_files": len(pdf_records),
+            "unique_pdf_hashes": len(set(pdf_hashes)),
+            "chunk_files": len(jsonl_records),
+            "chunk_rows": chunk_row_count,
+            "unique_chunk_payloads": unique_chunk_payload_count,
+            "db_rows": int(db["row_count"]),
+        },
+        "files": {
+            "pdfs": [
+                {
+                    "path": record["path"],
+                    "byte_size": record["byte_size"],
+                    "sha256": record["sha256"],
+                    "page_count": record["page_count"],
+                }
+                for record in sorted(pdf_records, key=lambda item: item["path"])
+            ],
+            "chunks": [
+                {
+                    key: record[key]
+                    for key in (
+                        "path",
+                        "byte_size",
+                        "sha256",
+                        "row_count",
+                        "unique_payload_count",
+                        "duplicate_payload_count",
+                        "invalid_row_count",
+                        "mojibake_rows",
+                    )
+                }
+                for record in sorted(jsonl_records, key=lambda item: item["path"])
+            ],
+        },
+        "duplicates": {
+            "duplicate_pdf_hashes": _duplicate_pdf_groups(pdf_records),
+            "duplicate_chunk_payload_hashes": _duplicate_payload_groups(payload_occurrences),
+        },
+        "mojibake": {
+            "jsonl_files": len(mojibake_files),
+            "rows": sum(int(record["mojibake_rows"]) for record in jsonl_records),
+            "files": sorted(record["path"] for record in mojibake_files),
+        },
+        "sources": sources,
+    }
+    # A source map may identify a source with a locator but no retained bytes;
+    # it is intentionally represented as an untracked source, not a selected
+    # missing source.  All emitted paths above are root-relative by construction.
+    return report
+
+
+build_readiness_report = build_report
+reconcile_corpus = build_report
+
+
+def write_atomic_json(path: Path, value: Mapping[str, Any]) -> None:
+    """Write canonical JSON atomically in the output file's directory."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(canonical_json(value))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--gdrive-root", type=Path, required=True)
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--selection", type=Path, required=True)
+    parser.add_argument("--url-map", type=Path, action="append", default=[])
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = build_report(
+            gdrive_root=args.gdrive_root,
+            db_path=args.db,
+            selection_path=args.selection,
+            url_maps=args.url_map,
+        )
+        write_atomic_json(args.output, report)
+    except (OSError, ReadinessError, sqlite3.Error) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(f"Wrote deterministic readiness receipt: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/textbook_curriculum_coverage.py
+++ b/scripts/projects/open_model_data/textbook_curriculum_coverage.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Evaluate official textbook curriculum cells against a readiness receipt.
+
+The denominator is a curriculum-cell inventory, not a publisher-edition
+Cartesian product. Readiness is evidence for a cell; the 116-book selection
+remains a separate receipt field.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "textbook_curriculum_coverage_v1"
+DENOMINATOR_SCHEMA_VERSION = "textbook_curriculum_denominator_v1"
+READINESS_SCHEMA_VERSION = "textbook_corpus_readiness_v1"
+
+REQUIREMENT_CLASSES = (
+    "required_common",
+    "required_one_of",
+    "profile_or_track",
+    "optional_elective",
+    "no_textbook_required_or_unresolved",
+)
+TEXTBOOK_APPLICABILITY = {
+    "required",
+    "choice_required",
+    "profile_conditional",
+    "optional",
+    "not_required",
+    "unresolved",
+}
+EVIDENCE_STATES = {"resolved", "unresolved", "legacy_only"}
+CELL_STATUSES = {
+    "covered",
+    "degraded",
+    "acquisition_missing",
+    "extraction_missing",
+    "choice_satisfied",
+    "not_required",
+    "unresolved",
+}
+READINESS_STATUSES = {
+    "ready",
+    "pdf_without_chunks",
+    "chunks_without_pdf",
+    "chunks_not_ingested",
+    "db_without_chunks",
+    "suspect_extraction",
+    "missing_selected_source",
+    "untracked",
+}
+_STATUS_RANK = {
+    "not_required": 0,
+    "choice_satisfied": 1,
+    "acquisition_missing": 2,
+    "extraction_missing": 3,
+    "degraded": 4,
+    "covered": 5,
+    "unresolved": 6,
+}
+
+
+class CoverageError(ValueError):
+    """Raised when an input violates the curriculum coverage schema."""
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise CoverageError(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def canonical_json(value: Any) -> str:
+    """Return deterministic JSON for receipts and test comparisons."""
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _read_document(path: Path) -> Any:
+    try:
+        return yaml.load(path.read_text(encoding="utf-8"), Loader=_UniqueKeyLoader)
+    except CoverageError:
+        raise
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise CoverageError(f"cannot read document: {path}") from exc
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CoverageError(f"{label} must be a mapping")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CoverageError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _string_list(value: Any, label: str, *, allow_empty: bool = True) -> list[str]:
+    if not isinstance(value, list):
+        raise CoverageError(f"{label} must be a list")
+    result = [_string(item, f"{label}[{index}]") for index, item in enumerate(value)]
+    if not allow_empty and not result:
+        raise CoverageError(f"{label} must not be empty")
+    if len(result) != len(set(result)):
+        raise CoverageError(f"{label} contains duplicate values")
+    return result
+
+
+def _validate_denominator(document: Any) -> dict[str, Any]:
+    root = dict(_mapping(document, "denominator"))
+    if root.get("schema_version") != DENOMINATOR_SCHEMA_VERSION:
+        raise CoverageError("unsupported denominator schema_version")
+    locators = _mapping(root.get("locator_registry"), "locator_registry")
+    for locator_id, locator in locators.items():
+        _string(locator_id, "locator_registry key")
+        _string(locator, f"locator_registry[{locator_id!r}]")
+    classes = _string_list(root.get("requirement_classes"), "requirement_classes", allow_empty=False)
+    if tuple(classes) != REQUIREMENT_CLASSES:
+        raise CoverageError("requirement_classes must list the canonical five classes in order")
+
+    raw_cells = root.get("cells")
+    if not isinstance(raw_cells, list) or not raw_cells:
+        raise CoverageError("cells must be a non-empty list")
+    cells: list[dict[str, Any]] = []
+    cell_ids: set[str] = set()
+    for index, raw_cell in enumerate(raw_cells):
+        cell = dict(_mapping(raw_cell, f"cells[{index}]"))
+        cell_id = _string(cell.get("cell_id"), f"cells[{index}].cell_id")
+        if cell_id in cell_ids:
+            raise CoverageError(f"duplicate cell_id: {cell_id}")
+        cell_ids.add(cell_id)
+        grade = cell.get("grade")
+        if isinstance(grade, bool) or not isinstance(grade, int) or not 1 <= grade <= 11:
+            raise CoverageError(f"{cell_id}: grade must be an explicit integer from 1 to 11")
+        for field in ("canonical_subject_id", "display_name_uk", "cohort_or_effective_basis", "evidence_note"):
+            _string(cell.get(field), f"{cell_id}.{field}")
+        requirement_class = _string(cell.get("requirement_class"), f"{cell_id}.requirement_class")
+        if requirement_class not in REQUIREMENT_CLASSES:
+            raise CoverageError(f"{cell_id}: unknown requirement_class {requirement_class!r}")
+        for field in ("official_program_locator_ids", "official_edition_catalog_locator_ids"):
+            values = _string_list(cell.get(field), f"{cell_id}.{field}", allow_empty=False)
+            for locator_id in values:
+                if locator_id not in locators:
+                    raise CoverageError(f"{cell_id}: unknown locator id {locator_id!r}")
+        applicability = _string(cell.get("textbook_applicability"), f"{cell_id}.textbook_applicability")
+        if applicability not in TEXTBOOK_APPLICABILITY:
+            raise CoverageError(f"{cell_id}: unknown textbook_applicability {applicability!r}")
+
+        coverage = dict(_mapping(cell.get("coverage"), f"{cell_id}.coverage"))
+        _string(coverage.get("coverage_unit_id"), f"{cell_id}.coverage.coverage_unit_id")
+        source_ids = _string_list(coverage.get("source_ids"), f"{cell_id}.coverage.source_ids")
+        raw_groups = coverage.get("source_groups")
+        if not isinstance(raw_groups, list):
+            raise CoverageError(f"{cell_id}.coverage.source_groups must be a list")
+        source_groups: list[list[str]] = []
+        for group_index, group in enumerate(raw_groups):
+            source_groups.append(
+                _string_list(group, f"{cell_id}.coverage.source_groups[{group_index}]", allow_empty=False)
+            )
+        mode = _string(coverage.get("source_match_mode"), f"{cell_id}.coverage.source_match_mode")
+        if mode not in {"any", "all"}:
+            raise CoverageError(f"{cell_id}: source_match_mode must be any or all")
+        if source_groups and mode != "all":
+            raise CoverageError(f"{cell_id}: source_groups require source_match_mode=all")
+        evidence_state = _string(coverage.get("evidence_state"), f"{cell_id}.coverage.evidence_state")
+        if evidence_state not in EVIDENCE_STATES:
+            raise CoverageError(f"{cell_id}: unknown evidence_state {evidence_state!r}")
+        legacy = _string_list(
+            coverage.get("legacy_inventory_source_ids"),
+            f"{cell_id}.coverage.legacy_inventory_source_ids",
+        )
+        _string(coverage.get("edition_policy"), f"{cell_id}.coverage.edition_policy")
+        coverage.update(
+            source_ids=source_ids,
+            source_groups=source_groups,
+            source_match_mode=mode,
+            evidence_state=evidence_state,
+            legacy_inventory_source_ids=legacy,
+        )
+        cell["coverage"] = coverage
+
+        group_id = cell.get("choice_group_id")
+        member_id = cell.get("choice_member_id")
+        requires = cell.get("choice_member_requires")
+        if requirement_class == "required_one_of" and (group_id is None or member_id is None):
+            raise CoverageError(f"{cell_id}: required_one_of needs choice_group_id and choice_member_id")
+        if group_id is not None:
+            _string(group_id, f"{cell_id}.choice_group_id")
+            _string(member_id, f"{cell_id}.choice_member_id")
+            if not isinstance(requires, list) or not requires:
+                raise CoverageError(f"{cell_id}: choice_member_requires must be a non-empty list")
+            cell["choice_member_requires"] = _string_list(
+                requires,
+                f"{cell_id}.choice_member_requires",
+                allow_empty=False,
+            )
+        elif requires is not None:
+            raise CoverageError(f"{cell_id}: choice_member_requires without choice_group_id")
+        cells.append(cell)
+
+    for cell in cells:
+        for required_id in cell.get("choice_member_requires", []):
+            if required_id not in cell_ids:
+                raise CoverageError(f"{cell['cell_id']}: unknown choice member cell {required_id!r}")
+    root["cells"] = cells
+    return root
+
+
+def load_denominator(path: Path) -> dict[str, Any]:
+    """Read and validate denominator YAML."""
+    return _validate_denominator(_read_document(Path(path)))
+
+
+def _validate_readiness(document: Any) -> dict[str, Any]:
+    root = dict(_mapping(document, "readiness"))
+    if root.get("schema_version") != READINESS_SCHEMA_VERSION:
+        raise CoverageError("unsupported readiness schema_version")
+    sources = root.get("sources")
+    if not isinstance(sources, list):
+        raise CoverageError("readiness.sources must be a list")
+    seen: set[str] = set()
+    for index, raw_source in enumerate(sources):
+        source = _mapping(raw_source, f"readiness.sources[{index}]")
+        source_id = _string(source.get("source"), f"readiness.sources[{index}].source")
+        if source_id in seen:
+            raise CoverageError(f"duplicate readiness source: {source_id}")
+        seen.add(source_id)
+        status = _string(source.get("status"), f"{source_id}.status")
+        if status not in READINESS_STATUSES:
+            raise CoverageError(f"{source_id}: unsupported readiness status {status!r}")
+        selection_ids = source.get("selection_ids", [])
+        if not isinstance(selection_ids, list) or any(not isinstance(item, str) for item in selection_ids):
+            raise CoverageError(f"{source_id}: selection_ids must be a string list")
+    selection = root.get("selection", {})
+    if not isinstance(selection, Mapping):
+        raise CoverageError("readiness.selection must be a mapping")
+    selected_count = selection.get("selected_count")
+    if selected_count is not None and (
+        isinstance(selected_count, bool) or not isinstance(selected_count, int) or selected_count < 0
+    ):
+        raise CoverageError("readiness.selection.selected_count must be a non-negative integer")
+    return root
+
+
+def load_readiness(path: Path) -> dict[str, Any]:
+    """Read and validate readiness JSON/YAML."""
+    return _validate_readiness(_read_document(Path(path)))
+
+
+def _source_keys(source: Mapping[str, Any]) -> set[str]:
+    return {_string(source["source"], "source"), *map(str, source.get("selection_ids", []))}
+
+
+def _index_sources(readiness: Mapping[str, Any]) -> dict[str, list[Mapping[str, Any]]]:
+    index: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for source in readiness["sources"]:
+        for key in sorted(_source_keys(source)):
+            index[key].append(source)
+    return index
+
+
+def _readiness_status(source: Mapping[str, Any]) -> str:
+    status = str(source["status"])
+    if status == "ready":
+        return "covered"
+    if status == "suspect_extraction":
+        return "degraded"
+    if status in {"pdf_without_chunks", "chunks_not_ingested"}:
+        return "extraction_missing"
+    if status in {"chunks_without_pdf", "db_without_chunks"}:
+        return "degraded"
+    return "acquisition_missing"
+
+
+def _combine_statuses(statuses: Iterable[str], *, empty: str = "acquisition_missing") -> str:
+    values = list(statuses)
+    if not values:
+        return empty
+    return max(values, key=lambda value: (_STATUS_RANK[value], value))
+
+
+def _all_required_statuses(statuses: Iterable[str]) -> str:
+    """Combine statuses for a cell/member whose every component is required."""
+    values = list(statuses)
+    if not values:
+        return "acquisition_missing"
+    if all(status == "covered" for status in values):
+        return "covered"
+    if all(status in {"covered", "degraded"} for status in values):
+        return "degraded"
+    for status in ("unresolved", "extraction_missing", "acquisition_missing", "degraded"):
+        if status in values:
+            return status
+    return _combine_statuses(values)
+
+
+def _candidate_status(
+    source_ids: Sequence[str],
+    source_index: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> tuple[str, list[dict[str, Any]], list[str]]:
+    matches: list[dict[str, Any]] = []
+    statuses: list[str] = []
+    missing: list[str] = []
+    seen_sources: set[str] = set()
+    for source_id in source_ids:
+        records = source_index.get(source_id, ())
+        if not records:
+            missing.append(source_id)
+            continue
+        for record in records:
+            source_name = str(record["source"])
+            if source_name in seen_sources:
+                continue
+            seen_sources.add(source_name)
+            mapped = _readiness_status(record)
+            statuses.append(mapped)
+            matches.append(
+                {
+                    "source": source_name,
+                    "readiness_status": str(record["status"]),
+                    "coverage_status": mapped,
+                }
+            )
+    return _combine_statuses(statuses), sorted(matches, key=lambda item: item["source"]), sorted(missing)
+
+
+def _raw_cell_evaluation(
+    cell: Mapping[str, Any],
+    source_index: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> dict[str, Any]:
+    coverage = cell["coverage"]
+    source_ids = list(coverage["source_ids"])
+    source_groups = list(coverage["source_groups"])
+    matches: list[dict[str, Any]] = []
+    missing: list[str] = []
+    if source_groups:
+        group_results: list[str] = []
+        for group in source_groups:
+            status, group_matches, group_missing = _candidate_status(group, source_index)
+            group_results.append(status)
+            matches.extend(group_matches)
+            missing.extend(group_missing)
+        status = _all_required_statuses(group_results)
+    else:
+        status, matches, missing = _candidate_status(source_ids, source_index)
+
+    requirement_class = cell["requirement_class"]
+    applicability = cell["textbook_applicability"]
+    evidence_state = coverage["evidence_state"]
+    if requirement_class == "no_textbook_required_or_unresolved":
+        status = "not_required" if applicability == "not_required" else "unresolved"
+    elif evidence_state == "unresolved" or applicability == "unresolved":
+        status = "unresolved"
+    elif requirement_class in {"profile_or_track", "optional_elective"} and not source_ids and not source_groups:
+        status = "not_required"
+    elif evidence_state == "legacy_only":
+        status = "acquisition_missing"
+
+    reason_by_status = {
+        "covered": "an accepted readiness source is ready",
+        "degraded": "readiness has content but the source is incomplete or suspect",
+        "extraction_missing": "an accepted source exists but extraction or ingest is missing",
+        "acquisition_missing": "no accepted current source is present in the readiness receipt",
+        "not_required": "the cell is conditional or optional and has no selected source evidence",
+        "choice_satisfied": "another approved alternative in the choice group is covered",
+        "unresolved": "official title-level enumeration or textbook applicability remains unresolved",
+    }
+    reason = reason_by_status[status]
+    if evidence_state == "legacy_only":
+        reason = "legacy inventory is retained as evidence but cannot satisfy the current cohort"
+    return {
+        "cell_id": cell["cell_id"],
+        "grade": cell["grade"],
+        "canonical_subject_id": cell["canonical_subject_id"],
+        "display_name_uk": cell["display_name_uk"],
+        "requirement_class": requirement_class,
+        "textbook_applicability": applicability,
+        "coverage_unit_id": coverage["coverage_unit_id"],
+        "choice_group_id": cell.get("choice_group_id"),
+        "choice_member_id": cell.get("choice_member_id"),
+        "raw_status": status,
+        "status": status,
+        "reason": reason,
+        "readiness_matches": matches,
+        "missing_source_ids": missing,
+        "legacy_inventory_source_ids": list(coverage["legacy_inventory_source_ids"]),
+        "evidence_state": evidence_state,
+    }
+
+
+def _choice_groups(cells: Sequence[Mapping[str, Any]], evaluations: Mapping[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, list[Mapping[str, Any]]]] = defaultdict(lambda: defaultdict(list))
+    for cell in cells:
+        group_id = cell.get("choice_group_id")
+        if group_id:
+            grouped[str(group_id)][str(cell["choice_member_id"])].append(cell)
+
+    reports: list[dict[str, Any]] = []
+    for group_id in sorted(grouped):
+        members = grouped[group_id]
+        member_reports: list[dict[str, Any]] = []
+        for member_id in sorted(members):
+            member_cells = sorted(members[member_id], key=lambda item: str(item["cell_id"]))
+            required_ids = sorted({required for cell in member_cells for required in cell["choice_member_requires"]})
+            component_statuses = [evaluations[cell_id]["raw_status"] for cell_id in required_ids]
+            member_status = _all_required_statuses(component_statuses)
+            member_reports.append(
+                {
+                    "member_id": member_id,
+                    "cell_ids": [str(cell["cell_id"]) for cell in member_cells],
+                    "required_cell_ids": required_ids,
+                    "status": member_status,
+                }
+            )
+
+        covered = [item for item in member_reports if item["status"] == "covered"]
+        degraded = [item for item in member_reports if item["status"] == "degraded"]
+        selected_member = (covered or degraded or [None])[0]
+        group_status = "choice_satisfied" if covered else "degraded" if degraded else _combine_statuses(
+            item["status"] for item in member_reports
+        )
+
+        if selected_member is not None and group_status == "choice_satisfied":
+            selected_id = selected_member["member_id"]
+            for item in member_reports:
+                if item["member_id"] == selected_id:
+                    continue
+                for cell_id in item["cell_ids"]:
+                    if evaluations[cell_id]["status"] in {
+                        "acquisition_missing",
+                        "extraction_missing",
+                        "degraded",
+                        "not_required",
+                        "covered",
+                    }:
+                        evaluations[cell_id]["status"] = "choice_satisfied"
+                        evaluations[cell_id]["reason"] = (
+                            "another approved alternative in the choice group is covered"
+                        )
+        reports.append(
+            {
+                "choice_group_id": group_id,
+                "status": group_status,
+                "selected_member_id": selected_member["member_id"] if selected_member else None,
+                "members": member_reports,
+            }
+        )
+    return reports
+
+
+def _coverage_units(evaluations: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for evaluation in evaluations:
+        grouped[str(evaluation["coverage_unit_id"])].append(evaluation)
+    result: list[dict[str, Any]] = []
+    for unit_id in sorted(grouped):
+        items = sorted(grouped[unit_id], key=lambda item: str(item["cell_id"]))
+        statuses = [str(item["status"]) for item in items]
+        if all(status in {"covered", "choice_satisfied", "not_required"} for status in statuses):
+            status = "covered" if "covered" in statuses else statuses[0]
+        else:
+            status = _combine_statuses(statuses)
+        result.append(
+            {
+                "coverage_unit_id": unit_id,
+                "cell_ids": [str(item["cell_id"]) for item in items],
+                "status": status,
+            }
+        )
+    return result
+
+
+def evaluate(denominator: Mapping[str, Any], readiness: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate validated mappings and return a deterministic report."""
+    denominator_doc = _validate_denominator(denominator)
+    readiness_doc = _validate_readiness(readiness)
+    cells = sorted(denominator_doc["cells"], key=lambda item: str(item["cell_id"]))
+    source_index = _index_sources(readiness_doc)
+    evaluations_by_id = {
+        str(cell["cell_id"]): _raw_cell_evaluation(cell, source_index) for cell in cells
+    }
+    choice_groups = _choice_groups(cells, evaluations_by_id)
+    evaluations = [evaluations_by_id[str(cell["cell_id"])] for cell in cells]
+    for evaluation in evaluations:
+        evaluation.pop("raw_status", None)
+        evaluation["readiness_matches"] = sorted(
+            evaluation["readiness_matches"],
+            key=lambda item: (item["source"], item["readiness_status"]),
+        )
+        evaluation["missing_source_ids"] = sorted(set(evaluation["missing_source_ids"]))
+
+    requirement_counts = Counter(str(cell["requirement_class"]) for cell in cells)
+    status_counts = Counter(str(item["status"]) for item in evaluations)
+    grade_counts = Counter(int(cell["grade"]) for cell in cells)
+    unresolved_cells = sorted(str(item["cell_id"]) for item in evaluations if item["status"] == "unresolved")
+    units = _coverage_units(evaluations)
+    required_classes = {"required_common", "required_one_of"}
+    required_evaluations = [item for item in evaluations if item["requirement_class"] in required_classes]
+    required_status_counts = Counter(str(item["status"]) for item in required_evaluations)
+
+    selection = readiness_doc.get("selection", {})
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "denominator": {
+            "schema_version": denominator_doc["schema_version"],
+            "cell_count": len(cells),
+            "grade_counts": {str(grade): grade_counts[grade] for grade in sorted(grade_counts)},
+            "requirement_class_counts": {
+                requirement_class: requirement_counts[requirement_class]
+                for requirement_class in REQUIREMENT_CLASSES
+            },
+            "coverage_unit_count": len(units),
+        },
+        "selection": {
+            "selected_count": selection.get("selected_count"),
+            "source": "readiness.selection.selected_count",
+            "is_official_curriculum_denominator": False,
+            "note": "The selection count is reported separately and does not define cell completeness.",
+        },
+        "readiness": {
+            "schema_version": readiness_doc["schema_version"],
+            "source_count": len(readiness_doc["sources"]),
+            "receipt_counts": readiness_doc.get("counts", {}),
+        },
+        "counts": {
+            "cells": len(evaluations),
+            "by_requirement_class": {
+                requirement_class: requirement_counts[requirement_class]
+                for requirement_class in REQUIREMENT_CLASSES
+            },
+            "by_status": {status: status_counts[status] for status in sorted(CELL_STATUSES)},
+            "required_cells": len(required_evaluations),
+            "required_by_status": {
+                status: required_status_counts[status] for status in sorted(CELL_STATUSES)
+            },
+            "coverage_units": len(units),
+            "coverage_units_by_status": {
+                status: sum(unit["status"] == status for unit in units) for status in sorted(CELL_STATUSES)
+            },
+        },
+        "choice_groups": choice_groups,
+        "coverage_units": units,
+        "unresolved_evidence_cells": unresolved_cells,
+        "cells": evaluations,
+        "limitations": [
+            "The report evaluates only source identities and readiness states recorded in the inputs.",
+            "It does not claim title-level official enumeration where the denominator evidence marks it unresolved.",
+            "A legacy source listed in legacy_inventory_source_ids cannot satisfy a current cohort cell.",
+        ],
+    }
+    return report
+
+
+def build_report(*, denominator_path: Path, readiness_path: Path) -> dict[str, Any]:
+    """Load both inputs, validate them, and build a deterministic report."""
+    denominator_path = Path(denominator_path)
+    readiness_path = Path(readiness_path)
+    report = evaluate(load_denominator(denominator_path), load_readiness(readiness_path))
+    report["input_hashes"] = {
+        "denominator_sha256": _sha256_file(denominator_path),
+        "readiness_sha256": _sha256_file(readiness_path),
+    }
+    return report
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _write_output(path: Path, report: Mapping[str, Any]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(canonical_json(report) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--denominator", type=Path, required=True)
+    parser.add_argument("--readiness", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = build_report(denominator_path=args.denominator, readiness_path=args.readiness)
+    except (CoverageError, OSError, yaml.YAMLError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    serialized = canonical_json(report)
+    if args.output:
+        _write_output(args.output, report)
+        print(f"Wrote deterministic curriculum coverage receipt: {args.output}")
+    else:
+        print(serialized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rag/apple_vision_ocr.swift
+++ b/scripts/rag/apple_vision_ocr.swift
@@ -1,0 +1,307 @@
+import CoreGraphics
+import Darwin
+import Foundation
+import PDFKit
+import Vision
+
+private let schemaVersion = "apple-vision-ocr.v1"
+private let helperVersion = "apple-vision-ocr.swift.v1"
+
+private struct RuntimeMetadata: Codable {
+    let helper_version: String
+    let os_version: String
+    let swift_language_version: String
+}
+
+private struct RecognizerMetadata: Codable {
+    let framework: String
+    let request: String
+    let recognition_languages: [String]
+    let recognition_level: String
+    let uses_cpu_only: Bool
+    let revision: Int
+}
+
+private struct OCRMetadata: Codable {
+    let runtime: RuntimeMetadata
+    let recognizer: RecognizerMetadata
+}
+
+private struct OCRPage: Codable {
+    let page_number: Int
+    let text: String
+    let observation_count: Int
+    let mean_confidence: Double
+    let line_break_count: Int
+}
+
+private struct OCRResponse: Codable {
+    let schema_version: String
+    let metadata: OCRMetadata
+    let pages: [OCRPage]
+}
+
+private struct OrderedObservation {
+    let text: String
+    let confidence: Float
+    let box: CGRect
+}
+
+private enum OCRFailure: LocalizedError {
+    case usage(String)
+    case invalidPage(String)
+    case unreadablePDF
+    case missingPage(Int)
+    case renderFailure(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .usage(let message):
+            return message
+        case .invalidPage(let message):
+            return message
+        case .unreadablePDF:
+            return "Could not open the PDF with PDFKit"
+        case .missingPage(let page):
+            return "PDF has no requested page \(page)"
+        case .renderFailure(let page):
+            return "Could not render PDF page \(page) in memory"
+        }
+    }
+}
+
+private func parseArguments() throws -> (URL, String, String) {
+    var pdfPath: String?
+    var pagesArgument: String?
+    var mode = "ocr"
+    var index = 1
+
+    while index < CommandLine.arguments.count {
+        let argument = CommandLine.arguments[index]
+        switch argument {
+        case "--pdf":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw OCRFailure.usage("--pdf requires a path")
+            }
+            pdfPath = CommandLine.arguments[index]
+        case "--pages":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw OCRFailure.usage("--pages requires a comma-separated list")
+            }
+            pagesArgument = CommandLine.arguments[index]
+        case "--mode":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw OCRFailure.usage("--mode requires native or ocr")
+            }
+            mode = CommandLine.arguments[index]
+        default:
+            throw OCRFailure.usage("unknown argument \(argument)")
+        }
+        index += 1
+    }
+
+    guard let pdfPath, !pdfPath.isEmpty else {
+        throw OCRFailure.usage("usage: apple_vision_ocr.swift --pdf PATH --pages 1,10")
+    }
+    guard let pagesArgument, !pagesArgument.isEmpty else {
+        throw OCRFailure.usage("--pages is required; page numbers are one-based")
+    }
+
+    guard mode == "native" || mode == "ocr" else {
+        throw OCRFailure.usage("--mode must be native or ocr")
+    }
+    return (URL(fileURLWithPath: pdfPath), pagesArgument, mode)
+}
+
+private func renderPage(_ page: PDFPage, pageNumber: Int) throws -> CGImage {
+    let bounds = page.bounds(for: .mediaBox)
+    // Textbook scans need enough raster detail for Ukrainian Cyrillic glyphs;
+    // 2x produced pervasive Latin-lookalike substitutions in the live canary.
+    let scale: CGFloat = 3.0
+    let width = max(1, Int(ceil(bounds.width * scale)))
+    let height = max(1, Int(ceil(bounds.height * scale)))
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    guard let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else {
+        throw OCRFailure.renderFailure(pageNumber)
+    }
+
+    context.setFillColor(CGColor(gray: 1.0, alpha: 1.0))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.saveGState()
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: scale, y: -scale)
+    page.draw(with: .mediaBox, to: context)
+    context.restoreGState()
+
+    guard let image = context.makeImage() else {
+        throw OCRFailure.renderFailure(pageNumber)
+    }
+    return image
+}
+
+private func recognizePage(
+    _ page: PDFPage,
+    pageNumber: Int,
+    requestRevision: Int
+) throws -> OCRPage {
+    let image = try renderPage(page, pageNumber: pageNumber)
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+    let bandCount = 8
+    let overlap: CGFloat = 0.015
+    var allObservations: [OrderedObservation] = []
+    var pageLines: [String] = []
+
+    // Vision downsamples a full textbook page aggressively enough to miss
+    // body text. Eight in-memory horizontal regions keep glyphs large for the
+    // recognizer without writing page or tile images to disk.
+    for band in 0..<bandCount {
+        let bandHeight = 1.0 / CGFloat(bandCount)
+        let coreY = 1.0 - CGFloat(band + 1) * bandHeight
+        let y = max(0.0, coreY - overlap)
+        let top = min(1.0, coreY + bandHeight + overlap)
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.recognitionLanguages = ["uk-UA"]
+        request.usesLanguageCorrection = true
+        request.usesCPUOnly = true
+        request.regionOfInterest = CGRect(x: 0.0, y: y, width: 1.0, height: top - y)
+        try handler.perform([request])
+
+        let observations: [OrderedObservation] = (request.results ?? []).compactMap { observation in
+            guard let candidate = observation.topCandidates(1).first else {
+                return nil
+            }
+            return OrderedObservation(
+                text: candidate.string,
+                confidence: candidate.confidence,
+                box: observation.boundingBox
+            )
+        }
+        allObservations.append(contentsOf: observations)
+        let ordered = observations.sorted { left, right in
+            if abs(left.box.midY - right.box.midY) > 0.02 {
+                return left.box.midY > right.box.midY
+            }
+            return left.box.minX < right.box.minX
+        }
+        var lines: [[OrderedObservation]] = []
+        for observation in ordered {
+            if let last = lines.last,
+               let first = last.first,
+               abs(first.box.midY - observation.box.midY) <= 0.025 {
+                lines[lines.count - 1].append(observation)
+            } else {
+                lines.append([observation])
+            }
+        }
+        for line in lines {
+            let value = line.sorted { $0.box.minX < $1.box.minX }
+                .map(\.text)
+                .joined(separator: " ")
+            if pageLines.last != value {
+                pageLines.append(value)
+            }
+        }
+    }
+    let text = pageLines.joined(separator: "\n")
+    let confidence = allObservations.isEmpty
+        ? 0.0
+        : allObservations.reduce(0.0) { $0 + Double($1.confidence) } / Double(allObservations.count)
+
+    _ = requestRevision
+    return OCRPage(
+        page_number: pageNumber,
+        text: text,
+        observation_count: allObservations.count,
+        mean_confidence: confidence,
+        line_break_count: max(0, pageLines.count - 1)
+    )
+}
+
+private func nativePage(_ page: PDFPage, pageNumber: Int) -> OCRPage {
+    let text = page.string ?? ""
+    return OCRPage(
+        page_number: pageNumber,
+        text: text,
+        observation_count: 0,
+        mean_confidence: text.isEmpty ? 0.0 : 1.0,
+        line_break_count: text.reduce(0) { $1 == "\n" ? $0 + 1 : $0 }
+    )
+}
+
+private func run() throws -> OCRResponse {
+    let (pdfURL, pagesArgument, mode) = try parseArguments()
+    guard let document = PDFDocument(url: pdfURL) else {
+        throw OCRFailure.unreadablePDF
+    }
+
+    let requestedPages: [Int]
+    if pagesArgument == "all" {
+        requestedPages = Array(1...document.pageCount)
+    } else {
+        let parsed = try pagesArgument.split(separator: ",").map { component -> Int in
+            guard let page = Int(component), page > 0 else {
+                throw OCRFailure.invalidPage("invalid one-based page number \(component)")
+            }
+            return page
+        }
+        requestedPages = Array(Set(parsed)).sorted()
+    }
+    guard !requestedPages.isEmpty else {
+        throw OCRFailure.invalidPage("at least one page is required")
+    }
+
+    var pages: [OCRPage] = []
+    let requestRevision = VNRecognizeTextRequest().revision
+    for pageNumber in requestedPages {
+        guard let page = document.page(at: pageNumber - 1) else {
+            throw OCRFailure.missingPage(pageNumber)
+        }
+        if mode == "native" {
+            pages.append(nativePage(page, pageNumber: pageNumber))
+        } else {
+            pages.append(try recognizePage(page, pageNumber: pageNumber, requestRevision: requestRevision))
+        }
+    }
+
+    let runtime = RuntimeMetadata(
+        helper_version: helperVersion,
+        os_version: ProcessInfo.processInfo.operatingSystemVersionString,
+        swift_language_version: "Swift 5+"
+    )
+    let recognizer = RecognizerMetadata(
+        framework: mode == "native" ? "PDFKit" : "Vision",
+        request: mode == "native" ? "PDFPage.string" : "VNRecognizeTextRequest",
+        recognition_languages: mode == "native" ? [] : ["uk-UA"],
+        recognition_level: mode == "native" ? "native" : "accurate",
+        uses_cpu_only: true,
+        revision: mode == "native" ? 0 : requestRevision
+    )
+    return OCRResponse(
+        schema_version: schemaVersion,
+        metadata: OCRMetadata(runtime: runtime, recognizer: recognizer),
+        pages: pages
+    )
+}
+
+do {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(run())
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([0x0A]))
+} catch {
+    fputs("apple_vision_ocr.swift: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/scripts/rag/extract_text.py
+++ b/scripts/rag/extract_text.py
@@ -1,28 +1,42 @@
 """Extract text from PDF textbooks into structured chunks.
 
-Two extraction modes:
-- Fast (pymupdf): For digital PDFs with selectable text. Extracts text per page.
-- OCR (marker): For scanned PDFs. Uses Surya OCR (slow, ~4 min/page).
+Extraction is hybrid and page-aware:
+- Native PyMuPDF text is retained when sampled coverage and per-page text are adequate.
+- Missing/unusable pages use the bundled macOS PDFKit + Vision helper in memory.
 
-Auto-detects mode by sampling 5 pages for text content.
+Digital classification samples twelve evenly distributed pages with an explicit
+coverage predicate; final JSONL and a page-coverage receipt are atomically written.
 
 Usage:
     .venv/bin/python scripts/rag/extract_text.py data/textbooks/grade-03/3-klas-ukrainska-mova-vashulenko-2020-1.pdf
     .venv/bin/python scripts/rag/extract_text.py --all
     .venv/bin/python scripts/rag/extract_text.py --grade 1 3
+    .venv/bin/python scripts/rag/extract_text.py --output-dir /path/to/textbook_chunks \
+        data/textbooks/grade-03/3-klas-ukrainska-mova-vashulenko-2020-1.pdf
     .venv/bin/python scripts/rag/extract_text.py --force-ocr data/textbooks/grade-01/1-klas-bukvar-bolshakova-2025-1.pdf
 """
 
 import argparse
 import json
+import math
+import os
 import re
+import subprocess
 import sys
+import tempfile
 import unicodedata
+from collections.abc import Callable
+from dataclasses import dataclass
+from itertools import pairwise
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from rag.chunk_quality import DEFAULT_SYMBOL_NOISE_THRESHOLD, apply_symbol_noise_gate
+from rag.chunk_quality import (
+    DEFAULT_SYMBOL_NOISE_THRESHOLD,
+    NoiseGateStats,
+    apply_symbol_noise_gate,
+)
 from rag.config import (
     CHUNK_MAX_TOKENS,
     CHUNK_MIN_TOKENS,
@@ -34,29 +48,183 @@ from rag.config import (
     parse_pdf_metadata,
 )
 
+# The sample is deliberately larger than the old "two readable pages" rule.
+# Twelve evenly distributed pages means a long image-only book cannot be
+# classified as digital because of two front-matter pages with embedded text.
+DIGITAL_SAMPLE_PAGE_COUNT = 12
+DIGITAL_MIN_SAMPLE_COVERAGE = 0.60
+DIGITAL_MIN_READABLE_SAMPLE_PAGES = 3
 
-def is_digital_pdf(pdf_path: Path, sample_pages: int = 5) -> bool:
-    """Check if a PDF has selectable text (vs scanned images).
+# A recovered page must contain enough actual text to count as content.  The
+# thresholds are intentionally explicit so a receipt can explain why a book
+# was accepted or rejected; they are not a Ukrainian-language quality claim.
+MIN_USABLE_PAGE_CHARS = 80
+MIN_CONTENT_PAGE_CHARS = 80
+# A textbook with most pages missing is not acceptable extraction coverage.
+# Sixty percent still permits covers, image-only separators, and short answer
+# pages while failing closed on partial-book recovery.
+MIN_CONTENT_PAGE_COVERAGE = 0.60
+MIN_CONTENT_PAGES = 3
+# OCR confidence is recognizer-native and language-neutral.  This is an
+# alternate acceptance route for legitimate Latin-script textbooks; Ukrainian
+# pages can instead pass the existing 0.80 clean-character ratio.
+MIN_OCR_MEAN_CONFIDENCE = 0.75
 
-    Samples up to `sample_pages` pages and checks if any have text.
+SWIFT_OCR_SCRIPT = Path(__file__).with_name("apple_vision_ocr.swift")
+SWIFT_OCR_SCHEMA = "apple-vision-ocr.v1"
+
+_TERMINAL_PUNCTUATION = frozenset(".!?…")
+_FORMULA_MARKERS = frozenset("=+*/^√∑≤≥≠∞$")
+_MOJIBAKE_PASSTHROUGH = frozenset(
+    {
+        0x00A0,  # non-breaking space
+        0x00AB,
+        0x00BB,  # guillemets
+        0x2018,
+        0x2019,
+        0x201C,
+        0x201D,  # smart quotes
+        0x2013,
+        0x2014,  # en/em dash
+        0x2022,  # bullet
+        0x2026,  # ellipsis
+    }
+)
+
+
+class ExtractionError(RuntimeError):
+    """Raised when a deterministic extraction step cannot complete."""
+
+
+class ExtractionQualityError(ExtractionError):
+    """Raised when a PDF does not meet the minimum recovered-page floor."""
+
+    def __init__(self, message: str, *, receipt: dict):
+        super().__init__(message)
+        self.receipt = receipt
+
+
+@dataclass(frozen=True)
+class PageCoverage:
+    """Sampled native-text coverage used for digital-PDF classification."""
+
+    total_pages: int
+    sampled_pages: tuple[int, ...]
+    readable_pages: tuple[int, ...]
+
+    @property
+    def coverage(self) -> float:
+        return len(self.readable_pages) / len(self.sampled_pages) if self.sampled_pages else 0.0
+
+    @property
+    def required_readable_pages(self) -> int:
+        return min(
+            len(self.sampled_pages),
+            max(1, DIGITAL_MIN_READABLE_SAMPLE_PAGES),
+        )
+
+    @property
+    def accepted(self) -> bool:
+        return (
+            len(self.readable_pages) >= self.required_readable_pages
+            and self.coverage >= DIGITAL_MIN_SAMPLE_COVERAGE
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "total_pages": self.total_pages,
+            "sampled_pages": list(self.sampled_pages),
+            "readable_pages": list(self.readable_pages),
+            "readable_page_count": len(self.readable_pages),
+            "sample_coverage": round(self.coverage, 4),
+            "minimum_sample_coverage": DIGITAL_MIN_SAMPLE_COVERAGE,
+            "minimum_readable_sample_pages": self.required_readable_pages,
+            "accepted": self.accepted,
+            "predicate": (
+                "readable sampled pages >= 3 (or all sampled pages for shorter PDFs) "
+                "and sampled coverage >= 60%"
+            ),
+        }
+
+
+def _sample_page_numbers(total_pages: int, sample_pages: int) -> tuple[int, ...]:
+    """Return deterministic, one-based, evenly distributed sample pages."""
+    if total_pages <= 0:
+        return ()
+    if sample_pages <= 0:
+        raise ValueError("sample_pages must be positive")
+    count = min(total_pages, sample_pages)
+    if count == 1:
+        return (1,)
+    return tuple(
+        sorted(
+            {
+                1 + round(index * (total_pages - 1) / (count - 1))
+                for index in range(count)
+            }
+        )
+    )
+
+
+def _is_usable_page_text(text: str) -> bool:
+    """Return whether text is substantial enough for native-page retention."""
+    normalized = text.strip()
+    if len(normalized) < MIN_USABLE_PAGE_CHARS:
+        return False
+    return sum(character.isalpha() for character in normalized) >= 10
+
+
+def _is_content_page_text(text: str) -> bool:
+    """Return whether text counts toward the post-extraction content floor."""
+    normalized = text.strip()
+    if len(normalized) < MIN_CONTENT_PAGE_CHARS:
+        return False
+    return sum(character.isalpha() for character in normalized) >= 10
+
+
+def _page_coverage_from_texts(
+    page_texts: dict[int, str],
+    *,
+    total_pages: int,
+    sample_pages: int,
+) -> PageCoverage:
+    sampled = _sample_page_numbers(total_pages, sample_pages)
+    readable = tuple(
+        page_number
+        for page_number in sampled
+        if _is_usable_page_text(page_texts.get(page_number, ""))
+    )
+    return PageCoverage(
+        total_pages=total_pages,
+        sampled_pages=sampled,
+        readable_pages=readable,
+    )
+
+
+def assess_digital_pdf(pdf_path: Path, sample_pages: int = DIGITAL_SAMPLE_PAGE_COUNT) -> PageCoverage:
+    """Measure sampled native-text coverage for deterministic mode selection.
+
+    The predicate is deliberately coverage-based: at least 60% of twelve
+    evenly distributed pages (or all pages for shorter PDFs) must contain at
+    least ``MIN_USABLE_PAGE_CHARS`` of selectable text, and at least three
+    sampled pages must be readable for a longer PDF.  This rejects a 273-page
+    scan whose first two pages happen to contain front matter text.
     """
-    import pymupdf
+    pages = extract_native_pages(pdf_path)
+    total_pages = len(pages)
+    sampled = _sample_page_numbers(total_pages, sample_pages)
+    by_number = {int(page["page_number"]): str(page["text"]) for page in pages}
+    page_texts = {page_number: by_number.get(page_number, "") for page_number in sampled}
+    return _page_coverage_from_texts(
+        page_texts,
+        total_pages=total_pages,
+        sample_pages=sample_pages,
+    )
 
-    doc = pymupdf.open(str(pdf_path))
-    pages_with_text = 0
-    sample_indices = list(range(min(sample_pages, len(doc))))
-    # Also sample some middle/end pages
-    if len(doc) > 10:
-        sample_indices.extend([len(doc) // 4, len(doc) // 2, 3 * len(doc) // 4])
 
-    for i in set(sample_indices):
-        if i < len(doc):
-            text = doc[i].get_text().strip()
-            if len(text) > 50:  # More than just page numbers
-                pages_with_text += 1
-
-    doc.close()
-    return pages_with_text >= 2  # At least 2 pages with real text
+def is_digital_pdf(pdf_path: Path, sample_pages: int = DIGITAL_SAMPLE_PAGE_COUNT) -> bool:
+    """Return whether sampled native text meets the documented coverage predicate."""
+    return assess_digital_pdf(pdf_path, sample_pages=sample_pages).accepted
 
 
 def _repair_cp1251_mojibake(text: str) -> str:
@@ -66,38 +234,72 @@ def _repair_cp1251_mojibake(text: str) -> str:
     it as Latin-1, producing garbled output (e.g., "Òîìì³" instead of
     "Томмі"). This function detects and repairs the encoding mismatch.
 
-    Characters in the Latin-1 range (128-255) that aren't valid Unicode
-    punctuation are re-decoded as CP1251. Already-valid Unicode chars
-    (smart quotes, dashes, Cyrillic) are preserved.
+    Suspicious Latin-1 runs are considered independently. A candidate is
+    accepted only when CP1251 decoding clearly increases Cyrillic content and
+    removes suspicious bytes; clean Cyrillic and ordinary accented Latin words
+    remain unchanged.
     """
-    # Characters that are valid Unicode, not mojibake — preserve as-is
-    passthrough = {
-        0x2019, 0x2018, 0x201C, 0x201D,  # smart quotes
-        0x2013, 0x2014,                    # en/em dash
-        0x2026,                            # ellipsis
-        0x00AB, 0x00BB,                    # guillemets
-        0x2022,                            # bullet
-        0x00A0,                            # non-breaking space
-    }
+    def suspicious(character: str) -> bool:
+        code = ord(character)
+        return 0x80 <= code <= 0xFF and code not in _MOJIBAKE_PASSTHROUGH
 
-    # Quick check: if text is already mostly Cyrillic, skip repair
-    cyrillic = sum(1 for c in text if "\u0400" <= c <= "\u04FF")
-    alpha = sum(1 for c in text if c.isalpha())
-    if alpha > 0 and cyrillic / alpha > 0.7:
-        return text  # Already clean
+    def cyrillic_count(value: str) -> int:
+        return sum("\u0400" <= character <= "\u04FF" for character in value)
 
-    result = []
-    for c in text:
-        code = ord(c)
-        if code <= 127 or code in passthrough:
-            result.append(c)
-        elif code <= 255:
-            try:
-                result.append(bytes([code]).decode("cp1251"))
-            except Exception:
-                result.append(c)
-        else:
-            result.append(c)
+    def candidate_for(run: str, start: int, end: int) -> str | None:
+        if len(run) < 2:
+            return None
+        try:
+            candidate = bytes(ord(character) for character in run).decode("cp1251")
+        except (UnicodeDecodeError, ValueError):
+            return None
+
+        candidate_cyrillic = cyrillic_count(candidate)
+        if candidate_cyrillic < 2:
+            return None
+        candidate_letters = sum(character.isalpha() for character in candidate)
+        candidate_ratio = candidate_cyrillic / candidate_letters if candidate_letters else 0.0
+        if candidate_ratio < 0.75:
+            return None
+
+        # A run of one or two accented Latin letters inside an ordinary word
+        # is much more likely to be a genuine word (café, naïve) than broken
+        # CP1251.  Isolated two-byte runs remain eligible when token-bounded;
+        # longer runs must still beat the same score gate.
+        left = text[start - 1] if start else ""
+        right = text[end] if end < len(text) else ""
+        if len(run) < 3 and (
+            (left.isascii() and left.isalpha())
+            or (right.isascii() and right.isalpha())
+        ):
+            return None
+
+        source_cyrillic = cyrillic_count(run)
+        source_letters = sum(character.isalpha() for character in run)
+        source_ratio = source_cyrillic / source_letters if source_letters else 0.0
+        source_suspicious = sum(suspicious(character) for character in run)
+        candidate_suspicious = sum(suspicious(character) for character in candidate)
+        if candidate_ratio <= source_ratio + 0.25:
+            return None
+        if candidate_suspicious >= source_suspicious:
+            return None
+        if any(character.isalpha() and not ("\u0400" <= character <= "\u04FF") for character in candidate):
+            return None
+        return candidate
+
+    result: list[str] = []
+    index = 0
+    while index < len(text):
+        if not suspicious(text[index]):
+            result.append(text[index])
+            index += 1
+            continue
+        end = index + 1
+        while end < len(text) and suspicious(text[end]):
+            end += 1
+        run = text[index:end]
+        result.append(candidate_for(run, index, end) or run)
+        index = end
     return "".join(result)
 
 
@@ -115,31 +317,380 @@ def _repair_dollar_hyphen(text: str) -> str:
     return _DOLLAR_HYPHEN_RE.sub(r"\1-\2", text)
 
 
-def extract_text_fast(pdf_path: Path) -> str:
-    """Extract text from digital PDF using pymupdf (fast, no OCR)."""
-    import pymupdf
+def _native_page_record(page_number: int, text: str) -> dict[str, object]:
+    """Build a page record from PDFKit-independent native text extraction."""
+    normalized = _repair_dollar_hyphen(_repair_cp1251_mojibake(text.strip()))
+    return {
+        "page_number": page_number,
+        "text": normalized,
+        "extraction_mode": "native_text",
+        "layout": {
+            "line_breaks_preserved": True,
+            "formula_structure": "lossy",
+            "latex_preserved": False,
+            "mathml_preserved": False,
+            "source_order": "PyMuPDF text blocks",
+        },
+    }
+
+
+def extract_native_pages(pdf_path: Path) -> list[dict[str, object]]:
+    """Extract every PDF page natively, retaining empty/unusable page records."""
+    try:
+        import pymupdf
+    except ModuleNotFoundError:
+        return run_apple_pdfkit_native(pdf_path)
 
     doc = pymupdf.open(str(pdf_path))
-    pages = []
-    for i in range(len(doc)):
-        text = doc[i].get_text()
-        if text.strip():
-            text = _repair_cp1251_mojibake(text.strip())
-            text = _repair_dollar_hyphen(text)
-            pages.append(f"## Сторінка {i + 1}\n\n{text}")
-    doc.close()
-    return "\n\n".join(pages)
+    try:
+        return [_native_page_record(i + 1, doc[i].get_text()) for i in range(len(doc))]
+    finally:
+        doc.close()
+
+
+def run_apple_pdfkit_native(
+    pdf_path: Path,
+    *,
+    helper_path: Path = SWIFT_OCR_SCRIPT,
+) -> list[dict[str, object]]:
+    """Extract all native page strings with bundled macOS PDFKit.
+
+    This dependency-free path is used when the optional PyMuPDF package is not
+    installed. It emits text only through captured JSON stdout and creates no
+    page images or temporary source copies.
+    """
+    helper_path = Path(helper_path)
+    if not helper_path.is_file():
+        raise ExtractionError(f"Apple PDFKit helper missing: {helper_path}")
+    command = [
+        "swift",
+        str(helper_path),
+        "--pdf",
+        str(Path(pdf_path)),
+        "--pages",
+        "all",
+        "--mode",
+        "native",
+    ]
+    try:
+        completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise ExtractionError("Swift is required for the macOS PDFKit fallback") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        raise ExtractionError(
+            f"Apple PDFKit extraction failed with exit code {exc.returncode}: "
+            f"{detail or 'no diagnostic'}"
+        ) from exc
+    try:
+        payload = json.loads(completed.stdout)
+        pages = payload["pages"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ExtractionError("Apple PDFKit helper emitted invalid JSON") from exc
+    if payload.get("schema_version") != SWIFT_OCR_SCHEMA or not isinstance(pages, list):
+        raise ExtractionError("Apple PDFKit helper schema mismatch")
+    numbers = [int(page.get("page_number", -1)) for page in pages]
+    if numbers != list(range(1, len(pages) + 1)):
+        raise ExtractionError("Apple PDFKit pages are not complete and ordered")
+    records = []
+    for page in pages:
+        record = _native_page_record(int(page["page_number"]), str(page.get("text") or ""))
+        record["layout"]["source_order"] = "PDFKit page.string"
+        record["native_runtime"] = payload.get("metadata", {}).get("runtime", {})
+        records.append(record)
+    return records
+
+
+def extract_text_fast(pdf_path: Path) -> str:
+    """Extract native text as the legacy page-marked markdown string."""
+    pages = extract_native_pages(pdf_path)
+    return "\n\n".join(
+        f"## Сторінка {page['page_number']}\n\n{page['text']}"
+        for page in pages
+        if str(page["text"]).strip()
+    )
+
+
+def _validate_ocr_page(page: dict, *, requested_pages: set[int]) -> dict[str, object]:
+    """Validate and normalize one page from the Swift JSON contract."""
+    try:
+        page_number = int(page["page_number"])
+        text = str(page.get("text") or "")
+        observation_count = int(page.get("observation_count", 0))
+        mean_confidence = float(page.get("mean_confidence", 0.0))
+        line_break_count = int(page.get("line_break_count", 0) or 0)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ExtractionError("Apple Vision OCR returned an invalid page record") from exc
+    if page_number not in requested_pages:
+        raise ExtractionError(f"Apple Vision OCR returned unexpected page {page_number}")
+    if observation_count < 0 or line_break_count < 0 or not 0.0 <= mean_confidence <= 1.0:
+        raise ExtractionError(f"Apple Vision OCR returned invalid confidence metadata for page {page_number}")
+    return {
+        "page_number": page_number,
+        "text": _repair_dollar_hyphen(_repair_cp1251_mojibake(text.strip())),
+        "extraction_mode": "apple_vision_ocr",
+        "ocr": {
+            "observation_count": observation_count,
+            "mean_confidence": round(mean_confidence, 6),
+            "runtime": page.get("runtime", {}),
+            "recognizer": page.get("recognizer", {}),
+        },
+        "layout": {
+            "line_breaks_preserved": bool(line_break_count),
+            "line_break_count": line_break_count,
+            "formula_structure": "lossy",
+            "latex_preserved": False,
+            "mathml_preserved": False,
+            "source_order": "Vision bounding-box order",
+        },
+    }
+
+
+def run_apple_vision_ocr(
+    pdf_path: Path,
+    page_numbers: list[int] | tuple[int, ...],
+    *,
+    helper_path: Path = SWIFT_OCR_SCRIPT,
+) -> list[dict[str, object]]:
+    """Run the bundled, offline, one-page-at-a-time macOS OCR helper.
+
+    The subprocess contract is one JSON object on stdout with schema
+    ``apple-vision-ocr.v1`` and no diagnostic text on stdout.  The helper
+    renders pages in memory, so this path does not write page images or source
+    text to logs and never installs/downloads an OCR model.
+    """
+    requested = tuple(sorted(set(int(page) for page in page_numbers)))
+    if not requested:
+        return []
+    if any(page <= 0 for page in requested):
+        raise ValueError("page_numbers must be one-based positive integers")
+    helper_path = Path(helper_path)
+    if not helper_path.is_file():
+        raise ExtractionError(f"Apple Vision OCR helper missing: {helper_path}")
+    command = [
+        "swift",
+        str(helper_path),
+        "--pdf",
+        str(Path(pdf_path)),
+        "--pages",
+        ",".join(str(page) for page in requested),
+        "--mode",
+        "ocr",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ExtractionError("Swift is required for the macOS Vision OCR fallback") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        raise ExtractionError(
+            f"Apple Vision OCR failed with exit code {exc.returncode}: {detail or 'no diagnostic'}"
+        ) from exc
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ExtractionError("Apple Vision OCR emitted invalid JSON on stdout") from exc
+    if not isinstance(payload, dict):
+        raise ExtractionError("Apple Vision OCR payload must be a JSON object")
+    if payload.get("schema_version") != SWIFT_OCR_SCHEMA:
+        raise ExtractionError("Apple Vision OCR schema version mismatch")
+    pages = payload.get("pages")
+    metadata = payload.get("metadata", {})
+    if not isinstance(pages, list) or not isinstance(metadata, dict):
+        raise ExtractionError("Apple Vision OCR payload must contain pages and metadata")
+    try:
+        page_numbers = [int(page.get("page_number", -1)) for page in pages]
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ExtractionError("Apple Vision OCR page numbers are invalid") from exc
+    if page_numbers != list(requested):
+        raise ExtractionError("Apple Vision OCR pages are not ordered or complete")
+    normalized_pages = []
+    for page in pages:
+        normalized = _validate_ocr_page(page, requested_pages=set(requested))
+        normalized["ocr"]["runtime"] = metadata.get("runtime", {})
+        normalized["ocr"]["recognizer"] = metadata.get("recognizer", {})
+        normalized_pages.append(normalized)
+    return normalized_pages
+
+
+def _content_page_requirement(total_pages: int) -> int:
+    """Return the explicit minimum number of recovered content pages."""
+    if total_pages <= 0:
+        return 0
+    return min(
+        total_pages,
+        max(MIN_CONTENT_PAGES, math.ceil(total_pages * MIN_CONTENT_PAGE_COVERAGE)),
+    )
+
+
+def _is_content_page_record(page: dict[str, object]) -> bool:
+    """Return whether one recovered page is substantial and usable.
+
+    Native text keeps the existing explicit character predicate. OCR text must
+    additionally pass either the repository's Ukrainian clean-text threshold
+    or a language-neutral recognizer-confidence floor. This prevents dense
+    Latin-lookalike garbage from satisfying coverage merely by being long.
+    """
+    text = str(page.get("text") or "")
+    if not _is_content_page_text(text):
+        return False
+    if page.get("extraction_mode") != "apple_vision_ocr":
+        return True
+    is_clean, _ratio = check_quality(text)
+    ocr = page.get("ocr")
+    mean_confidence = (
+        float(ocr.get("mean_confidence", 0.0))
+        if isinstance(ocr, dict)
+        else 0.0
+    )
+    return is_clean or mean_confidence >= MIN_OCR_MEAN_CONFIDENCE
+
+
+def _page_coverage_receipt(
+    page_records: list[dict[str, object]],
+    *,
+    total_pages: int,
+    digital_coverage: PageCoverage,
+    ocr_requested_pages: list[int],
+) -> dict[str, object]:
+    content_pages = [
+        int(page["page_number"])
+        for page in page_records
+        if _is_content_page_record(page)
+    ]
+    rejected_ocr_pages = [
+        int(page["page_number"])
+        for page in page_records
+        if page.get("extraction_mode") == "apple_vision_ocr"
+        and _is_content_page_text(str(page.get("text") or ""))
+        and not _is_content_page_record(page)
+    ]
+    required_pages = _content_page_requirement(total_pages)
+    coverage = len(content_pages) / total_pages if total_pages else 0.0
+    receipt = {
+        "schema_version": "textbook-page-coverage.v1",
+        "total_pages": total_pages,
+        "recovered_pages": len(page_records),
+        "content_pages": content_pages,
+        "content_page_count": len(content_pages),
+        "content_page_coverage": round(coverage, 4),
+        "minimum_content_page_coverage": MIN_CONTENT_PAGE_COVERAGE,
+        "minimum_content_pages": required_pages,
+        "native_pages": sum(page["extraction_mode"] == "native_text" for page in page_records),
+        "ocr_requested_pages": ocr_requested_pages,
+        "ocr_recovered_pages": [
+            int(page["page_number"])
+            for page in page_records
+            if page["extraction_mode"] == "apple_vision_ocr"
+        ],
+        "ocr_quality_rejected_pages": rejected_ocr_pages,
+        "minimum_ocr_mean_confidence": MIN_OCR_MEAN_CONFIDENCE,
+        "digital_detection": digital_coverage.as_dict(),
+        "status": (
+            "pass"
+            if len(content_pages) >= required_pages and coverage >= MIN_CONTENT_PAGE_COVERAGE
+            else "fail"
+        ),
+        "predicate": (
+            f"at least {MIN_CONTENT_PAGE_COVERAGE:.0%} of all PDF pages and "
+            f"at least {MIN_CONTENT_PAGES} content pages (capped by PDF length), "
+            f"where a content page has >= {MIN_CONTENT_PAGE_CHARS} characters; "
+            "OCR pages additionally require the clean-text ratio or mean "
+            f"confidence >= {MIN_OCR_MEAN_CONFIDENCE:.2f}"
+        ),
+    }
+    return receipt
+
+
+def extract_page_records(
+    pdf_path: Path,
+    *,
+    force_ocr: bool = False,
+    ocr_runner: Callable[[Path, list[int]], list[dict[str, object]]] | None = None,
+) -> tuple[list[dict[str, object]], dict[str, object]]:
+    """Extract native pages and OCR only missing/unusable pages.
+
+    Native text is retained whenever it passes the usable-page predicate.
+    Other pages are handed to the Swift helper in one call; the helper itself
+    processes and orders one PDF page at a time.  The returned receipt is
+    fail-closed by raising ``ExtractionQualityError`` when too few content
+    pages are recovered.
+    """
+    native_pages = extract_native_pages(pdf_path)
+    total_pages = len(native_pages)
+    native_texts = {
+        int(page["page_number"]): str(page.get("text") or "")
+        for page in native_pages
+    }
+    digital_coverage = _page_coverage_from_texts(
+        native_texts,
+        total_pages=total_pages,
+        sample_pages=DIGITAL_SAMPLE_PAGE_COUNT,
+    )
+    if force_ocr:
+        ocr_requested_pages = list(range(1, total_pages + 1))
+    else:
+        ocr_requested_pages = [
+            int(page["page_number"])
+            for page in native_pages
+            if not _is_usable_page_text(str(page.get("text") or ""))
+        ]
+
+    ocr_pages: dict[int, dict[str, object]] = {}
+    if ocr_requested_pages:
+        runner = ocr_runner or run_apple_vision_ocr
+        for page in runner(Path(pdf_path), ocr_requested_pages):
+            page_number = int(page["page_number"])
+            if page_number in ocr_pages:
+                raise ExtractionError(f"OCR returned duplicate page {page_number}")
+            ocr_pages[page_number] = page
+
+    selected_pages: list[dict[str, object]] = []
+    for native_page in native_pages:
+        page_number = int(native_page["page_number"])
+        native_text = str(native_page.get("text") or "")
+        ocr_page = ocr_pages.get(page_number)
+        if ocr_page is not None:
+            ocr_text = str(ocr_page.get("text") or "")
+            if force_ocr or _is_usable_page_text(ocr_text) or not _is_usable_page_text(native_text):
+                selected = ocr_page
+            else:
+                selected = native_page
+        else:
+            selected = native_page
+        if str(selected.get("text") or "").strip():
+            selected_pages.append(selected)
+
+    selected_pages.sort(key=lambda page: int(page["page_number"]))
+    receipt = _page_coverage_receipt(
+        selected_pages,
+        total_pages=total_pages,
+        digital_coverage=digital_coverage,
+        ocr_requested_pages=ocr_requested_pages,
+    )
+    if receipt["status"] != "pass":
+        raise ExtractionQualityError(
+            "Textbook extraction failed closed: recovered content-page coverage "
+            f"{receipt['content_page_coverage']:.2%} does not meet the explicit floor",
+            receipt=receipt,
+        )
+    return selected_pages, receipt
 
 
 def extract_markdown_ocr(pdf_path: Path) -> str:
-    """Convert scanned PDF to markdown using marker OCR (slow)."""
-    from marker.converters.pdf import PdfConverter
-    from marker.models import create_model_dict
-
-    models = create_model_dict()
-    converter = PdfConverter(artifact_dict=models)
-    result = converter(str(pdf_path))
-    return result.markdown
+    """Return the Swift Vision fallback output in the legacy markdown shape."""
+    native_pages = extract_native_pages(pdf_path)
+    pages = run_apple_vision_ocr(pdf_path, list(range(1, len(native_pages) + 1)))
+    return "\n\n".join(
+        f"## Сторінка {page['page_number']}\n\n{page['text']}"
+        for page in pages
+        if str(page["text"]).strip()
+    )
 
 
 def split_into_sections(markdown: str) -> list[dict]:
@@ -303,59 +854,175 @@ def check_quality(text: str) -> tuple[bool, float]:
     return ratio >= MIN_CLEAN_CHAR_RATIO, ratio
 
 
-def process_pdf(pdf_path: Path, output_dir: Path | None = None,
-                force_ocr: bool = False,
-                symbol_noise_threshold: float = DEFAULT_SYMBOL_NOISE_THRESHOLD) -> dict:
-    """Process a single PDF into chunks.
+def _ends_without_terminal_punctuation(text: str) -> bool:
+    """Return whether a chunk ends without sentence-terminal punctuation."""
+    stripped = text.rstrip()
+    while stripped and stripped[-1] in ")]}>»”'":
+        stripped = stripped[:-1].rstrip()
+    return not stripped or stripped[-1] not in _TERMINAL_PUNCTUATION
 
-    Returns summary dict with counts and quality stats.
-    """
+
+def _starts_with_lowercase_token(text: str) -> bool:
+    """Return whether the first alphabetic token starts with a lowercase letter."""
+    for character in text.lstrip():
+        if character.isalpha():
+            return character.islower()
+    return False
+
+
+def _looks_like_formula(text: str) -> bool:
+    """Detect math-layout chunks that must remain retrievable when flattened."""
+    marker_count = sum(character in _FORMULA_MARKERS for character in text)
+    digit_count = sum(character.isdigit() for character in text)
+    return marker_count >= 1 and digit_count >= 1
+
+
+def _mark_continuations(chunks: list[dict[str, object]]) -> None:
+    """Mark only deterministic page/chunk continuation pairs, never merge them."""
+    for chunk in chunks:
+        chunk["continuation"] = False
+        chunk["continuation_of_previous"] = False
+    for current, following in pairwise(chunks):
+        is_continuation = (
+            _ends_without_terminal_punctuation(str(current.get("text") or ""))
+            and _starts_with_lowercase_token(str(following.get("text") or ""))
+        )
+        if is_continuation:
+            current["continuation"] = True
+            following["continuation_of_previous"] = True
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    """Atomically replace one output file and remove temp files on every path."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _atomic_write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    """Write JSONL through the common atomic path."""
+    content = "".join(
+        json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+        for record in records
+    )
+    _atomic_write(path, content)
+
+
+def process_pdf(
+    pdf_path: Path,
+    output_dir: Path | None = None,
+    force_ocr: bool = False,
+    symbol_noise_threshold: float = DEFAULT_SYMBOL_NOISE_THRESHOLD,
+    ocr_runner: Callable[[Path, list[int]], list[dict[str, object]]] | None = None,
+) -> dict:
+    """Process one PDF into page-provenant chunks and a coverage receipt."""
     pdf_path = Path(pdf_path)
     meta = parse_pdf_metadata(pdf_path)
 
     if output_dir is None:
         output_dir = CHUNKS_DIR / f"grade-{meta['grade']:02d}"
+    output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / f"{meta['pdf_stem']}.jsonl"
+    receipt_file = output_dir / f"{meta['pdf_stem']}.receipt.json"
 
     print(f"[extract] Processing {pdf_path.name}...")
     print(f"  Metadata: grade={meta['grade']}, author={meta['author']}, "
           f"year={meta['year']}, trust_tier={meta['trust_tier']}")
 
-    # Step 1: Detect PDF type and extract text
-    if force_ocr:
-        print("  Mode: OCR (forced) — this will be slow (~4 min/page)...")
-        markdown = extract_markdown_ocr(pdf_path)
-    elif is_digital_pdf(pdf_path):
-        print("  Mode: FAST (digital PDF with selectable text)")
-        markdown = extract_text_fast(pdf_path)
-    else:
-        print("  Mode: OCR (scanned PDF) — this will be slow (~4 min/page)...")
-        markdown = extract_markdown_ocr(pdf_path)
-    print(f"  Extracted text: {len(markdown)} chars")
+    # Step 1: Native extraction plus bounded, per-page Vision fallback.
+    try:
+        page_records, coverage_receipt = extract_page_records(
+            pdf_path,
+            force_ocr=force_ocr,
+            ocr_runner=ocr_runner,
+        )
+    except ExtractionQualityError as exc:
+        # A failed quality gate leaves an auditable receipt but never a
+        # partially accepted JSONL source.
+        _atomic_write(
+            receipt_file,
+            json.dumps(
+                {
+                    "pdf": pdf_path.name,
+                    "source_file": meta["pdf_stem"],
+                    "page_coverage": exc.receipt,
+                    "status": "fail",
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+        )
+        raise
+    mode = "apple_vision_ocr" if force_ocr else (
+        "hybrid" if coverage_receipt["ocr_requested_pages"] else "native_text"
+    )
+    extracted_chars = sum(len(str(page["text"])) for page in page_records)
+    print(f"  Mode: {mode}")
+    print(f"  Extracted text: {extracted_chars} chars from {len(page_records)} pages")
+    print(f"  Page coverage: {json.dumps(coverage_receipt, ensure_ascii=False, sort_keys=True)}")
 
-    # Step 2: Split into sections
-    sections = split_into_sections(markdown)
-    print(f"  Found {len(sections)} sections")
-
-    # Step 3: Chunk each section
+    # Step 2: Chunk each recovered page independently.  This retains page
+    # identity even when a long page must be split; no arbitrary page merge is
+    # performed.  Section inference can later use the page title/body pair.
     raw_chunks = []
     quality_stats = {"clean": 0, "flagged": 0}
 
-    for section in sections:
-        chunks = chunk_text(section["text"], section["title"])
+    for page in page_records:
+        page_number = int(page["page_number"])
+        chunks = chunk_text(str(page["text"]), f"Сторінка {page_number}")
         for _i, chunk in enumerate(chunks):
             raw_chunks.append({
                 "text": chunk["text"],
                 "token_count": chunk["token_count"],
-                "section_title": section["title"],
-                "section_level": section["level"],
+                "section_title": f"Сторінка {page_number}",
+                "section_level": 0,
+                "page_start": page_number,
+                "page_end": page_number,
+                "page_extraction_mode": page["extraction_mode"],
+                "layout": page.get("layout", {}),
+                "ocr": page.get("ocr", {}),
             })
 
-    kept_chunks, noise_stats = apply_symbol_noise_gate(
-        raw_chunks,
+    for order, chunk in enumerate(raw_chunks):
+        chunk["_order"] = order
+    formula_chunks = [chunk for chunk in raw_chunks if _looks_like_formula(chunk["text"])]
+    gate_candidates = [chunk for chunk in raw_chunks if chunk not in formula_chunks]
+    kept_candidates, gate_stats = apply_symbol_noise_gate(
+        gate_candidates,
         source_file=meta["pdf_stem"],
         threshold=symbol_noise_threshold,
         warn=lambda message: print(f"  {message}"),
+    )
+    for chunk in formula_chunks:
+        layout = dict(chunk.get("layout", {}))
+        layout["formula_structure"] = "lossy"
+        layout["formula_gate_override"] = True
+        chunk["layout"] = layout
+    kept_chunks = sorted(
+        [*kept_candidates, *formula_chunks],
+        key=lambda chunk: int(chunk["_order"]),
+    )
+    noise_stats = NoiseGateStats(
+        source_file=gate_stats.source_file,
+        chunks_kept=gate_stats.chunks_kept + len(formula_chunks),
+        chunks_dropped_noise=gate_stats.chunks_dropped_noise,
     )
     print(f"  Noise gate: {json.dumps(noise_stats.manifest_record(), ensure_ascii=False)}")
 
@@ -369,6 +1036,12 @@ def process_pdf(pdf_path: Path, output_dir: Path | None = None,
             "token_count": chunk["token_count"],
             "section_title": chunk["section_title"],
             "section_level": chunk["section_level"],
+            "page_start": chunk["page_start"],
+            "page_end": chunk["page_end"],
+            "page_extraction_mode": chunk["page_extraction_mode"],
+            "extraction_mode": chunk["page_extraction_mode"],
+            "layout": chunk["layout"],
+            "ocr": chunk["ocr"],
             "quality": {
                 "is_clean": is_clean,
                 "clean_ratio": round(ratio, 3),
@@ -383,11 +1056,32 @@ def process_pdf(pdf_path: Path, output_dir: Path | None = None,
         else:
             quality_stats["flagged"] += 1
 
-    # Save chunks as JSONL
-    output_file = output_dir / f"{meta['pdf_stem']}.jsonl"
-    with open(output_file, "w", encoding="utf-8") as f:
-        for chunk in all_chunks:
-            f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
+    _mark_continuations(all_chunks)
+
+    if not all_chunks:
+        raise ExtractionError(
+            f"{pdf_path.name}: symbol-noise gate removed every recovered page chunk"
+        )
+
+    # Save chunks and the receipt through separate same-directory atomic
+    # replacements.  Temporary files are cleaned even when serialization,
+    # fsync, or rename fails; the final JSONL is never partially written.
+    _atomic_write_jsonl(output_file, all_chunks)
+    _atomic_write(
+        receipt_file,
+        json.dumps(
+            {
+                "pdf": pdf_path.name,
+                "source_file": meta["pdf_stem"],
+                "page_coverage": coverage_receipt,
+                "chunks": len(all_chunks),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
 
     summary = {
         "pdf": pdf_path.name,
@@ -399,8 +1093,10 @@ def process_pdf(pdf_path: Path, output_dir: Path | None = None,
         "symbol_noise_threshold": symbol_noise_threshold,
         "clean_chunks": quality_stats["clean"],
         "flagged_chunks": quality_stats["flagged"],
-        "sections": len(sections),
+        "pages_recovered": len(page_records),
+        "page_coverage": coverage_receipt,
         "output_file": str(output_file),
+        "receipt_file": str(receipt_file),
     }
     print(f"  Result: {summary['total_chunks']} chunks "
           f"({summary['clean_chunks']} clean, {summary['flagged_chunks']} flagged)")
@@ -429,7 +1125,12 @@ def main():
     parser.add_argument("--all", action="store_true", help="Process all PDFs")
     parser.add_argument("--grade", type=int, nargs="+", help="Process specific grades")
     parser.add_argument("--force-ocr", action="store_true",
-                        help="Force OCR mode even for digital PDFs (slow)")
+                        help="Force the offline macOS Vision helper for every page")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for the atomically-written JSONL and page-coverage receipt",
+    )
     parser.add_argument(
         "--noise-threshold",
         type=float,
@@ -445,6 +1146,7 @@ def main():
             sys.exit(1)
         summary = process_pdf(
             pdf_path,
+            output_dir=args.output_dir,
             force_ocr=args.force_ocr,
             symbol_noise_threshold=args.noise_threshold,
         )
@@ -460,6 +1162,7 @@ def main():
         for pdf in pdfs:
             summary = process_pdf(
                 pdf,
+                output_dir=args.output_dir,
                 force_ocr=args.force_ocr,
                 symbol_noise_threshold=args.noise_threshold,
             )

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -365,16 +365,20 @@ def _build_textbook_row(
             "supply the canonical Cyrillic author form. See ADR "
             "docs/decisions/2026-05-15-cyrillic-native-matcher.md."
         )
+    text = str(entry.get("text") or "")
     return (
         entry.get("chunk_id", f"tb-{source_file}-{chunk_index}"),
         entry.get("section_title", ""),
-        entry.get("text", ""),
+        text,
         source_file,
         subject,
         entry.get("grade", grade),
         author,
         author_uk,
-        entry.get("token_count", len(entry.get("text", ""))),
+        # ``char_count`` is a storage/API field, not an extraction token
+        # estimate. Token counts remain in JSONL provenance but must never
+        # replace the actual SQLite text length.
+        len(text),
     )
 
 

--- a/tests/ingest/test_incremental_textbook_ingest.py
+++ b/tests/ingest/test_incremental_textbook_ingest.py
@@ -48,7 +48,7 @@ def fixture_env(tmp_path, monkeypatch):
     jsonl = chunks / "grade-09" / f"{slug}.jsonl"
     jsonl.parent.mkdir(parents=True)
     entries = [
-        {"chunk_id": f"{slug}_s{i:04d}", "section_title": f"Сторінка {i}",
+        {"chunk_id": f"{slug}_s{i:04d}", "section_title": "§ 1. Хімія",
          "text": f"Хімія фотосинтез рівняння приклад {i}",
          "author": "popel", "author_uk": None, "grade": 9, "token_count": 10}
         for i in range(3)
@@ -66,6 +66,25 @@ def test_ingest_inserts_with_subject_and_author_uk(fixture_env):
         "SELECT subject, author_uk FROM textbooks WHERE source_file=?", (slug,)
     ).fetchall()
     assert rows == [("khimiya", "Попель")] * 3
+    char_counts = conn.execute(
+        "SELECT char_count, length(text) FROM textbooks WHERE source_file=? ORDER BY id",
+        (slug,),
+    ).fetchall()
+    assert char_counts == [(len(text), len(text)) for text in (
+        "Хімія фотосинтез рівняння приклад 0",
+        "Хімія фотосинтез рівняння приклад 1",
+        "Хімія фотосинтез рівняння приклад 2",
+    )]
+    sections = conn.execute(
+        "SELECT section_title, chunk_count FROM textbook_sections WHERE source_file=?",
+        (slug,),
+    ).fetchall()
+    assert sections == [("§ 1. Хімія", 3)]
+    linked = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NOT NULL",
+        (slug,),
+    ).fetchone()[0]
+    assert linked == 3
     fts = conn.execute(
         "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH 'фотосинтез'"
     ).fetchone()[0]
@@ -94,6 +113,169 @@ def test_dry_run_rolls_back(fixture_env):
     conn = sqlite3.connect(str(db))
     n = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
     assert n == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='textbook_sections'"
+    ).fetchone()[0] == 0
+    conn.close()
+
+
+def test_chunks_root_override_is_threaded_without_using_default(fixture_env, tmp_path):
+    db, slug = fixture_env
+    canonical = tmp_path / "canonical-drive" / "textbook_chunks"
+    jsonl = canonical / "grade-09" / f"{slug}.jsonl"
+    jsonl.parent.mkdir(parents=True)
+    jsonl.write_text(
+        json.dumps(
+            {
+                "chunk_id": "canonical_s0000",
+                "section_title": "§ 1. Канонічне джерело",
+                "text": "Канонічний текст фотосинтезу для перевірки.",
+                "author": "popel",
+                "author_uk": None,
+                "grade": 9,
+                "token_count": 1,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+    )
+    assert iti.find_jsonl(slug, chunks_root=canonical) == jsonl
+    assert iti.ingest([slug], db_path=db, dry_run=False, chunks_root=canonical) == {slug: 1}
+    conn = sqlite3.connect(str(db))
+    assert conn.execute("SELECT chunk_id FROM textbooks").fetchone()[0] == "canonical_s0000"
+    conn.close()
+
+
+def test_section_replacement_preserves_other_sources_and_fts(fixture_env):
+    db, slug = fixture_env
+    iti.ingest([slug], db_path=db, dry_run=False)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """INSERT INTO textbooks
+           (chunk_id, title, text, source_file, subject, grade, author, author_uk, char_count)
+           VALUES ('other_s0000', 'Other', 'інший корпус', 'other-source', 'other', '9', '', '', 12)"""
+    )
+    other_id = conn.execute("SELECT id FROM textbooks WHERE chunk_id='other_s0000'").fetchone()[0]
+    conn.execute(
+        """INSERT INTO textbook_sections
+           (source_file, grade, section_title, section_number, page_start, page_end, chunk_count, full_text)
+           VALUES ('other-source', 9, '§ other', 'other', 1, 1, 1, 'інший корпус')"""
+    )
+    other_section = conn.execute(
+        "SELECT section_id FROM textbook_sections WHERE source_file='other-source'"
+    ).fetchone()[0]
+    conn.execute("UPDATE textbooks SET parent_section_id=? WHERE id=?", (other_section, other_id))
+    conn.commit()
+    conn.close()
+
+    jsonl = iti.CHUNKS_DIR / "grade-09" / f"{slug}.jsonl"
+    entries = [
+        {
+            "chunk_id": f"replacement_s{i:04d}",
+            "section_title": "§ 2. Оновлена тема",
+            "text": f"Оновлений хлорофіл рядок {i}.",
+            "author": "popel",
+            "author_uk": None,
+            "grade": 9,
+            "token_count": 999,
+        }
+        for i in range(2)
+    ]
+    jsonl.write_text(
+        "\n".join(json.dumps(entry, ensure_ascii=False) for entry in entries) + "\n",
+        encoding="utf-8",
+    )
+    iti.ingest([slug], db_path=db, dry_run=False)
+
+    conn = sqlite3.connect(str(db))
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=?", (slug,)
+    ).fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT section_title FROM textbook_sections WHERE source_file=?", (slug,)
+    ).fetchall() == [("§ 2. Оновлена тема",)]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NOT NULL",
+        (slug,),
+    ).fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT section_title FROM textbook_sections WHERE source_file='other-source'"
+    ).fetchall() == [("§ other",)]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH 'оновлений'"
+    ).fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH 'хлорофіл'"
+    ).fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH 'фотосинтез'"
+    ).fetchone()[0] == 0
+    conn.close()
+
+
+def test_failure_after_replacement_rolls_back_rows_sections_and_fts(fixture_env, monkeypatch):
+    db, slug = fixture_env
+    iti.ingest([slug], db_path=db, dry_run=False)
+    jsonl = iti.CHUNKS_DIR / "grade-09" / f"{slug}.jsonl"
+    jsonl.write_text(
+        json.dumps(
+            {
+                "chunk_id": "failed_s0000",
+                "section_title": "§ 9. Не застосовано",
+                "text": "Нова лексема, яка не має залишитися.",
+                "author": "popel",
+                "author_uk": None,
+                "grade": 9,
+                "token_count": 1,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fail_fts(*_args, **_kwargs):
+        raise iti.IngestError("forced FTS failure")
+
+    monkeypatch.setattr(iti, "_fts_source_evidence", fail_fts)
+    with pytest.raises(iti.IngestError, match="forced FTS failure"):
+        iti.ingest([slug], db_path=db, dry_run=False)
+
+    conn = sqlite3.connect(str(db))
+    assert conn.execute(
+        "SELECT chunk_id FROM textbooks WHERE source_file=?", (slug,)
+    ).fetchall() == [(f"{slug}_s0000",), (f"{slug}_s0001",), (f"{slug}_s0002",)]
+    assert conn.execute(
+        "SELECT section_title FROM textbook_sections WHERE source_file=?", (slug,)
+    ).fetchall() == [("§ 1. Хімія",)]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH 'фотосинтез'"
+    ).fetchone()[0] == 3
+    conn.close()
+
+
+def test_unlinked_school_rows_fail_closed(fixture_env):
+    db, slug = fixture_env
+    jsonl = iti.CHUNKS_DIR / "grade-09" / f"{slug}.jsonl"
+    entries = [
+        {
+            "chunk_id": f"unlinked_s{i:04d}",
+            "section_title": f"Сторінка {i + 1}",
+            "text": "Текст без заголовка, який не можна невидимо прийняти.",
+            "author": "popel",
+            "author_uk": None,
+            "grade": 9,
+        }
+        for i in range(2)
+    ]
+    jsonl.write_text(
+        "\n".join(json.dumps(entry, ensure_ascii=False) for entry in entries) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(iti.IngestError, match="remain unlinked"):
+        iti.ingest([slug], db_path=db, dry_run=False)
+    conn = sqlite3.connect(str(db))
+    assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 0
     conn.close()
 
 

--- a/tests/test_download_textbooks.py
+++ b/tests/test_download_textbooks.py
@@ -8,10 +8,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from scripts.crawl.download_textbooks import (
+    DownloadValidationError,
     TitleGuardError,
+    _fallback_for_component,
     check_filename_overlap,
     download_from_gdrive,
+    download_pdf,
     extract_pdf_links,
+    extract_shkola_pdf_links,
+    find_retained_book_pdfs,
 )
 
 
@@ -84,6 +89,110 @@ def test_drive_iframe_extraction():
     assert "uc?export=download&id=1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G" in pdfs[0]["url"]
 
 
+def test_direct_pdf_and_drive_link_are_one_book_with_a_mirror():
+    html_content = """
+    <html>
+    <head><title>Українська мова 6 клас Заболотний 2023</title></head>
+    <body>
+      <a href="https://schoolbook.example/Zabolotnyi_2023.pdf">PDF</a>
+      <a href="https://drive.google.com/uc?export=download&id=DRIVE_MIRROR">Drive</a>
+    </body>
+    </html>
+    """
+
+    with patch("requests.get", return_value=MockResponse(html_content)):
+        pdfs = extract_pdf_links(
+            slug="2591-ukrmova-6-klas-zabolotnyi-2023",
+            author="Заболотний",
+            grade=6,
+            target_year=2023,
+        )
+
+    assert len(pdfs) == 1
+    assert pdfs[0]["filename"] == "Zabolotnyi_2023.pdf"
+    assert pdfs[0]["alternate_downloads"] == [
+        {
+            "url": "https://docs.google.com/uc?export=download&id=DRIVE_MIRROR",
+            "label": "Google Drive mirror",
+            "filename": "DRIVE_MIRROR.pdf",
+            "gdrive_id": "DRIVE_MIRROR",
+        }
+    ]
+
+
+def test_shkola_form_resolves_only_requested_edition_to_drive():
+    html_content = """
+    <html><head><title>Підручник Українська мова 6 клас Заболотний 2023</title></head>
+    <body>
+      <form method="POST"><button name="vslink" value="NEW" title="Завантажити Заболотний 2023">Завантажити</button></form>
+      <form method="POST"><button name="vslink" value="OLD" title="Завантажити Заболотний 2020">2020</button></form>
+    </body></html>
+    """
+
+    class RedirectResponse(MockResponse):
+        def __init__(self, location):
+            super().__init__("", status_code=303, headers={"Location": location})
+
+        def close(self):
+            pass
+
+    class FakeSession:
+        def __init__(self):
+            self.headers = {}
+            self.posts = []
+
+        def get(self, url, **_kwargs):
+            response = MockResponse(html_content)
+            response.url = url
+            return response
+
+        def post(self, url, *, data, **_kwargs):
+            self.posts.append((url, data))
+            return RedirectResponse(
+                "https://drive.google.com/uc?export=download&id=DRIVE_2023"
+            )
+
+    session = FakeSession()
+    with patch("requests.Session", return_value=session):
+        pdfs = extract_shkola_pdf_links(
+            "https://shkola.in.ua/2835-ukrainska-mova-6-klas-zabolotnyi.html",
+            author="Заболотний",
+            grade=6,
+            target_year=2023,
+        )
+
+    assert session.posts == [
+        (
+            "https://shkola.in.ua/2835-ukrainska-mova-6-klas-zabolotnyi.html",
+            {"vslink": "NEW"},
+        )
+    ]
+    assert pdfs == [
+        {
+            "url": "https://drive.google.com/uc?export=download&id=DRIVE_2023",
+            "label": "Завантажити Заболотний 2023 Завантажити",
+            "filename": "DRIVE_2023.pdf",
+            "gdrive_id": "DRIVE_2023",
+        }
+    ]
+
+
+def test_multi_part_fallback_matches_primary_component_position():
+    fallback = [
+        {"gdrive_id": "PART_1"},
+        {"gdrive_id": "PART_2"},
+    ]
+
+    assert _fallback_for_component(
+        fallback,
+        primary_count=2,
+        component_index=1,
+    ) == {"gdrive_id": "PART_2"}
+
+    with pytest.raises(DownloadValidationError, match="volume count"):
+        _fallback_for_component(fallback, primary_count=1, component_index=0)
+
+
 def test_check_filename_overlap():
     # Test our warn-only filename overlap checks
     # Case 1: Overlap exists
@@ -94,6 +203,53 @@ def test_check_filename_overlap():
 
     # Case 3: Overlap missing
     assert check_filename_overlap("random_filename_123.pdf", "ukrainska_mova", "Большакова") is False
+
+
+def test_retained_store_must_already_exist(tmp_path):
+    from scripts.crawl.download_textbooks import resolve_retained_store
+
+    with pytest.raises(ValueError, match="existing directory"):
+        resolve_retained_store(tmp_path / "missing-drive-store")
+
+
+def test_retained_match_uses_metadata_without_opening_cloud_pdf(tmp_path):
+    retained = tmp_path / "grade-06" / "6-klas-ukrmova-golub-2023.pdf"
+    retained.parent.mkdir()
+    retained.write_bytes(b"cloud-placeholder")
+    wrong_year = retained.parent / "6-klas-ukrmova-golub-2022.pdf"
+    wrong_year.write_bytes(b"other")
+    wrong_subject = retained.parent / "6-klas-ukrlit-golub-2023.pdf"
+    wrong_subject.write_bytes(b"other")
+
+    matches = find_retained_book_pdfs(
+        tmp_path,
+        {
+            "grade": 6,
+            "subject": "ukrainska_mova",
+            "author": "Голуб",
+            "year": 2023,
+        },
+    )
+
+    assert matches == [retained]
+
+
+def test_retained_match_accepts_combined_grade_volume(tmp_path):
+    retained = tmp_path / "grade-10" / "10-11-klas-mystectvo-nazarenko-2018.pdf"
+    retained.parent.mkdir()
+    retained.write_bytes(b"cloud-placeholder")
+
+    matches = find_retained_book_pdfs(
+        tmp_path,
+        {
+            "grade": 10,
+            "subject": "mystetstvo",
+            "author": "Назаренко",
+            "year": 2018,
+        },
+    )
+
+    assert matches == [retained]
 
 
 class MockGdriveResponse:
@@ -139,7 +295,7 @@ def test_gdrive_uuid_form_confirm(tmp_path):
     <html>
     <head><title>Google Drive - Warning</title></head>
     <body>
-        <form id="downloadForm" action="/uc" method="GET">
+        <form id="downloadForm" action="https://drive.usercontent.google.com/download" method="GET">
             <input type="hidden" name="confirm" value="TOKEN_ABC">
             <input type="hidden" name="uuid" value="UUID_DEF">
         </form>
@@ -152,6 +308,7 @@ def test_gdrive_uuid_form_confirm(tmp_path):
     def mock_get(url, params=None, **kwargs):
         params = params or {}
         if "confirm" in params:
+            assert url == "https://drive.usercontent.google.com/download"
             assert params["confirm"] == "TOKEN_ABC"
             assert params.get("uuid") == "UUID_DEF"
             return MockGdriveResponse(pdf_data, headers={"Content-Type": "application/pdf"})
@@ -193,3 +350,102 @@ def test_title_guard_nbsp_both_ways():
     with patch("requests.get", return_value=MockResponse(html_content_2)):
         pdfs = extract_pdf_links(slug="test-slug", author="О.\xa0Большакова", grade=9)
     assert len(pdfs) == 1
+
+
+def test_download_pdf_atomic_success(tmp_path):
+    dest = tmp_path / "grade-06" / "book.pdf"
+    pdf_data = b"%PDF-1.7\nfixture-bytes"
+    response = MockGdriveResponse(pdf_data, headers={"Content-Length": str(len(pdf_data))})
+
+    with patch("requests.get", return_value=response):
+        assert download_pdf("https://example.test/book.pdf", dest, retained_store=tmp_path) is True
+
+    assert dest.read_bytes() == pdf_data
+    assert list(dest.parent.glob("*.part")) == []
+
+
+def test_duplicate_download_reuse(tmp_path):
+    existing = tmp_path / "grade-06" / "existing.pdf"
+    existing.parent.mkdir(parents=True)
+    pdf_data = b"%PDF-1.7\nidentical"
+    existing.write_bytes(pdf_data)
+    dest = tmp_path / "grade-06" / "new-name.pdf"
+    response = MockGdriveResponse(pdf_data)
+
+    with patch("requests.get", return_value=response):
+        assert download_pdf("https://example.test/book.pdf", dest, retained_store=tmp_path) is False
+
+    assert not dest.exists()
+    assert existing.read_bytes() == pdf_data
+    assert list(dest.parent.glob("*.part")) == []
+
+
+def test_duplicate_scan_hashes_only_same_size_cloud_candidates(tmp_path):
+    from scripts.crawl import download_textbooks
+
+    same_size = tmp_path / "same.pdf"
+    different_size = tmp_path / "different.pdf"
+    candidate = b"%PDF-1.7\ncandidate"
+    same_size.write_bytes(b"%PDF-1.7\nnot-same!")
+    assert same_size.stat().st_size == len(candidate)
+    different_size.write_bytes(b"%PDF-1.7\nmuch-longer-than-the-candidate")
+    hashed: list[str] = []
+    real_hash = download_textbooks._sha256_file
+
+    def tracked_hash(path):
+        hashed.append(path.name)
+        return real_hash(path)
+
+    response = MockGdriveResponse(candidate)
+    dest = tmp_path / "new.pdf"
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(download_textbooks, "_sha256_file", side_effect=tracked_hash),
+    ):
+        assert download_pdf("https://example.test/book.pdf", dest, retained_store=tmp_path) is True
+
+    assert hashed == ["same.pdf"]
+
+
+def test_download_pdf_rejects_bad_signature_and_cleans_temp(tmp_path):
+    dest = tmp_path / "book.pdf"
+    response = MockGdriveResponse(b"not a PDF", headers={"Content-Type": "text/html"})
+
+    with patch("requests.get", return_value=response), pytest.raises(DownloadValidationError, match="not a PDF"):
+        download_pdf("https://example.test/book.pdf", dest, retained_store=tmp_path)
+
+    assert not dest.exists()
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_download_pdf_rejects_declared_size_limit_before_retain(tmp_path):
+    dest = tmp_path / "book.pdf"
+    response = MockGdriveResponse(
+        b"%PDF-1.7\nlarge",
+        headers={"Content-Length": "100"},
+    )
+
+    with patch("requests.get", return_value=response), pytest.raises(DownloadValidationError, match="declared response size"):
+        download_pdf(
+            "https://example.test/book.pdf",
+            dest,
+            retained_store=tmp_path,
+            max_size_bytes=10,
+        )
+
+    assert not dest.exists()
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_download_pdf_removes_temp_after_stream_exception(tmp_path):
+    class RaisingResponse(MockGdriveResponse):
+        def iter_content(self, chunk_size=8192):
+            yield b"%PDF-1.7\npartial"
+            raise RuntimeError("fixture stream failed")
+
+    dest = tmp_path / "book.pdf"
+    with patch("requests.get", return_value=RaisingResponse(b"unused")), pytest.raises(RuntimeError, match="fixture stream failed"):
+        download_pdf("https://example.test/book.pdf", dest, retained_store=tmp_path)
+
+    assert not dest.exists()
+    assert list(tmp_path.glob("*.part")) == []

--- a/tests/test_rag_ingestion.py
+++ b/tests/test_rag_ingestion.py
@@ -4,8 +4,12 @@ Tests pure functions only — no network calls, no Qdrant.
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -288,6 +292,307 @@ class TestCheckQuality:
     def test_ascii_only(self):
         is_clean, _ratio = self.check_quality("This is English text only.")
         assert not is_clean
+
+
+class TestTextbookExtractionReadiness:
+    def test_mojibake_repairs_mixed_run_without_whole_page_bypass(self):
+        from scripts.rag.extract_text import _repair_cp1251_mojibake
+
+        assert _repair_cp1251_mojibake("Українська: äóøà. Îñü") == "Українська: душа. Ось"
+
+    def test_mojibake_preserves_clean_and_ordinary_accented_text(self):
+        from scripts.rag.extract_text import _repair_cp1251_mojibake
+
+        clean = "Українська мова — café naïve, déjà vu."
+        assert _repair_cp1251_mojibake(clean) == clean
+        assert _repair_cp1251_mojibake("Ось чистий текст.") == "Ось чистий текст."
+
+    def test_digital_detection_requires_sample_coverage(self, monkeypatch):
+        from scripts.rag.extract_text import is_digital_pdf
+
+        class FakeDoc:
+            def __init__(self, pages):
+                self.pages = pages
+
+            def __len__(self):
+                return len(self.pages)
+
+            def __getitem__(self, index):
+                return SimpleNamespace(get_text=lambda: self.pages[index])
+
+            def close(self):
+                return None
+
+        sparse = ["front matter " * 12, "front matter " * 12] + [""] * 10
+        adequate = ["content page " * 12] * 8 + [""] * 4
+        monkeypatch.setitem(
+            sys.modules,
+            "pymupdf",
+            SimpleNamespace(open=lambda _path: FakeDoc(sparse)),
+        )
+        assert not is_digital_pdf(Path("sparse.pdf"))
+        monkeypatch.setitem(
+            sys.modules,
+            "pymupdf",
+            SimpleNamespace(open=lambda _path: FakeDoc(adequate)),
+        )
+        assert is_digital_pdf(Path("adequate.pdf"))
+
+    def test_hybrid_selection_ocr_only_targets_unusable_pages(self, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        native = [
+            {"page_number": 1, "text": "Нативний текст сторінки один. " * 5,
+             "extraction_mode": "native_text", "layout": {}},
+            {"page_number": 2, "text": "", "extraction_mode": "native_text", "layout": {}},
+            {"page_number": 3, "text": "Нативний текст сторінки три. " * 5,
+             "extraction_mode": "native_text", "layout": {}},
+            {"page_number": 4, "text": "коротко", "extraction_mode": "native_text", "layout": {}},
+        ]
+        monkeypatch.setattr(extract, "extract_native_pages", lambda _path: native)
+        calls = []
+
+        def fake_ocr(_path, pages):
+            calls.append(pages)
+            return [
+                {"page_number": page, "text": f"Оцифрований текст сторінки {page}. " * 5,
+                 "extraction_mode": "apple_vision_ocr", "layout": {},
+                 "ocr": {"observation_count": 4, "mean_confidence": 0.9}}
+                for page in pages
+            ]
+
+        pages, receipt = extract.extract_page_records(Path("fixture.pdf"), ocr_runner=fake_ocr)
+        assert calls == [[2, 4]]
+        assert [page["extraction_mode"] for page in pages] == [
+            "native_text", "apple_vision_ocr", "native_text", "apple_vision_ocr"
+        ]
+        assert receipt["status"] == "pass"
+        assert receipt["content_page_count"] == 4
+
+    def test_quality_gate_fails_closed_and_leaves_only_failure_receipt(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        native = [
+            {
+                "page_number": index,
+                "text": "Лише дві сторінки мають текст. " * 5 if index <= 2 else "",
+                "extraction_mode": "native_text",
+                "layout": {},
+            }
+            for index in range(1, 11)
+        ]
+        monkeypatch.setattr(extract, "extract_native_pages", lambda _path: native)
+        output_dir = tmp_path / "chunks"
+        with pytest.raises(extract.ExtractionQualityError) as caught:
+            extract.process_pdf(
+                Path("7-klas-test-author-2024-1.pdf"),
+                output_dir=output_dir,
+                ocr_runner=lambda _path, _pages: [],
+            )
+        assert caught.value.receipt["status"] == "fail"
+        assert not list(output_dir.glob("*.jsonl"))
+        assert list(output_dir.glob("*.receipt.json"))
+        assert list(output_dir.glob(".*.tmp")) == []
+
+    def test_quality_gate_rejects_long_low_confidence_garbled_ocr(self, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        native = [
+            {"page_number": index, "text": "", "extraction_mode": "native_text", "layout": {}}
+            for index in range(1, 11)
+        ]
+        monkeypatch.setattr(extract, "extract_native_pages", lambda _path: native)
+
+        def garbled_ocr(_path, pages):
+            return [
+                {
+                    "page_number": page,
+                    "text": "N H O I S T R Latin lookalikes " * 8,
+                    "extraction_mode": "apple_vision_ocr",
+                    "layout": {},
+                    "ocr": {"observation_count": 20, "mean_confidence": 0.4},
+                }
+                for page in pages
+            ]
+
+        with pytest.raises(extract.ExtractionQualityError) as caught:
+            extract.extract_page_records(Path("fixture.pdf"), ocr_runner=garbled_ocr)
+
+        assert caught.value.receipt["content_page_count"] == 0
+        assert caught.value.receipt["ocr_quality_rejected_pages"] == list(range(1, 11))
+
+    def test_swift_subprocess_contract_orders_pages_and_preserves_metadata(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        helper = tmp_path / "apple_vision_ocr.swift"
+        helper.write_text("// fixture helper", encoding="utf-8")
+        payload = {
+            "schema_version": "apple-vision-ocr.v1",
+            "metadata": {
+                "runtime": {"os_version": "fixture"},
+                "recognizer": {"revision": 7},
+            },
+            "pages": [
+                {"page_number": 2, "text": "Ось текст.", "observation_count": 2,
+                 "mean_confidence": 0.91, "line_break_count": 1},
+                {"page_number": 10, "text": "Ще текст.", "observation_count": 3,
+                 "mean_confidence": 0.92, "line_break_count": 0},
+            ],
+        }
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return SimpleNamespace(stdout=json.dumps(payload), stderr="")
+
+        monkeypatch.setattr(extract.subprocess, "run", fake_run)
+        pages = extract.run_apple_vision_ocr(
+            Path("fixture.pdf"), [10, 2], helper_path=helper
+        )
+        assert calls[0][0][calls[0][0].index("--pages") + 1] == "2,10"
+        assert calls[0][0][-2:] == ["--mode", "ocr"]
+        assert calls[0][1]["capture_output"] is True
+        assert [page["page_number"] for page in pages] == [2, 10]
+        assert pages[0]["ocr"]["recognizer"] == {"revision": 7}
+
+    def test_pdfkit_native_subprocess_contract_extracts_all_pages(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        helper = tmp_path / "apple_vision_ocr.swift"
+        helper.write_text("// fixture helper", encoding="utf-8")
+        payload = {
+            "schema_version": "apple-vision-ocr.v1",
+            "metadata": {"runtime": {"os_version": "fixture"}},
+            "pages": [
+                {"page_number": 1, "text": "Перша сторінка."},
+                {"page_number": 2, "text": "Друга сторінка."},
+            ],
+        }
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return SimpleNamespace(stdout=json.dumps(payload), stderr="")
+
+        monkeypatch.setattr(extract.subprocess, "run", fake_run)
+        pages = extract.run_apple_pdfkit_native(Path("fixture.pdf"), helper_path=helper)
+
+        assert calls[0][0][-4:] == ["--pages", "all", "--mode", "native"]
+        assert [page["page_number"] for page in pages] == [1, 2]
+        assert pages[0]["layout"]["source_order"] == "PDFKit page.string"
+        assert pages[0]["native_runtime"] == {"os_version": "fixture"}
+
+    def test_legacy_markdown_ocr_uses_dependency_free_page_inventory(self, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        monkeypatch.setattr(
+            extract,
+            "extract_native_pages",
+            lambda _path: [{"page_number": 1}, {"page_number": 2}],
+        )
+        calls = []
+
+        def fake_ocr(_path, pages):
+            calls.append(pages)
+            return [
+                {"page_number": page, "text": f"Текст {page}."}
+                for page in pages
+            ]
+
+        monkeypatch.setattr(extract, "run_apple_vision_ocr", fake_ocr)
+
+        assert extract.extract_markdown_ocr(Path("fixture.pdf")) == (
+            "## Сторінка 1\n\nТекст 1.\n\n## Сторінка 2\n\nТекст 2."
+        )
+        assert calls == [[1, 2]]
+
+    def test_atomic_output_cleanup_on_replace_failure(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        output = tmp_path / "output.jsonl"
+        monkeypatch.setattr(extract.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("boom")))
+        with pytest.raises(OSError, match="boom"):
+            extract._atomic_write(output, "fixture\n")
+        assert not output.exists()
+        assert list(tmp_path.glob(".*.tmp")) == []
+
+    def test_process_writes_page_provenance_continuation_and_receipt(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        page_texts = [
+            "Це сторінка без завершення " * 8,
+            "продовжується на наступній сторінці. " * 8,
+            "Завершена сторінка тексту. " * 8,
+        ]
+        page_records = [
+            {
+                "page_number": index,
+                "text": text,
+                "extraction_mode": "native_text" if index != 2 else "apple_vision_ocr",
+                "layout": {"formula_structure": "lossy", "latex_preserved": False},
+                "ocr": ({"observation_count": 12, "mean_confidence": 0.88,
+                         "runtime": {"os_version": "fixture"}}
+                         if index == 2 else {}),
+            }
+            for index, text in enumerate(page_texts, start=1)
+        ]
+        receipt = {
+            "schema_version": "textbook-page-coverage.v1",
+            "status": "pass",
+            "total_pages": 3,
+            "content_page_count": 3,
+            "content_page_coverage": 1.0,
+            "ocr_requested_pages": [2],
+        }
+        monkeypatch.setattr(
+            extract,
+            "extract_page_records",
+            lambda _path, **_kwargs: (page_records, receipt),
+        )
+        output_dir = tmp_path / "chunks"
+        summary = extract.process_pdf(
+            Path("3-klas-test-author-2024-1.pdf"), output_dir=output_dir
+        )
+        output_path = Path(summary["output_file"])
+        rows = [
+            json.loads(line)
+            for line in output_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert {row["page_start"] for row in rows} == {1, 2, 3}
+        assert rows[0]["continuation"] is True
+        assert rows[1]["continuation_of_previous"] is True
+        assert rows[1]["page_extraction_mode"] == "apple_vision_ocr"
+        assert rows[1]["layout"]["latex_preserved"] is False
+        assert rows[1]["ocr"]["observation_count"] == 12
+        assert Path(summary["receipt_file"]).exists()
+        assert list(output_dir.glob(".*.tmp")) == []
+
+    def test_formula_layout_is_retained_and_flagged_instead_of_dropped(self, tmp_path, monkeypatch):
+        import scripts.rag.extract_text as extract
+
+        formula = "Розв’язання: 2x + 3 = 7; x = 2. " * 20
+        monkeypatch.setattr(
+            extract,
+            "extract_page_records",
+            lambda _path, **_kwargs: (
+                [{
+                    "page_number": 27,
+                    "text": formula,
+                    "extraction_mode": "native_text",
+                    "layout": {"formula_structure": "lossy"},
+                }],
+                {"status": "pass", "total_pages": 27, "content_page_count": 27,
+                 "content_page_coverage": 1.0, "ocr_requested_pages": []},
+            ),
+        )
+        summary = extract.process_pdf(
+            Path("7-klas-algebra-merzliak-2024-1.pdf"),
+            output_dir=tmp_path / "chunks",
+            symbol_noise_threshold=0.0,
+        )
+        row = json.loads(Path(summary["output_file"]).read_text(encoding="utf-8"))
+        assert row["layout"]["formula_structure"] == "lossy"
+        assert row["layout"]["formula_gate_override"] is True
 
 
 # ── crawl_ulp: extract_topics, get_season_info, get_fmu_level, parse_ulp_itunes ──

--- a/tests/test_textbook_corpus_readiness.py
+++ b/tests/test_textbook_corpus_readiness.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import textbook_corpus_readiness as readiness
+
+
+def _write_jsonl(path: Path, rows: list[object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_selection(path: Path, *slugs: str) -> None:
+    path.write_text(
+        "books:\n" + "".join(f"  - id: {slug}-id\n    slug: {slug}\n" for slug in slugs),
+        encoding="utf-8",
+    )
+
+
+def _write_db(path: Path, rows: list[tuple[str, int]]) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE textbooks (id INTEGER PRIMARY KEY, source_file TEXT, text TEXT)"
+        )
+        row_id = 1
+        for source, count in rows:
+            for _ in range(count):
+                connection.execute(
+                    "INSERT INTO textbooks(id, source_file, text) VALUES (?, ?, ?)",
+                    (row_id, source, "fixture"),
+                )
+                row_id += 1
+
+
+def _source(report: dict, name: str) -> dict:
+    return next(item for item in report["sources"] if item["source"] == name)
+
+
+def test_reconciles_required_statuses_and_counts(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    (root / "ready.pdf").write_bytes(b"%PDF-ready")
+    _write_jsonl(root / "ready.jsonl", [{"text": "one"}, {"text": "two"}, {"text": "three"}])
+    (root / "pdf-only.pdf").write_bytes(b"%PDF-only")
+    _write_jsonl(root / "chunks-only.jsonl", [{"text": "orphan"}, {"text": "orphan-2"}, {"text": "orphan-3"}])
+    (root / "not-ingested.pdf").write_bytes(b"%PDF-not-ingested")
+    _write_jsonl(root / "not-ingested.jsonl", [{"text": str(index)} for index in range(3)])
+    (root / "tiny.pdf").write_bytes(b"%PDF-tiny")
+    _write_jsonl(root / "tiny.jsonl", [{"text": "front"}, {"text": "matter"}])
+
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "ready", "pdf-only", "chunks-only", "not-ingested", "tiny", "missing")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("ready", 3), ("tiny", 2), ("db-only", 4)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert _source(report, "ready")["status"] == "ready"
+    assert _source(report, "pdf-only")["status"] == "pdf_without_chunks"
+    assert _source(report, "chunks-only")["states"] == ["chunks_without_pdf", "chunks_not_ingested"]
+    assert _source(report, "not-ingested")["status"] == "chunks_not_ingested"
+    assert _source(report, "db-only")["status"] == "db_without_chunks"
+    assert _source(report, "tiny")["status"] == "suspect_extraction"
+    assert _source(report, "missing")["status"] == "missing_selected_source"
+    assert report["counts"] == {
+        "chunk_files": 4,
+        "chunk_rows": 11,
+        "db_rows": 9,
+        "pdf_files": 4,
+        "unique_chunk_payloads": 11,
+        "unique_pdf_hashes": 4,
+    }
+
+
+def test_split_volumes_are_one_selected_source_with_explicit_components(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    slug = "6-klas-matematyka-ister-2023"
+    pdf_data = b"%PDF-split-volume"
+    (root / f"{slug}-1.pdf").write_bytes(pdf_data)
+    (root / f"{slug}-2.pdf").write_bytes(pdf_data)
+    rows = [
+        {"chunk_id": "one", "text": "a"},
+        {"chunk_id": "two", "text": "b"},
+        {"chunk_id": "three", "text": "c"},
+    ]
+    _write_jsonl(root / f"{slug}-1.jsonl", rows)
+    _write_jsonl(root / f"{slug}-2.jsonl", rows)
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, slug)
+    db = tmp_path / "sources.db"
+    _write_db(db, [(f"{slug}-1", 3), (f"{slug}-2", 3)])
+    first_map = tmp_path / "source-map.yaml"
+    first_map.write_text(f"{slug}: https://one.example/book.html\n", encoding="utf-8")
+    second_map = tmp_path / "acquisition-map.yaml"
+    second_map.write_text(f"{slug}-2: https://two.example/book-part-2.pdf\n", encoding="utf-8")
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+        url_maps=[first_map, second_map],
+    )
+    source = _source(report, slug)
+
+    assert len(report["sources"]) == 1
+    assert source["status"] == "ready"
+    assert [component["component"] for component in source["components"]] == ["part-1", "part-2"]
+    assert {item["locator"] for item in source["acquisition_locators"]} == {
+        "https://one.example/book.html",
+        "https://two.example/book-part-2.pdf",
+    }
+    assert {item["map_index"] for item in source["acquisition_locators"]} == {0, 1}
+    assert len(report["duplicates"]["duplicate_pdf_hashes"]) == 1
+    assert report["duplicates"]["duplicate_pdf_hashes"][0]["count"] == 2
+    assert len(report["duplicates"]["duplicate_chunk_payload_hashes"]) == 3
+    assert source["chunks"]["row_count"] == 6
+    assert source["chunks"]["unique_payload_count"] == 3
+    assert report["counts"]["unique_pdf_hashes"] == 1
+    assert report["counts"]["unique_chunk_payloads"] == 3
+
+
+def test_sparse_273_page_fixture_and_mojibake_are_flagged_without_text_output(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    (root / "biology.pdf").write_bytes(b"%PDF-1.4\n" + b"/Type /Page " * 273)
+    _write_jsonl(
+        root / "biology.jsonl",
+        [{"text": "ОÂА пошкоджено; äóøà. Îñü"}, {"text": "front matter"}],
+    )
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "biology")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("biology", 2)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+    source = _source(report, "biology")
+    assert source["status"] == "suspect_extraction"
+    assert report["files"]["pdfs"][0]["page_count"] == 273
+    assert report["mojibake"] == {
+        "files": ["biology.jsonl"],
+        "jsonl_files": 1,
+        "rows": 1,
+    }
+    serialized = readiness.canonical_json(report)
+    assert "ОÂА" not in serialized
+    assert "äóøà" not in serialized
+    assert str(tmp_path) not in serialized
+
+
+def test_mojibake_detector_does_not_flag_single_accented_letters(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    (root / "book.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(
+        root / "book.jsonl",
+        [
+            {"text": "café, naïve, à la carte"},
+            {"text": "clean Ukrainian"},
+            {"text": "another clean row"},
+        ],
+    )
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "book")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("book", 3)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert report["mojibake"]["rows"] == 0
+
+
+def test_project_drive_layout_ignores_non_textbook_corpora(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    (root / "textbooks" / "grade-06").mkdir(parents=True)
+    (root / "textbook_chunks" / "grade-06").mkdir(parents=True)
+    (root / "literary_texts").mkdir()
+    (root / "textbooks" / "grade-06" / "book.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(
+        root / "textbook_chunks" / "grade-06" / "book.jsonl",
+        [{"text": "one"}, {"text": "two"}, {"text": "three"}],
+    )
+    (root / "literary_texts" / "not-a-textbook.pdf").write_bytes(b"%PDF-literary")
+    _write_jsonl(root / "literary_texts" / "not-a-textbook.jsonl", [{"text": "literary"}])
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "book")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("book", 3)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert report["counts"]["pdf_files"] == 1
+    assert report["counts"]["chunk_files"] == 1
+    assert report["counts"]["chunk_rows"] == 3
+
+
+def test_selection_page_slug_matches_canonical_retained_name_by_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    retained = "6-klas-ukrmova-golub-2023"
+    (root / f"{retained}.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(
+        root / f"{retained}.jsonl",
+        [{"text": "one"}, {"text": "two"}, {"text": "three"}],
+    )
+    selection = tmp_path / "selection.yaml"
+    selection.write_text(
+        """books:
+  - id: g6-mova-golub
+    grade: 6
+    subject: ukrainska_mova
+    author: Голуб
+    year: 2023
+    slug: 2595-ukrmova-6-klas-golub
+""",
+        encoding="utf-8",
+    )
+    db = tmp_path / "sources.db"
+    _write_db(db, [(retained, 3)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert len(report["sources"]) == 1
+    source = _source(report, "2595-ukrmova-6-klas-golub")
+    assert source["selected"] is True
+    assert source["status"] == "ready"
+    assert source["pdf"]["paths"] == [f"{retained}.pdf"]
+    assert source["chunks"]["paths"] == [f"{retained}.jsonl"]
+    assert source["db"]["source_files"] == [retained]
+
+
+def test_metadata_match_refuses_wrong_year_and_ambiguous_selection(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    retained = "6-klas-ukrmova-golub-2022"
+    (root / f"{retained}.pdf").write_bytes(b"%PDF-book")
+    selection = tmp_path / "selection.yaml"
+    selection.write_text(
+        """books:
+  - id: first
+    grade: 6
+    subject: ukrainska_mova
+    author: Голуб
+    year: 2023
+    slug: first-page-slug
+  - id: second
+    grade: 6
+    subject: ukrainska_mova
+    author: Голуб
+    year: 2023
+    slug: second-page-slug
+""",
+        encoding="utf-8",
+    )
+    db = tmp_path / "sources.db"
+    _write_db(db, [])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert _source(report, "first-page-slug")["status"] == "missing_selected_source"
+    assert _source(report, "second-page-slug")["status"] == "missing_selected_source"
+    assert _source(report, retained)["selected"] is False
+
+
+def test_metadata_match_handles_grade_one_bukvar_and_combined_grade_volume(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    sources = [
+        "1-klas-bukvar-bolshakova-2025-1",
+        "10-11-klas-mystectvo-nazarenko-2018",
+    ]
+    for source in sources:
+        (root / f"{source}.pdf").write_bytes(f"%PDF-{source}".encode())
+        _write_jsonl(
+            root / f"{source}.jsonl",
+            [{"text": "one"}, {"text": "two"}, {"text": "three"}],
+        )
+    selection = tmp_path / "selection.yaml"
+    selection.write_text(
+        """books:
+  - id: bukvar
+    grade: 1
+    subject: ukrainska_mova
+    author: Большакова
+    year: 2025
+    slug: page-bukvar
+  - id: art
+    grade: 10
+    subject: mystetstvo
+    author: Назаренко
+    year: 2018
+    slug: page-art
+""",
+        encoding="utf-8",
+    )
+    db = tmp_path / "sources.db"
+    _write_db(db, [(source, 3) for source in sources])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    assert _source(report, "page-bukvar")["status"] == "ready"
+    assert _source(report, "page-art")["status"] == "ready"
+
+
+def test_missing_url_map_is_tolerated_and_output_is_atomic_deterministic(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    (root / "book.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(root / "book.jsonl", [{"text": "a"}, {"text": "b"}, {"text": "c"}])
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "book")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("book", 3)])
+    existing_map = tmp_path / "existing.yaml"
+    existing_map.write_text("book: https://example.test/book\n", encoding="utf-8")
+    missing_map = tmp_path / "missing.yaml"
+    output = tmp_path / "receipts" / "readiness.json"
+    output.parent.mkdir()
+    output.write_text("old\n", encoding="utf-8")
+
+    first = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+        url_maps=[existing_map, missing_map],
+    )
+    second = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+        url_maps=[existing_map, missing_map],
+    )
+    assert first == second
+    readiness.write_atomic_json(output, first)
+    assert json.loads(output.read_text(encoding="utf-8")) == first
+    assert not list(output.parent.glob("*.tmp"))
+    assert [item["present"] for item in first["url_maps"]] == [True, False]
+    assert first["sources"][0]["acquisition_locators"] == [
+        {"map_index": 0, "locator": "https://example.test/book"}
+    ]
+    assert str(tmp_path) not in output.read_text(encoding="utf-8")
+
+
+def test_cli_writes_canonical_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    (root / "book.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(root / "book.jsonl", [{"text": "one"}, {"text": "two"}, {"text": "three"}])
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "book")
+    db = tmp_path / "sources.db"
+    _write_db(db, [("book", 3)])
+    output = tmp_path / "receipt.json"
+
+    assert readiness.main(
+        [
+            "--gdrive-root",
+            str(root),
+            "--db",
+            str(db),
+            "--selection",
+            str(selection),
+            "--output",
+            str(output),
+        ]
+    ) == 0
+    assert output.read_text(encoding="utf-8").endswith("\n")
+    assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == readiness.SCHEMA_VERSION
+
+
+def test_missing_database_fails_closed_without_writing_a_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    selection = tmp_path / "selection.yaml"
+    _write_selection(selection, "book")
+    output = tmp_path / "receipt.json"
+
+    with pytest.raises(readiness.ReadinessError, match="database_missing"):
+        readiness.build_report(
+            gdrive_root=root,
+            db_path=tmp_path / "missing.db",
+            selection_path=selection,
+        )
+
+    assert readiness.main(
+        [
+            "--gdrive-root",
+            str(root),
+            "--db",
+            str(tmp_path / "missing.db"),
+            "--selection",
+            str(selection),
+            "--output",
+            str(output),
+        ]
+    ) == 2
+    assert not output.exists()

--- a/tests/test_textbook_curriculum_coverage.py
+++ b/tests/test_textbook_curriculum_coverage.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import textbook_curriculum_coverage as coverage
+
+ROOT = Path(__file__).resolve().parents[1]
+DENOMINATOR = ROOT / "data" / "textbook_curriculum_denominator.yaml"
+
+
+def _cell(
+    cell_id: str,
+    *,
+    grade: int = 1,
+    requirement_class: str = "required_common",
+    applicability: str = "required",
+    source_ids: list[str] | None = None,
+    evidence_state: str = "resolved",
+    coverage_unit_id: str | None = None,
+    choice_group_id: str | None = None,
+    choice_member_id: str | None = None,
+    choice_member_requires: list[str] | None = None,
+    legacy_ids: list[str] | None = None,
+) -> dict:
+    result = {
+        "cell_id": cell_id,
+        "grade": grade,
+        "canonical_subject_id": "fixture_subject",
+        "display_name_uk": "Тестова клітинка",
+        "cohort_or_effective_basis": "fixture current basis",
+        "requirement_class": requirement_class,
+        "official_program_locator_ids": ["PROGRAM"],
+        "official_edition_catalog_locator_ids": ["EDITION"],
+        "textbook_applicability": applicability,
+        "coverage": {
+            "coverage_unit_id": coverage_unit_id or cell_id,
+            "source_ids": source_ids or [],
+            "source_groups": [],
+            "source_match_mode": "any",
+            "evidence_state": evidence_state,
+            "legacy_inventory_source_ids": legacy_ids or [],
+            "edition_policy": "fixture_current",
+        },
+        "evidence_note": "Fixture evidence note.",
+    }
+    if choice_group_id is not None:
+        result["choice_group_id"] = choice_group_id
+        result["choice_member_id"] = choice_member_id
+        result["choice_member_requires"] = choice_member_requires or [cell_id]
+    return result
+
+
+def _denominator(*cells: dict) -> dict:
+    return {
+        "schema_version": "textbook_curriculum_denominator_v1",
+        "requirement_classes": list(coverage.REQUIREMENT_CLASSES),
+        "locator_registry": {
+            "PROGRAM": "https://example.test/program",
+            "EDITION": "https://example.test/edition",
+        },
+        "cells": list(cells),
+    }
+
+
+def _readiness(*sources: tuple[str, str], selected_count: int = 0) -> dict:
+    return {
+        "schema_version": "textbook_corpus_readiness_v1",
+        "selection": {"selected_count": selected_count},
+        "sources": [
+            {"source": source, "status": status, "selection_ids": []}
+            for source, status in sources
+        ],
+        "counts": {},
+    }
+
+
+def test_range_expansion_is_materialized_and_selection_is_separate(tmp_path: Path) -> None:
+    denominator = coverage.load_denominator(DENOMINATOR)
+    readiness_path = tmp_path / "readiness.json"
+    readiness_path.write_text(
+        json.dumps(_readiness(selected_count=116), sort_keys=True),
+        encoding="utf-8",
+    )
+    report = coverage.build_report(
+        denominator_path=DENOMINATOR,
+        readiness_path=readiness_path,
+    )
+
+    assert len(denominator["cells"]) == 176
+    assert {cell["grade"] for cell in denominator["cells"]} == set(range(1, 12))
+    assert all(isinstance(cell["grade"], int) for cell in denominator["cells"])
+    assert report["counts"]["by_requirement_class"] == {
+        "required_common": 68,
+        "required_one_of": 59,
+        "profile_or_track": 26,
+        "optional_elective": 12,
+        "no_textbook_required_or_unresolved": 11,
+    }
+    assert report["selection"]["selected_count"] == 116
+    assert report["selection"]["is_official_curriculum_denominator"] is False
+    assert report["input_hashes"] == {
+        "denominator_sha256": hashlib.sha256(DENOMINATOR.read_bytes()).hexdigest(),
+        "readiness_sha256": hashlib.sha256(readiness_path.read_bytes()).hexdigest(),
+    }
+
+
+def test_one_of_choice_is_satisfied_by_one_approved_alternative() -> None:
+    first = _cell(
+        "g01.choice_a",
+        source_ids=["source-a"],
+        choice_group_id="g01.fixture_choice",
+        choice_member_id="a",
+    )
+    second = _cell(
+        "g01.choice_b",
+        source_ids=["source-b"],
+        choice_group_id="g01.fixture_choice",
+        choice_member_id="b",
+    )
+    report = coverage.evaluate(
+        _denominator(first, second),
+        _readiness(("source-a", "ready"), selected_count=2),
+    )
+
+    statuses = {item["cell_id"]: item["status"] for item in report["cells"]}
+    assert statuses == {
+        "g01.choice_a": "covered",
+        "g01.choice_b": "choice_satisfied",
+    }
+    assert report["choice_groups"][0]["status"] == "choice_satisfied"
+    assert report["choice_groups"][0]["selected_member_id"] == "a"
+
+
+def test_combined_ten_eleven_art_volume_covers_both_grade_cells() -> None:
+    report = coverage.evaluate(
+        coverage.load_denominator(DENOMINATOR),
+        _readiness(("3090-mystectvo-10-11-klas-nazarenko", "ready")),
+    )
+    cells = {
+        item["cell_id"]: item
+        for item in report["cells"]
+        if item["cell_id"] in {"g10.mystetstvo", "g11.mystetstvo"}
+    }
+    assert {item["coverage_unit_id"] for item in cells.values()} == {"g10-11.mystetstvo_combined"}
+    assert {item["status"] for item in cells.values()} == {"covered"}
+    assert all(
+        match["source"] == "3090-mystectvo-10-11-klas-nazarenko"
+        for item in cells.values()
+        for match in item["readiness_matches"]
+    )
+
+
+def test_combined_grade_two_language_reading_volume_covers_both_cells() -> None:
+    report = coverage.evaluate(
+        coverage.load_denominator(DENOMINATOR),
+        _readiness(("3037-ukrmova-bolshakova-2-klas", "ready")),
+    )
+    cells = {
+        item["cell_id"]: item
+        for item in report["cells"]
+        if item["cell_id"] in {"g02.ukrmova", "g02.chytannia"}
+    }
+    assert {item["coverage_unit_id"] for item in cells.values()} == {
+        "g02.ukrmova_chytannia_combined"
+    }
+    assert {item["status"] for item in cells.values()} == {"covered"}
+
+
+def test_no_textbook_applicability_is_not_an_automatic_pdf_gap() -> None:
+    report = coverage.evaluate(coverage.load_denominator(DENOMINATOR), _readiness())
+    physical_education = next(item for item in report["cells"] if item["cell_id"] == "g01.fizychna_kultura")
+    assert physical_education["status"] == "unresolved"
+    assert physical_education["status"] not in {"acquisition_missing", "extraction_missing"}
+
+    not_required = _cell(
+        "g01.no_book",
+        requirement_class="no_textbook_required_or_unresolved",
+        applicability="not_required",
+    )
+    fixture_report = coverage.evaluate(_denominator(not_required), _readiness())
+    assert fixture_report["cells"][0]["status"] == "not_required"
+
+
+def test_suspect_extraction_is_degraded() -> None:
+    cell = _cell("g07.suspect", source_ids=["suspect-source"])
+    report = coverage.evaluate(
+        _denominator(cell),
+        _readiness(("suspect-source", "suspect_extraction")),
+    )
+    assert report["cells"][0]["status"] == "degraded"
+
+
+def test_current_cell_does_not_accept_legacy_inventory_source() -> None:
+    cell = _cell(
+        "g09.current_language",
+        grade=9,
+        source_ids=["current-2026"],
+        evidence_state="legacy_only",
+        legacy_ids=["legacy-2020"],
+    )
+    report = coverage.evaluate(
+        _denominator(cell),
+        _readiness(("legacy-2020", "ready"), selected_count=1),
+    )
+    result = report["cells"][0]
+    assert result["status"] == "acquisition_missing"
+    assert result["readiness_matches"] == []
+    assert result["legacy_inventory_source_ids"] == ["legacy-2020"]
+
+
+def test_pdf_without_chunks_is_extraction_missing() -> None:
+    cell = _cell("g06.pdf_only", source_ids=["pdf-only"])
+    report = coverage.evaluate(
+        _denominator(cell),
+        _readiness(("pdf-only", "pdf_without_chunks")),
+    )
+    assert report["cells"][0]["status"] == "extraction_missing"
+
+
+def test_all_source_groups_require_every_curricular_component() -> None:
+    cell = _cell("g10.history", source_ids=["history-ua"])
+    cell["coverage"].update(
+        source_ids=[],
+        source_groups=[["history-ua"], ["history-world"]],
+        source_match_mode="all",
+    )
+    report = coverage.evaluate(
+        _denominator(cell),
+        _readiness(("history-ua", "ready")),
+    )
+    assert report["cells"][0]["status"] == "acquisition_missing"
+
+
+def test_report_is_deterministic() -> None:
+    denominator = coverage.load_denominator(DENOMINATOR)
+    readiness = _readiness(("3090-mystectvo-10-11-klas-nazarenko", "ready"))
+    first = coverage.evaluate(denominator, readiness)
+    second = coverage.evaluate(denominator, readiness)
+    assert coverage.canonical_json(first) == coverage.canonical_json(second)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda document: document["cells"][0].update(grade="1-4"), "explicit integer"),
+        (lambda document: document["cells"][0].update(requirement_class="made_up"), "unknown requirement_class"),
+        (
+            lambda document: document["cells"].append(copy.deepcopy(document["cells"][0])),
+            "duplicate cell_id",
+        ),
+    ],
+)
+def test_schema_failures_are_rejected(mutation, message: str) -> None:
+    document = _denominator(_cell("g01.fixture"))
+    mutation(document)
+    with pytest.raises(coverage.CoverageError, match=message):
+        coverage.evaluate(document, _readiness())


### PR DESCRIPTION
## What changed

- adds a deterministic corpus reconciliation receipt across retained Drive PDFs, chunk JSONL, SQLite rows, selected sources, duplicates, and mojibake signals;
- adds a 176-cell, Grades 1–11 official curriculum denominator and a hash-bound coverage evaluator that keeps the 116-book selection separate;
- makes Pidruchnyk direct links, same-page Drive links, and Shkola pages alternate transports for one retained book, including multi-part volumes;
- adds atomic, page-provenant hybrid extraction with dependency-free PDFKit native text and fail-closed OCR quality gates;
- adds transactional per-source ingest/section rebuild behavior and focused regression tests.

## Why

Phase 3 was incorrectly using a selected-book count as a proxy for official grade/subject coverage. It also lacked safe mirror handling and could accept partial or garbled scan extraction. This change makes the real denominator, source state, extraction gaps, and retained-copy policy machine-readable before any labeling begins.

Live v4 evidence: 171 PDFs / 169 unique hashes, 158 chunk files / 48,996 rows, and 54,979 SQLite rows. Official coverage is 75 covered, 6 choice-satisfied, 4 degraded, 5 extraction-missing, 23 acquisition-missing, 4 not-required, and 59 unresolved title/applicability cells. Denominator SHA-256: `c32b55b5284cf29a2e288d87c8d664889c017cf44937f4e7df26787343bf09ee`.

## Phase 3 status (all four required statuses)

- `ENGINE_READY`: **not met** for the complete Phase 3 engine; this PR supplies the corpus foundation only.
- `SOURCE_COVERAGE_READY`: **not met**; scan extraction, acquisition gaps, unresolved official title enumeration, Правопис conversion, and remaining source dispositions continue under #6375.
- `LINGUISTICALLY_VALIDATED`: **not met**; joint Grok + Gemini 3.6 Flash labeling/review has not started because the corpus is not frozen.
- `CONSUMER_PROVEN`: **not met**; no final outsider reproduction has run.

This PR does not close #6375 and does not start Phase 4, training, paid compute, upload, outreach, or Hugging Face mutation. Per the operator's current instruction, no formal review is requested.

## Validation

- 118 focused tests passed across acquisition, reconciliation, official coverage, extraction, and ingest;
- Ruff passed for every changed Python file;
- Swift type-check passed (with the macOS 14 deprecation warning for the still-effective CPU-only Vision flag);
- staged and committed OPSEC checks passed with zero leaks;
- agent trailer lint passed;
- `git diff --check` passed;
- live source-mirror comparisons used one capped temporary PDF at a time and removed every comparison/debug/rejected-OCR artifact.

Disk at push: 29 GB free. One Phase 3 worktree, approximately 385 MB; no extra worker worktree and no Phase 3 `/tmp` residue.
