### PR TITLE
data(phase3): add three current Grade 9 textbooks

### DIFF
--- a/data/pidruchnyk_urls.yaml
+++ b/data/pidruchnyk_urls.yaml
@@ -88,14 +88,17 @@
 9-klas-algebra-merzliak-2017: https://pidruchnyk.com.ua/982-algebra-merzlyak-9-klas-2017.html
 9-klas-biolohiya-zadorozhnyi-2026: https://pidruchnyk.com.ua/3152-biologiia-9-klas-zadorozhnyi-2026.html
 9-klas-fizyka-bariakhtar-2022: https://pidruchnyk.com.ua/3115-fizyka-9-klas-bariakhtar.html
+9-klas-finansova-rolik-2026: https://pidruchnyk.com.ua/3215-pidpryiemnyctvo-9-klas-rolik-2026.html
 9-klas-fizyka-zasiekina-2026: https://pidruchnyk.com.ua/3256-pidruchnyk-fizyka-9-klas-zasiekina-2026.html
 9-klas-heometriya-bevz-2026: https://pidruchnyk.com.ua/3168-geometriia-9-klas-bevz-2026.html
 9-klas-heometriya-merzliak-2017: https://pidruchnyk.com.ua/996-geometriya-merzlyak-9-klas-2017.html
 9-klas-informatyka-bios-2026: https://pidruchnyk.com.ua/3187-informatyka-9-klas-bios-2026.html
 9-klas-informatyka-ryvkind-2017: https://pidruchnyk.com.ua/1046-informatika-9-klas-ryvkind-2017.html
+9-klas-istoriya-ukr-galimov-2026: https://pidruchnyk.com.ua/3194-istoriia-ukrainy-9-klas-galimov-2026.html
 9-klas-istorija-ukrajini-burnejko-2017: https://pidruchnyk.com.ua/1007-ukr-istoriya-9-burneyko.html
 9-klas-istorija-ukrajini-gisem-2017: https://pidruchnyk.com.ua/1002-istoriya-ukrainy-9-klas-gisem-2017.html
 9-klas-khimiya-popel-2017: https://pidruchnyk.com.ua/1041-himiya-9-klas-popel-2017.html
+9-klas-pravoznavstvo-berendieiev-2026: https://pidruchnyk.com.ua/3232-pravoznavstvo-9-klas-berendieiev-2026.html
 9-klas-ukrajinska-literatura-avramenko-2017: https://pidruchnyk.com.ua/967-ukrliteratura-9-klas-avramenko-2017.html
 9-klas-ukrajinska-literatura-mishhenko-2017: https://pidruchnyk.com.ua/1030-ukrliteratura-mischenko-9klas.html
 9-klas-ukrlit-zabolotnyi-2026: https://pidruchnyk.com.ua/3244-ukr-literatura-9-klas-zabolotnyi-2026.html

--- a/data/textbook_curriculum_denominator.yaml
+++ b/data/textbook_curriculum_denominator.yaml
@@ -2462,13 +2462,13 @@ cells:
   coverage:
     coverage_unit_id: g09.finansova
     source_ids:
-    - 3211-pidruchnyk-pidpryiemnyctvo-i-finansova-gramotnist-9-klas-gilberg-2026
+    - 3215-pidpryiemnyctvo-9-klas-rolik-2026
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: current_nus_cohort
-  evidence_note: Official MNP 66; Grade 8 present; Grade 9 deferred.
+  evidence_note: Official MNP 66; current 2026 Rolik edition is selected.
 - cell_id: g05.vstup_istorii
   grade: 5
   canonical_subject_id: vstup_istorii
@@ -2644,13 +2644,13 @@ cells:
     coverage_unit_id: g09.history_separate
     source_ids: []
     source_groups:
-    - - 3127-istoriia-ukrainy-9-klas-gisem
+    - - 3194-istoriia-ukrainy-9-klas-galimov-2026
     - - 3159-vsesvitnia-istoriia-9-klas-pometun-2026
     source_match_mode: all
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: current_nus_cohort
-  evidence_note: Present under istoriya and vsesvitnia.
+  evidence_note: Current 2026 Galimov history of Ukraine and Pometun world history editions are selected.
   choice_group_id: g09.history_realization
   choice_member_id: separate
   choice_member_requires:
