### PR TITLE
feat(corpus): ingest complete Saint Sophia public archive

### DIFF
--- a/data/historical_language_corpus_denominator.yaml
+++ b/data/historical_language_corpus_denominator.yaml
@@ -1,0 +1,66 @@
+schema_version: historical-language-corpus-denominator.v1
+status: complete_current_public_api
+phase3_boundary:
+  corpus_role: auxiliary_historical_evidence
+  correction_denominator_member: false
+  linguistic_numerator_member: false
+  rationale: >-
+    Historical inscriptions support provenance-aware language-history work but
+    are not modern correction examples and must not alter the pinned Phase 3
+    correction denominators or evaluation numerators.
+
+collections:
+  - collection_id: saint-sophia-inscriptions
+    source_name: Saint Sophia of Kyiv inscriptions portal
+    portal_url: https://saintsophia.dh.gu.se/
+    api_root: https://saintsophia.dh.gu.se/api/
+    retrieved_at: '2026-08-09T03:57:40.414682Z'
+    retrieval_scope: complete_current_public_api
+    public_record_count: 4157
+    public_record_id_set_sha256: 44b6428c07a8f496e7b933b53fa7476b8ddd54c548c9c397f2a516f26d3e584b
+    endpoint_count: 18
+    raw_response_page_count: 200
+    known_identified_total_lower_bound: 7000
+    known_unexposed_residual: true
+    inaccessible_records_claimed_as_crawled: false
+    disposition_counts:
+      text_bearing: 4144
+      non_textual_or_no_text: 11
+      quarantined_metadata: 2
+    deterministic_quality_findings:
+      date_range_inversion: 1
+      year_outside_configured_ce_bounds: 1
+      epidoc_parse_failure: 0
+    preserved_text_evidence:
+      epidoc_nonempty_parsed: 3133
+      ukrainian_translation_nonempty: 1917
+      ukrainian_commentary_nonempty: 2956
+    historical_stage_labels:
+      current_value: null
+      status: pending_qualified_ukrainian_historical_language_review
+    media_policy:
+      image_or_media_requests: 0
+      images_downloaded: false
+      iiif_or_rti_downloaded: false
+    rights_and_release:
+      storage: private_google_drive
+      redistribution: prohibited_without_explicit_rights_clearance
+      public_repo_posture: locator_and_receipt_only
+    drive_snapshot_relative_path: historical_language_corpus/snapshots/saint-sophia-inscriptions-2026-08-09T033900Z
+    drive_canonical_relative_path: historical_language_corpus/canonical/saint-sophia-inscriptions
+    artifact_sha256:
+      historical_source_records_jsonl: 6199f2a92bd948dfe63d12e9da68637b02a4d16ff58b0ddba3d5e252bb3ec4fe
+      dispositions_jsonl: cde50a40302ef36b7f18b92cf0e43e56e4b230eb7440a3bc6fb8e85261fcc572
+      raw_hash_manifest_json: 2cbb10688e7d044d0eb7b5d54e40551eb61d8bda8121e7398ff19e0dd2d71a94
+      coverage_receipt_json: 2a12ad921efc1d88f7f039e1de133ceed7c4c39715d622c316e1af14ea29c5a7
+      ingest_receipt_json: 84b2d570686b53da9e36af5a7360511f3b987bfbdaa0a011aeb852121ffbad5d
+    canonical_database:
+      historical_source_rows: 4157
+      historical_fts_rows: 4157
+      integrity_check: ok
+      wal_checkpoint: [0, 0, 0]
+      sha256: 98e93c9560ede71bb4affa8626c932604b84dd435f8b2a8606c872ebcfd3a8d5
+      unaffected_table_counts:
+        textbooks: 48760
+        textbooks_fts: 48760
+        textbook_sections: 35293

