### PR TITLE
feat(atlas): LINT-003 DRILL_SENSE_ID_MISSING + enrich honesty tags (#6437 PR2)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -647,7 +647,7 @@ Additional audit guardrails:
 - `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
 - `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
 - `scripts/audit/atlas_source_entry_count.py` - aggregate-only Word Atlas source-corpus entry-demand census by finalized entry-model bucket; public reports must not include source text, private paths, filenames, or candidate lists
-- `scripts/audit/lint_word_atlas.py` - read-only, advisory sense-first Word Atlas entry lint (#6437 PR1): LINT-001 `TRUNCATED_TEXT_CUTOFF` + LINT-002 `AMBIGUOUS_BARE_EN` against `senses[]`; skips entries without sense data; no CI gate wired yet
+- `scripts/audit/lint_word_atlas.py` - read-only, advisory sense-first Word Atlas entry lint (#6437): LINT-001 `TRUNCATED_TEXT_CUTOFF` + LINT-002 `AMBIGUOUS_BARE_EN` against `senses[]`, plus LINT-003 `DRILL_SENSE_ID_MISSING` on practice bindings / optional `--practice-deck` shards; skips sense rules when entries lack sense data; no CI gate wired yet
 - `scripts/atlas/atlas_db.py` - rebuild `data/atlas.db` from the hydrated Atlas manifest, materialize the Astro article payload projection, and validate alias targets
 - `scripts/atlas/fill_local.py` - Phase-1 offline local enrichment writer for `data/atlas.db`; reads local dictionary/cache data only and reports per-section before/after coverage
 - `site/scripts/benchmark-atlas-db.mjs` - benchmark Atlas DB build, preload, and getStaticPaths mapping at current and synthetic sizes
@@ -862,7 +862,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
 | `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
 | `scripts/audit/atlas_source_entry_count.py` | Estimate aggregate source-corpus Atlas entry backlog by finalized bucket | `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` |
-| `scripts/audit/lint_word_atlas.py` | Advisory sense-first Atlas entry lint (LINT-001/LINT-002, #6437) | `.venv/bin/python scripts/audit/lint_word_atlas.py --manifest path/to/manifest.json` |
+| `scripts/audit/lint_word_atlas.py` | Advisory sense-first Atlas entry lint (LINT-001/002/003, #6437) | `.venv/bin/python scripts/audit/lint_word_atlas.py --manifest path/to/manifest.json` |
 | `scripts/atlas/atlas_db.py` | Rebuild `data/atlas.db`, materialize article payloads, and validate public alias targets | `.venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db` |
 | `scripts/atlas/fill_local.py` | Fill `data/atlas.db` with Phase-1 local Atlas enrichment rows | `.venv/bin/python -m scripts.atlas.fill_local --db data/atlas.db --report-json /tmp/atlas-fill-local-report.json` |
 | `site/scripts/benchmark-atlas-db.mjs` | Benchmark Atlas DB build, preloaded payload read, and getStaticPaths mapping | `npm --prefix site run atlas:perf` |

--- a/docs/runbooks/word-atlas-entry-model.md
+++ b/docs/runbooks/word-atlas-entry-model.md
@@ -246,19 +246,18 @@ senses:
     learner_uk: "недолік, вада"
     learner_en: ["defect", "flaw", "scarcity"]
     en_disambiguation: "imperfection/flaw (not marriage/ordinal second)"
-    source: "sum20_vetted|btc|dmklinger|manual_native|rag_verified"
+    source: "sum20_vetted|btc|dmklinger|manual_native|rag_verified|ai_minimum"
     completeness: "complete|truncated|draft"
 ```
 
 Field notes:
 
 - `id`: stable per-sense slug. Practice/drill wiring keys off `senses[id]`,
-  never off array position or `learner_en[0]`, so re-ordering or adding a
-  sense cannot silently drift what a learner drills (LINT-003 in the
-  companion issue, not implemented in this PR).
+  never off array position or `learner_en[0]` / `enrichment.translation.en[0]`,
+  so re-ordering or adding a sense cannot silently drift what a learner drills
+  (LINT-003).
 - `uk_source_def`: the raw lexicographical definition (СУМ-20/BTC/etc). This
-  is ingestion data — the lint gate reads it read-only and PR1 does not
-  mutate it.
+  is ingestion data — the lint gate reads it read-only and does not mutate it.
 - `learner_uk` / `learner_en`: the pedagogy-facing gloss and drill target(s).
   `learner_en` is a list because a sense can have more than one accepted EN
   target; a single-item list on a high-risk polysemous word is exactly what
@@ -266,28 +265,33 @@ Field notes:
 - `en_disambiguation`: required whenever `learner_en` is a bare single word
   that reads as a different, unrelated sense in general English (see
   LINT-002 denylist in `scripts/audit/lint_word_atlas.py`).
+- `source`: dictionary-backed values (`sum20_vetted`, `btc`, `dmklinger`,
+  `manual_native`, `rag_verified`) for sourced senses. Use `ai_minimum` when
+  the learner gloss is an AI-minimum placeholder rather than a vetted
+  dictionary sense — honesty over silent thinness (#6437 enrich honesty tags).
 - `completeness`: `truncated` is the honest tag for text a hard cap cut off
   mid-word; a `learner_uk`/`learner_en`/`en_disambiguation` value ending in
-  `...`/`…` without this tag is what LINT-001 flags. `enrich_manifest.py`
-  stopping mid-word hard slices and tagging honestly is tracked separately
-  (issue #6437 D3-4) and is not part of this PR.
+  `...`/`…` without this tag is what LINT-001 flags. `draft` marks thin /
+  incomplete learner text (including AI-minimum glosses). Enrich helpers
+  `truncate_with_honesty` + `apply_sense_honesty_tags` in
+  `scripts/lexicon/enrich_manifest.py` stamp these labels when emitting
+  sense-shaped rows.
 
-### Lint gate (PR1 scope)
+### Lint gate (PR1 + PR2 scope)
 
-`scripts/audit/lint_word_atlas.py` implements two read-only, advisory rules
-against any manifest carrying `senses[]`:
+`scripts/audit/lint_word_atlas.py` implements three read-only, advisory rules:
 
 | ID | Name | Checks |
 | --- | --- | --- |
 | LINT-001 | `TRUNCATED_TEXT_CUTOFF` | A learner-facing sense field ends `...`/`…` while `completeness != "truncated"`. |
 | LINT-002 | `AMBIGUOUS_BARE_EN` | `learner_en` is a single-item list, the word is in a high-risk polysemy denylist, and `en_disambiguation` is empty. |
+| LINT-003 | `DRILL_SENSE_ID_MISSING` | A practice binding / deck item references a lemma without a non-empty `senseId` / `sense_id` (no `en[0]` fallback). |
 
-LINT-003 (`DRILL_SENSE_ID_MISSING`), LINT-004 (`UNVETTED_EN_SOURCE`), and the
-P1 advisory rules (`MULTI_SENSE_UK_SINGLE_EN`, `POS_TRANSFORMATION_MISMATCH`)
-are scoped for later PRs against this same issue; they are not implemented
-here. No CI gate is wired to `lint_word_atlas.py` in this PR — it runs as a
-standalone advisory check until a residual-count policy is agreed (issue
-#6437 D6-7).
+LINT-004 (`UNVETTED_EN_SOURCE`) and the P1 advisory rules
+(`MULTI_SENSE_UK_SINGLE_EN`, `POS_TRANSFORMATION_MISMATCH`) remain for later PRs
+against this same issue. No CI gate is wired to `lint_word_atlas.py` yet —
+it runs as a standalone advisory check until a residual-count policy is
+agreed (issue #6437 D6-7).
 
 ## Open Decisions
 

--- a/docs/runbooks/word-atlas-entry-model.md
+++ b/docs/runbooks/word-atlas-entry-model.md
@@ -269,13 +269,16 @@ Field notes:
   `manual_native`, `rag_verified`) for sourced senses. Use `ai_minimum` when
   the learner gloss is an AI-minimum placeholder rather than a vetted
   dictionary sense — honesty over silent thinness (#6437 enrich honesty tags).
+  `apply_sense_honesty_tags` must not overwrite a dictionary-backed `source`
+  already in that sourced set.
 - `completeness`: `truncated` is the honest tag for text a hard cap cut off
   mid-word; a `learner_uk`/`learner_en`/`en_disambiguation` value ending in
   `...`/`…` without this tag is what LINT-001 flags. `draft` marks thin /
-  incomplete learner text (including AI-minimum glosses). Enrich helpers
+  incomplete learner text (including AI-minimum glosses). Helpers
   `truncate_with_honesty` + `apply_sense_honesty_tags` in
-  `scripts/lexicon/enrich_manifest.py` stamp these labels when emitting
-  sense-shaped rows.
+  `scripts/lexicon/enrich_manifest.py` exist for that stamping, but they are
+  **not yet wired into enrich emit paths** in this PR — call-site integration
+  lands in #6437 PR3.
 
 ### Lint gate (PR1 + PR2 scope)
 

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -634,8 +634,57 @@ def _is_english_learner_gloss(label: str) -> bool:
     return latin_letters > cyrillic_letters
 
 
-def _english_translation_gloss(entry: dict[str, Any]) -> str | None:
-    """First short English sense from enrichment.translation.en, if any."""
+def _practice_sense(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """First sense-first row with a stable id (#6437 LINT-003 binding)."""
+    senses = entry.get("senses")
+    if not isinstance(senses, list):
+        return None
+    for sense in senses:
+        if not isinstance(sense, dict):
+            continue
+        sense_id = sense.get("id")
+        if isinstance(sense_id, str) and sense_id.strip():
+            return sense
+    return None
+
+
+def _sense_learner_en(sense: dict[str, Any]) -> str | None:
+    """Short English drill target from a bound sense's ``learner_en`` list."""
+    learner_en = sense.get("learner_en")
+    if not isinstance(learner_en, list):
+        return None
+    cleaned: list[str] = []
+    for raw in learner_en:
+        text = re.sub(r"\s+", " ", str(raw)).strip()
+        text = re.sub(r"^\([^)]*\)\s*", "", text).strip()
+        head = re.split(r"[;(]", text, maxsplit=1)[0]
+        clean = _gloss_clean(head)
+        if clean and _is_english_learner_gloss(clean):
+            cleaned.append(clean)
+    if not cleaned:
+        return None
+    multi = [
+        item
+        for item in cleaned
+        if 1 < _meaning_label_word_count(item) <= 4 and not _meaning_label_is_phrase(item)
+    ]
+    return multi[0] if multi else cleaned[0]
+
+
+def _english_translation_gloss(
+    entry: dict[str, Any],
+    *,
+    sense: dict[str, Any] | None = None,
+) -> str | None:
+    """English gloss for practice: bound sense first, else legacy enrichment.en.
+
+    When ``sense`` is provided (sense-first entry), only that sense's
+    ``learner_en`` is used — never a silent ``enrichment.translation.en[0]``
+    fallback (#6437 LINT-003).
+    """
+    if sense is not None:
+        return _sense_learner_en(sense)
+
     enrichment = entry.get("enrichment")
     if not isinstance(enrichment, dict):
         return None
@@ -663,21 +712,28 @@ def _english_translation_gloss(entry: dict[str, Any]) -> str | None:
     # Prefer short multi-word learner senses ("fairy tale") over a single academic
     # first gloss ("fable") when both are offered.
     multi = [
-        sense
-        for sense in cleaned
-        if 1 < _meaning_label_word_count(sense) <= 4 and not _meaning_label_is_phrase(sense)
+        item
+        for item in cleaned
+        if 1 < _meaning_label_word_count(item) <= 4 and not _meaning_label_is_phrase(item)
     ]
     return multi[0] if multi else cleaned[0]
 
 
-def _practice_display_gloss(entry: dict[str, Any], level: str | None, fallback: str) -> str:
+def _practice_display_gloss(
+    entry: dict[str, Any],
+    level: str | None,
+    fallback: str,
+    *,
+    sense: dict[str, Any] | None = None,
+) -> str:
     """Learner-facing gloss for flashcards / recognition.
 
     A1 always prefers English scaffolding when available.
     A1–A2 never keep a long Ukrainian dictionary definition when English exists —
     Wiktionary-style «розповідний твір про вигаданих осіб…» is not an A2 gloss.
+    Sense-first entries bind via ``sense`` and never fall back to ``en[0]``.
     """
-    en = _english_translation_gloss(entry)
+    en = _english_translation_gloss(entry, sense=sense)
     if not en:
         return fallback
     if level == "A1":
@@ -1764,7 +1820,10 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     level = _cefr_level(entry)
     if not lemma or not raw_gloss:
         return None
-    gloss = _practice_display_gloss(entry, level, raw_gloss)
+    # Sense-first binding (#6437): when senses[] exists, key the lexeme off a
+    # stable sense id and read learner_en from that sense — never en[0].
+    sense = _practice_sense(entry)
+    gloss = _practice_display_gloss(entry, level, raw_gloss, sense=sense)
     lemma_plain = _plain(lemma)
     pos = _clean_text(entry.get("pos"))
     gloss_clean = _gloss_clean(gloss)
@@ -1792,6 +1851,8 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
         "paradigm": paradigm,
         "semanticBucket": _clean_text(entry.get("semantic_bucket")),
     }
+    if sense is not None:
+        lexeme["senseId"] = str(sense["id"]).strip()
     example = entry.get("practice_example")
     if isinstance(example, dict):
         text = _clean_text(example.get("text"))

--- a/scripts/audit/lint_word_atlas.py
+++ b/scripts/audit/lint_word_atlas.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Sense-first Word Atlas entry lint (#6437 PR1): LINT-001 + LINT-002.
+"""Sense-first Word Atlas entry lint (#6437): LINT-001 + LINT-002 + LINT-003.
 
-Read-only, advisory lint over the `senses[]` array documented in
-``docs/runbooks/word-atlas-entry-model.md`` (§ Sense-Level Fields, #6437
-delta). It never mutates a manifest — it only reports.
+Read-only, advisory lint over the `senses[]` array and practice bindings
+documented in ``docs/runbooks/word-atlas-entry-model.md`` (§ Sense-Level
+Fields, #6437 delta). It never mutates a manifest — it only reports.
 
 Rules implemented
 ==================
@@ -14,17 +14,23 @@ Rules implemented
 - **LINT-002** ``AMBIGUOUS_BARE_EN`` — ``learner_en`` is a single-item list,
   the word is in the high-risk polysemy denylist below, and
   ``en_disambiguation`` is missing or blank.
+- **LINT-003** ``DRILL_SENSE_ID_MISSING`` — a practice binding / deck item
+  references a lemma (``lemmaId`` / ``lemma``) without a non-empty
+  ``senseId`` / ``sense_id``. This prohibits silent ``en[0]`` drill
+  fallbacks once sense-first wiring is present.
 
 Rules NOT implemented here (tracked against issue #6437, later PRs):
-LINT-003 ``DRILL_SENSE_ID_MISSING``, LINT-004 ``UNVETTED_EN_SOURCE``,
-LINT-101 ``MULTI_SENSE_UK_SINGLE_EN``, LINT-102 ``POS_TRANSFORMATION_MISMATCH``.
+LINT-004 ``UNVETTED_EN_SOURCE``, LINT-101 ``MULTI_SENSE_UK_SINGLE_EN``,
+LINT-102 ``POS_TRANSFORM_MISMATCH``.
 
 Scope
 =====
-Entries without a ``senses`` array are silently skipped — most of the
-production manifest predates this schema, and PR1 does not bulk-migrate or
-retranslate existing entries (issue #6437 non-goals). This script only lints
-manifests/entries that already carry sense-first data.
+- LINT-001/002: entries without a ``senses`` array are silently skipped —
+  most of the production manifest predates this schema.
+- LINT-003: inspects explicit practice bindings on the manifest
+  (``practice_items`` / per-entry ``practice_bindings``) and optional
+  ``--practice-deck`` shards. Legacy decks without sense-first migration
+  are reported as advisory residual, not CI blockers.
 
 Use when
 ========
@@ -38,6 +44,7 @@ Examples
     .venv/bin/python scripts/audit/lint_word_atlas.py
     .venv/bin/python scripts/audit/lint_word_atlas.py --manifest path/to/manifest.json
     .venv/bin/python scripts/audit/lint_word_atlas.py --manifest path/to/manifest.json \\
+        --practice-deck site/public/lexicon/practice-index.A1.json \\
         --report batch_state/atlas-drive/lint-word-atlas-residual.json
     .venv/bin/python scripts/audit/lint_word_atlas.py --strict   # exit 1 on any finding
 
@@ -117,8 +124,24 @@ AMBIGUOUS_BARE_EN_DENYLIST = frozenset(
     }
 )
 
+# Practice-deck body keys that carry lemma-bound cards (#6437 LINT-003).
+_PRACTICE_CARD_LIST_KEYS = (
+    "items",
+    "cloze",
+    "stress",
+    "classify",
+    "paradigm",
+    "synonym",
+    "heritage",
+    "paronym",
+    "antonym",
+    "homonym",
+)
+
 LINT_001 = "LINT-001"
 LINT_002 = "LINT-002"
+LINT_003 = "LINT-003"
+IMPLEMENTED_RULE_IDS = (LINT_001, LINT_002, LINT_003)
 
 
 @dataclass(frozen=True)
@@ -231,11 +254,86 @@ def _check_ambiguous_bare_en(
     ]
 
 
-def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
-    """Return every LINT-001/LINT-002 finding for a manifest's ``senses[]``.
+def _binding_lemma(item: dict[str, Any]) -> str | None:
+    for key in ("lemmaId", "lemma_id", "lemma", "entry_slug", "slug"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
-    Entries without a ``senses`` array are silently skipped (see module
-    docstring: PR1 does not lint or migrate legacy non-sense-first entries).
+
+def _binding_sense_id(item: dict[str, Any]) -> str | None:
+    for key in ("senseId", "sense_id", "sense_slug"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _check_drill_sense_id_missing(item: dict[str, Any]) -> LintFinding | None:
+    lemma = _binding_lemma(item)
+    if lemma is None:
+        return None
+    if _binding_sense_id(item) is not None:
+        return None
+    return LintFinding(
+        rule_id=LINT_003,
+        rule_name="DRILL_SENSE_ID_MISSING",
+        entry_slug=lemma,
+        sense_id="<missing-sense-id>",
+        field="senseId",
+        detail=(
+            f"practice binding for lemma {lemma!r} has no senseId/sense_id "
+            "(en[0] fallback is not allowed)"
+        ),
+    )
+
+
+def _practice_bindings_from_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    bindings: list[dict[str, Any]] = []
+    top_level = manifest.get("practice_items")
+    if isinstance(top_level, list):
+        bindings.extend(item for item in top_level if isinstance(item, dict))
+    for entry in _entries(manifest):
+        per_entry = entry.get("practice_bindings")
+        if not isinstance(per_entry, list):
+            continue
+        slug = _entry_slug(entry)
+        for item in per_entry:
+            if not isinstance(item, dict):
+                continue
+            enriched = dict(item)
+            if _binding_lemma(enriched) is None:
+                enriched.setdefault("lemma", slug)
+            bindings.append(enriched)
+    return bindings
+
+
+def _practice_cards_from_deck(deck: dict[str, Any]) -> list[dict[str, Any]]:
+    cards: list[dict[str, Any]] = []
+    for key in _PRACTICE_CARD_LIST_KEYS:
+        value = deck.get(key)
+        if isinstance(value, list):
+            cards.extend(item for item in value if isinstance(item, dict))
+    return cards
+
+
+def lint_practice_items(items: list[dict[str, Any]]) -> list[LintFinding]:
+    """Return LINT-003 findings for lemma-bound practice items missing sense_id."""
+    findings: list[LintFinding] = []
+    for item in items:
+        finding = _check_drill_sense_id_missing(item)
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
+    """Return LINT-001/002/003 findings for a manifest.
+
+    Entries without a ``senses`` array are skipped for LINT-001/002 (see module
+    docstring). LINT-003 reads explicit practice bindings even when senses are
+    absent, so residual legacy decks stay visible during the advisory soak.
     """
     findings: list[LintFinding] = []
     for entry in _entries(manifest):
@@ -244,14 +342,15 @@ def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
             sense_id = _sense_id(sense)
             findings.extend(_check_truncated_text_cutoff(slug, sense_id, sense))
             findings.extend(_check_ambiguous_bare_en(slug, sense_id, sense))
+    findings.extend(lint_practice_items(_practice_bindings_from_manifest(manifest)))
     return findings
 
 
-def _load_manifest(path: Path) -> dict[str, Any]:
+def _load_json_object(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        print(f"::error::cannot read manifest {path}: {exc}", file=sys.stderr)
+        print(f"::error::cannot read {path}: {exc}", file=sys.stderr)
         sys.exit(2)
     if not isinstance(data, dict):
         print(f"::error::{path} must contain a JSON object", file=sys.stderr)
@@ -259,9 +358,13 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     return data
 
 
+def _load_manifest(path: Path) -> dict[str, Any]:
+    return _load_json_object(path)
+
+
 def print_report(findings: list[LintFinding]) -> None:
     if not findings:
-        print("No LINT-001/LINT-002 findings — sense-first entries lint clean.")
+        print("No LINT-001/LINT-002/LINT-003 findings — sense-first entries lint clean.")
         return
 
     rows = [
@@ -296,7 +399,7 @@ def print_report(findings: list[LintFinding]) -> None:
 def write_report(findings: list[LintFinding], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
-        "rule_ids": [LINT_001, LINT_002],
+        "rule_ids": list(IMPLEMENTED_RULE_IDS),
         "finding_count": len(findings),
         "findings": [asdict(finding) for finding in findings],
     }
@@ -307,7 +410,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Advisory sense-first Word Atlas lint: LINT-001 TRUNCATED_TEXT_CUTOFF + "
-            "LINT-002 AMBIGUOUS_BARE_EN (issue #6437 PR1)."
+            "LINT-002 AMBIGUOUS_BARE_EN + LINT-003 DRILL_SENSE_ID_MISSING (issue #6437)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
@@ -317,6 +420,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=DEFAULT_FIXTURE,
         help=f"Manifest JSON path with a top-level 'entries' list. Default: {DEFAULT_FIXTURE}.",
+    )
+    parser.add_argument(
+        "--practice-deck",
+        type=Path,
+        action="append",
+        default=None,
+        help=(
+            "Optional practice deck shard JSON to scan for LINT-003 "
+            "(repeatable). Cards with lemmaId/lemma but no senseId are flagged."
+        ),
     )
     parser.add_argument(
         "--report",
@@ -348,6 +461,14 @@ def main(argv: list[str] | None = None) -> int:
 
     manifest = _load_manifest(manifest_path)
     findings = lint_manifest(manifest)
+
+    for deck_arg in args.practice_deck or []:
+        deck_path = deck_arg if deck_arg.is_absolute() else PROJECT_ROOT / deck_arg
+        if not deck_path.exists() or not deck_path.is_file():
+            parser.error(f"practice deck does not exist or is not a file: {deck_path}")
+        deck = _load_json_object(deck_path)
+        findings.extend(lint_practice_items(_practice_cards_from_deck(deck)))
+
     print_report(findings)
 
     if args.report:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1263,6 +1263,66 @@ def _entry_text_without_headword(text: str, lemma: str, headword: str | None = N
     return cleaned
 
 
+# Sense honesty tags (#6437 PR2). Sourced senses keep dictionary provenance;
+# AI-minimum / truncated learner text must be labelled so it is never silently
+# thin. LINT-001 reads ``completeness: truncated``; LINT-004 (later) will read
+# ``source`` provenance including ``ai_minimum``.
+SENSE_SOURCE_AI_MINIMUM = "ai_minimum"
+SENSE_SOURCE_SOURCED = frozenset(
+    {
+        "sum20_vetted",
+        "btc",
+        "dmklinger",
+        "manual_native",
+        "rag_verified",
+    }
+)
+SENSE_COMPLETENESS_COMPLETE = "complete"
+SENSE_COMPLETENESS_TRUNCATED = "truncated"
+SENSE_COMPLETENESS_DRAFT = "draft"
+SENSE_COMPLETENESS_VALUES = frozenset(
+    {
+        SENSE_COMPLETENESS_COMPLETE,
+        SENSE_COMPLETENESS_TRUNCATED,
+        SENSE_COMPLETENESS_DRAFT,
+    }
+)
+
+
+def apply_sense_honesty_tags(
+    sense: dict[str, Any],
+    *,
+    truncated: bool = False,
+    ai_minimum: bool = False,
+) -> dict[str, Any]:
+    """Stamp honest ``completeness`` / ``source`` labels on a sense-shaped dict.
+
+    Call whenever enrich emits or mutates a ``senses[]`` row after a hard cap or
+    an AI-minimum gloss write. Does not invent gloss text — it only labels.
+    """
+    out = dict(sense)
+    if truncated:
+        out["completeness"] = SENSE_COMPLETENESS_TRUNCATED
+    elif ai_minimum and out.get("completeness") not in SENSE_COMPLETENESS_VALUES:
+        out["completeness"] = SENSE_COMPLETENESS_DRAFT
+    if ai_minimum:
+        out["source"] = SENSE_SOURCE_AI_MINIMUM
+    return out
+
+
+def truncate_with_honesty(text: str, limit: int) -> tuple[str, bool]:
+    """Hard-cap prose and report whether truncation occurred (#6437 honesty).
+
+    Prefer this over bare ``_truncate_text`` when the caller can stamp
+    ``completeness: truncated`` (or ``apply_sense_honesty_tags``) on the
+    surrounding record. Returns ``(text, truncated)``.
+    """
+    cleaned = clean_html_entities(text)
+    if len(cleaned) <= limit:
+        return cleaned, False
+    return _truncate_text(text, limit), True
+
+
 def _truncate_text(text: str, limit: int) -> str:
     """Hard-cap prose when a limit is intentional (idioms, excerpts).
 
@@ -1270,6 +1330,10 @@ def _truncate_text(text: str, limit: int) -> str:
     sentence end so learners never see mid-word / mid-sense cutoffs. Dictionary
     definition cards should pass ``limit=None`` to ``_definition_body`` instead
     of relying on this for primary VTS/СУМ text (#6437).
+
+    Callers that can carry sense-level honesty metadata should use
+    ``truncate_with_honesty`` + ``apply_sense_honesty_tags`` so truncated text
+    is never silently thin.
     """
     cleaned = clean_html_entities(text)
     if len(cleaned) <= limit:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1299,13 +1299,16 @@ def apply_sense_honesty_tags(
 
     Call whenever enrich emits or mutates a ``senses[]`` row after a hard cap or
     an AI-minimum gloss write. Does not invent gloss text — it only labels.
+
+    ``ai_minimum`` never overwrites a dictionary-backed ``source`` already in
+    ``SENSE_SOURCE_SOURCED`` (provenance beats the thin-gloss flag).
     """
     out = dict(sense)
     if truncated:
         out["completeness"] = SENSE_COMPLETENESS_TRUNCATED
     elif ai_minimum and out.get("completeness") not in SENSE_COMPLETENESS_VALUES:
         out["completeness"] = SENSE_COMPLETENESS_DRAFT
-    if ai_minimum:
+    if ai_minimum and out.get("source") not in SENSE_SOURCE_SOURCED:
         out["source"] = SENSE_SOURCE_AI_MINIMUM
     return out
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "2daf0826ce62d087cce1d0cc909bf108957b4639ebf67abab4a3f1d22d5becd6",
+  "fingerprint": "419cdc5877c4ff88f03cba90f5c3e9c9373fdfbb751f5aecaf43be7a799012a5",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "ee1914f203a75f84b2ca0d83f8c1bbaebd957f27b0357b81fdae4b4e4cf0be02"
+        "sha256": "7bd6e211d02b83bc7bf7fdc94aa228a907c7ae4daaba2935a7d85bb35a0591c9"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/fixtures/atlas/sense_lint_sample.json
+++ b/tests/fixtures/atlas/sense_lint_sample.json
@@ -1,6 +1,17 @@
 {
   "generated_at": "2026-08-07T00:00:00+00:00",
-  "note": "Small fixture for scripts/audit/lint_word_atlas.py (#6437 PR1). Not derived from the production manifest.",
+  "note": "Small fixture for scripts/audit/lint_word_atlas.py (#6437). Not derived from the production manifest.",
+  "practice_items": [
+    {
+      "lemmaId": "брак",
+      "senseId": "brak_defect",
+      "mode": "classify"
+    },
+    {
+      "lemmaId": "брак",
+      "mode": "classify"
+    }
+  ],
   "entries": [
     {
       "slug": "брак",
@@ -26,6 +37,15 @@
           "en_disambiguation": "matrimony (not the defect/scarcity sense)",
           "source": "sum20_vetted",
           "completeness": "complete"
+        }
+      ],
+      "practice_bindings": [
+        {
+          "sense_id": "brak_defect",
+          "mode": "flashcard"
+        },
+        {
+          "mode": "flashcard"
         }
       ]
     },
@@ -70,6 +90,16 @@
           "en_disambiguation": "",
           "source": "btc",
           "completeness": "truncated"
+        },
+        {
+          "id": "tsytata_ai_minimum",
+          "pos": "noun",
+          "uk_source_def": "короткий AI-мінімум без словникового джерела",
+          "learner_uk": "цитата",
+          "learner_en": ["quote"],
+          "en_disambiguation": "",
+          "source": "ai_minimum",
+          "completeness": "draft"
         }
       ]
     },

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1312,6 +1312,39 @@ def test_a2_replaces_ukrainian_dictionary_gloss_with_english_translation() -> No
     assert dated_lexeme["glossClean"] == "fairy tale"
 
 
+
+def test_build_lexeme_emits_sense_id_and_prefers_sense_learner_en() -> None:
+    """#6437: sense-first entries bind senseId and never fall back to en[0]."""
+    verifier = JsonVesumVerifier({})
+    entry = {
+        "lemma": "брак",
+        "url_slug": "брак",
+        "gloss": "вада",
+        "pos": "noun",
+        "primary_source": "atlas",
+        "cefr": "A1",
+        "enrichment": {
+            "translation": {
+                "en": ["second", "defect"],
+                "source": "dmklinger",
+            }
+        },
+        "senses": [
+            {
+                "id": "brak_defect",
+                "learner_en": ["defect", "flaw"],
+                "source": "sum20_vetted",
+                "completeness": "complete",
+            }
+        ],
+    }
+    lexeme = _build_lexeme(entry, verifier)
+    assert lexeme is not None
+    assert lexeme["senseId"] == "brak_defect"
+    assert lexeme["glossClean"] == "defect"
+    assert "second" not in lexeme["gloss"].casefold()
+
+
 def test_meaning_mc_eligibility_requires_a_latin_majority_gloss() -> None:
     assert _meaning_mc_eligible("justice", "справедливість", "noun") is True
     assert _meaning_mc_eligible("сукупність прав", "право", "noun") is False

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4329,6 +4329,38 @@ def test_sense_honesty_tags_mark_truncated_and_ai_minimum() -> None:
     assert intact == "short gloss"
 
 
+def test_apply_sense_honesty_tags_preserves_dictionary_backed_source() -> None:
+    """#6437: ai_minimum must not overwrite sourced dictionary provenance."""
+    from scripts.lexicon.enrich_manifest import (
+        SENSE_COMPLETENESS_DRAFT,
+        SENSE_SOURCE_AI_MINIMUM,
+        SENSE_SOURCE_SOURCED,
+        apply_sense_honesty_tags,
+    )
+
+    for sourced in sorted(SENSE_SOURCE_SOURCED):
+        tagged = apply_sense_honesty_tags(
+            {
+                "id": f"sense-{sourced}",
+                "learner_en": ["stub"],
+                "source": sourced,
+            },
+            ai_minimum=True,
+        )
+        assert tagged["source"] == sourced, (
+            f"ai_minimum must not clobber dictionary-backed source={sourced!r}; "
+            f"got {tagged['source']!r}"
+        )
+        assert tagged["completeness"] == SENSE_COMPLETENESS_DRAFT
+
+    unset_source = apply_sense_honesty_tags(
+        {"id": "sense-unset", "learner_en": ["stub"]},
+        ai_minimum=True,
+    )
+    assert unset_source["source"] == SENSE_SOURCE_AI_MINIMUM
+    assert unset_source["completeness"] == SENSE_COMPLETENESS_DRAFT
+
+
 def test_definition_body_keeps_full_dictionary_article_by_default() -> None:
     """#6437: multi-sense dictionary articles must not hard-cap mid-definition."""
     from scripts.lexicon.enrich_manifest import _definition_body, _truncate_text

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4297,6 +4297,38 @@ def test_synonyms_slovnyk_sense_groups_parse_nested_senses() -> None:
     assert len(block.get("synsets") or []) >= 2
 
 
+
+def test_sense_honesty_tags_mark_truncated_and_ai_minimum() -> None:
+    """#6437 PR2: enrich honesty tags label thin/truncated senses explicitly."""
+    from scripts.lexicon.enrich_manifest import (
+        SENSE_COMPLETENESS_DRAFT,
+        SENSE_COMPLETENESS_TRUNCATED,
+        SENSE_SOURCE_AI_MINIMUM,
+        apply_sense_honesty_tags,
+        truncate_with_honesty,
+    )
+
+    clipped, truncated = truncate_with_honesty("a" * 50 + " " + "b" * 50, 40)
+    assert truncated is True
+    assert clipped.endswith("…")
+    tagged = apply_sense_honesty_tags(
+        {"id": "sense-1", "learner_en": ["stub"]},
+        truncated=True,
+    )
+    assert tagged["completeness"] == SENSE_COMPLETENESS_TRUNCATED
+
+    ai_tagged = apply_sense_honesty_tags(
+        {"id": "sense-2", "learner_en": ["stub"]},
+        ai_minimum=True,
+    )
+    assert ai_tagged["source"] == SENSE_SOURCE_AI_MINIMUM
+    assert ai_tagged["completeness"] == SENSE_COMPLETENESS_DRAFT
+
+    intact, was_cut = truncate_with_honesty("short gloss", 40)
+    assert was_cut is False
+    assert intact == "short gloss"
+
+
 def test_definition_body_keeps_full_dictionary_article_by_default() -> None:
     """#6437: multi-sense dictionary articles must not hard-cap mid-definition."""
     from scripts.lexicon.enrich_manifest import _definition_body, _truncate_text

--- a/tests/test_lint_word_atlas.py
+++ b/tests/test_lint_word_atlas.py
@@ -10,23 +10,27 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from audit import lint_word_atlas
 
 
-def _manifest(*senses: dict) -> dict:
-    return {"entries": [{"slug": "test-entry", "senses": list(senses)}]}
+def _manifest(*senses: dict, practice_items: list[dict] | None = None) -> dict:
+    payload: dict = {"entries": [{"slug": "test-entry", "senses": list(senses)}]}
+    if practice_items is not None:
+        payload["practice_items"] = practice_items
+    return payload
 
 
 def test_default_fixture_flags_exactly_the_known_cases(capsys) -> None:
-    """The committed small fixture has one honest LINT-001 dodge, one dishonest
-    hit, one flagged bare-EN, and one disambiguated bare-EN that must not fire."""
+    """Fixture covers LINT-001/002 sense cases plus two LINT-003 practice misses."""
     assert lint_word_atlas.main([]) == 0
     output = capsys.readouterr().out
 
     assert "LINT-001" in output
     assert "LINT-002" in output
+    assert "LINT-003" in output
     assert "tsytata_quote" in output
     assert "tsytata_honest_truncation" not in output
     assert "sekunda_time_unit" in output
     assert "sekunda_disambiguated" not in output
-    assert "2 finding(s)" in output
+    assert "брак" in output
+    assert "4 finding(s)" in output
 
 
 def test_truncated_text_cutoff_fires_without_honest_tag() -> None:
@@ -122,6 +126,66 @@ def test_entries_without_senses_are_skipped() -> None:
     assert lint_word_atlas.lint_manifest(manifest) == []
 
 
+def test_drill_sense_id_missing_flags_practice_item_without_sense_id() -> None:
+    manifest = _manifest(
+        practice_items=[{"lemmaId": "брак", "mode": "classify"}],
+    )
+    findings = lint_word_atlas.lint_manifest(manifest)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "LINT-003"
+    assert findings[0].entry_slug == "брак"
+    assert findings[0].field == "senseId"
+
+
+def test_drill_sense_id_missing_suppressed_when_sense_id_present() -> None:
+    manifest = _manifest(
+        practice_items=[{"lemmaId": "брак", "senseId": "brak_defect", "mode": "classify"}],
+    )
+    assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def test_drill_sense_id_missing_reads_per_entry_practice_bindings() -> None:
+    manifest = {
+        "entries": [
+            {
+                "slug": "брак",
+                "practice_bindings": [{"mode": "flashcard"}],
+            }
+        ]
+    }
+    findings = lint_word_atlas.lint_manifest(manifest)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "LINT-003"
+    assert findings[0].entry_slug == "брак"
+
+
+def test_practice_deck_mode_flags_cards_without_sense_id(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"entries": []}), encoding="utf-8")
+    deck_path = tmp_path / "practice-cloze.A1.json"
+    deck_path.write_text(
+        json.dumps(
+            {
+                "cloze": [
+                    {"lemmaId": "автобус", "clozeId": "автобус:1"},
+                    {"lemmaId": "мова", "senseId": "mova_language", "clozeId": "мова:1"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = lint_word_atlas.main(
+        ["--manifest", str(manifest_path), "--practice-deck", str(deck_path)]
+    )
+    assert exit_code == 0
+    findings = lint_word_atlas.lint_practice_items(
+        [{"lemmaId": "автобус"}, {"lemmaId": "мова", "senseId": "mova_language"}]
+    )
+    assert len(findings) == 1
+    assert findings[0].entry_slug == "автобус"
+
+
 def test_report_mode_writes_json_and_stays_advisory(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(
@@ -138,6 +202,7 @@ def test_report_mode_writes_json_and_stays_advisory(tmp_path: Path) -> None:
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     assert payload["finding_count"] == 1
     assert payload["findings"][0]["rule_id"] == "LINT-002"
+    assert "LINT-003" in payload["rule_ids"]
 
 
 def test_strict_mode_fails_on_findings(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR2 of the sense-first lintable entry gate (issue #6437, parent #4387), extending the PR1 module from #6438.

- **LINT-003 `DRILL_SENSE_ID_MISSING`**: advisory rule in `scripts/audit/lint_word_atlas.py` for practice bindings / optional `--practice-deck` shards that bind a lemma without `senseId`/`sense_id` (no silent `en[0]` fallback).
- **Enrich honesty tags**: `apply_sense_honesty_tags` + `truncate_with_honesty` in `enrich_manifest.py`, with schema docs recognizing `source: ai_minimum` and `completeness: draft|truncated|complete`. Helpers are **not yet wired into enrich emit paths** — call-site integration lands in #6437 PR3. `apply_sense_honesty_tags` preserves dictionary-backed `source` ∈ `SENSE_SOURCE_SOURCED` when `ai_minimum=True`.
- **Practice deck**: `_build_lexeme` emits `senseId` when `senses[]` is present and prefers that sense's `learner_en` over `enrichment.translation.en[0]`.
- Advisory only — no CI hard-fail wiring (residual policy still #6437 D6–7 / PR3+).

## Evidence (#M-4, tool-backed)

Ran against the hydrated local manifest (`site/src/data/lexicon-manifest.json`, 19203 entries), 2026-08-09:

| Signal | Count |
| --- | --- |
| LINT-001 / LINT-002 / LINT-003 on manifest | **0** (no `senses[]` / practice bindings on production entries yet) |
| Legacy top-level `gloss` ending `...`/`…` | **8450 / 19203** (re-derived; same residual class as PR1) |
| LINT-003 on published practice mode shards | **22401** advisory (cards with `lemmaId`, no `senseId`) |
| LINT-003 on `practice-index.*.json` | **6000** advisory |

```
$ .venv/bin/python scripts/audit/lint_word_atlas.py --manifest site/src/data/lexicon-manifest.json
No LINT-001/LINT-002/LINT-003 findings — sense-first entries lint clean.

$ .venv/bin/python -m pytest tests/test_lint_word_atlas.py \
    tests/test_generate_practice_deck.py::test_build_lexeme_emits_sense_id_and_prefers_sense_learner_en \
    tests/test_lexicon_enrich_manifest.py::test_sense_honesty_tags_mark_truncated_and_ai_minimum \
    tests/test_lexicon_enrich_manifest.py::test_apply_sense_honesty_tags_preserves_dictionary_backed_source -q
20 passed

$ .venv/bin/ruff check scripts/audit/lint_word_atlas.py scripts/audit/generate_practice_deck.py \
    scripts/lexicon/enrich_manifest.py tests/test_lint_word_atlas.py
All checks passed!

$ .venv/bin/python -m scripts.lexicon.check_manifest_freshness
Atlas manifest freshness OK: 55 lexicon code files.
```

## Residual for PR3 (#6437)

- Bulk sense migration / closing the **8450** legacy ellipsis glosses (still out of scope).
- LINT-004 `UNVETTED_EN_SOURCE` + P1 rules (`MULTI_SENSE_UK_SINGLE_EN`, `POS_TRANSFORMA_MISMATCH`).
- Wire `truncate_with_honesty` + `apply_sense_honesty_tags` into enrich emit paths.
- Wiring practice shards to emit `senseId` at scale once senses exist; today's deck residual is advisory soak evidence.
- Propagate `senseId` from lexeme → mode cards.
- Add `lexemes` to LINT-003 scan keys (or document exclusion).
- Empty-`learner_en` generator regression test.
- CI residual policy / blocking gate (issue #6437 D6–7).

## Non-goals

- No section-extraction edits (sibling #6503 / #6464).
- No bulk retranslation; no CI auto-merge.

Closes: none (PR2 of #6437 — issue stays open).

Refs: #6437 #4387