### PR TITLE
fix(orchestration): centralize worktree deletion paths

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -41,6 +41,29 @@ reaps immediately. The first seven days are capped by
 For regular dispatch worktrees, `post_task_reap` delegates automatic removal
 to this same P0 reaper rather than maintaining a second deletion path.
 
+## Deletion ownership
+
+`reap_worktrees._remove_worktree` is the single deletion hand for regular
+dispatch worktrees. `post_task_reap`'s main path and `delegate`'s completed
+worktree cleanup must call the P0 reaper; they must not invoke Git removal
+directly.
+
+The following narrowly bounded dual paths are allowed because they do not
+represent ordinary merged-PR dispatch cleanup:
+
+- `post_task_reap._remove_worktree` removes only task-state-bound ACP runtime
+  paths below `.worktrees/dispatch/acp/`, after its own terminal, clean, and
+  liveness checks; it always uses `--force` for ignored runtime residue.
+- `_acp_execution.acp_execution_cwd` force-removes only the detached,
+  no-checkout ACP workspace it created below `.worktrees/dispatch/acp/` during
+  setup failure or context teardown.
+- `delegate._release_stale_branch_holders` performs a non-force release after
+  clean, synced, terminal-owner checks so a blocked dispatch may reattach its
+  branch. Its normal completed-worktree cleanup still uses the P0 reaper.
+- `task_family.git_safety.remove_worktree` remains the task-family bundle path:
+  its executor repeats frozen-plan, merged-PR, bundle, and candidate checks
+  immediately before deletion. Do not replace or remove that path here.
+
 ## Immediate cleanup after merge
 
 The merge owner removes the exact worktree as soon as GitHub reports the PR

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -236,11 +236,16 @@ def _unlock_worktree(path: Path, repo_root: Path) -> None:
     _run_git(["worktree", "unlock", str(path)], cwd=repo_root)
 
 
-def _remove_worktree(path: Path, repo_root: Path, *, force: bool = True) -> tuple[bool, str | None]:
-    cmd = ["worktree", "remove"]
-    if force:
-        cmd.append("--force")
-    cmd.append(str(path))
+def _remove_worktree(path: Path, repo_root: Path) -> tuple[bool, str | None]:
+    """Force-remove one state-bound ACP runtime beneath its dedicated subtree.
+
+    This is deliberately not the regular dispatch deletion path: callers must
+    first establish terminal task ownership, cleanliness, and no live process.
+    Regular dispatch worktrees always go through ``reap_worktrees`` instead.
+    """
+    if not _is_under_acp_runtime_root(path):
+        return False, "ACP runtime path is outside .worktrees/dispatch/acp/"
+    cmd = ["worktree", "remove", "--force", str(path)]
     proc = _run_git(cmd, cwd=repo_root)
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "git worktree remove failed").strip()

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -171,43 +171,85 @@ def test_post_task_reap_routes_regular_dispatch_deletion_through_p0_reaper() -> 
     assert "_remove_worktree(" not in source
 
 
-def test_orchestration_worktree_remove_call_sites_are_allowlisted() -> None:
-    """Keep P0 as the deletion hand, except for explicit task-family cleanup."""
-    project_root = Path(__file__).resolve().parents[2]
+def test_acp_runtime_remove_is_force_limited_to_its_dedicated_subtree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ACP exception cannot become a general direct worktree deleter."""
+    commands: list[list[str]] = []
+
+    def fake_run_git(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(post_task_reap, "_run_git", fake_run_git)
+    runtime = post_task_reap._ACP_RUNTIME_ROOT / "p2b-runtime"
+
+    ok, error = post_task_reap._remove_worktree(runtime, tmp_path)
+
+    assert ok is True
+    assert error is None
+    assert commands == [["worktree", "remove", "--force", str(runtime)]]
+
+    outside_ok, outside_error = post_task_reap._remove_worktree(tmp_path / "outside", tmp_path)
+
+    assert outside_ok is False
+    assert outside_error == "ACP runtime path is outside .worktrees/dispatch/acp/"
+    assert len(commands) == 1
+
+
+def _raw_worktree_remove_callers(project_root: Path) -> dict[str, set[str]]:
+    """Return production functions constructing a literal ``worktree remove`` command."""
     actual: dict[str, set[str]] = {}
 
-    for source_path in (project_root / "scripts" / "orchestration").rglob("*.py"):
+    for source_path in (project_root / "scripts").rglob("*.py"):
         source = source_path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(source_path))
         functions: set[str] = set()
         for function in ast.walk(tree):
             if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            command_lists = (
-                list_node
-                for list_node in ast.walk(function)
-                if isinstance(list_node, ast.List)
-            )
+            literal_sequences: list[list[str]] = []
+            for node in ast.walk(function):
+                if isinstance(node, (ast.List, ast.Tuple)):
+                    literal_sequences.append(
+                        [
+                            element.value
+                            for element in node.elts
+                            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+                        ]
+                    )
+            for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
+                literal_args: list[str] = []
+                for arg in call.args:
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        literal_args.append(arg.value)
+                    elif isinstance(arg, (ast.List, ast.Tuple)):
+                        literal_args.extend(
+                            element.value
+                            for element in arg.elts
+                            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+                        )
+                literal_sequences.append(literal_args)
             if any(
-                [
-                    element.value
-                    for element in command_list.elts
-                    if isinstance(element, ast.Constant) and isinstance(element.value, str)
-                ][:3]
-                == ["git", "worktree", "remove"]
-                or [
-                    element.value
-                    for element in command_list.elts
-                    if isinstance(element, ast.Constant) and isinstance(element.value, str)
-                ][:2]
-                == ["worktree", "remove"]
-                for command_list in command_lists
+                sequence[index : index + 3] == ["git", "worktree", "remove"]
+                or sequence[index : index + 2] == ["worktree", "remove"]
+                for sequence in literal_sequences
+                for index in range(len(sequence))
             ):
                 functions.add(function.name)
         if functions:
             actual[str(source_path.relative_to(project_root))] = functions
+    return actual
 
-    assert actual == {
+
+def test_production_worktree_remove_call_sites_are_allowlisted() -> None:
+    """Reject a new raw deletion hand anywhere below production ``scripts/``."""
+    project_root = Path(__file__).resolve().parents[2]
+    assert _raw_worktree_remove_callers(project_root) == {
+        "scripts/ai_agent_bridge/_acp_execution.py": {"acp_execution_cwd"},
+        "scripts/delegate.py": {"_release_stale_branch_holders"},
+        "scripts/fleet/post_task_reap.py": {"_remove_worktree"},
         "scripts/orchestration/reap_worktrees.py": {"_remove_worktree"},
         "scripts/orchestration/task_family/git_safety.py": {"remove_worktree"},
     }


### PR DESCRIPTION
## Summary

- document P0 reaper ownership and the four bounded direct-deletion exceptions
- constrain post-task ACP removal to `.worktrees/dispatch/acp/` and require `--force`
- guard all production `scripts/` worktree-remove call sites with an AST allowlist

## Validation

- `.venv/bin/python -m pytest tests/orchestration/test_reap_worktrees.py tests/ai_agent_bridge/test_acp_execution.py tests/test_fleet_post_task_reap.py -q`
- `.venv/bin/python -m ruff check scripts/fleet/post_task_reap.py tests/orchestration/test_reap_worktrees.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No auto-merge requested.