### PR TITLE
feat(fleet-comms): authority-aware metrics (cold-start PR-3 / WP-C)

### DIFF
--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -17,7 +17,8 @@ verdict accept). Optional ``--publish`` posts GitHub comment/status via PR-G.
 Does not cut over ``review-pr`` itself.
 
 ``metrics`` / ``backlog`` / ``dead-letters`` are Sol PR-M efficiency surfaces
-(metadata only; never message content).
+(metadata only; never message content). In plane mode ``authority`` they read
+Fleet Comms authority tables by default; ``--legacy`` forces the broker path.
 """
 
 from __future__ import annotations
@@ -35,9 +36,13 @@ from typing import Any
 
 from scripts.fleet_comms.efficiency_metrics import (
     collect_dead_letters,
+    collect_dead_letters_authority,
     collect_delivery_backlog,
+    collect_delivery_backlog_authority,
     collect_efficiency_metrics,
+    collect_efficiency_metrics_authority,
     collect_stream_bottleneck_metrics,
+    resolve_metrics_source,
 )
 from scripts.fleet_comms.github_pr_metrics import collect_github_pr_metrics
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
@@ -101,14 +106,50 @@ def _resolve_message_db(args: argparse.Namespace) -> Path:
     return _default_message_db()
 
 
+def _resolve_plane_db(args: argparse.Namespace) -> Path:
+    root = Path(args.root).expanduser() if getattr(args, "root", None) else default_plane_root()
+    return root / "comms.sqlite3"
+
+
+def _force_legacy(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "legacy", False))
+
+
 def cmd_metrics(args: argparse.Namespace) -> int:
     """Efficiency metrics from durable timestamps (no content)."""
-    db = _resolve_message_db(args)
-    if not db.is_file():
-        sys.stdout.write(_json_dump({"content_included": False, "db_missing": True, "db_path": str(db)}))
-        return EXIT_OK
-    payload = collect_efficiency_metrics(db)
+    source = resolve_metrics_source(force_legacy=_force_legacy(args))
+    if source == "authority":
+        db = _resolve_plane_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "content_included": False,
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
+            )
+            return EXIT_OK
+        payload = collect_efficiency_metrics_authority(db)
+    else:
+        db = _resolve_message_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "content_included": False,
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
+            )
+            return EXIT_OK
+        payload = collect_efficiency_metrics(db)
     payload["db_path"] = str(db)
+    payload["source"] = source
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 
@@ -135,51 +176,99 @@ def cmd_bottleneck_metrics(args: argparse.Namespace) -> int:
 
 def cmd_backlog(args: argparse.Namespace) -> int:
     """Pending delivery backlog excluding retired endpoints by default."""
-    db = _resolve_message_db(args)
-    if not db.is_file():
-        sys.stdout.write(
-            _json_dump(
-                {
-                    "total": 0,
-                    "by_agent": {},
-                    "by_status": {},
-                    "rows": [],
-                    "db_missing": True,
-                    "db_path": str(db),
-                }
+    source = resolve_metrics_source(force_legacy=_force_legacy(args))
+    exclude_retired = not args.include_retired
+    if source == "authority":
+        db = _resolve_plane_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "total": 0,
+                        "by_agent": {},
+                        "by_status": {},
+                        "rows": [],
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
             )
+            return EXIT_OK
+        payload = collect_delivery_backlog_authority(
+            db,
+            limit=args.limit,
+            exclude_retired=exclude_retired,
         )
-        return EXIT_OK
-    payload = collect_delivery_backlog(
-        db,
-        limit=args.limit,
-        exclude_retired=not args.include_retired,
-    )
+    else:
+        db = _resolve_message_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "total": 0,
+                        "by_agent": {},
+                        "by_status": {},
+                        "rows": [],
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
+            )
+            return EXIT_OK
+        payload = collect_delivery_backlog(
+            db,
+            limit=args.limit,
+            exclude_retired=exclude_retired,
+        )
     payload["db_path"] = str(db)
     payload["content_included"] = False
+    payload["source"] = source
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 
 
 def cmd_dead_letters(args: argparse.Namespace) -> int:
     """Dead-letter inventory (metadata only)."""
-    db = _resolve_message_db(args)
-    if not db.is_file():
-        sys.stdout.write(
-            _json_dump(
-                {
-                    "total": 0,
-                    "by_reason": {},
-                    "rows": [],
-                    "db_missing": True,
-                    "db_path": str(db),
-                }
+    source = resolve_metrics_source(force_legacy=_force_legacy(args))
+    if source == "authority":
+        db = _resolve_plane_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "total": 0,
+                        "by_reason": {},
+                        "rows": [],
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
             )
-        )
-        return EXIT_OK
-    payload = collect_dead_letters(db, limit=args.limit)
+            return EXIT_OK
+        payload = collect_dead_letters_authority(db, limit=args.limit)
+    else:
+        db = _resolve_message_db(args)
+        if not db.is_file():
+            sys.stdout.write(
+                _json_dump(
+                    {
+                        "total": 0,
+                        "by_reason": {},
+                        "rows": [],
+                        "db_missing": True,
+                        "db_path": str(db),
+                        "source": source,
+                    }
+                )
+            )
+            return EXIT_OK
+        payload = collect_dead_letters(db, limit=args.limit)
     payload["db_path"] = str(db)
     payload["content_included"] = False
+    payload["source"] = source
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 
@@ -736,6 +825,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
     )
+    metrics.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root for authority reads (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    metrics.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Force broker SQLite even when plane mode is authority (source=legacy_forced)",
+    )
     metrics.set_defaults(func=cmd_metrics)
 
     bottlenecks = sub.add_parser(
@@ -764,6 +863,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
     )
     backlog.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root for authority reads (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    backlog.add_argument(
         "--limit",
         type=int,
         default=100,
@@ -773,6 +877,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-retired",
         action="store_true",
         help="Include retired endpoints such as gemini (default: exclude)",
+    )
+    backlog.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Force broker SQLite even when plane mode is authority (source=legacy_forced)",
     )
     backlog.set_defaults(func=cmd_backlog)
 
@@ -786,10 +895,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
     )
     dead.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root for authority reads (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    dead.add_argument(
         "--limit",
         type=int,
         default=100,
         help="Max dead-letter rows (default: 100)",
+    )
+    dead.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Force broker SQLite even when plane mode is authority (source=legacy_forced)",
     )
     dead.set_defaults(func=cmd_dead_letters)
 

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -1,4 +1,9 @@
-"""Sol PR-M: efficiency metrics from durable broker timestamps (no content)."""
+"""Sol PR-M: efficiency metrics from durable broker timestamps (no content).
+
+WP-C (#cold-start-opt): when the message plane is ``authority``, backlog /
+dead-letters / metrics prefer Fleet Comms authority tables (RO). Legacy broker
+collectors stay byte-compatible; callers add an additive ``source`` label.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +14,9 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+from scripts.fleet_comms.message_plane import resolve_plane_mode
 
 # Alert thresholds are intentionally reported, not enforced here. #5646 owns
 # consuming them. Dispatch uses the delegate default floor of 7,200 seconds.
@@ -17,11 +24,29 @@ DISPATCH_BOTTLENECK_THRESHOLD_S = 7_200
 FORMAL_CF_PUBLICATION_THRESHOLD_S = 3_600
 GATE_TO_MERGE_THRESHOLD_S = 3_600
 
+MetricsSource = Literal["authority", "legacy", "legacy_forced"]
+_AUTHORITY_BACKLOG_STATES = ("queued", "running")
+_RETIRED_AGENTS = frozenset({"gemini"})
+
 
 @contextmanager
 def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
     """Open a read path connection and always close it (sqlite3 `with` only commits)."""
     conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def _connect_ro(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """Open an existing SQLite file read-only (never creates/writes)."""
+    if not db_path.is_file():
+        raise FileNotFoundError(db_path)
+    uri = f"file:{db_path.resolve().as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     try:
         yield conn
@@ -41,6 +66,15 @@ def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(r[1]) for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
 
 
+def resolve_metrics_source(*, force_legacy: bool = False) -> MetricsSource:
+    """Choose metrics read source from plane mode and optional ``--legacy`` force."""
+    if force_legacy:
+        return "legacy_forced"
+    if resolve_plane_mode() == "authority":
+        return "authority"
+    return "legacy"
+
+
 def collect_delivery_backlog(
     db_path: Path,
     *,
@@ -48,7 +82,7 @@ def collect_delivery_backlog(
     exclude_retired: bool = True,
 ) -> dict[str, Any]:
     """Pending/dispatched delivery backlog without message bodies."""
-    retired = {"gemini"}
+    retired = set(_RETIRED_AGENTS)
     with _connect(db_path) as conn:
         if not _table_exists(conn, "deliveries"):
             return {"total": 0, "by_agent": {}, "by_status": {}, "rows": []}
@@ -244,6 +278,180 @@ def collect_efficiency_metrics(db_path: Path) -> dict[str, Any]:
             }
 
         return metrics
+
+
+def _empty_backlog(*, exclude_retired: bool) -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_agent": {},
+        "by_status": {},
+        "exclude_retired": sorted(_RETIRED_AGENTS) if exclude_retired else [],
+        "rows": [],
+    }
+
+
+def collect_delivery_backlog_authority(
+    plane_db: Path,
+    *,
+    limit: int = 100,
+    exclude_retired: bool = True,
+) -> dict[str, Any]:
+    """Authority-plane backlog from ``authority_deliveries`` (queued/running)."""
+    if not plane_db.is_file():
+        return _empty_backlog(exclude_retired=exclude_retired)
+    with _connect_ro(plane_db) as conn:
+        if not _table_exists(conn, "authority_deliveries"):
+            return _empty_backlog(exclude_retired=exclude_retired)
+        placeholders = ",".join("?" for _ in _AUTHORITY_BACKLOG_STATES)
+        rows = conn.execute(
+            f"""
+            SELECT delivery_id, message_id, recipient, state, attempt_count,
+                   created_at, updated_at
+            FROM authority_deliveries
+            WHERE state IN ({placeholders})
+            ORDER BY COALESCE(updated_at, created_at, '') DESC
+            LIMIT ?
+            """,
+            (*_AUTHORITY_BACKLOG_STATES, limit),
+        ).fetchall()
+        by_agent: dict[str, int] = {}
+        by_status: dict[str, int] = {}
+        out_rows: list[dict[str, Any]] = []
+        for r in rows:
+            agent = str(r["recipient"] or "")
+            if exclude_retired and agent in _RETIRED_AGENTS:
+                continue
+            status = str(r["state"] or "")
+            by_agent[agent] = by_agent.get(agent, 0) + 1
+            by_status[status] = by_status.get(status, 0) + 1
+            out_rows.append(
+                {
+                    "delivery_id": r["delivery_id"],
+                    "message_id": r["message_id"],
+                    "to_agent": agent,
+                    "status": status,
+                    "attempt_count": int(r["attempt_count"] or 0),
+                    "dispatched_at": r["updated_at"] or r["created_at"],
+                }
+            )
+        return {
+            "total": len(out_rows),
+            "by_agent": by_agent,
+            "by_status": by_status,
+            "exclude_retired": sorted(_RETIRED_AGENTS) if exclude_retired else [],
+            "rows": out_rows,
+        }
+
+
+def collect_dead_letters_authority(plane_db: Path, *, limit: int = 100) -> dict[str, Any]:
+    """Authority-plane dead letters from ``authority_dead_letters`` (metadata only)."""
+    empty: dict[str, Any] = {"total": 0, "by_reason": {}, "rows": []}
+    if not plane_db.is_file():
+        return empty
+    with _connect_ro(plane_db) as conn:
+        if not _table_exists(conn, "authority_dead_letters"):
+            return empty
+        total = conn.execute("SELECT COUNT(*) AS c FROM authority_dead_letters").fetchone()["c"]
+        by_reason_rows = conn.execute(
+            """
+            SELECT reason_code, COUNT(*) AS c
+            FROM authority_dead_letters
+            GROUP BY reason_code
+            ORDER BY c DESC
+            """
+        ).fetchall()
+        rows = conn.execute(
+            """
+            SELECT dead_letter_id, delivery_id, job_id, reason_code, created_at
+            FROM authority_dead_letters
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return {
+            "total": int(total),
+            "by_reason": {str(r["reason_code"]): int(r["c"]) for r in by_reason_rows},
+            "rows": [
+                {
+                    "dead_letter_id": r["dead_letter_id"],
+                    "delivery_id": r["delivery_id"],
+                    "job_id": r["job_id"],
+                    "reason": r["reason_code"],
+                    "reason_code": r["reason_code"],
+                    "created_at": r["created_at"],
+                }
+                for r in rows
+            ],
+        }
+
+
+def collect_efficiency_metrics_authority(plane_db: Path) -> dict[str, Any]:
+    """Aggregate authority-plane delivery/job efficiency (timestamps only)."""
+    metrics: dict[str, Any] = {
+        "content_included": False,
+        "deliveries": {},
+        "jobs": {},
+        "dead_letters": 0,
+        "latency_seconds": {},
+    }
+    if not plane_db.is_file():
+        return metrics
+    with _connect_ro(plane_db) as conn:
+        if _table_exists(conn, "authority_deliveries"):
+            for r in conn.execute(
+                "SELECT state, COUNT(*) AS c FROM authority_deliveries GROUP BY state"
+            ):
+                metrics["deliveries"][str(r["state"])] = int(r["c"])
+            lat = conn.execute(
+                """
+                SELECT
+                  COUNT(*) AS n,
+                  AVG(
+                    (julianday(completed_at) - julianday(created_at)) * 86400.0
+                  ) AS avg_s,
+                  MIN(
+                    (julianday(completed_at) - julianday(created_at)) * 86400.0
+                  ) AS min_s,
+                  MAX(
+                    (julianday(completed_at) - julianday(created_at)) * 86400.0
+                  ) AS max_s
+                FROM authority_deliveries
+                WHERE completed_at IS NOT NULL
+                  AND completed_at != ''
+                  AND created_at IS NOT NULL
+                  AND created_at != ''
+                """
+            ).fetchone()
+            if lat and lat["n"]:
+                metrics["latency_seconds"]["delivery_created_to_done"] = {
+                    "n": int(lat["n"]),
+                    "avg": round(float(lat["avg_s"] or 0.0), 3),
+                    "min": round(float(lat["min_s"] or 0.0), 3),
+                    "max": round(float(lat["max_s"] or 0.0), 3),
+                }
+            gemini_pending = conn.execute(
+                f"""
+                SELECT COUNT(*) AS c FROM authority_deliveries
+                WHERE recipient = 'gemini'
+                  AND state IN ({",".join("?" for _ in _AUTHORITY_BACKLOG_STATES)})
+                """,
+                _AUTHORITY_BACKLOG_STATES,
+            ).fetchone()["c"]
+            metrics["retired_endpoint_pending"] = {"gemini": int(gemini_pending)}
+
+        if _table_exists(conn, "authority_jobs"):
+            for r in conn.execute(
+                "SELECT state, COUNT(*) AS c FROM authority_jobs GROUP BY state"
+            ):
+                metrics["jobs"][str(r["state"])] = int(r["c"])
+
+        if _table_exists(conn, "authority_dead_letters"):
+            metrics["dead_letters"] = int(
+                conn.execute("SELECT COUNT(*) AS c FROM authority_dead_letters").fetchone()["c"]
+            )
+
+    return metrics
 
 
 def _parse_timestamp(value: object) -> datetime | None:

--- a/tests/fleet_comms/test_efficiency_metrics_authority.py
+++ b/tests/fleet_comms/test_efficiency_metrics_authority.py
@@ -1,0 +1,246 @@
+"""WP-C: authority-aware metrics/backlog/dead-letters (cold-start-opt PR-3)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.fleet_comms.cli import EXIT_OK
+from scripts.fleet_comms.cli import main as cli_main
+from scripts.fleet_comms.efficiency_metrics import (
+    collect_dead_letters,
+    collect_delivery_backlog,
+    collect_delivery_backlog_authority,
+    collect_efficiency_metrics,
+    resolve_metrics_source,
+)
+
+
+def _seed_broker(db: Path) -> None:
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE deliveries (
+          delivery_id TEXT PRIMARY KEY,
+          message_id TEXT,
+          to_agent TEXT,
+          status TEXT,
+          attempt_count INTEGER DEFAULT 0,
+          dispatched_at TEXT,
+          delivered_at TEXT
+        );
+        CREATE TABLE dead_letters (
+          dead_letter_id TEXT PRIMARY KEY,
+          request_id TEXT,
+          delivery_id TEXT,
+          reason TEXT NOT NULL,
+          successor TEXT,
+          original_expires_at TEXT,
+          created_at TEXT NOT NULL
+        );
+        INSERT INTO deliveries VALUES
+          ('broker-d1','m1','claude','pending',0,NULL,NULL),
+          ('broker-d2','m2','codex','dispatched',1,'2026-08-01T10:00:00',NULL);
+        INSERT INTO dead_letters VALUES
+          ('broker-dl1',NULL,'broker-d9','recipient_retired','agy',NULL,'2026-08-01T09:00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_authority_plane(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    plane_db = root / "comms.sqlite3"
+    conn = sqlite3.connect(plane_db)
+    conn.executescript(
+        """
+        CREATE TABLE authority_deliveries (
+          delivery_id TEXT PRIMARY KEY,
+          message_id TEXT NOT NULL,
+          recipient TEXT NOT NULL,
+          state TEXT NOT NULL,
+          deadline_at TEXT,
+          lease_owner TEXT,
+          lease_expires_at TEXT,
+          fence_token INTEGER NOT NULL DEFAULT 0,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          acknowledgment_artifact_id TEXT,
+          terminal_sha256 TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          completed_at TEXT
+        );
+        CREATE TABLE authority_dead_letters (
+          dead_letter_id TEXT PRIMARY KEY,
+          delivery_id TEXT UNIQUE,
+          job_id TEXT UNIQUE,
+          reason_code TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE authority_jobs (
+          job_id TEXT PRIMARY KEY,
+          job_kind TEXT NOT NULL,
+          subject_id TEXT NOT NULL,
+          payload_artifact_id TEXT NOT NULL,
+          state TEXT NOT NULL,
+          deadline_at TEXT,
+          lease_owner TEXT,
+          lease_expires_at TEXT,
+          fence_token INTEGER NOT NULL DEFAULT 0,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          result_artifact_id TEXT,
+          terminal_sha256 TEXT,
+          idempotency_key TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          completed_at TEXT
+        );
+        INSERT INTO authority_deliveries VALUES
+          ('auth-d1','auth-m1','claude','queued',NULL,NULL,NULL,0,0,NULL,NULL,
+           '2026-08-01T12:00:00Z','2026-08-01T12:00:00Z',NULL),
+          ('auth-d2','auth-m2','codex','running',NULL,'worker',NULL,1,1,NULL,NULL,
+           '2026-08-01T12:01:00Z','2026-08-01T12:02:00Z',NULL),
+          ('auth-d3','auth-m3','gemini','queued',NULL,NULL,NULL,0,0,NULL,NULL,
+           '2026-08-01T12:03:00Z','2026-08-01T12:03:00Z',NULL),
+          ('auth-d4','auth-m4','agy','acknowledged',NULL,NULL,NULL,0,1,NULL,'sha',
+           '2026-08-01T11:00:00Z','2026-08-01T11:05:00Z','2026-08-01T11:05:00Z');
+        INSERT INTO authority_dead_letters VALUES
+          ('auth-dl1','auth-d4',NULL,'attempts_exhausted','2026-08-01T11:06:00Z');
+        INSERT INTO authority_jobs VALUES
+          ('auth-j1','request','auth-m1','art1','queued',NULL,NULL,NULL,0,0,NULL,NULL,'k1',
+           '2026-08-01T12:00:00Z','2026-08-01T12:00:00Z',NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
+    return plane_db
+
+
+def _run_cli(argv: list[str], capsys) -> dict:
+    code = cli_main(argv)
+    assert code == EXIT_OK
+    captured = capsys.readouterr()
+    return json.loads(captured.out)
+
+
+def test_resolve_metrics_source_labels(monkeypatch) -> None:
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+    assert resolve_metrics_source() == "authority"
+    assert resolve_metrics_source(force_legacy=True) == "legacy_forced"
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")
+    assert resolve_metrics_source() == "legacy"
+    assert resolve_metrics_source(force_legacy=True) == "legacy_forced"
+
+
+def test_backlog_defaults_authority_when_plane_authority(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    plane_root = tmp_path / "plane"
+    plane_db = _seed_authority_plane(plane_root)
+    broker = tmp_path / "broker.db"
+    _seed_broker(broker)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+
+    payload = _run_cli(
+        ["backlog", "--root", str(plane_root), "--db", str(broker)],
+        capsys,
+    )
+    assert payload["source"] == "authority"
+    assert payload["db_path"] == str(plane_db)
+    assert payload["total"] == 2
+    assert payload["by_agent"] == {"claude": 1, "codex": 1}
+    assert payload["by_status"] == {"queued": 1, "running": 1}
+    assert "gemini" not in payload["by_agent"]
+
+    direct = collect_delivery_backlog_authority(plane_db, exclude_retired=True)
+    assert direct["total"] == 2
+
+    metrics = _run_cli(
+        ["metrics", "--root", str(plane_root), "--db", str(broker)],
+        capsys,
+    )
+    assert metrics["source"] == "authority"
+    assert metrics["deliveries"]["queued"] == 2
+    assert metrics["dead_letters"] == 1
+    assert metrics["jobs"]["queued"] == 1
+
+    dead = _run_cli(
+        ["dead-letters", "--root", str(plane_root), "--db", str(broker)],
+        capsys,
+    )
+    assert dead["source"] == "authority"
+    assert dead["total"] == 1
+    assert dead["by_reason"]["attempts_exhausted"] == 1
+
+
+def test_backlog_legacy_flag_forces_broker(tmp_path: Path, capsys, monkeypatch) -> None:
+    plane_root = tmp_path / "plane"
+    _seed_authority_plane(plane_root)
+    broker = tmp_path / "broker.db"
+    _seed_broker(broker)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+
+    payload = _run_cli(
+        ["backlog", "--legacy", "--root", str(plane_root), "--db", str(broker)],
+        capsys,
+    )
+    assert payload["source"] == "legacy_forced"
+    assert payload["db_path"] == str(broker)
+    assert payload["total"] == 2
+    assert payload["by_agent"] == {"claude": 1, "codex": 1}
+    assert payload["by_status"]["pending"] == 1
+    assert payload["by_status"]["dispatched"] == 1
+
+    dead = _run_cli(
+        ["dead-letters", "--legacy", "--db", str(broker), "--root", str(plane_root)],
+        capsys,
+    )
+    assert dead["source"] == "legacy_forced"
+    assert dead["by_reason"]["recipient_retired"] == 1
+
+
+def test_backlog_unchanged_when_mode_off(tmp_path: Path, capsys, monkeypatch) -> None:
+    """Non-authority modes keep legacy collector shape; source is additive only."""
+    plane_root = tmp_path / "plane"
+    _seed_authority_plane(plane_root)
+    broker = tmp_path / "broker.db"
+    _seed_broker(broker)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")
+
+    baseline = collect_delivery_backlog(broker, exclude_retired=True)
+    payload = _run_cli(
+        ["backlog", "--db", str(broker), "--root", str(plane_root)],
+        capsys,
+    )
+    assert payload["source"] == "legacy"
+    stripped = {k: v for k, v in payload.items() if k not in {"source", "db_path", "content_included"}}
+    # CLI adds db_path/content_included/source; collector keys must match baseline.
+    for key, value in baseline.items():
+        assert stripped[key] == value
+
+    metrics_baseline = collect_efficiency_metrics(broker)
+    metrics = _run_cli(["metrics", "--db", str(broker)], capsys)
+    assert metrics["source"] == "legacy"
+    for key, value in metrics_baseline.items():
+        assert metrics[key] == value
+
+    dead_baseline = collect_dead_letters(broker)
+    dead = _run_cli(["dead-letters", "--db", str(broker)], capsys)
+    assert dead["source"] == "legacy"
+    for key, value in dead_baseline.items():
+        assert dead[key] == value
+
+
+def test_authority_collectors_are_read_only(tmp_path: Path) -> None:
+    plane_db = _seed_authority_plane(tmp_path / "plane")
+    with patch("sqlite3.connect", wraps=sqlite3.connect) as connect:
+        collect_delivery_backlog_authority(plane_db)
+        assert connect.called
+        uri = connect.call_args.args[0]
+        assert isinstance(uri, str)
+        assert uri.startswith("file:")
+        assert "mode=ro" in uri
+        assert connect.call_args.kwargs.get("uri") is True


### PR DESCRIPTION
## Summary
- When `resolve_plane_mode() == authority`, `metrics` / `backlog` / `dead-letters` read Fleet Comms `authority_*` tables (RO) and emit `source: "authority"`.
- Non-authority modes keep the legacy broker collectors byte-compatible and add `source: "legacy"`.
- `--legacy` forces the broker path even in authority mode (`source: "legacy_forced"`). No writes, no plane flip.

Closes nothing directly; stream epic: #4707 (cold-start-opt WP-C).

## Test plan
- [x] `.venv/bin/pytest tests/fleet_comms/test_efficiency_metrics_authority.py tests/test_efficiency_metrics.py -x -q`
- [x] `.venv/bin/ruff check` on owned paths
- [x] `.venv/bin/python -m scripts.fleet_comms backlog` → `source` in `{authority,legacy,legacy_forced}`
- [x] `.venv/bin/python -m scripts.fleet_comms backlog --legacy` → `legacy` in `source`
- [ ] Cross-family review (no auto-merge)


Made with [Cursor](https://cursor.com)