### PR TITLE
feat(corpus): cover primary arts and informatics gaps

### DIFF
--- a/data/pidruchnyk_urls.yaml
+++ b/data/pidruchnyk_urls.yaml
@@ -1,5 +1,6 @@
 1-klas-bukvar-zaharijchuk-2025-1: https://pidruchnyk.com.ua/3028-bukvar-1-klas-zakhariichuk.html
 1-klas-bukvar-zaharijchuk-2025-2: https://pidruchnyk.com.ua/3028-bukvar-1-klas-zakhariichuk.html
+1-klas-mystetstvo-rublia-2024: https://pidruchnyk.com.ua/2719-mystetstvo-1-klas-rublia.html
 10-klas-istorija-ukrajiny-gisem-2018: https://pidruchnyk.com.ua/3096-istoriia-ukrainy-10-klas-gisem.html
 10-klas-ukrajinska-literatura-avramenko-2018: https://pidruchnyk.com.ua/392-ukrayinska-lteratura-avramenko-paharenko-10-klas.html
 10-klas-ukrajinska-mova-avramenko-2018: https://pidruchnyk.com.ua/1229-ukrmova-10-klas-avramenko.html
@@ -22,6 +23,9 @@
 2-klas-ukrmova-kravcova-2019-2: https://pidruchnyk.com.ua/1297-ukrmova-ta-chitannya-kravcova-2-klas.html
 2-klas-ukrmova-vashulenko-2019-1: https://pidruchnyk.com.ua/57-ukrayinska-mova-vashulenko-dubovyk-2-klas.html
 2-klas-ukrmova-vashulenko-2019-2: https://pidruchnyk.com.ua/57-ukrayinska-mova-vashulenko-dubovyk-2-klas.html
+2-klas-mystetstvo-rublia-2024: https://pidruchnyk.com.ua/3051-mystectvo-2-klas-rublia.html
+3-klas-informatyka-morze-2025: https://pidruchnyk.com.ua/1506-ya-doslidzhuyu-svit-3-klas-morze.html
+3-klas-mystetstvo-arystova-2025: https://pidruchnyk.com.ua/3042-mystectvo-3-klas-arystova.html
 3-klas-ukrainska-mova-kravtsova-2020-1: https://pidruchnyk.com.ua/1501-ukrmova-ta-chytannja-3-klas-kravcova.html
 3-klas-ukrainska-mova-ponomarova-2020-1: https://pidruchnyk.com.ua/1503-ukrmova-ta-chytannja-3-klas-nush-ponomarova.html
 3-klas-ukrainska-mova-savchenko-2020-2: https://pidruchnyk.com.ua/1504-ukrmova-ta-chytannja-sachenko-3-klas-nush.html
@@ -30,8 +34,11 @@
 4-klas-ukrayinska-mova-ponomarova-2021-1: https://pidruchnyk.com.ua/1576-ukrmova-4-klas-ponomarova.html
 4-klas-ukrayinska-mova-savchenko-2021-2: https://pidruchnyk.com.ua/1575-ukrmova-4-klas-savchenko.html
 4-klas-ukrmova-zaharijchuk: https://pidruchnyk.com.ua/652-ukrayinska-mova-zaharychuk-4-klas.html
+4-klas-informatyka-vorontsova-2021: https://pidruchnyk.com.ua/1592-nformatika-4-klas-voroncova.html
+4-klas-mystetstvo-rublia-2021: https://pidruchnyk.com.ua/1610-mystectvo-4-klas-rublya.html
 5-klas-informatyka-ryvkind-2022: https://pidruchnyk.com.ua/1660-informatyka-5-klas-ryvkind-2022.html
 5-klas-matematyka-ister-2022: https://pidruchnyk.com.ua/1632-matematyka-5-klas-ister-2022.html
+5-klas-mystetstvo-rublia-2022: https://pidruchnyk.com.ua/1709-mystectvo-rublia-5-klas.html
 5-klas-ukrlit-avramenko-2022: https://pidruchnyk.com.ua/1685-5_ukrlit_avramenko.html
 5-klas-ukrlit-zabolotnyi-2022: https://pidruchnyk.com.ua/1684-5_ukrlit_zabolotnyi.html
 5-klas-ukrmova-avramenko-2022: https://pidruchnyk.com.ua/1643-ukrainska-mova-avramenko-5-klas-2022.html