--- a/scripts/crawl/crawl_saint_sophia.py
+++ b/scripts/crawl/crawl_saint_sophia.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Create a failure-atomic, byte-preserving Saint Sophia API snapshot.
+
+This crawler deliberately collects only the public text and metadata API.  It
+does not discover or fetch any image, IIIF, annotation-media, RTI, mesh, or
+geospatial endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from collections.abc import Callable, Iterable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
+from urllib.request import Request, urlopen
+from xml.etree import ElementTree
+
+API_ROOT = "https://saintsophia.dh.gu.se/api/"
+PORTAL_ROOT = "https://saintsophia.dh.gu.se/"
+COLLECTION_ID = "saint-sophia-inscriptions"
+SCHEMA_VERSION = "historical-source-record.v1"
+KNOWN_IDENTIFIED_TOTAL_LOWER_BOUND = 7000
+DEFAULT_CE_MIN_YEAR = 0
+DEFAULT_CE_MAX_YEAR = 2100
+
+# These endpoints are intentionally an allow-list.  In particular, it excludes
+# every endpoint that could expose media or a download URL.
+ENDPOINTS = (
+    "inscriptions/inscription/?depth=2",
+    "inscriptions/language/",
+    "inscriptions/writingsystem/",
+    "inscriptions/tags/",
+    "inscriptions/historicalperson/",
+    "inscriptions/panel-metadata/",
+    "inscriptions/inscription-contributors/",
+    "inscriptions/genre-with-data/",
+    "inscriptions/bibliography-item/",
+    "inscriptions/inscriptiontype/",
+    "inscriptions/extraalphabeticalsign/",
+    "inscriptions/graffiticondition/",
+    "inscriptions/graffitialignment/",
+    "inscriptions/datingcriterium/",
+    "inscriptions/author/",
+    "inscriptions/medium/",
+    "inscriptions/material/",
+    "inscriptions/section/",
+)
+INSCRIPTION_ENDPOINT = ENDPOINTS[0]
+NON_PAGINATED_ENDPOINTS = {"inscriptions/inscription-contributors/"}
+MEDIA_URL_TERMS = ("image", "iiif", "korniienko-image", "annotation-media", "rti", "mesh", "geojson", "download")
+FetchBytes = Callable[[str, float], bytes]
+
+
+class CrawlError(RuntimeError):
+    """Raised when an API response cannot support a complete snapshot."""
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _stable_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_bytes(_stable_json_bytes(value))
+
+
+def _endpoint_directory(endpoint: str) -> str:
+    return endpoint.split("?", 1)[0].strip("/").replace("/", "__")
+
+
+def _with_page_size(url: str, page_size: int) -> str:
+    parsed = urlparse(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query.setdefault("page_size", str(page_size))
+    return urlunparse(parsed._replace(query=urlencode(sorted(query.items()))))
+
+
+def _http_get(url: str, timeout: float) -> bytes:
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": "learn-ukrainian-sophia-crawler/1"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return response.read()
+    except URLError as error:
+        raise CrawlError(f"request failed for {url}: {error}") from error
+
+
+def _fetch_with_retries(fetch_bytes: FetchBytes, url: str, timeout: float, retries: int) -> bytes:
+    last_error: Exception | None = None
+    for _attempt in range(retries + 1):
+        try:
+            return fetch_bytes(url, timeout)
+        except (CrawlError, OSError, TimeoutError, URLError) as error:
+            last_error = error
+    raise CrawlError(f"request failed after {retries + 1} attempt(s): {url}") from last_error
+
+
+def _validate_url(url: str, api_root: str) -> None:
+    candidate = urlparse(url)
+    allowed = urlparse(api_root)
+    if candidate.scheme != allowed.scheme or candidate.netloc != allowed.netloc:
+        raise CrawlError(f"unexpected pagination scheme or host: {url}")
+    if any(term in candidate.path.casefold() for term in MEDIA_URL_TERMS):
+        raise CrawlError(f"refusing media or download endpoint: {url}")
+
+
+def _secure_pagination_url(url: str | None, api_root: str) -> tuple[str | None, bool]:
+    """Repair only the portal's same-host HTTP pagination downgrade."""
+    if url is None:
+        return None, False
+    candidate = urlparse(url)
+    allowed = urlparse(api_root)
+    if candidate.scheme == "http" and allowed.scheme == "https" and candidate.netloc == allowed.netloc:
+        return urlunparse(candidate._replace(scheme="https")), True
+    return url, False
+
+
+def _decode_page(raw: bytes, url: str, *, allow_bare_list: bool = False) -> dict[str, Any]:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise CrawlError(f"invalid JSON response: {url}") from error
+    if allow_bare_list and isinstance(payload, list):
+        return {"count": len(payload), "next": None, "results": payload}
+    if not isinstance(payload, dict) or not isinstance(payload.get("count"), int) or not isinstance(payload.get("results"), list):
+        raise CrawlError(f"unexpected paginated response shape: {url}")
+    if payload.get("next") is not None and not isinstance(payload["next"], str):
+        raise CrawlError(f"unexpected pagination next value: {url}")
+    return payload
+
+
+def fetch_endpoint(
+    endpoint: str,
+    *,
+    api_root: str,
+    raw_directory: Path,
+    timeout: float,
+    retries: int,
+    page_size: int,
+    fetch_bytes: FetchBytes,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Fetch one fully paginated endpoint, retaining every response byte-for-byte."""
+    initial_url = _with_page_size(urljoin(api_root, endpoint), page_size)
+    endpoint_path = urlparse(initial_url).path
+    url: str | None = initial_url
+    seen_urls: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    page_manifest: list[dict[str, Any]] = []
+    expected_count: int | None = None
+    page_number = 1
+    page_dir = raw_directory / "pages" / _endpoint_directory(endpoint)
+    page_dir.mkdir(parents=True, exist_ok=True)
+
+    while url is not None:
+        _validate_url(url, api_root)
+        if urlparse(url).path != endpoint_path:
+            raise CrawlError(f"pagination escaped the allowed endpoint path: {url}")
+        if url in seen_urls:
+            raise CrawlError(f"pagination loop for {endpoint}: {url}")
+        seen_urls.add(url)
+        raw = _fetch_with_retries(fetch_bytes, url, timeout, retries)
+        payload = _decode_page(
+            raw,
+            url,
+            allow_bare_list=endpoint in NON_PAGINATED_ENDPOINTS,
+        )
+        if expected_count is None:
+            expected_count = payload["count"]
+        elif expected_count != payload["count"]:
+            raise CrawlError(f"pagination count changed for {endpoint}")
+        page_path = page_dir / f"page-{page_number:06d}.json"
+        page_path.write_bytes(raw)
+        next_url, upgraded = _secure_pagination_url(payload["next"], api_root)
+        page_manifest.append(
+            {
+                "path": page_path.relative_to(raw_directory.parent).as_posix(),
+                "sha256": _sha256(raw),
+                "requested_url": url,
+                "pagination_http_to_https_upgrade": upgraded,
+            }
+        )
+        page_rows = payload["results"]
+        if not all(isinstance(row, dict) for row in page_rows):
+            raise CrawlError(f"unexpected result row shape: {url}")
+        rows.extend(page_rows)
+        url = next_url
+        page_number += 1
+
+    if expected_count is None or len(rows) != expected_count:
+        raise CrawlError(f"incomplete pagination for {endpoint}: expected {expected_count}, received {len(rows)}")
+    return rows, page_manifest
+
+
+def _field(record: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in record:
+            return record[name]
+    return None
+
+
+def _reference_id(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _field(value, "id", "pk", "url")
+    return value
+
+
+def _lookup_label(row: Mapping[str, Any]) -> Any:
+    return _field(row, "label", "name", "title", "display_name", "text")
+
+
+def _lookup_index(rows: Iterable[Mapping[str, Any]]) -> dict[str, Any | None]:
+    """Index labels only when the corresponding source identifier is unique."""
+    index: dict[str, Any | None] = {}
+    for row in rows:
+        identifier = _field(row, "id", "pk", "url")
+        if identifier is None:
+            continue
+        key = str(identifier)
+        if key in index:
+            index[key] = None
+        else:
+            index[key] = _lookup_label(row)
+    return index
+
+
+def _resolve_lookup(value: Any, index: Mapping[str, Any | None]) -> tuple[Any, Any, bool]:
+    """Return label, unmodified source ID, and whether a supplied ID resolved."""
+    if value is None:
+        return None, None, True
+    raw_id = _reference_id(value)
+    if raw_id is None and isinstance(value, Mapping):
+        direct_label = _lookup_label(value)
+        if direct_label is not None:
+            return direct_label, raw_id, True
+    label = index.get(str(raw_id))
+    return label, raw_id, label is not None
+
+
+def _text_value(record: Mapping[str, Any], *names: str) -> Any:
+    """Copy a text-layer field exactly; missing is distinct from an empty string."""
+    return _field(record, *names)
+
+
+def _epidoc_values(record: Mapping[str, Any]) -> tuple[Any, Any]:
+    text = _text_value(record, "epidoc_text", "epidoc", "tei_xml")
+    interpretation = _text_value(record, "epidoc_interpretation", "epidoc_interpretative")
+    if isinstance(text, Mapping):
+        nested = text
+        text = _field(nested, "text", "xml", "tei")
+        if interpretation is None:
+            interpretation = _field(nested, "interpretation", "interpretative")
+    return text, interpretation
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and value != ""
+
+
+def _validate_epidoc(value: Any) -> bool:
+    if not _nonempty_string(value):
+        return True
+    try:
+        ElementTree.fromstring(value)
+    except ElementTree.ParseError:
+        return False
+    return True
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_source_record(
+    raw_record: Mapping[str, Any],
+    *,
+    language_index: Mapping[str, Any | None],
+    writing_system_index: Mapping[str, Any | None],
+    ce_min_year: int = DEFAULT_CE_MIN_YEAR,
+    ce_max_year: int = DEFAULT_CE_MAX_YEAR,
+) -> dict[str, Any]:
+    """Produce one derived row without changing any portal-supplied value."""
+    raw_id = _field(raw_record, "id", "pk", "source_record_id")
+    language_value = _field(raw_record, "language", "source_language")
+    writing_value = _field(raw_record, "writingsystem", "writing_system", "source_writing_system")
+    language_label, language_id, language_ok = _resolve_lookup(language_value, language_index)
+    writing_label, writing_id, writing_ok = _resolve_lookup(writing_value, writing_system_index)
+    epidoc_text, epidoc_interpretation = _epidoc_values(raw_record)
+    min_year = _text_value(raw_record, "min_year", "year_from", "date_from", "start_year")
+    max_year = _text_value(raw_record, "max_year", "year_to", "date_to", "end_year")
+    min_year_number = _as_int(min_year)
+    max_year_number = _as_int(max_year)
+    flags: list[str] = []
+    if raw_id in (None, ""):
+        flags.append("missing_source_record_id")
+    if not language_ok:
+        flags.append("source_language_lookup_failure")
+    if not writing_ok:
+        flags.append("source_writing_system_lookup_failure")
+    if not _validate_epidoc(epidoc_text) or not _validate_epidoc(epidoc_interpretation):
+        flags.append("epidoc_parse_failure")
+    if min_year_number is not None and max_year_number is not None and min_year_number > max_year_number:
+        flags.append("date_range_inversion")
+    for year in (min_year_number, max_year_number):
+        if year is not None and not ce_min_year <= year <= ce_max_year:
+            flags.append("year_outside_configured_ce_bounds")
+            break
+
+    original_transcription = _text_value(raw_record, "transcription", "original_transcription")
+    interpretative_edition = _text_value(raw_record, "interpretative_edition", "interpretativeedition")
+    romanisation = _text_value(raw_record, "romanisation", "romanization")
+    translation_ukr = _text_value(raw_record, "translation_ukr", "ukrainian_translation")
+    translation_eng = _text_value(raw_record, "translation_eng", "english_translation")
+    commentary_ukr = _text_value(
+        raw_record,
+        "commentary_ukr",
+        "comments_ukr",
+        "ukrainian_commentary",
+    )
+    commentary_eng = _text_value(
+        raw_record,
+        "commentary_eng",
+        "comments_eng",
+        "english_commentary",
+    )
+    text_layers = (
+        original_transcription,
+        epidoc_text,
+        epidoc_interpretation,
+        interpretative_edition,
+        romanisation,
+        translation_ukr,
+        translation_eng,
+        commentary_ukr,
+        commentary_eng,
+    )
+    disposition = "quarantined_metadata" if flags else "text_bearing" if any(map(_nonempty_string, text_layers)) else "non_textual_or_no_text"
+    raw_hash = _sha256(_stable_json_bytes(raw_record))
+    record_id = "" if raw_id is None else str(raw_id)
+    source_url = _text_value(raw_record, "url", "source_url")
+    if source_url is None and record_id:
+        source_url = urljoin(PORTAL_ROOT, f"inscriptions/inscription/{record_id}/")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collection_id": COLLECTION_ID,
+        "source_record_id": record_id,
+        "title": _text_value(raw_record, "title", "name"),
+        "source_url": source_url,
+        "published": _text_value(raw_record, "published", "is_published"),
+        "original_transcription": original_transcription,
+        "epidoc_text": epidoc_text,
+        "epidoc_interpretation": epidoc_interpretation,
+        "interpretative_edition": interpretative_edition,
+        "romanisation": romanisation,
+        "translation_ukr": translation_ukr,
+        "translation_eng": translation_eng,
+        "commentary_ukr": commentary_ukr,
+        "commentary_eng": commentary_eng,
+        "source_language_label": language_label,
+        "source_writing_system_label": writing_label,
+        "min_year": min_year,
+        "max_year": max_year,
+        "stage_label": None,
+        "disposition": disposition,
+        "quality_flags": sorted(flags),
+        "metadata": {
+            "source_language_id": language_id,
+            "source_writing_system_id": writing_id,
+            "source_record": raw_record,
+        },
+        "raw_record_sha256": raw_hash,
+    }
+
+
+def _numeric_record_id(record: Mapping[str, Any]) -> int:
+    try:
+        return int(str(record["source_record_id"]))
+    except (KeyError, TypeError, ValueError) as error:
+        raise CrawlError("missing or non-numeric source_record_id") from error
+
+
+def _validate_inscription_ids(records: Iterable[Mapping[str, Any]], expected_count: int) -> list[dict[str, Any]]:
+    ordered = sorted((dict(record) for record in records), key=_numeric_record_id)
+    ids = [record["source_record_id"] for record in ordered]
+    if len(ordered) != expected_count or len(set(ids)) != len(ids) or any(not record_id for record_id in ids):
+        raise CrawlError("duplicate, missing, or count-mismatched inscription IDs")
+    return ordered
+
+
+def _read_previous(path: Path | None) -> dict[str, str]:
+    if path is None:
+        return {}
+    previous: dict[str, str] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            try:
+                row = json.loads(line)
+                record_id = str(row["source_record_id"])
+                raw_hash = row["raw_record_sha256"]
+            except (TypeError, KeyError, json.JSONDecodeError) as error:
+                raise CrawlError(f"invalid previous JSONL at line {line_number}") from error
+            if not isinstance(raw_hash, str) or record_id in previous:
+                raise CrawlError(f"invalid or duplicate previous ID at line {line_number}")
+            previous[record_id] = raw_hash
+    return previous
+
+
+def _id_list_hash(ids: Iterable[str]) -> str:
+    return _sha256(_stable_json_bytes(list(ids)))
+
+
+def _newline_sorted_id_hash(ids: Iterable[str]) -> str:
+    """Compatibility-friendly set hash: one sorted identifier per UTF-8 line."""
+    return _sha256("".join(f"{record_id}\n" for record_id in sorted(ids, key=int)).encode("utf-8"))
+
+
+def _write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]]) -> None:
+    with path.open("wb") as handle:
+        for row in rows:
+            handle.write(_stable_json_bytes(row))
+
+
+def _output_hashes(directory: Path, relative_paths: Iterable[str]) -> dict[str, str]:
+    return {relative: _sha256((directory / relative).read_bytes()) for relative in sorted(relative_paths)}
+
+
+def crawl_snapshot(
+    output_dir: Path,
+    *,
+    api_root: str = API_ROOT,
+    timeout: float = 30.0,
+    retries: int = 2,
+    page_size: int = 100,
+    previous_jsonl: Path | None = None,
+    fetch_bytes: FetchBytes | None = None,
+) -> Path:
+    """Fetch the complete currently-public API universe and publish it atomically."""
+    output_dir = output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise CrawlError(f"output directory already contains data: {output_dir}")
+    if timeout <= 0 or retries < 0 or page_size <= 0:
+        raise CrawlError("timeout must be positive; retries non-negative; page size positive")
+    _validate_url(api_root, api_root)
+    fetch = fetch_bytes or _http_get
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=f".{output_dir.name}.tmp-", dir=output_dir.parent))
+    try:
+        raw_dir = stage / "raw"
+        raw_dir.mkdir()
+        api_root_bytes = _fetch_with_retries(fetch, api_root, timeout, retries)
+        (raw_dir / "api-root.json").write_bytes(api_root_bytes)
+        all_rows: dict[str, list[dict[str, Any]]] = {}
+        page_manifest = [{"path": "raw/api-root.json", "sha256": _sha256(api_root_bytes)}]
+        for endpoint in ENDPOINTS:
+            rows, manifest = fetch_endpoint(
+                endpoint,
+                api_root=api_root,
+                raw_directory=raw_dir,
+                timeout=timeout,
+                retries=retries,
+                page_size=page_size,
+                fetch_bytes=fetch,
+            )
+            all_rows[endpoint] = rows
+            page_manifest.extend(manifest)
+
+        language_index = _lookup_index(all_rows["inscriptions/language/"])
+        writing_system_index = _lookup_index(all_rows["inscriptions/writingsystem/"])
+        source_rows = [
+            build_source_record(raw_row, language_index=language_index, writing_system_index=writing_system_index)
+            for raw_row in all_rows[INSCRIPTION_ENDPOINT]
+        ]
+        source_rows = _validate_inscription_ids(source_rows, len(all_rows[INSCRIPTION_ENDPOINT]))
+        dispositions = [
+            {
+                "source_record_id": row["source_record_id"],
+                "disposition": row["disposition"],
+                "quality_flags": row["quality_flags"],
+                "raw_record_sha256": row["raw_record_sha256"],
+            }
+            for row in source_rows
+        ]
+        if {row["source_record_id"] for row in dispositions} != {row["source_record_id"] for row in source_rows}:
+            raise CrawlError("disposition IDs do not match source-record IDs")
+        _write_jsonl(stage / "historical_source_records.jsonl", source_rows)
+        _write_jsonl(stage / "dispositions.jsonl", dispositions)
+        _write_json(raw_dir / "hash-manifest.json", {item["path"]: item["sha256"] for item in page_manifest})
+
+        previous = _read_previous(previous_jsonl)
+        current = {str(row["source_record_id"]): str(row["raw_record_sha256"]) for row in source_rows}
+        added = sorted(set(current) - set(previous), key=int)
+        removed = sorted(set(previous) - set(current), key=int)
+        changed = sorted((record_id for record_id in set(current) & set(previous) if current[record_id] != previous[record_id]), key=int)
+        disposition_counts = {name: sum(row["disposition"] == name for row in source_rows) for name in sorted({row["disposition"] for row in source_rows})}
+        epidoc_values = [row["epidoc_text"] for row in source_rows] + [row["epidoc_interpretation"] for row in source_rows]
+        receipt = {
+            "schema_version": "saint-sophia-coverage-receipt.v1",
+            "retrieved_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "portal_root": PORTAL_ROOT,
+            "api_root": api_root,
+            "api_root_sha256": _sha256(api_root_bytes),
+            "endpoint_counts": {endpoint: len(rows) for endpoint, rows in all_rows.items()},
+            "response_pages": page_manifest,
+            "pagination_http_to_https_upgrade_count": sum(
+                bool(page.get("pagination_http_to_https_upgrade"))
+                for page in page_manifest
+            ),
+            "public_inscription_count": len(source_rows),
+            "sorted_source_record_id_set_sha256": _id_list_hash([row["source_record_id"] for row in source_rows]),
+            "id_set_sha256": _newline_sorted_id_hash([row["source_record_id"] for row in source_rows]),
+            "disposition_counts": disposition_counts,
+            "epidoc_nonempty_count": sum(_nonempty_string(value) for value in epidoc_values),
+            "epidoc_parse_failure_count": sum("epidoc_parse_failure" in row["quality_flags"] for row in source_rows),
+            "ce_year_bounds": {"minimum": DEFAULT_CE_MIN_YEAR, "maximum": DEFAULT_CE_MAX_YEAR},
+            "known_identified_total_lower_bound": KNOWN_IDENTIFIED_TOTAL_LOWER_BOUND,
+            "known_unexposed_residual": True,
+            "diff": {
+                "added_source_record_ids": added,
+                "changed_source_record_ids": changed,
+                "removed_source_record_ids": removed,
+                "added_count": len(added),
+                "changed_count": len(changed),
+                "removed_count": len(removed),
+                "added_source_record_ids_sha256": _id_list_hash(added),
+                "changed_source_record_ids_sha256": _id_list_hash(changed),
+                "removed_source_record_ids_sha256": _id_list_hash(removed),
+            },
+        }
+        _write_json(stage / "coverage-receipt.json", receipt)
+        receipt["output_hashes"] = _output_hashes(
+            stage,
+            ("historical_source_records.jsonl", "dispositions.jsonl", "raw/hash-manifest.json"),
+        )
+        _write_json(stage / "coverage-receipt.json", receipt)
+        if output_dir.exists():
+            output_dir.rmdir()  # The earlier guard established that it is empty.
+        os.replace(stage, output_dir)
+    except BaseException:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+    return output_dir
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--previous-jsonl", type=Path)
+    parser.add_argument("--api-root", default=API_ROOT)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--page-size", type=int, default=100)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        crawl_snapshot(
+            args.output_dir,
+            api_root=args.api_root,
+            timeout=args.timeout,
+            retries=args.retries,
+            page_size=args.page_size,
+            previous_jsonl=args.previous_jsonl,
+        )
+    except CrawlError as error:
+        print(f"crawl failed: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingest/incremental_historical_source_ingest.py
+++ b/scripts/ingest/incremental_historical_source_ingest.py
@@ -1,0 +1,220 @@
+"""Transactionally replace one historical evidence collection in sources.db."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCRIPT_PATH = Path(__file__).resolve()
+PROJECT_ROOT = SCRIPT_PATH.parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from wiki.historical_sources import (
+    HistoricalSourceError,
+    ensure_historical_source_schema,
+    insert_rows,
+    load_rows,
+    sha256_file,
+    validate_historical_fts,
+)
+
+DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
+RECEIPT_SCHEMA_VERSION = "incremental-historical-source-ingest.v1"
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
+def _sha256_lines(values: list[str]) -> str:
+    def sort_key(value: str) -> tuple[int, int | str]:
+        return (0, int(value)) if value.isdecimal() else (1, value)
+
+    payload = "".join(f"{value}\n" for value in sorted(values, key=sort_key)).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(_canonical_bytes(value))
+            handle.flush()
+            os.fsync(handle.fileno())
+        Path(temp_name).replace(path)
+    except BaseException:
+        Path(temp_name).unlink(missing_ok=True)
+        raise
+
+
+def _read_coverage_receipt(path: Path, *, jsonl_path: Path, rows: list[tuple]) -> dict[str, Any]:
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HistoricalSourceError(f"invalid coverage receipt {path}: {exc}") from exc
+    if not isinstance(receipt, dict):
+        raise HistoricalSourceError(f"coverage receipt {path} must be an object")
+    expected_count = receipt.get("public_inscription_count")
+    if expected_count != len(rows):
+        raise HistoricalSourceError(
+            f"coverage receipt count {expected_count!r} does not match {len(rows)} JSONL rows"
+        )
+    expected_id_hash = receipt.get("id_set_sha256")
+    actual_id_hash = _sha256_lines([str(row[1]) for row in rows])
+    if expected_id_hash != actual_id_hash:
+        raise HistoricalSourceError("coverage receipt ID-set hash does not match JSONL")
+    output_hashes = receipt.get("output_hashes")
+    expected_jsonl_hash = (
+        output_hashes.get("historical_source_records.jsonl")
+        if isinstance(output_hashes, dict)
+        else None
+    )
+    if expected_jsonl_hash != sha256_file(jsonl_path):
+        raise HistoricalSourceError("coverage receipt JSONL hash does not match input bytes")
+    return receipt
+
+
+def _counts(conn: sqlite3.Connection, collection_id: str) -> dict[str, int]:
+    return {
+        "global_rows": conn.execute(
+            "SELECT COUNT(*) FROM historical_source_records"
+        ).fetchone()[0],
+        "collection_rows": conn.execute(
+            "SELECT COUNT(*) FROM historical_source_records WHERE collection_id = ?",
+            (collection_id,),
+        ).fetchone()[0],
+        "fts_rows": conn.execute(
+            "SELECT COUNT(*) FROM historical_source_records_fts"
+        ).fetchone()[0],
+    }
+
+
+def ingest(
+    *,
+    db_path: Path,
+    jsonl_path: Path,
+    coverage_receipt_path: Path,
+    output_receipt_path: Path,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    rows = load_rows(jsonl_path)
+    collection_id = str(rows[0][0])
+    source_ids = [str(row[1]) for row in rows]
+    coverage = _read_coverage_receipt(
+        coverage_receipt_path,
+        jsonl_path=jsonl_path,
+        rows=rows,
+    )
+    disposition_counts = dict(sorted(Counter(str(row[18]) for row in rows).items()))
+    plan = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "collection_id": collection_id,
+        "source_jsonl": str(jsonl_path),
+        "source_jsonl_sha256": sha256_file(jsonl_path),
+        "coverage_receipt": str(coverage_receipt_path),
+        "coverage_receipt_sha256": sha256_file(coverage_receipt_path),
+        "input_rows": len(rows),
+        "source_id_set_sha256": _sha256_lines(source_ids),
+        "disposition_counts": disposition_counts,
+        "dry_run": dry_run,
+    }
+    if dry_run:
+        return plan
+    if not db_path.is_file():
+        raise HistoricalSourceError(f"database does not exist: {db_path}")
+
+    conn = sqlite3.connect(str(db_path), timeout=60)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        ensure_historical_source_schema(conn)
+        before = _counts(conn, collection_id)
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "DELETE FROM historical_source_records WHERE collection_id = ?",
+            (collection_id,),
+        )
+        insert_rows(conn, rows)
+        actual_ids = [
+            str(row[0])
+            for row in conn.execute(
+                "SELECT source_record_id FROM historical_source_records "
+                "WHERE collection_id = ? ORDER BY source_record_id",
+                (collection_id,),
+            )
+        ]
+        if set(actual_ids) != set(source_ids) or len(actual_ids) != len(source_ids):
+            raise HistoricalSourceError("database collection IDs do not equal input IDs")
+        conn.execute(
+            "INSERT INTO historical_source_records_fts(historical_source_records_fts) "
+            "VALUES ('rebuild')"
+        )
+        validate_historical_fts(conn)
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if integrity != "ok":
+            raise HistoricalSourceError(f"PRAGMA integrity_check returned {integrity!r}")
+        after = _counts(conn, collection_id)
+        if after["collection_rows"] != len(rows):
+            raise HistoricalSourceError(
+                f"collection has {after['collection_rows']} rows, expected {len(rows)}"
+            )
+        conn.commit()
+        checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
+    except BaseException:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    receipt = {
+        **plan,
+        "dry_run": False,
+        "before_transaction": before,
+        "after_transaction": after,
+        "integrity_check": "ok",
+        "wal_checkpoint": checkpoint,
+        "database_sha256": sha256_file(db_path),
+        "coverage_known_identified_total_lower_bound": coverage.get(
+            "known_identified_total_lower_bound"
+        ),
+        "coverage_known_unexposed_residual": coverage.get("known_unexposed_residual"),
+    }
+    _atomic_write_json(output_receipt_path, receipt)
+    return receipt
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument("--jsonl", type=Path, required=True)
+    parser.add_argument("--coverage-receipt", type=Path, required=True)
+    parser.add_argument("--output-receipt", type=Path, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    receipt = ingest(
+        db_path=args.db,
+        jsonl_path=args.jsonl,
+        coverage_receipt_path=args.coverage_receipt,
+        output_receipt_path=args.output_receipt,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -73,6 +73,15 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from wiki.config import GDRIVE_DATA
     from wiki.extract_sections import DEFAULT_REPORT_PATH, extract_sections
+    from wiki.historical_sources import (
+        ensure_historical_source_schema,
+    )
+    from wiki.historical_sources import (
+        insert_rows as insert_historical_source_rows,
+    )
+    from wiki.historical_sources import (
+        load_rows as load_historical_source_rows,
+    )
     from wiki.sources import build_literary_row
     from wiki.sources_db import (
         ensure_ulif_dictua_schema,
@@ -84,6 +93,15 @@ if __package__ in {None, ""}:
 else:
     from .config import GDRIVE_DATA
     from .extract_sections import DEFAULT_REPORT_PATH, extract_sections
+    from .historical_sources import (
+        ensure_historical_source_schema,
+    )
+    from .historical_sources import (
+        insert_rows as insert_historical_source_rows,
+    )
+    from .historical_sources import (
+        load_rows as load_historical_source_rows,
+    )
     from .sources import build_literary_row
     from .sources_db import (
         ensure_ulif_dictua_schema,
@@ -677,7 +695,13 @@ def _validate_build(conn: sqlite3.Connection, expected_counts: dict[str, int]) -
     if integrity != "ok":
         raise BuildValidationError(f"PRAGMA integrity_check returned {integrity!r}")
 
-    for fts_table in ("textbooks_fts", "external_fts", "literary_fts", "wikipedia_fts"):
+    for fts_table in (
+        "textbooks_fts",
+        "external_fts",
+        "literary_fts",
+        "wikipedia_fts",
+        "historical_source_records_fts",
+    ):
         conn.execute(f"INSERT INTO {fts_table}({fts_table}) VALUES ('integrity-check')")
 
 
@@ -817,6 +841,7 @@ def build(db_path: Path | None = None,
         conn.executescript(SCHEMA)
         ensure_ulif_dictua_schema(conn)
         ensure_ukrainian_wiki_schema(conn)
+        ensure_historical_source_schema(conn)
 
         expected_counts: dict[str, int] = {
             "wikipedia": len(wiki_rows),
@@ -910,6 +935,28 @@ def build(db_path: Path | None = None,
                 print(f"  📚 {source_file}: {len(batch)} chunks")
         expected_counts["literary_texts"] = lit_total
         total += lit_total
+
+        # --- Historical source records ---
+        print("\n🏛️ Historical source records")
+        historical_root = gd / "historical_language_corpus" / "canonical"
+        historical_total = 0
+        seen_collections: set[str] = set()
+        if historical_root.exists():
+            for jsonl_path in sorted(
+                historical_root.glob("*/historical_source_records.jsonl")
+            ):
+                rows = load_historical_source_rows(jsonl_path)
+                collection_id = str(rows[0][0])
+                if collection_id in seen_collections:
+                    raise BuildValidationError(
+                        f"duplicate historical collection {collection_id!r} under "
+                        f"{historical_root}"
+                    )
+                seen_collections.add(collection_id)
+                historical_total += insert_historical_source_rows(conn, rows)
+                print(f"  🏛️ {collection_id}: {len(rows)} records")
+        expected_counts["historical_source_records"] = historical_total
+        total += historical_total
 
         # --- Dictionaries ---
         print("\n📕 Dictionaries")

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -702,6 +702,12 @@ def _validate_build(conn: sqlite3.Connection, expected_counts: dict[str, int]) -
         "wikipedia_fts",
         "historical_source_records_fts",
     ):
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (fts_table,),
+        ).fetchone()
+        if exists is None:
+            continue
         conn.execute(f"INSERT INTO {fts_table}({fts_table}) VALUES ('integrity-check')")
 
 

--- a/scripts/wiki/historical_sources.py
+++ b/scripts/wiki/historical_sources.py
@@ -1,0 +1,236 @@
+"""Schema and exact-row ingestion for private historical source corpora."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "historical-source-record.v1"
+ALLOWED_DISPOSITIONS = {
+    "text_bearing",
+    "non_textual_or_no_text",
+    "quarantined_metadata",
+}
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+HISTORICAL_SOURCE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS historical_source_records (
+    id INTEGER PRIMARY KEY,
+    collection_id TEXT NOT NULL,
+    source_record_id TEXT NOT NULL,
+    title TEXT,
+    source_url TEXT,
+    published INTEGER NOT NULL DEFAULT 0 CHECK (published IN (0, 1)),
+    original_transcription TEXT,
+    epidoc_text TEXT,
+    epidoc_interpretation TEXT,
+    interpretative_edition TEXT,
+    romanisation TEXT,
+    translation_ukr TEXT,
+    translation_eng TEXT,
+    commentary_ukr TEXT,
+    commentary_eng TEXT,
+    source_language_label TEXT,
+    source_writing_system_label TEXT,
+    min_year INTEGER,
+    max_year INTEGER,
+    disposition TEXT NOT NULL,
+    stage_label TEXT,
+    quality_flags_json TEXT NOT NULL DEFAULT '[]',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    raw_record_sha256 TEXT NOT NULL,
+    UNIQUE(collection_id, source_record_id)
+);
+CREATE INDEX IF NOT EXISTS idx_historical_collection
+    ON historical_source_records(collection_id);
+CREATE INDEX IF NOT EXISTS idx_historical_disposition
+    ON historical_source_records(collection_id, disposition);
+CREATE VIRTUAL TABLE IF NOT EXISTS historical_source_records_fts USING fts5(
+    title,
+    original_transcription,
+    epidoc_text,
+    epidoc_interpretation,
+    interpretative_edition,
+    romanisation,
+    translation_ukr,
+    translation_eng,
+    commentary_ukr,
+    commentary_eng,
+    content='historical_source_records',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+CREATE TRIGGER IF NOT EXISTS historical_source_records_ai
+AFTER INSERT ON historical_source_records BEGIN
+    INSERT INTO historical_source_records_fts(
+        rowid, title, original_transcription, epidoc_text,
+        epidoc_interpretation, interpretative_edition, romanisation,
+        translation_ukr, translation_eng, commentary_ukr, commentary_eng
+    ) VALUES (
+        new.id, new.title, new.original_transcription, new.epidoc_text,
+        new.epidoc_interpretation, new.interpretative_edition, new.romanisation,
+        new.translation_ukr, new.translation_eng, new.commentary_ukr,
+        new.commentary_eng
+    );
+END;
+"""
+
+INSERT_SQL = """INSERT INTO historical_source_records (
+    collection_id, source_record_id, title, source_url, published,
+    original_transcription, epidoc_text, epidoc_interpretation,
+    interpretative_edition, romanisation, translation_ukr, translation_eng,
+    commentary_ukr, commentary_eng, source_language_label,
+    source_writing_system_label, min_year, max_year, disposition, stage_label,
+    quality_flags_json, metadata_json, raw_record_sha256
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+
+TEXT_FIELDS = (
+    "title",
+    "source_url",
+    "original_transcription",
+    "epidoc_text",
+    "epidoc_interpretation",
+    "interpretative_edition",
+    "romanisation",
+    "translation_ukr",
+    "translation_eng",
+    "commentary_ukr",
+    "commentary_eng",
+    "source_language_label",
+    "source_writing_system_label",
+)
+
+
+class HistoricalSourceError(RuntimeError):
+    """Raised when historical source evidence is incomplete or malformed."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def ensure_historical_source_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(HISTORICAL_SOURCE_SCHEMA)
+
+
+def _require_optional_year(row: dict[str, Any], field: str, *, source: str) -> int | None:
+    value = row.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HistoricalSourceError(f"{source}: {field} must be an integer or null")
+    return value
+
+
+def build_row(row: dict[str, Any], *, source: str) -> tuple[Any, ...]:
+    if row.get("schema_version") != SCHEMA_VERSION:
+        raise HistoricalSourceError(
+            f"{source}: schema_version must be {SCHEMA_VERSION!r}"
+        )
+    collection_id = row.get("collection_id")
+    source_record_id = row.get("source_record_id")
+    if not isinstance(collection_id, str) or not collection_id:
+        raise HistoricalSourceError(f"{source}: collection_id must be a nonempty string")
+    if not isinstance(source_record_id, str) or not source_record_id:
+        raise HistoricalSourceError(f"{source}: source_record_id must be a nonempty string")
+    disposition = row.get("disposition")
+    if disposition not in ALLOWED_DISPOSITIONS:
+        raise HistoricalSourceError(f"{source}: invalid disposition {disposition!r}")
+    published = row.get("published")
+    if not isinstance(published, bool):
+        raise HistoricalSourceError(f"{source}: published must be boolean")
+    stage_label = row.get("stage_label")
+    if stage_label is not None and not isinstance(stage_label, str):
+        raise HistoricalSourceError(f"{source}: stage_label must be a string or null")
+    flags = row.get("quality_flags")
+    if not isinstance(flags, list) or any(not isinstance(flag, str) for flag in flags):
+        raise HistoricalSourceError(f"{source}: quality_flags must be a list of strings")
+    metadata = row.get("metadata")
+    if not isinstance(metadata, dict):
+        raise HistoricalSourceError(f"{source}: metadata must be an object")
+    raw_hash = row.get("raw_record_sha256")
+    if not isinstance(raw_hash, str) or SHA256_RE.fullmatch(raw_hash) is None:
+        raise HistoricalSourceError(f"{source}: raw_record_sha256 must be lowercase SHA-256")
+    text_values: list[str | None] = []
+    for field in TEXT_FIELDS:
+        value = row.get(field)
+        if value is not None and not isinstance(value, str):
+            raise HistoricalSourceError(f"{source}: {field} must be a string or null")
+        text_values.append(value)
+    min_year = _require_optional_year(row, "min_year", source=source)
+    max_year = _require_optional_year(row, "max_year", source=source)
+    return (
+        collection_id,
+        source_record_id,
+        text_values[0],
+        text_values[1],
+        int(published),
+        *text_values[2:],
+        min_year,
+        max_year,
+        disposition,
+        stage_label,
+        canonical_json(flags),
+        canonical_json(metadata),
+        raw_hash,
+    )
+
+
+def load_rows(path: Path) -> list[tuple[Any, ...]]:
+    rows: list[tuple[Any, ...]] = []
+    seen: set[tuple[str, str]] = set()
+    with path.open(encoding="utf-8", newline="") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                raise HistoricalSourceError(f"{path}:{line_number}: blank lines are not allowed")
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise HistoricalSourceError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+            if not isinstance(value, dict):
+                raise HistoricalSourceError(f"{path}:{line_number}: row must be an object")
+            built = build_row(value, source=f"{path}:{line_number}")
+            key = (built[0], built[1])
+            if key in seen:
+                raise HistoricalSourceError(f"{path}:{line_number}: duplicate key {key!r}")
+            seen.add(key)
+            rows.append(built)
+    if not rows:
+        raise HistoricalSourceError(f"{path}: no records")
+    collections = {row[0] for row in rows}
+    if len(collections) != 1:
+        raise HistoricalSourceError(f"{path}: expected one collection, found {sorted(collections)}")
+    return rows
+
+
+def insert_rows(conn: sqlite3.Connection, rows: Iterable[tuple[Any, ...]]) -> int:
+    materialized = list(rows)
+    conn.executemany(INSERT_SQL, materialized)
+    return len(materialized)
+
+
+def validate_historical_fts(conn: sqlite3.Connection) -> None:
+    source_count = conn.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0]
+    fts_count = conn.execute("SELECT COUNT(*) FROM historical_source_records_fts").fetchone()[0]
+    if source_count != fts_count:
+        raise HistoricalSourceError(
+            "historical_source_records/FTS row parity failed "
+            f"({source_count} source, {fts_count} indexed)"
+        )
+    conn.execute(
+        "INSERT INTO historical_source_records_fts(historical_source_records_fts) "
+        "VALUES ('integrity-check')"
+    )

--- a/tests/ingest/test_incremental_historical_source_ingest.py
+++ b/tests/ingest/test_incremental_historical_source_ingest.py
@@ -1,0 +1,243 @@
+"""Tests for transactional historical-source ingestion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from ingest import incremental_historical_source_ingest as ingest
+from wiki.historical_sources import ensure_historical_source_schema, sha256_file
+
+
+def _record(record_id: str, text: str, *, disposition: str = "text_bearing") -> dict:
+    return {
+        "schema_version": "historical-source-record.v1",
+        "collection_id": "saint-sophia-inscriptions",
+        "source_record_id": record_id,
+        "title": f"Inscription {record_id}",
+        "source_url": f"https://saintsophia.dh.gu.se/inscription/{record_id}",
+        "published": True,
+        "original_transcription": text,
+        "epidoc_text": f"<ab>{text}</ab>",
+        "epidoc_interpretation": "",
+        "interpretative_edition": text,
+        "romanisation": "",
+        "translation_ukr": "",
+        "translation_eng": "",
+        "commentary_ukr": "",
+        "commentary_eng": "",
+        "source_language_label": "Church Slavonic",
+        "source_writing_system_label": "Cyrillic",
+        "min_year": 1100,
+        "max_year": 1200,
+        "stage_label": None,
+        "disposition": disposition,
+        "quality_flags": [],
+        "metadata": {"portal_id": int(record_id)},
+        "raw_record_sha256": hashlib.sha256(f"raw-{record_id}".encode()).hexdigest(),
+    }
+
+
+def _write_source(tmp_path: Path, records: list[dict]) -> tuple[Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    jsonl = tmp_path / "historical_source_records.jsonl"
+    payload = "".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+        for row in records
+    )
+    jsonl.write_text(payload, encoding="utf-8")
+    id_payload = "".join(
+        f"{value}\n"
+        for value in sorted(
+            (row["source_record_id"] for row in records),
+            key=lambda value: int(value),
+        )
+    )
+    coverage = tmp_path / "coverage-receipt.json"
+    coverage.write_text(
+        json.dumps(
+            {
+                "public_inscription_count": len(records),
+                "id_set_sha256": hashlib.sha256(id_payload.encode()).hexdigest(),
+                "output_hashes": {"historical_source_records.jsonl": sha256_file(jsonl)},
+                "known_identified_total_lower_bound": 7000,
+                "known_unexposed_residual": True,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return jsonl, coverage
+
+
+def _database(tmp_path: Path) -> Path:
+    path = tmp_path / "sources.db"
+    conn = sqlite3.connect(path)
+    ensure_historical_source_schema(conn)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_ingest_replaces_collection_preserves_exact_layers_and_rebuilds_fts(tmp_path: Path):
+    db = _database(tmp_path)
+    old_jsonl, old_coverage = _write_source(tmp_path / "old", [_record("1", "старий")])
+    ingest.ingest(
+        db_path=db,
+        jsonl_path=old_jsonl,
+        coverage_receipt_path=old_coverage,
+        output_receipt_path=tmp_path / "old-receipt.json",
+    )
+
+    exact = "слово <supplied reason=\"lost\">[ѣ]</supplied>"
+    records = [_record("1", exact), _record("2", "другий")]
+    jsonl, coverage = _write_source(tmp_path / "new", records)
+    receipt_path = tmp_path / "ingest-receipt.json"
+    receipt = ingest.ingest(
+        db_path=db,
+        jsonl_path=jsonl,
+        coverage_receipt_path=coverage,
+        output_receipt_path=receipt_path,
+    )
+
+    conn = sqlite3.connect(db)
+    assert conn.execute(
+        "SELECT original_transcription FROM historical_source_records "
+        "WHERE collection_id=? AND source_record_id='1'",
+        ("saint-sophia-inscriptions",),
+    ).fetchone()[0] == exact
+    assert conn.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM historical_source_records_fts").fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT COUNT(*) FROM historical_source_records_fts "
+        "WHERE historical_source_records_fts MATCH 'другий'"
+    ).fetchone()[0] == 1
+    conn.close()
+    assert receipt["before_transaction"]["collection_rows"] == 1
+    assert receipt["after_transaction"]["collection_rows"] == 2
+    assert receipt["coverage_known_unexposed_residual"] is True
+    assert receipt_path.is_file()
+
+
+def test_ingest_preserves_null_text_layers(tmp_path: Path):
+    db = _database(tmp_path)
+    record = _record("1", "")
+    record["title"] = None
+    record["epidoc_text"] = None
+    record["translation_ukr"] = None
+    record["source_language_label"] = None
+    jsonl, coverage = _write_source(tmp_path / "source", [record])
+    ingest.ingest(
+        db_path=db,
+        jsonl_path=jsonl,
+        coverage_receipt_path=coverage,
+        output_receipt_path=tmp_path / "receipt.json",
+    )
+    conn = sqlite3.connect(db)
+    assert conn.execute(
+        "SELECT title, epidoc_text, translation_ukr, source_language_label "
+        "FROM historical_source_records"
+    ).fetchone() == (None, None, None, None)
+    conn.close()
+
+
+def test_coverage_mismatch_fails_before_database_mutation(tmp_path: Path):
+    db = _database(tmp_path)
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    jsonl, coverage = _write_source(source_dir, [_record("1", "текст")])
+    value = json.loads(coverage.read_text(encoding="utf-8"))
+    value["public_inscription_count"] = 2
+    coverage.write_text(json.dumps(value), encoding="utf-8")
+
+    with pytest.raises(ingest.HistoricalSourceError, match="count"):
+        ingest.ingest(
+            db_path=db,
+            jsonl_path=jsonl,
+            coverage_receipt_path=coverage,
+            output_receipt_path=tmp_path / "receipt.json",
+        )
+
+    conn = sqlite3.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 0
+    conn.close()
+
+
+def test_failure_rolls_back_replacement_and_fts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db = _database(tmp_path)
+    source_dir = tmp_path / "old"
+    source_dir.mkdir()
+    old_jsonl, old_coverage = _write_source(source_dir, [_record("1", "збережений")])
+    ingest.ingest(
+        db_path=db,
+        jsonl_path=old_jsonl,
+        coverage_receipt_path=old_coverage,
+        output_receipt_path=tmp_path / "old-receipt.json",
+    )
+    new_dir = tmp_path / "new"
+    new_dir.mkdir()
+    jsonl, coverage = _write_source(new_dir, [_record("2", "не має лишитися")])
+
+    def fail_validation(_conn: sqlite3.Connection) -> None:
+        raise ingest.HistoricalSourceError("injected validation failure")
+
+    monkeypatch.setattr(ingest, "validate_historical_fts", fail_validation)
+    with pytest.raises(ingest.HistoricalSourceError, match="injected"):
+        ingest.ingest(
+            db_path=db,
+            jsonl_path=jsonl,
+            coverage_receipt_path=coverage,
+            output_receipt_path=tmp_path / "failed-receipt.json",
+        )
+
+    conn = sqlite3.connect(db)
+    assert conn.execute(
+        "SELECT source_record_id FROM historical_source_records"
+    ).fetchall() == [("1",)]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM historical_source_records_fts "
+        "WHERE historical_source_records_fts MATCH 'збережений'"
+    ).fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM historical_source_records_fts "
+        "WHERE historical_source_records_fts MATCH 'лишитися'"
+    ).fetchone()[0] == 0
+    conn.close()
+
+
+def test_dry_run_does_not_create_database(tmp_path: Path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    jsonl, coverage = _write_source(source_dir, [_record("1", "текст")])
+    missing_db = tmp_path / "missing.db"
+    receipt = ingest.ingest(
+        db_path=missing_db,
+        jsonl_path=jsonl,
+        coverage_receipt_path=coverage,
+        output_receipt_path=tmp_path / "unused.json",
+        dry_run=True,
+    )
+    assert receipt["dry_run"] is True
+    assert not missing_db.exists()
+
+
+def test_numeric_id_hash_order_matches_crawler(tmp_path: Path):
+    db = _database(tmp_path)
+    jsonl, coverage = _write_source(
+        tmp_path / "source",
+        [_record("2", "два"), _record("10", "десять")],
+    )
+    receipt = ingest.ingest(
+        db_path=db,
+        jsonl_path=jsonl,
+        coverage_receipt_path=coverage,
+        output_receipt_path=tmp_path / "receipt.json",
+    )
+    assert receipt["input_rows"] == 2

--- a/tests/test_crawl_saint_sophia.py
+++ b/tests/test_crawl_saint_sophia.py
@@ -1,0 +1,344 @@
+"""Network-free coverage for the Saint Sophia historical-source crawler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from scripts.crawl import crawl_saint_sophia as crawler
+
+ROOT = "https://saintsophia.dh.gu.se/api/"
+
+
+def _record(record_id: int, **changes: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "id": record_id,
+        "title": f"Inscription {record_id}",
+        "published": True,
+        "transcription": "[α]·β",
+        "epidoc_text": "<TEI><text>[α]·β</text></TEI>",
+        "epidoc_interpretation": "<TEI><text>β</text></TEI>",
+        "interpretative_edition": "[α] β",
+        "romanisation": "a b",
+        "translation_ukr": "тест",
+        "translation_eng": "test",
+        "comments_ukr": "примітка",
+        "comments_eng": "note",
+        "language": 1,
+        "writingsystem": 2,
+        "min_year": 100,
+        "max_year": 200,
+    }
+    record.update(changes)
+    return record
+
+
+class FakeApi:
+    def __init__(self, inscription_pages: list[list[dict[str, object]]] | None = None) -> None:
+        self.calls: list[str] = []
+        self.inscription_pages = inscription_pages or [[_record(1), _record(2)], [_record(3)]]
+
+    def __call__(self, url: str, _timeout: float) -> bytes:
+        self.calls.append(url)
+        if url == ROOT:
+            return b'{"version":"fixture-v1", "spacing": true}'
+        parsed = urlparse(url)
+        endpoint = parsed.path.removeprefix("/api/")
+        page = int(parse_qs(parsed.query).get("page", ["1"])[0])
+        if endpoint == "inscriptions/inscription/":
+            results = self.inscription_pages[page - 1]
+            next_url = None
+            if page < len(self.inscription_pages):
+                next_url = f"{ROOT}inscriptions/inscription/?depth=2&page={page + 1}"
+            return json.dumps(
+                {"count": sum(map(len, self.inscription_pages)), "next": next_url, "results": results},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode()
+        if endpoint == "inscriptions/language/":
+            results = [{"id": 1, "text": "Greek"}]
+        elif endpoint == "inscriptions/writingsystem/":
+            results = [{"id": 2, "text": "Greek alphabet"}]
+        else:
+            results = []
+        return json.dumps({"count": len(results), "next": None, "results": results}, separators=(",", ":")).encode()
+
+
+def _crawl(tmp_path: Path, fake: FakeApi, *, previous: Path | None = None) -> Path:
+    return crawler.crawl_snapshot(
+        tmp_path / "snapshot",
+        api_root=ROOT,
+        previous_jsonl=previous,
+        fetch_bytes=fake,
+        page_size=2,
+    )
+
+
+def _jsonl(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_complete_pagination_preserves_raw_bytes_and_text_layers(tmp_path: Path) -> None:
+    fake = FakeApi()
+    output = _crawl(tmp_path, fake)
+
+    rows = _jsonl(output / "historical_source_records.jsonl")
+    assert [row["source_record_id"] for row in rows] == ["1", "2", "3"]
+    assert rows[0]["original_transcription"] == "[α]·β"
+    assert rows[0]["epidoc_text"] == "<TEI><text>[α]·β</text></TEI>"
+    assert rows[0]["interpretative_edition"] == "[α] β"
+    assert rows[0]["commentary_ukr"] == "примітка"
+    assert rows[0]["source_language_label"] == "Greek"
+    assert rows[0]["metadata"]["source_record"]["transcription"] == "[α]·β"
+    raw_root = output / "raw" / "api-root.json"
+    assert raw_root.read_bytes() == b'{"version":"fixture-v1", "spacing": true}'
+
+
+def test_raw_page_bytes_are_stored_without_reserialization(tmp_path: Path) -> None:
+    fake = FakeApi()
+    output = _crawl(tmp_path, fake)
+    expected = json.dumps(
+        {"count": 3, "next": f"{ROOT}inscriptions/inscription/?depth=2&page=2", "results": fake.inscription_pages[0]},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    assert (output / "raw" / "pages" / "inscriptions__inscription" / "page-000001.json").read_bytes() == expected
+
+
+def test_epidoc_parse_failure_and_invalid_dates_are_quarantined_without_repair(tmp_path: Path) -> None:
+    bad = _record(1, epidoc_text="<TEI><text>unclosed", min_year=400, max_year=100)
+    fake = FakeApi([[bad]])
+    output = _crawl(tmp_path, fake)
+    row = _jsonl(output / "historical_source_records.jsonl")[0]
+    assert row["epidoc_text"] == "<TEI><text>unclosed"
+    assert row["min_year"] == 400
+    assert row["max_year"] == 100
+    assert row["disposition"] == "quarantined_metadata"
+    assert row["quality_flags"] == ["date_range_inversion", "epidoc_parse_failure"]
+
+
+def test_nontextual_record_is_retained(tmp_path: Path) -> None:
+    no_text = _record(
+        1,
+        transcription="",
+        epidoc_text="",
+        epidoc_interpretation="",
+        interpretative_edition="",
+        romanisation="",
+        translation_ukr="",
+        translation_eng="",
+        comments_ukr="",
+        comments_eng="",
+    )
+    output = _crawl(tmp_path, FakeApi([[no_text]]))
+    row = _jsonl(output / "historical_source_records.jsonl")[0]
+    assert row["source_record_id"] == "1"
+    assert row["disposition"] == "non_textual_or_no_text"
+
+
+def test_lookup_failure_is_quarantined_instead_of_inventing_a_label(tmp_path: Path) -> None:
+    output = _crawl(tmp_path, FakeApi([[_record(1, language=999)]]))
+    row = _jsonl(output / "historical_source_records.jsonl")[0]
+    assert row["source_language_label"] is None
+    assert row["metadata"]["source_language_id"] == 999
+    assert row["disposition"] == "quarantined_metadata"
+    assert row["quality_flags"] == ["source_language_lookup_failure"]
+
+
+def test_null_portal_layers_are_preserved_as_null(tmp_path: Path) -> None:
+    source = _record(
+        1,
+        title=None,
+        epidoc_text=None,
+        epidoc_interpretation=None,
+        translation_ukr=None,
+        comments_ukr=None,
+        language=None,
+        writingsystem=None,
+    )
+    row = _jsonl(_crawl(tmp_path, FakeApi([[source]])) / "historical_source_records.jsonl")[0]
+    assert row["title"] is None
+    assert row["epidoc_text"] is None
+    assert row["translation_ukr"] is None
+    assert row["commentary_ukr"] is None
+    assert row["source_language_label"] is None
+    assert "source_language_lookup_failure" not in row["quality_flags"]
+
+
+@pytest.mark.parametrize(
+    ("pages", "message"),
+    [
+        ([[_record(1)], [_record(1)]], "duplicate"),
+        ([[_record(1)]], "incomplete pagination"),
+    ],
+)
+def test_duplicate_ids_and_count_mismatches_fail_without_partial_output(
+    tmp_path: Path, pages: list[list[dict[str, object]]], message: str
+) -> None:
+    fake = FakeApi(pages)
+    if message == "incomplete pagination":
+        original = fake
+
+        def count_mismatch(url: str, timeout: float) -> bytes:
+            raw = original(url, timeout)
+            if "inscription" in url and url != ROOT:
+                payload = json.loads(raw)
+                payload["count"] = 2
+                return json.dumps(payload).encode()
+            return raw
+
+        fetch = count_mismatch
+    else:
+        fetch = fake
+    target = tmp_path / "snapshot"
+    with pytest.raises(crawler.CrawlError, match=message):
+        crawler.crawl_snapshot(target, api_root=ROOT, fetch_bytes=fetch)
+    assert not target.exists()
+    assert not list(tmp_path.glob(".snapshot.tmp-*"))
+
+
+def test_rejects_cross_host_next_url(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+
+    def bad_next(_url: str, _timeout: float) -> bytes:
+        return b'{"count":1,"next":"https://example.invalid/api/next","results":[{}]}'
+
+    with pytest.raises(crawler.CrawlError, match="unexpected pagination scheme or host"):
+        crawler.fetch_endpoint(
+            "inscriptions/language/",
+            api_root=ROOT,
+            raw_directory=raw_dir,
+            timeout=1,
+            retries=0,
+            page_size=1,
+            fetch_bytes=bad_next,
+        )
+
+
+def test_same_host_http_next_is_upgraded_without_insecure_request(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def downgraded_next(url: str, _timeout: float) -> bytes:
+        calls.append(url)
+        page = int(parse_qs(urlparse(url).query).get("page", ["1"])[0])
+        if page == 1:
+            return (
+                b'{"count":2,"next":"http://saintsophia.dh.gu.se/api/inscriptions/'
+                b'language/?page=2","results":[{"id":1}]}'
+            )
+        return b'{"count":2,"next":null,"results":[{"id":2}]}'
+
+    rows, manifest = crawler.fetch_endpoint(
+        "inscriptions/language/",
+        api_root=ROOT,
+        raw_directory=tmp_path / "raw",
+        timeout=1,
+        retries=0,
+        page_size=1,
+        fetch_bytes=downgraded_next,
+    )
+    assert [row["id"] for row in rows] == [1, 2]
+    assert calls[1].startswith("https://saintsophia.dh.gu.se/")
+    assert manifest[0]["pagination_http_to_https_upgrade"] is True
+
+
+def test_only_allowlisted_contributor_endpoint_accepts_bare_list(tmp_path: Path) -> None:
+    def bare_list(_url: str, _timeout: float) -> bytes:
+        return b'[{"authors_ordered":["Contributor"],"author_id":[1]}]'
+
+    rows, _manifest = crawler.fetch_endpoint(
+        "inscriptions/inscription-contributors/",
+        api_root=ROOT,
+        raw_directory=tmp_path / "allowed" / "raw",
+        timeout=1,
+        retries=0,
+        page_size=1,
+        fetch_bytes=bare_list,
+    )
+    assert rows == [{"authors_ordered": ["Contributor"], "author_id": [1]}]
+    with pytest.raises(crawler.CrawlError, match="unexpected paginated response shape"):
+        crawler.fetch_endpoint(
+            "inscriptions/language/",
+            api_root=ROOT,
+            raw_directory=tmp_path / "rejected" / "raw",
+            timeout=1,
+            retries=0,
+            page_size=1,
+            fetch_bytes=bare_list,
+        )
+
+
+def test_rejects_media_next_url_before_requesting_it(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def media_next(url: str, _timeout: float) -> bytes:
+        calls.append(url)
+        return b'{"count":1,"next":"https://saintsophia.dh.gu.se/api/images/1","results":[{}]}'
+
+    with pytest.raises(crawler.CrawlError, match="refusing media"):
+        crawler.fetch_endpoint(
+            "inscriptions/language/",
+            api_root=ROOT,
+            raw_directory=tmp_path / "raw",
+            timeout=1,
+            retries=0,
+            page_size=1,
+            fetch_bytes=media_next,
+        )
+    assert calls == [f"{ROOT}inscriptions/language/?page_size=1"]
+
+
+def test_rejects_same_host_next_url_outside_allowed_endpoint(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def escaped_next(url: str, _timeout: float) -> bytes:
+        calls.append(url)
+        return (
+            b'{"count":1,"next":"https://saintsophia.dh.gu.se/api/inscriptions/tags/",'
+            b'"results":[{}]}'
+        )
+
+    with pytest.raises(crawler.CrawlError, match="escaped the allowed endpoint"):
+        crawler.fetch_endpoint(
+            "inscriptions/language/",
+            api_root=ROOT,
+            raw_directory=tmp_path / "raw",
+            timeout=1,
+            retries=0,
+            page_size=1,
+            fetch_bytes=escaped_next,
+        )
+    assert calls == [f"{ROOT}inscriptions/language/?page_size=1"]
+
+
+def test_dispositions_have_exactly_the_source_record_ids_and_no_media_calls(tmp_path: Path) -> None:
+    fake = FakeApi()
+    output = _crawl(tmp_path, fake)
+    records = _jsonl(output / "historical_source_records.jsonl")
+    dispositions = _jsonl(output / "dispositions.jsonl")
+    assert {row["source_record_id"] for row in records} == {row["source_record_id"] for row in dispositions}
+    media_terms = ("image", "iiif", "annotation-media", "rti", "mesh", "geojson", "download")
+    assert not any(term in url.lower() for term in media_terms for url in fake.calls)
+
+
+def test_incremental_diff_lists_added_changed_and_removed_ids(tmp_path: Path) -> None:
+    previous = tmp_path / "previous.jsonl"
+    previous.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"source_record_id": "1", "raw_record_sha256": crawler._sha256(crawler._stable_json_bytes(_record(1)))},
+                {"source_record_id": "2", "raw_record_sha256": "changed"},
+                {"source_record_id": "9", "raw_record_sha256": "removed"},
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    receipt = json.loads(_crawl(tmp_path, FakeApi(), previous=previous).joinpath("coverage-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["diff"]["added_source_record_ids"] == ["3"]
+    assert receipt["diff"]["changed_source_record_ids"] == ["2"]
+    assert receipt["diff"]["removed_source_record_ids"] == ["9"]

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -63,6 +63,42 @@ def sample_data(tmp_path):
     # Dictionaries (on fake gdrive)
     gdrive = tmp_path / "gdrive"
 
+    historical_dir = (
+        gdrive
+        / "historical_language_corpus"
+        / "canonical"
+        / "saint-sophia-inscriptions"
+    )
+    historical_dir.mkdir(parents=True)
+    historical_row = {
+        "schema_version": "historical-source-record.v1",
+        "collection_id": "saint-sophia-inscriptions",
+        "source_record_id": "1",
+        "title": "Графіті 1",
+        "source_url": "https://saintsophia.dh.gu.se/inscription/1",
+        "published": True,
+        "original_transcription": "тестовий напис",
+        "epidoc_text": "<ab>тестовий напис</ab>",
+        "epidoc_interpretation": "",
+        "interpretative_edition": "тестовий напис",
+        "romanisation": "",
+        "translation_ukr": "",
+        "translation_eng": "",
+        "commentary_ukr": "",
+        "commentary_eng": "",
+        "source_language_label": "Church Slavonic",
+        "source_writing_system_label": "Cyrillic",
+        "min_year": 1100,
+        "max_year": 1200,
+        "stage_label": None,
+        "disposition": "text_bearing",
+        "quality_flags": [],
+        "metadata": {"portal_id": 1},
+        "raw_record_sha256": "0" * 64,
+    }
+    with open(historical_dir / "historical_source_records.jsonl", "w") as f:
+        f.write(json.dumps(historical_row, ensure_ascii=False) + "\n")
+
     # Literary texts (under gdrive, same as real layout)
     lit_dir = gdrive / "literary_texts"
     lit_dir.mkdir(parents=True)
@@ -155,6 +191,7 @@ class TestBuildSourcesDb:
         assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 1
         assert conn.execute("SELECT subject FROM textbooks").fetchone()[0] == "ukrmova"
         assert conn.execute("SELECT COUNT(*) FROM literary_texts").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM sum11").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM grinchenko").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM balla_en_uk").fetchone()[0] == 1
@@ -169,6 +206,11 @@ class TestBuildSourcesDb:
             "SELECT COUNT(*) FROM textbooks_fts WHERE textbooks_fts MATCH '\"родовий\"'"
         ).fetchone()[0]
         assert fts >= 1
+        historical_fts = conn.execute(
+            "SELECT COUNT(*) FROM historical_source_records_fts "
+            "WHERE historical_source_records_fts MATCH '\"напис\"'"
+        ).fetchone()[0]
+        assert historical_fts == 1
         conn.close()
 
     def test_rebuilds_cleanly(self, sample_data, monkeypatch):


### PR DESCRIPTION
## Outcome

Adds a complete, reproducible crawl and exact private-database ingest for the currently public Saint Sophia of Kyiv inscription API.

- Crawls all 18 allow-listed text/metadata endpoints to pagination completion.
- Current production receipt: 4,157/4,157 unique public inscriptions, 200 raw API pages, 0 media requests.
- Preserves raw response bytes and separate transcription/EpiDoc/interpretation/translation/commentary layers, including source `null` values.
- Quarantines two deterministic date anomalies without repair; all 3,133 nonempty EpiDoc fields parse.
- Stores all 4,157 rows in `historical_source_records` with 4,157-row FTS parity, exact JSONL→DB readback, integrity `ok`, WAL `(0,0,0)`.
- Full rebuild and incremental ingest share the schema/row builder; incremental replacement is transactional and failure-tested.
- Private Drive snapshot and canonical JSONL/receipts are complete. No source data or images are committed.

This is an auxiliary historical-evidence corpus. Per advisor-approved boundary it is **not** added to the pinned Phase 3 correction denominators or linguistic numerators, and its historical-stage labels remain null pending qualified Ukrainian historical-language review.

## Verification

- `50 passed`: crawler, transactional ingest, and full sources DB tests
- Ruff: clean
- `git diff --check`: clean
- OPSEC staged-diff audit: clean
- Commit trailer lint: clean
- Production JSONL→DB equality: every ID, hash, metadata object, quality flags, and text layer matched
- Production DB after ingest: 4,157 historical rows / 4,157 FTS rows; existing textbooks 48,760 / FTS 48,760 / sections 35,293; integrity `ok`

## Phase 3 statuses

- `ENGINE_READY`: **UNMET**
- `SOURCE_COVERAGE_READY`: **UNMET**
- `LINGUISTICALLY_VALIDATED`: **UNMET**
- `CONSUMER_PROVEN`: **UNMET**

Intermediate corpus hardening only; no Phase 4, training, paid compute, Hugging Face mutation, upload, or outreach.

Tracking: #6375

X-Agent: codex/phase3-sophia-crawler-v1
