### PR TITLE
fix(acpx): reserve output for terminal frames

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -443,12 +443,14 @@ unrestricted loop, hidden failover, or retry. Each model call is capped at 300
 seconds, the whole conversation at 1,200 seconds, and content at 160k reliable
 tokens or 512 KiB.
 
-Raw ACP JSON-RPC traffic and parsed answer content have separate hard bounds.
-Each enabled participant may emit at most a 16 MiB protocol envelope so a
-valid terminal frame is not killed by provider-specific progress events. The
-strict parser then admits at most 512 KiB of answer text to the caller or
-fleet-authority receipt. Exceeding either bound fails terminally without a
-provider retry or bridge fallback.
+Captured ACP JSON-RPC traffic and parsed answer content have separate hard
+bounds. Parser-ignored `progress` notifications retain at most 256 KiB of
+diagnostic content, then continue to drain without consuming the protocol
+envelope; this reserves room for the answer, tool trace, and terminal receipt.
+All retained protocol events remain capped at 16 MiB, while the strict parser
+admits at most 512 KiB of answer text to the caller or fleet-authority receipt.
+Exceeding either retained-envelope or parsed-answer bound fails terminally
+without a provider retry or bridge fallback.
 
 Calls initiated from the protected primary checkout keep the same containment
 guard. The compatibility entrypoints create a short-lived detached,

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import importlib
+import json
 import logging
 import os
 import re