@@ -41,6 +48,7 @@
 6-klas-istoriia-shchupak-2023: https://pidruchnyk.com.ua/2610-istoriia-6-klas-shchupak-2023.html
 6-klas-istoriya-gisem-2023: https://pidruchnyk.com.ua/2606-istoriia-6-klas-gisem-2023.html
 6-klas-matematyka-ister-2023: https://pidruchnyk.com.ua/2590-matematyka-6-klas-ister-2023.html
+6-klas-zarubizhna-literatura-voloshchuk-2023: https://pidruchnyk.com.ua/2623-zaralit-6-klas-voloshchuk-2023.html
 6-klas-ukrlit-avramenko-2023: https://pidruchnyk.com.ua/2618-ukralit-6-klas-avramenko-2023.html
 6-klas-ukrlit-kovalenko-2023: https://pidruchnyk.com.ua/2614-ukralit-6-klas-kovalenko-2023.html
 6-klas-ukrlit-zabolotnyi-2023: https://pidruchnyk.com.ua/2617-ukralit-6-klas-zabolotnyi.html

--- a/data/textbook_curriculum_denominator.yaml
+++ b/data/textbook_curriculum_denominator.yaml
@@ -23,7 +23,7 @@ operation:
 selection_reference:
   path: docs/l2-uk-direct/textbook-selection.yaml
   selected_book_count_is_inventory_only: true
-  selection_note: The 116-book selection is a local inventory selection, not the official curriculum denominator.
+  selection_note: The 127-book selection is a local inventory selection, not the official curriculum denominator.
 requirement_classes:
 - required_common
 - required_one_of
@@ -554,13 +554,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g03.informatyka
-    source_ids: []
+    source_ids:
+    - 1506-ya-doslidzhuyu-svit-3-klas-morze
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: TOP table has Informatics in both grades; no current DB source.
+  evidence_note: Current 2025 Part 2 integrates the informatics educational field; selected as the accepted Grade 3 source.
 - cell_id: g04.informatyka
   grade: 4
   canonical_subject_id: informatyka
@@ -574,13 +575,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g04.informatyka
-    source_ids: []
+    source_ids:
+    - 1592-nformatika-4-klas-voroncova
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: TOP table has Informatics in both grades; no current DB source.
+  evidence_note: Current Grade 4 TOP cohort source selected from the 2021 approved edition catalog.
 - cell_id: g01.mystetstvo
   grade: 1
   canonical_subject_id: mystetstvo
@@ -595,13 +597,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g01.mystetstvo
-    source_ids: []
+    source_ids:
+    - 2719-mystetstvo-1-klas-rublia
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: Official cell; title-level acquisition reconciliation pending.
+  evidence_note: Current 2024 integrated arts source selected from the approved primary cohort.
 - cell_id: g02.mystetstvo
   grade: 2
   canonical_subject_id: mystetstvo
@@ -616,13 +619,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g02.mystetstvo
-    source_ids: []
+    source_ids:
+    - 3051-mystectvo-2-klas-rublia
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: Official cell; title-level acquisition reconciliation pending.
+  evidence_note: Current 2024 integrated arts source selected from the approved primary cohort.
 - cell_id: g03.mystetstvo
   grade: 3
   canonical_subject_id: mystetstvo
@@ -637,13 +641,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g03.mystetstvo
-    source_ids: []
+    source_ids:
+    - 3042-mystectvo-3-klas-arystova
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: Official cell; title-level acquisition reconciliation pending.
+  evidence_note: Current 2025 integrated arts source selected from the approved primary cohort.
 - cell_id: g04.mystetstvo
   grade: 4
   canonical_subject_id: mystetstvo
@@ -658,13 +663,14 @@ cells:
   textbook_applicability: required
   coverage:
     coverage_unit_id: g04.mystetstvo
-    source_ids: []
+    source_ids:
+    - 1610-mystectvo-4-klas-rublya
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: approved_primary_basis
-  evidence_note: Official cell; title-level acquisition reconciliation pending.
+  evidence_note: Current Grade 4 TOP cohort source selected from the 2021 approved edition catalog.
 - cell_id: g01.fizychna_kultura
   grade: 1
   canonical_subject_id: fizychna_kultura
