### PR TITLE
fix(orchestration): stop provisioning worktree venvs

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -170,13 +170,22 @@ Same-family helper output, design panels, and channel chat never seal a PR.
 
 ### Delegate is execution, not coordination
 
+#### Shared Python environment
+
+The primary checkout's `.venv` is shared project tooling; a dispatch worktree
+must never create, copy, symlink, activate, or use its own `.venv`. Derive the
+primary root from the linked worktree and invoke its interpreter by absolute
+path. Never fall back to `python`, `.venv/bin/python`, or `python -m venv .venv`.
+
 ```bash
-.venv/bin/python scripts/delegate.py dispatch \
-  --agent <lane> \
-  --task-id <id> \
-  --prompt-file <path> \
-  --worktree
+PRIMARY_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+"$PRIMARY_REPO/.venv/bin/python" scripts/delegate.py dispatch \
+  --agent <lane> --task-id <id> --prompt-file <path> --worktree
 ```
+
+The delegate worker preamble repeats this constraint. If preparation finds a
+local worktree `.venv`, it records a warning rather than removing a potentially
+active environment; the merged-PR worktree reaper disposes of it safely.
 
 Workers implement inside `.worktrees/dispatch/<agent>/<task>/`. They do not
 become a second coordination plane.

--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -3,6 +3,24 @@
 This runbook covers immediate post-merge cleanup and the local macOS Git
 hygiene backstop for both Learn Ukrainian repositories.
 
+## Shared Python environment
+
+The primary checkout's `.venv` is the only project virtual environment.
+Dispatch worktrees must never create, copy, symlink, activate, or use a local
+`.venv`. From any linked worktree, derive and invoke the absolute primary
+interpreter instead:
+
+```bash
+PRIMARY_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+"$PRIMARY_REPO/.venv/bin/python" -m pytest tests/test_delegate.py
+```
+
+Do not substitute `python`, `.venv/bin/python`, or `python -m venv .venv`.
+The dispatch launcher records a warning when a local `.venv` is already present;
+do not delete it while a task might be active. After the normal merged-PR guards
+pass, the P0 reaper removes the entire disposable worktree, including ignored
+environment residue.
+
 ## Safety contract
 
 Cleanup is fail-closed. A worktree is preserved when any of these is true:
