### PR TITLE
fix(gitignore): ignore .venv symlinks, not only directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ temp/
 *.yml.bak
 *.yaml.orig
 *.yml.orig
-.venv/
+.venv
 .agent/
 # Local state owned by scripts/deploy_prompts.sh. It records which shared files
 # deploy placed in .agent/ so only those paths can be reaped on a later deploy.


### PR DESCRIPTION
## Summary
- Change `.gitignore` rule `.venv/` → `.venv` so dispatch worktree `.venv` **symlinks** are ignored (trailing slash matches directories only).
- Leaves `embed-venv/` and comment references to `.venv/bin/python` untouched.
- Fixes workers’ scratch trees going dirty and the finalizer publishing junk-only PRs (#6497).

## Test plan
- [x] `git check-ignore -v .venv` → `.gitignore:127:.venv	.venv` (symlink present)
- [x] `git status --porcelain` shows no `?? .venv` with the symlink in place
- [x] `lint_agent_trailer.py` PASS
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)