@@ -1033,13 +1039,14 @@ cells:
   textbook_applicability: choice_required
   coverage:
     coverage_unit_id: g06.zarlit
-    source_ids: []
+    source_ids:
+    - 2623-zaralit-6-klas-voloshchuk-2023
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: current_nus_cohort
-  evidence_note: Separate identity present in DB for every grade 5-9.
+  evidence_note: Current 2023 NUS separate literature source selected for Grade 6.
   choice_group_id: g06.literature_realization
   choice_member_id: separate
   choice_member_requires: *id002
@@ -2785,7 +2792,7 @@ cells:
   coverage:
     coverage_unit_id: g05.mystetstvo_one_of
     source_ids:
-    - 1709-mystectstvo-rublia-5-klas
+    - 1709-mystectvo-rublia-5-klas
     source_groups: []
     source_match_mode: any
     evidence_state: resolved

--- a/docs/l2-uk-direct/textbook-selection.yaml
+++ b/docs/l2-uk-direct/textbook-selection.yaml
@@ -1,6 +1,6 @@
 # Textbook Selection for RAG Database
 # Selected: 2026-08-08
-# Total: 120 books from pidruchnyk.com.ua and shkola.in.ua, retained once in Google Drive
+# Total: 127 books from pidruchnyk.com.ua and shkola.in.ua, retained once in Google Drive
 # Strategy: 2 мова per grade, 1 literature (5-11), 1-2 history (5-11)
 #
 # PDF URL pattern: https://pidruchnyk.com.ua/uploads/book/{filename}.pdf
@@ -30,6 +30,18 @@ books:
     slug: 3028-bukvar-1-klas-zakhariichuk
     note: "Second opinion, different letter sequence"
 
+  - id: g1-mystetstvo-rublia
+    grade: 1
+    subject: mystetstvo
+    author: Рубля
+    year: 2024
+    slug: 2719-mystetstvo-1-klas-rublia
+    canonical_source: 1-klas-mystetstvo-rublia-2024
+    source_url: https://pidruchnyk.com.ua/2719-mystetstvo-1-klas-rublia.html
+    fallback_page_urls:
+      - "https://shkola.in.ua/1213-mystetstvo-1-klas-rublia-2018.html"
+    note: "Current 2024 integrated arts edition; one canonical Drive copy"
+
   # ── GRADE 2 ──────────────────────────────────────────
   - id: g2-mova-bolshakova
     grade: 2
@@ -47,6 +59,16 @@ books:
     slug: 57-ukrayinska-mova-vashulenko-dubovyk-2-klas
     note: "Classic widely-adopted author"
 
+  - id: g2-mystetstvo-rublia
+    grade: 2
+    subject: mystetstvo
+    author: Рубля
+    year: 2024
+    slug: 3051-mystectvo-2-klas-rublia
+    canonical_source: 2-klas-mystetstvo-rublia-2024
+    source_url: https://pidruchnyk.com.ua/3051-mystectvo-2-klas-rublia.html
+    note: "Current 2024 integrated arts edition; one canonical Drive copy"
+
   # ── GRADE 3 ──────────────────────────────────────────
   - id: g3-mova-vashulenko
     grade: 3
@@ -63,6 +85,32 @@ books:
     year: 2020
     slug: 1504-ukrmova-ta-chytannja-sachenko-3-klas-nush
     note: "Leading reading pedagogy expert"
