### PR TITLE
feat(lexicon): additive EN delta-merge recovers 5905 Atlas translations

### DIFF
--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -109,7 +109,6 @@ class MergeStats:
     skipped_live_has_translation: int = 0
     skipped_pulled_missing_slug: int = 0
     skipped_pulled_lacks_translation: int = 0
-    overwritten_nonempty_en: int = 0
     filled_slugs: list[str] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
@@ -176,10 +175,6 @@ def merge_translation_delta(
     if after_count != before_count:
         raise RuntimeError(
             f"entry-count invariant broken: before={before_count} after={after_count}"
-        )
-    if stats.overwritten_nonempty_en != 0:
-        raise RuntimeError(
-            f"overwrite invariant broken: overwritten_nonempty_en={stats.overwritten_nonempty_en}"
         )
 
     if stamp_generated_at:
@@ -281,6 +276,20 @@ def main() -> int:
         report_path = args.report if args.report.is_absolute() else ROOT / args.report
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    if overwrite_proof != 0:
+        print(
+            json.dumps(
+                {
+                    "error": "overwrite_proof_modified_nonempty_en",
+                    "overwrite_proof_modified_nonempty_en": overwrite_proof,
+                    "wrote": False,
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return 1
 
     if args.write:
         if live_path.resolve() == DEFAULT_MANIFEST.resolve():

--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Additive slug-keyed merge of EN translation cards onto a live Atlas manifest.
+
+Copies ``enrichment.translation`` from a pulled (donor) manifest onto live
+entries that lack EN, keyed by ``url_slug``. Never adds or drops entries, and
+never overwrites a live entry that already has a non-empty EN translation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+DEFAULT_PULLED = ROOT / "batch_state" / "full-en-reenrich-pulled" / "manifest.json"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT
+from scripts.lexicon.manifest_io import load_manifest, write_manifest
+
+
+def sync_embedded_fingerprint_from_sidecar(
+    manifest: dict[str, Any],
+    *,
+    fingerprint_path: Path = DEFAULT_FINGERPRINT,
+) -> dict[str, Any]:
+    """Embed the committed fingerprint sidecar without regenerating it.
+
+    Sparse worktrees may omit fingerprint inputs (for example ``curriculum/``),
+    so ``write_fingerprint`` / ``build_fingerprint`` can drift. Publishing only
+    requires the embedded value to match the committed sidecar.
+    """
+    payload = json.loads(fingerprint_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{fingerprint_path} must contain a JSON object")
+    schema_version = payload.get("schema_version")
+    fingerprint = payload.get("fingerprint")
+    if schema_version is None or not isinstance(fingerprint, str) or not fingerprint:
+        raise ValueError(f"{fingerprint_path} missing schema_version/fingerprint")
+    manifest["manifest_fingerprint"] = {
+        "schema_version": schema_version,
+        "fingerprint": fingerprint,
+    }
+    return payload
+
+
+def entry_has_translation(entry: dict[str, Any]) -> bool:
+    """Return True when ``enrichment.translation.en`` has a non-empty term."""
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return False
+    translation = enrichment.get("translation")
+    if not isinstance(translation, dict):
+        return False
+    terms = translation.get("en")
+    return isinstance(terms, list) and any(str(term).strip() for term in terms)
+
+
+def entry_translation(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the translation object when it carries a non-empty EN list."""
+    if not entry_has_translation(entry):
+        return None
+    enrichment = entry.get("enrichment")
+    assert isinstance(enrichment, dict)
+    translation = enrichment.get("translation")
+    assert isinstance(translation, dict)
+    return translation
+
+
+def _slug_index(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("manifest.entries must be a list")
+    index: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("url_slug")
+        if isinstance(slug, str) and slug:
+            index[slug] = entry
+    return index
+
+
+def _add_source(enrichment: dict[str, Any], source: object) -> None:
+    if not source:
+        return
+    sources = set(enrichment.get("sources") or [])
+    sources.add(str(source))
+    enrichment["sources"] = sorted(sources)
+
+
+@dataclass
+class MergeStats:
+    """Deterministic summary of an additive translation merge."""
+
+    live_entry_count_before: int
+    live_entry_count_after: int
+    pulled_entry_count: int
+    filled: int = 0
+    skipped_live_has_translation: int = 0
+    skipped_pulled_missing_slug: int = 0
+    skipped_pulled_lacks_translation: int = 0
+    overwritten_nonempty_en: int = 0
+    filled_slugs: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def merge_translation_delta(
+    live: dict[str, Any],
+    pulled: dict[str, Any],
+    *,
+    stamp_generated_at: bool = True,
+) -> MergeStats:
+    """Merge pulled EN translations into ``live`` in place.
+
+    Hard invariants:
+    - ``len(live["entries"])`` is unchanged
+    - entries that already have EN keep their existing translation object
+    - pulled-only slugs never create new live entries
+    """
+    entries = live.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("live manifest.entries must be a list")
+
+    before_count = len(entries)
+    pulled_by_slug = _slug_index(pulled)
+    stats = MergeStats(
+        live_entry_count_before=before_count,
+        live_entry_count_after=before_count,
+        pulled_entry_count=len(pulled.get("entries") or []),
+    )
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("url_slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+
+        if entry_has_translation(entry):
+            stats.skipped_live_has_translation += 1
+            continue
+
+        donor = pulled_by_slug.get(slug)
+        if donor is None:
+            stats.skipped_pulled_missing_slug += 1
+            continue
+
+        donor_translation = entry_translation(donor)
+        if donor_translation is None:
+            stats.skipped_pulled_lacks_translation += 1
+            continue
+
+        enrichment = entry.get("enrichment")
+        if not isinstance(enrichment, dict):
+            enrichment = {}
+            entry["enrichment"] = enrichment
+        enrichment["translation"] = copy.deepcopy(donor_translation)
+        _add_source(enrichment, donor_translation.get("source"))
+        stats.filled += 1
+        stats.filled_slugs.append(slug)
+
+    after_count = len(live.get("entries") or [])
+    stats.live_entry_count_after = after_count
+    if after_count != before_count:
+        raise RuntimeError(
+            f"entry-count invariant broken: before={before_count} after={after_count}"
+        )
+    if stats.overwritten_nonempty_en != 0:
+        raise RuntimeError(
+            f"overwrite invariant broken: overwritten_nonempty_en={stats.overwritten_nonempty_en}"
+        )
+
+    if stamp_generated_at:
+        live["generated_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return stats
+
+
+def prove_no_nonempty_en_overwrites(
+    before_by_slug: dict[str, dict[str, Any]],
+    after_by_slug: dict[str, dict[str, Any]],
+) -> int:
+    """Count entries whose previously non-empty EN changed after the merge."""
+    modified = 0
+    for slug, before_entry in before_by_slug.items():
+        before_tr = entry_translation(before_entry)
+        if before_tr is None:
+            continue
+        after_entry = after_by_slug.get(slug)
+        if after_entry is None:
+            modified += 1
+            continue
+        after_tr = entry_translation(after_entry)
+        if after_tr != before_tr:
+            modified += 1
+    return modified
+
+
+def _read_local_manifest(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Additive slug-keyed merge of EN translation cards from a pulled "
+            "manifest onto the live Atlas catalog (no entry add/drop, no EN overwrite)."
+        )
+    )
+    parser.add_argument("--live", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--pulled", type=Path, default=DEFAULT_PULLED)
+    parser.add_argument(
+        "--local-live",
+        action="store_true",
+        help="Read --live directly instead of hydrating the release-pinned default path.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist the merged live manifest. Default is dry-run (in-memory only).",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Optional path to write the merge stats JSON.",
+    )
+    parser.add_argument(
+        "--no-stamp-generated-at",
+        action="store_true",
+        help="Leave live generated_at unchanged (tests / deterministic fixtures).",
+    )
+    args = parser.parse_args()
+
+    live_path = args.live if args.live.is_absolute() else ROOT / args.live
+    pulled_path = args.pulled if args.pulled.is_absolute() else ROOT / args.pulled
+
+    if args.local_live or live_path.resolve() != DEFAULT_MANIFEST.resolve():
+        live = _read_local_manifest(live_path)
+    else:
+        live = load_manifest(live_path)
+    pulled = _read_local_manifest(pulled_path)
+
+    before_by_slug = {slug: copy.deepcopy(entry) for slug, entry in _slug_index(live).items()}
+    stats = merge_translation_delta(
+        live,
+        pulled,
+        stamp_generated_at=not args.no_stamp_generated_at,
+    )
+    after_by_slug = _slug_index(live)
+    overwrite_proof = prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug)
+
+    payload = stats.as_dict()
+    payload["overwrite_proof_modified_nonempty_en"] = overwrite_proof
+    payload["missing_translation_after"] = sum(
+        1 for entry in (live.get("entries") or []) if isinstance(entry, dict) and not entry_has_translation(entry)
+    )
+    # Keep report compact for large fills.
+    if len(payload["filled_slugs"]) > 50:
+        payload["filled_slugs_sample"] = payload["filled_slugs"][:50]
+        payload["filled_slugs"] = []
+
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if args.report is not None:
+        report_path = args.report if args.report.is_absolute() else ROOT / args.report
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    if args.write:
+        if live_path.resolve() == DEFAULT_MANIFEST.resolve():
+            sync_embedded_fingerprint_from_sidecar(live)
+        write_manifest(live_path, live)
+        print(json.dumps({"wrote": str(live_path), "entries": stats.live_entry_count_after}, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "74e4ed1db4463c6b4f0ee5ce256e0e311e326b13690250f395efdf7d38410d12",
+  "fingerprint": "826cc225ec1db87714441f2fdf240d47632019e6f1d19bd161b49d88e059a326",
   "inputs": {
     "lexicon_code": [
       {
@@ -151,6 +151,10 @@
         "sha256": "b76c9ff8e5db5929aa051f111fb50cb27cb0a304dc6d260f0f650ffc3f2bcf24"
       },
       {
+        "path": "scripts/lexicon/merge_translation_delta.py",
+        "sha256": "cba0e82499265562ae20e6323b357f3c1f1ce1e88ee5da7166706ced8b161955"
+      },
+      {
         "path": "scripts/lexicon/migrate_source_labels.py",
         "sha256": "08a943e9fa5e39923a30d330af2eb5511e77de4d6116824d863302f8ddf1a056"
       },
@@ -227,6 +231,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 55
+    "lexicon_code_files": 56
   }
 }

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,33 +1,33 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-0778b59991c5.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-3d19f7e85ca7.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "b1ec63f8d8cdf0b1b2d3d7a537c116aadc456fc7dcd6d39a383f07217d701588",
+  "manifest_fingerprint": "74e4ed1db4463c6b4f0ee5ce256e0e311e326b13690250f395efdf7d38410d12",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-08-05T20:32:25Z",
-  "gz_sha256": "c025ccad9e27f9133f52c13c945d49496281e357333d58f23437aa814a1cd523",
-  "json_sha256": "0778b59991c5ba16564935df08ddd7896d2ea3ceefa2ad3768096e66c4658f39",
-  "gz_bytes": 14196623,
-  "json_bytes": 102569555,
+  "generated_at": "2026-08-09T01:18:30Z",
+  "gz_sha256": "a7c0c8fc0ae58c34360d0ab65690bc599683f941471766367603071d1d51c554",
+  "json_sha256": "3d19f7e85ca711ec9b2031f225815844d2cc06b27a5bc2211395a88376f75867",
+  "gz_bytes": 14560392,
+  "json_bytes": 104498278,
   "richness_gate": {
     "baseline": {
-      "poc_thin_pages": 1270,
+      "poc_thin_pages": 2024,
       "search_no_visible_gloss": 43,
-      "old_gate_no_english_anchor": 50
+      "old_gate_no_english_anchor": 48
     },
     "candidate": {
-      "poc_thin_pages": 2024,
+      "poc_thin_pages": 7924,
       "search_no_visible_gloss": 43,
       "old_gate_no_english_anchor": 48
     },
     "regressions": {
       "poc_thin_pages": {
-        "baseline": 1270,
-        "candidate": 2024
+        "baseline": 2024,
+        "candidate": 7924
       }
     },
-    "override_reason": "#6369 residual Class-B EN fill: generic release asset stale vs versioned canonical; operator override from existing pointer",
+    "override_reason": "Additive #4220/#4387 EN delta-merge: 5905 translation fills pull previously bare entries into old_gate_enriched, so poc_thin_pages rises (2024→7924) while old_gate_no_english_anchor stays 48, entry count stays 19203, and zero nonempty-EN overwrites. Override authorized by atlas-reenrich-delta-merge brief (option 2).",
     "bootstrap": false
   },
-  "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON. richness_gate.baseline.poc_thin_pages dropped from the prior pointer's recorded 2278 to 1270 because publish_manifest.py recomputes baseline live off the currently published GitHub release asset (download_published_manifest -> audit_manifest, scripts/lexicon/publish_manifest.py) rather than reusing the value recorded in the previous pointer commit; the intervening park_thin_entries.py run (scripts/lexicon/park_thin_entries.py) removed audit-classified thin lemma_article entries from that canonical asset between the two publishes, so 1270 reflects the true current published count, not a re-baselined/relaxed target. The remaining override covers old_gate_no_english_anchor (residual 48, unreachable without wired EN per #6369 scope); teacher P1's own residual on that gate is 0."
+  "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -1,0 +1,148 @@
+"""Fixture tests for additive slug-keyed EN translation delta merge."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from scripts.lexicon.merge_translation_delta import (
+    entry_has_translation,
+    entry_translation,
+    merge_translation_delta,
+    prove_no_nonempty_en_overwrites,
+)
+
+
+def _entry(slug: str, lemma: str, *, en: list[str] | None = None, source: str = "fixture") -> dict:
+    entry: dict = {"url_slug": slug, "lemma": lemma, "pos": "noun"}
+    if en is not None:
+        entry["enrichment"] = {
+            "translation": {"en": en, "source": source},
+            "sources": [source],
+        }
+    else:
+        entry["enrichment"] = {"stress": {"form": lemma, "source": "fixture"}}
+    return entry
+
+
+def test_copies_missing_en_from_pulled() -> None:
+    live = {"entries": [_entry("alpha", "альфа"), _entry("beta", "бета", en=["keep"])]}
+    pulled = {
+        "entries": [
+            _entry("alpha", "альфа", en=["apple"], source="pulled-src"),
+            _entry("beta", "бета", en=["banana"], source="pulled-src"),
+        ]
+    }
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    assert stats.filled == 1
+    assert stats.filled_slugs == ["alpha"]
+    assert entry_translation(live["entries"][0]) == {"en": ["apple"], "source": "pulled-src"}
+    assert "pulled-src" in live["entries"][0]["enrichment"]["sources"]
+    assert entry_translation(live["entries"][1]) == {"en": ["keep"], "source": "fixture"}
+
+
+def test_preserves_existing_en_even_when_pulled_differs() -> None:
+    live = {"entries": [_entry("kiwi", "ківі", en=["kiwi 2"], source="live-balla")]}
+    pulled = {"entries": [_entry("kiwi", "ківі", en=["different"], source="pulled")]}
+    before = copy.deepcopy(live["entries"][0]["enrichment"]["translation"])
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    assert stats.filled == 0
+    assert stats.skipped_live_has_translation == 1
+    assert live["entries"][0]["enrichment"]["translation"] == before
+    assert stats.overwritten_nonempty_en == 0
+
+
+def test_slug_absent_in_pulled_is_ignored() -> None:
+    live = {"entries": [_entry("only-live", "лише"), _entry("shared", "спільне")]}
+    pulled = {"entries": [_entry("shared", "спільне", en=["shared"], source="pulled")]}
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    assert stats.filled == 1
+    assert stats.skipped_pulled_missing_slug == 1
+    assert not entry_has_translation(live["entries"][0])
+    assert entry_has_translation(live["entries"][1])
+
+
+def test_entry_count_invariance_and_no_pulled_only_inserts() -> None:
+    live = {
+        "entries": [
+            _entry("a", "а"),
+            _entry("b", "б", en=["bee"]),
+            _entry("c", "в"),
+        ]
+    }
+    pulled = {
+        "entries": [
+            _entry("a", "а", en=["and"]),
+            _entry("pulled-only", "зайве", en=["extra"]),
+            _entry("c", "в"),  # present but no EN
+        ]
+    }
+    before_slugs = [e["url_slug"] for e in live["entries"]]
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    assert stats.live_entry_count_before == 3
+    assert stats.live_entry_count_after == 3
+    assert [e["url_slug"] for e in live["entries"]] == before_slugs
+    assert stats.filled == 1
+    assert stats.filled_slugs == ["a"]
+    assert stats.skipped_pulled_lacks_translation == 1
+    assert all(e["url_slug"] != "pulled-only" for e in live["entries"])
+
+
+def test_overwrite_proof_reports_zero_for_clean_merge() -> None:
+    live = {
+        "entries": [
+            _entry("млн", "млн", en=["m", "million"], source="live"),
+            _entry("gap", "прогалина"),
+        ]
+    }
+    before_by_slug = {e["url_slug"]: copy.deepcopy(e) for e in live["entries"]}
+    pulled = {
+        "entries": [
+            _entry("млн", "млн", en=["should-not-apply"], source="pulled"),
+            _entry("gap", "прогалина", en=["gap"], source="pulled"),
+        ]
+    }
+
+    merge_translation_delta(live, pulled, stamp_generated_at=False)
+    after_by_slug = {e["url_slug"]: e for e in live["entries"]}
+
+    assert prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug) == 0
+    assert entry_translation(live["entries"][0]) == {"en": ["m", "million"], "source": "live"}
+    assert entry_translation(live["entries"][1]) == {"en": ["gap"], "source": "pulled"}
+
+
+def test_sync_embedded_fingerprint_from_sidecar(tmp_path: Path) -> None:
+    sidecar = tmp_path / "lexicon-manifest.fingerprint.json"
+    sidecar.write_text(
+        json.dumps({"schema_version": 1, "fingerprint": "abc123"}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    live = {"entries": [_entry("x", "ікс")]}
+    from scripts.lexicon.merge_translation_delta import sync_embedded_fingerprint_from_sidecar
+
+    payload = sync_embedded_fingerprint_from_sidecar(live, fingerprint_path=sidecar)
+    assert payload["fingerprint"] == "abc123"
+    assert live["manifest_fingerprint"] == {"schema_version": 1, "fingerprint": "abc123"}
+
+
+def test_write_roundtrip_preserves_fill(tmp_path: Path) -> None:
+    from scripts.lexicon.manifest_io import write_manifest
+
+    live_path = tmp_path / "live.json"
+    live = {"version": "0.1", "entries": [_entry("x", "ікс")]}
+    pulled = {"version": "0.1", "entries": [_entry("x", "ікс", en=["x"], source="pulled")]}
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+    assert stats.filled == 1
+    write_manifest(live_path, live)
+    rewritten = json.loads(live_path.read_text(encoding="utf-8"))
+    assert entry_has_translation(rewritten["entries"][0])

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -54,7 +54,6 @@ def test_preserves_existing_en_even_when_pulled_differs() -> None:
     assert stats.filled == 0
     assert stats.skipped_live_has_translation == 1
     assert live["entries"][0]["enrichment"]["translation"] == before
-    assert stats.overwritten_nonempty_en == 0
 
 
 def test_slug_absent_in_pulled_is_ignored() -> None:
@@ -118,6 +117,21 @@ def test_overwrite_proof_reports_zero_for_clean_merge() -> None:
     assert prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug) == 0
     assert entry_translation(live["entries"][0]) == {"en": ["m", "million"], "source": "live"}
     assert entry_translation(live["entries"][1]) == {"en": ["gap"], "source": "pulled"}
+
+
+def test_overwrite_proof_returns_nonzero_when_nonempty_en_changes() -> None:
+    """Mutation check: the proof must fail when a nonempty EN object actually changes."""
+    before_by_slug = {
+        "kiwi": _entry("kiwi", "ківі", en=["kiwi 2"], source="live-balla"),
+        "млн": _entry("млн", "млн", en=["m", "million"], source="live"),
+    }
+    after_by_slug = {
+        "kiwi": _entry("kiwi", "ківі", en=["different"], source="mutated"),
+        "млн": copy.deepcopy(before_by_slug["млн"]),
+    }
+
+    assert prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug) > 0
+    assert prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug) == 1
 
 
 def test_sync_embedded_fingerprint_from_sidecar(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds `scripts/lexicon/merge_translation_delta.py`: slug-keyed additive copy of `enrichment.translation` from a pulled donor manifest onto the live catalog (no entry add/drop; never overwrite non-empty EN).
- Lands the VPS full-EN reenrich donor (`batch_state/full-en-reenrich-pulled/manifest.json`, sha256 `922f04649b5e…`, 17724 entries) onto published lineage `0778b59991c5…` → new release asset `3d19f7e85ca7…` (19203 entries unchanged).
- Publishes through the existing `publish_manifest` richness gate with a recorded `poc_thin_pages` override (expected denominator expansion when bare entries gain EN-only enrichment).

Refs: #4220 #4387  
Brief: `batch_state/briefs/atlas-reenrich-delta-merge.md` (option 2 authorized after `atlas-land-full-en-reenrich` STOP).

## Invariant proofs (re-derived locally)

```text
cwd=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/cursor/atlas-reenrich-delta-merge

# donor
pulled_sha256 922f04649b5e11359f67e6f1758e3da1c3faac4f9846d9b433c3d9c7d093b47e
pulled_entries 17724

# 1) entry count invariance
invariant1_entry_count: before=19203 after=19203 ok=true

# 2) zero overwrites of previously non-empty EN
invariant2_overwrite_modified_nonempty_en: 0
filled: 5905

# 3) #6432 anchors unchanged (ківі, млн)
ківі {'en': ['kiwi 2'], 'source': 'Українсько-англійський словник (М. Балла)', ...}
млн {'en': ['m', 'million'], 'source': 'Українсько-англійський словник (М. Балла)', ...}
unchanged: true

# 4) old_gate_no_english_anchor does not rise
invariant4_old_gate: before=48 after=48 ok=true

# 5) residual missing_translation
missing_translation: before=10834 after=4929 (filled=5905)
```

Published pointer: `lexicon-manifest-3d19f7e85ca7.json.gz`  
`richness_gate.candidate.old_gate_no_english_anchor=48` (flat)  
`richness_gate` records `poc_thin_pages` 2024→7924 with override reason (5900/5905 fills were previously enrichment-less; translation alone does not clear the 5-section thin bar).

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_merge_translation_delta.py tests/test_publish_manifest.py tests/test_reenrich_thin_manifest_entries.py -q` (29+7 paths green during verification)
- [x] `.venv/bin/ruff check scripts/lexicon/merge_translation_delta.py tests/test_merge_translation_delta.py`
- [x] `.venv/bin/python -m scripts.lexicon.publish_manifest --allow-richness-regression '…'` (uploaded versioned + canonical assets; pointer committed)
- [x] `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Do **not** arm auto-merge — driver owns merge.

Made with [Cursor](https://cursor.com)