### PR TITLE
feat(orchestration): enforce closed-loop merged worktree reap

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -19,6 +19,22 @@ The scheduled job never commits work on the operator's behalf and never uses
 pointers are reported as recovery candidates and are never deleted
 automatically.
 
+P0 automatic reaping is restricted to clean `.worktrees/` checkouts whose
+GitHub PR is `MERGED` at the exact local head. Before removal it writes an
+append-only local journal, reserves the path as reap-pending, and creates a
+`refs/reaper-rescue/...` ref. Set `LU_REAPER_DISABLED=1` to stop automatic
+reaps immediately. The first seven days are capped by
+`LU_REAPER_MAX_REAPS_PER_DAY` (default 10); an approved policy lift uses
+`LU_REAPER_LIFT_FIRST_CLASS_CAP=1`. Restore only to a new path under
+`.worktrees/`:
+
+```bash
+.venv/bin/python scripts/orchestration/reap_worktrees.py restore \
+  --restore-ref refs/reaper-rescue/<timestamp>/<branch>-<sha> \
+  --restore-branch <branch> \
+  --restore-worktree .worktrees/dispatch/<agent>/<task>
+```
+
 ## Immediate cleanup after merge
 
 The merge owner removes the exact worktree as soon as GitHub reports the PR
@@ -72,9 +88,8 @@ Each run performs the following in both repository roots:
 
 1. fetches `origin` and prunes deleted remote refs;
 2. prunes stale Git worktree registrations;
-3. removes clean, inactive worktrees that have exact finalized-PR or settled
-   dispatch evidence, plus old detached worktrees already contained by
-   `origin/main`;
+3. automatically removes only clean, inactive worktrees with exact merged-PR
+   head evidence; other legacy/residue classes are observed and skipped;
 4. deletes local branches whose upstream is gone only when their exact head is
    proven merged or is already an ancestor of `origin/main`;
 5. preserves and reports unproven gone branches and orphaned worktree

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.common.repo_root import main_checkout_root
+from scripts.orchestration import reap_worktrees, reaper_lifecycle
 
 ROOT = main_checkout_root(Path(__file__).resolve().parents[2])
 _TASKS_DIR = ROOT / "batch_state" / "tasks"
@@ -312,11 +313,53 @@ def _reap_main_worktree(
             "error": None,
         }
 
+    state_task_id = state.get("task_id")
+    if state_task_id not in (None, task_id):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "unknown ownership: task-state task_id does not match requested task",
+            "error": None,
+        }
+    try:
+        relative = bound_path.relative_to(_DISPATCH_WORKTREES_ROOT)
+    except ValueError:  # guarded above; retain if the filesystem changed.
+        relative = ()
+    expected_agent = str(state.get("agent") or "")
+    if (
+        len(relative.parts) != 2
+        or relative.parts[1] != task_id
+        or not expected_agent
+        or relative.parts[0] != expected_agent
+    ):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "unknown ownership: task binding does not match dispatch path",
+            "error": None,
+        }
+
+    if reaper_lifecycle.is_reap_pending(repo_root, bound_path):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "reap-pending reservation blocks a new task bind",
+            "error": None,
+        }
+
     if not _is_registered_worktree(bound_path, repo_root):
         return {
             "path": str(bound_path),
             "action": "retained",
             "reason": "unknown ownership: path is not a registered git worktree",
+            "error": None,
+        }
+
+    if _git_worktree_is_locked(bound_path, repo_root):
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "registered worktree is locked",
             "error": None,
         }
 
@@ -354,20 +397,38 @@ def _reap_main_worktree(
                 "error": None,
             }
 
-    if not apply:
+    try:
+        rows = reap_worktrees.reap_worktrees(
+            repo_root=repo_root,
+            apply=apply,
+            preserve_then_reap=False,
+            prune_merged_branches=True,
+            target_paths=[bound_path],
+            merged_pr_only=True,
+            require_activity_probe=apply,
+        )
+    except RuntimeError as exc:
         return {
             "path": str(bound_path),
-            "action": "would_remove",
-            "reason": f"task terminal (status={status_str}) and worktree clean",
+            "action": "retained",
+            "reason": "canonical P0 reaper guard failed",
+            "error": str(exc),
+        }
+    if not rows:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "canonical P0 reaper did not evaluate bound path",
             "error": None,
         }
-
-    ok, error = _remove_worktree(bound_path, repo_root)
+    row = rows[0]
     return {
-        "path": str(bound_path),
-        "action": "removed" if ok else "error",
-        "reason": f"task terminal (status={status_str}) and worktree clean",
-        "error": error,
+        "path": row.path,
+        "action": row.action,
+        "reason": row.reason,
+        "error": row.error,
+        "pr": row.pr,
+        "recovery_ref": row.recovery_ref,
     }
 
 

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -23,6 +23,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.orchestration import reaper_lifecycle
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUILD_AGE_HOURS = 6.0
 
@@ -64,6 +66,7 @@ class ReapResult:
     pr: dict[str, Any] | None = None
     error: str | None = None
     branch_pruned: bool = False
+    recovery_ref: str | None = None
 
 
 def sanitized_git_env() -> dict[str, str]:
