### PR TITLE
fix(acp): preserve responses on terminalization conflicts

### DIFF
--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -283,7 +283,7 @@ def _run_compat_ask_impl(
 
     from agent_runtime.runner import invoke_inter_agent
 
-    from scripts.fleet_comms.authority import AuthorityService
+    from scripts.fleet_comms.authority import AuthorityService, AuthorityServiceError
 
     key = _idempotency_key(
         participant=participant,
@@ -293,6 +293,7 @@ def _run_compat_ask_impl(
         effort=effort,
     )
     worker_id = f"acp-compat:{os.getpid()}"
+    terminalization_error: Exception | None = None
     with AuthorityService() as authority:
         job = authority.enqueue_request(
             recipient=participant,
@@ -306,13 +307,25 @@ def _run_compat_ask_impl(
             },
             idempotency_key=key,
         )
-        if job.state in {"complete", "failed", "expired", "dead_lettered"}:
+        terminal_states = {"complete", "failed", "expired", "dead_lettered"}
+        if job.state not in terminal_states:
+            try:
+                lease = authority.claim_job(
+                    job.job_id, worker_id, lease_seconds=hard_timeout + 30
+                )
+            except AuthorityServiceError:
+                # A concurrent terminalizer may win after enqueue_request() returns.
+                # Re-read before invoking a provider so an already-durable result is
+                # replayed instead of spending another provider invocation.
+                job = authority.get_job(job.job_id)
+                if job.state not in terminal_states:
+                    raise
+        if job.state in terminal_states:
             replay = authority.read_job_result(job.job_id)
             if replay is None:
                 raise RuntimeError(f"terminal ACP job {job.job_id} has no result receipt")
             result = _replay_result(replay)
         else:
-            lease = authority.claim_job(job.job_id, worker_id, lease_seconds=hard_timeout + 30)
             previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
             os.environ["LU_ACPX_TRANSPORT"] = "active"
             try:
@@ -362,18 +375,24 @@ def _run_compat_ask_impl(
                     os.environ.pop("LU_ACPX_TRANSPORT", None)
                 else:
                     os.environ["LU_ACPX_TRANSPORT"] = previous_transport
-            authority.finish_job(
-                job.job_id,
-                worker_id=worker_id,
-                fence_token=lease.fence_token,
-                state="complete" if bool(getattr(result, "ok", False)) else "failed",
-                result=_result_receipt(result),
-                failure=(
-                    None
-                    if bool(getattr(result, "ok", False))
-                    else _failure_metadata(result=result)
-                ),
-            )
+            try:
+                authority.finish_job(
+                    job.job_id,
+                    worker_id=worker_id,
+                    fence_token=lease.fence_token,
+                    state="complete" if bool(getattr(result, "ok", False)) else "failed",
+                    result=_result_receipt(result),
+                    failure=(
+                        None
+                        if bool(getattr(result, "ok", False))
+                        else _failure_metadata(result=result)
+                    ),
+                )
+            except Exception as exc:
+                # Provider output is the user-visible result.  Do not lose it when
+                # a concurrent terminalizer or another authority failure rejects
+                # bookkeeping after a completed invocation.
+                terminalization_error = exc
     response = str(getattr(result, "response", ""))
     if output_path:
         Path(output_path).write_text(response, encoding="utf-8")
@@ -384,4 +403,11 @@ def _run_compat_ask_impl(
         f"outcome={getattr(result, 'transport_outcome', None) or 'error'}",
         file=sys.stderr,
     )
+    if terminalization_error is not None:
+        message = (
+            "ACP terminal bookkeeping failed after provider response: "
+            f"{terminalization_error}"
+        )
+        print(message, file=sys.stderr)
+        raise RuntimeError(message) from terminalization_error
     return result

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -104,6 +105,122 @@ def test_terminal_failure_replays_without_invoking_provider_again(
     assert replay.transport_outcome == "error"
     assert replay.usage_record == {"replayed": True, "transport": "acp"}
     assert invoke.call_count == 1
+
+
+def test_terminalization_conflict_preserves_completed_provider_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A bookkeeping collision must not hide the completed provider response."""
+    from scripts.fleet_comms.authority import AuthorityStaleLeaseError
+
+    class TerminalConflictAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_request(self, **_kwargs):
+            return SimpleNamespace(job_id="job-6367", state="queued")
+
+        def claim_job(self, *_args, **_kwargs):
+            return SimpleNamespace(fence_token=1)
+
+        def finish_job(self, *_args, **_kwargs):
+            raise AuthorityStaleLeaseError("terminalization_conflict")
+
+    @contextmanager
+    def execution_cwd(*_args, **_kwargs):
+        yield tmp_path
+
+    provider_result = SimpleNamespace(
+        ok=True,
+        agent="agy",
+        model="gemini-3.6-flash-high",
+        response="completed provider response",
+        stderr_excerpt=None,
+        duration_s=1.0,
+        returncode=0,
+        effort="high",
+        transport_metadata=None,
+        transport_outcome="ok",
+    )
+    invoke = Mock(return_value=provider_result)
+    output_path = tmp_path / "response.txt"
+    monkeypatch.setattr("scripts.fleet_comms.authority.AuthorityService", TerminalConflictAuthority)
+    monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+    monkeypatch.setattr("ai_agent_bridge._acp_execution.acp_execution_cwd", execution_cwd)
+
+    with pytest.raises(RuntimeError, match="terminal bookkeeping failed after provider response"):
+        _acp_compat._run_compat_ask_impl(
+            "agy",
+            "question",
+            task_id="terminalization-conflict",
+            model="gemini-3.6-flash-high",
+            effort="high",
+            output_path=str(output_path),
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out == "completed provider response\n"
+    assert "terminalization_conflict" in captured.err
+    assert output_path.read_text(encoding="utf-8") == "completed provider response"
+    assert invoke.call_count == 1
+
+
+def test_claim_race_to_terminal_replays_without_invoking_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal race after enqueue must replay instead of spending a provider call."""
+    from scripts.fleet_comms.authority import AuthorityServiceError
+
+    replay_result = SimpleNamespace(
+        ok=True,
+        agent="agy",
+        model="gemini-3.6-flash-high",
+        response="durably completed response",
+        stderr_excerpt=None,
+        duration_s=1.0,
+        returncode=0,
+        effort="high",
+        transport_metadata=None,
+        transport_outcome="ok",
+    )
+
+    class ConcurrentTerminalAuthority:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def enqueue_request(self, **_kwargs):
+            return SimpleNamespace(job_id="job-race", state="queued")
+
+        def claim_job(self, *_args, **_kwargs):
+            raise AuthorityServiceError("job_not_claimable")
+
+        def get_job(self, _job_id):
+            return SimpleNamespace(job_id="job-race", state="complete")
+
+        def read_job_result(self, _job_id):
+            return _acp_compat._result_receipt(replay_result)
+
+    invoke = Mock(side_effect=AssertionError("terminal job reinvoked provider"))
+    monkeypatch.setattr("scripts.fleet_comms.authority.AuthorityService", ConcurrentTerminalAuthority)
+    monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+
+    result = _acp_compat._run_compat_ask_impl(
+        "agy",
+        "question",
+        task_id="terminal-claim-race",
+        model="gemini-3.6-flash-high",
+        effort="high",
+    )
+
+    assert result.response == "durably completed response"
+    assert result.usage_record == {"replayed": True, "transport": "acp"}
+    assert invoke.call_count == 0
 
 
 def test_cli_returns_nonzero_for_replayed_or_live_failure(

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -243,6 +243,43 @@ def test_exact_claim_and_terminal_result_replay_do_not_take_unrelated_work(tmp_p
         assert service.get_job(older.job_id).state == "queued"
 
 
+def test_finish_job_matching_terminal_replay_is_idempotent(tmp_path: Path) -> None:
+    with AuthorityService(root=_root(tmp_path)) as service:
+        job = service.enqueue_request(
+            recipient="agy", body="idempotent finish", idempotency_key="terminal-replay"
+        )
+        lease = service.claim_job(job.job_id, "worker", now="2036-06-01T00:00:00Z")
+        first = service.finish_job(
+            job.job_id,
+            worker_id="worker",
+            fence_token=lease.fence_token,
+            state="complete",
+            result=b"provider response",
+            now="2036-06-01T00:00:01Z",
+        )
+
+        replay = service.finish_job(
+            job.job_id,
+            worker_id="worker",
+            fence_token=lease.fence_token,
+            state="complete",
+            result=b"provider response",
+            now="2036-06-01T00:00:02Z",
+        )
+
+        assert replay == first
+        assert service.read_job_result(job.job_id) == b"provider response"
+        with pytest.raises(AuthorityStaleLeaseError, match="terminalization_conflict"):
+            service.finish_job(
+                job.job_id,
+                worker_id="worker",
+                fence_token=lease.fence_token,
+                state="complete",
+                result=b"different provider response",
+                now="2036-06-01T00:00:03Z",
+            )
+
+
 def test_failed_job_retry_preserves_identity_and_attempt_history(tmp_path: Path) -> None:
     with AuthorityService(root=_root(tmp_path)) as service:
         job = service.enqueue_request(


### PR DESCRIPTION
## Summary

Fixes #6367.

- replay a job that becomes terminal between enqueue and claim instead of invoking a provider again
- emit the completed provider response before surfacing a terminal bookkeeping failure
- verify matching terminal finish replays are idempotent and divergent results remain conflicts

## Root cause

The compatibility bridge called `finish_job` before writing the provider response. A `terminalization_conflict` therefore exited the caller before its response could be emitted.

## Validation

- `.venv/bin/ruff check scripts/ai_agent_bridge/_acp_compat.py tests/ai_agent_bridge/test_ask_contract.py tests/test_fleet_comms_authority_cutover.py`
- `.venv/bin/python -m pytest tests/ai_agent_bridge/test_ask_contract.py tests/test_fleet_comms_authority_cutover.py -q` (67 passed)
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --all`
- Independent AGY/Gemini exact-head review: no material findings. The requested Gemini 3.1 pin was rejected by the registered route, so review ran through the registered `gemini-3.6-flash-high` lane.

Swarm: one read-only Codex reconnaissance helper.