### PR TITLE
fix(launcher): Claude model/effort inject only when asked

### DIFF
--- a/scripts/launchers/claude.sh
+++ b/scripts/launchers/claude.sh
@@ -29,10 +29,13 @@ launcher_adapter_canary() {
 }
 launcher_adapter_exec() {
   local cmd=(claude)
-  # Only pin --model when the caller asked for one; otherwise Claude Code keeps
-  # whatever model is selected in the TUI / user settings.
+  # Only pin --model / --effort when the caller asked for them; otherwise
+  # Claude Code keeps whatever was selected last in the TUI / user settings.
   if [ -n "${LC_MODEL:-}" ]; then
     cmd+=(--model "$LC_MODEL")
+  fi
+  if [ -n "${LC_EFFORT:-}" ]; then
+    cmd+=(--effort "$LC_EFFORT")
   fi
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -49,7 +49,9 @@ $driver_mode
 
 Options:
   -h, --help                 Show this help and exit.
-  --model MODEL              Provider model (default: ${LC_MODEL:-provider default}).
+  --model MODEL              Provider model. Claude: omit to keep last TUI/session model.
+  --effort LEVEL             Claude Code effort for this session (e.g. high, xhigh).
+                             Omit to keep last session effort. Other providers ignore.
   --harness HARNESS          Provider harness (default: ${LC_HARNESS}).
   --epic SELECTOR            Driver lane only; for example: devops or atlas.
   --governor SELECTOR        Codex driver only; one lease-free Sol cycle (AUTO allowed).
@@ -60,7 +62,10 @@ Options:
 
 Environment:
   LAUNCHER_DRY_RUN=1         Validate the route and print a redacted exact would-exec argv.
-  LAUNCHER_MODEL             Default model when --model is omitted.
+  LAUNCHER_MODEL             Default model when --model is omitted (empty for Claude =
+                             last session).
+  LAUNCHER_EFFORT            Default Claude effort when --effort is omitted (empty =
+                             last session).
   LAUNCHER_HARNESS           Default harness when --harness is omitted.
 $provider_env
 
@@ -134,8 +139,9 @@ launcher_clear_foreign_route_state() {
 launcher_defaults() {
   case "$LC_PROVIDER" in
     claude)
-      # Interactive leaves the TUI model alone unless --model / LAUNCHER_MODEL
-      # is set. Driver wrappers pin their own default via LAUNCHER_MODEL.
+      # Both interactive and driver leave model/effort alone unless the caller
+      # sets --model / --effort or LAUNCHER_MODEL / LAUNCHER_EFFORT. Empty means
+      # Claude Code keeps the last TUI/session selection.
       LC_MODEL="${LAUNCHER_MODEL:-}"
       LC_HARNESS="${LAUNCHER_HARNESS:-claude-code}"
       ;;
@@ -161,6 +167,7 @@ launcher_defaults() {
       ;;
     *) launcher_error "unknown provider '$LC_PROVIDER'"; exit 2 ;;
   esac
+  LC_EFFORT="${LAUNCHER_EFFORT:-}"
   LC_ENDPOINT="${LAUNCHER_ENDPOINT:-coding}"
   LC_ISOLATE_CONFIG="${LAUNCHER_ISOLATE_CONFIG:-1}"
   LC_DRY_RUN="${LAUNCHER_DRY_RUN:-0}"
@@ -197,6 +204,12 @@ launcher_parse() {
         shift 2
         ;;
       --model=*) LC_MODEL="${1#*=}"; shift ;;
+      --effort)
+        launcher_need_value "$1" "${2:-}"
+        LC_EFFORT="$2"
+        shift 2
+        ;;
+      --effort=*) LC_EFFORT="${1#*=}"; shift ;;
       --harness)
         launcher_need_value "$1" "${2:-}"
         LC_HARNESS="$2"
@@ -256,12 +269,27 @@ launcher_parse() {
 }
 
 launcher_normalize_model() {
-  # Interactive omits --model unless asked; driver pins Opus 5 via
-  # start-claude-driver.sh. Short aliases normalize to roster identifiers.
+  # Claude omits --model unless asked (interactive and driver). Short aliases
+  # normalize to roster identifiers when a model is provided.
   case "$LC_PROVIDER:$LC_MODEL" in
     claude:fable) LC_MODEL='claude-fable-5' ;;
     claude:sonnet) LC_MODEL='claude-sonnet-5' ;;
     claude:opus|claude:opus-5) LC_MODEL='claude-opus-5' ;;
