### PR TITLE
feat(fleet): add seat-facing facade and broker report

### DIFF
--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -230,3 +230,43 @@ Do **not** write `laguna-s2`, `laguna.s2`, or `laguna.m1` as IDs — hyphens and
 - [x] exact-head ACP sealed review: Claude, Codex, GLM, and Grok eligible; Kimi K3 adapter present but fail-closed pending its authenticated canary; AGY structurally fail-closed
 - [ ] operator: Claude + Grok + Codex + AGY cold-start stream smoke (launchers dual-aware; live multi-CLI soak optional)
 - [x] planned `dual_write`-default step superseded by #6159 authority cutover
+
+## Legacy Broker Ops retirement evidence (#6106)
+
+Use the seat-facing facade from any repository checkout:
+
+```bash
+.venv/bin/python -m scripts.fleet_comms fleet help
+.venv/bin/python -m scripts.fleet_comms fleet status
+.venv/bin/python -m scripts.fleet_comms fleet board
+.venv/bin/python -m scripts.fleet_comms fleet backlog
+.venv/bin/python -m scripts.fleet_comms fleet dead
+.venv/bin/python -m scripts.fleet_comms fleet metrics
+.venv/bin/python -m scripts.fleet_comms fleet reap-report
+```
+
+`fleet reap-report` is a dry run over merged PR heads. It passes through the
+existing reaper's active-worktree, exact-merged-head, and dirty-tree guards.
+`--apply` is available only for the same guarded reaper path.
+
+Before proposing deletion of a Broker Ops page or a legacy route, choose a
+window between 1 and 90 days and run:
+
+```bash
+.venv/bin/python -m scripts.fleet_comms fleet broker-report --days 7
+```
+
+The report reads `data/telemetry/legacy_comms_routes.db` without creating or
+modifying it. A separate `data/telemetry/legacy_bridge` file is read when
+present, and `--bridge-db` selects another explicit bridge store; current
+bridge aggregates may be co-located in the route telemetry database. The
+report separates direct seat activity, background automation, and `other`
+(canary/test/unknown). `other` is not
+silently treated as zero use.
+
+An operator declares a zero-use window by adding the exact command, report
+timestamp, requested window, and JSON `zero_use_candidate` result to the PR,
+then writing present-tense approval such as: “I approve retiring `<slice>`
+after the observed `<N>`-day zero-use window.” A deletion PR must retain that
+approval text and the report output, and must not delete any page or route when
+the report says `eligible: false`.

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -97,7 +97,7 @@ def cmd_plane_status(args: argparse.Namespace) -> int:
 
 def _short_plane_health(status: dict[str, Any]) -> dict[str, Any]:
     """Return a compact health projection without creating a second authority."""
-    schema = status.get("schema", {})
+    schema = status.get("schema") or {}
     enabled = status.get("enabled") is True
     read_only = status.get("read_only") is True
     db_exists = schema.get("db_exists") is True

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -9,6 +9,8 @@ Usage::
     .venv/bin/python -m scripts.fleet_comms metrics
     .venv/bin/python -m scripts.fleet_comms backlog
     .venv/bin/python -m scripts.fleet_comms dead-letters
+    .venv/bin/python -m scripts.fleet_comms fleet status
+    .venv/bin/python -m scripts.fleet_comms fleet broker-report --days 7
     .venv/bin/python -m scripts.fleet_comms github-metrics
     .venv/bin/python -m scripts.fleet_comms authority-import --legacy-db /path/to/messages.db --source legacy-broker
 
@@ -45,6 +47,7 @@ from scripts.fleet_comms.efficiency_metrics import (
     resolve_metrics_source,
 )
 from scripts.fleet_comms.github_pr_metrics import collect_github_pr_metrics
+from scripts.fleet_comms.legacy_broker_report import build_legacy_broker_report
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 from scripts.fleet_comms.review_publication import DEFAULT_GATE_KIND
 
@@ -89,6 +92,90 @@ def cmd_plane_status(args: argparse.Namespace) -> int:
         recent_limit=args.recent_limit,
     )
     sys.stdout.write(_json_dump(status))