@@ -2770,13 +2770,13 @@ cells:
   coverage:
     coverage_unit_id: g09.pravoznavstvo
     source_ids:
-    - 3236-pravoznavstvo-9-klas-remekh-2026
+    - 3232-pravoznavstvo-9-klas-berendieiev-2026
     source_groups: []
     source_match_mode: any
     evidence_state: resolved
     legacy_inventory_source_ids: []
     edition_policy: current_nus_cohort
-  evidence_note: Official MNP 75; deferred in current corpus.
+  evidence_note: Official MNP 75; current 2026 Berendieiev edition is selected.
 - cell_id: g05.mystetstvo_one_of
   grade: 5
   canonical_subject_id: mystetstvo_one_of

--- a/docs/l2-uk-direct/textbook-selection.yaml
+++ b/docs/l2-uk-direct/textbook-selection.yaml
@@ -1,6 +1,6 @@
 # Textbook Selection for RAG Database
 # Selected: 2026-08-08
-# Total: 127 books from pidruchnyk.com.ua and shkola.in.ua, retained once in Google Drive
+# Total: 128 books from catalog and publisher sources, retained once in Google Drive
 # Strategy: 2 мова per grade, 1 literature (5-11), 1-2 history (5-11)
 #
 # PDF URL pattern: https://pidruchnyk.com.ua/uploads/book/{filename}.pdf
@@ -835,7 +835,22 @@ books:
     year: 2025
     slug: 2950-pidpryiemnyctvo-i-finansova-gramotnist-plastun-8-klas-2025
 
-  # ── GRADE 9 (batch 3 — 2026 NUS rollout, all via Drive) ──
+  # ── GRADE 9 (batch 3 — 2026 NUS rollout, retained in Drive) ──
+  - id: g9-istoriya-ukr-galimov
+    grade: 9
+    subject: istoriya
+    author: Галімов
+    year: 2026
+    slug: 3194-istoriia-ukrainy-9-klas-galimov-2026
+    canonical_source: 9-klas-istoriya-ukr-galimov-2026
+    source_url: https://www.ranok.com.ua/pidruchnyky-9-klas-2026.html
+    fallback_page_urls:
+      - "https://pidruchnyk.com.ua/3194-istoriia-ukrainy-9-klas-galimov-2026.html"
+      - "https://shkola.in.ua/787-istoriia-ukrainy-9-klas-hisem.html"
+    override_pdfs:
+      - "https://api.izzi.digital/datastore/21/publication/1435412/files/2026/07/18/29f62dc1db3afcde8de815c54e21f2c5___istoriia_ukrainy___pidruchnyk_dlia_9_klasu_zakladiv_zagalnoi_serednoi_osvity__a._a._galimov__o._v._gisem__o._o._martinyk__o._m._syrtsova_.pdf"
+    note: "Complete 260-page current edition from the publisher; both catalog Drive previews are view-only"
+
   - id: g9-vsesvitnia-pometun
     grade: 9
     subject: vsesvitnia
@@ -865,15 +880,20 @@ books:
     status: needs_manual_pdf
     gdrive_id: 1zHXgiTgJ47l_0hFn2wIT09BJKVEx6GYc
 
-  - id: g9-pravoznavstvo-remekh
+  - id: g9-pravoznavstvo-berendieiev
     grade: 9
     subject: pravoznavstvo
-    author: Ремех
+    author: Берендєєв
     year: 2026
