### PR TITLE
fix(delegate): reject unsupported native grok effort

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -245,6 +245,17 @@ to Sol or the accountable orchestrator before making a consequential decision.
 - Plane / retention-apply / `formal_review_eligible` flips belong to the
   infra/harness lane after parity + present-tense operator/advisor GO.
 
+### Native Grok dispatch effort
+
+`scripts/delegate.py dispatch --agent grok` accepts only the native Grok CLI
+effort vocabulary: `low`, `medium`, or `high`. The permanent
+`--agent grok-build` alias has the identical contract. Dispatch checks this
+per-agent capability before it creates task state, a worktree, a runtime lease,
+or a worker process; `xhigh` and `max` are refused with a clear error rather
+than silently clamped to a different reasoning level. Omit `--effort` to use
+the native Grok default (`high`). This restriction does not apply to the
+separate historical `grok-hermes` transport.
+
 ### ACPX — structured transport boundary
 
 ACPX is **not** a coordination product and **not** a second fleet bus.

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -78,6 +78,7 @@ _MCP_REVIEW_DENY_RULES: tuple[str, ...] = (
     "Bash",
 )
 GROK_ALLOWED_MODELS: frozenset[str] = frozenset({"grok-4.5"})
+GROK_SUPPORTED_EFFORTS: frozenset[str] = frozenset({"low", "medium", "high"})
 GROK_BUILD_DEFAULT_MODEL = "grok-4.5"
 GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
 _TRAIL_ISOLATION_TOOL_CONFIG_KEYS: frozenset[str] = frozenset(
@@ -91,6 +92,23 @@ _TRAIL_ISOLATION_TOOL_CONFIG_KEYS: frozenset[str] = frozenset(
         "trail_isolation_cwd",
     }
 )
+
+
+def validate_grok_effort(effort: str | None) -> str | None:
+    """Return a native Grok effort after enforcing its CLI vocabulary.
+
+    ``delegate.py`` calls this before it creates a worker. Keeping the same
+    check here protects direct runtime callers and prevents a malformed
+    environment default from reaching the native CLI.
+    """
+    if effort is None:
+        return None
+    if effort not in GROK_SUPPORTED_EFFORTS:
+        raise ValueError(
+            "native Grok CLI supports --effort values "
+            f"{sorted(GROK_SUPPORTED_EFFORTS)}; got {effort!r}"
+        )
+    return effort
 
 
 def grok_session_dir(grok_home: Path, cwd: Path, session_id: str) -> Path:
@@ -256,10 +274,10 @@ class GrokBuildAdapter:
                     if rule:
                         cmd.extend(["--deny", str(rule)])
 
-        effective_effort = effort or self.default_effort
+        effective_effort = validate_grok_effort(effort or self.default_effort)
         cmd.extend(["-m", requested_model])
         if effective_effort:
-            # grok accepts the same levels as the runtime: low|medium|high|xhigh|max
+            # The native Grok CLI accepts only low|medium|high.
             cmd.extend(["--effort", effective_effort])
 
         disallowed = tc.get("disallowed_tools")

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -161,6 +161,15 @@ _DISPATCH_AGENT_CHOICES = (
     "glm",
 )
 _KIMI_HARNESSES = frozenset({"native", "kimicc"})
+# Dispatch agent → effort validator. Keep this mapping at the dispatch
+# boundary so an effort unsupported by a provider fails before a task state,
+# worktree, runtime lease, or worker process is created. The native Grok alias
+# deliberately shares the canonical adapter's vocabulary; grok-hermes is a
+# different transport and must not inherit the native CLI restriction.
+_EFFORT_VALIDATOR_BY_DISPATCH_AGENT = {
+    "grok": "native_grok",
+    "grok-build": "native_grok",
+}
 _MONITOR_API_BASE_URL = "http://127.0.0.1:8765"
 _logger = logging.getLogger(__name__)
 
@@ -174,6 +183,30 @@ def _resolve_dispatch_harness(agent: str, harness: str | None) -> str | None:
     if harness not in _KIMI_HARNESSES:
         raise ValueError(f"unsupported Kimi harness {harness!r}; expected one of {sorted(_KIMI_HARNESSES)}")
     return harness
+
+
+def _validate_dispatch_effort(agent: str, effort: str | None) -> None:
+    """Fail closed when a dispatch effort cannot reach its selected CLI.
+
+    The top-level ``--effort`` parser accepts the cross-runtime vocabulary.
+    Provider-specific limits belong here, before dispatch creates any durable
+    task or process state. Revalidate after a budget substitution because that
+    can change the effective provider.
+    """
+    if effort is None:
+        return
+    validator = _EFFORT_VALIDATOR_BY_DISPATCH_AGENT.get(agent.strip().lower())
+    if validator == "native_grok":
+        from agent_runtime.adapters.grok_build import validate_grok_effort
+
+        try:
+            validate_grok_effort(effort)
+        except ValueError as exc:
+            raise ValueError(
+                f"--agent {agent} cannot use --effort {effort!r}: {exc}. "
+                "Refusing before worker spawn; choose low, medium, or high, "
+                "or omit --effort for the native Grok default."
+            ) from exc
 
 
 def _read_github_token_from_bash_secrets(path: Path | None = None) -> str | None:
@@ -3537,6 +3570,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     task_id = args.task_id
     try:
+        _validate_dispatch_effort(args.agent, getattr(args, "effort", None))
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+    try:
         attribution = resolve_invocation_attribution(
             explicit=getattr(args, "initiator", None),
             task_id=task_id,
@@ -3698,6 +3736,12 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         dispatch_agent = _resolve_agent_with_budget_guard(args.agent)
     else:
         dispatch_agent = args.agent
+
+    try:
+        _validate_dispatch_effort(dispatch_agent, getattr(args, "effort", None))
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
 
     if requested_harness is not None and dispatch_agent != "kimi":
         print(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -828,6 +828,43 @@ def test_wait_detects_zombie_and_returns_nonzero(tmp_tasks_dir, capsys):
 # cmd_dispatch guards
 # ---------------------------------------------------------------------------
 
+
+@pytest.mark.parametrize("agent", ["grok", "grok-build"])
+@pytest.mark.parametrize("effort", ["xhigh", "max"])
+def test_dispatch_rejects_unsupported_native_grok_effort_before_spawn(
+    tmp_tasks_dir, monkeypatch, capsys, agent, effort
+):
+    """Native Grok must reject generic-only efforts before task side effects."""
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            agent,
+            "--task-id",
+            f"{agent}-{effort}",
+            "--prompt",
+            "hi",
+            "--effort",
+            effort,
+        ]
+    )
+
+    def _unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("unsupported native Grok effort must not spawn a worker")
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", _unexpected_spawn)
+
+    assert delegate.cmd_dispatch(args) == 2
+    assert delegate._read_state(delegate._state_path(f"{agent}-{effort}")) is None
+    assert "Refusing before worker spawn" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("agent", ["grok", "grok-build"])
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+def test_dispatch_accepts_native_grok_effort_vocabulary(agent, effort):
+    """The dispatch guard admits every native Grok CLI effort level."""
+    delegate._validate_dispatch_effort(agent, effort)
+
 def test_dispatch_refuses_to_clobber_running_task(tmp_tasks_dir, capsys):
     """Dispatching with a task-id that's already running must fail fast."""
     path = delegate._state_path("duplicate-task")

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -23,6 +23,7 @@ from agent_runtime.adapters.base import AgentAdapter, InvocationPlan
 from agent_runtime.adapters.grok_build import (
     GROK_BUILD_DEFAULT_EFFORT,
     GROK_BUILD_DEFAULT_MODEL,
+    GROK_SUPPORTED_EFFORTS,
     GrokBuildAdapter,
     _adapt_prompt_for_grok_build_mcp,
     _parse_json_object,
@@ -88,6 +89,16 @@ def test_default_effort_is_applied(tmp_path):
     plan = _build("x", tmp_path)
     assert _val(plan.cmd, "-m") == GROK_BUILD_DEFAULT_MODEL
     assert _val(plan.cmd, "--effort") == GROK_BUILD_DEFAULT_EFFORT
+
+
+@pytest.mark.parametrize("effort", ["xhigh", "max"])
+def test_unsupported_native_effort_raises_before_invocation(tmp_path, effort):
+    with pytest.raises(ValueError, match="native Grok CLI supports --effort values"):
+        _build("x", tmp_path, effort=effort)
+
+
+def test_native_grok_effort_vocabulary_matches_cli_contract():
+    assert frozenset({"low", "medium", "high"}) == GROK_SUPPORTED_EFFORTS
 
 
 def test_hyphen_leading_prompt_uses_prompt_file(tmp_path):


### PR DESCRIPTION
## Summary

- validate native Grok effort levels at the dispatch boundary for `grok` and its `grok-build` alias
- reject `xhigh` and `max` before task state, worktree, runtime lease, or worker spawn
- guard direct adapter calls and document the provider-specific vocabulary

## Root cause

`delegate.py` accepted its generic effort vocabulary and forwarded unsupported native Grok values unchanged, causing the worker to fail after it had been spawned.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py tests/test_grok_build_adapter.py tests/test_agent_runtime_effort.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/delegate.py scripts/agent_runtime/adapters/grok_build.py tests/test_delegate.py tests/test_grok_build_adapter.py tests/test_agent_runtime_effort.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/agent-seat-onboarding.md`
- direct CLI rejection for `--agent grok --effort xhigh` (exit 2; no task state created)

Refs #6477

Auto-merge intentionally not enabled.