+    return EXIT_OK
+
+
+def _short_plane_health(status: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact health projection without creating a second authority."""
+    schema = status.get("schema", {})
+    enabled = status.get("enabled") is True
+    read_only = status.get("read_only") is True
+    db_exists = schema.get("db_exists") is True
+    return {
+        "healthy": enabled and read_only and db_exists,
+        "enabled": enabled,
+        "mode": status.get("mode"),
+        "read_only": read_only,
+        "db_exists": db_exists,
+        "schema_version": schema.get("applied_version"),
+    }
+
+
+def cmd_fleet_status(args: argparse.Namespace) -> int:
+    """Facade status: existing plane-status data plus a short health summary."""
+    root = Path(args.root).expanduser() if args.root else None
+    repo_root = Path(args.repo_root).expanduser() if args.repo_root else None
+    telemetry = Path(args.telemetry).expanduser() if args.telemetry else None
+    status = read_plane_status(
+        repo_root=repo_root,
+        root=root,
+        telemetry_path=telemetry,
+        recent_limit=args.recent_limit,
+    )
+    sys.stdout.write(_json_dump({"plane_status": status, "health": _short_plane_health(status)}))
+    return EXIT_OK
+
+
+def cmd_broker_report(args: argparse.Namespace) -> int:
+    """Emit read-only #6106 legacy Broker Ops observation evidence."""
+    routes_db = Path(args.routes_db).expanduser() if args.routes_db else None
+    bridge_db = Path(args.bridge_db).expanduser() if args.bridge_db else None
+    try:
+        payload = build_legacy_broker_report(
+            args.days,
+            routes_db=routes_db,
+            bridge_db=bridge_db,
+        )
+    except ValueError as exc:
+        raise FleetCommsCliError(str(exc)) from exc
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK
+
+
+def cmd_fleet_reap_report(args: argparse.Namespace) -> int:
+    """Run the established reaper with its normal P0 guards, dry by default."""
+    from scripts.orchestration import reap_worktrees
+
+    command = ["--merged", "--apply" if args.apply else "--dry-run"]
+    if args.repo_root:
+        command.extend(["--repo-root", args.repo_root])
+    if args.json:
+        command.append("--json")
+    return int(reap_worktrees.main(command))
+
+
+def cmd_fleet_help(_args: argparse.Namespace) -> int:
+    """Map the facade to existing Truth, Hand, and Eyes surfaces."""
+    sys.stdout.write(
+        _json_dump(
+            {
+                "truth": {
+                    "status": "fleet status (plane-status plus compact health)",
+                    "metrics": "fleet metrics (durable authority metrics)",
+                    "broker_report": "fleet broker-report (legacy retirement evidence)",
+                },
+                "hand": {
+                    "reap_report": "fleet reap-report --apply (existing merged-head reaper guards)",
+                },
+                "eyes": {
+                    "board": "fleet board (cold-start driver board)",
+                    "backlog": "fleet backlog (pending deliveries)",
+                    "dead": "fleet dead (dead-letter inventory)",
+                },
+                "note": "Thin facade only; Fleet Comms remains the authoritative message plane.",
+            }
+        )
+    )
     return EXIT_OK
 
 
@@ -659,6 +746,70 @@ def build_parser() -> argparse.ArgumentParser:
         help="Max recent parity events to include (default: 50)",
     )
     plane.set_defaults(func=cmd_plane_status)
