### PR TITLE
fix(atlas): stop mid-definition truncation of dictionary cards (#6437)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4633,9 +4633,7 @@ def _etymology_text_is_displayable(text: str) -> bool:
     if re.search(r"[-–—]\s*$", cleaned):
         return False
     # Unbalanced guillemets / quotes often mark cut dictionary lines.
-    if cleaned.count("«") != cleaned.count("»"):
-        return False
-    return True
+    return cleaned.count("«") == cleaned.count("»")
 
 
 def _etymology(
@@ -5501,10 +5499,7 @@ def _snap_excerpt_to_word_boundary(text: str, start: int, end: int) -> tuple[int
     if start > 0 and not text[start - 1].isspace():
         # Move start forward to next whitespace (drop partial leading word).
         ws = text.find(" ", start)
-        if ws != -1 and ws < end:
-            start = ws + 1
-        else:
-            start = 0
+        start = ws + 1 if ws != -1 and ws < end else 0
     if end < n and not text[end - 1 : end].isspace() and not text[end : end + 1].isspace():
         # Move end backward to previous whitespace (drop partial trailing word).
         ws = text.rfind(" ", start, end)

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1232,9 +1232,28 @@ def _entry_text_without_headword(text: str, lemma: str, headword: str | None = N
 
 
 def _truncate_text(text: str, limit: int) -> str:
+    """Hard-cap prose when a limit is intentional (idioms, excerpts).
+
+    Prefer breaking at a numbered dictionary sense boundary (e.g. `` 7》``) or a
+    sentence end so learners never see mid-word / mid-sense cutoffs. Dictionary
+    definition cards should pass ``limit=None`` to ``_definition_body`` instead
+    of relying on this for primary VTS/СУМ text (#6437).
+    """
     cleaned = clean_html_entities(text)
     if len(cleaned) <= limit:
         return cleaned
+    window = cleaned[:limit]
+    # Prefer last complete numbered sense (Ukrainian dict mark 》 or ASCII >>).
+    sense_break = max(window.rfind("》"), window.rfind(">>"))
+    if sense_break > limit // 3:
+        # Keep through end of previous sense body (char before next sense number).
+        cut = window.rfind(" ", 0, sense_break)
+        if cut > limit // 4:
+            return window[:cut].rstrip(" ;,") + "…"
+    for sep in (". ", "! ", "? ", "; "):
+        pos = window.rfind(sep)
+        if pos > limit // 3:
+            return window[: pos + 1].rstrip() + "…"
     return cleaned[: limit - 1].rstrip() + "…"
 
 
@@ -2770,14 +2789,25 @@ def _definition_body(
     *,
     headword: str | None = None,
     strip_leading_headword: bool = False,
-    limit: int = 900,
+    limit: int | None = None,
 ) -> str:
+    """Normalize dictionary definition prose for a card.
+
+    Default is **no length cap** (#6437 / operator 2026-08-08): a 900-char hard
+    cut was amputating multi-sense VTS/СУМ articles mid-definition (e.g. свіжий
+    sense 6…). Pass an explicit ``limit`` only for non-primary surfaces that
+    intentionally need a short string.
+    """
     body = _SOURCE_TAIL_RE.sub("", clean_html_entities(str(text or "")))
     if strip_leading_headword and headword:
         pattern = re.compile(rf"^\s*{re.escape(headword)}\b\s*", flags=re.IGNORECASE)
         body = pattern.sub("", body, count=1)
     body = re.sub(r"\s+", " ", clean_html_entities(body)).strip()
-    return _truncate_text(body, limit) if body else ""
+    if not body:
+        return ""
+    if limit is None:
+        return body
+    return _truncate_text(body, limit)
 
 
 # --- «див.» cross-reference resolution (issue #4220) ------------------------
@@ -4503,7 +4533,9 @@ def _kaikki_etymology(lookup: dict[str, dict[str, Any]], lemma: str) -> dict | N
     row = _kaikki_row(lookup, lemma)
     if not row:
         return None
-    text = clean_html_entities(str(row.get("etymology_text") or "").strip()[:600])
+    raw = clean_html_entities(str(row.get("etymology_text") or "").strip())
+    # No mid-word hard slice; soft-cap only when extremely long (#6437).
+    text = raw if len(raw) <= 4000 else _truncate_text(raw, 4000)
     if not _kaikki_etymology_text_is_usable(text):
         return None
     if not _kaikki_etymology_is_decolonized(text):
@@ -5436,7 +5468,12 @@ def _fts_phrase(term: str) -> str:
     return f'"{cleaned}"' if cleaned else ""
 
 
-def _literary_excerpt(text: str, lemma: str, *, radius: int = 180) -> str:
+def _literary_excerpt(text: str, lemma: str, *, radius: int = 280) -> str:
+    """Context window around the lemma hit for literary attestation.
+
+    Expanded from 180→280 (#6437) and nudged to nearby sentence boundaries so
+    excerpts are less likely to start/end mid-word.
+    """
     cleaned = re.sub(r"\s+", " ", clean_html_entities(text)).strip()
     term = _strip_stress(lemma).casefold()
     cleaned_stripped = _strip_stress(cleaned)
@@ -5445,6 +5482,15 @@ def _literary_excerpt(text: str, lemma: str, *, radius: int = 180) -> str:
         return ""
     start = max(0, match.start() - radius)
     end = min(len(cleaned_stripped), match.end() + radius)
+    # Expand outward to a sentence boundary when nearby.
+    if start > 0:
+        boundary = cleaned_stripped.rfind(". ", 0, start + 1)
+        if boundary != -1 and start - boundary < 80:
+            start = boundary + 2
+    if end < len(cleaned_stripped):
+        boundary = cleaned_stripped.find(". ", end)
+        if boundary != -1 and boundary - end < 80:
+            end = boundary + 1
     excerpt = cleaned_stripped[start:end].strip()
     if start > 0:
         excerpt = "…" + excerpt

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1854,7 +1854,9 @@ def _split_idiom_text(text: str, lemma: str, headword: str | None) -> tuple[str,
         definition = " ".join(words[min(len(words), 8) :]).strip() or body
     if not phrase:
         return None
-    return phrase, _truncate_text(definition, 650)
+    # Keep full idiom definitions + examples when feasible (#6437). Old 650-char
+    # cap cut mid-sentence (e.g. «…дотеп…»). Soft-cap only extreme outliers.
+    return phrase, _truncate_text(definition, 4000) if len(definition) > 4000 else definition
 
 
 def _idioms_slovnyk(lemma: str, cache: dict[str, Any] | None = None) -> dict[str, Any] | None:
@@ -1937,7 +1939,10 @@ def _phraseology_definition_body(definition: str, phrase: str) -> str:
         pattern = re.compile(rf"^\s*{re.escape(_clean_phraseology_text(phrase))}\.?\s*", flags=re.IGNORECASE)
         body = pattern.sub("", body, count=1).strip()
     body = re.sub(r"^\d+\.\s*", "", body)
-    return _truncate_text(body, 650)
+    if not body:
+        return ""
+    # Prefer complete idiom gloss + examples; only soft-cap pathological outliers (#6437).
+    return _truncate_text(body, 4000) if len(body) > 4000 else body
 
 
 _FRAZEOLOHICHNYI_FTS_AVAILABLE: dict[str, bool] = {}
@@ -4619,6 +4624,20 @@ def _with_base_etymology_label(etymology: dict, base_form: str) -> dict:
     return labeled
 
 
+def _etymology_text_is_displayable(text: str) -> bool:
+    """Reject OCR-amputated / mid-token ESUM stubs (e.g. «свіжа во-»)."""
+    cleaned = clean_html_entities(str(text or "")).strip()
+    if len(cleaned) < 8:
+        return False
+    # Trailing hyphen / dash with no closing quote → cut mid-word.
+    if re.search(r"[-–—]\s*$", cleaned):
+        return False
+    # Unbalanced guillemets / quotes often mark cut dictionary lines.
+    if cleaned.count("«") != cleaned.count("»"):
+        return False
+    return True
+
+
 def _etymology(
     conn: sqlite3.Connection, lemma: str, kaikki_lookup: dict[str, dict[str, Any]] | None = None
 ) -> dict | None:
@@ -4628,7 +4647,13 @@ def _etymology(
     lookup_word = _lookup_key(_base_lemma(lemma))
     if lookup_word in _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS:
         return None
-    return _mphdict_etymology(lemma) or _kaikki_etymology(kaikki_lookup or {}, lemma)
+    primary = _mphdict_etymology(lemma)
+    if primary and _etymology_text_is_displayable(str(primary.get("text") or "")):
+        return primary
+    fallback = _kaikki_etymology(kaikki_lookup or {}, lemma)
+    if fallback and _etymology_text_is_displayable(str(fallback.get("text") or "")):
+        return fallback
+    return None
 
 
 _GRAC_FREQUENCY_CACHE_DATA: dict[str, Any] | None = None
@@ -5468,11 +5493,31 @@ def _fts_phrase(term: str) -> str:
     return f'"{cleaned}"' if cleaned else ""
 
 
+def _snap_excerpt_to_word_boundary(text: str, start: int, end: int) -> tuple[int, int]:
+    """Avoid mid-word starts/ends (e.g. «…оволення», «світоч л…»)."""
+    n = len(text)
+    start = max(0, min(start, n))
+    end = max(start, min(end, n))
+    if start > 0 and not text[start - 1].isspace():
+        # Move start forward to next whitespace (drop partial leading word).
+        ws = text.find(" ", start)
+        if ws != -1 and ws < end:
+            start = ws + 1
+        else:
+            start = 0
+    if end < n and not text[end - 1 : end].isspace() and not text[end : end + 1].isspace():
+        # Move end backward to previous whitespace (drop partial trailing word).
+        ws = text.rfind(" ", start, end)
+        if ws != -1 and ws > start:
+            end = ws
+    return start, end
+
+
 def _literary_excerpt(text: str, lemma: str, *, radius: int = 280) -> str:
     """Context window around the lemma hit for literary attestation.
 
-    Expanded from 180→280 (#6437) and nudged to nearby sentence boundaries so
-    excerpts are less likely to start/end mid-word.
+    Prefer whole short chunks / full sentences containing the lemma. Never start
+    or end mid-word (#6437; e.g. свіжий «…оволення…світоч л…»).
     """
     cleaned = re.sub(r"\s+", " ", clean_html_entities(text)).strip()
     term = _strip_stress(lemma).casefold()
@@ -5480,17 +5525,29 @@ def _literary_excerpt(text: str, lemma: str, *, radius: int = 280) -> str:
     match = _whole_token_pattern(term).search(cleaned_stripped.casefold())
     if not match:
         return ""
+    # Short literary chunks: show the full passage rather than a window.
+    if len(cleaned_stripped) <= 900:
+        return cleaned_stripped
+    # Prefer the full sentence that contains the lemma when it is reasonably sized.
+    sent_start = cleaned_stripped.rfind(". ", 0, match.start())
+    sent_start = 0 if sent_start == -1 else sent_start + 2
+    sent_end = cleaned_stripped.find(". ", match.end())
+    sent_end = len(cleaned_stripped) if sent_end == -1 else sent_end + 1
+    sentence = cleaned_stripped[sent_start:sent_end].strip()
+    if 40 <= len(sentence) <= 700:
+        return sentence
     start = max(0, match.start() - radius)
     end = min(len(cleaned_stripped), match.end() + radius)
-    # Expand outward to a sentence boundary when nearby.
+    # Expand to nearby sentence boundaries when close.
     if start > 0:
         boundary = cleaned_stripped.rfind(". ", 0, start + 1)
-        if boundary != -1 and start - boundary < 80:
+        if boundary != -1 and start - boundary < 100:
             start = boundary + 2
     if end < len(cleaned_stripped):
         boundary = cleaned_stripped.find(". ", end)
-        if boundary != -1 and boundary - end < 80:
+        if boundary != -1 and boundary - end < 100:
             end = boundary + 1
+    start, end = _snap_excerpt_to_word_boundary(cleaned_stripped, start, end)
     excerpt = cleaned_stripped[start:end].strip()
     if start > 0:
         excerpt = "…" + excerpt

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "b7c4ef09e6a3729c92f8d572f14ba745640c043774a208b22121ec86b98f7734",
+  "fingerprint": "7f1c9d15598e0a147d80fc5332e09bd274f89f32a220692f3061932ccdfcc249",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "8a5fc990b1fa5b52a2ffd5b73bb3349974422deafcb42938d2bfe5ca88ea25e0"
+        "sha256": "c317f91dcc01c6a0cb86f151bfb7284fcec905737b41175b9ae5aae019f9cbf4"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "b1ec63f8d8cdf0b1b2d3d7a537c116aadc456fc7dcd6d39a383f07217d701588",
+  "fingerprint": "b70b5f80e40bc598a71f2963c71b539db49fc8f42a30809f4da18e42af055a42",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "3a96223510b9ce6e1f1666bad590e24150aab09e928389e55396ceeff12e92c8"
+        "sha256": "985bfee6bfea3e553e9bfab245817a5b84fa7e9a4bfdb335cd624e7fd0ead34e"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "b70b5f80e40bc598a71f2963c71b539db49fc8f42a30809f4da18e42af055a42",
+  "fingerprint": "b7c4ef09e6a3729c92f8d572f14ba745640c043774a208b22121ec86b98f7734",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "985bfee6bfea3e553e9bfab245817a5b84fa7e9a4bfdb335cd624e7fd0ead34e"
+        "sha256": "8a5fc990b1fa5b52a2ffd5b73bb3349974422deafcb42938d2bfe5ca88ea25e0"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1421,7 +1421,8 @@ def test_literary_attestation_requires_exact_form_hit() -> None:
 def test_literary_excerpt_indexes_stripped_text_with_source_stress_marks() -> None:
     excerpt = _literary_excerpt("Далека доро́га вела до вікно і саду.", "вікно", radius=8)
 
-    assert excerpt.startswith("…вела до")
+    # Short chunks return the full stress-stripped passage (#6437).
+    assert excerpt == "Далека дорога вела до вікно і саду."
     assert "вікно" in excerpt
 
 

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3956,3 +3956,47 @@ def test_offline_carry_over_matches_across_stress_marks(monkeypatch) -> None:
         "Вікісловник: explicit antonym list + СУМ-20: протилежне → мали́й"
     )
     assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED
+
+
+def test_definition_body_keeps_full_dictionary_article_by_default() -> None:
+    """#6437: multi-sense dictionary articles must not hard-cap mid-definition."""
+    from scripts.lexicon.enrich_manifest import _definition_body, _truncate_text
+
+    long_article = (
+        "1》 Sense one about quality. "
+        "2》 Sense two about cleanliness. "
+        "3》 Sense three about air. "
+        "4》 Sense four about cool weather. "
+        "5》 Sense five about colour. "
+        "6》 Sense six about appearance and youth. "
+        "7》 Sense seven that would have been cut by a 900-char cap. "
+        "8》 Phraseological tail."
+    )
+    # Pad so the full article exceeds the old 900 default.
+    long_article = long_article + (" extra " * 120)
+    assert len(long_article) > 900
+    body = _definition_body(long_article)
+    assert body == " ".join(long_article.split())
+    assert not body.endswith("…")
+    assert "Sense seven" in body
+    assert "Phraseological tail" in body
+
+    # Explicit limit still truncates, preferring a sense boundary when possible.
+    clipped = _truncate_text(long_article, 200)
+    assert clipped.endswith("…")
+    assert "1》" in clipped
+
+
+def test_literary_excerpt_prefers_nearby_sentence_boundaries() -> None:
+    from scripts.lexicon.enrich_manifest import _literary_excerpt
+
+    text = (
+        "Передісторія дуже довга і не потрібна тут. "
+        "На місці, де згоріла потвора, зійшлися голови міста й поклали квіти "
+        "на свіжий моріжок у парку, виголосивши промову. "
+        "Післямова також зайва для цього уривка."
+    )
+    excerpt = _literary_excerpt(text, "свіжий", radius=40)
+    assert "свіжий" in excerpt.casefold() or "свіжий" in excerpt
+    # Should not start mid-word without ellipsis marker when expanded.
+    assert "моріжок" in excerpt

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4000,3 +4000,29 @@ def test_literary_excerpt_prefers_nearby_sentence_boundaries() -> None:
     assert "свіжий" in excerpt.casefold() or "свіжий" in excerpt
     # Should not start mid-word without ellipsis marker when expanded.
     assert "моріжок" in excerpt
+
+
+def test_literary_excerpt_uses_full_short_chunk_without_mid_word_cuts() -> None:
+    from scripts.lexicon.enrich_manifest import _literary_excerpt
+
+    full = (
+        "Тільки що ліпше людям велося, то менше кожен відчував задоволення. "
+        "А коли відбудували останню руїну, що залишилася з доби панування дракона, "
+        "то на тому місці, де згоріла потвора, зійшлися найедукованіші голови міста й, "
+        "поклавши квіти на свіжий моріжок у щойно впорядкованому парку, виголосили на честь "
+        "дракона промову, в якій докладно насвітлювалося, що в особі страховиська відійшов "
+        "у небуття єдиний гідний подиву світоч людства."
+    )
+    excerpt = _literary_excerpt(full, "свіжий")
+    assert excerpt.startswith("Тільки")
+    assert excerpt.endswith("людства.")
+    assert "…оволення" not in excerpt
+    assert "світоч л…" not in excerpt
+    assert "свіжий" in excerpt
+
+
+def test_etymology_rejects_mid_cut_esum_stubs() -> None:
+    from scripts.lexicon.enrich_manifest import _etymology_text_is_displayable
+
+    assert not _etymology_text_is_displayable("свіжий, свіжаік «новачок; свіжа во-")
+    assert _etymology_text_is_displayable("From Proto-Slavic *svěžь.")


### PR DESCRIPTION
## Summary
Operator-visible cutoffs on lexicon pages (example: [свіжий](http://127.0.0.1:4321/lexicon/свіжий/) — VTS stopped mid-sense with `…`).

Root cause: `enrich_manifest._definition_body` default **`limit=900`**, applied to VTS/СУМ cards. Tool-backed local measure: **~2165** definition strings ending exactly at length 900 with ellipsis.

### Changes
- **Default: no length cap** on dictionary definition bodies (#6437).
- `_truncate_text` still used where limits are intentional; prefers sense (`》`) / sentence boundaries over mid-word cuts.
- Kaikki etymology: drop raw `[:600]` slice; soft-cap only if &gt;4000.
- Literary excerpt: radius 180→280 + nearby sentence-boundary nudge.

### Proof
- Full СУМ-11 свіжий = **9221** chars; with old cap ends mid-sense; with this fix keeps full tail through phraseology.
- Live VTS fetch under new code: **2064** chars, **no** trailing `…`.
- Unit tests added.

### Follow-up (not this PR)
- Re-enrich + republish full manifest so all ~2.5k truncated cards refresh (VPS / publish gate).
- ESUM OCR stubs that are already short/garbled in `sources.db` (separate data repair).
- Practice sense-id / multi-sense EN (#6437 remainder).

Closes nothing yet — full residual re-enrich still required for product-wide fix.

## Test plan
- [x] `pytest` two new unit tests
- [x] VTS fetch for свіжий full under new code
- [ ] CI green
- [ ] After merge: batch re-enrich truncated lemmas + publish