### PR TITLE
fix(corpus): preserve textbook OCR orientation

### DIFF
--- a/scripts/rag/apple_vision_ocr.swift
+++ b/scripts/rag/apple_vision_ocr.swift
@@ -139,8 +139,10 @@ private func renderPage(_ page: PDFPage, pageNumber: Int) throws -> CGImage {
     context.setFillColor(CGColor(gray: 1.0, alpha: 1.0))
     context.fill(CGRect(x: 0, y: 0, width: width, height: height))
     context.saveGState()
-    context.translateBy(x: 0, y: CGFloat(height))
-    context.scaleBy(x: scale, y: -scale)
+    // PDFPage.draw renders into Core Graphics' native bottom-left coordinate
+    // space. Flipping the context here produces an upside-down CGImage for
+    // Vision even though ordinary PDF renderers display the source upright.
+    context.scaleBy(x: scale, y: scale)
     page.draw(with: .mediaBox, to: context)
     context.restoreGState()
 

--- a/tests/test_rag_ingestion.py
+++ b/tests/test_rag_ingestion.py
@@ -5,6 +5,8 @@ Tests pure functions only — no network calls, no Qdrant.
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -295,6 +297,45 @@ class TestCheckQuality:
 
 
 class TestTextbookExtractionReadiness:
+    @pytest.mark.skipif(
+        sys.platform != "darwin" or shutil.which("cupsfilter") is None,
+        reason="Apple Vision OCR regression requires macOS and cupsfilter",
+    )
+    def test_apple_vision_ocr_keeps_upright_pdf_orientation(self, tmp_path):
+        source = tmp_path / "upright-ukrainian.txt"
+        source.write_text(
+            "Українська мова. Це якісний шкільний підручник.\n" * 12,
+            encoding="utf-8",
+        )
+        pdf = tmp_path / "upright-ukrainian.pdf"
+        rendered = subprocess.run(
+            ["cupsfilter", "-m", "application/pdf", str(source)],
+            check=True,
+            capture_output=True,
+        )
+        pdf.write_bytes(rendered.stdout)
+
+        helper = ROOT / "scripts" / "rag" / "apple_vision_ocr.swift"
+        completed = subprocess.run(
+            [
+                "swift",
+                str(helper),
+                "--pdf",
+                str(pdf),
+                "--pages",
+                "1",
+                "--mode",
+                "ocr",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        text = json.loads(completed.stdout)["pages"][0]["text"]
+
+        assert "Українська мова" in text
+        assert "шкільний підручник" in text
+
     def test_mojibake_repairs_mixed_run_without_whole_page_bypass(self):
         from scripts.rag.extract_text import _repair_cp1251_mojibake
 


### PR DESCRIPTION
## Outcome

Fixes the macOS PDFKit-to-Vision raster transform that inverted scanned textbook pages and produced high-confidence gibberish.

- removes the extra vertical flip before Vision OCR
- adds a macOS behavior regression using a freshly generated upright Ukrainian PDF
- recovers the six retained Phase 3 extraction gaps without duplicate downloads

## Evidence

- `tests/test_rag_ingestion.py`: 67 passed
- focused orientation regression: passed
- Ruff: passed
- Swift type-check: passed (existing macOS deprecation warning only)
- `git diff --check`: passed
- agent trailer: passed
- live retained sources after fix: 1,822 valid JSONL chunks across six files; page coverage 98.99%-100%

Part of #6375. This PR fixes the extractor only; corpus DB ingestion and remaining acquisition stay tracked in the Phase 3 issue.