-    slug: 3236-pravoznavstvo-9-klas-remekh-2026
-    status: needs_manual_pdf
-    gdrive_id: 1fyEjfNw9gUGrtlyPrCNAyj4iXdyxpz2F
-    note: "DEFERRED wave-3b: ALL 6 pravoznavstvo-9 2026 editions Drive view-only (probed 2026-07-06)"
+    slug: 3232-pravoznavstvo-9-klas-berendieiev-2026
+    canonical_source: 9-klas-pravoznavstvo-berendieiev-2026
+    source_url: https://www.ranok.com.ua/pidruchnyky-9-klas-2026.html
+    fallback_page_urls:
+      - "https://pidruchnyk.com.ua/3232-pravoznavstvo-9-klas-berendieiev-2026.html"
+      - "https://shkola.in.ua/3422-pravoznavstvo-9-klas-berendieiev.html"
+    override_pdfs:
+      - "https://api.izzi.digital/datastore/21/publication/1445222/files/2026/07/18/a8370dae1543b17cd78619bb4c1ca353___pravoznavstvo___pidruchnyk_dlia_9_klasu_zakladiv_zagalnoi_serednoi_osvity__berendieiev__s._o.__serhiienko__v._s._.pdf"
+    note: "Complete 180-page current edition from the publisher; catalog Drive copies remain view-only"
 
   - id: g9-pryroda-mandrenko
     grade: 9
@@ -905,15 +925,18 @@ books:
     status: needs_manual_pdf
     gdrive_id: 1vJu-vNVtSMMFfoxiA8QBh7oPbc3Hk-6k
 
-  - id: g9-finansova-hilberh
+  - id: g9-finansova-rolik
     grade: 9
     subject: finansova
-    author: Гільберг
+    author: Ролік
     year: 2026