+  esac
+}
+
+launcher_normalize_effort() {
+  # Claude Code accepts low|medium|high|xhigh|max (and future levels). Empty
+  # means "do not inject --effort" so the last session effort is kept.
+  if [ -z "${LC_EFFORT:-}" ]; then
+    return 0
+  fi
+  case "$LC_EFFORT" in
+    low|medium|high|xhigh|max) return 0 ;;
+    *)
+      launcher_error "unknown --effort '$LC_EFFORT' (expected low|medium|high|xhigh|max)."
+      exit 2
+      ;;
   esac
 }
 
@@ -326,6 +354,10 @@ launcher_validate_mode() {
 launcher_validate_driver_certification() {
   [ "$LC_MODE" = "driver" ] || return 0
   [ "$LC_GOVERNOR" = "0" ] || return 0
+  # Claude may omit --model so the TUI keeps the last session selection.
+  if [ "$LC_PROVIDER" = "claude" ] && [ -z "${LC_MODEL:-}" ]; then
+    return 0
+  fi
   case "$LC_PROVIDER:$LC_MODEL" in
     claude:claude-opus-5|claude:claude-fable-5|claude:claude-sonnet-5|codex:gpt-5.6-terra|codex:gpt-5.6-sol|gemini:gemini-3.6-flash-high|gemini:gemini-3.1-pro-high|grok:grok-4.5)
       return 0
@@ -489,6 +521,7 @@ launcher_main() {
   launcher_defaults
   launcher_parse "$@"
   launcher_normalize_model
+  launcher_normalize_effort
   # Provider adapters are sourced dynamically and consume these values.
   export LC_ENDPOINT LC_ISOLATE_CONFIG
   launcher_resolve_roots

--- a/start-claude-driver.sh
+++ b/start-claude-driver.sh
@@ -3,37 +3,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$ROOT/scripts/lib/launcher_core.sh"
 
-# Default Anthropic driver seat: Opus 5 @ xhigh. Override with --model /
-# LAUNCHER_MODEL, or with --effort (any position; normalized after the
-# selector so launcher_core can forward it to `claude`).
-export LAUNCHER_MODEL="${LAUNCHER_MODEL:-claude-opus-5}"
-
-effort_value="xhigh"
-args=()
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --effort)
-      if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
-        echo "Error: --effort requires a value; run --help." >&2
-        exit 2
-      fi
-      effort_value="$2"
-      shift 2
-      ;;
-    --effort=*)
-      effort_value="${1#*=}"
-      if [ -z "$effort_value" ]; then
-        echo "Error: --effort requires a value; run --help." >&2
-        exit 2
-      fi
-      shift
-      ;;
-    *)
-      args+=("$1")
-      shift
-      ;;
-  esac
-done
-args+=(--effort "$effort_value")
-
-launcher_main claude driver "${args[@]}"
+# Model/effort: inject only when --model / --effort (or LAUNCHER_MODEL /
+# LAUNCHER_EFFORT) are set. Otherwise Claude Code keeps the last session
+# selection — same contract as ./start-claude.sh.
+launcher_main claude driver "$@"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -2,4 +2,8 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$ROOT/scripts/lib/launcher_core.sh"
+
+# Model/effort: inject only when --model / --effort (or LAUNCHER_MODEL /
+# LAUNCHER_EFFORT) are set. Otherwise Claude Code keeps the last session
+# selection — same contract as ./start-claude-driver.sh.
 launcher_main claude interactive "$@"

--- a/tests/test_start_claude_profiles.py
+++ b/tests/test_start_claude_profiles.py
@@ -34,9 +34,21 @@ def test_claude_interactive_keeps_tui_model_unless_explicit() -> None:
     assert default.returncode == sonnet.returncode == 0
     assert fable.returncode == 0
     assert "would exec claude --model" not in default.stdout