@@ -624,6 +627,28 @@ def find_needs_finalize_worktrees(repo_root: Path) -> list[dict[str, Any]]:
     return results
 
 
+def adopt_dispatch_worktrees(repo_root: Path) -> list[dict[str, Any]]:
+    """Journal already-mounted dispatch worktrees without inferring ownership.
+
+    Adoption is observation only.  A later enforce pass must still independently
+    prove an exact merged PR head and every P0 guard before it removes anything.
+    """
+    adopted: list[dict[str, Any]] = []
+    for info in list_git_worktrees(repo_root):
+        task_id = _dispatch_task_id(repo_root, info)
+        if task_id is None or not is_under_worktrees(repo_root, info.path):
+            continue
+        row = {
+            "path": str(info.path),
+            "branch": info.branch,
+            "head": info.head,
+            "task_id": task_id,
+        }
+        reaper_lifecycle.append_journal(repo_root, "adopt", **row)
+        adopted.append(row)
+    return adopted
+
+
 def _preserve_dirty_worktree(info: WorktreeInfo) -> str | None:
     branch = info.branch or "detached"
     add_proc = _run(["git", "add", "-A"], cwd=info.path)
@@ -723,103 +748,160 @@ def _reap_qualified_worktree(
             pr=_pr_dict(pr_state),
         )
 
-    if dirty:
-        preserve_error = _preserve_dirty_worktree(info)
-        if preserve_error is not None:
-            return ReapResult(
-                path=str(info.path),
-                branch=info.branch,
-                action="error",
-                reason=f"preserve before reap failed: {reason}",
-                dirty=True,
-                pr=_pr_dict(pr_state),
-                error=preserve_error,
-            )
-        refreshed_head = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
-        if refreshed_head.returncode != 0:
-            return ReapResult(
-                path=str(info.path),
-                branch=info.branch,
-                action="error",
-                reason=f"cannot verify preserved worktree HEAD: {reason}",
-                dirty=True,
-                pr=_pr_dict(pr_state),
-                error=_format_failure(refreshed_head),
-            )
-        expected_head = (refreshed_head.stdout or "").strip()
-
-    current_head_proc = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
-    current_head = (current_head_proc.stdout or "").strip()
-    if current_head_proc.returncode != 0 or not expected_head or current_head != expected_head:
+    if os.environ.get("LU_REAPER_DISABLED") == "1":
         return ReapResult(
             path=str(info.path),
             branch=info.branch,
             action="skipped",
-            reason=f"HEAD changed during cleanup; originally qualified because {reason}",
+            reason="reaper disabled by LU_REAPER_DISABLED=1",
             dirty=dirty,
             pr=_pr_dict(pr_state),
         )
 
-    current_clean = _worktree_clean(info.path)
-    if current_clean is not True:
+    cap_allowed, cap_reason = reaper_lifecycle.cap_allows_reap(repo_root)
+    if not cap_allowed:
         return ReapResult(
             path=str(info.path),
             branch=info.branch,
             action="skipped",
-            reason=f"worktree changed during cleanup; originally qualified because {reason}",
-            dirty=None if current_clean is None else True,
+            reason=cap_reason or "first-class daily reap cap reached",
+            dirty=dirty,
             pr=_pr_dict(pr_state),
         )
 
-    remove_error = _remove_worktree(repo_root, info)
-    if remove_error is not None:
+    pending_marked = False
+    recovery_ref: str | None = None
+    try:
+        # This reservation is intentionally before the final TOCTOU checks.
+        # Scheduler/delegate consumers can reject a new bind while it exists.
+        reaper_lifecycle.mark_reap_pending(
+            repo_root,
+            worktree_path=info.path,
+            branch=info.branch,
+            head=expected_head,
+            task_id=_dispatch_task_id(repo_root, info),
+        )
+        pending_marked = True
+
+        if dirty:
+            preserve_error = _preserve_dirty_worktree(info)
+            if preserve_error is not None:
+                return ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="error",
+                    reason=f"preserve before reap failed: {reason}",
+                    dirty=True,
+                    pr=_pr_dict(pr_state),
+                    error=preserve_error,
+                )
+            refreshed_head = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
+            if refreshed_head.returncode != 0:
+                return ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="error",
+                    reason=f"cannot verify preserved worktree HEAD: {reason}",
+                    dirty=True,
+                    pr=_pr_dict(pr_state),
+                    error=_format_failure(refreshed_head),
+                )
+            expected_head = (refreshed_head.stdout or "").strip()
+
+        current_head_proc = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
+        current_head = (current_head_proc.stdout or "").strip()
+        if current_head_proc.returncode != 0 or not expected_head or current_head != expected_head:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="skipped",
+                reason=f"HEAD changed during cleanup; originally qualified because {reason}",
+                dirty=dirty,
+                pr=_pr_dict(pr_state),
+            )
+
+        current_clean = _worktree_clean(info.path)
+        if current_clean is not True:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="skipped",
+                reason=f"worktree changed during cleanup; originally qualified because {reason}",
+                dirty=None if current_clean is None else True,
+                pr=_pr_dict(pr_state),
+            )
+
+        recovery_ref, recovery_error = reaper_lifecycle.create_recovery_ref(
+            repo_root,
+            branch=info.branch,
+            head=current_head,
+        )
+        if recovery_error is not None:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="error",
+                reason=f"could not create recovery material; {reason}",
+                dirty=dirty,
+                pr=_pr_dict(pr_state),
+                error=recovery_error,
+            )
+
+        remove_error = _remove_worktree(repo_root, info)
+        if remove_error is not None:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="error",
+                reason=reason,
+                dirty=dirty,
+                pr=_pr_dict(pr_state),
+                error=remove_error,
+                recovery_ref=recovery_ref,
+            )
+
+        branch_prune_error = None
+        branch_pruned = False
+        if (
+            prune_merged_branches
+            and pr_state is not None
+            and pr_state.state == "MERGED"
+            and pr_state.head_sha == current_head
+        ):
+            branch_prune_error = _prune_branch(
+                repo_root,
+                info.branch,
+                force=True,
+                expected_head=current_head,
+            )
+            branch_pruned = branch_prune_error is None
+
+        if branch_prune_error is not None:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="removed",
+                reason=f"{reason}; branch prune failed",
+                dirty=dirty,
+                pr=_pr_dict(pr_state),
+                error=branch_prune_error,
+                recovery_ref=recovery_ref,
+            )
+
+        reaper_lifecycle.record_reap_for_cap(repo_root)
         return ReapResult(
             path=str(info.path),
             branch=info.branch,
-            action="error",
+            action="preserved_then_removed" if dirty else "removed",
             reason=reason,
             dirty=dirty,
             pr=_pr_dict(pr_state),
-            error=remove_error,
+            branch_pruned=branch_pruned,
+            recovery_ref=recovery_ref,
         )
