### PR TITLE
docs(fleet): truth-fix cold-start plane/cutover claims (PR-1 of cold-start-opt)

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -332,27 +332,30 @@ Then run the Entire dual-write steps in §8.
 
 ---
 
-## Fleet-comms state — dual-aware, do not race the cutover
+## Fleet-comms state — dual-aware, cutover is closed
 
-The message plane exists but the `dual_write` cutover is an **operator/advisor-gated
-flip owned by the infra/harness lane** (parity receipt → approved enable). Until it
-flips, **file handoffs remain authoritative** (`session_streams --help` itself says: "do
-not use it to cut over or retire file handoffs").
+The message plane's `authority` cutover is **done**: mode `authority` is the production
+default (operator GO 2026-08-01, closed with evidence on
+[#6159](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6159)).
+Fleet-comms is now durable authority for messages/jobs; legacy broker/channel file
+stores are read-only migration/projection inputs, not a live write target.
 
-- **Check first:** `.venv/bin/python -m scripts.fleet_comms plane-status` and
+- **Cold-start first action:**
+  `.venv/bin/python -m scripts.fleet_comms cold-start-board` — probes fleet/plane/stream
+  state so you orient from live data, never memory.
+- **Check plane state:** `.venv/bin/python -m scripts.fleet_comms plane-status` and
   `.venv/bin/python -m agents_extensions.shared.session_streams dual-write-status`.
-- **While `mode: off` / dual-write:** coordinate via the plane where available AND keep
-  the file handoff current (`.claude/<epic>-epic/*DRIVER-HANDOFF.md` where the epic uses
-  one — gitignored local state; or `docs/session-state/` for infra). Successor-claim
-  diagnostics: `session_streams handoff-status` / `handoff-claim` (#5530).
-- **Plane modes are only `off → shadow → dual_write`** (`plane-status`). In **all** of
-  them the file handoff stays authoritative — `dual_write` is shadow/mirror, **not**
-  cutover, and there is **no implemented post-cutover authority state** today. **Never
-  drop the file handoff on your own.** Retiring file handoffs is a future infra step
-  gated on an implemented authority signal the plane does not yet expose — not a config
-  edit a driver makes.
+  Implemented modes are `off | shadow | dual_write | authority` — do not hard-code a
+  mode in prose; always query it fresh.
+- **File handoff still matters:** fleet-comms is durable authority for messages/jobs,
+  but you still write file continuity where the epic uses one (`.claude/<epic>-epic/
+  *DRIVER-HANDOFF.md` — gitignored local state — or `docs/session-state/` for infra); see
+  the dual-write steps in §8. Successor-claim diagnostics: `session_streams
+  handoff-status` / `handoff-claim` (#5530).
+- **Sealed formal CF is retired** — CF is the direct `ask-<lane>` + PR-post flow in §6,
+  not `review-pr` / sealed `lu-review-*`.
 - **Never** flip the plane, enable retention apply, or invent a competing comms design
-  from this skill — those are the infra lane's gated actions.
+  from this skill — those remain the infra lane's gated actions, even post-cutover.
 
 ---
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -328,7 +328,7 @@ and apply every `unread` or `read-but-not-live-consumed` entry, then run:
 ```
 Record any action or unresolved request in the authoritative file handoff after this
 drain; never claim the handoff is complete because a one-shot worker acknowledged it.
-Then run the Entire dual-write steps in §8.
+Then run the Entire file-handoff steps in §8.
 
 ---
 
@@ -350,7 +350,7 @@ stores are read-only migration/projection inputs, not a live write target.
 - **File handoff still matters:** fleet-comms is durable authority for messages/jobs,
   but you still write file continuity where the epic uses one (`.claude/<epic>-epic/
   *DRIVER-HANDOFF.md` — gitignored local state — or `docs/session-state/` for infra); see
-  the dual-write steps in §8. Successor-claim diagnostics: `session_streams
+  the file-handoff steps in §8. Successor-claim diagnostics: `session_streams
   handoff-status` / `handoff-claim` (#5530).
 - **Sealed formal CF is retired** — CF is the direct `ask-<lane>` + PR-post flow in §6,
   not `review-pr` / sealed `lu-review-*`.

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -17,6 +17,8 @@ caps or live modes.
 
 ## Read first (cold-start order)
 
+0. **Epic drivers:** run `.venv/bin/python -m scripts.fleet_comms cold-start-board` first —
+   it probes fleet/plane/stream state so this list starts from live data, not memory.
 1. Operator contract + model assignment via `GET /api/rules` (offline fallbacks
    under `agents_extensions/shared/rules/`).
 2. This runbook — ownership matrix, experimental ACPX boundary, Kimi routes.

--- a/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
+++ b/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
@@ -3,9 +3,16 @@ session: "Fleet-comms #5512 — operator cutovers are NEXT SESSION primary targe
 date: 2026-07-22
 epic: 5512
 stream: 4707
-status: open
+status: superseded
 priority: P0-next-cold-start
 ---
+
+> **SUPERSEDED — historical-only.** The `dual_write`/plane-cutover queue below predates the
+> completed cutover. Live state: mode `authority` (production default since operator GO
+> 2026-08-01), cutover closed with evidence on
+> [#6159](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6159). Cold-start
+> action is `.venv/bin/python -m scripts.fleet_comms cold-start-board`, not this file's queue.
+> Body kept below for archive/history only — do not execute it.
 
 # 2026-07-22 — Fleet-comms cutover handoff (binding for next cold-start)
 

--- a/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
+++ b/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
@@ -4,7 +4,8 @@ date: 2026-07-22
 epic: 5512
 stream: 4707
 status: superseded
-priority: P0-next-cold-start
+priority: archived
+superseded-by: "#6159"
 ---
 
 > **SUPERSEDED — historical-only.** The `dual_write`/plane-cutover queue below predates the
@@ -14,9 +15,9 @@ priority: P0-next-cold-start
 > action is `.venv/bin/python -m scripts.fleet_comms cold-start-board`, not this file's queue.
 > Body kept below for archive/history only — do not execute it.
 
-# 2026-07-22 — Fleet-comms cutover handoff (binding for next cold-start)
+# 2026-07-22 — Fleet-comms cutover handoff (HISTORICAL — do not execute)
 
-**Do not wait for the operator to restate targets.** On cold-start, orient then **execute** the queue below.
+**Historical body below is not actionable.** On cold-start, run `cold-start-board` and live #4707 / plane-status instead of this queue.
 
 ## NEXT SESSION — PRIMARY TARGETS (binding)
 

--- a/docs/session-state/current.claude-infra.md
+++ b/docs/session-state/current.claude-infra.md
@@ -20,10 +20,12 @@
 3. Use the validated automatic SessionStart rollover output as authoritative. Do not manually parse flat handoff files or leases if a rollover packet was surfaced at startup.
 4. If the SessionStart hook output is unavailable, or the API is down, or the hook explicitly surfaces the legacy file, use the legacy flat file fallback: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local).
 5. Orient via Monitor API (lean cold-start mode): `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true&session=$LEARN_UKRAINIAN_SESSION_ID"`
-6. **BINDING queue (2026-07-22):** read and execute  
-   `docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md`  
-   — fleet-comms **#5512** operator cutovers first (dual_write · retention Gate 5 · cold-start smoke).  
-   Isolation fan-out #5614–#5622 parallel. Do not wait for the operator to restate targets.
+6. **Cold-start board first:** `.venv/bin/python -m scripts.fleet_comms cold-start-board` —
+   fleet-comms cutover is closed (mode `authority` since operator GO 2026-08-01, evidence on
+   [#6159](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6159)); the
+   2026-07-22 dual_write handoff queue is superseded/historical-only, not a binding P0. Live
+   infra queue: stream [#4707](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4707)
+   (`infra-harness`) + `.venv/bin/python -m scripts.fleet_comms plane-status`.
 
 
 ## Lane boundaries


### PR DESCRIPTION
## What
PR-1 of the cold-start-opt plan (`batch_state/cold-start-opt/PLAN-FINAL.md`, gitignored local plan) — WP-E + WP-F + WP-B: truth fixes only, no code, no plane/config flip, no lease ops.

Stream: #4707 (`infra-harness`)

## Changes
- **`agents_extensions/shared/skills/drive-epic/SKILL.md`** — the "Fleet-comms state" section asserted plane modes are "only `off → shadow → dual_write`" and "no implemented post-cutover authority state" exists. That's stale: fleet-comms cutover to `authority` mode closed on 2026-08-01 (operator GO), evidenced on #6159. Rewrote the section to state the live mode, added a `cold-start-board` pointer, and pointed formal-CF language at §6's already-documented retirement of sealed CF.
- **`docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md`** — archived in place: `status: superseded` + a SUPERSEDED/historical-only banner pointing to #6159 closed evidence. Body kept intact (not deleted) for history.
- **`docs/session-state/current.claude-infra.md`** — removed the binding "execute dual_write handoff as P0" cold-start step (item 6); replaced with a `cold-start-board` pointer + live stream #4707 / `plane-status`.
- **`docs/runbooks/agent-seat-onboarding.md`** — added one line at the top of "Read first (cold-start order)" telling epic drivers to run `cold-start-board` first. Rest of the file untouched — it already correctly documented `authority` mode, so no truth-fix was needed there.
- **#6159** — prepended a one-line CLOSED banner and checked all 14 AC checkboxes that the issue's own "Completed cutover evidence" closing comment (2026-08-01) claims complete (merged-PR ledger + authority/migration/telemetry/cleanup receipts quoted per-AC). No new ACs invented.

Note: `cold-start-board` (the CLI these docs now point to) is scoped to PR-2 of the same plan and may land the same day; referencing it ahead of merge is intentional per the plan's sequencing (truth docs first, then the board).

## Evidence (#M-4)
```
$ rg -n 'no implemented post-cutover authority|only `off → shadow → dual_write`|Plane modes are only' agents_extensions/shared/skills/drive-epic/SKILL.md && exit 1 || true
(no output — pattern absent)

$ rg -n 'cold-start-board' agents_extensions/shared/skills/drive-epic/SKILL.md docs/runbooks/agent-seat-onboarding.md
agents_extensions/shared/skills/drive-epic/SKILL.md:344:  `.venv/bin/python -m scripts.fleet_comms cold-start-board` — probes fleet/plane/stream
docs/runbooks/agent-seat-onboarding.md:20:0. **Epic drivers:** run `.venv/bin/python -m scripts.fleet_comms cold-start-board` first —

$ head -20 docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md | rg -i 'superseded|historical|archive'
status: superseded
> **SUPERSEDED — historical-only.** The `dual_write`/plane-cutover queue below predates the
> Body kept below for archive/history only — do not execute it.
```

markdownlint on the 4 touched files: same 19 pre-existing findings before and after this diff (verified via `git stash` compare) — no new lint issues introduced.

#6159 verified live: `gh issue view 6159 --json body -q '.body' | grep -c '\[x\] \*\*AC-'` → 14; `grep -c '\[ \] \*\*AC-'` → 0.

## Residual
- `cold-start-board` itself (new CLI module) is PR-2 scope, not this PR — the docs reference it ahead of merge per plan sequencing.
- Formal CF retirement language already existed in SKILL.md §6 before this PR; only the fleet-comms-state section needed a pointer added.

X-Agent: claude/cold-start-pr1-truth-claude
🤖 Generated with [Claude Code](https://claude.com/claude-code)