+
+    fleet = sub.add_parser(
+        "fleet",
+        help="Seat-facing facade over existing Fleet Comms read-only surfaces",
+    )
+    fleet_sub = fleet.add_subparsers(dest="fleet_command", required=True)
+
+    fleet_status = fleet_sub.add_parser("status", help="plane-status plus compact health")
+    fleet_status.add_argument("--root", default=None, help="Plane storage root")
+    fleet_status.add_argument("--repo-root", default=None, help="Repo root for plane resolution")
+    fleet_status.add_argument("--telemetry", default=None, help="Parity telemetry JSONL path")
+    fleet_status.add_argument("--recent-limit", type=int, default=50, help="Max recent parity events")
+    fleet_status.set_defaults(func=cmd_fleet_status)
+
+    fleet_board = fleet_sub.add_parser("board", help="Delegate to cold-start-board")
+    fleet_board.add_argument("--format", choices=["json", "markdown"], default="json")
+    fleet_board.add_argument("--stream-id", default=None)
+    fleet_board.add_argument("--agent", default=None)
+    fleet_board.add_argument("--needle", default=None)
+    fleet_board.add_argument("--root", default=None)
+    fleet_board.add_argument("--repo-root", default=None)
+    fleet_board.set_defaults(func=cmd_cold_start_board)
+
+    fleet_metrics = fleet_sub.add_parser("metrics", help="Delegate to metrics")
+    fleet_metrics.add_argument("--db", default=None, help="Legacy broker SQLite path")
+    fleet_metrics.add_argument("--root", default=None, help="Plane storage root")
+    fleet_metrics.add_argument("--legacy", action="store_true", help="Force legacy broker source")
+    fleet_metrics.set_defaults(func=cmd_metrics)
+
+    fleet_backlog = fleet_sub.add_parser("backlog", help="Delegate to backlog")
+    fleet_backlog.add_argument("--db", default=None, help="Legacy broker SQLite path")
+    fleet_backlog.add_argument("--root", default=None, help="Plane storage root")
+    fleet_backlog.add_argument("--limit", type=int, default=100, help="Max rows")
+    fleet_backlog.add_argument("--include-retired", action="store_true")
+    fleet_backlog.add_argument("--legacy", action="store_true", help="Force legacy broker source")
+    fleet_backlog.set_defaults(func=cmd_backlog)
+
+    fleet_dead = fleet_sub.add_parser("dead", help="Delegate to dead-letters")
+    fleet_dead.add_argument("--db", default=None, help="Legacy broker SQLite path")
+    fleet_dead.add_argument("--root", default=None, help="Plane storage root")
+    fleet_dead.add_argument("--limit", type=int, default=100, help="Max rows")
+    fleet_dead.add_argument("--legacy", action="store_true", help="Force legacy broker source")
+    fleet_dead.set_defaults(func=cmd_dead_letters)
+
+    fleet_reap = fleet_sub.add_parser(
+        "reap-report",
+        help="Dry-run merged worktree reap report; --apply keeps established guards",
+    )
+    fleet_reap.add_argument("--repo-root", default=None, help="Repository root to inspect")
+    fleet_reap.add_argument("--apply", action="store_true", help="Apply only existing reaper safeguards")
+    fleet_reap.add_argument("--json", action="store_true", help="Emit reaper JSON")
+    fleet_reap.set_defaults(func=cmd_fleet_reap_report)
+
+    fleet_broker = fleet_sub.add_parser(
+        "broker-report",
+        help="Read-only #6106 legacy Broker Ops usage report",
+    )
+    fleet_broker.add_argument("--days", type=int, default=7, help="Observation window, 1-90 days")
+    fleet_broker.add_argument("--routes-db", default=None, help="Legacy HTTP telemetry SQLite path")
+    fleet_broker.add_argument("--bridge-db", default=None, help="Optional legacy bridge SQLite path")
+    fleet_broker.set_defaults(func=cmd_broker_report)
+
+    fleet_help = fleet_sub.add_parser("help", help="Map Truth, Hand, and Eyes")
+    fleet_help.set_defaults(func=cmd_fleet_help)
 
     formal = sub.add_parser(
         "formal-job",

--- a/scripts/fleet_comms/legacy_broker_report.py
+++ b/scripts/fleet_comms/legacy_broker_report.py
@@ -1,0 +1,302 @@
+"""Read-only retirement evidence for legacy Broker Ops telemetry (#6106).
+
+The legacy HTTP-route and one-shot bridge telemetry currently share a private
+SQLite store.  This report intentionally opens candidate databases read-only:
+asking whether a zero-use window exists must never create a store, advance
+coverage, or change the evidence it is evaluating.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.common.repo_root import main_checkout_root
+
+_SOURCE_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ROUTES_TABLE = "legacy_comms_route_usage"
+_BRIDGE_TABLE = "legacy_bridge_ask_usage"
+_ROUTE_SEAT_CALLERS = frozenset({"browser", "broker-ops", "cli", "dashboard"})
+_ROUTE_BACKGROUND_CALLERS = frozenset({"automation", "programmatic"})
+_BRIDGE_BACKGROUND_CALLERS = frozenset(
+    {
+        "anthropic",
+        "cursor",
+        "deepseek",
+        "google",
+        "moonshot",
+        "openai",
+        "xai",
+        "zhipu",
+    }
+)
+
+
+def default_routes_db() -> Path:
+    """Return the shared legacy telemetry database without creating it."""
+    return main_checkout_root(_SOURCE_REPO_ROOT) / "data" / "telemetry" / "legacy_comms_routes.db"
+
+
+def default_legacy_bridge_path() -> Path:
+    """Return the optional historical bridge store path without creating it."""
+    return main_checkout_root(_SOURCE_REPO_ROOT) / "data" / "telemetry" / "legacy_bridge"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _open_read_only(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+
+
+def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+    return (
+        connection.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)).fetchone()
+        is not None
+    )
+
+
+def _meta_value(connection: sqlite3.Connection, key: str) -> str | None:
+    if not _table_exists(connection, "telemetry_meta"):
+        return None
+    row = connection.execute("SELECT value FROM telemetry_meta WHERE key = ?", (key,)).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _coverage_is_complete(coverage_started_at: str | None, window_start: datetime) -> bool | None:
+    if coverage_started_at is None:
+        return None
+    try:
+        coverage_start = datetime.fromisoformat(coverage_started_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return coverage_start.astimezone(UTC) <= window_start
+
+
+def _usage_bucket(caller: str, *, bridge: bool) -> str:
+    if bridge:
+        if caller == "operator":
+            return "seat"
+        if caller in _BRIDGE_BACKGROUND_CALLERS:
+            return "background"
+        return "other"
+    if caller in _ROUTE_SEAT_CALLERS:
+        return "seat"
+    if caller in _ROUTE_BACKGROUND_CALLERS:
+        return "background"
+    return "other"
+
+
+def _usage_summary(rows: list[sqlite3.Row], *, bridge: bool) -> dict[str, Any]:
+    buckets: dict[str, dict[str, Any]] = {
+        name: {"count": 0, "by_caller": {}} for name in ("seat", "background", "other")
+    }
+    for row in rows:
+        caller = str(row["caller"])
+        count = int(row["count"])
+        bucket = buckets[_usage_bucket(caller, bridge=bridge)]
+        bucket["count"] += count
+        bucket["by_caller"][caller] = bucket["by_caller"].get(caller, 0) + count
+    for bucket in buckets.values():
+        bucket["by_caller"] = dict(sorted(bucket["by_caller"].items()))
+    return buckets
+
+
+def _missing_store(path: Path, *, kind: str) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "path": str(path),
+        "state": "missing",
+        "coverage_started_at": None,
+        "window_fully_observed": None,
+        "usage": _usage_summary([], bridge=kind == "legacy_bridge"),
+    }
+
+
+def _read_store(
+    path: Path,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    try:
+        connection = _open_read_only(path)
+    except sqlite3.Error as exc:
+        return [
+            {
+                "kind": "telemetry_store",
+                "path": str(path),
+                "state": "unreadable",
+                "reason": type(exc).__name__,
+            }
+        ]
+
+    connection.row_factory = sqlite3.Row
+    try:
+        query_start = _iso_z(window_start.replace(minute=0, second=0, microsecond=0))
+        query_end = _iso_z(window_end.replace(minute=0, second=0, microsecond=0))
+        reports: list[dict[str, Any]] = []
+        if _table_exists(connection, _ROUTES_TABLE):
+            rows = connection.execute(
+                f"""
+                SELECT caller_class AS caller, SUM(count) AS count
+                FROM {_ROUTES_TABLE}
+                WHERE hour_utc >= ? AND hour_utc <= ?
+                GROUP BY caller_class
+                ORDER BY caller_class
+                """,
+                (query_start, query_end),
+            ).fetchall()
+            coverage = _meta_value(connection, "coverage_started_at")
+            reports.append(
+                {
+                    "kind": "legacy_comms_routes",
+                    "path": str(path),
+                    "state": "ok",
+                    "coverage_started_at": coverage,
+                    "window_fully_observed": _coverage_is_complete(coverage, window_start),
+                    "usage": _usage_summary(rows, bridge=False),
+                }
+            )
+        if _table_exists(connection, _BRIDGE_TABLE):
+            rows = connection.execute(
+                f"""
+                SELECT caller_family AS caller, SUM(started_count) AS count,
+                       SUM(succeeded_count) AS succeeded,
+                       SUM(failed_count) AS failed
+                FROM {_BRIDGE_TABLE}
+                WHERE hour_utc >= ? AND hour_utc <= ?
+                GROUP BY caller_family
+                ORDER BY caller_family
+                """,
+                (query_start, query_end),
+            ).fetchall()
+            coverage = _meta_value(connection, "bridge_coverage_started_at")
+            report = {
+                "kind": "legacy_bridge",
+                "path": str(path),
+                "state": "ok",
+                "coverage_started_at": coverage,
+                "window_fully_observed": _coverage_is_complete(coverage, window_start),
+                "usage": _usage_summary(rows, bridge=True),
+            }
+            report["outcomes"] = {
+                "succeeded": sum(int(row["succeeded"] or 0) for row in rows),
+                "failed": sum(int(row["failed"] or 0) for row in rows),
+                "unfinished": sum(
+                    max(
+                        int(row["count"] or 0) - int(row["succeeded"] or 0) - int(row["failed"] or 0),
+                        0,
+                    )
+                    for row in rows
+                ),
+            }
+            reports.append(report)
+        return reports
+    except sqlite3.Error as exc:
+        return [
+            {
+                "kind": "telemetry_store",
+                "path": str(path),
+                "state": "unreadable",
+                "reason": type(exc).__name__,
+            }
+        ]
+    finally:
+        connection.close()
+
+
+def build_legacy_broker_report(
+    days: int,
+    *,
+    routes_db: Path | None = None,
+    bridge_db: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return a body-free, read-only legacy Broker Ops retirement report."""
+    if not 1 <= days <= 90:
+        raise ValueError("days must be between 1 and 90")
+
+    generated_at = (now or _utc_now()).astimezone(UTC)
+    window_start = generated_at - timedelta(days=days)
+    routes_path = (routes_db or default_routes_db()).expanduser().resolve(strict=False)
+    bridge_path = (bridge_db or default_legacy_bridge_path()).expanduser().resolve(strict=False)
+
+    reports = _read_store(
+        routes_path,
+        window_start=window_start,
+        window_end=generated_at,
+    )
+    use_separate_bridge = bridge_path != routes_path and (bridge_db is not None or bridge_path.is_file())
+    if use_separate_bridge:
+        reports = [report for report in reports if report.get("kind") != "legacy_bridge"]
+    route_kinds = {str(report.get("kind")) for report in reports}
+    if "legacy_comms_routes" not in route_kinds:
+        reports.append(_missing_store(routes_path, kind="legacy_comms_routes"))
+    if not use_separate_bridge and "legacy_bridge" not in route_kinds:
+        reports.append(_missing_store(routes_path, kind="legacy_bridge"))
+    if use_separate_bridge:
+        bridge_reports = _read_store(
+            bridge_path,
+            window_start=window_start,
+            window_end=generated_at,
+        )
+        bridge_reports = [
+            report for report in bridge_reports if report.get("kind") in {"legacy_bridge", "telemetry_store"}
+        ]
+        if any(report.get("kind") == "legacy_bridge" for report in bridge_reports):
+            reports.extend(bridge_reports)
+        else:
+            reports.append(_missing_store(bridge_path, kind="legacy_bridge"))
+
+    totals: dict[str, dict[str, int]] = defaultdict(lambda: {"seat": 0, "background": 0, "other": 0})
+    zero_use_reasons: list[str] = []
+    observed_reports = [report for report in reports if report.get("kind") in {"legacy_comms_routes", "legacy_bridge"}]
+    for report in observed_reports:
+        kind = str(report["kind"])
+        usage = report.get("usage", {})
+        for bucket in ("seat", "background", "other"):
+            totals[kind][bucket] += int(usage.get(bucket, {}).get("count", 0))
+        if report.get("state") != "ok":
+            zero_use_reasons.append(f"{kind}_not_readable")
+        elif report.get("window_fully_observed") is not True:
+            zero_use_reasons.append(f"{kind}_window_incomplete")
+        elif any(int(usage.get(bucket, {}).get("count", 0)) for bucket in ("seat", "background", "other")):
+            zero_use_reasons.append(f"{kind}_has_usage")
+
+    if not observed_reports:
+        zero_use_reasons.append("no_telemetry_store")
+    zero_use_reasons = sorted(set(zero_use_reasons))
+    return {
+        "schema": "fleet-broker-report.v1",
+        "content_included": False,
+        "read_only": True,
+        "generated_at": _iso_z(generated_at),
+        "window": {
+            "days": days,
+            "start": _iso_z(window_start),
+            "retention_days": 90,
+        },
+        "classification": {
+            "seat": "HTTP browser/cli/dashboard/broker-ops callers; bridge caller_family=operator.",
+            "background": "HTTP automation/programmatic callers; allowlisted non-operator bridge families.",
+            "other": "canary, test, and unknown callers are retained separately and block a zero-use claim.",
+        },
+        "stores": reports,
+        "totals": {kind: dict(counts) for kind, counts in sorted(totals.items())},
+        "zero_use_candidate": {
+            "eligible": not zero_use_reasons,
+            "reason_codes": zero_use_reasons,
+            "operator_declaration_required": True,
+        },
+    }

--- a/scripts/fleet_comms/legacy_broker_report.py
+++ b/scripts/fleet_comms/legacy_broker_report.py
@@ -101,7 +101,7 @@ def _usage_summary(rows: list[sqlite3.Row], *, bridge: bool) -> dict[str, Any]:
     }
     for row in rows:
         caller = str(row["caller"])