-
-    branch_prune_error = None
-    branch_pruned = False
-    if (
-        prune_merged_branches
-        and pr_state is not None
-        and pr_state.state == "MERGED"
-        and pr_state.head_sha == current_head
-    ):
-        branch_prune_error = _prune_branch(
-            repo_root,
-            info.branch,
-            force=True,
-            expected_head=current_head,
-        )
-        branch_pruned = branch_prune_error is None
-
-    if branch_prune_error is not None:
-        return ReapResult(
-            path=str(info.path),
-            branch=info.branch,
-            action="removed",
-            reason=f"{reason}; branch prune failed",
-            dirty=dirty,
-            pr=_pr_dict(pr_state),
-            error=branch_prune_error,
-        )
-
-    return ReapResult(
-        path=str(info.path),
-        branch=info.branch,
-        action="preserved_then_removed" if dirty else "removed",
-        reason=reason,
-        dirty=dirty,
-        pr=_pr_dict(pr_state),
-        branch_pruned=branch_pruned,
-    )
-
+    finally:
+        if pending_marked:
+            reaper_lifecycle.clear_reap_pending(repo_root, info.path)
 
 def _target_filter(target_paths: list[Path] | None) -> set[Path] | None:
     if target_paths is None:
@@ -838,7 +920,7 @@ def reap_worktrees(
     now: float | None = None,
     safe_only: bool = False,
     live_cwds: set[Path] | None = None,
-    merged_pr_only: bool = False,
+    merged_pr_only: bool = True,
     require_activity_probe: bool = False,
 ) -> list[ReapResult]:
     """Evaluate and optionally reap eligible worktrees."""
@@ -909,6 +991,19 @@ def reap_worktrees(
                 pr_states, pr_error = _query_pr_states(repo_root, info.branch)
                 pr_state = _best_pr(pr_states)
 
+            if merged_pr_only and pr_error is not None:
+                results.append(
+                    ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason=f"PR guard unavailable; {pr_error}",
+                        dirty=dirty,
+                        pr=_pr_dict(pr_state),
+                    )
+                )
+                continue
+
             reason = _qualifying_reason(
                 repo_root=repo_root,
                 info=info,
@@ -940,6 +1035,15 @@ def reap_worktrees(
                 )
                 continue
 
+            reaper_lifecycle.append_journal(
+                repo_root,
+                "plan" if apply else "observe",
+                path=str(info.path),
+                branch=info.branch,
+                head=info.head,
+                reason=reason,
+                pr=_pr_dict(pr_state),
+            )
             results.append(
                 _reap_qualified_worktree(
                     repo_root=repo_root,
@@ -966,6 +1070,20 @@ def reap_worktrees(
                 )
             )
 
+    for result in results:
+        event = "reap" if result.action in {"removed", "preserved_then_removed"} else "skip"
+        reaper_lifecycle.append_journal(
+            repo_root,
+            event,
+            path=result.path,
+            branch=result.branch,
+            action=result.action,
+            reason=result.reason,
+            dirty=result.dirty,
+            pr=result.pr,
+            error=result.error,
+            recovery_ref=result.recovery_ref,
+        )
     return results
 
 
@@ -1055,6 +1173,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Repository root to inspect (default: current git worktree root).",
     )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("report", "plan", "apply", "journal", "restore"),
+        help="Optional verb: report/plan are dry-run, apply enforces, journal prints evidence.",
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--dry-run",
@@ -1106,12 +1230,20 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--legacy-classes",
+        action="store_true",
+        help="Enable pre-P0 non-merged cleanup classes for an explicit manual run.",
+    )
+    parser.add_argument(
         "--worktree",
         action="append",
         type=Path,
         default=None,
         help="Limit evaluation to a registered worktree path. Repeatable.",
     )
