### PR TITLE
feat(api): expose fleet facade routes

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -8,6 +8,23 @@ FastAPI auto-docs: `http://localhost:8765/docs` (Swagger UI)
 
 This (plus the live `meta` objects returned by many endpoints) is the enforced, machine-readable definition of the declared API surface. The running code in `scripts/api/*.py` is the ultimate behavioral authority. `docs/MONITOR-API.md` is the human narrative. Dashboards are consumers/visualizers that should (and increasingly do) derive from the contracts. See `scripts/api/route_contracts.py` and `tests/test_monitor_route_contracts.py`. The 2026-06-07 Monitor API/UI Audit (#2794) is the origin of this registry.
 
+## Fleet facade — `/api/fleet/facade`
+
+This thin, read-only namespace makes the existing `python -m scripts.fleet_comms fleet …` seat-facing surfaces available to Monitor clients. It does not introduce a message bus, write to the Fleet Comms plane, retrieve message bodies, or expose reaper apply mode.
+
+| Method | Path | Existing source |
+| --- | --- | --- |
+| GET | `/api/fleet/facade` or `/help` | Truth/Hand/Eyes map and endpoint index |
+| GET | `/api/fleet/facade/status` | `fleet status` plane status plus compact health |
+| GET | `/api/fleet/facade/board` | JSON cold-start board |
+| GET | `/api/fleet/facade/metrics` | Authority metrics collector |
+| GET | `/api/fleet/facade/backlog` | Authority backlog collector |
+| GET | `/api/fleet/facade/dead` | Authority dead-letter collector |
+| GET | `/api/fleet/facade/broker-report?days=7` | Legacy Broker Ops report (`days` is 1–90) |
+| GET | `/api/fleet/facade/reap-report` | Guarded reaper dry-run only; the response always has `"apply": false` |
+
+The facade is fail-open when the plane SQLite file is absent or unavailable: authority collector responses include `db_missing` or `db_error`, while status retains the plane schema diagnostic. Reaper apply remains CLI-only and is never an HTTP option.
+
 ---
 
 ## Optional Context Telemetry Footer

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -24,12 +24,21 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 
+from scripts.fleet_comms.cli import fleet_help_payload, fleet_status_payload
+from scripts.fleet_comms.cold_start_board import build_cold_start_board
+from scripts.fleet_comms.efficiency_metrics import (
+    collect_dead_letters_authority,
+    collect_delivery_backlog_authority,
+    collect_efficiency_metrics_authority,
+)
 from scripts.fleet_comms.endpoints import load_endpoint_registry
+from scripts.fleet_comms.legacy_broker_report import build_legacy_broker_report
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 from scripts.fleet_comms.migrations import MIGRATIONS
+from scripts.orchestration import reap_worktrees
 
 from . import comms_router as legacy_comms
-from .config import PROJECT_ROOT
+from .config import LIVE_REPO_ROOT, PROJECT_ROOT
 from .runtime_router import get_acp_conversation, list_acp_conversations, recent_runtime_records
 
 router = APIRouter(tags=["fleet"])
@@ -368,6 +377,213 @@ def _safe_plane_status() -> dict[str, Any]:
             "parity_fail_count": int(telemetry.get("parity_fail_count") or 0),
         },
     }
