### PR TITLE
feat(hygiene): auto-reap settled dispatches + home session inventory

### DIFF
--- a/docs/runbooks/home-session-inventory.md
+++ b/docs/runbooks/home-session-inventory.md
@@ -1,0 +1,42 @@
+# Home session inventory
+
+Use the inventory to inspect the local agent-session stores covered by #4956.
+It reports each provider-home root's size and age, then lists only stale files
+inside the session allowlist. It never treats a provider root or configuration
+file as a deletion candidate.
+
+```bash
+.venv/bin/python scripts/hygiene/inventory_home_sessions.py --json
+```
+
+The fixed provider allowlist is intentionally small:
+
+- `~/.codex/sessions` and `~/.codex/archived_sessions`;
+- `~/.claude/projects`;
+- `~/.cursor/chats`;
+- `~/.grok/sessions` (the documented peer in lane-retention policy).
+
+The default retention boundary is 14 days. Missing roots are reported; they are
+not created. Symlinked homes, session roots, and files are skipped.
+
+## Apply
+
+Apply is deliberately double-gated. It requires both `--apply` and the exact
+environment variable `LU_HOME_SESSION_APPLY=1`. Without that variable the
+command exits before scanning or mutating.
+
+Archive is the default apply action and moves only freshly revalidated stale
+session files to the supplied archive root. Deletion is explicit:
+
+```bash
+LU_HOME_SESSION_APPLY=1 .venv/bin/python scripts/hygiene/inventory_home_sessions.py \
+  --apply --archive-root "$HOME/Library/Application Support/learn-ukrainian/home-session-archives"
+
+LU_HOME_SESSION_APPLY=1 .venv/bin/python scripts/hygiene/inventory_home_sessions.py \
+  --apply --action delete --retention-days 30
+```
+
+Before every mutation, the command revalidates that the path is a regular file
+under one of the allowlisted session subtrees and still older than the selected
+retention boundary. It does not remove directories, provider configuration,
+symlinks, or any file outside the listed paths.

--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -22,8 +22,14 @@ task, or live-process guards. Unregistered directories with broken `.git`
 pointers are reported as recovery candidates and are never deleted
 automatically.
 
-P0 automatic reaping is restricted to clean `.worktrees/` checkouts whose
-GitHub PR is `MERGED` at the exact local head. Before removal it writes an
+P0 automatic reaping includes clean `.worktrees/` checkouts whose GitHub PR is
+`MERGED` at the exact local head. The scheduled job also enables a separately
+guarded terminal-dispatch class: only worktrees below `.worktrees/dispatch/`
+whose task record is explicitly `done`, `failed`, or `no_deliverable`, whose PID
+is dead, whose active-task and live-CWD probes are available and clear, and
+whose GitHub query confirms no open PR. Set `LU_REAPER_TERMINAL_DISPATCHES=0`
+to disable only this optional scheduled class during an incident; merged-clean
+reaping remains enabled. Before removal the reaper writes an
 append-only local journal, reserves the path as reap-pending, and creates a
 `refs/reaper-rescue/...` ref. Set `LU_REAPER_DISABLED=1` to stop automatic
 reaps immediately. The first seven days are capped by
@@ -118,7 +124,8 @@ Each run performs the following in both repository roots:
 1. fetches `origin` and prunes deleted remote refs;
 2. prunes stale Git worktree registrations;
 3. automatically removes only clean, inactive worktrees with exact merged-PR
-   head evidence; other legacy/residue classes are observed and skipped;
+   head evidence, plus the terminal-dispatch class described above; open or
+   GitHub-unknown PR state remains a hard skip;
 4. deletes local branches whose upstream is gone only when their exact head is
    proven merged or is already an ancestor of `origin/main`;
 5. preserves and reports unproven gone branches and orphaned worktree