-    slug: 3211-pidruchnyk-pidpryiemnyctvo-i-finansova-gramotnist-9-klas-gilberg-2026
-    status: needs_manual_pdf
-    gdrive_id: 1iOQa-xFK8ro8n4fKUImI_gF9KMs7_voQ
-    note: "DEFERRED wave-3b: Гільберг + Пластун (shkola 3415) + Ролік all view-only/no-link"
+    slug: 3215-pidpryiemnyctvo-9-klas-rolik-2026
+    canonical_source: 9-klas-finansova-rolik-2026
+    source_url: https://pidruchnyk.com.ua/3215-pidpryiemnyctvo-9-klas-rolik-2026.html
+    fallback_page_urls:
+      - "https://shkola.in.ua/3416-pidpryiemnytstvo-i-finansova-hramotnist-9-klas-rolik.html"
+    gdrive_id: 1Nqiflh0e7WegA3ZVutFVHW3ZYbuROowo
+    note: "Download-enabled current edition selected after six alternatives proved view-only; retained once in Google Drive"
 
   # ── GRADE 10 (batch 3) ──
   - id: g10-algebra-ister

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -116,8 +116,11 @@ KNOWN_SOURCE_FILE_SUBJECTS: dict[str, str] = {
     "9-klas-ukrajinska-mova-zabolotnij-2017": "ukrmova",
     "9-klas-ukrmova-zabolotnyi-2017": "ukrmova",
     "9-klas-fizyka-zasiekina-2026": "fizyka",
+    "9-klas-finansova-rolik-2026": "finansova",
     "9-klas-heometriya-bevz-2026": "heometriya",
     "9-klas-informatyka-bios-2026": "informatyka",
+    "9-klas-istoriya-ukr-galimov-2026": "istoriya",
+    "9-klas-pravoznavstvo-berendieiev-2026": "pravoznavstvo",
     "9-klas-ukrlit-zabolotnyi-2026": "ukrlit",
     "9-klas-zdorovia-gushchyna-2026": "zdorovia",
     "anna-ohoiko-1000-words-2nd-ed": "lexicon",
@@ -355,6 +358,8 @@ AUTHOR_UK_BY_TRANSLIT: dict[str, str] = {
     "masol": "Масол",
     "zapotockyi": "Запотоцький",
     "hilberh": "Гільберг",
+    "rolik": "Ролік",
+    "berendieiev": "Берендєєв",
     # Non-textbook author-name strings already stored in Latin/English on
     # ingestion (literary works, podcast, style-guide author). Map them
     # to Cyrillic so author_uk is uniformly Cyrillic when populated.

--- a/tests/test_textbook_subjects.py
+++ b/tests/test_textbook_subjects.py
@@ -133,9 +133,12 @@ CURRENT_TEXTBOOK_SOURCE_FILES = (
     "9-klas-ukrajinska-mova-avramenko-2017",
     "9-klas-ukrajinska-mova-voron-2017",
     "9-klas-ukrajinska-mova-zabolotnij-2017",
+    "9-klas-finansova-rolik-2026",
     "9-klas-fizyka-zasiekina-2026",
     "9-klas-heometriya-bevz-2026",
     "9-klas-informatyka-bios-2026",
+    "9-klas-istoriya-ukr-galimov-2026",
+    "9-klas-pravoznavstvo-berendieiev-2026",
     "9-klas-ukrlit-zabolotnyi-2026",
     "9-klas-ukrmova-zabolotnyi-2017",
     "9-klas-zdorovia-gushchyna-2026",
@@ -153,19 +156,21 @@ CURRENT_TEXTBOOK_SOURCE_FILES = (
 
 
 def test_current_textbook_source_files_all_map_to_canonical_subjects() -> None:
-    assert len(CURRENT_TEXTBOOK_SOURCE_FILES) == 96
+    assert len(CURRENT_TEXTBOOK_SOURCE_FILES) == 99
     subjects = [subject_for_source_file(source) for source in CURRENT_TEXTBOOK_SOURCE_FILES]
 
     assert None not in subjects
     assert Counter(subjects) == {
         "ukrmova": 45,
         "ukrlit": 17,
-        "istoriya": 16,
+        "istoriya": 17,
         "bukvar": 4,
         "lexicon": 10,
         "fizyka": 1,
+        "finansova": 1,
         "heometriya": 1,
         "informatyka": 1,
+        "pravoznavstvo": 1,
         "zdorovia": 1,
     }
     assert set(CURRENT_TEXTBOOK_SOURCE_FILES) == set(KNOWN_SOURCE_FILE_SUBJECTS)
@@ -354,8 +359,11 @@ def test_batch3_author_translits_resolve_to_cyrillic() -> None:
     ("stem", "expected_subject"),
     [
         ("9-klas-fizyka-zasiekina-2026", "fizyka"),
+        ("9-klas-finansova-rolik-2026", "finansova"),
         ("9-klas-heometriya-bevz-2026", "heometriya"),
         ("9-klas-informatyka-bios-2026", "informatyka"),
+        ("9-klas-istoriya-ukr-galimov-2026", "istoriya"),
+        ("9-klas-pravoznavstvo-berendieiev-2026", "pravoznavstvo"),
         ("9-klas-ukrlit-zabolotnyi-2026", "ukrlit"),
         ("9-klas-zdorovia-gushchyna-2026", "zdorovia"),
     ],
@@ -392,6 +400,8 @@ def test_new_authors_mapping_sample() -> None:
         "merzlyak": "Мерзляк",
         "grygorovych": "Григорович",
         "zadorozhnyj": "Задорожний",
+        "rolik": "Ролік",
+        "berendieiev": "Берендєєв",
     }
     for translit, expected_uk in samples.items():
         assert AUTHOR_UK_BY_TRANSLIT[translit] == expected_uk


### PR DESCRIPTION
## Outcome

Adds complete current 2026 Grade 9 editions for:

- History of Ukraine — Galimov et al. (260 pages, 465 chunks)
- Law — Berendieiev/Serhiienko (180 pages, 188 chunks)
- Entrepreneurship and financial literacy — Rolik (227 pages, 253 chunks)

The PDFs and extracted JSONL remain in the canonical Google Drive corpus, not Git. The live SQLite corpus received 906 section-linked chunks with exact FTS parity. Curriculum acquisition gaps fall from 9 to 6; covered cells rise from 97 to 100.

Partial publisher previews were not treated as complete books.

## Verification

- `109 passed` across textbook subject, readiness, coverage, and incremental-ingest tests
- Ruff passed
- YAML safe-load passed for all three changed YAML files
- `git diff --check` passed
- DB integrity: `ok`; 906/906 chunks linked; FTS parity exact
- selection: 128 books / 128 unique IDs
- protected/generated-file and OPSEC checks passed

Tracks #6375.