+
+
+def _facade_authority_payload(
+    collector: Callable[[Path], dict[str, Any]],
+) -> dict[str, Any]:
+    """Run an authority collector fail-open without creating a plane database."""
+    db_path = _plane_db_path()
+    if not db_path.is_file():
+        return {
+            "content_included": False,
+            "db_missing": True,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    try:
+        payload = collector(db_path)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        logger.warning("Fleet facade authority collector unavailable: %s", type(exc).__name__)
+        return {
+            "content_included": False,
+            "db_error": type(exc).__name__,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    payload["db_path"] = str(db_path)
+    payload["read_only"] = True
+    payload["source"] = "authority"
+    return payload
+
+
+def _facade_backlog_payload(limit: int) -> dict[str, Any]:
+    """Return the existing authority backlog projection for the thin facade."""
+    db_path = _plane_db_path()
+    if not db_path.is_file():
+        return {
+            "total": 0,
+            "by_agent": {},
+            "by_status": {},
+            "rows": [],
+            "content_included": False,
+            "db_missing": True,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    try:
+        payload = collect_delivery_backlog_authority(
+            db_path, limit=limit, exclude_retired=True
+        )
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        logger.warning("Fleet facade authority backlog unavailable: %s", type(exc).__name__)
+        return {
+            "total": 0,
+            "by_agent": {},
+            "by_status": {},
+            "rows": [],
+            "content_included": False,
+            "db_error": type(exc).__name__,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    payload["content_included"] = False
+    payload["db_path"] = str(db_path)
+    payload["read_only"] = True
+    payload["source"] = "authority"
+    return payload
+
+
+def _facade_dead_letters_payload(limit: int) -> dict[str, Any]:
+    """Return the existing authority dead-letter projection for the thin facade."""
+    db_path = _plane_db_path()
+    if not db_path.is_file():
+        return {
+            "total": 0,
+            "by_reason": {},
+            "rows": [],
+            "content_included": False,
+            "db_missing": True,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    try:
+        payload = collect_dead_letters_authority(db_path, limit=limit)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        logger.warning("Fleet facade authority dead letters unavailable: %s", type(exc).__name__)
+        return {
+            "total": 0,
+            "by_reason": {},
+            "rows": [],
+            "content_included": False,
+            "db_error": type(exc).__name__,
+            "db_path": str(db_path),
+            "read_only": True,
+            "source": "authority",
+        }
+    payload["content_included"] = False
+    payload["db_path"] = str(db_path)
+    payload["read_only"] = True
+    payload["source"] = "authority"
+    return payload
+
+
+def _facade_reap_report() -> dict[str, Any]:
+    """Return the established merged-head reaper report in dry-run mode only."""
+    try:
+        results = reap_worktrees.reap_worktrees(
+            repo_root=reap_worktrees.primary_checkout_root(Path(LIVE_REPO_ROOT)),
+            apply=False,
+            prune_merged_branches=True,
+            safe_only=True,
+            merged_pr_only=True,
+            require_activity_probe=False,
+        )
+        return {
+            "read_only": True,
+            "apply": False,
+            "report": [reap_worktrees._result_payload(result) for result in results],
+        }
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("Fleet facade dry-run reaper unavailable: %s", type(exc).__name__)
+        return {
+            "read_only": True,
+            "apply": False,
+            "error": f"dry_run_unavailable: {type(exc).__name__}",
+            "report": [],
+        }
+
+
+@router.get("/facade")
+@router.get("/facade/help")
+def fleet_facade_help() -> dict[str, Any]:
+    """Index the read-only CLI facade routes available to seats and the Monitor UI."""
+    payload = fleet_help_payload()
+    payload.update(
+        {
+            "read_only": True,
+            "endpoints": {
+                "help": "/api/fleet/facade/help",
+                "status": "/api/fleet/facade/status",
+                "board": "/api/fleet/facade/board",
+                "metrics": "/api/fleet/facade/metrics",
+                "backlog": "/api/fleet/facade/backlog",
+                "dead": "/api/fleet/facade/dead",
+                "broker_report": "/api/fleet/facade/broker-report?days=7",
+                "reap_report": "/api/fleet/facade/reap-report",
+            },
+        }
+    )
+    return payload
+
+
+@router.get("/facade/status")
+def fleet_facade_status() -> dict[str, Any]:
+    """Expose the CLI fleet-status payload without a second health authority."""
+    status = read_plane_status(repo_root=Path(PROJECT_ROOT), recent_limit=50)
+    payload = fleet_status_payload(status)
+    payload["read_only"] = True
+    return payload
+
+
+@router.get("/facade/board")
+def fleet_facade_board(
+    stream_id: str | None = Query(default=None),
+    agent: str | None = Query(default=None),
+    needle: str | None = Query(default=None),
+) -> dict[str, Any]:
+    """Expose the JSON cold-start board already used by the fleet CLI."""
+    return build_cold_start_board(
+        stream_id=stream_id,
+        agent=agent,
+        needle=needle,
+        repo_root=Path(PROJECT_ROOT),
+    )
+
+
+@router.get("/facade/metrics")
+def fleet_facade_metrics() -> dict[str, Any]:
+    """Return authority-plane metrics through the existing collector."""
+    return _facade_authority_payload(collect_efficiency_metrics_authority)
+
+
+@router.get("/facade/backlog")
+def fleet_facade_backlog(limit: int = Query(default=100, ge=1, le=500)) -> dict[str, Any]:
+    """Return the authority-plane delivery backlog; retired endpoints stay excluded."""
+    return _facade_backlog_payload(limit)
+
+
+@router.get("/facade/dead")
+def fleet_facade_dead(limit: int = Query(default=100, ge=1, le=500)) -> dict[str, Any]:
+    """Return the authority-plane dead-letter inventory without message bodies."""
+    return _facade_dead_letters_payload(limit)
+
+
+@router.get("/facade/broker-report")
+def fleet_facade_broker_report(days: int = Query(default=7, ge=1, le=90)) -> dict[str, Any]:
+    """Expose the legacy Broker Ops retirement report through its shared builder."""
+    return build_legacy_broker_report(days)
+
+
+@router.get("/facade/reap-report")
+def fleet_facade_reap_report() -> dict[str, Any]:
+    """Expose the guarded reaper's dry-run report; apply is never an API option."""
+    return _facade_reap_report()
 
 
 def _count_by_state(connection: sqlite3.Connection, table: str, column: str) -> dict[str, int]:

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -95,6 +95,11 @@ def cmd_plane_status(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def fleet_status_payload(status: dict[str, Any]) -> dict[str, Any]:
+    """Return the shared facade status payload for CLI and Monitor callers."""
+    return {"plane_status": status, "health": _short_plane_health(status)}
+
+
 def _short_plane_health(status: dict[str, Any]) -> dict[str, Any]:
     """Return a compact health projection without creating a second authority."""
     schema = status.get("schema") or {}
@@ -122,7 +127,7 @@ def cmd_fleet_status(args: argparse.Namespace) -> int:
         telemetry_path=telemetry,
         recent_limit=args.recent_limit,
     )
-    sys.stdout.write(_json_dump({"plane_status": status, "health": _short_plane_health(status)}))
+    sys.stdout.write(_json_dump(fleet_status_payload(status)))
     return EXIT_OK
 
 
@@ -154,27 +159,30 @@ def cmd_fleet_reap_report(args: argparse.Namespace) -> int:
     return int(reap_worktrees.main(command))
 
 
+def fleet_help_payload() -> dict[str, Any]:
+    """Map the seat-facing facade to the existing Truth, Hand, and Eyes surfaces."""
+    return {
+        "truth": {
+            "status": "fleet status (plane-status plus compact health)",
+            "metrics": "fleet metrics (durable authority metrics)",
+            "broker_report": "fleet broker-report (legacy retirement evidence)",
+        },
+        "hand": {
+            "reap_report": "fleet reap-report --apply (existing merged-head reaper guards)",
+        },
+        "eyes": {
+            "board": "fleet board (cold-start driver board)",
+            "backlog": "fleet backlog (pending deliveries)",
+            "dead": "fleet dead (dead-letter inventory)",
+        },
+        "note": "Thin facade only; Fleet Comms remains the authoritative message plane.",
+    }
+
+
 def cmd_fleet_help(_args: argparse.Namespace) -> int:
     """Map the facade to existing Truth, Hand, and Eyes surfaces."""
     sys.stdout.write(
-        _json_dump(
-            {
-                "truth": {
-                    "status": "fleet status (plane-status plus compact health)",
-                    "metrics": "fleet metrics (durable authority metrics)",
-                    "broker_report": "fleet broker-report (legacy retirement evidence)",
-                },
-                "hand": {
-                    "reap_report": "fleet reap-report --apply (existing merged-head reaper guards)",
-                },
-                "eyes": {
-                    "board": "fleet board (cold-start driver board)",
-                    "backlog": "fleet backlog (pending deliveries)",
-                    "dead": "fleet dead (dead-letter inventory)",
-                },
-                "note": "Thin facade only; Fleet Comms remains the authoritative message plane.",
-            }
-        )
+        _json_dump(fleet_help_payload())
     )
     return EXIT_OK
 

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -203,6 +203,111 @@ def test_absent_plane_db_returns_deterministic_read_only_empty_states(
     assert not fleet_root.exists(), "observer must not create a missing plane root"
 
 
+def test_facade_routes_reuse_read_only_fleet_projections(
+    client: TestClient,
+    fleet_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_plane(fleet_root)
+    monkeypatch.setattr(
+        fleet_router,
+        "build_cold_start_board",
+        lambda **_kwargs: {"board_status": "ok", "probes": {}},
+    )
+    monkeypatch.setattr(
+        fleet_router,
+        "_facade_reap_report",
+        lambda: {"read_only": True, "apply": False, "report": []},
+    )
+
+    help_response = client.get("/api/fleet/facade")
+    help_alias = client.get("/api/fleet/facade/help")
+    status = client.get("/api/fleet/facade/status")
+    board = client.get("/api/fleet/facade/board", params={"stream_id": "core"})
+    metrics = client.get("/api/fleet/facade/metrics")
+    backlog = client.get("/api/fleet/facade/backlog", params={"limit": 1})
+    dead = client.get("/api/fleet/facade/dead", params={"limit": 1})
+    broker = client.get("/api/fleet/facade/broker-report", params={"days": 7})
+    reap = client.get("/api/fleet/facade/reap-report")
+
+    for response in (
+        help_response,
+        help_alias,
+        status,
+        board,
+        metrics,
+        backlog,
+        dead,
+        broker,
+        reap,
+    ):
+        assert response.status_code == 200
+
+    assert help_response.json()["endpoints"]["reap_report"].endswith("/reap-report")
+    assert help_alias.json()["truth"] == help_response.json()["truth"]
+    assert status.json()["health"]["mode"] == "shadow"
+    assert board.json() == {"board_status": "ok", "probes": {}}
+    assert metrics.json()["source"] == "authority"
+    assert metrics.json()["read_only"] is True
+    assert backlog.json()["content_included"] is False
+    assert dead.json()["content_included"] is False
+    assert broker.json()["schema"] == "fleet-broker-report.v1"
+    assert broker.json()["read_only"] is True
+    assert reap.json() == {"read_only": True, "apply": False, "report": []}
+
+
+def test_facade_missing_plane_db_is_fail_open(
+    client: TestClient, fleet_root: Path
+) -> None:
+    assert not fleet_root.exists()
+
+    status = client.get("/api/fleet/facade/status").json()
+    metrics = client.get("/api/fleet/facade/metrics").json()
+    backlog = client.get("/api/fleet/facade/backlog").json()
+    dead = client.get("/api/fleet/facade/dead").json()
+
+    assert status["plane_status"]["schema"]["db_exists"] is False
+    for payload in (metrics, backlog, dead):
+        assert payload["db_missing"] is True
+        assert payload["read_only"] is True
+
+
+def test_facade_reap_report_is_dry_run_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_reap_worktrees(**kwargs: object) -> list:
+        calls.append(kwargs)
+        return [
+            fleet_router.reap_worktrees.ReapResult(
+                path="/repo/.worktrees/dispatch/codex/facade",
+                branch="codex/api-fleet-facade",
+                action="would_remove",
+                reason="PR #1 MERGED",
+                dirty=False,
+            )
+        ]
+
+    monkeypatch.setattr(fleet_router.reap_worktrees, "reap_worktrees", fake_reap_worktrees)
+
+    payload = fleet_router._facade_reap_report()
+
+    assert payload["read_only"] is True
+    assert payload["apply"] is False
+    assert payload["report"][0]["action"] == "would_remove"
+    assert calls == [
+        {
+            "repo_root": fleet_router.reap_worktrees.primary_checkout_root(
+                fleet_router.Path(fleet_router.LIVE_REPO_ROOT)
+            ),
+            "apply": False,
+            "prune_merged_branches": True,
+            "safe_only": True,
+            "merged_pr_only": True,
+            "require_activity_probe": False,
+        }
+    ]
+
+
 def test_plane_health_and_overview_expose_pre_flip_read_only_posture(
     client: TestClient, fleet_root: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- expose the existing fleet CLI read models under `/api/fleet/facade/*`
- keep authority metrics, backlog, and dead-letter views read-only and fail-open
- expose only the guarded reaper dry-run report; HTTP apply is impossible
- document the endpoint index and add TestClient coverage

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/api/fleet_router.py scripts/fleet_comms/cli.py tests/test_fleet_observer_api.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_fleet_observer_api.py tests/test_fleet_comms_legacy_broker_report.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_fleet_comms_cli.py -q --deselect tests/test_fleet_comms_cli.py::test_supported_bridge_command_defaults_to_durable_acp`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_monitor_route_contracts.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

The deselected CLI test is unrelated to this change and is environment-sensitive: this worktree currently reports `grok-infra` instead of its hard-coded `codex` initiator.