+
+  - id: g3-informatyka-morze
+    grade: 3
+    subject: informatyka
+    author: Морзе
+    year: 2025
+    slug: 1506-ya-doslidzhuyu-svit-3-klas-morze
+    canonical_source: 3-klas-informatyka-morze-2025
+    source_url: https://pidruchnyk.com.ua/1506-ya-doslidzhuyu-svit-3-klas-morze.html
+    fallback_page_urls:
+      - "https://shkola.in.ua/1391-ya-doslidzhuyu-svit-3-klas-morze-2020-ch-2.html"
+    gdrive_id: 1GkgwJfBO19e2yPWxqJ9KS_uz7-8nm5tm
+    note: "Current 2025 Part 2 integrates informatics; not an obsolete standalone title"
+
+  - id: g3-mystetstvo-arystova
+    grade: 3
+    subject: mystetstvo
+    author: Аристова
+    year: 2025
+    slug: 3042-mystectvo-3-klas-arystova
+    canonical_source: 3-klas-mystetstvo-arystova-2025
+    source_url: https://pidruchnyk.com.ua/3042-mystectvo-3-klas-arystova.html
+    fallback_page_urls:
+      - "https://shkola.in.ua/588-muzychne-mystetstvo-3-klas-arystova.html"
+    gdrive_id: 1Ui8DEcKsPLls8oIJdCeutoxoDPe05tGm
+    note: "Current 2025 integrated arts edition; one canonical Drive copy"
 
   # NUS Grade 3 has no separate reading book — reading is integrated into мова та читання
 
@@ -82,6 +130,26 @@ books:
     year: 2021
     slug: 652-ukrayinska-mova-zaharychuk-4-klas
     note: "NUS 2021 edition"
+
+  - id: g4-informatyka-vorontsova
+    grade: 4
+    subject: informatyka
+    author: Воронцова
+    year: 2021
+    slug: 1592-nformatika-4-klas-voroncova
+    canonical_source: 4-klas-informatyka-vorontsova-2021
+    source_url: https://pidruchnyk.com.ua/1592-nformatika-4-klas-voroncova.html
+    note: "Current Grade 4 TOP cohort edition; one canonical Drive copy"
+
+  - id: g4-mystetstvo-rublia
+    grade: 4
+    subject: mystetstvo
+    author: Рубля
+    year: 2021
+    slug: 1610-mystectvo-4-klas-rublya
+    canonical_source: 4-klas-mystetstvo-rublia-2021
+    source_url: https://pidruchnyk.com.ua/1610-mystectvo-4-klas-rublya.html
+    note: "Current Grade 4 TOP cohort edition; one canonical Drive copy"
 
   # NUS Grade 4 has no separate reading book — reading is integrated into мова та читання
 
@@ -171,6 +239,19 @@ books:
     year: 2023
     slug: 2606-istoriia-6-klas-gisem-2023
     note: "Fallback with PDF available"
+
+  - id: g6-zarlit-voloshchuk
+    grade: 6
+    subject: zarlit
+    author: Волощук
+    year: 2023
+    slug: 2623-zaralit-6-klas-voloshchuk-2023
+    canonical_source: 6-klas-zarubizhna-literatura-voloshchuk-2023
+    source_url: https://pidruchnyk.com.ua/2623-zaralit-6-klas-voloshchuk-2023.html
+    fallback_page_urls:
+      - "https://shkola.in.ua/2866-zarubizhna-literatura-6-klas-voloshchuk-2023.html"
+    gdrive_id: 1BmLetDjtE2F9KwyOzvrfVJTu_ZmVVCpo
+    note: "Current NUS edition; one canonical Drive copy"
 
   # ── GRADE 7 ──────────────────────────────────────────
   - id: g7-mova-avramenko
@@ -621,6 +702,7 @@ books:
     author: Рубля
     year: 2022
     slug: 1709-mystectvo-rublia-5-klas
+    canonical_source: 5-klas-mystetstvo-rublia-2022
     note: "year not in page title — verify on title page at QA"
 
   - id: g5-etyka-meleshchenko

