### PR TITLE
fix(delegate): refuse junk-only finalizer PRs

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -881,6 +881,7 @@ _NO_DELIVERABLE_STATUS = "no_deliverable"
 _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON = "commit_count_unknown"
 _NO_DELIVERABLE_SHORT_RESPONSE_REASON = "write_capable_clean_worktree_zero_commits_short_response"
 _NO_DELIVERABLE_INVALID_DECLARATION_REASON = "invalid_delivery_declaration"
+_NO_DELIVERABLE_JUNK_ONLY_WORKTREE_REASON = "junk_only_worktree_changes"
 _DELIVERY_DECLARATION_PREFIX = "DELIVERABLE:"
 # A declaration is an optional positive signal, so tolerate a few closing
 # lines after it — but do not scan the whole report, or a quoted example of
@@ -1728,6 +1729,27 @@ def _auto_finalize_changed_files(worktree: Path) -> tuple[str, ...]:
     return tuple(sorted(changed))
 
 
+def _is_disposable_auto_finalize_path(path: str) -> bool:
+    """Return whether a changed path is scratch residue, not deliverable content.
+
+    This is intentionally a narrow allowlist of known generated dependency and
+    cache paths. A single other path means the auto-finalizer retains its
+    existing preserve-and-publish behavior rather than guessing whether that
+    content is important.
+    """
+    parts = tuple(part for part in path.replace("\\", "/").split("/") if part and part != ".")
+    if not parts:
+        return True
+    if any(part in {".venv", "node_modules", "__pycache__", ".pytest_cache"} for part in parts):
+        return True
+    return parts[-1].endswith(".pyc")
+
+
+def _auto_finalize_is_junk_only(changed_files: tuple[str, ...]) -> bool:
+    """Return whether auto-finalization would publish only disposable residue."""
+    return bool(changed_files) and all(_is_disposable_auto_finalize_path(path) for path in changed_files)
+
+
 def _current_branch(worktree: Path) -> str | None:
     proc = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -1831,6 +1853,12 @@ def _auto_finalize_dirty_worktree(
 
     if not changed_files:
         return AutoFinalizeResult(ok=False, error="clean-tree")
+    if _auto_finalize_is_junk_only(changed_files):
+        return AutoFinalizeResult(
+            ok=False,
+            error=_NO_DELIVERABLE_JUNK_ONLY_WORKTREE_REASON,
+            changed_files=changed_files,
+        )
 
     resolved_branch = branch or _current_branch(worktree)
     if not resolved_branch or resolved_branch in {"HEAD", "main", "master"}:
@@ -3277,6 +3305,13 @@ def _run_worker(
                         needs_finalize = False
                         ok_outcome = True
                         final_status = "done"
+                    elif auto_finalize.error == _NO_DELIVERABLE_JUNK_ONLY_WORKTREE_REASON:
+                        # A dirty tree with only known scratch residue has no
+                        # user-visible deliverable. Refuse before staging so it
+                        # cannot create a branch, push, or public PR.
+                        needs_finalize = False
+                        no_deliverable = True
+                        no_deliverable_reason = _NO_DELIVERABLE_JUNK_ONLY_WORKTREE_REASON
         # Deliberately broad: this is measurement about a worker that has already
         # finished, and no measurement failure may cost the task its terminal status.
         except Exception as finalize_exc:
@@ -3297,7 +3332,13 @@ def _run_worker(
         # ``DELIVERABLE:`` line is honoured as an optional positive signal.
         # Read-only tasks are excluded: their deliverable may be analysis or
         # an external side effect such as a posted review comment.
-        if mode in _WRITE_CAPABLE_MODES and final_status == "done" and returncode == 0 and not needs_finalize:
+        if (
+            mode in _WRITE_CAPABLE_MODES
+            and final_status == "done"
+            and returncode == 0
+            and not needs_finalize
+            and no_deliverable_reason is None
+        ):
             delivery_declaration = _parse_delivery_declaration(response)
             no_deliverable_reason = _delivery_failure_reason(
                 response,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2240,6 +2240,137 @@ def test_run_worker_auto_finalizes_dirty_agy_worktree(
     assert "X-Agent: agy/auto-finalize-test" in message
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (".venv", True),
+        (".venv/bin/python", True),
+        ("node_modules/example/index.js", True),
+        ("package/__pycache__/module.cpython-312.pyc", True),
+        (".pytest_cache/v/cache/nodeids", True),
+        ("generated.pyc", True),
+        ("scripts/delegate.py", False),
+        ("docs/decision.md", False),
+    ],
+)
+def test_auto_finalize_disposable_path_classification(path: str, expected: bool):
+    assert delegate._is_disposable_auto_finalize_path(path) is expected
+
+
+def test_run_worker_refuses_junk_only_auto_finalize_without_git_mutations(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Junk-only residue must settle without staging, pushing, or opening a PR (#6497)."""
+    _sanitize_git_env_for_test(monkeypatch)
+    origin = tmp_path / "origin.git"
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(worktree)],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    (worktree / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(origin)],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "agy/junk-only-finalize-test"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    state_path = delegate._state_path("agy-junk-only-finalize-test")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "agy-junk-only-finalize-test",
+        "worktree_path": str(worktree),
+        "worktree_branch": "agy/junk-only-finalize-test",
+        "worktree_base": "main",
+    })
+    (worktree / ".venv").symlink_to(tmp_path / "primary-venv", target_is_directory=True)
+
+    def fail_push(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("junk-only auto-finalize must not push")
+
+    def fail_create_pr(*_args: Any, **_kwargs: Any) -> str:
+        pytest.fail("junk-only auto-finalize must not create a PR")
+
+    monkeypatch.setattr(delegate, "_push_auto_finalize_branch", fail_push)
+    monkeypatch.setattr(delegate, "_create_auto_finalize_pr", fail_create_pr)
+
+    with patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()):
+        rc = delegate._run_worker(
+            task_id="agy-junk-only-finalize-test",
+            agent="agy",
+            prompt="hi",
+            mode="danger",
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort=None,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 1
+    assert state is not None
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "junk_only_worktree_changes"
+    assert state["auto_finalize"] == {
+        "ok": False,
+        "commit_sha": None,
+        "pr_url": None,
+        "error": "junk_only_worktree_changes",
+        "changed_files": [".venv"],
+    }
+    assert (worktree / ".venv").is_symlink()
+    assert subprocess.run(
+        ["git", "rev-list", "--count", "origin/main..HEAD"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip() == "0"
+
+
 def test_auto_finalize_push_failure_soft_resets_local_commit(tmp_path, monkeypatch):
     _sanitize_git_env_for_test(monkeypatch)
     worktree = tmp_path / "worktree"


### PR DESCRIPTION
## Summary

- Refuse automatic finalization before staging when every changed path is disposable scratch residue.
- Record the terminal task as `no_deliverable` with `junk_only_worktree_changes`; no branch push or PR is attempted.
- Cover `.venv`, `node_modules`, `__pycache__`, `.pytest_cache`, and `*.pyc`, while preserving the substantive-change path.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py -q` — 197 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/delegate.py tests/test_delegate.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

Closes #6497