+    assert "--effort" not in default.stdout
     assert "would exec claude " in default.stdout
     assert "would exec claude --model claude-fable-5" in fable.stdout
     assert "would exec claude --model claude-sonnet-5" in sonnet.stdout
+
+
+def test_claude_interactive_injects_effort_when_explicit() -> None:
+    result = run_launcher("start-claude.sh", "--effort", "high")
+    assert result.returncode == 0, result.stderr
+    assert "would exec claude --effort high" in result.stdout
+    assert "would exec claude --model" not in result.stdout
+
+    both = run_launcher("start-claude.sh", "--model", "fable", "--effort", "xhigh")
+    assert both.returncode == 0, both.stderr
+    assert "would exec claude --model claude-fable-5 --effort xhigh" in both.stdout
 
 
 @pytest.mark.parametrize("model", ("not-certified", "gpt-5.6-sol"))
@@ -55,11 +67,13 @@ def test_certified_claude_driver_models_are_revalidated() -> None:
     assert untrusted.returncode == 4
 
 
-def test_claude_driver_defaults_to_opus_xhigh() -> None:
+def test_claude_driver_defaults_to_last_session_without_pins() -> None:
+    """No hardwired model/effort — Claude keeps last TUI/session selection."""
     result = run_launcher("start-claude-driver.sh", "--epic", "devops")
     assert result.returncode == 0, result.stderr
-    assert "would exec claude --model claude-opus-5" in result.stdout
-    assert "--effort xhigh" in result.stdout
+    assert "would exec claude " in result.stdout
+    assert "would exec claude --model" not in result.stdout
+    assert "--effort" not in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -73,9 +87,28 @@ def test_claude_driver_defaults_to_opus_xhigh() -> None:
 def test_claude_driver_accepts_effort_before_or_after_epic(argv: tuple[str, ...]) -> None:
     result = run_launcher("start-claude-driver.sh", *argv)
     assert result.returncode == 0, result.stderr
-    assert "would exec claude --model claude-opus-5" in result.stdout
-    assert "--effort high" in result.stdout
-    assert "--effort xhigh" not in result.stdout
+    assert "would exec claude --effort high" in result.stdout
+    assert "would exec claude --model" not in result.stdout
+
+
+def test_claude_driver_injects_model_and_effort_when_explicit() -> None:
+    result = run_launcher(
+        "start-claude-driver.sh",
+        "--epic",
+        "devops",
+        "--model",
+        "fable",
+        "--effort",
+        "high",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "would exec claude --model claude-fable-5 --effort high" in result.stdout
+
+
+def test_claude_rejects_unknown_effort() -> None:
+    result = run_launcher("start-claude.sh", "--effort", "ludicrous")
+    assert result.returncode == 2
+    assert "effort" in result.stderr.lower()
 
 
 def test_native_claude_clears_foreign_route_and_capacity_overrides(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Both `./start-claude.sh` and `./start-claude-driver.sh` now share the same model/effort contract:

- **Inject** `--model` / `--effort` only when the caller sets `--model` / `--effort` or `LAUNCHER_MODEL` / `LAUNCHER_EFFORT`.
- **Otherwise** leave Claude Code alone so it keeps **whatever model and effort were last selected** in the TUI/session.

Removes the driver hardwire of `claude-opus-5` @ `xhigh`.

## Changes

- `start-claude-driver.sh` — thin wrapper like interactive (no default model/effort).
- `scripts/lib/launcher_core.sh` — first-class `--effort` / `LAUNCHER_EFFORT`; allow empty Claude model on driver certification.
- `scripts/launchers/claude.sh` — inject `--effort` when set.
- Tests updated for last-session default + explicit inject paths.

## Usage

```bash
# Keep last Claude model + effort
./start-claude.sh
./start-claude-driver.sh --epic devops

# Pin this session
./start-claude.sh --model fable --effort high
./start-claude-driver.sh --epic devops --model fable --effort high

# Or via env
LAUNCHER_MODEL=claude-fable-5 LAUNCHER_EFFORT=high ./start-claude.sh
```

## Verification

```text
pytest tests/test_start_claude_profiles.py tests/test_start_claude_supervisor.py -q
→ 20 passed
```

X-Agent: grok/claude-launcher-last-session