@@ -142,6 +143,12 @@ _PRIVACY_LIMITED_USAGE_ENTRYPOINTS = frozenset(
 # the adapter independently caps parsed answer text before it can be returned
 # to fleet authority.
 _ACPX_DIRECT_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
+# ACPX ``progress`` notifications are explicitly ignored by the strict parser:
+# they can carry verbose provider/tool display text, while session updates and
+# terminal results carry the answer and durable outcome. Retain a small,
+# bounded diagnostic prefix of those ignored events, then keep draining (rather
+# than killing) so the final answer and terminal receipt can still arrive.
+_ACPX_INTERMEDIATE_PROGRESS_LIMIT_BYTES = 256 * 1024
 _SAFE_ACP_FAILURE_CODES = frozenset(
     {
         "acp_adapter_incompatible",
@@ -211,6 +218,34 @@ def _streamed_output_limit(*, agent_name: str, entrypoint: str) -> int | None:
     ):
         return _ACPX_DIRECT_OUTPUT_LIMIT_BYTES
     return None
+
+
+def _bounded_acpx_progress_filter() -> Callable[[str], str | None]:
+    """Retain only a bounded prefix of parser-ignored ACPX progress events.
+
+    The transform deliberately preserves every non-progress line, including
+    ``session/update`` messages (answer, usage, and tool trace) and terminal
+    JSON-RPC results/errors.  A malformed line is retained so the ACPX parser
+    continues to fail closed instead of silently hiding protocol corruption.
+    """
+    retained_progress_bytes = 0
+
+    def filter_line(line: str) -> str | None:
+        nonlocal retained_progress_bytes
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return line
+        if not isinstance(event, dict) or event.get("method") != "progress":
+            return line
+
+        line_bytes = len(line.encode("utf-8", errors="replace"))
+        if line_bytes > _ACPX_INTERMEDIATE_PROGRESS_LIMIT_BYTES - retained_progress_bytes:
+            return None
+        retained_progress_bytes += line_bytes
+        return line
+
+    return filter_line
 
 
 def _resolve_plan_telemetry(
@@ -1346,12 +1381,18 @@ def _execute_invocation_plan(
         liveness_paths = tuple(adapter.liveness_signal_paths(plan))
         if plan.output_file is not None and plan.output_file not in liveness_paths:
             liveness_paths = (*liveness_paths, plan.output_file)
+        stdout_line_transform = (
+            _bounded_acpx_progress_filter()
+            if output_limit is not None
+            else None
+        )
         watchdog_state, watchdog_threads = start_watchdog(
             proc,
             list(liveness_paths),
             stdout_master_fd=stdout_master_fd,
             stderr_master_fd=stderr_master_fd,
             track_process_activity=bool(stdout_silence_timeout is not None and stdout_silence_timeout > 0),
+            stdout_line_transform=stdout_line_transform,
         )
         capture_repo_raw = None
         if tool_config:

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -38,7 +38,7 @@ import re
 import subprocess
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -121,7 +121,12 @@ class WatchdogState:
     stderr_lines: list[str] = field(default_factory=list)
 
 
-def _stdout_streamer(proc: subprocess.Popen, state: WatchdogState) -> None:
+def _stdout_streamer(
+    proc: subprocess.Popen,
+    state: WatchdogState,
+    *,
+    stdout_line_transform: Callable[[str], str | None] | None = None,
+) -> None:
     """Background thread: read stdout line-by-line, bump last_activity.
 
     Exits when the pipe closes (subprocess terminates) or state.stop is True.
@@ -131,9 +136,12 @@ def _stdout_streamer(proc: subprocess.Popen, state: WatchdogState) -> None:
         for line in iter(proc.stdout.readline, ""):
             if state.stop:
                 break
-            state.stdout_lines.append(line)
-            state.last_activity = time.monotonic()
-            state.last_stdout_activity = state.last_activity
+            _emit_line(
+                state,
+                line,
+                is_stderr=False,
+                stdout_line_transform=stdout_line_transform,
+            )
     except (ValueError, OSError):
         # Pipe closed or subprocess killed. Normal shutdown path.
         pass
@@ -188,6 +196,7 @@ def _pty_line_streamer(
     state: WatchdogState,
     *,
     is_stderr: bool,
+    stdout_line_transform: Callable[[str], str | None] | None = None,
 ) -> None:
     """Background thread: read from a PTY master fd, emit complete lines.
 
@@ -236,7 +245,12 @@ def _pty_line_streamer(
                 if line.endswith("\r\n"):
                     line = line[:-2] + "\n"
                 line = _strip_ansi(line)
-                _emit_line(state, line, is_stderr=is_stderr)
+                _emit_line(
+                    state,
+                    line,
+                    is_stderr=is_stderr,
+                    stdout_line_transform=stdout_line_transform,
+                )
     except (ValueError, OSError):
         # Master fd closed underneath us (e.g. cleanup raced ahead);
         # treat as clean shutdown — same semantics as the pipe path.
@@ -248,16 +262,33 @@ def _pty_line_streamer(
             tail = bytes(buffer).decode("utf-8", errors="replace")
             tail = tail.replace("\r\n", "\n")
             tail = _strip_ansi(tail)
-            _emit_line(state, tail, is_stderr=is_stderr)
+            _emit_line(
+                state,
+                tail,
+                is_stderr=is_stderr,
+                stdout_line_transform=stdout_line_transform,
+            )
 
 
-def _emit_line(state: WatchdogState, line: str, *, is_stderr: bool) -> None:
+def _emit_line(
+    state: WatchdogState,
+    line: str,
+    *,
+    is_stderr: bool,
+    stdout_line_transform: Callable[[str], str | None] | None = None,
+) -> None:
     """Append a decoded line to the relevant state buffer + bump activity."""
     now = time.monotonic()
     if is_stderr:
         state.stderr_lines.append(line)
     else:
-        state.stdout_lines.append(line)
+        retained_line = (
+            stdout_line_transform(line)
+            if stdout_line_transform is not None
+            else line
+        )
+        if retained_line is not None:
+            state.stdout_lines.append(retained_line)
         state.last_stdout_activity = now
     state.last_activity = now
     state.observed_io = True
@@ -407,6 +438,7 @@ def start_watchdog(
     stdout_master_fd: int | None = None,
     stderr_master_fd: int | None = None,
     track_process_activity: bool = False,
+    stdout_line_transform: Callable[[str], str | None] | None = None,
 ) -> tuple[WatchdogState, list[threading.Thread]]:
     """Start the stdout streamer + mtime poller threads for a running subprocess.
 
@@ -423,6 +455,8 @@ def start_watchdog(
             semantics as ``stdout_master_fd``.
         track_process_activity: When True, poll process-tree CPU/disk activity
             and refresh ``last_activity`` while the process tree is doing work.
+        stdout_line_transform: Optional runner-owned transform applied before
+            retaining a stdout line. Dropped lines still refresh liveness.
 
     When the fd kwargs are ``None`` the watchdog falls back to the
     legacy pipe-mode streamers — exercised by the ``DELEGATE_DISABLE_PTY``
@@ -443,7 +477,10 @@ def start_watchdog(
         t_stdout = threading.Thread(
             target=_pty_line_streamer,
             args=(stdout_master_fd, state),
-            kwargs={"is_stderr": False},
+            kwargs={
+                "is_stderr": False,
+                "stdout_line_transform": stdout_line_transform,
+            },
             name=f"watchdog-stdout-{proc.pid}",
             daemon=True,
         )
@@ -453,6 +490,7 @@ def start_watchdog(
         t_stdout = threading.Thread(
             target=_stdout_streamer,
             args=(proc, state),
+            kwargs={"stdout_line_transform": stdout_line_transform},
             name=f"watchdog-stdout-{proc.pid}",
             daemon=True,
         )

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4333,16 +4333,28 @@ def test_acpx_direct_route_output_limit_kills_child_and_raises_typed_error(
     assert error.value.observed_bytes > error.value.limit_bytes
 
 
-def test_acpx_protocol_envelope_above_legacy_cap_reaches_terminal(tmp_path):
+def test_acpx_over_cap_progress_is_dropped_while_answer_and_terminal_survive(
+    tmp_path, monkeypatch
+):
+    from agent_runtime import runner as runtime_runner
     from agent_runtime.adapters.acpx import AcpxAdapter
+
+    monkeypatch.setattr(runtime_runner, "_ACPX_DIRECT_OUTPUT_LIMIT_BYTES", 4 * 1024)
+    monkeypatch.setattr(runtime_runner, "_ACPX_INTERMEDIATE_PROGRESS_LIMIT_BYTES", 1024)
 
     child = (
         "import json; "
         "print(json.dumps({'jsonrpc':'2.0','method':'progress','params':"
-        "{'text':'x'*(300*1024)}})); "
+        "{'text':'x'*(8*1024)}})); "
         "print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':"
         "{'update':{'sessionUpdate':'agent_message_chunk','content':"
-        "{'type':'text','text':'ok'}}}})); "
+        "{'type':'text','text':'final '}}}})); "
+        "print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':"
+        "{'update':{'sessionUpdate':'tool_call','toolCallId':'read-1',"
+        "'name':'read','status':'completed','rawOutput':'receipt'}}})); "
+        "print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':"
+        "{'update':{'sessionUpdate':'agent_message_chunk','content':"
+        "{'type':'text','text':'answer'}}}})); "
         "print(json.dumps({'jsonrpc':'2.0','id':2,'result':"
         "{'stopReason':'end_turn'}}))"
     )
@@ -4361,7 +4373,58 @@ def test_acpx_protocol_envelope_above_legacy_cap_reaches_terminal(tmp_path):
         stall_timeout=30,
     )
 
-    assert len(execution.stdout_text.encode("utf-8")) > 256 * 1024
+    assert len(execution.stdout_text.encode("utf-8")) < 4 * 1024
+    assert '"method": "progress"' not in execution.stdout_text
+    assert '"stopReason": "end_turn"' in execution.stdout_text
+    assert execution.kill_reason is None
+    assert execution.parse.ok is True
+    assert execution.parse.response == "final answer"
+    assert execution.parse.tool_calls == [
+        {
+            "id": "read-1",
+            "name": "read",
+            "title": "",
+            "arguments": {},
+            "result": "receipt",
+            "status": "completed",
+        }
+    ]
+
+
+def test_acpx_under_cap_progress_is_retained_with_answer_and_terminal(tmp_path, monkeypatch):
+    from agent_runtime import runner as runtime_runner
+    from agent_runtime.adapters.acpx import AcpxAdapter
+
+    monkeypatch.setattr(runtime_runner, "_ACPX_DIRECT_OUTPUT_LIMIT_BYTES", 4 * 1024)
+    monkeypatch.setattr(runtime_runner, "_ACPX_INTERMEDIATE_PROGRESS_LIMIT_BYTES", 1024)
+
+    child = (
+        "import json; "
+        "print(json.dumps({'jsonrpc':'2.0','method':'progress','params':"
+        "{'text':'x'*128}})); "
+        "print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':"
+        "{'update':{'sessionUpdate':'agent_message_chunk','content':"
+        "{'type':'text','text':'ok'}}}})); "
+        "print(json.dumps({'jsonrpc':'2.0','id':2,'result':"
+        "{'stopReason':'end_turn'}}))"
+    )
+    execution = _execute_invocation_plan(
+        agent_name="acpx-kimi-shadow",
+        adapter=AcpxAdapter(),
+        plan=InvocationPlan(cmd=[_TEST_PYTHON, "-c", child], cwd=tmp_path),
+        prompt="fixture",
+        mode="read-only",
+        cwd=tmp_path,
+        model="fixture",
+        task_id="fixture",
+        session_id=None,
+        entrypoint="acpx-transport",
+        hard_timeout=30,
+        stall_timeout=30,
+    )
+
+    assert '"method": "progress"' in execution.stdout_text
+    assert '"stopReason": "end_turn"' in execution.stdout_text
     assert execution.kill_reason is None
     assert execution.parse.ok is True
     assert execution.parse.response == "ok"


### PR DESCRIPTION
## Summary

- retain only a bounded 256 KiB diagnostic prefix of ACPX `progress` notifications
- keep answer chunks, tool-call trace, and terminal JSON-RPC result intact
- cover Kimi over-cap truncation and under-cap retention without altering model selection or review authority

## Root cause

The runner counted every raw ACPX line against the protocol-envelope cap, including parser-ignored `progress` frames. Verbose intermediate output could exhaust the cap before the final answer and terminal receipt arrived.

## Validation

- `env -u LU_RUNTIME_INITIATOR -u LU_RUNTIME_INITIATOR_SOURCE /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_agent_runtime.py -q --tb=short` (196 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/agent_runtime/test_pty_subprocess_wrap.py tests/agent_runtime/test_acpx_adapter.py -q` (153 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/runner.py scripts/agent_runtime/watchdog.py tests/test_agent_runtime.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/agent-seat-onboarding.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

Fixes #6229