--- a/scripts/projects/open_model_data/textbook_corpus_readiness.py
+++ b/scripts/projects/open_model_data/textbook_corpus_readiness.py
@@ -104,6 +104,7 @@ _LOCATOR_KEYS = frozenset(
 )
 _SOURCE_KEYS = (
     "source_file",
+    "canonical_source",
     "source_slug",
     "slug",
     "book_slug",
@@ -234,7 +235,23 @@ def _selection_source(
         value = _stem(item)
         return value, value, {_slug_key(value)}, {}
     values = {key: str(item.get(key) or "").strip() for key in _SOURCE_KEYS}
-    display = next((values[key] for key in ("source_file", "slug", "book_slug", "file", "filename", "id", "name") if values[key]), "")
+    display = next(
+        (
+            values[key]
+            for key in (
+                "source_file",
+                "slug",
+                "book_slug",
+                "canonical_source",
+                "file",
+                "filename",
+                "id",
+                "name",
+            )
+            if values[key]
+        ),
+        "",
+    )
     if not display:
         return None
     display = _stem(display)

--- a/scripts/projects/open_model_data/textbook_curriculum_coverage.py
+++ b/scripts/projects/open_model_data/textbook_curriculum_coverage.py
@@ -2,7 +2,7 @@
 """Evaluate official textbook curriculum cells against a readiness receipt.
 
 The denominator is a curriculum-cell inventory, not a publisher-edition
-Cartesian product. Readiness is evidence for a cell; the 116-book selection
+Cartesian product. Readiness is evidence for a cell; the selected-book count
 remains a separate receipt field.
 """
 

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -315,6 +315,8 @@ AUTHOR_UK_BY_TRANSLIT: dict[str, str] = {
     "golub": "Голуб",
     "varzatska": "Варзацька",
     "ponomarova": "Пономарова",
+    "arystova": "Аристова",
+    "morze": "Морзе",
     # Additional textbook authors present in the corpus
     "borzenko": "Борзенко",
     "burnejko": "Бурнейко",

--- a/tests/test_textbook_corpus_readiness.py
+++ b/tests/test_textbook_corpus_readiness.py
@@ -256,6 +256,40 @@ def test_selection_page_slug_matches_canonical_retained_name_by_metadata(tmp_pat
     assert source["db"]["source_files"] == [retained]
 
 
+def test_selection_canonical_source_is_an_exact_retained_alias(tmp_path: Path) -> None:
+    root = tmp_path / "drive"
+    root.mkdir()
+    retained = "5-klas-mystetstvo-rublia-2022"
+    (root / f"{retained}.pdf").write_bytes(b"%PDF-book")
+    _write_jsonl(
+        root / f"{retained}.jsonl",
+        [{"text": "one"}, {"text": "two"}, {"text": "three"}],
+    )
+    selection = tmp_path / "selection.yaml"
+    selection.write_text(
+        """books:
+  - id: g5-mystetstvo-rublia
+    slug: 1709-mystectstvo-rublia-5-klas
+    canonical_source: 5-klas-mystetstvo-rublia-2022
+""",
+        encoding="utf-8",
+    )
+    db = tmp_path / "sources.db"
+    _write_db(db, [(retained, 3)])
+
+    report = readiness.build_report(
+        gdrive_root=root,
+        db_path=db,
+        selection_path=selection,
+    )
+
+    source = _source(report, "1709-mystectstvo-rublia-5-klas")
+    assert source["status"] == "ready"
+    assert source["pdf"]["paths"] == [f"{retained}.pdf"]
+    assert source["chunks"]["paths"] == [f"{retained}.jsonl"]
+    assert source["db"]["source_files"] == [retained]
+
+
 def test_metadata_match_refuses_wrong_year_and_ambiguous_selection(tmp_path: Path) -> None:
     root = tmp_path / "drive"
     root.mkdir()


### PR DESCRIPTION
## Outcome

- Adds one current canonical source for Grade 1-4 arts, Grade 3-4 informatics, and Grade 6 foreign literature.
- Keeps exactly one retained PDF per selected logical book in Google Drive; Pidruchnyk and Shkola remain acquisition locators.
- Adds canonical_source as an exact readiness alias, fixing the existing Grade 5 arts false gap.
- Preserves the 176-cell official denominator and only fills accepted source evidence.

## Live corpus evidence

- 7 PDFs retained: 238.4 MiB total.
- 1,115 new chunks; 962 recovered pages.
- 1,115/1,115 rows section-linked and FTS-indexed.
- sources.db: 59,748 textbook rows; 59,748 FTS rows; integrity_check=ok; WAL truncated to 0.
- Coverage: covered 89 -> 97; acquisition_missing 17 -> 9; degraded=0; extraction_missing=0.

## Verification

- 95 targeted tests passed.
- Ruff passed.
- YAML parsed successfully; yamllint executable is not installed locally.
- OPSEC staged scan passed.
- git diff --check passed.

Tracks #6375
Parent epic: #6321

X-Agent: codex/phase3-textbook-coverage-v1