--- a/scripts/hygiene/inventory_home_sessions.py
+++ b/scripts/hygiene/inventory_home_sessions.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Inventory and safely retain old local agent-session files (#4956).
+
+The command is dry-run by default.  ``--apply`` requires the explicit
+``LU_HOME_SESSION_APPLY=1`` environment gate and acts only on session files
+under the fixed provider allowlist below.  It never removes a provider root,
+configuration file, symlink, or file newer than the retention cutoff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+DEFAULT_RETENTION_DAYS = 14.0
+DEFAULT_ARCHIVE_ROOT = (
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "learn-ukrainian"
+    / "home-session-archives"
+)
+APPLY_ENV = "LU_HOME_SESSION_APPLY"
+
+
+@dataclass(frozen=True)
+class SessionStore:
+    provider: str
+    home_directory: str
+    session_directories: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SessionRootReport:
+    provider: str
+    path: str
+    exists: bool
+    size_bytes: int | None
+    age_days: float | None
+    session_files: int
+    skipped_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionCandidate:
+    provider: str
+    path: str
+    relative_path: str
+    size_bytes: int
+    age_days: float
+
+
+# These are the provider homes already documented by the lane-retention
+# scanner.  Apply targets only the session subtrees, never the home roots.
+SESSION_STORES: tuple[SessionStore, ...] = (
+    SessionStore("codex", ".codex", ("sessions", "archived_sessions")),
+    SessionStore("claude", ".claude", ("projects",)),
+    SessionStore("cursor", ".cursor", ("chats",)),
+    SessionStore("grok", ".grok", ("sessions",)),
+)
+
+
+def _size_bytes(path: Path) -> int | None:
+    """Return regular-file size below a real directory, or ``None`` on error."""
+    try:
+        return sum(
+            entry.stat().st_size
+            for entry in path.rglob("*")
+            if entry.is_file() and not entry.is_symlink()
+        )
+    except OSError:
+        return None
+
+
+def _raw_age_days(path: Path, *, now: float) -> float | None:
+    try:
+        return max((now - path.stat().st_mtime) / 86400.0, 0.0)
+    except OSError:
+        return None
+
+
+def _age_days(path: Path, *, now: float) -> float | None:
+    raw_age = _raw_age_days(path, now=now)
+    return None if raw_age is None else round(raw_age, 1)
+
+
+def _real_directory(path: Path) -> bool:
+    return path.is_dir() and not path.is_symlink()
+
+
+def _is_allowed_session_file(*, root: Path, session_root: Path, candidate: Path) -> bool:
+    """Ensure a regular candidate remains within a non-symlink allowlisted root."""
+    if not (_real_directory(root) and _real_directory(session_root)):
+        return False
+    if not candidate.is_file() or candidate.is_symlink():
+        return False
+    try:
+        candidate.resolve().relative_to(session_root.resolve())
+        session_root.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def inventory_home_sessions(
+    *,
+    home: Path | None = None,
+    retention_days: float = DEFAULT_RETENTION_DAYS,
+    now: float | None = None,
+) -> tuple[list[SessionRootReport], list[SessionCandidate]]:
+    """Return root size/age reports and stale, allowlisted session-file candidates."""
+    if retention_days < 0:
+        raise ValueError("retention_days must be non-negative")
+    home_root = (home or Path.home()).expanduser()
+    clock = time.time() if now is None else now
+    roots: list[SessionRootReport] = []
+    candidates: list[SessionCandidate] = []
+
+    for store in SESSION_STORES:
+        root = home_root / store.home_directory
+        if not root.exists():
+            roots.append(
+                SessionRootReport(
+                    provider=store.provider,
+                    path=str(root),
+                    exists=False,
+                    size_bytes=0,
+                    age_days=None,
+                    session_files=0,
+                )
+            )
+            continue
+        if not _real_directory(root):
+            roots.append(
+                SessionRootReport(
+                    provider=store.provider,
+                    path=str(root),
+                    exists=True,
+                    size_bytes=None,
+                    age_days=None,
+                    session_files=0,
+                    skipped_reason="provider home is not a real directory",
+                )
+            )
+            continue
+
+        session_count = 0
+        for relative_dir in store.session_directories:
+            session_root = root / relative_dir
+            if not _real_directory(session_root):
+                continue
+            try:
+                files = sorted(path for path in session_root.rglob("*") if path.is_file())
+            except OSError:
+                continue
+            for candidate in files:
+                if not _is_allowed_session_file(
+                    root=root,
+                    session_root=session_root,
+                    candidate=candidate,
+                ):
+                    continue
+                session_count += 1
+                raw_age = _raw_age_days(candidate, now=clock)
+                if raw_age is None or raw_age < retention_days:
+                    continue
+                candidates.append(
+                    SessionCandidate(
+                        provider=store.provider,
+                        path=str(candidate),
+                        relative_path=str(candidate.relative_to(root)),
+                        size_bytes=candidate.stat().st_size,
+                        age_days=round(raw_age, 1),
+                    )
+                )
+
+        roots.append(
+            SessionRootReport(
+                provider=store.provider,
+                path=str(root),
+                exists=True,
+                size_bytes=_size_bytes(root),
+                age_days=_age_days(root, now=clock),
+                session_files=session_count,
+            )
+        )
+    return roots, candidates
+
+
+def apply_retention(
+    *,
+    candidates: list[SessionCandidate],
+    home: Path,
+    archive_root: Path,
+    action: Literal["archive", "delete"],
+    retention_days: float,
+) -> list[dict[str, object]]:
+    """Archive or delete freshly revalidated allowlisted session files."""
+    if os.environ.get(APPLY_ENV) != "1":
+        raise PermissionError(f"--apply requires {APPLY_ENV}=1")
+
+    store_by_provider = {store.provider: store for store in SESSION_STORES}
+    results: list[dict[str, object]] = []
+    for candidate in candidates:
+        store = store_by_provider.get(candidate.provider)
+        if store is None:
+            results.append({"path": candidate.path, "action": "skipped", "reason": "unknown provider"})
+            continue
+        root = home / store.home_directory
+        session_roots = [root / item for item in store.session_directories]
+        path = Path(candidate.path)
+        allowed_root = next(
+            (
+                session_root
+                for session_root in session_roots
+                if _is_allowed_session_file(root=root, session_root=session_root, candidate=path)
+            ),
+            None,
+        )
+        if allowed_root is None:
+            results.append(
+                {"path": candidate.path, "action": "skipped", "reason": "outside session allowlist"}
+            )
+            continue
+        current_age = _raw_age_days(path, now=time.time())
+        if current_age is None or current_age < retention_days:
+            results.append(
+                {"path": candidate.path, "action": "skipped", "reason": "file is no longer stale"}
+            )
+            continue
+        if action == "delete":
+            path.unlink()
+            results.append({"path": candidate.path, "action": "deleted"})
+            continue
+
+        destination = archive_root / candidate.provider / candidate.relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            results.append(
+                {"path": candidate.path, "action": "skipped", "reason": "archive destination exists"}
+            )
+            continue
+        shutil.move(str(path), str(destination))
+        results.append({"path": candidate.path, "action": "archived", "archive_path": str(destination)})
+    return results
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--retention-days", type=float, default=DEFAULT_RETENTION_DAYS)
+    parser.add_argument("--apply", action="store_true", help=f"Mutate only with {APPLY_ENV}=1.")
+    parser.add_argument(
+        "--action",
+        choices=("archive", "delete"),
+        default="archive",
+        help="Apply action; archive is the default.",
+    )
+    parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.retention_days < 0:
+        raise SystemExit("--retention-days must be non-negative")
+    if args.apply and os.environ.get(APPLY_ENV) != "1":
+        print(f"--apply requires {APPLY_ENV}=1", file=sys.stderr)
+        return 2
+
+    home = Path.home()
+    roots, candidates = inventory_home_sessions(home=home, retention_days=args.retention_days)
+    results: list[dict[str, object]] = []
+    mode = "dry_run"
+    if args.apply:
+        mode = args.action
+        results = apply_retention(
+            candidates=candidates,
+            home=home,
+            archive_root=args.archive_root.expanduser(),
+            action=args.action,
+            retention_days=args.retention_days,
+        )
+    else:
+        results = [{"path": candidate.path, "action": "would_" + args.action} for candidate in candidates]
+
+    payload = {
+        "schema": "home-session-inventory.v1",
+        "mode": mode,
+        "retention_days": args.retention_days,
+        "roots": [asdict(root) for root in roots],
+        "candidates": [asdict(candidate) for candidate in candidates],
+        "results": results,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    print(f"Home session inventory ({mode}; stale >= {args.retention_days:g} days)")
+    for root in roots:
+        size = "unknown" if root.size_bytes is None else str(root.size_bytes)
+        age = "unknown" if root.age_days is None else f"{root.age_days:g}d"
+        print(f"  {root.provider}: {root.path} size={size}B age={age} sessions={root.session_files}")
+    for result in results:
+        print(f"  {result['action']}: {result['path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -482,6 +482,33 @@ def _is_ancestor_of_origin_main(path: Path) -> bool:
     return proc.returncode == 0
 
 
+_TERMINAL_DISPATCH_STATUSES = frozenset({"done", "failed", "no_deliverable"})
+
+
+def _terminal_dispatch_reason(
+    *,
+    repo_root: Path,
+    info: WorktreeInfo,
+    active_ids: set[str] | None,
+) -> str | None:
+    """Prove that a dispatch worktree is terminal and no longer owned.
+
+    This deliberately does not infer terminality from a dead PID.  A stale
+    ``running`` record may be recoverable; scheduled cleanup may only reap an
+    explicit terminal record and a known-empty active-task probe.
+    """
+    task_id = _dispatch_task_id(repo_root, info)
+    if task_id is None or active_ids is None or task_id in active_ids:
+        return None
+    task_data = _task_record(repo_root, task_id)
+    if task_data is None:
+        return None
+    task_status = task_data.get("status")
+    if task_status not in _TERMINAL_DISPATCH_STATUSES or _task_pid_alive(task_data):
+        return None
+    return f"settled dispatch task-id={task_id} status={task_status}"
+
+
 def _qualifying_reason(
     *,
     repo_root: Path,
@@ -492,6 +519,7 @@ def _qualifying_reason(
     active_ids: set[str] | None = None,
     safe_only: bool = False,
     merged_pr_only: bool = False,
+    include_terminal_dispatches: bool = False,
 ) -> str | None:
     if info.branch is not None:
         if pr_state is not None:
@@ -518,7 +546,7 @@ def _qualifying_reason(
             ):
                 return f"HEAD matches origin/{info.branch}"
 
-    if merged_pr_only:
+    if merged_pr_only and not include_terminal_dispatches:
         return None
 
     # Class B: detached-HEAD worktrees under .worktrees/
@@ -527,7 +555,13 @@ def _qualifying_reason(
     task_id = _dispatch_task_id(repo_root, info)
     is_dispatch_candidate = task_id is not None
 
-    if is_under_wt and info.detached and clean is True:
+    if (
+        not merged_pr_only
+        and not include_terminal_dispatches
+        and is_under_wt
+        and info.detached
+        and clean is True
+    ):
         has_matching_task = False
         task_settled = False
         if is_dispatch_candidate:
@@ -555,52 +589,21 @@ def _qualifying_reason(
             if age_hours is not None and age_hours > 24.0:
                 return f"detached HEAD ancestor of origin/main; age {age_hours:.1f}h > 24h"
 
-    # Class A: settled dispatch worktree (clean, worker gone).
-    # Open PRs live on the remote — a clean worktree matching origin/<branch>
-    # is safe to drop for disk recovery without closing the PR.
-    if is_dispatch_candidate and clean is True:
-        task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
-        if task_file.exists():
-            try:
-                task_data = json.loads(task_file.read_text(encoding="utf-8"))
-                if not isinstance(task_data, dict):
-                    return None
-                task_status = task_data.get("status")
-                pid_alive = _task_pid_alive(task_data)
-                terminal = task_status in ("done", "failed", "no_deliverable")
-                stuck_dead = (
-                    task_status in ("queued", "starting", "running", "needs_finalize")
-                    and not pid_alive
-                )
-                # Fail closed when Monitor active-task probe is unavailable.
-                settled = (
-                    (terminal or stuck_dead)
-                    and active_ids is not None
-                    and task_id not in active_ids
-                )
-                if settled and not pid_alive:
-                    if info.branch:
-                        prs, pr_error = _query_pr_states(repo_root, info.branch)
-                        if pr_error is not None:
-                            return None
-                        open_prs = [pr for pr in prs if pr.state == "OPEN"]
-                        if not open_prs:
-                            return (
-                                f"settled dispatch task-id={task_id} "
-                                f"status={task_status}"
-                            )
-                        if _origin_matches_head(info.path, info.branch):
-                            return (
-                                f"settled dispatch task-id={task_id} "
-                                f"status={task_status}; open PR remains on remote"
-                            )
-                    else:
-                        return (
-                            f"settled dispatch task-id={task_id} "
-                            f"status={task_status}"
-                        )
-            except Exception:
-                pass
+    # Optional Class A: settled dispatch worktree.  This class is intentionally
+    # narrower than the legacy classes: an explicit terminal task record, no
+    # live PID, a known-empty active-task probe, and no open PR are all required.
+    if (
+        is_dispatch_candidate
+        and clean is True
+        and (include_terminal_dispatches or not merged_pr_only)
+    ):
+        terminal_reason = _terminal_dispatch_reason(
+            repo_root=repo_root,
+            info=info,
+            active_ids=active_ids,
+        )
+        if terminal_reason is not None and (pr_state is None or pr_state.state != "OPEN"):
+            return terminal_reason
 
     return None
 
@@ -723,6 +726,7 @@ def _reap_qualified_worktree(
     apply: bool,
     preserve_then_reap: bool,
     prune_merged_branches: bool,
+    require_terminal_dispatch_guards: bool,
 ) -> ReapResult:
     expected_head = info.head
     if dirty is None:
@@ -837,6 +841,59 @@ def _reap_qualified_worktree(
                 pr=_pr_dict(pr_state),
             )
 
+        if require_terminal_dispatch_guards:
+            current_active_ids = _active_task_ids()
+            current_live_cwds = _live_cwd_paths(repo_root)
+            if current_active_ids is None or current_live_cwds is None:
+                return ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="skipped",
+                    reason="terminal dispatch guards unavailable during cleanup",
+                    dirty=dirty,
+                    pr=_pr_dict(pr_state),
+                )
+            terminal_reason = _terminal_dispatch_reason(
+                repo_root=repo_root,
+                info=info,
+                active_ids=current_active_ids,
+            )
+            activity = _activity_reason(
+                repo_root=repo_root,
+                info=info,
+                active_ids=current_active_ids,
+                live_cwds=current_live_cwds,
+            )
+            if terminal_reason is None or activity is not None:
+                return ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="skipped",
+                    reason=activity or "terminal dispatch state changed during cleanup",
+                    dirty=dirty,
+                    pr=_pr_dict(pr_state),
+                )
+            if info.branch is not None:
+                current_prs, current_pr_error = _query_pr_states(repo_root, info.branch)
+                if current_pr_error is not None:
+                    return ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason=f"PR guard unavailable during cleanup; {current_pr_error}",
+                        dirty=dirty,
+                        pr=_pr_dict(pr_state),
+                    )
+                if any(pr.state == "OPEN" for pr in current_prs):
+                    return ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason="open PR appeared during cleanup",
+                        dirty=dirty,
+                        pr=_pr_dict(pr_state),
+                    )
+
         recovery_ref, recovery_error = reaper_lifecycle.create_recovery_ref(
             repo_root,
             branch=info.branch,
@@ -928,6 +985,7 @@ def reap_worktrees(
     live_cwds: set[Path] | None = None,
     merged_pr_only: bool = True,
     require_activity_probe: bool | None = None,
+    include_terminal_dispatches: bool = False,
 ) -> list[ReapResult]:
     """Evaluate and optionally reap eligible worktrees.
 
@@ -1003,7 +1061,7 @@ def reap_worktrees(
                 pr_states, pr_error = _query_pr_states(repo_root, info.branch)
                 pr_state = _best_pr(pr_states)
 
-            if merged_pr_only and pr_error is not None:
+            if (merged_pr_only or include_terminal_dispatches) and pr_error is not None:
                 results.append(
                     ReapResult(
                         path=str(info.path),
@@ -1025,6 +1083,7 @@ def reap_worktrees(
                 active_ids=active_ids,
                 safe_only=safe_only,
                 merged_pr_only=merged_pr_only,
+                include_terminal_dispatches=include_terminal_dispatches,
             )
             if reason is None:
                 if info.branch is None:
@@ -1066,6 +1125,10 @@ def reap_worktrees(
                     apply=apply,
                     preserve_then_reap=preserve_then_reap,
                     prune_merged_branches=prune_merged_branches,
+                    require_terminal_dispatch_guards=(
+                        include_terminal_dispatches
+                        and reason.startswith("settled dispatch task-id=")
+                    ),
                 )
             )
 
@@ -1144,6 +1207,7 @@ def reap_success_worktree(
         apply=apply,
         preserve_then_reap=preserve_then_reap,
         prune_merged_branches=False,
+        require_terminal_dispatch_guards=False,
     )
 
 
@@ -1247,6 +1311,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable pre-P0 non-merged cleanup classes for an explicit manual run.",
     )
     parser.add_argument(
+        "--terminal-dispatches",
+        action="store_true",
+        help=(
+            "Also reap clean terminal dispatch worktrees only when their task is "
+            "inactive, its PID is dead, and GitHub confirms no open PR."
+        ),
+    )
+    parser.add_argument(
         "--worktree",
         action="append",
         type=Path,
@@ -1268,7 +1340,9 @@ def main(argv: list[str] | None = None) -> int:
         else primary_checkout_root(resolve_repo_root())
     )
     apply = bool(args.apply) or args.command == "apply"
-    merged_mode = bool(args.merged) or not bool(args.legacy_classes)
+    merged_mode = bool(args.merged) or (
+        not bool(args.legacy_classes) and not bool(args.terminal_dispatches)
+    )
     preserve = bool(args.preserve_then_reap)
     prune = bool(args.prune_merged_branches) or bool(args.merged)
     safe_only = bool(args.safe_only) or merged_mode
@@ -1298,6 +1372,7 @@ def main(argv: list[str] | None = None) -> int:
         safe_only=safe_only,
         merged_pr_only=merged_mode,
         require_activity_probe=apply,
+        include_terminal_dispatches=bool(args.terminal_dispatches),
     )
     if args.json:
         print(json.dumps([_result_payload(result) for result in results], indent=2))

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -34,6 +34,16 @@ SCHEMA_VERSION = "scheduled-git-hygiene.v2"
 DEFAULT_INTERVAL_MINUTES = 240
 
 
+def terminal_dispatch_reaping_enabled() -> bool:
+    """Return whether the scheduled terminal-dispatch class is enabled.
+
+    The class is on by default for disk-pressure recovery.  Setting
+    ``LU_REAPER_TERMINAL_DISPATCHES=0`` disables only this optional class while
+    preserving exact merged-PR cleanup.
+    """
+    return os.environ.get("LU_REAPER_TERMINAL_DISPATCHES", "1") != "0"
+
+
 def default_public_repo() -> Path:
     return PROJECT_ROOT
 
@@ -394,9 +404,11 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
             prune_merged_branches=True,
             safe_only=True,
             live_cwds=live_cwds,
-            # P0 automatic enforcement is deliberately limited to exact merged
-            # heads.  Legacy settled/open-PR classes remain manual-only.
+            # Exact merged PR heads remain the primary class.  The terminal
+            # dispatch class is independently fail-closed and can be disabled
+            # with LU_REAPER_TERMINAL_DISPATCHES=0 for incident containment.
             merged_pr_only=True,
+            include_terminal_dispatches=terminal_dispatch_reaping_enabled(),
         )
         result["results"] = [asdict(row) for row in rows]
         try:

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -453,6 +453,115 @@ def test_class_a_no_deliverable_dispatch_removed(
     assert not worktree_path.exists()
 
 
+def test_terminal_dispatch_class_reaps_only_explicit_terminal_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "terminal-scheduled"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/terminal-scheduled", path=worktree)
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "failed"}), encoding="utf-8")
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
+    patch_gh(monkeypatch, {"codex/terminal-scheduled": []})
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+            include_terminal_dispatches=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.reason == "settled dispatch task-id=terminal-scheduled status=failed"
+    assert not worktree.exists()
+
+
+def test_terminal_dispatch_class_preserves_open_or_unknown_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "terminal-pr-guard"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/terminal-pr-guard", path=worktree)
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
+    patch_gh(monkeypatch, {"codex/terminal-pr-guard": [{"number": 99, "state": "OPEN"}]})
+
+    open_result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+            include_terminal_dispatches=True,
+        ),
+        worktree,
+    )
+
+    assert open_result.action == "skipped"
+    assert worktree.exists()
+
+    monkeypatch.setattr(rw, "_query_pr_states", lambda _repo, _branch: ([], "gh unavailable"))
+    unknown_result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+            include_terminal_dispatches=True,
+        ),
+        worktree,
+    )
+
+    assert unknown_result.action == "skipped"
+    assert unknown_result.reason == "PR guard unavailable; gh unavailable"
+    assert worktree.exists()
+
+
+def test_terminal_dispatch_class_does_not_infer_terminal_from_dead_running_pid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "dead-running-pid"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/dead-running-pid", path=worktree)
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({"status": "running", "pid": 999999}), encoding="utf-8"
+    )
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
+    patch_gh(monkeypatch, {"codex/dead-running-pid": []})
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+            include_terminal_dispatches=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert worktree.exists()
+
+
 def test_class_a_fail_safe_skips(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -510,13 +619,12 @@ def test_class_a_fail_safe_skips(
     results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
 
-    # Case 7: open PR + clean tip already on origin → free local worktree
+    # Case 7: an open PR remains protected even when its clean head is on origin.
     monkeypatch.setattr(rw, "_origin_matches_head", lambda _path, _branch: True)
     results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
     result = result_for(results, worktree_path)
-    assert result.action == "removed"
-    assert "open PR remains on remote" in (result.reason or "")
-    assert not worktree_path.exists()
+    assert result.action == "skipped"
+    assert worktree_path.exists()
 
 
 def test_class_b_detached_head_removed(

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -56,6 +56,51 @@ def test_apply_fails_closed_without_process_probe(tmp_path: Path, monkeypatch) -
     assert result["results"] == []
 
 
+def test_scheduled_cleanup_enables_terminal_dispatch_class_by_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(cleanup, "_worktree_prune", lambda _repo, *, apply: {"ok": True})
+    monkeypatch.setattr(cleanup.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "reap_worktrees",
+        lambda **kwargs: captured.update(kwargs) or [],
+    )
+    monkeypatch.setattr(cleanup, "cleanup_gone_local_branches", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
+    monkeypatch.setattr(cleanup, "_git_maintenance", lambda _repo, *, apply: {"ok": True})
+    monkeypatch.setattr(cleanup, "sweep_review_temp_orphans", lambda: {"errors": 0})
+
+    cleanup._repo_result(repo, apply=False)
+
+    assert captured["merged_pr_only"] is True
+    assert captured["include_terminal_dispatches"] is True
+
+
+def test_scheduled_terminal_dispatch_class_can_be_disabled(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("LU_REAPER_TERMINAL_DISPATCHES", "0")
+    monkeypatch.setattr(cleanup, "_worktree_prune", lambda _repo, *, apply: {"ok": True})
+    monkeypatch.setattr(cleanup.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "reap_worktrees",
+        lambda **kwargs: captured.update(kwargs) or [],
+    )
+    monkeypatch.setattr(cleanup, "cleanup_gone_local_branches", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
+    monkeypatch.setattr(cleanup, "_git_maintenance", lambda _repo, *, apply: {"ok": True})
+    monkeypatch.setattr(cleanup, "sweep_review_temp_orphans", lambda: {"errors": 0})
+
+    cleanup._repo_result(repo, apply=False)
+
+    assert captured["include_terminal_dispatches"] is False
+
+
 def test_orphaned_broken_gitdir_is_reported_not_deleted(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     orphan = repo / ".worktrees" / "dispatch" / "codex" / "orphan"

--- a/tests/test_inventory_home_sessions.py
+++ b/tests/test_inventory_home_sessions.py
@@ -1,0 +1,95 @@
+"""Tests for the allowlisted home-session inventory and retention CLI."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts.hygiene import inventory_home_sessions as inventory
+
+
+def _old_file(path: Path, *, age_days: float = 15.0) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("session\n", encoding="utf-8")
+    timestamp = time.time() - age_days * 86400
+    os.utime(path, (timestamp, timestamp))
+    return path
+
+
+def test_inventory_reports_provider_roots_and_only_stale_session_files(tmp_path: Path) -> None:
+    old = _old_file(tmp_path / ".codex" / "sessions" / "2026" / "old.jsonl")
+    _old_file(tmp_path / ".codex" / "config.toml")
+    recent = _old_file(tmp_path / ".claude" / "projects" / "recent.jsonl", age_days=2)
+
+    roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+
+    by_provider = {root.provider: root for root in roots}
+    assert by_provider["codex"].exists is True
+    assert by_provider["codex"].size_bytes is not None
+    assert by_provider["claude"].session_files == 1
+    assert {candidate.path for candidate in candidates} == {str(old)}
+    assert str(recent) not in {candidate.path for candidate in candidates}
+
+
+def test_apply_requires_explicit_environment_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    old = _old_file(tmp_path / ".codex" / "sessions" / "old.jsonl")
+    _roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+    monkeypatch.delenv(inventory.APPLY_ENV, raising=False)
+
+    with pytest.raises(PermissionError, match="LU_HOME_SESSION_APPLY=1"):
+        inventory.apply_retention(
+            candidates=candidates,
+            home=tmp_path,
+            archive_root=tmp_path / "archive",
+            action="archive",
+            retention_days=14,
+        )
+
+    assert old.exists()
+
+
+def test_apply_archives_only_stale_allowlisted_session_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = _old_file(tmp_path / ".codex" / "sessions" / "old.jsonl")
+    config = _old_file(tmp_path / ".codex" / "config.toml")
+    _roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+    monkeypatch.setenv(inventory.APPLY_ENV, "1")
+
+    results = inventory.apply_retention(
+        candidates=candidates,
+        home=tmp_path,
+        archive_root=tmp_path / "archive",
+        action="archive",
+        retention_days=14,
+    )
+
+    archived = tmp_path / "archive" / "codex" / "sessions" / "old.jsonl"
+    assert results == [{"path": str(old), "action": "archived", "archive_path": str(archived)}]
+    assert not old.exists()
+    assert archived.read_text(encoding="utf-8") == "session\n"
+    assert config.exists()
+
+
+def test_symlinked_session_file_is_never_a_candidate(tmp_path: Path) -> None:
+    outside = _old_file(tmp_path / "outside.jsonl")
+    session_dir = tmp_path / ".cursor" / "chats"
+    session_dir.mkdir(parents=True)
+    (session_dir / "linked.jsonl").symlink_to(outside)
+
+    _roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+
+    assert candidates == []
+    assert outside.exists()
+
+
+def test_retention_boundary_uses_unrounded_file_age(tmp_path: Path) -> None:
+    almost_old = _old_file(tmp_path / ".grok" / "sessions" / "almost-old.jsonl", age_days=13.99)
+
+    _roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+
+    assert str(almost_old) not in {candidate.path for candidate in candidates}


### PR DESCRIPTION
## Summary
- Expand fail-closed auto-reap to terminal settled dispatch worktrees (no open PR, clean, dead PID)
- Home session inventory CLI with apply gated by `LU_HOME_SESSION_APPLY=1`
- Docs/tests

Closes part of #4956 hygiene. Stream #4707.

## Full drive
Part of operator end-to-end residual: onboard / venv / reaper-home / facade.

X-Agent: codex/full-reaper-home