+    parser.add_argument("--restore-ref", help="Recovery ref to restore from.")
+    parser.add_argument("--restore-branch", help="Branch identity expected for --restore-ref.")
+    parser.add_argument("--restore-worktree", type=Path, help="New .worktrees/ target for restore.")
     return parser
 
 
@@ -1123,11 +1255,27 @@ def main(argv: list[str] | None = None) -> int:
         if args.repo_root
         else primary_checkout_root(resolve_repo_root())
     )
-    apply = bool(args.apply)
-    merged_mode = bool(getattr(args, "merged", False))
+    apply = bool(args.apply) or args.command == "apply"
+    merged_mode = bool(args.merged) or not bool(args.legacy_classes)
     preserve = bool(args.preserve_then_reap)
-    prune = bool(args.prune_merged_branches) or merged_mode
+    prune = bool(args.prune_merged_branches) or bool(args.merged)
     safe_only = bool(args.safe_only) or merged_mode
+    if args.command == "journal":
+        journal = reaper_lifecycle.journal_path(repo_root)
+        print(journal.read_text(encoding="utf-8") if journal.exists() else "")
+        return 0
+    if args.command == "restore":
+        if not (args.restore_ref and args.restore_branch and args.restore_worktree):
+            parser.error("restore requires --restore-ref, --restore-branch, and --restore-worktree")
+        restored, error = reaper_lifecycle.restore_worktree(
+            repo_root,
+            recovery_ref=args.restore_ref,
+            branch=args.restore_branch,
+            worktree_path=args.restore_worktree,
+        )
+        print(json.dumps({"restored": restored, "error": error}, indent=2))
+        return 0 if restored else 2
+
     results = reap_worktrees(
         repo_root=repo_root,
         apply=apply,

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -921,13 +921,19 @@ def reap_worktrees(
     safe_only: bool = False,
     live_cwds: set[Path] | None = None,
     merged_pr_only: bool = True,
-    require_activity_probe: bool = False,
+    require_activity_probe: bool | None = None,
 ) -> list[ReapResult]:
-    """Evaluate and optionally reap eligible worktrees."""
+    """Evaluate and optionally reap eligible worktrees.
+
+    Apply mode requires a process-CWD activity probe unless a caller
+    deliberately overrides that policy.
+    """
     repo_root = repo_root.resolve()
     targets = _target_filter(target_paths)
     results: list[ReapResult] = []
     active_ids = _active_task_ids()
+    if require_activity_probe is None:
+        require_activity_probe = bool(apply)
     if live_cwds is None:
         live_cwds = _live_cwd_paths(repo_root)
     if require_activity_probe and live_cwds is None:

--- a/scripts/orchestration/reaper_lifecycle.py
+++ b/scripts/orchestration/reaper_lifecycle.py
@@ -1,0 +1,262 @@
+"""Durable, fail-closed state for the merged-worktree reaper.
+
+State intentionally lives in ignored ``batch_state/`` rather than a database:
+the JSONL journal is append-only, while the small pending/cap files provide the
+atomic coordination needed around a destructive ``git worktree remove``.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_STATE_RELATIVE = Path("batch_state") / "worktree-reaper"
+_PENDING_NAME = "reap-pending.json"
+_CAP_NAME = "first-class-cap.json"
+_JOURNAL_NAME = "journal.jsonl"
+_FIRST_CLASS_DAYS = 7
+_DEFAULT_MAX_REAPS_PER_DAY = 10
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _state_dir(repo_root: Path) -> Path:
+    return repo_root / _STATE_RELATIVE
+
+
+def journal_path(repo_root: Path) -> Path:
+    return _state_dir(repo_root) / _JOURNAL_NAME
+
+
+def pending_path(repo_root: Path) -> Path:
+    return _state_dir(repo_root) / _PENDING_NAME
+
+
+def _cap_path(repo_root: Path) -> Path:
+    return _state_dir(repo_root) / _CAP_NAME
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _read_mapping(path: Path) -> dict[str, Any]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def append_journal(repo_root: Path, event: str, **evidence: Any) -> None:
+    """Append one fsync'd event; journal failures must stop enforcement."""
+    path = journal_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    row = {
+        "schema_version": "worktree-reaper-journal.v1",
+        "at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "event": event,
+        **evidence,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def mark_reap_pending(
+    repo_root: Path,
+    *,
+    worktree_path: Path,
+    branch: str | None,
+    head: str | None,
+    task_id: str | None,
+) -> None:
+    """Atomically reserve a path before its final deletion checks.
+
+    Consumers that bind dispatch paths can call :func:`is_reap_pending` and
+    refuse reuse while this reservation exists.  The reaper clears it after a
+    terminal remove or any abort path.
+    """
+    path = pending_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.seek(0)
+        try:
+            current = json.load(handle)
+        except json.JSONDecodeError:
+            current = {}
+        if not isinstance(current, dict):
+            current = {}
+        entries = current.get("paths")
+        if not isinstance(entries, dict):
+            entries = {}
+        entries[str(worktree_path.resolve())] = {
+            "branch": branch,
+            "head": head,
+            "task_id": task_id,
+            "marked_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        }
+        _atomic_write(path, {"schema_version": "worktree-reaper-pending.v1", "paths": entries})
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def clear_reap_pending(repo_root: Path, worktree_path: Path) -> None:
+    path = pending_path(repo_root)
+    if not path.exists():
+        return
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.seek(0)
+        try:
+            current = json.load(handle)
+        except json.JSONDecodeError:
+            current = {}
+        entries = current.get("paths") if isinstance(current, dict) else None
+        if isinstance(entries, dict):
+            entries.pop(str(worktree_path.resolve()), None)
+            _atomic_write(path, {"schema_version": "worktree-reaper-pending.v1", "paths": entries})
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def is_reap_pending(repo_root: Path, worktree_path: Path) -> bool:
+    entries = _read_mapping(pending_path(repo_root)).get("paths")
+    return isinstance(entries, dict) and str(worktree_path.resolve()) in entries
+
+
+def _max_reaps_per_day() -> int:
+    raw = os.environ.get("LU_REAPER_MAX_REAPS_PER_DAY")
+    if raw is None:
+        return _DEFAULT_MAX_REAPS_PER_DAY
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_REAPS_PER_DAY
+    return max(0, parsed)
+
+
+def cap_allows_reap(repo_root: Path, *, now: datetime | None = None) -> tuple[bool, str | None]:
+    """Apply the first-seven-days daily cap unless the policy flag lifts it."""
+    if os.environ.get("LU_REAPER_LIFT_FIRST_CLASS_CAP") == "1":
+        return True, None
+    current = now or utc_now()
+    state = _read_mapping(_cap_path(repo_root))
+    enabled_raw = state.get("enabled_at")
+    try:
+        enabled_at = datetime.fromisoformat(str(enabled_raw).replace("Z", "+00:00"))
+    except ValueError:
+        enabled_at = current
+    if (current - enabled_at).days >= _FIRST_CLASS_DAYS:
+        return True, None
+    counts = state.get("counts")
+    count = counts.get(current.date().isoformat(), 0) if isinstance(counts, dict) else 0
+    if isinstance(count, int) and count >= _max_reaps_per_day():
+        return False, f"first-class daily reap cap reached ({_max_reaps_per_day()})"
+    return True, None
+
+
+def record_reap_for_cap(repo_root: Path, *, now: datetime | None = None) -> None:
+    current = now or utc_now()
+    path = _cap_path(repo_root)
+    state = _read_mapping(path)
+    counts = state.get("counts") if isinstance(state.get("counts"), dict) else {}
+    day = current.date().isoformat()
+    previous = counts.get(day, 0)
+    counts[day] = previous + 1 if isinstance(previous, int) else 1
+    state = {
+        "schema_version": "worktree-reaper-first-class-cap.v1",
+        "enabled_at": state.get("enabled_at")
+        or current.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "counts": counts,
+    }
+    _atomic_write(path, state)
+
+
+def create_recovery_ref(
+    repo_root: Path,
+    *,
+    branch: str | None,
+    head: str,
+) -> tuple[str | None, str | None]:
+    """Pin the exact pre-reap commit under a private local rescue ref."""
+    label = re.sub(r"[^A-Za-z0-9._/-]+", "-", branch or "detached").strip("./-")
+    label = label or "detached"
+    stamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+    ref = f"refs/reaper-rescue/{stamp}/{label}-{head[:12]}"
+    proc = subprocess.run(
+        ["git", "update-ref", ref, head],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or "git update-ref failed").strip()
+    return ref, None
+
+
+def restore_worktree(
+    repo_root: Path,
+    *,
+    recovery_ref: str,
+    branch: str,
+    worktree_path: Path,
+) -> tuple[bool, str | None]:
+    """Reconstruct a reaped dispatch worktree from its rescue ref.
+
+    This deliberately never moves old directories: Git recreates the checkout
+    from the recovery ref after the target and branch identity are verified.
+    """
+    target = worktree_path.resolve()
+    try:
+        target.relative_to((repo_root / ".worktrees").resolve())
+    except ValueError:
+        return False, "restore target is outside repo .worktrees/"
+    if target.exists():
+        return False, "restore target already exists"
+    resolved = subprocess.run(
+        ["git", "rev-parse", "--verify", recovery_ref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if resolved.returncode != 0:
+        return False, "recovery ref is unavailable"
+    sha = (resolved.stdout or "").strip()
+    branch_ref = subprocess.run(
+        ["git", "rev-parse", "--verify", f"refs/heads/{branch}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if branch_ref.returncode == 0 and (branch_ref.stdout or "").strip() != sha:
+        return False, "branch no longer matches recovery ref"
+    command = ["git", "worktree", "add"]
+    if branch_ref.returncode == 0:
+        command.extend([str(target), branch])
+    else:
+        command.extend(["-b", branch, str(target), sha])
+    proc = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "git worktree add failed").strip()
+    return True, None

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -399,7 +399,14 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
             merged_pr_only=True,
         )
         result["results"] = [asdict(row) for row in rows]
-        result["adopted"] = reap_worktrees.adopt_dispatch_worktrees(repo_root)
+        try:
+            result["adopted"] = reap_worktrees.adopt_dispatch_worktrees(repo_root)
+        except Exception as exc:
+            # Adoption only journals currently mounted dispatch worktrees.  A
+            # broken or incomplete repository must not prevent the remaining
+            # local hygiene steps from running.
+            result["adopted"] = []
+            result["errors"].append(f"adoption skipped: {exc}")
         result["errors"].extend(
             f"{row.path}: {row.error or row.reason}"
             for row in rows

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -347,10 +347,12 @@ def _empty_repo_result(repo_root: Path) -> dict[str, Any]:
         "worktree_prune": None,
         "activity_probe": None,
         "results": [],
+        "adopted": [],
         "branches": [],
         "maintenance": None,
         "orphans": [],
         "errors": [],
+        "reaper_disabled": False,
         "needs_finalize_worktrees": [],
     }
 
@@ -392,15 +394,22 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
             prune_merged_branches=True,
             safe_only=True,
             live_cwds=live_cwds,
-            merged_pr_only=False,
+            # P0 automatic enforcement is deliberately limited to exact merged
+            # heads.  Legacy settled/open-PR classes remain manual-only.
+            merged_pr_only=True,
         )
         result["results"] = [asdict(row) for row in rows]
+        result["adopted"] = reap_worktrees.adopt_dispatch_worktrees(repo_root)
         result["errors"].extend(
             f"{row.path}: {row.error or row.reason}"
             for row in rows
             if row.action == "error"
         )
-        branches = cleanup_gone_local_branches(repo_root, apply=apply)
+        if apply and os.environ.get("LU_REAPER_DISABLED") == "1":
+            branches = []
+            result["reaper_disabled"] = True
+        else:
+            branches = cleanup_gone_local_branches(repo_root, apply=apply)
         result["branches"] = branches
         result["errors"].extend(
             f"{row['branch']}: {row.get('error') or row['reason']}"

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -689,6 +689,42 @@ def test_apply_cli_requires_process_activity_probe(
         rw.main(["--repo-root", str(repo), "--apply", "--merged"])
 
 
+def test_apply_default_requires_process_activity_probe_before_removal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/probe-default")
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: None)
+    patch_gh(monkeypatch, {"codex/probe-default": [{"number": 72, "state": "MERGED"}]})
+
+    with pytest.raises(
+        RuntimeError,
+        match="process-CWD activity probe unavailable",
+    ):
+        rw.reap_worktrees(repo_root=repo, apply=True)
+
+    assert worktree.exists()
+
+
+def test_apply_default_accepts_explicit_empty_live_cwds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/empty-live-cwds")
+    patch_gh(monkeypatch, {"codex/empty-live-cwds": [{"number": 73, "state": "MERGED"}]})
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert not worktree.exists()
+
+
 def test_reaper_lock_rejects_concurrent_cleanup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 
 from scripts.orchestration import reap_worktrees as rw
+from scripts.orchestration import reaper_lifecycle
 
 _REAL_RUN = subprocess.run
 
@@ -44,7 +45,7 @@ def init_repo(tmp_path: Path) -> Path:
     git(tmp_path, "init", "--initial-branch=main", str(repo))
     git(repo, "config", "user.email", "tester@example.com")
     git(repo, "config", "user.name", "Test User")
-    (repo / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+    (repo / ".gitignore").write_text(".worktrees/\nbatch_state/\n", encoding="utf-8")
     (repo / "README.md").write_text("base\n", encoding="utf-8")
     git(repo, "add", ".gitignore", "README.md")
     git(repo, "commit", "-m", "base")
@@ -223,7 +224,7 @@ def test_pushed_origin_clean_worktree_is_removed(
     git(worktree, "push", "-u", "origin", "codex/pushed")
     patch_gh(monkeypatch, {})
 
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
 
     result = result_for(results, worktree)
     assert result.action == "removed"
@@ -299,7 +300,7 @@ def test_class_a_settled_dispatch_removed(
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     patch_gh(monkeypatch, {"codex/5102-raisa": []})
 
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     result = result_for(results, worktree_path)
     assert result.action == "removed"
     assert "settled dispatch" in result.reason
@@ -326,7 +327,7 @@ def test_class_a_no_deliverable_dispatch_removed(
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     patch_gh(monkeypatch, {"codex/5800-false-success": []})
 
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     result = result_for(results, worktree_path)
     assert result.action == "removed"
     assert "settled dispatch" in result.reason
@@ -351,18 +352,18 @@ def test_class_a_fail_safe_skips(
     # Case 1: active task
     monkeypatch.setattr(rw, "_active_task_ids", lambda: {task_id})
     patch_gh(monkeypatch, {"codex/5102-raisa-fail": []})
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Case 2: API down
     monkeypatch.setattr(rw, "_active_task_ids", lambda: None)
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Case 3: missing task file
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     task_file.unlink()
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Re-create task file for remaining cases — live worker PID required
@@ -371,7 +372,7 @@ def test_class_a_fail_safe_skips(
     )
 
     # Case 4: task status is not done/failed and worker PID is live
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Set status back to done (no live pid)
@@ -379,7 +380,7 @@ def test_class_a_fail_safe_skips(
 
     # Case 5: dirty tree
     (worktree_path / "dirty.txt").write_text("uncommitted change", encoding="utf-8")
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Clean up dirty file
@@ -388,12 +389,12 @@ def test_class_a_fail_safe_skips(
     # Case 6: open PR but worktree not matching origin tip → keep
     monkeypatch.setattr(rw, "_origin_matches_head", lambda _path, _branch: False)
     patch_gh(monkeypatch, {"codex/5102-raisa-fail": [{"number": 42, "state": "OPEN"}]})
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
     # Case 7: open PR + clean tip already on origin → free local worktree
     monkeypatch.setattr(rw, "_origin_matches_head", lambda _path, _branch: True)
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     result = result_for(results, worktree_path)
     assert result.action == "removed"
     assert "open PR remains on remote" in (result.reason or "")
@@ -417,7 +418,7 @@ def test_class_b_detached_head_removed(
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
 
     # Check it is removed because age > 24h and no matching task
-    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now, merged_pr_only=False)
     result = result_for(results, worktree_path)
     assert result.action == "removed"
     assert "detached HEAD ancestor of origin/main" in result.reason
@@ -445,7 +446,7 @@ def test_class_b_settled_task_removed(
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
 
     # Check it is removed even if age is fresh (e.g. 0h) because task is settled
-    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     result = result_for(results, worktree_path)
     assert result.action == "removed"
     assert "detached HEAD ancestor of origin/main; settled dispatch task-id=detached-task" in result.reason
@@ -469,7 +470,7 @@ def test_class_b_fail_safe_skips(
     os.utime(worktree_path, (old, old))
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
 
-    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now)
+    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
 
@@ -625,6 +626,7 @@ def test_closed_pr_requires_matching_worktree_head(
         apply=True,
         safe_only=True,
         live_cwds=set(),
+        merged_pr_only=False,
     )
 
     assert result_for(results, matching).action == "removed"
@@ -749,3 +751,120 @@ def test_merged_flag_does_not_remove_settled_dispatch_without_merged_pr(
 
     assert rc == 0
     assert worktree.exists()
+
+
+def test_p0_merged_dispatch_reap_journals_recovery_and_restores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "p0-round-trip"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/p0-round-trip", path=worktree)
+    head = git(worktree, "rev-parse", "HEAD")
+    patch_gh(monkeypatch, {"codex/p0-round-trip": [{"number": 71, "state": "MERGED"}]})
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.recovery_ref is not None
+    assert not worktree.exists()
+    assert reaper_lifecycle.is_reap_pending(repo, worktree) is False
+    journal = reaper_lifecycle.journal_path(repo).read_text(encoding="utf-8")
+    assert '"event": "plan"' in journal
+    assert '"event": "reap"' in journal
+
+    restored, error = reaper_lifecycle.restore_worktree(
+        repo,
+        recovery_ref=result.recovery_ref,
+        branch="codex/p0-round-trip",
+        worktree_path=worktree,
+    )
+    assert restored is True
+    assert error is None
+    assert git(worktree, "rev-parse", "HEAD") == head
+
+
+def test_p0_gh_guard_failure_never_deletes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "gh-unavailable"
+    add_worktree(repo, "codex/gh-unavailable", path=worktree)
+    monkeypatch.setattr(rw, "_query_pr_states", lambda _repo, _branch: ([], "gh timeout"))
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert result.reason == "PR guard unavailable; gh timeout"
+    assert worktree.exists()
+
+
+def test_p0_daily_cap_is_configurable_and_policy_lift_overrides_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "cap"
+    add_worktree(repo, "codex/cap", path=worktree)
+    patch_gh(monkeypatch, {"codex/cap": [{"number": 72, "state": "MERGED"}]})
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "0")
+
+    capped = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+    assert capped.action == "skipped"
+    assert "daily reap cap" in capped.reason
+
+    monkeypatch.setenv("LU_REAPER_LIFT_FIRST_CLASS_CAP", "1")
+    lifted = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+    assert lifted.action == "removed"
+
+
+def test_p0_kill_switch_keeps_eligible_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "disabled"
+    add_worktree(repo, "codex/disabled", path=worktree)
+    patch_gh(monkeypatch, {"codex/disabled": [{"number": 73, "state": "MERGED"}]})
+    monkeypatch.setenv("LU_REAPER_DISABLED", "1")
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert result.reason == "reaper disabled by LU_REAPER_DISABLED=1"
+    assert worktree.exists()
+
+
+def test_adoption_journals_existing_dispatch_worktree(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "adopt-me"
+    add_worktree(repo, "codex/adopt-me", path=worktree)
+
+    adopted = rw.adopt_dispatch_worktrees(repo)
+
+    assert adopted == [
+        {
+            "path": str(worktree),
+            "branch": "codex/adopt-me",
+            "head": git(worktree, "rev-parse", "HEAD"),
+            "task_id": "adopt-me",
+        }
+    ]
+    assert '"event": "adopt"' in reaper_lifecycle.journal_path(repo).read_text(encoding="utf-8")

--- a/tests/review/test_temp_lifecycle.py
+++ b/tests/review/test_temp_lifecycle.py
@@ -137,6 +137,12 @@ def test_fetch_failure_degrades_gracefully(tmp_path: Path, monkeypatch: pytest.M
     monkeypatch.setattr(scheduled_worktree_cleanup, "_worktree_prune", lambda r, apply: {"ok": True})
     monkeypatch.setattr(reap_worktrees, "_live_cwd_paths", lambda r: set())
     monkeypatch.setattr(reap_worktrees, "reap_worktrees", lambda **kw: [])
+    monkeypatch.setattr(
+        reap_worktrees,
+        "adopt_dispatch_worktrees",
+        lambda r: (_ for _ in ()).throw(RuntimeError("adoption probe failed")),
+    )
+    monkeypatch.setattr(reap_worktrees, "find_needs_finalize_worktrees", lambda r: [])
     monkeypatch.setattr(scheduled_worktree_cleanup, "cleanup_gone_local_branches", lambda r, apply: [])
     monkeypatch.setattr(scheduled_worktree_cleanup, "find_orphaned_worktree_directories", lambda r: [])
     monkeypatch.setattr(scheduled_worktree_cleanup, "_git_maintenance", lambda r, apply: {"ok": True})
@@ -144,6 +150,8 @@ def test_fetch_failure_degrades_gracefully(tmp_path: Path, monkeypatch: pytest.M
 
     res = scheduled_worktree_cleanup._repo_result_unlocked(repo, apply=False)
     assert any("fetch failed" in err for err in res["errors"])
+    assert res["adopted"] == []
+    assert "adoption skipped: adoption probe failed" in res["errors"]
     assert res["worktree_prune"] is not None
     assert res["maintenance"] is not None
 

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -46,6 +46,16 @@ def hermetic_reap(monkeypatch, tmp_path):
 
     # Tests control process liveness so we stay independent of lsof availability.
     monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: False)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+
+    def merged_pr(_repo: Path, branch: str | None):
+        if branch is None:
+            return [], None
+        proc = _run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo_root)
+        head = (proc.stdout or "").strip() if proc.returncode == 0 else None
+        return [post_task_reap.reap_worktrees.PullRequestState(1, "MERGED", head)], None
+
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", merged_pr)
 
     return repo_root, tasks_dir
 
@@ -184,7 +194,7 @@ def test_clean_terminal_reap_dry_run(hermetic_reap):
     report = post_task_reap.post_task_reap("clean-task", tasks_dir=tasks_dir, repo_root=repo_root)
 
     assert report["main_worktree"]["action"] == "would_remove"
-    assert "terminal" in report["main_worktree"]["reason"]
+    assert report["main_worktree"]["reason"] == "PR #1 MERGED"
     assert worktree.exists()
 
 
@@ -246,6 +256,25 @@ def test_ambiguous_retain_unregistered_directory(hermetic_reap):
     assert report["main_worktree"]["action"] == "retained"
     assert "not a registered git worktree" in report["main_worktree"]["reason"]
     assert bogus.exists()
+
+
+def test_reap_pending_reservation_refuses_bound_task(hermetic_reap):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pending-task")
+    _write_task_state(tasks_dir, "pending-task", "done", worktree)
+    post_task_reap.reaper_lifecycle.mark_reap_pending(
+        repo_root,
+        worktree_path=worktree,
+        branch="kimi/pending-task",
+        head=_run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip(),
+        task_id="pending-task",
+    )
+
+    report = post_task_reap.post_task_reap("pending-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert report["main_worktree"]["reason"] == "reap-pending reservation blocks a new task bind"
+    assert worktree.exists()
 
 
 def test_main_worktree_retain_when_pid_alive(hermetic_reap, monkeypatch):


### PR DESCRIPTION
## Summary
- Enforces P0 cleanup only for clean exact-MERGED worktree heads; schedule and terminal cleanup use the canonical guard path.
- Adds append-only local journal, atomic reap-pending marker, rescue refs and verified restore, 7-day cap, kill switch, and legacy adoption observations.
- Tightens task/path binding and documents the kill switch and restore command.

## Binding authority
- `batch_state/comms-elegance-plan/OPERATOR-APPROVED-R3.md`
- Stream epic #4707; related #4956 and #5340.

## Acceptance evidence
- [x] eligible merged-clean fixture reaps with recovery ref and restores identical HEAD
- [x] dirty/open/live/bound/guard-failure paths retain
- [x] gh failure causes zero deletion
- [x] reap-pending reservation blocks a bound task path
- [x] first-class cap and `LU_REAPER_DISABLED=1` prevent deletion
- [x] unregistered/unknown residue remains observed, not deleted

Kill switch: set `LU_REAPER_DISABLED=1` to stop automatic reap and merged-branch pruning.

## Verification
- `.venv/bin/ruff check ...`
- `.venv/bin/python -m pytest tests/orchestration/test_reap_worktrees.py tests/test_fleet_post_task_reap.py tests/orchestration/test_scheduled_worktree_cleanup.py -q` — 71 passed
- `npx markdownlint-cli2 docs/runbooks/worktree-cleanup.md`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

X-Agent: codex/p0-auto-reap-closed-loop