### PR TITLE
fix(security): remove showdown (CVE-2026-59710/59711)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "better-sqlite3": "^12.5.0",
-        "showdown": "^2.1.0"
+        "better-sqlite3": "^12.5.0"
       },
       "devDependencies": {
         "@agentclientprotocol/claude-agent-acp": ">=0.64.2 <1",
@@ -23,7 +22,6 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.10.1",
-        "@types/showdown": "^2.0.6",
         "@typescript-eslint/eslint-plugin": "^8.49.0",
         "@typescript-eslint/parser": "^8.49.0",
         "acpx": ">=0.13.0",
@@ -3596,13 +3594,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/showdown": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
-      "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -5292,15 +5283,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/comment-parser": {
@@ -10858,22 +10840,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/showdown": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^9.0.0"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://www.paypal.me/tiviesantos"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
-    "@types/showdown": "^2.0.6",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "acpx": ">=0.13.0",
@@ -118,8 +117,7 @@
     "yaml-language-server": "^1.23.0"
   },
   "dependencies": {
-    "better-sqlite3": "^12.5.0",
-    "showdown": "^2.1.0"
+    "better-sqlite3": "^12.5.0"
   },
   "overrides": {
     "uuid": "11.1.1",

--- a/scripts/legacy/typescript/lib/utils/markdown.ts
+++ b/scripts/legacy/typescript/lib/utils/markdown.ts
@@ -1,13 +1,10 @@
 /**
- * Markdown utilities with Showdown extensions
+ * Markdown utilities for legacy TypeScript activity parsers.
  *
- * Handles:
- * - Standard markdown conversion
- * - Callout blocks: > [!answer], > [!explanation], > [!alt]
- * - Answer hiding with toggle buttons
+ * Showdown was removed (CVE-2026-59710 / CVE-2026-59711; no patched npm
+ * release — vulnerable range is <=2.1.0). HTML conversion is unsupported;
+ * callout / answer *parsing* helpers below remain pure string utilities.
  */
-
-import * as showdown from 'showdown';
 
 // =============================================================================
 // Callout Block Types
@@ -21,194 +18,34 @@ export interface CalloutBlock {
 }
 
 // =============================================================================
-// Showdown Extensions
-// =============================================================================
-
-/**
- * Extension to parse callout blocks like > [!answer] content
- * Converts them to semantic HTML that can be styled/hidden
- * Handles both start-of-line and indented callouts (under list items)
- */
-const calloutExtension: showdown.ShowdownExtension = {
-  type: 'lang',
-  regex: /^(\s*)>\s*\[!(\w+)\]\s*(.+)$/gm,
-  replace: (match: string, indent: string, type: string, content: string) => {
-    const calloutType = type.toLowerCase() as CalloutType;
-    // Process inline markdown (bold, italic) in content
-    const html = content.trim()
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>');
-    return `${indent}<div class="callout callout-${calloutType}" data-callout="${calloutType}">${html}</div>`;
-  }
-};
-
-/**
- * Extension to convert [🔊](audio_id) to Forvo buttons
- * Tries to find preceding **Word** to use as search term.
- * If not found, uses the ID suffix (e.g. "boryspil") which Forvo search might handle.
- */
-const audioLinkExtension: showdown.ShowdownExtension = {
-  type: 'lang',
-  filter: (text: string) => {
-    // 1. Match: **Word** [🔊](audio_id)
-    text = text.replace(
-      /\*\*([^*]+)\*\*\s*\[🔊\]\(audio_[^)]+\)/g,
-      (match, word) => {
-        // Keep the bold word, add the button
-        return `<strong>${word}</strong> <button class="audio-btn" onclick="openForvo('${word}')" title="Listen on Forvo">🔊</button>`;
-      }
-    );
-
-    // 2. Match remaining orphan [🔊](audio_id) (fallback)
-    text = text.replace(
-      /\[🔊\]\(audio_([a-zA-Z0-9_]+)\)/g,
-      (match, idSuffix) => {
-        const fallback = idSuffix.replace(/_/g, ' ');
-        return `<button class="audio-btn" onclick="openForvo('${fallback}')" title="Listen on Forvo (Search)">🔊</button>`;
-      }
-    );
-
-    return text;
-  }
-};
-
-
-
-/**
- * Extension to handle answer blocks with toggle functionality
- * Groups consecutive callouts into hideable sections
- */
-const answerBlockExtension: showdown.ShowdownExtension = {
-  type: 'output',
-  filter: (text: string) => {
-    let answerCount = 0;
-
-    // Find consecutive answer + explanation callouts and wrap them
-    text = text.replace(
-      /(<div class="callout callout-answer"[^>]*>[\s\S]*?<\/div>)(\s*<div class="callout callout-(?:explanation|alt)"[^>]*>[\s\S]*?<\/div>)*/g,
-      (match) => {
-        const id = `ans-${answerCount++}`;
-        return `<button class="show-answer-btn" onclick="toggleAnswer('${id}', this)">Показати відповідь</button><div class="answer-block" id="${id}">${match}</div>`;
-      }
-    );
-
-    return text;
-  }
-};
-
-/**
- * Extension to handle legacy answer formats for backward compatibility
- * Converts old formats to new callout format during parsing
- */
-const legacyAnswerExtension: showdown.ShowdownExtension = {
-  type: 'lang',
-  filter: (text: string) => {
-    // Pattern 1: **Відповідь:** answer
-    text = text.replace(
-      /\*\*(?:Відповідь|Відповіді|Answer|Answers?):\*\*\s*(.+?)(?:\n|$)/gi,
-      '> [!answer] $1\n'
-    );
-
-    // Pattern 2: → ✅ **Правда.** explanation
-    text = text.replace(
-      /→\s*✅\s*\*\*Правда\.\*\*\s*(.+?)(?:\n|$)/g,
-      '> [!answer] true\n> [!explanation] $1\n'
-    );
-
-    // Pattern 3: → ❌ **Міф.** explanation
-    text = text.replace(
-      /→\s*❌\s*\*\*Міф\.\*\*\s*(.+?)(?:\n|$)/g,
-      '> [!answer] false\n> [!explanation] $1\n'
-    );
-
-    // Pattern 4: → **answer** (bold answer)
-    text = text.replace(
-      /→\s*\*\*(.+?)\*\*\s*(?:\n|$)/g,
-      '> [!answer] $1\n'
-    );
-
-    // Pattern 5: → answer (explanation) - arrow with parenthetical
-    text = text.replace(
-      /→\s*(.+?)\s*\((.+?)\)\s*(?:\n|$)/g,
-      '> [!answer] $1\n> [!explanation] $2\n'
-    );
-
-    // Pattern 6: → answer (simple arrow, no parens)
-    // Only match if not already converted and not starting with emoji
-    text = text.replace(
-      /^(\s*)→\s*([^✅❌\*\n][^\n]*?)$/gm,
-      '$1> [!answer] $2'
-    );
-
-    return text;
-  }
-};
-
-// =============================================================================
-// Markdown Converter
+// Markdown Converter (removed)
 // =============================================================================
 
 export interface MarkdownConverterOptions {
-  /**
-   * Enable legacy answer format conversion
-   * When true, old formats (→, **Відповідь:**) are converted to callouts
-   */
   convertLegacyAnswers?: boolean;
-
-  /**
-   * Enable answer hiding with toggle buttons
-   * When true, answer callouts are wrapped in hideable blocks
-   */
   hideAnswers?: boolean;
-
-  /**
-   * Enable table support
-   */
   tables?: boolean;
 }
 
-const defaultOptions: MarkdownConverterOptions = {
-  convertLegacyAnswers: false,  // Disabled: all modules now use native > [!answer] syntax
-  hideAnswers: true,
-  tables: true,
-};
-
 /**
- * Create a configured Showdown converter
+ * @deprecated Showdown removed for XSS CVEs with no upstream patch.
+ * Site content uses Astro / @astrojs/markdown-remark instead.
  */
-export function createMarkdownConverter(options: MarkdownConverterOptions = {}): showdown.Converter {
-  const opts = { ...defaultOptions, ...options };
-
-  const extensions: showdown.ShowdownExtension[] = [
-    calloutExtension,
-    audioLinkExtension,
-  ];
-
-  if (opts.convertLegacyAnswers) {
-    extensions.unshift(legacyAnswerExtension); // Run first
-  }
-
-  if (opts.hideAnswers) {
-    extensions.push(answerBlockExtension); // Run last (on output)
-  }
-
-  const converter = new showdown.Converter({
-    tables: opts.tables,
-    strikethrough: true,
-    simpleLineBreaks: true,
-    extensions,
-  });
-
-  return converter;
+export function createMarkdownConverter(_options: MarkdownConverterOptions = {}): never {
+  throw new Error(
+    "createMarkdownConverter is unavailable: showdown was removed " +
+      "(CVE-2026-59710 / CVE-2026-59711; no fixed npm release). " +
+      "Use the site markdown pipeline."
+  );
 }
 
 /**
- * Convert markdown to HTML with answer handling
+ * @deprecated See createMarkdownConverter.
  */
-export function markdownToHtml(markdown: string, options?: MarkdownConverterOptions): string {
-  const converter = createMarkdownConverter(options);
-  return converter.makeHtml(markdown);
+export function markdownToHtml(_markdown: string, _options?: MarkdownConverterOptions): never {
+  return createMarkdownConverter();
 }
+
 
 // =============================================================================
 // Answer Parsing Utilities


### PR DESCRIPTION
## Summary
- Dependabot **#263** / **#264** (medium): showdown XSS CVEs; vulnerable range **<=2.1.0** with **no patched npm release**.
- Root `package.json` / lock still pulled **showdown@2.1.0** for legacy TypeScript only.
- **Remove** `showdown` + `@types/showdown`.
- Legacy `createMarkdownConverter` / `markdownToHtml` fail closed; pure string helpers (`parseCallouts`, `extractAnswer`) kept.
- Active site uses Astro / `@astrojs/markdown-remark`, not showdown.

## Test plan
- [x] lock has zero `showdown` package entries
- [ ] CI green
- [ ] Dependabot #263/#264 close after scan