@@ -32,7 +50,8 @@ reaps immediately. The first seven days are capped by
 `.worktrees/`:
 
 ```bash
-.venv/bin/python scripts/orchestration/reap_worktrees.py restore \
+PRIMARY_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+"$PRIMARY_REPO/.venv/bin/python" scripts/orchestration/reap_worktrees.py restore \
   --restore-ref refs/reaper-rescue/<timestamp>/<branch>-<sha> \
   --restore-branch <branch> \
   --restore-worktree .worktrees/dispatch/<agent>/<task>
@@ -74,7 +93,7 @@ terminal has left the target worktree:
 PRIMARY_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 cd "$PRIMARY_REPO"
 
-.venv/bin/python scripts/orchestration/reap_worktrees.py \
+"$PRIMARY_REPO/.venv/bin/python" scripts/orchestration/reap_worktrees.py \
   --repo-root "$PRIMARY_REPO" \
   --apply \
   --merged \

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2104,10 +2104,12 @@ def _validate_existing_worktree(
 def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
     """Symlink heavy local-only files into a delegated worktree.
 
-    Worktrees omit gitignored DBs and dependency directories, but quality
+    Worktrees omit gitignored DBs and Node dependency directories, but quality
     gates open them relative to the running checkout. Use symlinks so each
     delegated worktree sees the same local files without copying multi-GB
-    directories.
+    directories. The primary Python environment is deliberately excluded:
+    workers invoke its absolute interpreter and must not receive a local
+    ``.venv`` symlink.
 
     Self-link guard: if ``worktree_path`` *is* the main checkout, provisioning
     would create ``node_modules -> node_modules`` (a self-referential loop) that
@@ -2127,7 +2129,6 @@ def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
     for relative_path in (
         "data/vesum.db",
         "data/sources.db",
-        ".venv",
         "node_modules",
         "site/node_modules",
     ):
@@ -2345,6 +2346,53 @@ def _apply_dispatch_sparse_checkout(
     return telemetry
 
 
+def _inspect_worktree_local_venv(worktree_path: Path) -> dict[str, str | bool | None]:
+    """Describe a prohibited worktree-local environment without modifying it.
+
+    Dispatch worktrees share the primary checkout's project interpreter. Git
+    does not copy ignored files into a new worktree, but an adapter or worker
+    can still create a local ``.venv`` after creation. Record an early warning
+    in dispatch state instead of deleting a possibly active environment; the
+    P0 reaper remains the sole automatic deletion hand after merge.
+    """
+    candidate = worktree_path / ".venv"
+    try:
+        candidate.lstat()
+    except FileNotFoundError:
+        return {"present": False, "kind": None, "path": None}
+    except OSError as exc:
+        return {
+            "present": False,
+            "kind": "unreadable",
+            "path": str(candidate),
+            "error": type(exc).__name__,
+        }
+
+    if candidate.is_symlink():
+        kind = "symlink"
+    elif candidate.is_dir():
+        kind = "directory"
+    else:
+        kind = "file"
+    return {"present": True, "kind": kind, "path": str(candidate)}
+
+
+def _record_worktree_local_venv_warning(
+    worktree_path: Path,
+    telemetry: dict[str, Any],
+) -> None:
+    """Attach local-venv state to telemetry and warn when it is present."""
+    local_venv = _inspect_worktree_local_venv(worktree_path)
+    telemetry["local_venv"] = local_venv
+    if local_venv.get("present"):
+        print(
+            "⚠️  dispatch worktree contains a local .venv; do not use, copy, or "
+            f"replace it. Use the primary interpreter {_REPO_ROOT / '.venv' / 'bin' / 'python'} "
+            f"instead: {worktree_path / '.venv'} ({local_venv.get('kind')}).",
+            file=sys.stderr,
+        )
+
+
 def _resolve_worktree_base_sha(
     *,
     agent: str,
@@ -2437,6 +2485,7 @@ def _ensure_worktree(
         "layout": layout,
         "reused": False,
         "sparse": None,
+        "local_venv": None,
     }
 
     if requested_branch:
@@ -2506,6 +2555,7 @@ def _ensure_worktree(
             full_checkout=full_checkout,
             sparse_include=sparse_include,
         )
+        _record_worktree_local_venv_warning(worktree_path, telemetry)
         return worktree_path, worktree_branch, telemetry
 
     if dry_run:
@@ -2612,6 +2662,7 @@ def _ensure_worktree(
         full_checkout=full_checkout,
         sparse_include=sparse_include,
     )
+    _record_worktree_local_venv_warning(worktree_path, telemetry)
     return worktree_path, worktree_branch, telemetry
 
 
@@ -2656,6 +2707,12 @@ def _augment_prompt_with_worktree(
         "`origin` here points at the canonical GitHub remote and fetch works from any "
         "linked worktree. NEVER use the primary checkout as a source of freshness "
         "(no `git -C <primary> pull/fetch/checkout`); it is the human's interactive home.\n"
+        "\n[shared project interpreter]\n"
+        "Never create, copy, symlink, activate, or use a `.venv` inside this worktree. "
+        f"Run every project Python command with `{_REPO_ROOT / '.venv' / 'bin' / 'python'}` "
+        "(the absolute primary interpreter), never `python`, `.venv/bin/python`, or "
+        "`python -m venv .venv`. Do not change `PYTHONPATH` merely because the worker "
+        "cwd is a worktree.\n"
         f"{sparse_note}{delivery_note}\n"
         f"{prompt}"
     )
@@ -3939,6 +3996,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_reused": bool(worktree_telemetry.get("reused")),
         "worktree_layout": worktree_layout,
         "worktree_sparse": worktree_telemetry.get("sparse"),
+        "worktree_local_venv": worktree_telemetry.get("local_venv"),
         "runtime_tmp_root": str(runtime_tmp_root),
         "tmp_bytes_freed": None,
         "tmp_reap_error": None,

--- a/tests/test_agent_seat_onboarding_docs.py
+++ b/tests/test_agent_seat_onboarding_docs.py
@@ -104,6 +104,17 @@ def test_five_ownership_surfaces(onboarding: str) -> None:
     assert "deferred" in lower
 
 
+def test_onboarding_requires_the_primary_venv_for_dispatch(onboarding: str) -> None:
+    """Worker onboarding must prevent a per-worktree environment copy."""
+    assert "Shared Python environment" in onboarding
+    assert '"$PRIMARY_REPO/.venv/bin/python"' in onboarding
+    for prohibited in (
+        "must never create, copy, symlink, activate, or use its own `.venv`",
+        "`python -m venv .venv`",
+    ):
+        assert prohibited in onboarding
+
+
 def test_human_comms_pages_have_distinct_read_only_roles(onboarding: str) -> None:
     lower = onboarding.lower()
     for page in ("acp conversations", "channels", "broker ops", "build events", "runtime"):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2868,6 +2868,7 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, tmp_path, monke
     assert state["pid"] == 24680
     assert state["worktree_base_sha"] == "deadbeef"
     assert state["worktree_reused"] is False
+    assert state["worktree_local_venv"] == {"present": False, "kind": None, "path": None}
     assert "delegate worktree" in recorded_prompt["text"]
     assert ".worktrees/codex-1383" in recorded_prompt["text"]
     # At minimum: git fetch + git rev-parse --verify + git worktree add + git rev-parse HEAD.
@@ -3936,6 +3937,51 @@ def test_ensure_worktree_branches_from_origin_main(tmp_tasks_dir, tmp_path, monk
     assert "scripts" in set_calls[0]
     assert telemetry["sparse"] is not None
     assert telemetry["sparse"]["excluded"] == ["curriculum", "wiki"]
+    assert telemetry["local_venv"] == {"present": False, "kind": None, "path": None}
+
+
+def test_inspect_worktree_local_venv_records_directory_and_symlink(tmp_path):
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    assert delegate._inspect_worktree_local_venv(worktree) == {
+        "present": False,
+        "kind": None,
+        "path": None,
+    }
+
+    local_venv = worktree / ".venv"
+    local_venv.mkdir()
+    assert delegate._inspect_worktree_local_venv(worktree) == {
+        "present": True,
+        "kind": "directory",
+        "path": str(local_venv),
+    }
+
+    local_venv.rmdir()
+    local_venv.symlink_to(tmp_path / "primary-venv", target_is_directory=True)
+    assert delegate._inspect_worktree_local_venv(worktree) == {
+        "present": True,
+        "kind": "symlink",
+        "path": str(local_venv),
+    }
+
+
+def test_record_worktree_local_venv_warning_is_non_destructive(tmp_path, capsys):
+    worktree = tmp_path / "worktree"
+    local_venv = worktree / ".venv"
+    local_venv.mkdir(parents=True)
+    telemetry: dict[str, object] = {}
+
+    delegate._record_worktree_local_venv_warning(worktree, telemetry)
+
+    assert local_venv.is_dir()
+    assert telemetry["local_venv"] == {
+        "present": True,
+        "kind": "directory",
+        "path": str(local_venv),
+    }
+    assert "contains a local .venv" in capsys.readouterr().err
 
 
 def test_normalize_sparse_include_dedupes_and_strips():
@@ -4039,6 +4085,18 @@ def test_augment_prompt_mentions_sparse_exclusions():
     assert "curriculum" in text
     assert "wiki" in text
     assert "sparse" in text.lower() or "Sparse" in text
+
+
+def test_augment_prompt_requires_absolute_primary_venv():
+    worktree = Path("/tmp/dispatch-worktree")
+
+    text = delegate._augment_prompt_with_worktree("Implement the fix.", worktree)
+
+    primary_python = delegate._REPO_ROOT / ".venv" / "bin" / "python"
+    assert str(primary_python) in text
+    assert "Never create, copy, symlink, activate, or use a `.venv`" in text
+    assert "`python -m venv .venv`" in text
+    assert "Do not change `PYTHONPATH`" in text
 
 
 def test_augment_write_prompt_offers_optional_delivery_declaration():

--- a/tests/test_delegate_data_symlinks.py
+++ b/tests/test_delegate_data_symlinks.py
@@ -21,7 +21,7 @@ def test_main_checkout_root_resolves_primary_checkout_from_worktree(tmp_path):
     assert delegate._main_checkout_root(worktree) == main_repo
 
 
-def test_provision_data_symlinks_links_heavy_dbs_and_is_idempotent(tmp_path):
+def test_provision_data_symlinks_links_data_and_node_modules_but_not_venv(tmp_path):
     main_repo = tmp_path / "main"
     worktree = tmp_path / "worktree"
     data_dir = main_repo / "data"
@@ -30,10 +30,10 @@ def test_provision_data_symlinks_links_heavy_dbs_and_is_idempotent(tmp_path):
     sources_db = data_dir / "sources.db"
     vesum_db.touch()
     sources_db.touch()
-    venv_dir = main_repo / ".venv"
+    primary_venv = main_repo / ".venv"
     node_modules_dir = main_repo / "node_modules"
     site_node_modules_dir = main_repo / "site" / "node_modules"
-    venv_dir.mkdir()
+    primary_venv.mkdir()
     node_modules_dir.mkdir()
     site_node_modules_dir.mkdir(parents=True)
 
@@ -41,17 +41,16 @@ def test_provision_data_symlinks_links_heavy_dbs_and_is_idempotent(tmp_path):
 
     vesum_link = worktree / "data" / "vesum.db"
     sources_link = worktree / "data" / "sources.db"
-    venv_link = worktree / ".venv"
     node_modules_link = worktree / "node_modules"
     site_node_modules_link = worktree / "site" / "node_modules"
     assert vesum_link.is_symlink()
     assert sources_link.is_symlink()
-    assert venv_link.is_symlink()
+    assert not (worktree / ".venv").exists()
+    assert not (worktree / ".venv").is_symlink()
     assert node_modules_link.is_symlink()
     assert site_node_modules_link.is_symlink()
     assert vesum_link.readlink() == vesum_db.resolve()
     assert sources_link.readlink() == sources_db.resolve()
-    assert venv_link.readlink() == venv_dir.resolve()
     assert node_modules_link.readlink() == node_modules_dir.resolve()
     assert site_node_modules_link.readlink() == site_node_modules_dir.resolve()
 
@@ -59,12 +58,12 @@ def test_provision_data_symlinks_links_heavy_dbs_and_is_idempotent(tmp_path):
 
     assert vesum_link.is_symlink()
     assert sources_link.is_symlink()
-    assert venv_link.is_symlink()
+    assert not (worktree / ".venv").exists()
+    assert not (worktree / ".venv").is_symlink()
     assert node_modules_link.is_symlink()
     assert site_node_modules_link.is_symlink()
     assert vesum_link.readlink() == vesum_db.resolve()
     assert sources_link.readlink() == sources_db.resolve()
-    assert venv_link.readlink() == venv_dir.resolve()
     assert node_modules_link.readlink() == node_modules_dir.resolve()
     assert site_node_modules_link.readlink() == site_node_modules_dir.resolve()
 


### PR DESCRIPTION
## Summary
- stop delegate worktree setup from symlinking the primary `.venv`
- add worker preamble and onboarding/cleanup guidance for the absolute primary interpreter
- record and warn about pre-existing local worktree environments without deleting active state

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py tests/test_delegate_data_symlinks.py tests/test_agent_seat_onboarding_docs.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/delegate.py tests/test_delegate.py tests/test_delegate_data_symlinks.py tests/test_agent_seat_onboarding_docs.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No auto-merge armed per operator instruction.