-        count = int(row["count"])
+        count = int(row["count"] or 0)
         bucket = buckets[_usage_bucket(caller, bridge=bridge)]
         bucket["count"] += count
         bucket["by_caller"][caller] = bucket["by_caller"].get(caller, 0) + count

--- a/tests/test_fleet_comms_legacy_broker_report.py
+++ b/tests/test_fleet_comms_legacy_broker_report.py
@@ -1,0 +1,230 @@
+"""Tests for the read-only #6106 legacy Broker Ops report and facade."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.fleet_comms.cli import EXIT_ERROR, EXIT_OK, main
+from scripts.fleet_comms.legacy_broker_report import build_legacy_broker_report
+
+
+def _seed_telemetry(path: Path, *, coverage_started_at: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE telemetry_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE legacy_comms_route_usage (
+                hour_utc TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                method TEXT NOT NULL,
+                caller_class TEXT NOT NULL,
+                status_class TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL
+            );
+            CREATE TABLE legacy_bridge_ask_usage (
+                hour_utc TEXT NOT NULL,
+                target TEXT NOT NULL,
+                caller_family TEXT NOT NULL,
+                started_count INTEGER NOT NULL,
+                succeeded_count INTEGER NOT NULL,
+                failed_count INTEGER NOT NULL,
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL
+            );
+            """
+        )
+        started = coverage_started_at.isoformat().replace("+00:00", "Z")
+        connection.executemany(
+            "INSERT INTO telemetry_meta(key, value) VALUES (?, ?)",
+            [
+                ("coverage_started_at", started),
+                ("bridge_coverage_started_at", started),
+            ],
+        )
+
+
+def _insert_usage(path: Path, *, now: datetime) -> None:
+    observed = now.isoformat().replace("+00:00", "Z")
+    with sqlite3.connect(path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO legacy_comms_route_usage(
+                hour_utc, route_id, method, caller_class, status_class,
+                count, first_seen, last_seen
+            ) VALUES (?, 'messages', 'GET', ?, '2xx', ?, ?, ?)
+            """,
+            [
+                (observed, "browser", 2, observed, observed),
+                (observed, "automation", 3, observed, observed),
+                (observed, "canary", 1, observed, observed),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO legacy_bridge_ask_usage(
+                hour_utc, target, caller_family, started_count,
+                succeeded_count, failed_count, first_seen, last_seen
+            ) VALUES (?, 'glm', ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (observed, "operator", 4, 3, 1, observed, observed),
+                (observed, "openai", 2, 2, 0, observed, observed),
+                (observed, "unknown", 1, 0, 0, observed, observed),
+            ],
+        )
+
+
+def _store_for(report: dict, kind: str) -> dict:
+    return next(item for item in report["stores"] if item["kind"] == kind)
+
+
+def test_report_classifies_all_usage_without_mutating_telemetry(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    database = tmp_path / "legacy.db"
+    _seed_telemetry(database, coverage_started_at=now - timedelta(days=8))
+    _insert_usage(database, now=now)
+    before = hashlib.sha256(database.read_bytes()).hexdigest()
+
+    report = build_legacy_broker_report(7, routes_db=database, now=now)
+
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == before
+    assert report["read_only"] is True
+    routes = _store_for(report, "legacy_comms_routes")
+    assert routes["window_fully_observed"] is True
+    assert routes["usage"] == {
+        "seat": {"count": 2, "by_caller": {"browser": 2}},
+        "background": {"count": 3, "by_caller": {"automation": 3}},
+        "other": {"count": 1, "by_caller": {"canary": 1}},
+    }
+    bridge = _store_for(report, "legacy_bridge")
+    assert bridge["usage"] == {
+        "seat": {"count": 4, "by_caller": {"operator": 4}},
+        "background": {"count": 2, "by_caller": {"openai": 2}},
+        "other": {"count": 1, "by_caller": {"unknown": 1}},
+    }
+    assert bridge["outcomes"] == {"succeeded": 5, "failed": 1, "unfinished": 1}
+    assert report["zero_use_candidate"] == {
+        "eligible": False,
+        "reason_codes": ["legacy_bridge_has_usage", "legacy_comms_routes_has_usage"],
+        "operator_declaration_required": True,
+    }
+
+
+def test_report_allows_only_complete_empty_windows(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    database = tmp_path / "legacy.db"
+    _seed_telemetry(database, coverage_started_at=now - timedelta(days=8))
+
+    report = build_legacy_broker_report(7, routes_db=database, now=now)
+
+    assert report["zero_use_candidate"] == {
+        "eligible": True,
+        "reason_codes": [],
+        "operator_declaration_required": True,
+    }
+
+
+def test_explicit_bridge_store_replaces_co_located_bridge_counts(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    routes_database = tmp_path / "routes.db"
+    bridge_database = tmp_path / "bridge.db"
+    _seed_telemetry(routes_database, coverage_started_at=now - timedelta(days=8))
+    _insert_usage(routes_database, now=now)
+    _seed_telemetry(bridge_database, coverage_started_at=now - timedelta(days=8))
+
+    report = build_legacy_broker_report(
+        7,
+        routes_db=routes_database,
+        bridge_db=bridge_database,
+        now=now,
+    )
+
+    bridge_reports = [item for item in report["stores"] if item["kind"] == "legacy_bridge"]
+    assert len(bridge_reports) == 1
+    assert bridge_reports[0]["path"] == str(bridge_database)
+    assert bridge_reports[0]["usage"]["seat"]["count"] == 0
+
+
+def test_report_refuses_to_treat_missing_or_incomplete_telemetry_as_zero_use(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    missing = build_legacy_broker_report(7, routes_db=tmp_path / "missing.db", now=now)
+    assert missing["zero_use_candidate"]["eligible"] is False
+    assert missing["zero_use_candidate"]["reason_codes"] == [
+        "legacy_bridge_not_readable",
+        "legacy_comms_routes_not_readable",
+    ]
+
+    database = tmp_path / "incomplete.db"
+    _seed_telemetry(database, coverage_started_at=now - timedelta(days=6))
+    incomplete = build_legacy_broker_report(7, routes_db=database, now=now)
+    assert incomplete["zero_use_candidate"]["reason_codes"] == [
+        "legacy_bridge_window_incomplete",
+        "legacy_comms_routes_window_incomplete",
+    ]
+
+
+def test_fleet_broker_report_cli_is_json_and_exit_zero(tmp_path: Path, capsys) -> None:
+    database = tmp_path / "missing.db"
+
+    rc = main(["fleet", "broker-report", "--days", "7", "--routes-db", str(database)])
+
+    assert rc == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "fleet-broker-report.v1"
+    assert payload["zero_use_candidate"]["eligible"] is False
+
+
+def test_fleet_broker_report_rejects_unsupported_windows(capsys) -> None:
+    rc = main(["fleet", "broker-report", "--days", "0"])
+
+    assert rc == EXIT_ERROR
+    assert "days must be between 1 and 90" in capsys.readouterr().err
+
+
+def test_fleet_status_and_help_expose_the_facade_contract(tmp_path: Path, capsys) -> None:
+    rc = main(["fleet", "status", "--root", str(tmp_path / "uninitialized")])
+    assert rc == EXIT_OK
+    status = json.loads(capsys.readouterr().out)
+    assert status["health"] == {
+        "db_exists": False,
+        "enabled": True,
+        "healthy": False,
+        "mode": "authority",
+        "read_only": True,
+        "schema_version": None,
+    }
+
+    rc = main(["fleet", "help"])
+    assert rc == EXIT_OK
+    help_payload = json.loads(capsys.readouterr().out)
+    assert set(help_payload) == {"truth", "hand", "eyes", "note"}
+    assert "broker_report" in help_payload["truth"]
+    assert "reap_report" in help_payload["hand"]
+    assert {"board", "backlog", "dead"} <= set(help_payload["eyes"])
+
+
+def test_fleet_reap_report_forwards_only_the_established_guards(monkeypatch, capsys) -> None:
+    from scripts.orchestration import reap_worktrees
+
+    observed: list[list[str]] = []
+
+    def fake_main(args: list[str]) -> int:
+        observed.append(args)
+        return 0
+
+    monkeypatch.setattr(reap_worktrees, "main", fake_main)
+
+    assert main(["fleet", "reap-report"]) == EXIT_OK
+    assert main(["fleet", "reap-report", "--apply", "--json", "--repo-root", "/repo"]) == EXIT_OK
+    assert capsys.readouterr().out == ""
+    assert observed == [
+        ["--merged", "--dry-run"],
+        ["--merged", "--apply", "--repo-root", "/repo", "--json"],
+    ]

--- a/tests/test_fleet_comms_legacy_broker_report.py
+++ b/tests/test_fleet_comms_legacy_broker_report.py
@@ -8,8 +8,8 @@ import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from scripts.fleet_comms.cli import EXIT_ERROR, EXIT_OK, main
-from scripts.fleet_comms.legacy_broker_report import build_legacy_broker_report
+from scripts.fleet_comms.cli import EXIT_ERROR, EXIT_OK, _short_plane_health, main
+from scripts.fleet_comms.legacy_broker_report import _usage_summary, build_legacy_broker_report
 
 
 def _seed_telemetry(path: Path, *, coverage_started_at: datetime) -> None:
@@ -208,6 +208,22 @@ def test_fleet_status_and_help_expose_the_facade_contract(tmp_path: Path, capsys
     assert "broker_report" in help_payload["truth"]
     assert "reap_report" in help_payload["hand"]
     assert {"board", "backlog", "dead"} <= set(help_payload["eyes"])
+
+
+def test_health_and_usage_helpers_tolerate_optional_values() -> None:
+    assert _short_plane_health({"schema": None}) == {
+        "db_exists": False,
+        "enabled": False,
+        "healthy": False,
+        "mode": None,
+        "read_only": False,
+        "schema_version": None,
+    }
+    assert _usage_summary([{"caller": "browser", "count": None}], bridge=False) == {
+        "seat": {"count": 0, "by_caller": {"browser": 0}},
+        "background": {"count": 0, "by_caller": {}},
+        "other": {"count": 0, "by_caller": {}},
+    }
 
 
 def test_fleet_reap_report_forwards_only_the_established_guards(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- add `fleet` facade subcommands over the existing Fleet Comms status, board, metrics, backlog, dead-letter, and guarded reaper surfaces
- add a read-only #6106 Broker Ops report with seat/background/other counts and conservative zero-use eligibility
- document the operator zero-use declaration required before any legacy route/page removal

## Validation
- `env LU_RUNTIME_INITIATOR=codex LU_RUNTIME_INITIATOR_SOURCE=explicit .venv/bin/pytest tests/test_fleet_comms_legacy_broker_report.py tests/test_fleet_comms_cli.py tests/test_legacy_comms_telemetry.py tests/test_legacy_bridge_telemetry.py`
- `.venv/bin/ruff check scripts/fleet_comms/legacy_broker_report.py scripts/fleet_comms/cli.py tests/test_fleet_comms_legacy_broker_report.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/fleet-comms-open-gaps.md`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

Refs #6106

No auto-merge: operator requested a review-held PR.