### PR TITLE
feat(atlas): Грінченко heritage attestation card (#6464)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -91,6 +91,7 @@ from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
     CORRECTION_DICTIONARIES_LABEL,
     ESUM_LABEL,
+    GRINCHENKO_LABEL,
     MPHDICT_SYNONYMS_LABEL,
     PHRASEOLOGY_LABEL,
     PROVERBS_LABEL,
@@ -3471,6 +3472,65 @@ def _sum11_definition_card(
     return None
 
 
+def _grinchenko_definition_row(conn: sqlite3.Connection, lemma: str) -> str | None:
+    """Return the attested headword spelling if ``lemma`` exists in Грінченко, else None."""
+    for variant in _split_lemma_variants(lemma):
+        row = conn.execute(
+            "SELECT word FROM grinchenko WHERE word = ? AND definition != '' LIMIT 1",
+            (variant,),
+        ).fetchone()
+        if row and row[0]:
+            headword = clean_html_entities(str(row[0])).strip()
+            if headword:
+                return headword
+    return None
+
+
+def _grinchenko_definition_card(
+    conn: sqlite3.Connection,
+    lemma: str,
+) -> dict[str, Any] | None:
+    """Heritage attestation card for Б. Грінченка «Словарь української мови» (1907).
+
+    #6464. Source choice: the offline ``grinchenko`` table (same digitized 1907 text
+    already used by heritage_classifier.py / search_grinchenko_1907), NOT a live
+    slovnyk.me ``/dict/hrinchenko/`` scrape — verified via WebFetch that the mirror
+    reproduces the identical raw entry, and search_slovnyk_me already blocks
+    re-fetching Грінченко because it is "already indexed locally". Offline avoids a
+    network dependency in CI and duplicate provenance for the same source.
+
+    Content choice: Грінченко's entries gloss Ukrainian headwords IN RUSSIAN — it was
+    compiled as a Ukrainian-Russian dictionary under the Ems-era restrictions.
+    Verified live on multiple samples (прапор → "Знамя"; хата → "Дом, изба, хижина";
+    серце → "Сердце... Гнев"). Reproducing that prose as a learner "definition" would
+    put Russian-language text in a max-immersion Ukrainian product — worse than the
+    already-excluded Soviet-era СУМ-11, which is at least Ukrainian-language. This
+    card therefore never surfaces the raw ``definition`` column: it states only the
+    verified fact of pre-Soviet attestation (headword found in the 1907 registry),
+    never a translated or paraphrased gloss (#M-4: no invented/untranslated text).
+    """
+    headword = _grinchenko_definition_row(conn, lemma)
+    if not headword:
+        # Inflected-form entries (e.g. водою) resolve to their VESUM base lemma —
+        # Грінченко only carries dictionary (base) headwords.
+        base = _vesum_base_lemma(lemma)
+        if base and base != lemma:
+            headword = _grinchenko_definition_row(conn, base)
+    if not headword:
+        return None
+    return {
+        "id": "grinchenko",
+        "source": GRINCHENKO_LABEL,
+        "source_pill": "Грінченко (1907)",
+        "note": "домодерна фіксація · не переклад",
+        "heritage": True,
+        "definitions": [
+            f"«{headword}» засвідчено в словнику Б. Грінченка (1907). "
+            "Це один із найповніших домодерних реєстрів української лексики."
+        ],
+    }
+
+
 def _definition_cards(
     conn: sqlite3.Connection,
     lemma: str,
@@ -3481,10 +3541,12 @@ def _definition_cards(
     # СУМ-11 (Soviet-era dictionary) is intentionally excluded — decolonization
     # decision 2026-06-26. Show clean modern Ukrainian dictionaries: VTS (Великий
     # тлумачний словник) on top, СУМ-20 below — both when available. Inflected-form
-    # entries resolve to their base lemma inside each builder.
+    # entries resolve to their base lemma inside each builder. Грінченко (1907) is an
+    # optional heritage attestation card, always last (#6464) — never primary.
     vts = _vts_definition_card(lemma, cache)
     sum20 = _sum20_definition_card(lemma, cache)
-    return [card for card in (vts, sum20) if card]
+    grinchenko = _grinchenko_definition_card(conn, lemma)
+    return [card for card in (vts, sum20, grinchenko) if card]
 
 
 _SYNONYM_ADDITION_CAP = 8

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3486,6 +3486,43 @@ def _grinchenko_definition_row(conn: sqlite3.Connection, lemma: str) -> str | No
     return None
 
 
+# Fixed (non-headword) Ukrainian words in the Грінченко heritage-card template
+# below (#6510 P1 fix). The headword changes per lemma; this prose does not, but
+# it still runs through the same VESUM gate on every call rather than being
+# assumed correct — ``_vesum_word_analyses`` is itself lru_cached per word, so
+# after the first real card build this costs a handful of dict reads, not a query.
+_GRINCHENKO_TEMPLATE_WORDS: tuple[str, ...] = (
+    "засвідчено",
+    "в",
+    "словнику",
+    "Грінченка",
+    "Це",
+    "один",
+    "із",
+    "найповніших",
+    "домодерних",
+    "реєстрів",
+    "української",
+    "лексики",
+)
+
+
+def _vesum_verified(word: str) -> bool:
+    """Fail-closed VESUM presence check for one word.
+
+    Tries the exact surface form first, then casefolded: VESUM stores most word
+    forms lowercase, so a sentence-initial capital like "Це" is pure orthography,
+    not a distinct word, while a proper noun like "Грінченка" verifies on its
+    exact (capitalized) form.
+    """
+    return bool(_vesum_word_analyses(word)) or bool(_vesum_word_analyses(word.casefold()))
+
+
+def _grinchenko_template_verified() -> bool:
+    """VESUM-gate the fixed prose in the Грінченко heritage card (#6510 P1 fix)."""
+    return all(_vesum_verified(word) for word in _GRINCHENKO_TEMPLATE_WORDS)
+
+
 def _grinchenko_definition_card(
     conn: sqlite3.Connection,
     lemma: str,
@@ -3517,6 +3554,14 @@ def _grinchenko_definition_card(
         if base and base != lemma:
             headword = _grinchenko_definition_row(conn, base)
     if not headword:
+        return None
+    # #6510 P1 fix (cross-family review of #6464): the prior version interpolated
+    # the DB ``word`` into this template with no morphological verification. Both
+    # the DB-sourced headword and the hand-authored fixed prose must be attested
+    # VESUM word forms before any Ukrainian text reaches a learner — either
+    # failing DROPS the card (fail closed) rather than emitting unverified
+    # Ukrainian (#M-4: no invented/unverified text).
+    if not _vesum_verified(headword) or not _grinchenko_template_verified():
         return None
     return {
         "id": "grinchenko",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "d8182fc7171861ccbd90ea251b75f348d9348567a4f179c6ec06adca5df59f83",
+  "fingerprint": "5431f8186d8aeb2cc3c5e57032be8f14f64d6f3f9fb3e8a7c7eb9a6fcdeb8f54",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "6eda83a951606d6bb5b9c62164aceb4ec4cccb66026b9f55d3a5e8037fc8cec8"
+        "sha256": "5e6516417e127c2ff7e27b2a1c80c404451d89c1241d481f3b5c52507088b910"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "5431f8186d8aeb2cc3c5e57032be8f14f64d6f3f9fb3e8a7c7eb9a6fcdeb8f54",
+  "fingerprint": "2daf0826ce62d087cce1d0cc909bf108957b4639ebf67abab4a3f1d22d5becd6",
   "inputs": {
     "lexicon_code": [
       {
@@ -88,7 +88,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "5e6516417e127c2ff7e27b2a1c80c404451d89c1241d481f3b5c52507088b910"
+        "sha256": "ee1914f203a75f84b2ca0d83f8c1bbaebd957f27b0357b81fdae4b4e4cf0be02"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -33,6 +33,7 @@ from scripts.lexicon.enrich_manifest import (
     _etymology,
     _etymology_lookup_variants,
     _fill_learner_english_anchor_from_slovnyk_cache,
+    _grinchenko_definition_card,
     _homonym_relations,
     _homonym_relations_by_headword,
     _idioms,
@@ -1342,10 +1343,79 @@ def test_definition_cards_exclude_sum11(monkeypatch) -> None:
 
     cards = _definition_cards(conn, "прапор", has_sum11_flags=True)
 
-    # СУМ-11 card (even a flagged one) must be absent — only the СУМ-20 card survives.
-    assert [card["id"] for card in cards] == ["sum20"]
+    # СУМ-11 card (even a flagged one) must be absent — only СУМ-20 and the
+    # Грінченко heritage attestation (#6464) survive, in that order.
+    assert [card["id"] for card in cards] == ["sum20", "grinchenko"]
     assert all("СУМ-11" not in (card.get("source") or "") for card in cards)
     assert all(card["id"] not in ("sum11", "sum11-flagged") for card in cards)
+    # Грінченко glosses Ukrainian headwords in Russian (pre-Soviet Ukrainian-Russian
+    # dictionary) — the card must never leak that raw Russian text to learners.
+    grinchenko_card = cards[-1]
+    assert "Знамя" not in grinchenko_card["definitions"][0]
+
+
+def test_grinchenko_definition_card_is_attestation_only_never_the_raw_gloss() -> None:
+    """#6464: the Грінченко (1907) heritage card proves pre-Soviet attestation but
+    never reproduces the raw ``definition`` column — that column glosses Ukrainian
+    headwords in Russian (a Ukrainian-Russian dictionary compiled under the Ems-era
+    restrictions), which would put Russian text in front of learners."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("хата", "Хата, -ти, ж. Дом, изба, хижина. Моя хата з краю.", "Грінченко"),
+    )
+
+    card = _grinchenko_definition_card(conn, "хата")
+
+    assert card is not None
+    assert card["id"] == "grinchenko"
+    assert card["source"] == "Словарь української мови Б. Грінченка (1907–1909)"
+    assert card["source_pill"] == "Грінченко (1907)"
+    assert "«хата»" in card["definitions"][0]
+    for russian_only in ("Дом", "изба", "хижина"):
+        assert russian_only not in card["definitions"][0]
+
+
+def test_grinchenko_definition_card_absent_when_not_attested() -> None:
+    conn = _conn()
+
+    assert _grinchenko_definition_card(conn, "гаджет") is None
+
+
+def test_grinchenko_definition_card_resolves_inflected_form_to_base_lemma(monkeypatch) -> None:
+    """Грінченко only carries dictionary (base) headwords, so an inflected form
+    (e.g. водою) must resolve through VESUM's base lemma, same as VTS/СУМ-20."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("вода", "ВодА, -дИ, ж. Вода.", "Грінченко"),
+    )
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_vesum_base_lemma",
+        lambda word: "вода" if word == "водою" else None,
+    )
+
+    card = _grinchenko_definition_card(conn, "водою")
+
+    assert card is not None
+    assert "«вода»" in card["definitions"][0]
+
+
+def test_definition_cards_grinchenko_always_last_and_optional(monkeypatch) -> None:
+    """Грінченко is additive/optional and always sorts after VTS + СУМ-20 (design doc:
+    'VTS primary; optional SUM-20 examples; optional Грінченко heritage card')."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("вода", "ВодА, -дИ, ж. Вода.", "Грінченко"),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_vts_definition_card", lambda lemma, cache=None: None)
+    monkeypatch.setattr(enrich_manifest_module, "_sum20_definition_card", lambda lemma, cache=None: None)
+
+    cards = _definition_cards(conn, "вода", has_sum11_flags=False)
+
+    assert [card["id"] for card in cards] == ["grinchenko"]
 
 
 def test_vts_fills_definition_when_sum20_missing(monkeypatch) -> None:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -92,6 +92,20 @@ def _patch_vesum_analyses(monkeypatch, pos_by_word: dict[str, str]) -> None:
     )
 
 
+def _patch_grinchenko_vesum(monkeypatch, *headwords: str) -> None:
+    """VESUM-verify the Грінченко card's fixed template prose plus ``headwords``
+    (#6510 P1 fix gate); everything else stays unverified. Call with no
+    ``headwords`` to verify the template only, e.g. to exercise the
+    headword-rejected fail-closed path."""
+    verified = {word.casefold() for word in enrich_manifest_module._GRINCHENKO_TEMPLATE_WORDS}
+    verified.update(word.casefold() for word in headwords)
+
+    def fake_analyses(word: str) -> tuple[tuple[str, str], ...]:
+        return (("x", "noun"),) if word.casefold() in verified else ()
+
+    monkeypatch.setattr(enrich_manifest_module, "_vesum_word_analyses", fake_analyses)
+
+
 def _conn() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.executescript(
@@ -1340,6 +1354,7 @@ def test_definition_cards_exclude_sum11(monkeypatch) -> None:
     )
     # Isolate from the live VTS lookup — this test asserts СУМ-11 exclusion, not coverage.
     monkeypatch.setattr(enrich_manifest_module, "_vts_definition_card", lambda lemma, cache=None: None)
+    _patch_grinchenko_vesum(monkeypatch, "прапор")
 
     cards = _definition_cards(conn, "прапор", has_sum11_flags=True)
 
@@ -1354,7 +1369,7 @@ def test_definition_cards_exclude_sum11(monkeypatch) -> None:
     assert "Знамя" not in grinchenko_card["definitions"][0]
 
 
-def test_grinchenko_definition_card_is_attestation_only_never_the_raw_gloss() -> None:
+def test_grinchenko_definition_card_is_attestation_only_never_the_raw_gloss(monkeypatch) -> None:
     """#6464: the Грінченко (1907) heritage card proves pre-Soviet attestation but
     never reproduces the raw ``definition`` column — that column glosses Ukrainian
     headwords in Russian (a Ukrainian-Russian dictionary compiled under the Ems-era
@@ -1364,6 +1379,7 @@ def test_grinchenko_definition_card_is_attestation_only_never_the_raw_gloss() ->
         "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
         ("хата", "Хата, -ти, ж. Дом, изба, хижина. Моя хата з краю.", "Грінченко"),
     )
+    _patch_grinchenko_vesum(monkeypatch, "хата")
 
     card = _grinchenko_definition_card(conn, "хата")
 
@@ -1382,6 +1398,53 @@ def test_grinchenko_definition_card_absent_when_not_attested() -> None:
     assert _grinchenko_definition_card(conn, "гаджет") is None
 
 
+def test_grinchenko_definition_card_drops_when_headword_not_vesum_verified(monkeypatch) -> None:
+    """#6510 P1 fix: fail-closed VESUM gate. codex flagged that the interpolated
+    headword was never morphologically verified. A headword attested in
+    Грінченко (1907) but absent from VESUM must drop the card — never emit
+    unverified Ukrainian to a learner — even though it is genuinely in the
+    (fixture) 1907 registry."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("хата", "Хата, -ти, ж. Дом, изба, хижина.", "Грінченко"),
+    )
+    # Template prose verifies; the headword itself deliberately does not.
+    _patch_grinchenko_vesum(monkeypatch)
+
+    assert _grinchenko_definition_card(conn, "хата") is None
+
+
+def test_grinchenko_definition_card_drops_when_template_not_vesum_verified(monkeypatch) -> None:
+    """The gate also protects the hand-authored template prose: if VESUM has no
+    record of it (e.g. a future edit introduces a typo or an unattested word),
+    the card must fail closed rather than ship regardless of the headword."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("хата", "Хата, -ти, ж. Дом, изба, хижина.", "Грінченко"),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_vesum_word_analyses", lambda word: ())
+
+    assert _grinchenko_definition_card(conn, "хата") is None
+
+
+def test_grinchenko_definition_card_present_when_headword_and_template_verified(monkeypatch) -> None:
+    """The positive path of the #6510 gate: a headword AND the fixed template
+    prose both verifying against VESUM is what actually lets the card through."""
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        ("хата", "Хата, -ти, ж. Дом, изба, хижина.", "Грінченко"),
+    )
+    _patch_grinchenko_vesum(monkeypatch, "хата")
+
+    card = _grinchenko_definition_card(conn, "хата")
+
+    assert card is not None
+    assert card["id"] == "grinchenko"
+
+
 def test_grinchenko_definition_card_resolves_inflected_form_to_base_lemma(monkeypatch) -> None:
     """Грінченко only carries dictionary (base) headwords, so an inflected form
     (e.g. водою) must resolve through VESUM's base lemma, same as VTS/СУМ-20."""
@@ -1395,6 +1458,7 @@ def test_grinchenko_definition_card_resolves_inflected_form_to_base_lemma(monkey
         "_vesum_base_lemma",
         lambda word: "вода" if word == "водою" else None,
     )
+    _patch_grinchenko_vesum(monkeypatch, "вода")
 
     card = _grinchenko_definition_card(conn, "водою")
 
@@ -1412,6 +1476,7 @@ def test_definition_cards_grinchenko_always_last_and_optional(monkeypatch) -> No
     )
     monkeypatch.setattr(enrich_manifest_module, "_vts_definition_card", lambda lemma, cache=None: None)
     monkeypatch.setattr(enrich_manifest_module, "_sum20_definition_card", lambda lemma, cache=None: None)
+    _patch_grinchenko_vesum(monkeypatch, "вода")
 
     cards = _definition_cards(conn, "вода", has_sum11_flags=False)
 


### PR DESCRIPTION
## Summary

Adds an optional Грінченко (1907) heritage attestation card to the Atlas
definition-cards layer, per the multi-dict hub design (docs/poc/word-atlas/SLOVNYK-HUB-LAYERS.md, #6461/#6467).

Refs #6464 #6460 #4387.

## Design (full rationale + tool-backed samples on the issue)

Full write-up: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6464#issuecomment-5229227930

- **Source**: offline `grinchenko` table (already indexed locally, 67,275
  entries), not a live slovnyk `/dict/hrinchenko/` scrape — verified the
  mirror reproduces the identical raw entry, and `search_slovnyk_me` already
  blocks re-fetching Грінченко as "already indexed locally."
- **Finding that changed the design**: Грінченко's dictionary entries gloss
  Ukrainian headwords in **Russian** (Ukrainian-Russian dictionary, Ems-era).
  Verified live: прапор → "...Белый платок..."; хата → "...Дом, изба,
  хижина..."; серце → "...Сердце... Гнев...". Reproducing that prose as a
  learner "definition" would put Russian text in a max-immersion Ukrainian
  product.
- **Result**: the card is an **attestation** card, not a translated
  definition. It states only the verified fact that the headword is attested
  in the 1907 registry, via a fixed VESUM-verified Ukrainian sentence —
  never the raw (Russian-glossed) `definition` text, never an invented
  translation.
- Card sits last in `_definition_cards` (VTS primary → СУМ-20 → Грінченко
  optional), matching the design doc's learner section order. No Soviet
  СУМ-11 as default primary — unchanged.

## Sampling (tool-backed, `search_grinchenko_1907`)

- Hit: прапор, хата, книга, вода, серце
- Miss: кобета (no Грінченко coverage for this regional form)

## Tests

`tests/test_lexicon_enrich_manifest.py`:
- `test_grinchenko_definition_card_is_attestation_only_never_the_raw_gloss`
- `test_grinchenko_definition_card_absent_when_not_attested`
- `test_grinchenko_definition_card_resolves_inflected_form_to_base_lemma`
- `test_definition_cards_grinchenko_always_last_and_optional`
- Updated `test_definition_cards_exclude_sum11` (its `прапор` grinchenko
  fixture row was already present, unused, before this change) to assert the
  card now appears and never leaks the Russian-only words from the fixture.

```
.venv/bin/pytest tests/test_lexicon_enrich_manifest.py -q
154 passed

.venv/bin/pytest tests/test_atlas_conformance.py tests/test_source_attribution.py tests/test_atlas_fill_local.py -q
239 passed, 1 skipped, 1 pre-existing failure (test_real_lexicon_manifest_conforms_to_atlas_gates
— FileNotFoundError on curriculum/l2-uk-en/curriculum.yaml, which this sparse
dispatch worktree does not check out; unrelated to this diff)

.venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py scripts/lexicon/source_attribution.py
All checks passed!
```

`site/src/data/lexicon-manifest.fingerprint.json` regenerated for the
`enrich_manifest.py` content hash change.

## Non-goals (per brief)

No full-catalog re-enrich (#6466), no other hub layers, no removal of the
existing offline Грінченко integrations (heritage_classifier.py,
calque_corrections.py, etc. — untouched).

## Not done, no auto-merge armed

Per dispatch brief — leaving merge to the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
