### PR TITLE
feat(phase3): migrate heldout source runtime to v2.1

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_heldout_partition_bundle_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_heldout_partition_bundle_v1.schema.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_heldout_partition_bundle_v1.schema.json",
-  "title": "Phase 3 held-out partition bundle v1",
-  "description": "Schemas for immutable input bindings, private held-out seal, private author clearance, public text-free receipt, and partition/leakage verification receipts.",
+  "title": "Phase 3 held-out partition bundle v2.1",
   "type": "object",
   "additionalProperties": false,
   "$defs": {
@@ -10,24 +9,110 @@
       "type": "string",
       "pattern": "^[a-f0-9]{64}$"
     },
+    "actionReceiptId": {
+      "type": "string",
+      "pattern": "^phase3_functional_action:[a-f0-9]{64}$"
+    },
     "roleBinding": {
       "type": "object",
       "additionalProperties": false,
       "required": [
         "role_id",
-        "seat_id",
-        "controller_identity_id",
-        "attestation_task_id",
-        "artifact_task_id"
+        "task_id"
       ],
       "properties": {
-        "role_id": {"const": "heldout_steward"},
-        "seat_id": {"const": "seat_heldout_steward"},
-        "controller_identity_id": {
-          "const": "controller_phase3_heldout_steward_cursor_runtime_01"
+        "role_id": {
+          "const": "heldout_steward"
         },
-        "attestation_task_id": {"const": "phase3-role-heldout-steward-cursor-v2"},
-        "artifact_task_id": {"const": "phase3-heldout-partition-seal-cursor-v1"}
+        "task_id": {
+          "const": "phase3-v2-1-heldout-stewardship"
+        }
+      }
+    },
+    "actionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receipt_id",
+        "role_id",
+        "task_id",
+        "action_kind",
+        "provider",
+        "exact_model",
+        "model_family",
+        "harness",
+        "input_manifest_sha256",
+        "output_sha256",
+        "evaluation_cycle_id",
+        "base_contract_sha256",
+        "amendment_sha256",
+        "combined_contract_sha256",
+        "functional_role_contract_sha256",
+        "conflict_graph_sha256",
+        "started_at",
+        "completed_at",
+        "status"
+      ],
+      "properties": {
+        "receipt_id": {
+          "$ref": "#/$defs/actionReceiptId"
+        },
+        "role_id": {
+          "const": "heldout_steward"
+        },
+        "task_id": {
+          "const": "phase3-v2-1-heldout-stewardship"
+        },
+        "action_kind": {
+          "const": "partition_seal_and_clear_author_units"
+        },
+        "provider": {
+          "const": "local"
+        },
+        "exact_model": {
+          "const": "phase3-heldout-partition-v1"
+        },
+        "model_family": {
+          "const": "deterministic"
+        },
+        "harness": {
+          "const": "local-python"
+        },
+        "input_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "output_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_cycle_id": {
+          "const": "phase3-v2-1-evaluation-cycle-001"
+        },
+        "base_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "functional_role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "conflict_graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "started_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "completed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "status": {
+          "const": "completed"
+        }
       }
     },
     "zeroOverlap": {
@@ -39,9 +124,15 @@
         "test_excluded_from_author_clearance"
       ],
       "properties": {
-        "document_exact": {"const": true},
-        "unit_exact": {"const": true},
-        "test_excluded_from_author_clearance": {"const": true}
+        "document_exact": {
+          "const": true
+        },
+        "unit_exact": {
+          "const": true
+        },
+        "test_excluded_from_author_clearance": {
+          "const": true
+        }
       }
     },
     "inputBindings": {
@@ -49,10 +140,11 @@
       "additionalProperties": false,
       "required": [
         "schema_version",
+        "phase3_v2_contract_sha256",
+        "phase3_v2_1_amendment_sha256",
         "combined_contract_sha256",
-        "original_prompt_sha256",
-        "scope_amendment_sha256",
         "role_contract_sha256",
+        "conflict_graph_sha256",
         "evaluation_contract_sha256",
         "coverage_contract_sha256",
         "source_universe_receipt_sha256",
@@ -63,19 +155,74 @@
         "sources_db_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_input_bindings_v1"},
-        "combined_contract_sha256": {"$ref": "#/$defs/sha256"},
-        "original_prompt_sha256": {"$ref": "#/$defs/sha256"},
-        "scope_amendment_sha256": {"$ref": "#/$defs/sha256"},
-        "role_contract_sha256": {"$ref": "#/$defs/sha256"},
-        "evaluation_contract_sha256": {"$ref": "#/$defs/sha256"},
-        "coverage_contract_sha256": {"$ref": "#/$defs/sha256"},
-        "source_universe_receipt_sha256": {"$ref": "#/$defs/sha256"},
-        "near_duplicate_policy_sha256": {"$ref": "#/$defs/sha256"},
-        "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-        "ua_eval_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"},
-        "public_canary_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"},
-        "sources_db_sha256": {"$ref": "#/$defs/sha256"}
+        "schema_version": {
+          "const": "phase3_heldout_input_bindings_v2_1"
+        },
+        "phase3_v2_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "phase3_v2_1_amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "conflict_graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "coverage_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_universe_receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ua_eval_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "public_canary_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "sources_db_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "frozenUaGecLocator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "table",
+        "primary_key_fields",
+        "primary_key_sha256"
+      ],
+      "properties": {
+        "kind": {
+          "const": "sqlite_row"
+        },
+        "table": {
+          "const": "ua_gec_errors"
+        },
+        "primary_key_fields": {
+          "const": [
+            "id"
+          ]
+        },
+        "primary_key_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "heldoutSealUnit": {
@@ -99,37 +246,124 @@
         "near_duplicate_policy_fingerprint_sha256"
       ],
       "properties": {
-        "unit_id": {"type": "string", "minLength": 1},
-        "unit_sha256": {"$ref": "#/$defs/sha256"},
-        "source_document_identity": {"type": "string", "minLength": 1},
-        "layer": {"type": "string", "minLength": 1},
-        "split": {"const": "test"},
-        "primary_key_sha256": {"$ref": "#/$defs/sha256"},
-        "ordinal": {"type": "integer", "minimum": 1},
-        "family_id": {"const": "ua_gec"},
-        "error": {"type": "string"},
-        "correct": {"type": "string"},
-        "locator": {"$ref": "#/$defs/frozenUaGecLocator"},
-        "error_span_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-        "correct_span_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-        "sources_db_sha256": {"$ref": "#/$defs/sha256"},
-        "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"}
+        "unit_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unit_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_document_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "layer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "split": {
+          "const": "test"
+        },
+        "primary_key_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ordinal": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "family_id": {
+          "const": "ua_gec"
+        },
+        "error": {
+          "type": "string"
+        },
+        "correct": {
+          "type": "string"
+        },
+        "locator": {
+          "$ref": "#/$defs/frozenUaGecLocator"
+        },
+        "error_span_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "correct_span_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "sources_db_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
-    "frozenUaGecLocator": {
+    "authorClearedUnit": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind", "table", "primary_key_fields", "primary_key_sha256"],
+      "required": [
+        "unit_id",
+        "unit_sha256",
+        "family_id"
+      ],
       "properties": {
-        "kind": {"const": "sqlite_row"},
-        "table": {"const": "ua_gec_errors"},
-        "primary_key_fields": {
-          "type": "array",
-          "minItems": 1,
-          "maxItems": 1,
-          "items": {"const": "id"}
+        "unit_id": {
+          "type": "string",
+          "minLength": 1
         },
-        "primary_key_sha256": {"$ref": "#/$defs/sha256"}
+        "unit_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "family_id": {
+          "const": "ua_gec"
+        }
+      }
+    },
+    "authorBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_v2_contract_sha256",
+        "phase3_v2_1_amendment_sha256",
+        "combined_contract_sha256",
+        "role_contract_sha256",
+        "evaluation_contract_sha256",
+        "coverage_contract_sha256",
+        "source_universe_receipt_sha256",
+        "near_duplicate_policy_fingerprint_sha256",
+        "ua_eval_exclusion_manifest_sha256",
+        "public_canary_exclusion_manifest_sha256"
+      ],
+      "properties": {
+        "phase3_v2_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "phase3_v2_1_amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "coverage_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_universe_receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ua_eval_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "public_canary_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "heldoutSealReceipt": {
@@ -140,6 +374,7 @@
         "text_free",
         "implementation_version",
         "role_binding",
+        "action_receipt",
         "input_bindings",
         "family_id",
         "sealed_units",
@@ -149,30 +384,47 @@
         "receipt_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_seal_receipt_v1"},
-        "text_free": {"const": false},
-        "implementation_version": {"const": "phase3_heldout_partition_v1"},
-        "role_binding": {"$ref": "#/$defs/roleBinding"},
-        "input_bindings": {"$ref": "#/$defs/inputBindings"},
-        "family_id": {"const": "ua_gec"},
+        "schema_version": {
+          "const": "phase3_heldout_seal_receipt_v2_1"
+        },
+        "text_free": {
+          "const": false
+        },
+        "implementation_version": {
+          "const": "phase3_heldout_partition_v2_1"
+        },
+        "role_binding": {
+          "$ref": "#/$defs/roleBinding"
+        },
+        "action_receipt": {
+          "$ref": "#/$defs/actionReceipt"
+        },
+        "input_bindings": {
+          "$ref": "#/$defs/inputBindings"
+        },
+        "family_id": {
+          "const": "ua_gec"
+        },
         "sealed_units": {
           "type": "array",
-          "items": {"$ref": "#/$defs/heldoutSealUnit"}
+          "items": {
+            "$ref": "#/$defs/heldoutSealUnit"
+          }
         },
-        "sealed_unit_count": {"type": "integer", "minimum": 0},
-        "sealed_document_count": {"type": "integer", "minimum": 0},
-        "label_state": {"const": "NOT_YET_LABELLED_OR_ACTIVATED"},
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
-      }
-    },
-    "authorClearedUnit": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["unit_id", "unit_sha256", "family_id"],
-      "properties": {
-        "unit_id": {"type": "string", "minLength": 1},
-        "unit_sha256": {"$ref": "#/$defs/sha256"},
-        "family_id": {"const": "ua_gec"}
+        "sealed_unit_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sealed_document_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "label_state": {
+          "const": "NOT_YET_LABELLED_OR_ACTIVATED"
+        },
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "authorClearanceReceipt": {
@@ -183,6 +435,7 @@
         "text_free",
         "implementation_version",
         "role_binding",
+        "action_receipt",
         "input_bindings",
         "cleared_units",
         "cleared_unit_count",
@@ -195,57 +448,219 @@
         "receipt_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_author_clearance_receipt_v1"},
-        "text_free": {"const": true},
-        "implementation_version": {"const": "phase3_heldout_partition_v1"},
-        "role_binding": {"$ref": "#/$defs/roleBinding"},
+        "schema_version": {
+          "const": "phase3_author_clearance_receipt_v2_1"
+        },
+        "text_free": {
+          "const": true
+        },
+        "implementation_version": {
+          "const": "phase3_heldout_partition_v2_1"
+        },
+        "role_binding": {
+          "$ref": "#/$defs/roleBinding"
+        },
+        "action_receipt": {
+          "$ref": "#/$defs/actionReceipt"
+        },
         "input_bindings": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "combined_contract_sha256",
-            "role_contract_sha256",
-            "evaluation_contract_sha256",
-            "coverage_contract_sha256",
-            "source_universe_receipt_sha256",
-            "near_duplicate_policy_fingerprint_sha256",
-            "ua_eval_exclusion_manifest_sha256",
-            "public_canary_exclusion_manifest_sha256"
-          ],
-          "properties": {
-            "combined_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "role_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "evaluation_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "coverage_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "source_universe_receipt_sha256": {"$ref": "#/$defs/sha256"},
-            "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-            "ua_eval_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"},
-            "public_canary_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"}
-          }
+          "$ref": "#/$defs/authorBindings"
         },
         "cleared_units": {
           "type": "array",
-          "items": {"$ref": "#/$defs/authorClearedUnit"}
+          "items": {
+            "$ref": "#/$defs/authorClearedUnit"
+          }
         },
-        "cleared_unit_count": {"type": "integer", "minimum": 0},
-        "heldout_excluded": {"const": true},
-        "ua_eval_exclusion_enforced": {"const": true},
-        "public_canary_exclusion_enforced": {"const": true},
-        "heldout_complement_encoded": {"const": false},
-        "fingerprints_encoded": {"const": false},
-        "locators_encoded": {"const": false},
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+        "cleared_unit_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "heldout_excluded": {
+          "const": true
+        },
+        "ua_eval_exclusion_enforced": {
+          "const": true
+        },
+        "public_canary_exclusion_enforced": {
+          "const": true
+        },
+        "heldout_complement_encoded": {
+          "const": false
+        },
+        "fingerprints_encoded": {
+          "const": false
+        },
+        "locators_encoded": {
+          "const": false
+        },
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "capabilityShortfall": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["code", "detail", "families_not_sealed", "denominator_shrinkage"],
+      "required": [
+        "code",
+        "detail",
+        "families_not_sealed",
+        "denominator_shrinkage"
+      ],
       "properties": {
-        "code": {"const": "NON_UA_GEC_LABEL_BLIND_HELDOUT_NOT_SEALED"},
-        "detail": {"const": "contract_requires_ua_gec_test_as_mandatory_private_side_only_at_partition_time"},
-        "families_not_sealed": {"const": "non_ua_gec_evaluation_families_deferred_hash_only"},
-        "denominator_shrinkage": {"const": false}
+        "code": {
+          "const": "NON_UA_GEC_LABEL_BLIND_HELDOUT_NOT_SEALED"
+        },
+        "detail": {
+          "const": "contract_requires_ua_gec_test_as_mandatory_private_side_only_at_partition_time"
+        },
+        "families_not_sealed": {
+          "const": "non_ua_gec_evaluation_families_deferred_hash_only"
+        },
+        "denominator_shrinkage": {
+          "const": false
+        }
+      }
+    },
+    "publicBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_v2_contract_sha256",
+        "phase3_v2_1_amendment_sha256",
+        "combined_contract_sha256",
+        "role_contract_sha256",
+        "conflict_graph_sha256",
+        "evaluation_contract_sha256",
+        "coverage_contract_sha256",
+        "source_universe_receipt_sha256",
+        "near_duplicate_policy_fingerprint_sha256",
+        "ua_eval_exclusion_manifest_sha256",
+        "public_canary_exclusion_manifest_sha256",
+        "sources_db_sha256"
+      ],
+      "properties": {
+        "phase3_v2_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "phase3_v2_1_amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "conflict_graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "coverage_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_universe_receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ua_eval_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "public_canary_exclusion_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "sources_db_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "artifactHashes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "heldout_seal_sha256",
+        "author_clearance_sha256",
+        "partition_verification_sha256",
+        "leakage_verification_sha256"
+      ],
+      "properties": {
+        "heldout_seal_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "author_clearance_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "partition_verification_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "leakage_verification_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "aggregates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ua_gec_input_total",
+        "heldout_sealed_unit_total",
+        "author_cleared_unit_total",
+        "author_omitted_unit_total",
+        "omit_reason_code_count"
+      ],
+      "properties": {
+        "ua_gec_input_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "heldout_sealed_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "author_cleared_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "author_omitted_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "omit_reason_code_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "per_phenomenon_floors_claimed",
+        "automatic_rule_activation_floors_claimed",
+        "shortfalls"
+      ],
+      "properties": {
+        "state": {
+          "const": "NOT_YET_LABELLED_OR_ACTIVATED"
+        },
+        "per_phenomenon_floors_claimed": {
+          "const": false
+        },
+        "automatic_rule_activation_floors_claimed": {
+          "const": false
+        },
+        "shortfalls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/capabilityShortfall"
+          }
+        }
       }
     },
     "publicReceipt": {
@@ -256,6 +671,7 @@
         "text_free",
         "implementation_version",
         "role_binding",
+        "action_receipt",
         "input_bindings",
         "artifact_hashes",
         "aggregates",
@@ -264,91 +680,39 @@
         "receipt_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_public_receipt_v1"},
-        "text_free": {"const": true},
-        "implementation_version": {"const": "phase3_heldout_partition_v1"},
-        "role_binding": {"$ref": "#/$defs/roleBinding"},
+        "schema_version": {
+          "const": "phase3_heldout_public_receipt_v2_1"
+        },
+        "text_free": {
+          "const": true
+        },
+        "implementation_version": {
+          "const": "phase3_heldout_partition_v2_1"
+        },
+        "role_binding": {
+          "$ref": "#/$defs/roleBinding"
+        },
+        "action_receipt": {
+          "$ref": "#/$defs/actionReceipt"
+        },
         "input_bindings": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "combined_contract_sha256",
-            "role_contract_sha256",
-            "evaluation_contract_sha256",
-            "coverage_contract_sha256",
-            "source_universe_receipt_sha256",
-            "near_duplicate_policy_fingerprint_sha256",
-            "ua_eval_exclusion_manifest_sha256",
-            "public_canary_exclusion_manifest_sha256",
-            "sources_db_sha256"
-          ],
-          "properties": {
-            "combined_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "role_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "evaluation_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "coverage_contract_sha256": {"$ref": "#/$defs/sha256"},
-            "source_universe_receipt_sha256": {"$ref": "#/$defs/sha256"},
-            "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-            "ua_eval_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"},
-            "public_canary_exclusion_manifest_sha256": {"$ref": "#/$defs/sha256"},
-            "sources_db_sha256": {"$ref": "#/$defs/sha256"}
-          }
+          "$ref": "#/$defs/publicBindings"
         },
         "artifact_hashes": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "heldout_seal_sha256",
-            "author_clearance_sha256",
-            "partition_verification_sha256",
-            "leakage_verification_sha256"
-          ],
-          "properties": {
-            "heldout_seal_sha256": {"$ref": "#/$defs/sha256"},
-            "author_clearance_sha256": {"$ref": "#/$defs/sha256"},
-            "partition_verification_sha256": {"$ref": "#/$defs/sha256"},
-            "leakage_verification_sha256": {"$ref": "#/$defs/sha256"}
-          }
+          "$ref": "#/$defs/artifactHashes"
         },
         "aggregates": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "ua_gec_input_total",
-            "heldout_sealed_unit_total",
-            "author_cleared_unit_total",
-            "author_omitted_unit_total",
-            "omit_reason_code_count"
-          ],
-          "properties": {
-            "ua_gec_input_total": {"type": "integer", "minimum": 0},
-            "heldout_sealed_unit_total": {"type": "integer", "minimum": 0},
-            "author_cleared_unit_total": {"type": "integer", "minimum": 0},
-            "author_omitted_unit_total": {"type": "integer", "minimum": 0},
-            "omit_reason_code_count": {"type": "integer", "minimum": 0}
-          }
+          "$ref": "#/$defs/aggregates"
         },
-        "zero_overlap": {"$ref": "#/$defs/zeroOverlap"},
+        "zero_overlap": {
+          "$ref": "#/$defs/zeroOverlap"
+        },
         "capability": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "state",
-            "per_phenomenon_floors_claimed",
-            "automatic_rule_activation_floors_claimed",
-            "shortfalls"
-          ],
-          "properties": {
-            "state": {"const": "NOT_YET_LABELLED_OR_ACTIVATED"},
-            "per_phenomenon_floors_claimed": {"const": false},
-            "automatic_rule_activation_floors_claimed": {"const": false},
-            "shortfalls": {
-              "type": "array",
-              "items": {"$ref": "#/$defs/capabilityShortfall"}
-            }
-          }
+          "$ref": "#/$defs/capability"
         },
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "partitionVerificationReceipt": {
@@ -367,19 +731,44 @@
         "receipt_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_partition_verification_v1"},
-        "text_free": {"const": true},
-        "ua_gec_input_total": {"type": "integer", "minimum": 0},
-        "heldout_sealed_unit_total": {"type": "integer", "minimum": 0},
-        "author_cleared_unit_total": {"type": "integer", "minimum": 0},
-        "author_omitted_unit_total": {"type": "integer", "minimum": 0},
+        "schema_version": {
+          "const": "phase3_heldout_partition_verification_v1"
+        },
+        "text_free": {
+          "const": true
+        },
+        "ua_gec_input_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "heldout_sealed_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "author_cleared_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "author_omitted_unit_total": {
+          "type": "integer",
+          "minimum": 0
+        },
         "omit_reason_totals": {
           "type": "object",
-          "additionalProperties": {"type": "integer", "minimum": 0}
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
         },
-        "zero_overlap": {"$ref": "#/$defs/zeroOverlap"},
-        "role_binding": {"$ref": "#/$defs/roleBinding"},
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+        "zero_overlap": {
+          "$ref": "#/$defs/zeroOverlap"
+        },
+        "role_binding": {
+          "$ref": "#/$defs/roleBinding"
+        },
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "leakageVerificationReceipt": {
@@ -397,15 +786,33 @@
         "receipt_sha256"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_leakage_verification_v1"},
-        "text_free": {"const": true},
-        "zero_overlap": {"$ref": "#/$defs/zeroOverlap"},
-        "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"},
-        "ua_eval_exclusion_enforced": {"const": true},
-        "public_canary_exclusion_enforced": {"const": true},
-        "malformed_comparisons_fail_closed": {"const": true},
-        "cross_layer_doc_id_collapsed": {"const": true},
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+        "schema_version": {
+          "const": "phase3_heldout_leakage_verification_v1"
+        },
+        "text_free": {
+          "const": true
+        },
+        "zero_overlap": {
+          "$ref": "#/$defs/zeroOverlap"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ua_eval_exclusion_enforced": {
+          "const": true
+        },
+        "public_canary_exclusion_enforced": {
+          "const": true
+        },
+        "malformed_comparisons_fail_closed": {
+          "const": true
+        },
+        "cross_layer_doc_id_collapsed": {
+          "const": true
+        },
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "bundle": {
@@ -421,13 +828,27 @@
         "leakage_verification"
       ],
       "properties": {
-        "schema_version": {"const": "phase3_heldout_partition_bundle_v1"},
-        "input_bindings": {"$ref": "#/$defs/inputBindings"},
-        "heldout_seal": {"$ref": "#/$defs/heldoutSealReceipt"},
-        "author_clearance": {"$ref": "#/$defs/authorClearanceReceipt"},
-        "public_receipt": {"$ref": "#/$defs/publicReceipt"},
-        "partition_verification": {"$ref": "#/$defs/partitionVerificationReceipt"},
-        "leakage_verification": {"$ref": "#/$defs/leakageVerificationReceipt"}
+        "schema_version": {
+          "const": "phase3_heldout_partition_bundle_v2_1"
+        },
+        "input_bindings": {
+          "$ref": "#/$defs/inputBindings"
+        },
+        "heldout_seal": {
+          "$ref": "#/$defs/heldoutSealReceipt"
+        },
+        "author_clearance": {
+          "$ref": "#/$defs/authorClearanceReceipt"
+        },
+        "public_receipt": {
+          "$ref": "#/$defs/publicReceipt"
+        },
+        "partition_verification": {
+          "$ref": "#/$defs/partitionVerificationReceipt"
+        },
+        "leakage_verification": {
+          "$ref": "#/$defs/leakageVerificationReceipt"
+        }
       }
     }
   }

--- a/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_rule_author_source_rows_v1.schema.json
@@ -1,91 +1,460 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_rule_author_source_rows_v1.schema.json",
-  "title": "Phase 3 steward-bound rule-author source rows v1",
-  "description": "Private exact UA-GEC rows for the rule-author packet compiler and a text-free public receipt.",
+  "title": "Phase 3 steward-bound rule-author source rows v2.1",
   "type": "object",
   "additionalProperties": false,
   "$defs": {
-    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
-    "sourceRow": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["family_id", "unit_id", "unit_sha256", "source_locator", "source_text", "corrected_text", "source_record", "span_start", "span_end", "source_sha256", "candidate_signals", "heldout", "ua_eval", "public_canary_neighbour"],
-      "properties": {
-        "family_id": {"const": "ua_gec"},
-        "unit_id": {"type": "string", "minLength": 1},
-        "unit_sha256": {"$ref": "#/$defs/sha256"},
-        "source_locator": {"$ref": "#/$defs/frozenLocator"},
-        "source_text": {"type": "string", "minLength": 1},
-        "corrected_text": {"type": "string"},
-        "source_record": {"$ref": "#/$defs/uaGecRecord"},
-        "span_start": {"const": 0},
-        "span_end": {"type": "integer", "minimum": 1},
-        "source_sha256": {"$ref": "#/$defs/sha256"},
-        "candidate_signals": {"const": []},
-        "heldout": {"const": false},
-        "ua_eval": {"const": false},
-        "public_canary_neighbour": {"const": false}
-      }
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "actionReceiptId": {
+      "type": "string",
+      "pattern": "^phase3_functional_action:[a-f0-9]{64}$"
     },
     "frozenLocator": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind", "table", "primary_key_fields", "primary_key_sha256"],
+      "required": [
+        "kind",
+        "table",
+        "primary_key_fields",
+        "primary_key_sha256"
+      ],
       "properties": {
-        "kind": {"const": "sqlite_row"},
-        "table": {"const": "ua_gec_errors"},
-        "primary_key_fields": {"const": ["id"]},
-        "primary_key_sha256": {"$ref": "#/$defs/sha256"}
+        "kind": {
+          "const": "sqlite_row"
+        },
+        "table": {
+          "const": "ua_gec_errors"
+        },
+        "primary_key_fields": {
+          "const": [
+            "id"
+          ]
+        },
+        "primary_key_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
     },
     "uaGecRecord": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "error", "correct", "error_type", "doc_id", "annotator_id", "partition", "is_native", "source_lang"],
+      "required": [
+        "id",
+        "error",
+        "correct",
+        "error_type",
+        "doc_id",
+        "annotator_id",
+        "partition",
+        "is_native",
+        "source_lang"
+      ],
       "properties": {
-        "id": {"type": "integer", "minimum": 1},
-        "error": {"type": "string", "minLength": 1},
-        "correct": {"type": "string"},
-        "error_type": {"type": "string", "minLength": 1},
-        "doc_id": {"type": "string", "minLength": 1},
-        "annotator_id": {"type": "string", "minLength": 1},
-        "partition": {"type": "string", "pattern": ".+/train$"},
-        "is_native": {"type": "integer"},
-        "source_lang": {"type": "string"}
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1
+        },
+        "correct": {
+          "type": "string"
+        },
+        "error_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "doc_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotator_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "partition": {
+          "type": "string",
+          "pattern": ".+/train$"
+        },
+        "is_native": {
+          "type": "integer"
+        },
+        "source_lang": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "family_id",
+        "unit_id",
+        "unit_sha256",
+        "source_locator",
+        "source_text",
+        "corrected_text",
+        "source_record",
+        "span_start",
+        "span_end",
+        "source_sha256",
+        "candidate_signals",
+        "heldout",
+        "ua_eval",
+        "public_canary_neighbour"
+      ],
+      "properties": {
+        "family_id": {
+          "const": "ua_gec"
+        },
+        "unit_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unit_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_locator": {
+          "$ref": "#/$defs/frozenLocator"
+        },
+        "source_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "corrected_text": {
+          "type": "string"
+        },
+        "source_record": {
+          "$ref": "#/$defs/uaGecRecord"
+        },
+        "span_start": {
+          "const": 0
+        },
+        "span_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "candidate_signals": {
+          "const": []
+        },
+        "heldout": {
+          "const": false
+        },
+        "ua_eval": {
+          "const": false
+        },
+        "public_canary_neighbour": {
+          "const": false
+        }
+      }
+    },
+    "roleBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role_id",
+        "task_id"
+      ],
+      "properties": {
+        "role_id": {
+          "const": "heldout_steward"
+        },
+        "task_id": {
+          "const": "phase3-v2-1-heldout-stewardship"
+        }
+      }
+    },
+    "ruleAuthorBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role_id",
+        "task_id"
+      ],
+      "properties": {
+        "role_id": {
+          "const": "rule_author_extractor"
+        },
+        "task_id": {
+          "const": "phase3-v2-1-rule-author-extraction"
+        }
+      }
+    },
+    "actionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receipt_id",
+        "role_id",
+        "task_id",
+        "action_kind",
+        "provider",
+        "exact_model",
+        "model_family",
+        "harness",
+        "input_manifest_sha256",
+        "output_sha256",
+        "evaluation_cycle_id",
+        "base_contract_sha256",
+        "amendment_sha256",
+        "combined_contract_sha256",
+        "functional_role_contract_sha256",
+        "conflict_graph_sha256",
+        "started_at",
+        "completed_at",
+        "status"
+      ],
+      "properties": {
+        "receipt_id": {
+          "$ref": "#/$defs/actionReceiptId"
+        },
+        "role_id": {
+          "const": "heldout_steward"
+        },
+        "task_id": {
+          "const": "phase3-v2-1-heldout-stewardship"
+        },
+        "action_kind": {
+          "const": "partition_seal_and_clear_author_units"
+        },
+        "provider": {
+          "const": "local"
+        },
+        "exact_model": {
+          "const": "phase3-heldout-partition-v1"
+        },
+        "model_family": {
+          "const": "deterministic"
+        },
+        "harness": {
+          "const": "local-python"
+        },
+        "input_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "output_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_cycle_id": {
+          "const": "phase3-v2-1-evaluation-cycle-001"
+        },
+        "base_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "functional_role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "conflict_graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "started_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "completed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "status": {
+          "const": "completed"
+        }
+      }
+    },
+    "inputBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_v2_contract_sha256",
+        "phase3_v2_1_amendment_sha256",
+        "combined_contract_sha256",
+        "source_universe_receipt_sha256",
+        "ua_gec_ledger_sha256",
+        "sources_db_sha256",
+        "evaluation_contract_sha256",
+        "coverage_contract_sha256",
+        "role_contract_sha256",
+        "conflict_graph_sha256",
+        "near_duplicate_policy_sha256",
+        "near_duplicate_policy_fingerprint_sha256",
+        "author_clearance_receipt_sha256",
+        "author_clearance_file_sha256",
+        "partition_public_receipt_body_sha256",
+        "partition_public_receipt_file_sha256",
+        "compiler_script_sha256",
+        "compiler_schema_sha256",
+        "adapter_script_sha256",
+        "adapter_schema_sha256"
+      ],
+      "properties": {
+        "phase3_v2_contract_sha256": {
+          "const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+        },
+        "phase3_v2_1_amendment_sha256": {
+          "const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"
+        },
+        "combined_contract_sha256": {
+          "const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"
+        },
+        "source_universe_receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "ua_gec_ledger_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "sources_db_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "coverage_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "role_contract_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "conflict_graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "near_duplicate_policy_fingerprint_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "author_clearance_receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "author_clearance_file_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "partition_public_receipt_body_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "partition_public_receipt_file_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "compiler_script_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "compiler_schema_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "adapter_script_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "adapter_schema_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "exclusions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "heldout_excluded",
+        "ua_eval_exclusion_enforced",
+        "public_canary_exclusion_enforced",
+        "complement_inference_used",
+        "all_rows_train",
+        "clearance_source_row_set_equal"
+      ],
+      "properties": {
+        "heldout_excluded": {
+          "const": true
+        },
+        "ua_eval_exclusion_enforced": {
+          "const": true
+        },
+        "public_canary_exclusion_enforced": {
+          "const": true
+        },
+        "complement_inference_used": {
+          "const": false
+        },
+        "all_rows_train": {
+          "const": true
+        },
+        "clearance_source_row_set_equal": {
+          "const": true
+        }
       }
     },
     "receipt": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["schema_version", "text_free", "implementation_version", "role_binding", "rule_author_binding", "input_bindings", "exclusions", "aggregates", "source_rows_sha256", "receipt_sha256"],
+      "required": [
+        "schema_version",
+        "text_free",
+        "implementation_version",
+        "role_binding",
+        "rule_author_binding",
+        "action_receipt",
+        "input_bindings",
+        "exclusions",
+        "aggregates",
+        "source_rows_sha256",
+        "receipt_sha256"
+      ],
       "properties": {
-        "schema_version": {"const": "phase3_rule_author_source_rows_receipt_v1"},
-        "text_free": {"const": true},
-        "implementation_version": {"const": "phase3_rule_author_source_rows_v1"},
-        "role_binding": {"$ref": "#/$defs/roleBinding"},
-        "rule_author_binding": {"$ref": "#/$defs/ruleAuthorBinding"},
-        "input_bindings": {"$ref": "#/$defs/inputBindings"},
-        "exclusions": {"type": "object", "additionalProperties": false, "required": ["heldout_excluded", "ua_eval_exclusion_enforced", "public_canary_exclusion_enforced", "complement_inference_used", "all_rows_train", "clearance_source_row_set_equal"], "properties": {"heldout_excluded": {"const": true}, "ua_eval_exclusion_enforced": {"const": true}, "public_canary_exclusion_enforced": {"const": true}, "complement_inference_used": {"const": false}, "all_rows_train": {"const": true}, "clearance_source_row_set_equal": {"const": true}}},
-        "aggregates": {"type": "object", "additionalProperties": false, "required": ["source_row_count"], "properties": {"source_row_count": {"type": "integer", "minimum": 0}}},
-        "source_rows_sha256": {"$ref": "#/$defs/sha256"},
-        "receipt_sha256": {"$ref": "#/$defs/sha256"}
+        "schema_version": {
+          "const": "phase3_rule_author_source_rows_receipt_v2_1"
+        },
+        "text_free": {
+          "const": true
+        },
+        "implementation_version": {
+          "const": "phase3_rule_author_source_rows_v2_1"
+        },
+        "role_binding": {
+          "$ref": "#/$defs/roleBinding"
+        },
+        "rule_author_binding": {
+          "$ref": "#/$defs/ruleAuthorBinding"
+        },
+        "action_receipt": {
+          "$ref": "#/$defs/actionReceipt"
+        },
+        "input_bindings": {
+          "$ref": "#/$defs/inputBindings"
+        },
+        "exclusions": {
+          "$ref": "#/$defs/exclusions"
+        },
+        "aggregates": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source_row_count"
+          ],
+          "properties": {
+            "source_row_count": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "source_rows_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "receipt_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
       }
-    },
-    "roleBinding": {
-      "type": "object", "additionalProperties": false,
-      "required": ["role_id", "seat_id", "controller_identity_id", "attestation_task_id", "artifact_task_id"],
-      "properties": {"role_id": {"const": "heldout_steward"}, "seat_id": {"const": "seat_heldout_steward"}, "controller_identity_id": {"const": "controller_phase3_heldout_steward_cursor_runtime_01"}, "attestation_task_id": {"const": "phase3-role-heldout-steward-cursor-v2"}, "artifact_task_id": {"const": "phase3-heldout-partition-seal-cursor-v1"}}
-    },
-    "ruleAuthorBinding": {
-      "type": "object", "additionalProperties": false,
-      "required": ["role_id", "controller_identity_id", "task_id"],
-      "properties": {"role_id": {"const": "rule_author_extractor"}, "controller_identity_id": {"const": "controller_phase3_rule_author_agy_runtime_01"}, "task_id": {"const": "phase3-role-rule-author-agy-v3"}}
-    },
-    "inputBindings": {
-      "type": "object", "additionalProperties": false,
-      "required": ["combined_contract_sha256", "source_universe_receipt_sha256", "ua_gec_ledger_sha256", "sources_db_sha256", "evaluation_contract_sha256", "coverage_contract_sha256", "role_contract_sha256", "near_duplicate_policy_sha256", "near_duplicate_policy_fingerprint_sha256", "author_clearance_receipt_sha256", "author_clearance_file_sha256", "partition_public_receipt_body_sha256", "partition_public_receipt_file_sha256", "compiler_script_sha256", "compiler_schema_sha256", "adapter_script_sha256", "adapter_schema_sha256"],
-      "properties": {"combined_contract_sha256": {"$ref": "#/$defs/sha256"}, "source_universe_receipt_sha256": {"$ref": "#/$defs/sha256"}, "ua_gec_ledger_sha256": {"$ref": "#/$defs/sha256"}, "sources_db_sha256": {"$ref": "#/$defs/sha256"}, "evaluation_contract_sha256": {"$ref": "#/$defs/sha256"}, "coverage_contract_sha256": {"$ref": "#/$defs/sha256"}, "role_contract_sha256": {"$ref": "#/$defs/sha256"}, "near_duplicate_policy_sha256": {"$ref": "#/$defs/sha256"}, "near_duplicate_policy_fingerprint_sha256": {"$ref": "#/$defs/sha256"}, "author_clearance_receipt_sha256": {"$ref": "#/$defs/sha256"}, "author_clearance_file_sha256": {"$ref": "#/$defs/sha256"}, "partition_public_receipt_body_sha256": {"$ref": "#/$defs/sha256"}, "partition_public_receipt_file_sha256": {"$ref": "#/$defs/sha256"}, "compiler_script_sha256": {"$ref": "#/$defs/sha256"}, "compiler_schema_sha256": {"$ref": "#/$defs/sha256"}, "adapter_script_sha256": {"$ref": "#/$defs/sha256"}, "adapter_schema_sha256": {"$ref": "#/$defs/sha256"}}
     }
   }
 }

--- a/data/projects/open_model_data/contracts/phase3_source_disposition_input_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_source_disposition_input_v1.schema.json
@@ -1,15 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_source_disposition_input_v1.schema.json",
-  "title": "Phase 3 reviewed source-disposition input (text-free)",
+  "title": "Phase 3 v2.1 reviewed source-disposition input (text-free)",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "text_free", "source_freeze_receipt_sha256", "role_contract_sha256", "author_binding", "source_review_binding", "families"],
+  "required": ["schema_version", "text_free", "phase3_v2_contract_sha256", "phase3_v2_1_amendment_sha256", "combined_contract_sha256", "producer_task_id", "source_freeze_receipt_sha256", "role_contract_sha256", "conflict_graph_sha256", "author_binding", "source_review_binding", "families"],
   "properties": {
-    "schema_version": {"const": "phase3_source_disposition_input_v1"},
+    "schema_version": {"const": "phase3_source_disposition_input_v2_1"},
     "text_free": {"const": true},
+    "phase3_v2_contract_sha256": {"const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"},
+    "phase3_v2_1_amendment_sha256": {"const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"},
+    "combined_contract_sha256": {"const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"},
+    "producer_task_id": {"const": "phase3-v2-1-disposition-ledger-production"},
     "source_freeze_receipt_sha256": {"$ref": "#/$defs/sha256"},
     "role_contract_sha256": {"$ref": "#/$defs/sha256"},
+    "conflict_graph_sha256": {"$ref": "#/$defs/sha256"},
     "author_binding": {"$ref": "#/$defs/author_binding"},
     "source_review_binding": {"$ref": "#/$defs/source_review_binding"},
     "families": {
@@ -23,24 +28,49 @@
     "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "opaque_id": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]{2,160}$"},
     "family_id": {"enum": ["antonenko_style_guide", "ua_gec", "school_textbooks", "antonenko_textbook_representation", "calque_inventory", "pravopys_2019_complete", "pravopys_2026_complete", "other_normative_style_inventory"]},
+    "action_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_id", "role_id", "task_id", "action_kind", "provider", "exact_model", "model_family", "harness", "input_manifest_sha256", "output_sha256", "evaluation_cycle_id", "base_contract_sha256", "amendment_sha256", "combined_contract_sha256", "functional_role_contract_sha256", "conflict_graph_sha256", "started_at", "completed_at", "status"],
+      "properties": {
+        "receipt_id": {"type": "string", "pattern": "^phase3_functional_action:[a-f0-9]{64}$"},
+        "role_id": {"const": "rule_author_extractor"},
+        "task_id": {"const": "phase3-v2-1-rule-author-extraction"},
+        "action_kind": {"const": "source_disposition_proposal"},
+        "provider": {"const": "google"},
+        "exact_model": {"type": "string", "minLength": 1},
+        "model_family": {"type": "string", "minLength": 1},
+        "harness": {"type": "string", "minLength": 1},
+        "input_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "output_sha256": {"$ref": "#/$defs/sha256"},
+        "evaluation_cycle_id": {"type": "string", "minLength": 1},
+        "base_contract_sha256": {"const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"},
+        "amendment_sha256": {"const": "ae36a961318b2a0a494837314929efd9849b4e6a6fa299b3d8dde17261777f5b"},
+        "combined_contract_sha256": {"const": "2f3ef840325d917b9f2763188627ad69d1b4e45b804860499a134586b112a907"},
+        "functional_role_contract_sha256": {"$ref": "#/$defs/sha256"},
+        "conflict_graph_sha256": {"$ref": "#/$defs/sha256"},
+        "started_at": {"type": "string", "minLength": 1},
+        "completed_at": {"type": "string", "minLength": 1},
+        "status": {"const": "completed"}
+      }
+    },
     "author_binding": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["role_id", "controller_identity_id", "task_id"],
+      "required": ["role_id", "task_id", "action_receipt"],
       "properties": {
         "role_id": {"const": "rule_author_extractor"},
-        "controller_identity_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{3,160}$"},
-        "task_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{3,160}$"}
+        "task_id": {"const": "phase3-v2-1-rule-author-extraction"},
+        "action_receipt": {"$ref": "#/$defs/action_receipt"}
       }
     },
     "source_review_binding": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["role_id", "controller_identity_id", "task_id", "receipt_sha256"],
+      "required": ["role_id", "task_id", "receipt_sha256"],
       "properties": {
         "role_id": {"const": "ukrainian_source_reviewer"},
-        "controller_identity_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{3,160}$"},
-        "task_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{3,160}$"},
+        "task_id": {"const": "phase3-v2-1-ukrainian-source-review"},
         "receipt_sha256": {"$ref": "#/$defs/sha256"}
       }
     },
@@ -72,7 +102,7 @@
         "unit_id": {"$ref": "#/$defs/opaque_id"},
         "unit_sha256": {"$ref": "#/$defs/sha256"},
         "locator_sha256": {"$ref": "#/$defs/sha256"},
-        "disposition_code": {"enum": ["converted", "not_rule_bearing", "duplicate_representation", "evaluation_only", "rights_limited_locator_only", "superseded_or_historical", "blocked_with_reason"]},
+        "disposition_code": {"enum": ["converted", "not_rule_bearing", "duplicate_representation", "evaluation_only", "superseded_or_historical", "blocked_with_reason"]},
         "canonical_identity": {"$ref": "#/$defs/opaque_id"},
         "source_role": {"type": "string", "pattern": "^[a-z][a-z0-9_]{2,80}$"},
         "claim_type": {"type": "string", "pattern": "^[a-z][a-z0-9_]{2,80}$"},

--- a/scripts/projects/open_model_data/phase3_heldout_partition.py
+++ b/scripts/projects/open_model_data/phase3_heldout_partition.py
@@ -28,6 +28,7 @@ if __package__ in (None, ""):
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
+from scripts.projects.open_model_data import phase3_functional_roles as functional_roles
 from scripts.projects.open_model_data import phase3_near_duplicate as near
 from scripts.projects.open_model_data import phase3_source_universe as freeze_mod
 from scripts.projects.open_model_data import verify_phase3_source_universe_freeze as source_freeze
@@ -36,7 +37,7 @@ ROOT = Path(__file__).resolve().parents[3]
 DATA = ROOT / "data/projects/open_model_data"
 DEFAULT_SOURCE_UNIVERSE = DATA / "evidence/source_universe_v1"
 DEFAULT_SOURCES_DB = ROOT / "data/sources.db"
-DEFAULT_ROLE_CONTRACT = DATA / "evidence/correction_protection_role_contract_v1.json"
+DEFAULT_ROLE_CONTRACT = DATA / "evidence/correction_protection_functional_role_contract_v2_1.json"
 DEFAULT_EVAL_CONTRACT = DATA / "evidence/correction_protection_evaluation_contract_v1.json"
 DEFAULT_COVERAGE_CONTRACT = DATA / "evidence/correction_protection_coverage_contract_v1.json"
 DEFAULT_NEAR_DUP_POLICY = DATA / "evidence/correction_protection_near_duplicate_policy_v1.json"
@@ -54,14 +55,18 @@ PUBLIC_CANARY_ARTIFACTS = (
     "data/projects/open_model_data/detector/correction_protection_known_answers_v1.json",
 )
 
-CONTROLLER_IDENTITY = "controller_phase3_heldout_steward_cursor_runtime_01"
-ARTIFACT_TASK_ID = "phase3-heldout-partition-seal-cursor-v1"
-ATTESTATION_TASK_ID = "phase3-role-heldout-steward-cursor-v2"
 ROLE_ID = "heldout_steward"
-SEAT_ID = "seat_heldout_steward"
+TASK_ID = "phase3-v2-1-heldout-stewardship"
 
 CAPABILITY_STATE = "NOT_YET_LABELLED_OR_ACTIVATED"
-IMPLEMENTATION_VERSION = "phase3_heldout_partition_v1"
+IMPLEMENTATION_VERSION = "phase3_heldout_partition_v2_1"
+PHASE3_V2_CONTRACT_SHA256 = functional_roles.BASE_SHA256
+PHASE3_V2_1_AMENDMENT_SHA256 = functional_roles.AMENDMENT_SHA256
+PHASE3_V2_1_COMBINED_CONTRACT_SHA256 = functional_roles.COMBINED_SHA256
+# Callers supply this execution metadata; identical metadata makes reruns
+# byte-identical without inventing a completed-action timestamp.
+EXECUTION_METADATA_FIELDS = frozenset({"provider", "started_at", "completed_at"})
+ACTION_KIND = "partition_seal_and_clear_author_units"
 UA_GEC_FAMILY = "ua_gec"
 UA_GEC_TABLE = "ua_gec_errors"
 SHORTFALL_CODE = "NON_UA_GEC_LABEL_BLIND_HELDOUT_NOT_SEALED"
@@ -69,13 +74,17 @@ SHORTFALL_DETAIL = "contract_requires_ua_gec_test_as_mandatory_private_side_only
 SHORTFALL_FAMILIES = "non_ua_gec_evaluation_families_deferred_hash_only"
 PUBLIC_TOKEN_STRINGS = frozenset(
     {
-        "phase3_heldout_public_receipt_v1",
+        "phase3_heldout_public_receipt_v2_1",
         IMPLEMENTATION_VERSION,
         ROLE_ID,
-        SEAT_ID,
-        CONTROLLER_IDENTITY,
-        ATTESTATION_TASK_ID,
-        ARTIFACT_TASK_ID,
+        TASK_ID,
+        "phase3-v2-1-evaluation-cycle-001",
+        ACTION_KIND,
+        "local",
+        "phase3-heldout-partition-v1",
+        "deterministic",
+        "local-python",
+        "completed",
         CAPABILITY_STATE,
         SHORTFALL_CODE,
         SHORTFALL_DETAIL,
@@ -707,90 +716,81 @@ def _build_exclusion_index(
 
 
 def verify_role_binding(role_contract: Mapping[str, Any]) -> dict[str, str]:
-    exclusivity = role_contract.get("identity_exclusivity_contract")
-    require(isinstance(exclusivity, Mapping), "identity exclusivity contract missing")
-    for invariant in (
-        "one_natural_person_or_continuing_agent_identity_per_decision_role_maximum",
-        "same_controller_reuses_identity_across_sessions_task_ids_harnesses_models_and_providers",
-        "controller_identity_attestation_required_before_role_action",
-        "assigned_controller_identity_ids_unique_across_decision_seats",
-        "root_controller_identity_forbidden_from_decision_seats",
-        "unassigned_reserved_seats_may_not_act_or_issue_receipts",
-        "task_binding_must_match_seat_controller_identity",
-    ):
-        require(exclusivity.get(invariant) is True, f"role exclusivity invariant disabled: {invariant}")
-
-    seats = role_contract.get("seats")
-    require(isinstance(seats, list), "role contract seats missing")
-    assigned = [item for item in seats if item.get("assignment_state") == "assigned_verified"]
-    require(assigned, "role contract has no assigned decision seats")
-    controllers = [item.get("controller_identity_id") for item in assigned]
-    require(all(isinstance(identity, str) and identity for identity in controllers), "assigned seat controller missing")
-    require(len(controllers) == len(set(controllers)), "assigned decision seats reuse a controller identity")
+    try:
+        functional_roles.verify_value(role_contract)
+        binding = functional_roles.binding_for_role(role_contract, ROLE_ID)
+    except functional_roles.FunctionalRoleError as exc:
+        raise PartitionError(str(exc)) from exc
+    require(binding == {"role_id": ROLE_ID, "task_id": TASK_ID}, "heldout steward task binding drift")
+    acl = role_contract["heldout_acl"]
+    require(binding["task_id"] in acl["pre_release_read_task_ids"], "heldout steward lacks pre-release access")
     require(
-        all(item.get("controller_identity_attested") is True for item in assigned),
-        "assigned decision seat controller unattested",
+        functional_roles.ROLE_TASKS["rule_author_extractor"] in acl["forbidden_task_ids"],
+        "rule author is not forbidden from heldout access",
     )
+    return binding
 
-    root = role_contract.get("root")
-    require(isinstance(root, Mapping), "root role boundary missing")
-    root_identity = root.get("controller_identity_id")
-    require(isinstance(root_identity, str) and root_identity not in controllers, "root occupies a decision seat")
-    require(root.get("may_hold_decision_role") is False, "root may hold a decision role")
-    require(root.get("decision_role_ids") == [], "root decision-role list is not empty")
 
-    seat = next((item for item in seats if item.get("seat_id") == SEAT_ID), None)
-    require(seat is not None, "heldout steward seat missing")
-    require(seat.get("role_id") == ROLE_ID, "heldout steward role drift")
-    require(seat.get("controller_identity_id") == CONTROLLER_IDENTITY, "heldout steward controller unbound")
-    require(seat.get("controller_identity_attested") is True, "heldout steward controller unattested")
-    require(seat.get("assignment_state") == "assigned_verified", "heldout steward seat not assigned_verified")
+def build_action_receipt(
+    *,
+    role_contract: Mapping[str, Any],
+    role_contract_path: Path,
+    input_bindings: Mapping[str, Any],
+    output: Any,
+    execution_metadata: Mapping[str, str],
+) -> dict[str, str]:
+    """Produce the closed, generic v2.1 action receipt for a steward artifact."""
+    binding = verify_role_binding(role_contract)
+    steward = next(item for item in role_contract["functional_roles"] if item["role_id"] == ROLE_ID)
     require(
-        {"label_linguistic_gold", "extract_rules", "implement_scorer_under_test"}.issubset(
-            set(seat.get("must_not", []))
-        ),
-        "heldout steward prohibited functions drift",
+        set(execution_metadata) == EXECUTION_METADATA_FIELDS
+        and execution_metadata.get("provider") == "local"
+        and all(isinstance(execution_metadata[key], str) and execution_metadata[key] for key in EXECUTION_METADATA_FIELDS),
+        "steward execution metadata is malformed",
     )
-    bindings = role_contract.get("task_bindings")
-    require(isinstance(bindings, list), "role contract task bindings missing")
-    binding_by_role: dict[str, Mapping[str, Any]] = {}
-    seat_by_role = {str(item.get("role_id")): item for item in assigned}
-    require(len(seat_by_role) == len(assigned), "assigned decision role duplicated")
-    for item in bindings:
-        require(isinstance(item, Mapping), "role contract task binding malformed")
-        role_id = item.get("role_id")
-        require(isinstance(role_id, str) and role_id not in binding_by_role, "task binding role missing or duplicated")
-        binding_by_role[role_id] = item
-    require(set(binding_by_role) == set(seat_by_role), "task bindings do not exactly cover assigned seats")
-    for role_id, assigned_seat in seat_by_role.items():
-        require(
-            binding_by_role[role_id].get("controller_identity_id") == assigned_seat.get("controller_identity_id"),
-            f"task binding controller differs from assigned seat: {role_id}",
-        )
-    binding = next((item for item in bindings if item.get("role_id") == ROLE_ID), None)
-    require(binding is not None, "heldout steward task binding missing")
-    require(binding.get("reserved_task_id") == ATTESTATION_TASK_ID, "heldout steward attestation task drift")
-    require(binding.get("controller_identity_id") == CONTROLLER_IDENTITY, "heldout steward task controller drift")
-
-    acl = role_contract.get("heldout_acl")
-    require(isinstance(acl, Mapping), "heldout ACL missing")
-    pre_release = set(acl.get("pre_release_read_roles", []))
-    post_release = set(acl.get("post_release_scorer_roles", []))
-    forbidden = set(acl.get("forbidden_roles", []))
-    require(pre_release == {"heldout_steward", "heldout_label_reviewer"}, "heldout pre-release ACL drift")
-    require(post_release == {"scorer"}, "heldout post-release scorer ACL drift")
-    require(
-        {"rule_author_extractor", "ukrainian_source_reviewer", "outsider_reproducer"}.issubset(forbidden),
-        "heldout forbidden-role ACL drift",
-    )
-    require(not (pre_release & forbidden) and not (post_release & forbidden), "heldout ACL roles overlap")
-    return {
-        "role_id": ROLE_ID,
-        "seat_id": SEAT_ID,
-        "controller_identity_id": CONTROLLER_IDENTITY,
-        "attestation_task_id": ATTESTATION_TASK_ID,
-        "artifact_task_id": ARTIFACT_TASK_ID,
+    input_manifest_sha256 = sha256_bytes(canonical_json(input_bindings).encode("utf-8"))
+    output_sha256 = sha256_bytes(canonical_json(output).encode("utf-8"))
+    identity = {
+        "role_id": binding["role_id"],
+        "task_id": binding["task_id"],
+        "input_manifest_sha256": input_manifest_sha256,
+        "evaluation_cycle_id": str(role_contract["evaluation_cycle"]["evaluation_cycle_id"]),
+        "output_sha256": output_sha256,
+        "status": "completed",
     }
+    receipt = {
+        "receipt_id": "phase3_functional_action:" + sha256_bytes(canonical_json(identity).encode("utf-8")),
+        **binding,
+        "action_kind": ACTION_KIND,
+        "provider": execution_metadata["provider"],
+        "exact_model": str(steward["exact_model"]),
+        "model_family": str(steward["model_family"]),
+        "harness": str(steward["harness"]),
+        "input_manifest_sha256": input_manifest_sha256,
+        "output_sha256": output_sha256,
+        "evaluation_cycle_id": str(role_contract["evaluation_cycle"]["evaluation_cycle_id"]),
+        "base_contract_sha256": PHASE3_V2_CONTRACT_SHA256,
+        "amendment_sha256": PHASE3_V2_1_AMENDMENT_SHA256,
+        "combined_contract_sha256": PHASE3_V2_1_COMBINED_CONTRACT_SHA256,
+        "functional_role_contract_sha256": sha256_file(role_contract_path),
+        "conflict_graph_sha256": functional_roles.conflict_graph_sha256(role_contract),
+        "started_at": execution_metadata["started_at"],
+        "completed_at": execution_metadata["completed_at"],
+        "status": "completed",
+    }
+    require(set(receipt) == set(functional_roles.ACTION_RECEIPT_FIELDS), "steward action receipt field set drift")
+    return receipt
+
+
+def execution_metadata_from_action(action_receipt: Mapping[str, Any]) -> dict[str, str]:
+    """Extract the explicit execution metadata while rejecting unsafe providers."""
+    metadata = {key: action_receipt.get(key) for key in EXECUTION_METADATA_FIELDS}
+    require(
+        metadata["provider"] == "local"
+        and all(isinstance(metadata[key], str) and metadata[key] for key in EXECUTION_METADATA_FIELDS),
+        "steward action execution metadata drift",
+    )
+    return {key: str(value) for key, value in metadata.items()}
 
 
 def _assert_no_forbidden_public_fields(value: Any, *, path: str = "$") -> None:
@@ -825,7 +825,10 @@ def _assert_no_forbidden_public_fields(value: Any, *, path: str = "$") -> None:
         # This receipt has a closed token vocabulary plus SHA-256 bindings.  Do
         # not accept arbitrary ASCII, which could still disclose source prose.
         require(
-            value in PUBLIC_TOKEN_STRINGS or re.fullmatch(r"[a-f0-9]{64}", value) is not None,
+            value in PUBLIC_TOKEN_STRINGS
+            or re.fullmatch(r"[a-f0-9]{64}", value) is not None
+            or re.fullmatch(r"phase3_functional_action:[a-f0-9]{64}", value) is not None
+            or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value) is not None,
             f"public receipt contains an unapproved string at {path}",
         )
 
@@ -955,11 +958,12 @@ def build_input_bindings(
     freeze_receipt = source_universe / "source-universe-freeze-receipt.json"
     require(freeze_receipt.is_file(), "source universe freeze receipt missing")
     return {
-        "schema_version": "phase3_heldout_input_bindings_v1",
-        "combined_contract_sha256": "bf387adaeb180d11ade272819d77e1eb3d3fdecc43982fff9c775039c9e0bed7",
-        "original_prompt_sha256": "6a563a7526c4ec7a89732f3de5651b0ab2e176ec089abf80f9eb733337db7662",
-        "scope_amendment_sha256": "da0f814f2f12e4974073de1a7b547fc3f27c07f6d903c95fde8f704d4e664132",
+        "schema_version": "phase3_heldout_input_bindings_v2_1",
+        "phase3_v2_contract_sha256": PHASE3_V2_CONTRACT_SHA256,
+        "phase3_v2_1_amendment_sha256": PHASE3_V2_1_AMENDMENT_SHA256,
+        "combined_contract_sha256": PHASE3_V2_1_COMBINED_CONTRACT_SHA256,
         "role_contract_sha256": sha256_file(role_contract_path),
+        "conflict_graph_sha256": functional_roles.conflict_graph_sha256(read_json(role_contract_path)),
         "evaluation_contract_sha256": sha256_file(eval_contract_path),
         "coverage_contract_sha256": sha256_file(coverage_contract_path),
         "source_universe_receipt_sha256": sha256_file(freeze_receipt),
@@ -974,6 +978,7 @@ def build_input_bindings(
 def build_artifacts(
     *,
     root: Path = ROOT,
+    execution_metadata: Mapping[str, str],
     source_universe: Path = DEFAULT_SOURCE_UNIVERSE,
     sources_db: Path = DEFAULT_SOURCES_DB,
     private_dir: Path = DEFAULT_PRIVATE_DIR,
@@ -1045,7 +1050,7 @@ def build_artifacts(
     )
 
     heldout_seal = {
-        "schema_version": "phase3_heldout_seal_receipt_v1",
+        "schema_version": "phase3_heldout_seal_receipt_v2_1",
         "text_free": False,
         "implementation_version": IMPLEMENTATION_VERSION,
         "role_binding": role_binding,
@@ -1056,17 +1061,25 @@ def build_artifacts(
         "sealed_document_count": partitioned["heldout_document_count"],
         "label_state": CAPABILITY_STATE,
     }
+    heldout_seal["action_receipt"] = build_action_receipt(
+        role_contract=role_contract,
+        role_contract_path=role_contract_path,
+        input_bindings=bindings,
+        output=sealed_units,
+        execution_metadata=execution_metadata,
+    )
     heldout_seal = attach_receipt_hash(heldout_seal)
 
-    author_clearance = attach_receipt_hash(
-        {
-            "schema_version": "phase3_author_clearance_receipt_v1",
+    author_clearance = {
+            "schema_version": "phase3_author_clearance_receipt_v2_1",
             "text_free": True,
             "implementation_version": IMPLEMENTATION_VERSION,
             "role_binding": role_binding,
             "input_bindings": {
                 key: bindings[key]
                 for key in (
+                    "phase3_v2_contract_sha256",
+                    "phase3_v2_1_amendment_sha256",
                     "combined_contract_sha256",
                     "role_contract_sha256",
                     "evaluation_contract_sha256",
@@ -1092,8 +1105,15 @@ def build_artifacts(
             "heldout_complement_encoded": False,
             "fingerprints_encoded": False,
             "locators_encoded": False,
-        }
+    }
+    author_clearance["action_receipt"] = build_action_receipt(
+        role_contract=role_contract,
+        role_contract_path=role_contract_path,
+        input_bindings=author_clearance["input_bindings"],
+        output=author_clearance["cleared_units"],
+        execution_metadata=execution_metadata,
     )
+    author_clearance = attach_receipt_hash(author_clearance)
 
     leakage = attach_receipt_hash(
         {
@@ -1130,13 +1150,16 @@ def build_artifacts(
     }
 
     public_receipt = {
-        "schema_version": "phase3_heldout_public_receipt_v1",
+        "schema_version": "phase3_heldout_public_receipt_v2_1",
         "text_free": True,
         "implementation_version": IMPLEMENTATION_VERSION,
         "role_binding": role_binding,
         "input_bindings": {
+            "phase3_v2_contract_sha256": bindings["phase3_v2_contract_sha256"],
+            "phase3_v2_1_amendment_sha256": bindings["phase3_v2_1_amendment_sha256"],
             "combined_contract_sha256": bindings["combined_contract_sha256"],
             "role_contract_sha256": bindings["role_contract_sha256"],
+            "conflict_graph_sha256": bindings["conflict_graph_sha256"],
             "evaluation_contract_sha256": bindings["evaluation_contract_sha256"],
             "coverage_contract_sha256": bindings["coverage_contract_sha256"],
             "source_universe_receipt_sha256": bindings["source_universe_receipt_sha256"],
@@ -1151,6 +1174,7 @@ def build_artifacts(
             "partition_verification_sha256": partition_verification["receipt_sha256"],
             "leakage_verification_sha256": leakage["receipt_sha256"],
         },
+        "action_receipt": author_clearance["action_receipt"],
         "aggregates": {
             "ua_gec_input_total": len(rows),
             "heldout_sealed_unit_total": len(partitioned["heldout_units"]),
@@ -1340,7 +1364,8 @@ def verify_artifacts(
     public_receipt = read_json(public_path)
     require(receipt_body_sha256(public_receipt) == public_receipt.get("receipt_sha256"), "public receipt hash drift")
     _assert_no_forbidden_public_fields(public_receipt)
-    role_binding = verify_role_binding(read_json(role_contract_path))
+    role_contract = read_json(role_contract_path)
+    role_binding = verify_role_binding(role_contract)
     require(public_receipt.get("role_binding") == role_binding, "public role binding drift")
     require(
         public_receipt.get("capability")
@@ -1362,6 +1387,64 @@ def verify_artifacts(
     require(
         public_receipt.get("input_bindings", {}).get("role_contract_sha256") == sha256_file(role_contract_path),
         "public receipt role-contract hash drift",
+    )
+    require(
+        public_receipt.get("input_bindings", {}).get("phase3_v2_contract_sha256") == PHASE3_V2_CONTRACT_SHA256
+        and public_receipt.get("input_bindings", {}).get("phase3_v2_1_amendment_sha256") == PHASE3_V2_1_AMENDMENT_SHA256
+        and public_receipt.get("input_bindings", {}).get("combined_contract_sha256") == PHASE3_V2_1_COMBINED_CONTRACT_SHA256
+        and public_receipt.get("input_bindings", {}).get("conflict_graph_sha256") == functional_roles.conflict_graph_sha256(role_contract),
+        "public receipt v2.1 contract binding drift",
+    )
+    action = public_receipt.get("action_receipt")
+    require(isinstance(action, Mapping), "public receipt lacks v2.1 action receipt")
+    execution_metadata = execution_metadata_from_action(action)
+    public_action_input_bindings = {
+        key: public_receipt["input_bindings"][key]
+        for key in (
+            "phase3_v2_contract_sha256",
+            "phase3_v2_1_amendment_sha256",
+            "combined_contract_sha256",
+            "role_contract_sha256",
+            "evaluation_contract_sha256",
+            "coverage_contract_sha256",
+            "source_universe_receipt_sha256",
+            "near_duplicate_policy_fingerprint_sha256",
+            "ua_eval_exclusion_manifest_sha256",
+            "public_canary_exclusion_manifest_sha256",
+        )
+    }
+    expected_public_action = build_action_receipt(
+        role_contract=role_contract,
+        role_contract_path=role_contract_path,
+        input_bindings=public_action_input_bindings,
+        output=[],
+        execution_metadata=execution_metadata,
+    )
+    # The public receipt carries the exact clearance action evidence; validate
+    # all metadata and contract bindings without deriving private identities.
+    require(set(action) == set(functional_roles.ACTION_RECEIPT_FIELDS), "public action receipt field set drift")
+    require(action["role_id"] == role_binding["role_id"] and action["task_id"] == role_binding["task_id"], "public action role binding drift")
+    require(all(action[key] == expected_public_action[key] for key in ("action_kind", "provider", "exact_model", "model_family", "harness", "evaluation_cycle_id", "base_contract_sha256", "amendment_sha256", "combined_contract_sha256", "functional_role_contract_sha256", "conflict_graph_sha256", "started_at", "completed_at", "status")), "public action receipt contract drift")
+    require(
+        action["input_manifest_sha256"] == expected_public_action["input_manifest_sha256"],
+        "public action input binding drift",
+    )
+    public_action_identity = {
+        key: action[key]
+        for key in (
+            "role_id",
+            "task_id",
+            "input_manifest_sha256",
+            "evaluation_cycle_id",
+            "output_sha256",
+            "status",
+        )
+    }
+    require(
+        action["receipt_id"]
+        == "phase3_functional_action:"
+        + sha256_bytes(canonical_json(public_action_identity).encode("utf-8")),
+        "public action receipt ID drift",
     )
     require(
         public_receipt.get("input_bindings", {}).get("evaluation_contract_sha256") == sha256_file(eval_contract_path),
@@ -1453,6 +1536,7 @@ def verify_artifacts(
         public_receipt["artifact_hashes"]["author_clearance_sha256"] == author["receipt_sha256"],
         "public author clearance hash binding drift",
     )
+    require(public_receipt.get("action_receipt") == author.get("action_receipt"), "public action receipt differs from clearance")
     require(
         public_receipt["artifact_hashes"]["partition_verification_sha256"] == partition_receipt["receipt_sha256"],
         "public partition verification hash binding drift",
@@ -1539,6 +1623,8 @@ def verify_artifacts(
     expected_author_bindings = {
         key: public_receipt["input_bindings"][key]
         for key in (
+            "phase3_v2_contract_sha256",
+            "phase3_v2_1_amendment_sha256",
             "combined_contract_sha256",
             "role_contract_sha256",
             "evaluation_contract_sha256",
@@ -1550,6 +1636,28 @@ def verify_artifacts(
         )
     }
     require(author.get("input_bindings") == expected_author_bindings, "author clearance input binding drift")
+    require(
+        author.get("action_receipt")
+        == build_action_receipt(
+            role_contract=role_contract,
+            role_contract_path=role_contract_path,
+            input_bindings=expected_author_bindings,
+            output=author.get("cleared_units"),
+            execution_metadata=execution_metadata_from_action(author.get("action_receipt", {})),
+        ),
+        "author clearance action receipt drift",
+    )
+    require(
+        heldout_receipt.get("action_receipt")
+        == build_action_receipt(
+            role_contract=role_contract,
+            role_contract_path=role_contract_path,
+            input_bindings=heldout_receipt.get("input_bindings", {}),
+            output=heldout_receipt.get("sealed_units"),
+            execution_metadata=execution_metadata_from_action(heldout_receipt.get("action_receipt", {})),
+        ),
+        "heldout seal action receipt drift",
+    )
     require(partition_receipt.get("zero_overlap") == leakage_receipt.get("zero_overlap"), "private zero-overlap drift")
     require(partition_receipt.get("zero_overlap") == public_receipt.get("zero_overlap"), "public zero-overlap drift")
     require(
@@ -1604,6 +1712,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     commands = parser.add_subparsers(dest="command", required=True)
     build_parser = commands.add_parser("build")
     build_parser.add_argument("--skip-source-freeze-git-binding", action="store_true")
+    build_parser.add_argument("--provider", required=True)
+    build_parser.add_argument("--started-at", required=True)
+    build_parser.add_argument("--completed-at", required=True)
     verify_parser = commands.add_parser("verify")
     verify_parser.add_argument(
         "--public-only",
@@ -1626,6 +1737,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "build":
             result = build_artifacts(
                 root=root,
+                execution_metadata={
+                    "provider": args.provider,
+                    "started_at": args.started_at,
+                    "completed_at": args.completed_at,
+                },
                 source_universe=source_universe,
                 sources_db=sources_db,
                 private_dir=private_dir,

--- a/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
+++ b/scripts/projects/open_model_data/phase3_rule_author_source_rows.py
@@ -14,6 +14,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import stat
 import sys
 import tempfile
@@ -26,6 +27,7 @@ if __package__ in (None, ""):
 
 from jsonschema import Draft202012Validator
 
+from scripts.projects.open_model_data import phase3_functional_roles as functional_roles
 from scripts.projects.open_model_data import phase3_heldout_partition as heldout
 from scripts.projects.open_model_data import phase3_near_duplicate as near_duplicate
 from scripts.projects.open_model_data import phase3_rule_author_packets as packets
@@ -36,7 +38,7 @@ SCHEMA_PATH = DATA / "contracts/phase3_rule_author_source_rows_v1.schema.json"
 PACKET_SCHEMA_PATH = DATA / "contracts/phase3_rule_author_packet_bundle_v1.schema.json"
 SCRIPT_PATH = "scripts/projects/open_model_data/phase3_rule_author_source_rows.py"
 PACKET_SCRIPT_PATH = "scripts/projects/open_model_data/phase3_rule_author_packets.py"
-IMPLEMENTATION_VERSION = "phase3_rule_author_source_rows_v1"
+IMPLEMENTATION_VERSION = "phase3_rule_author_source_rows_v2_1"
 ROWS_FILENAME = "rule_author_source_rows_v1.jsonl"
 PRIVATE_DIR_MODE = 0o700
 PRIVATE_FILE_MODE = 0o600
@@ -212,7 +214,6 @@ _SAFE_BINDING_KEYS = frozenset(
         "role",
         "role_name",
         "actor_role",
-        "controller_identity_id",
         "task_id",
         "attestation_task_id",
         "seat_id",
@@ -243,7 +244,7 @@ def _assert_public_safe(
     forbidden = ("unit_id", "locator", "fingerprint", "source_text", "corrected_text", "source_record", "error", "correct", "doc_id", "body")
     approved = approved_strings or frozenset(
         {
-            "phase3_rule_author_source_rows_receipt_v1",
+            "phase3_rule_author_source_rows_receipt_v2_1",
             IMPLEMENTATION_VERSION,
         }
     )
@@ -261,7 +262,13 @@ def _assert_public_safe(
     elif isinstance(value, str):
         require(
             value in approved
-            or (len(value) == SHA256_LENGTH and all(char in "0123456789abcdef" for char in value)),
+            or (len(value) == SHA256_LENGTH and all(char in "0123456789abcdef" for char in value))
+            or (
+                value.startswith("phase3_functional_action:")
+                and len(value) == len("phase3_functional_action:") + SHA256_LENGTH
+                and all(char in "0123456789abcdef" for char in value.removeprefix("phase3_functional_action:"))
+            )
+            or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value) is not None,
             f"receipt contains unapproved text at {path}",
         )
 
@@ -322,37 +329,31 @@ def _clearance_and_bindings(
             evaluation_path=evaluation_path,
             coverage_path=coverage_path,
             role_path=role_path,
-            allow_legacy_source_rows=True,
-        )
+    )
     except packets.PacketCompilerError as exc:
         raise SourceRowsError(str(exc)) from exc
-    require(partition_receipt.get("schema_version") == "phase3_heldout_public_receipt_v1", "wrong partition public receipt")
+    require(partition_receipt.get("schema_version") == "phase3_heldout_public_receipt_v2_1", "wrong partition public receipt")
     require(partition_receipt.get("text_free") is True, "partition public receipt is not text-free")
     require(heldout.receipt_body_sha256(partition_receipt) == partition_receipt.get("receipt_sha256"), "partition public receipt hash drift")
     role_contract = read_json(role_path, "role contract")
     try:
+        functional_roles.verify_value(role_contract)
         expected_steward = heldout.verify_role_binding(role_contract)
-    except heldout.PartitionError as exc:
+    except (functional_roles.FunctionalRoleError, heldout.PartitionError) as exc:
         raise SourceRowsError(str(exc)) from exc
     require(clearance.get("role_binding") == expected_steward, "clearance is not bound to assigned heldout steward")
     try:
         author = packets._derive_role_actor(role_contract, "rule_author_extractor")
     except packets.PacketCompilerError as exc:
         raise SourceRowsError(str(exc)) from exc
-    require(
-        author["controller_identity_id"] != expected_steward["controller_identity_id"],
-        "heldout steward and rule author identities must be distinct",
-    )
+    require(author["task_id"] != expected_steward["task_id"], "heldout steward and rule author task IDs must be distinct")
     public_bindings = partition_receipt.get("input_bindings")
     require(isinstance(public_bindings, Mapping), "partition public input bindings missing")
     clearance_bindings = clearance["input_bindings"]
-    clearance_contract_sha256 = (
-        packets.LEGACY_V1_V3_COMBINED_CONTRACT_SHA256
-        if clearance.get("schema_version") == "phase3_author_clearance_receipt_v1"
-        else packets.COMBINED_CONTRACT_SHA256
-    )
     for key, actual in {
-        "combined_contract_sha256": clearance_contract_sha256,
+        "phase3_v2_contract_sha256": functional_roles.BASE_SHA256,
+        "phase3_v2_1_amendment_sha256": functional_roles.AMENDMENT_SHA256,
+        "combined_contract_sha256": functional_roles.COMBINED_SHA256,
         "source_universe_receipt_sha256": freeze_sha,
         "evaluation_contract_sha256": sha256_file(evaluation_path),
         "coverage_contract_sha256": sha256_file(coverage_path),
@@ -364,9 +365,23 @@ def _clearance_and_bindings(
     require(public_bindings.get("sources_db_sha256") == sha256_file(sources_db), "sources DB binding drift")
     for key in ("ua_eval_exclusion_manifest_sha256", "public_canary_exclusion_manifest_sha256"):
         require(clearance_bindings.get(key) == public_bindings.get(key), f"clearance {key} binding drift")
+    action_receipt = clearance.get("action_receipt")
+    require(isinstance(action_receipt, Mapping), "clearance action receipt missing")
+    try:
+        expected_action_receipt = heldout.build_action_receipt(
+            role_contract=role_contract,
+            role_contract_path=role_path,
+            input_bindings=clearance_bindings,
+            output=clearance.get("cleared_units"),
+            execution_metadata=heldout.execution_metadata_from_action(action_receipt),
+        )
+    except heldout.PartitionError as exc:
+        raise SourceRowsError(str(exc)) from exc
+    require(action_receipt == expected_action_receipt, "clearance action receipt drift")
     artifact_hashes = partition_receipt.get("artifact_hashes")
     require(isinstance(artifact_hashes, Mapping), "partition artifact hashes missing")
     require(artifact_hashes.get("author_clearance_sha256") == clearance.get("receipt_sha256"), "clearance receipt binding drift")
+    require(partition_receipt.get("action_receipt") == clearance.get("action_receipt"), "partition action evidence drift")
     for field in ("heldout_excluded", "ua_eval_exclusion_enforced", "public_canary_exclusion_enforced"):
         require(clearance.get(field) is True, f"clearance {field} is not exactly true")
     require(clearance.get("heldout_complement_encoded") is False, "clearance encodes a heldout complement")
@@ -482,12 +497,15 @@ def build(
     _atomic_write(rows_path, payload, PRIVATE_FILE_MODE)
     require((rows_path.stat().st_mode & 0o777) == PRIVATE_FILE_MODE, "private source-row file permissions too open")
     receipt = {
-        "schema_version": "phase3_rule_author_source_rows_receipt_v1",
+        "schema_version": "phase3_rule_author_source_rows_receipt_v2_1",
         "text_free": True,
         "implementation_version": IMPLEMENTATION_VERSION,
         "role_binding": steward,
         "rule_author_binding": author,
+        "action_receipt": clearance["action_receipt"],
         "input_bindings": {
+            "phase3_v2_contract_sha256": clearance["input_bindings"]["phase3_v2_contract_sha256"],
+            "phase3_v2_1_amendment_sha256": clearance["input_bindings"]["phase3_v2_1_amendment_sha256"],
             "combined_contract_sha256": clearance["input_bindings"]["combined_contract_sha256"],
             "source_universe_receipt_sha256": sha256_file(source_universe_dir / packets.LEDGER_RECEIPT),
             "ua_gec_ledger_sha256": ledger_sha,
@@ -495,6 +513,7 @@ def build(
             "evaluation_contract_sha256": sha256_file(evaluation_path),
             "coverage_contract_sha256": sha256_file(coverage_path),
             "role_contract_sha256": sha256_file(role_path),
+            "conflict_graph_sha256": functional_roles.conflict_graph_sha256(read_json(role_path, "role contract")),
             "near_duplicate_policy_sha256": sha256_file(near_duplicate_policy_path),
             "near_duplicate_policy_fingerprint_sha256": near_duplicate.PINNED_POLICY_FINGERPRINT,
             "author_clearance_receipt_sha256": clearance["receipt_sha256"],
@@ -521,11 +540,19 @@ def build(
     _validate(receipt, "receipt", "source-row receipt")
     approved = frozenset(
         {
-            "phase3_rule_author_source_rows_receipt_v1",
+            "phase3_rule_author_source_rows_receipt_v2_1",
             IMPLEMENTATION_VERSION,
             "heldout_steward",
-            "seat_heldout_steward",
             "rule_author_extractor",
+            "phase3-v2-1-heldout-stewardship",
+            "phase3-v2-1-rule-author-extraction",
+            "partition_seal_and_clear_author_units",
+            "local",
+            "phase3-heldout-partition-v1",
+            "deterministic",
+            "local-python",
+            "phase3-v2-1-evaluation-cycle-001",
+            "completed",
             * _binding_identity_strings(steward),
             * _binding_identity_strings(author),
         }

--- a/scripts/projects/open_model_data/phase3_source_dispositions.py
+++ b/scripts/projects/open_model_data/phase3_source_dispositions.py
@@ -21,22 +21,30 @@ from typing import Any
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
+from scripts.projects.open_model_data import phase3_functional_roles as functional_roles
 from scripts.projects.open_model_data.phase3_source_universe import canonical_json, sha256_file
 
 ROOT = Path(__file__).resolve().parents[3]
 CONTRACTS = ROOT / "data/projects/open_model_data/contracts"
 DEFAULT_SCHEMA = CONTRACTS / "phase3_source_disposition_input_v1.schema.json"
-DEFAULT_ROLE_CONTRACT = ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
+DEFAULT_ROLE_CONTRACT = (
+    ROOT / "data/projects/open_model_data/evidence/correction_protection_functional_role_contract_v2_1.json"
+)
 FREEZE_RECEIPT_FILE = "source-universe-freeze-receipt.json"
 OUTPUT_LEDGER_FILE = "phase3-source-dispositions.jsonl"
 OUTPUT_RECEIPT_FILE = "phase3-source-dispositions-receipt.json"
 OUTPUT_FILES = frozenset({OUTPUT_LEDGER_FILE, OUTPUT_RECEIPT_FILE})
-INPUT_SCHEMA_VERSION = "phase3_source_disposition_input_v1"
-OUTPUT_SCHEMA_VERSION = "phase3_source_disposition_receipt_v1"
-SOURCE_REVIEW_RECEIPT_SCHEMA_VERSION = "phase3_source_disposition_review_receipt_v1"
+INPUT_SCHEMA_VERSION = "phase3_source_disposition_input_v2_1"
+OUTPUT_SCHEMA_VERSION = "phase3_source_disposition_receipt_v2_1"
+SOURCE_REVIEW_RECEIPT_SCHEMA_VERSION = "phase3_source_disposition_review_receipt_v2_1"
+PRODUCER_TASK_ID = "phase3-v2-1-disposition-ledger-production"
+ROLE_PROVIDERS = {
+    "rule_author_extractor": "google",
+    "ukrainian_source_reviewer": "xai",
+}
 DISPOSITION_CODES = frozenset({
     "converted", "not_rule_bearing", "duplicate_representation", "evaluation_only",
-    "rights_limited_locator_only", "superseded_or_historical", "blocked_with_reason",
+    "superseded_or_historical", "blocked_with_reason",
 })
 FAMILY_TOTALS = {
     "antonenko_style_guide": 342,
@@ -86,55 +94,101 @@ def _validate_input_schema(input_document: Mapping[str, Any], schema_path: Path)
         raise DispositionError(f"disposition input schema violation at {location}: {exc.message}") from exc
 
 
-def _load_role_bindings(role_contract_path: Path) -> dict[str, dict[str, str]]:
+def _load_role_bindings(role_contract_path: Path) -> tuple[dict[str, Any], dict[str, dict[str, str]]]:
     contract = _read_json(role_contract_path, "role contract")
-    seats = contract.get("seats")
-    task_bindings = contract.get("task_bindings")
-    require(isinstance(seats, list) and isinstance(task_bindings, list), "role contract lacks seats or task bindings")
-    assigned_identities = [
-        seat.get("controller_identity_id")
-        for seat in seats
-        if isinstance(seat, Mapping) and seat.get("assignment_state") == "assigned_verified"
-    ]
+    try:
+        verified = functional_roles.verify_value(contract)
+        result = {
+            role_id: functional_roles.binding_for_role(verified, role_id)
+            for role_id in ("rule_author_extractor", "ukrainian_source_reviewer")
+        }
+    except functional_roles.FunctionalRoleError as exc:
+        raise DispositionError(str(exc)) from exc
     require(
-        all(isinstance(identity, str) and identity for identity in assigned_identities)
-        and len(assigned_identities) == len(set(assigned_identities)),
-        "role contract assigned identities are not unique",
+        result["rule_author_extractor"]["task_id"] != result["ukrainian_source_reviewer"]["task_id"],
+        "role contract reuses extractor and source reviewer task",
     )
-    required_roles = ("rule_author_extractor", "ukrainian_source_reviewer")
-    result: dict[str, dict[str, str]] = {}
-    for role_id in required_roles:
-        seat_matches = [seat for seat in seats if isinstance(seat, Mapping) and seat.get("role_id") == role_id]
-        task_matches = [item for item in task_bindings if isinstance(item, Mapping) and item.get("role_id") == role_id]
-        require(len(seat_matches) == 1 and len(task_matches) == 1, f"role contract must contain exactly one {role_id} binding")
-        seat, task = seat_matches[0], task_matches[0]
-        controller, task_id = seat.get("controller_identity_id"), task.get("reserved_task_id")
-        require(seat.get("assignment_state") == "assigned_verified", f"{role_id} is not assigned and verified")
-        require(seat.get("controller_identity_attested") is True, f"{role_id} identity is not attested")
-        require(isinstance(controller, str) and controller, f"{role_id} lacks controller identity")
-        require(isinstance(task_id, str) and task_id, f"{role_id} lacks task binding")
-        require(task.get("controller_identity_id") == controller, f"{role_id} task binding controller drift")
-        require(task.get("status") == "identity_attested_pre_artifact", f"{role_id} task binding is not pre-artifact attested")
-        result[role_id] = {"controller_identity_id": controller, "task_id": task_id}
     require(
-        result["rule_author_extractor"]["controller_identity_id"] != result["ukrainian_source_reviewer"]["controller_identity_id"],
-        "role contract reuses extractor and source reviewer identity",
+        functional_roles.tasks_conflict(
+            verified,
+            result["rule_author_extractor"]["task_id"],
+            result["ukrainian_source_reviewer"]["task_id"],
+        ),
+        "role graph lacks the author-to-source-review edge",
     )
-    return result
+    return verified, result
+
+
+def _validate_action_receipt(
+    action: Mapping[str, Any],
+    *,
+    role_contract: Mapping[str, Any],
+    role_contract_path: Path,
+    actor: Mapping[str, str],
+    action_kind: str,
+    input_manifest_sha256: str,
+    output_sha256: str,
+) -> None:
+    require(set(action) == set(functional_roles.ACTION_RECEIPT_FIELDS), "functional action receipt fields drift")
+    require(
+        action.get("role_id") == actor["role_id"]
+        and action.get("task_id") == actor["task_id"],
+        "functional action receipt task binding mismatch",
+    )
+    role = next(item for item in role_contract["functional_roles"] if item["role_id"] == actor["role_id"])
+    require(
+        all(action.get(key) == role[key] for key in ("exact_model", "model_family", "harness")),
+        "functional action receipt lane mismatch",
+    )
+    require(
+        action.get("provider") == ROLE_PROVIDERS[actor["role_id"]],
+        "functional action provider mismatch",
+    )
+    require(action.get("action_kind") == action_kind, "functional action kind mismatch")
+    require(action.get("input_manifest_sha256") == input_manifest_sha256, "functional action input mismatch")
+    require(action.get("output_sha256") == output_sha256, "functional action output mismatch")
+    require(
+        action.get("evaluation_cycle_id") == role_contract["evaluation_cycle"]["evaluation_cycle_id"],
+        "functional action evaluation-cycle binding mismatch",
+    )
+    require(
+        action.get("base_contract_sha256") == functional_roles.BASE_SHA256
+        and action.get("amendment_sha256") == functional_roles.AMENDMENT_SHA256
+        and action.get("combined_contract_sha256") == functional_roles.COMBINED_SHA256,
+        "functional action contract binding mismatch",
+    )
+    require(
+        action.get("functional_role_contract_sha256") == sha256_file(role_contract_path)
+        and action.get("conflict_graph_sha256") == functional_roles.conflict_graph_sha256(role_contract),
+        "functional action role-graph binding mismatch",
+    )
+    require(action.get("status") == "completed", "functional action is not complete")
+    require(
+        all(isinstance(action.get(key), str) and action[key] for key in ("receipt_id", "started_at", "completed_at")),
+        "functional action metadata incomplete",
+    )
+    identity = {
+        key: action[key]
+        for key in ("role_id", "task_id", "input_manifest_sha256", "evaluation_cycle_id", "output_sha256", "status")
+    }
+    require(
+        action["receipt_id"]
+        == "phase3_functional_action:" + sha256_bytes(canonical_json(identity).encode("utf-8")),
+        "functional action receipt ID mismatch",
+    )
 
 
 def _validate_provenance_bindings(
     reviewed: Mapping[str, Any], role_contract_path: Path, source_review_receipt_path: Path,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     require(source_review_receipt_path.is_file() and not source_review_receipt_path.is_symlink(), "source review receipt is missing")
-    bindings = _load_role_bindings(role_contract_path)
+    role_contract, bindings = _load_role_bindings(role_contract_path)
     author = reviewed["author_binding"]
     reviewer = reviewed["source_review_binding"]
-    require(author["controller_identity_id"] != reviewer["controller_identity_id"], "extractor and source reviewer identities must differ")
+    require(author["task_id"] != reviewer["task_id"], "extractor and source reviewer tasks must differ")
     for role_id, supplied in (("rule_author_extractor", author), ("ukrainian_source_reviewer", reviewer)):
         expected = bindings[role_id]
         require(supplied["role_id"] == role_id, f"{role_id} role binding mismatch")
-        require(supplied["controller_identity_id"] == expected["controller_identity_id"], f"{role_id} controller binding mismatch")
         require(supplied["task_id"] == expected["task_id"], f"{role_id} task binding mismatch")
     require(reviewer["receipt_sha256"] == sha256_file(source_review_receipt_path), "source review receipt binding mismatch")
     receipt = _read_json(source_review_receipt_path, "source review receipt")
@@ -143,11 +197,11 @@ def _validate_provenance_bindings(
             "schema_version",
             "text_free",
             "reviewer_role_id",
-            "controller_identity_id",
             "task_id",
             "source_freeze_receipt_sha256",
             "disposition_families_sha256",
             "verdict",
+            "action_receipt",
         },
         "source review receipt fields are not closed and complete",
     )
@@ -156,7 +210,6 @@ def _validate_provenance_bindings(
         "source review receipt schema or text-free boundary mismatch",
     )
     require(receipt["reviewer_role_id"] == "ukrainian_source_reviewer", "source review receipt role mismatch")
-    require(receipt["controller_identity_id"] == reviewer["controller_identity_id"], "source review receipt controller mismatch")
     require(receipt["task_id"] == reviewer["task_id"], "source review receipt task mismatch")
     require(
         receipt["source_freeze_receipt_sha256"] == reviewed["source_freeze_receipt_sha256"],
@@ -168,6 +221,42 @@ def _validate_provenance_bindings(
         "source review receipt disposition binding mismatch",
     )
     require(receipt["verdict"] == "APPROVE", "source review receipt does not approve the exact dispositions")
+    author_action = author.get("action_receipt")
+    require(isinstance(author_action, Mapping), "source disposition proposal lacks action receipt")
+    families_sha256 = receipt["disposition_families_sha256"]
+    _validate_action_receipt(
+        author_action,
+        role_contract=role_contract,
+        role_contract_path=role_contract_path,
+        actor=author,
+        action_kind="source_disposition_proposal",
+        input_manifest_sha256=sha256_bytes(
+            canonical_json(
+                {"source_freeze_receipt_sha256": receipt["source_freeze_receipt_sha256"]}
+            ).encode("utf-8")
+        ),
+        output_sha256=families_sha256,
+    )
+    review_input_sha256 = sha256_bytes(
+        canonical_json(
+            {
+                "source_freeze_receipt_sha256": receipt["source_freeze_receipt_sha256"],
+                "disposition_families_sha256": families_sha256,
+                "author_action_receipt_id": author_action["receipt_id"],
+            }
+        ).encode("utf-8")
+    )
+    action = receipt.get("action_receipt")
+    require(isinstance(action, Mapping), "source review receipt lacks action receipt")
+    _validate_action_receipt(
+        action,
+        role_contract=role_contract,
+        role_contract_path=role_contract_path,
+        actor=reviewer,
+        action_kind="source_disposition_review",
+        input_manifest_sha256=review_input_sha256,
+        output_sha256=sha256_bytes(canonical_json({"verdict": "APPROVE"}).encode("utf-8")),
+    )
     return dict(author), dict(reviewer)
 
 
@@ -302,6 +391,22 @@ def compile_dispositions(
         require(not unexpected, f"output directory contains stale or unexpected files: {sorted(unexpected)}")
     reviewed = _read_json(reviewed_input_path, "reviewed disposition input")
     _validate_input_schema(reviewed, schema_path)
+    require(
+        reviewed["phase3_v2_contract_sha256"] == functional_roles.BASE_SHA256
+        and reviewed["phase3_v2_1_amendment_sha256"] == functional_roles.AMENDMENT_SHA256
+        and reviewed["combined_contract_sha256"] == functional_roles.COMBINED_SHA256,
+        "Phase 3 v2.1 contract binding mismatch",
+    )
+    require(reviewed["producer_task_id"] == PRODUCER_TASK_ID, "disposition producer task binding mismatch")
+    role_contract = _read_json(role_contract_path, "role contract")
+    try:
+        functional_roles.verify_value(role_contract)
+    except functional_roles.FunctionalRoleError as exc:
+        raise DispositionError(str(exc)) from exc
+    require(
+        reviewed["conflict_graph_sha256"] == functional_roles.conflict_graph_sha256(role_contract),
+        "role conflict-graph binding mismatch",
+    )
     frozen, freeze_receipt_hash, _ = _load_frozen_universe(source_freeze_dir)
     require(reviewed["source_freeze_receipt_sha256"] == freeze_receipt_hash, "source freeze receipt binding mismatch")
     require(reviewed["role_contract_sha256"] == sha256_file(role_contract_path), "role contract binding mismatch")
@@ -351,8 +456,13 @@ def compile_dispositions(
     receipt = {
         "schema_version": OUTPUT_SCHEMA_VERSION,
         "text_free": True,
+        "phase3_v2_contract_sha256": functional_roles.BASE_SHA256,
+        "phase3_v2_1_amendment_sha256": functional_roles.AMENDMENT_SHA256,
+        "combined_contract_sha256": functional_roles.COMBINED_SHA256,
+        "producer_task_id": PRODUCER_TASK_ID,
         "source_freeze_receipt_sha256": freeze_receipt_hash,
         "role_contract_sha256": sha256_file(role_contract_path),
+        "conflict_graph_sha256": functional_roles.conflict_graph_sha256(role_contract),
         "reviewed_input_sha256": sha256_file(reviewed_input_path),
         "author_binding": author_binding,
         "source_review_binding": source_review_binding,

--- a/tests/test_open_model_phase3_heldout_partition.py
+++ b/tests/test_open_model_phase3_heldout_partition.py
@@ -16,7 +16,12 @@ from scripts.projects.open_model_data import phase3_source_universe as freeze_mo
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "data/projects/open_model_data/contracts/phase3_heldout_partition_bundle_v1.schema.json"
 POLICY = ROOT / "data/projects/open_model_data/evidence/correction_protection_near_duplicate_policy_v1.json"
-ROLE = ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
+ROLE = ROOT / "data/projects/open_model_data/evidence/correction_protection_functional_role_contract_v2_1.json"
+EXECUTION_METADATA = {
+    "provider": "local",
+    "started_at": "2026-08-09T00:00:00Z",
+    "completed_at": "2026-08-09T00:00:01Z",
+}
 
 
 def _write(path: Path, value: object) -> None:
@@ -153,7 +158,7 @@ def _build_fixture_root(tmp_path: Path) -> Path:
 
     # Copy real role/eval/coverage/near-dup policy bindings into the fixture tree.
     for relative in (
-        "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json",
+        "data/projects/open_model_data/evidence/correction_protection_functional_role_contract_v2_1.json",
         "data/projects/open_model_data/evidence/correction_protection_evaluation_contract_v1.json",
         "data/projects/open_model_data/evidence/correction_protection_coverage_contract_v1.json",
         "data/projects/open_model_data/evidence/correction_protection_near_duplicate_policy_v1.json",
@@ -300,6 +305,7 @@ def _build_fixture_artifacts(root: Path) -> tuple[Path, Path]:
     public = root / "data/projects/open_model_data/evidence/phase3_heldout_partition_v1"
     heldout.build_artifacts(
         root=root,
+        execution_metadata=EXECUTION_METADATA,
         source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
         sources_db=root / "data/sources.db",
         private_dir=private,
@@ -403,6 +409,7 @@ def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) 
     public = root / "data/projects/open_model_data/evidence/phase3_heldout_partition_v1"
     first = heldout.build_artifacts(
         root=root,
+        execution_metadata=EXECUTION_METADATA,
         source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
         sources_db=root / "data/sources.db",
         private_dir=private,
@@ -419,6 +426,7 @@ def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) 
     public_bytes_before_reconstruction_metadata_rerun = (public / "public_receipt_v1.json").read_bytes()
     second = heldout.build_artifacts(
         root=root,
+        execution_metadata=EXECUTION_METADATA,
         source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
         sources_db=root / "data/sources.db",
         private_dir=private,
@@ -478,9 +486,8 @@ def test_deterministic_partition_and_public_receipt_constraints(tmp_path: Path) 
     heldout._assert_no_forbidden_public_fields(public_receipt)
     assert public_receipt["capability"]["state"] == "NOT_YET_LABELLED_OR_ACTIVATED"
     assert public_receipt["zero_overlap"]["test_excluded_from_author_clearance"] is True
-    assert public_receipt["role_binding"]["controller_identity_id"] == heldout.CONTROLLER_IDENTITY
-    assert public_receipt["role_binding"]["artifact_task_id"] == heldout.ARTIFACT_TASK_ID
-    assert public_receipt["role_binding"]["attestation_task_id"] == heldout.ATTESTATION_TASK_ID
+    assert public_receipt["role_binding"] == {"role_id": "heldout_steward", "task_id": "phase3-v2-1-heldout-stewardship"}
+    assert public_receipt["action_receipt"]["combined_contract_sha256"] == heldout.PHASE3_V2_1_COMBINED_CONTRACT_SHA256
     body = public / "public_receipt_v1.json"
     assert "alpha beta" not in body.read_text(encoding="utf-8")
 
@@ -505,6 +512,7 @@ def test_private_seal_tamper_byte_locator_fingerprint_fail(tmp_path: Path) -> No
     public = root / "data/projects/open_model_data/evidence/phase3_heldout_partition_v1"
     heldout.build_artifacts(
         root=root,
+        execution_metadata=EXECUTION_METADATA,
         source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
         sources_db=root / "data/sources.db",
         private_dir=private,
@@ -627,19 +635,55 @@ def test_public_receipt_rejects_arbitrary_ascii_after_rehash(tmp_path: Path) -> 
         _verify_fixture_artifacts(root, private, public, require_private=False)
 
 
-def test_role_contract_duplicate_controller_and_steward_permission_drift_fail() -> None:
-    role_contract = heldout.read_json(ROLE)
-    duplicate = json.loads(json.dumps(role_contract))
-    label_seat = next(seat for seat in duplicate["seats"] if seat["role_id"] == "heldout_label_reviewer")
-    label_seat["controller_identity_id"] = heldout.CONTROLLER_IDENTITY
-    with pytest.raises(heldout.PartitionError, match="reuse a controller identity"):
-        heldout.verify_role_binding(duplicate)
+def test_v2_1_schema_closure_and_action_receipt_tamper_fail_closed(tmp_path: Path) -> None:
+    root = _build_fixture_root(tmp_path)
+    private, public = _build_fixture_artifacts(root)
+    schema = heldout.read_json(root / SCHEMA.relative_to(ROOT))
+    author_path = private / "author_clearance_v1.json"
+    public_path = public / "public_receipt_v1.json"
+    author = heldout.read_json(author_path)
+    unexpected = json.loads(json.dumps(author))
+    unexpected["input_bindings"]["unexpected"] = "0" * 64
+    with pytest.raises(heldout.PartitionError, match="schema validation failed"):
+        heldout._schema_validate(unexpected, schema, "authorClearanceReceipt")
+    missing = json.loads(json.dumps(author))
+    del missing["action_receipt"]["task_id"]
+    with pytest.raises(heldout.PartitionError, match="schema validation failed"):
+        heldout._schema_validate(missing, schema, "authorClearanceReceipt")
 
-    weakened = json.loads(json.dumps(role_contract))
-    steward = next(seat for seat in weakened["seats"] if seat["role_id"] == heldout.ROLE_ID)
-    steward["must_not"].remove("extract_rules")
-    with pytest.raises(heldout.PartitionError, match="prohibited functions drift"):
-        heldout.verify_role_binding(weakened)
+    author["action_receipt"]["receipt_id"] = "phase3_functional_action:" + "0" * 64
+    author = heldout.attach_receipt_hash(author)
+    heldout.write_private_json(author_path, author)
+    receipt = heldout.read_json(public_path)
+    receipt["artifact_hashes"]["author_clearance_sha256"] = author["receipt_sha256"]
+    receipt["action_receipt"] = author["action_receipt"]
+    heldout.write_public_json(public_path, heldout.attach_receipt_hash(receipt))
+    with pytest.raises(heldout.PartitionError, match="public action receipt ID drift"):
+        _verify_fixture_artifacts(root, private, public)
+
+
+def test_public_only_verification_recomputes_action_identity(tmp_path: Path) -> None:
+    root = _build_fixture_root(tmp_path)
+    private, public = _build_fixture_artifacts(root)
+    public_path = public / "public_receipt_v1.json"
+    receipt = heldout.read_json(public_path)
+    receipt["action_receipt"]["receipt_id"] = "phase3_functional_action:" + "0" * 64
+    heldout.write_public_json(public_path, heldout.attach_receipt_hash(receipt))
+
+    with pytest.raises(heldout.PartitionError, match="public action receipt ID drift"):
+        _verify_fixture_artifacts(root, private, public, require_private=False)
+
+
+def test_v1_role_contract_and_v2_1_binding_drift_fail_closed() -> None:
+    role_contract = heldout.read_json(ROLE)
+    legacy = heldout.read_json(ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json")
+    with pytest.raises(heldout.PartitionError, match="functional-role"):
+        heldout.verify_role_binding(legacy)
+
+    drifted = json.loads(json.dumps(role_contract))
+    drifted["contract_inputs"]["combined_contract_sha256"] = "0" * 64
+    with pytest.raises(heldout.PartitionError, match="functional-role schema violation"):
+        heldout.verify_role_binding(drifted)
 
 
 def test_private_permissions_are_verified_for_directory_and_every_artifact(tmp_path: Path) -> None:
@@ -790,6 +834,7 @@ def test_malformed_comparison_fail_closed_and_source_drift(tmp_path: Path) -> No
     with pytest.raises(heldout.PartitionError, match=r"row count drifts|missing"):
         heldout.build_artifacts(
             root=root,
+            execution_metadata=EXECUTION_METADATA,
             source_universe=root / "data/projects/open_model_data/evidence/source_universe_v1",
             sources_db=root / "data/sources.db",
             private_dir=root / "batch_state/open-model-data/phase3-heldout",
@@ -822,6 +867,12 @@ def test_cli_build_verify_smoke(tmp_path: Path) -> None:
             "--schema",
             str(root / SCHEMA.relative_to(ROOT)),
             "build",
+            "--provider",
+            EXECUTION_METADATA["provider"],
+            "--started-at",
+            EXECUTION_METADATA["started_at"],
+            "--completed-at",
+            EXECUTION_METADATA["completed_at"],
             "--skip-source-freeze-git-binding",
         ]
     )

--- a/tests/test_open_model_phase3_rule_author_source_rows.py
+++ b/tests/test_open_model_phase3_rule_author_source_rows.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.projects.open_model_data import phase3_functional_roles as functional_roles
 from scripts.projects.open_model_data import phase3_heldout_partition as heldout
 from scripts.projects.open_model_data import phase3_rule_author_packets as packets
 from scripts.projects.open_model_data import phase3_rule_author_source_rows as rows
@@ -31,7 +32,7 @@ def _fixture(
 ) -> dict[str, Path]:
     root = tmp_path / "synthetic"
     data = root / "data/projects/open_model_data"
-    role = ROOT / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
+    role = ROOT / "data/projects/open_model_data/evidence/correction_protection_functional_role_contract_v2_1.json"
     evaluation = ROOT / "data/projects/open_model_data/evidence/correction_protection_evaluation_contract_v1.json"
     coverage = ROOT / "data/projects/open_model_data/evidence/correction_protection_coverage_contract_v1.json"
     policy = ROOT / "data/projects/open_model_data/evidence/correction_protection_near_duplicate_policy_v1.json"
@@ -62,11 +63,12 @@ def _fixture(
     freeze_receipt = {"schema_version": "phase3_source_universe_freeze_v1", "text_free": True, "merged_main_sha": "0" * 40, "families": [{"family_id": "ua_gec", "ledger_file": ledger.name, "ledger_sha256": rows.sha256_file(ledger)}]}
     _write(universe / "source-universe-freeze-receipt.json", freeze_receipt)
     steward = heldout.verify_role_binding(heldout.read_json(data / "role.json"))
-    clearance = {"schema_version": "phase3_author_clearance_receipt_v1", "text_free": True, "implementation_version": "phase3_heldout_partition_v1", "role_binding": steward, "input_bindings": {"combined_contract_sha256": packets.LEGACY_V1_V3_COMBINED_CONTRACT_SHA256, "role_contract_sha256": rows.sha256_file(data / "role.json"), "evaluation_contract_sha256": rows.sha256_file(data / "evaluation.json"), "coverage_contract_sha256": rows.sha256_file(data / "coverage.json"), "source_universe_receipt_sha256": rows.sha256_file(universe / "source-universe-freeze-receipt.json"), "near_duplicate_policy_fingerprint_sha256": packets.near_duplicate.PINNED_POLICY_FINGERPRINT, "ua_eval_exclusion_manifest_sha256": "2" * 64, "public_canary_exclusion_manifest_sha256": "3" * 64}, "cleared_units": [{key: unit[key] for key in ("family_id", "unit_id", "unit_sha256")} for unit in units], "cleared_unit_count": len(units), "heldout_excluded": True, "ua_eval_exclusion_enforced": True, "public_canary_exclusion_enforced": True, "heldout_complement_encoded": False, "fingerprints_encoded": False, "locators_encoded": False}
+    clearance = {"schema_version": "phase3_author_clearance_receipt_v2_1", "text_free": True, "implementation_version": "phase3_heldout_partition_v2_1", "role_binding": steward, "input_bindings": {"phase3_v2_contract_sha256": functional_roles.BASE_SHA256, "phase3_v2_1_amendment_sha256": functional_roles.AMENDMENT_SHA256, "combined_contract_sha256": functional_roles.COMBINED_SHA256, "role_contract_sha256": rows.sha256_file(data / "role.json"), "evaluation_contract_sha256": rows.sha256_file(data / "evaluation.json"), "coverage_contract_sha256": rows.sha256_file(data / "coverage.json"), "source_universe_receipt_sha256": rows.sha256_file(universe / "source-universe-freeze-receipt.json"), "near_duplicate_policy_fingerprint_sha256": packets.near_duplicate.PINNED_POLICY_FINGERPRINT, "ua_eval_exclusion_manifest_sha256": "2" * 64, "public_canary_exclusion_manifest_sha256": "3" * 64}, "cleared_units": [{key: unit[key] for key in ("family_id", "unit_id", "unit_sha256")} for unit in units], "cleared_unit_count": len(units), "heldout_excluded": True, "ua_eval_exclusion_enforced": True, "public_canary_exclusion_enforced": True, "heldout_complement_encoded": False, "fingerprints_encoded": False, "locators_encoded": False}
+    clearance["action_receipt"] = heldout.build_action_receipt(role_contract=heldout.read_json(data / "role.json"), role_contract_path=data / "role.json", input_bindings=clearance["input_bindings"], output=clearance["cleared_units"], execution_metadata={"provider": "local", "started_at": "2026-08-09T00:00:00Z", "completed_at": "2026-08-09T00:00:01Z"})
     clearance["receipt_sha256"] = packets.receipt_body_sha256(clearance)
     clearance_path = root / "private/author_clearance_v1.json"
     _write(clearance_path, clearance)
-    public = {"schema_version": "phase3_heldout_public_receipt_v1", "text_free": True, "input_bindings": {**clearance["input_bindings"], "sources_db_sha256": rows.sha256_file(db)}, "artifact_hashes": {"author_clearance_sha256": clearance["receipt_sha256"]}}
+    public = {"schema_version": "phase3_heldout_public_receipt_v2_1", "text_free": True, "input_bindings": {**clearance["input_bindings"], "sources_db_sha256": rows.sha256_file(db)}, "artifact_hashes": {"author_clearance_sha256": clearance["receipt_sha256"]}, "action_receipt": clearance["action_receipt"]}
     public["receipt_sha256"] = heldout.receipt_body_sha256(public)
     public_path = root / "public/partition.json"
     _write(public_path, public)
@@ -79,12 +81,14 @@ def _build(paths: dict[str, Path]) -> dict[str, object]:
 
 def _rewrite_clearance_and_public(paths: dict[str, Path], clearance: dict[str, object]) -> None:
     clearance["cleared_unit_count"] = len(clearance["cleared_units"])
+    clearance["action_receipt"] = heldout.build_action_receipt(role_contract=heldout.read_json(paths["role"]), role_contract_path=paths["role"], input_bindings=clearance["input_bindings"], output=clearance["cleared_units"], execution_metadata={"provider": "local", "started_at": "2026-08-09T00:00:00Z", "completed_at": "2026-08-09T00:00:01Z"})
     clearance["receipt_sha256"] = packets.receipt_body_sha256(
         {key: value for key, value in clearance.items() if key != "receipt_sha256"}
     )
     _write(paths["clearance"], clearance)
     public = rows.read_json(paths["public"], "public")
     public["artifact_hashes"]["author_clearance_sha256"] = clearance["receipt_sha256"]
+    public["action_receipt"] = clearance["action_receipt"]
     public["receipt_sha256"] = heldout.receipt_body_sha256(
         {key: value for key, value in public.items() if key != "receipt_sha256"}
     )
@@ -111,7 +115,7 @@ def test_rows_are_deterministic_private_complete_and_packet_compiler_compatible(
     receipt = rows.read_json(paths["receipt"], "public receipt")
     assert receipt["text_free"] is True and "source_text" not in rows.canonical_json(receipt)
     assert receipt["rule_author_binding"]["role_id"] == "rule_author_extractor"
-    assert receipt["rule_author_binding"]["controller_identity_id"] != receipt["role_binding"]["controller_identity_id"]
+    assert receipt["rule_author_binding"]["task_id"] != receipt["role_binding"]["task_id"]
     assert receipt["input_bindings"]["ua_gec_ledger_sha256"] == rows.sha256_file(paths["universe"] / "ua_gec.units.jsonl")
     assert receipt["input_bindings"]["partition_public_receipt_body_sha256"] == rows.read_json(paths["public"])["receipt_sha256"]
     assert receipt["input_bindings"]["partition_public_receipt_file_sha256"] == rows.sha256_file(paths["public"])
@@ -138,6 +142,19 @@ def test_empty_source_lang_is_schema_valid_and_preserves_frozen_hash(tmp_path: P
     )
     for item in materialized:
         validator.validate(item)
+
+
+def test_source_row_receipt_schema_closes_nested_objects(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    receipt = _build(paths)
+    closed = json.loads(json.dumps(receipt))
+    closed["exclusions"]["unexpected"] = True
+    with pytest.raises(rows.SourceRowsError, match="schema violation"):
+        rows._validate(closed, "receipt", "source-row receipt")
+    missing = json.loads(json.dumps(receipt))
+    del missing["action_receipt"]["task_id"]
+    with pytest.raises(rows.SourceRowsError, match="schema violation"):
+        rows._validate(missing, "receipt", "source-row receipt")
 
 
 def test_rejects_stale_db_test_injection_and_unexpected_or_symlink_private_inputs(tmp_path: Path) -> None:
@@ -180,8 +197,8 @@ def test_clearance_omission_is_exact_not_a_complement(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("mutation, match", [
-    (lambda clearance: clearance.__setitem__("cleared_units", [*clearance["cleared_units"], clearance["cleared_units"][0]]), "duplicate"),
-    (lambda clearance: clearance.__setitem__("cleared_units", [{"family_id": "ua_gec"}]), "schema violation"),
+    (lambda clearance: clearance.__setitem__("cleared_units", [*clearance["cleared_units"], clearance["cleared_units"][0]]), "count or uniqueness"),
+    (lambda clearance: clearance.__setitem__("cleared_units", [{"family_id": "ua_gec"}]), "identity malformed"),
     (lambda clearance: clearance["cleared_units"][0].__setitem__("unit_sha256", "0" * 64), "unit hash drift"),
 ])
 def test_rejects_duplicate_missing_or_wrong_hash_clearance(tmp_path: Path, mutation, match: str) -> None:
@@ -193,7 +210,7 @@ def test_rejects_duplicate_missing_or_wrong_hash_clearance(tmp_path: Path, mutat
         _build(paths)
 
 
-def test_rejects_stale_contract_or_partition_receipt_binding_and_permission_drift(tmp_path: Path) -> None:
+def test_rejects_stale_contract_or_partition_receipt_binding(tmp_path: Path) -> None:
     paths = _fixture(tmp_path)
     paths["coverage"].write_text("{}\n", encoding="utf-8")
     with pytest.raises(rows.SourceRowsError, match="coverage-contract binding drift"):
@@ -204,6 +221,41 @@ def test_rejects_stale_contract_or_partition_receipt_binding_and_permission_drif
     public["receipt_sha256"] = heldout.receipt_body_sha256({key: value for key, value in public.items() if key != "receipt_sha256"})
     _write(paths["public"], public)
     with pytest.raises(rows.SourceRowsError, match="sources DB binding drift"):
+        _build(paths)
+
+
+def test_rejects_rehashed_but_invalid_clearance_action_identity(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    clearance["action_receipt"]["receipt_id"] = "phase3_functional_action:" + "0" * 64
+    clearance["receipt_sha256"] = packets.receipt_body_sha256(
+        {key: value for key, value in clearance.items() if key != "receipt_sha256"}
+    )
+    _write(paths["clearance"], clearance)
+    public = rows.read_json(paths["public"], "public")
+    public["artifact_hashes"]["author_clearance_sha256"] = clearance["receipt_sha256"]
+    public["action_receipt"] = clearance["action_receipt"]
+    public["receipt_sha256"] = heldout.receipt_body_sha256(
+        {key: value for key, value in public.items() if key != "receipt_sha256"}
+    )
+    _write(paths["public"], public)
+
+    with pytest.raises(rows.SourceRowsError, match="clearance action receipt drift"):
+        _build(paths)
+
+
+def test_rejects_legacy_clearance_and_permission_drift(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path / "legacy-clearance")
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    clearance["schema_version"] = "phase3_author_clearance_receipt_v1"
+    _write(paths["clearance"], clearance)
+    with pytest.raises(rows.SourceRowsError, match="legacy v1 clearance"):
+        _build(paths)
+    paths = _fixture(tmp_path / "old-combined")
+    clearance = rows.read_json(paths["clearance"], "clearance")
+    clearance["input_bindings"]["combined_contract_sha256"] = packets.LEGACY_V1_V3_COMBINED_CONTRACT_SHA256
+    _rewrite_clearance_and_public(paths, clearance)
+    with pytest.raises(rows.SourceRowsError, match="combined-contract binding drift"):
         _build(paths)
     paths = _fixture(tmp_path / "permissions")
     _build(paths)

--- a/tests/test_open_model_phase3_source_dispositions.py
+++ b/tests/test_open_model_phase3_source_dispositions.py
@@ -70,16 +70,85 @@ def _freeze(tmp_path: Path, totals: dict[str, int]) -> tuple[Path, dict[str, lis
 
 
 def _role_contract(path: Path) -> None:
-    _json(path, {
-        "seats": [
-            {"role_id": "rule_author_extractor", "assignment_state": "assigned_verified", "controller_identity_attested": True, "controller_identity_id": "controller.extractor"},
-            {"role_id": "ukrainian_source_reviewer", "assignment_state": "assigned_verified", "controller_identity_attested": True, "controller_identity_id": "controller.source_reviewer"},
-        ],
-        "task_bindings": [
-            {"role_id": "rule_author_extractor", "reserved_task_id": "task.extractor", "controller_identity_id": "controller.extractor", "status": "identity_attested_pre_artifact"},
-            {"role_id": "ukrainian_source_reviewer", "reserved_task_id": "task.source_reviewer", "controller_identity_id": "controller.source_reviewer", "status": "identity_attested_pre_artifact"},
-        ],
-    })
+    path.write_bytes(dispositions.DEFAULT_ROLE_CONTRACT.read_bytes())
+
+
+def _action(
+    role: Path,
+    *,
+    role_id: str,
+    action_kind: str,
+    input_sha: str,
+    output_sha: str,
+) -> dict[str, object]:
+    contract = json.loads(role.read_text(encoding="utf-8"))
+    actor = next(item for item in contract["functional_roles"] if item["role_id"] == role_id)
+    identity = {
+        "role_id": actor["role_id"],
+        "task_id": actor["task_id"],
+        "input_manifest_sha256": input_sha,
+        "evaluation_cycle_id": contract["evaluation_cycle"]["evaluation_cycle_id"],
+        "output_sha256": output_sha,
+        "status": "completed",
+    }
+    return {
+        "receipt_id": "phase3_functional_action:"
+        + dispositions.sha256_bytes(canonical_json(identity).encode("utf-8")),
+        "role_id": actor["role_id"],
+        "task_id": actor["task_id"],
+        "action_kind": action_kind,
+        "provider": dispositions.ROLE_PROVIDERS[role_id],
+        "exact_model": actor["exact_model"],
+        "model_family": actor["model_family"],
+        "harness": actor["harness"],
+        "input_manifest_sha256": input_sha,
+        "output_sha256": output_sha,
+        "evaluation_cycle_id": contract["evaluation_cycle"]["evaluation_cycle_id"],
+        "base_contract_sha256": dispositions.functional_roles.BASE_SHA256,
+        "amendment_sha256": dispositions.functional_roles.AMENDMENT_SHA256,
+        "combined_contract_sha256": dispositions.functional_roles.COMBINED_SHA256,
+        "functional_role_contract_sha256": dispositions.sha256_file(role),
+        "conflict_graph_sha256": dispositions.functional_roles.conflict_graph_sha256(contract),
+        "started_at": "2026-08-09T00:00:00Z",
+        "completed_at": "2026-08-09T00:00:01Z",
+        "status": "completed",
+    }
+
+
+def _author_action(role: Path, *, freeze_sha: str, families_sha: str) -> dict[str, object]:
+    return _action(
+        role,
+        role_id="rule_author_extractor",
+        action_kind="source_disposition_proposal",
+        input_sha=dispositions.sha256_bytes(
+            canonical_json({"source_freeze_receipt_sha256": freeze_sha}).encode("utf-8")
+        ),
+        output_sha=families_sha,
+    )
+
+
+def _review_action(
+    role: Path,
+    *,
+    freeze_sha: str,
+    families_sha: str,
+    author_action_receipt_id: str,
+) -> dict[str, object]:
+    return _action(
+        role,
+        role_id="ukrainian_source_reviewer",
+        action_kind="source_disposition_review",
+        input_sha=dispositions.sha256_bytes(
+            canonical_json(
+                {
+                    "source_freeze_receipt_sha256": freeze_sha,
+                    "disposition_families_sha256": families_sha,
+                    "author_action_receipt_id": author_action_receipt_id,
+                }
+            ).encode("utf-8")
+        ),
+        output_sha=dispositions.sha256_bytes(canonical_json({"verdict": "APPROVE"}).encode("utf-8")),
+    )
 
 
 def _input(freeze: Path, units: dict[str, list[dict[str, str]]], totals: dict[str, int], role: Path) -> dict[str, object]:
@@ -105,23 +174,47 @@ def _input(freeze: Path, units: dict[str, list[dict[str, str]]], totals: dict[st
         })
     document = {
         "schema_version": dispositions.INPUT_SCHEMA_VERSION, "text_free": True,
+        "phase3_v2_contract_sha256": dispositions.functional_roles.BASE_SHA256,
+        "phase3_v2_1_amendment_sha256": dispositions.functional_roles.AMENDMENT_SHA256,
+        "combined_contract_sha256": dispositions.functional_roles.COMBINED_SHA256,
+        "producer_task_id": dispositions.PRODUCER_TASK_ID,
         "source_freeze_receipt_sha256": dispositions.sha256_file(freeze / dispositions.FREEZE_RECEIPT_FILE),
         "role_contract_sha256": dispositions.sha256_file(role),
-        "author_binding": {"role_id": "rule_author_extractor", "controller_identity_id": "controller.extractor", "task_id": "task.extractor"},
-        "source_review_binding": {"role_id": "ukrainian_source_reviewer", "controller_identity_id": "controller.source_reviewer", "task_id": "task.source_reviewer", "receipt_sha256": "0" * 64},
+        "conflict_graph_sha256": dispositions.functional_roles.conflict_graph_sha256(
+            json.loads(role.read_text(encoding="utf-8"))
+        ),
+        "author_binding": dispositions.functional_roles.binding_for_role(
+            json.loads(role.read_text(encoding="utf-8")), "rule_author_extractor"
+        ),
+        "source_review_binding": {
+            **dispositions.functional_roles.binding_for_role(
+                json.loads(role.read_text(encoding="utf-8")), "ukrainian_source_reviewer"
+            ),
+            "receipt_sha256": "0" * 64,
+        },
         "families": families,
     }
+    families_sha = dispositions.sha256_bytes(canonical_json(document["families"]).encode("utf-8"))
+    author_action = _author_action(
+        role,
+        freeze_sha=document["source_freeze_receipt_sha256"],
+        families_sha=families_sha,
+    )
+    document["author_binding"]["action_receipt"] = author_action
     review_receipt = {
         "schema_version": dispositions.SOURCE_REVIEW_RECEIPT_SCHEMA_VERSION,
         "text_free": True,
         "reviewer_role_id": "ukrainian_source_reviewer",
-        "controller_identity_id": "controller.source_reviewer",
-        "task_id": "task.source_reviewer",
+        "task_id": document["source_review_binding"]["task_id"],
         "source_freeze_receipt_sha256": document["source_freeze_receipt_sha256"],
-        "disposition_families_sha256": dispositions.sha256_bytes(
-            canonical_json(document["families"]).encode("utf-8")
-        ),
+        "disposition_families_sha256": families_sha,
         "verdict": "APPROVE",
+        "action_receipt": _review_action(
+            role,
+            freeze_sha=document["source_freeze_receipt_sha256"],
+            families_sha=families_sha,
+            author_action_receipt_id=author_action["receipt_id"],
+        ),
     }
     _json(role.parent / "source-review-receipt.json", review_receipt)
     document["source_review_binding"]["receipt_sha256"] = dispositions.sha256_file(
@@ -145,6 +238,18 @@ def _refresh_review_receipt(document: dict[str, object], role: Path) -> None:
     receipt["disposition_families_sha256"] = dispositions.sha256_bytes(
         canonical_json(document["families"]).encode("utf-8")
     )
+    author_action = _author_action(
+        role,
+        freeze_sha=receipt["source_freeze_receipt_sha256"],
+        families_sha=receipt["disposition_families_sha256"],
+    )
+    document["author_binding"]["action_receipt"] = author_action
+    receipt["action_receipt"] = _review_action(
+        role,
+        freeze_sha=receipt["source_freeze_receipt_sha256"],
+        families_sha=receipt["disposition_families_sha256"],
+        author_action_receipt_id=author_action["receipt_id"],
+    )
     _json(receipt_path, receipt)
     document["source_review_binding"]["receipt_sha256"] = dispositions.sha256_file(receipt_path)
 
@@ -160,6 +265,8 @@ def test_compiles_exact_text_free_bijection_and_zero_receipt(tmp_path: Path, tin
         "input_disposition_row_count": 0, "output_disposition_row_count": 0, "status": "ZERO_FAMILY_ACCOUNTED",
     }
     assert receipt["disposition_ledger"]["row_count"] == 7
+    assert receipt["combined_contract_sha256"] == dispositions.functional_roles.COMBINED_SHA256
+    assert receipt["producer_task_id"] == dispositions.PRODUCER_TASK_ID
     assert receipt["author_binding"] == document["author_binding"]
     assert receipt["source_review_binding"] == document["source_review_binding"]
     assert all(item["ledger_universe_sha256"] == item["audit_universe_sha256"] for item in receipt["families"])
@@ -256,6 +363,31 @@ def test_converted_disposition_forbids_nonconversion_payload(tmp_path: Path, tin
         _compile(tmp_path, freeze, document, role)
 
 
+def test_rights_limit_cannot_replace_a_v2_disposition(tmp_path: Path, tiny_totals: dict[str, int]) -> None:
+    freeze, units = _freeze(tmp_path, tiny_totals)
+    role = tmp_path / "roles.json"
+    _role_contract(role)
+    document = _input(freeze, units, tiny_totals, role)
+    row = next(item for item in document["families"] if item["family_id"] == "ua_gec")["dispositions"][0]
+    for key in (
+        "canonical_identity",
+        "source_role",
+        "claim_type",
+        "evidence_locator_sha256s",
+        "consumer_view",
+        "predicate_sha256",
+        "artifact_sha256",
+    ):
+        row.pop(key)
+    row["disposition_code"] = "rights_limited_locator_only"
+    row["nonconversion"] = {
+        "reason_code": "rights_limit_is_only_a_capability_tag",
+        "unit_specific_locator_sha256": _sha(row["unit_id"]),
+    }
+    with pytest.raises(dispositions.DispositionError, match="schema violation"):
+        _compile(tmp_path, freeze, document, role)
+
+
 def test_repeated_nonconversion_reason_requires_predicate_or_rationale(tmp_path: Path, tiny_totals: dict[str, int], monkeypatch: pytest.MonkeyPatch) -> None:
     totals = dict(tiny_totals)
     totals["ua_gec"] = 10
@@ -296,8 +428,8 @@ def test_fails_closed_on_provenance_binding_and_zero_receipt_tampering(tmp_path:
     role = tmp_path / "roles.json"
     _role_contract(role)
     document = _input(freeze, units, tiny_totals, role)
-    document["author_binding"]["controller_identity_id"] = "controller.other"
-    with pytest.raises(dispositions.DispositionError, match="rule_author_extractor controller binding mismatch"):
+    document["author_binding"]["controller_identity_id"] = "obsolete.controller.identity"
+    with pytest.raises(dispositions.DispositionError, match="schema violation"):
         _compile(tmp_path, freeze, document, role)
     document = _input(freeze, units, tiny_totals, role)
     zero = next(item for item in document["families"] if item["family_id"] == "other_normative_style_inventory")
@@ -318,9 +450,9 @@ def test_fails_closed_on_role_contract_hash_tampering(tmp_path: Path, tiny_total
 
 @pytest.mark.parametrize("tamper, error", [
     ("missing", "schema violation"),
-    ("swapped", "rule_author_extractor controller binding mismatch"),
-    ("self_review", "identities must differ"),
-    ("wrong_task", "rule_author_extractor task binding mismatch"),
+    ("swapped", "schema violation"),
+    ("self_review", "schema violation"),
+    ("wrong_task", "schema violation"),
     ("receipt", "source review receipt binding mismatch"),
 ])
 def test_fails_closed_on_source_authoring_provenance_tampering(
@@ -333,10 +465,11 @@ def test_fails_closed_on_source_authoring_provenance_tampering(
     if tamper == "missing":
         document.pop("author_binding")
     elif tamper == "swapped":
-        document["author_binding"]["controller_identity_id"] = "controller.source_reviewer"
-        document["source_review_binding"]["controller_identity_id"] = "controller.extractor"
+        author_task = document["author_binding"]["task_id"]
+        document["author_binding"]["task_id"] = document["source_review_binding"]["task_id"]
+        document["source_review_binding"]["task_id"] = author_task
     elif tamper == "self_review":
-        document["source_review_binding"]["controller_identity_id"] = "controller.extractor"
+        document["source_review_binding"]["task_id"] = document["author_binding"]["task_id"]
     elif tamper == "wrong_task":
         document["author_binding"]["task_id"] = "task.other"
     else:
@@ -345,30 +478,34 @@ def test_fails_closed_on_source_authoring_provenance_tampering(
         _compile(tmp_path, freeze, document, role)
 
 
-def test_fails_closed_on_drifted_role_contract_identity(tmp_path: Path, tiny_totals: dict[str, int]) -> None:
+def test_fails_closed_on_drifted_role_contract_task(tmp_path: Path, tiny_totals: dict[str, int]) -> None:
     freeze, units = _freeze(tmp_path, tiny_totals)
     role = tmp_path / "roles.json"
     _role_contract(role)
     document = _input(freeze, units, tiny_totals, role)
     contract = json.loads(role.read_text(encoding="utf-8"))
-    contract["seats"][0]["controller_identity_id"] = "controller.drifted"
-    contract["task_bindings"][0]["controller_identity_id"] = "controller.drifted"
+    next(item for item in contract["functional_roles"] if item["role_id"] == "rule_author_extractor")[
+        "task_id"
+    ] = "phase3-v2-1-drifted-author"
     _json(role, contract)
     document["role_contract_sha256"] = dispositions.sha256_file(role)
-    with pytest.raises(dispositions.DispositionError, match="rule_author_extractor controller binding mismatch"):
+    with pytest.raises(dispositions.DispositionError, match="functional-role schema violation"):
         _compile(tmp_path, freeze, document, role)
 
 
-def test_fails_closed_on_unattested_role_task_status(tmp_path: Path, tiny_totals: dict[str, int]) -> None:
+def test_fails_closed_on_obsolete_role_contract(tmp_path: Path, tiny_totals: dict[str, int]) -> None:
     freeze, units = _freeze(tmp_path, tiny_totals)
     role = tmp_path / "roles.json"
     _role_contract(role)
     document = _input(freeze, units, tiny_totals, role)
-    contract = json.loads(role.read_text(encoding="utf-8"))
-    contract["task_bindings"][0]["status"] = "reserved_not_launched"
-    _json(role, contract)
+    role.write_bytes(
+        (
+            dispositions.ROOT
+            / "data/projects/open_model_data/evidence/correction_protection_role_contract_v1.json"
+        ).read_bytes()
+    )
     document["role_contract_sha256"] = dispositions.sha256_file(role)
-    with pytest.raises(dispositions.DispositionError, match="task binding is not pre-artifact attested"):
+    with pytest.raises(dispositions.DispositionError, match="schema violation"):
         _compile(tmp_path, freeze, document, role)
 
 
@@ -380,6 +517,65 @@ def test_source_review_receipt_binds_exact_disposition_payload(tmp_path: Path, t
     family = next(item for item in document["families"] if item["family_id"] == "ua_gec")
     family["dispositions"][0]["artifact_sha256"] = "f" * 64
     with pytest.raises(dispositions.DispositionError, match="source review receipt disposition binding mismatch"):
+        _compile(tmp_path, freeze, document, role)
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("provider", "wrong-provider", "was expected"),
+        ("exact_model", "wrong-model", "lane mismatch"),
+        ("input_manifest_sha256", "0" * 64, "action input mismatch"),
+        ("output_sha256", "0" * 64, "action output mismatch"),
+        ("conflict_graph_sha256", "0" * 64, "role-graph binding mismatch"),
+        ("receipt_id", "phase3_functional_action:" + "0" * 64, "receipt ID mismatch"),
+    ],
+)
+def test_source_author_action_receipt_fails_closed(
+    tmp_path: Path,
+    tiny_totals: dict[str, int],
+    field: str,
+    value: str,
+    error: str,
+) -> None:
+    freeze, units = _freeze(tmp_path, tiny_totals)
+    role = tmp_path / "roles.json"
+    _role_contract(role)
+    document = _input(freeze, units, tiny_totals, role)
+    document["author_binding"]["action_receipt"][field] = value
+    with pytest.raises(dispositions.DispositionError, match=error):
+        _compile(tmp_path, freeze, document, role)
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("provider", "wrong-provider", "provider mismatch"),
+        ("task_id", "phase3-v2-1-heldout-label-review", "task binding mismatch"),
+        ("exact_model", "wrong-model", "lane mismatch"),
+        ("input_manifest_sha256", "0" * 64, "action input mismatch"),
+        ("conflict_graph_sha256", "0" * 64, "role-graph binding mismatch"),
+        ("status", "failed", "action is not complete"),
+        ("receipt_id", "phase3_functional_action:" + "0" * 64, "receipt ID mismatch"),
+    ],
+)
+def test_source_review_action_receipt_fails_closed(
+    tmp_path: Path,
+    tiny_totals: dict[str, int],
+    field: str,
+    value: str,
+    error: str,
+) -> None:
+    freeze, units = _freeze(tmp_path, tiny_totals)
+    role = tmp_path / "roles.json"
+    _role_contract(role)
+    document = _input(freeze, units, tiny_totals, role)
+    receipt_path = tmp_path / "source-review-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["action_receipt"][field] = value
+    _json(receipt_path, receipt)
+    document["source_review_binding"]["receipt_sha256"] = dispositions.sha256_file(receipt_path)
+    with pytest.raises(dispositions.DispositionError, match=error):
         _compile(tmp_path, freeze, document, role)
 
 


### PR DESCRIPTION
## What changed

- migrates held-out partition, rule-author source-row materialization, and source-disposition compilation from obsolete controller identities to the pinned Phase 3 v2.1 functional task contract
- binds every current receipt to the base, amendment, combined contract, functional-role ledger, conflict graph, exact task, exact execution lane, and action identity
- requires explicit held-out execution metadata instead of fabricated timestamps
- rejects legacy v1 clearance on the current source-row path
- preserves exact frozen family denominators and removes rights limits as a disposition escape
- closes nested schemas and adds rehashed-tamper coverage for public-only and private verification

## Why

PR #6405 migrated the packet compiler and runner, but these three live entry points still consumed the invalidated v1 controller schema. That prevented a truthful ENGINE_READY result and left current receipts unable to prove the v2.1 role graph.

## Validation

- 111 focused and integration tests passed
- Ruff passed on all changed Python and test files
- Python compilation passed
- all three Draft 2020-12 schemas validated
- staged OPSEC audit passed
- agent trailer lint passed
- git diff check passed

## Phase 3 status

- ENGINE_READY: unmet; additional disposition audit, lexical, textbook, Pravopys, scorer, and outsider runtime work remains
- SOURCE_COVERAGE_READY: unmet
- LINGUISTICALLY_VALIDATED: unmet
- CONSUMER_PROVEN: unmet

This PR makes no Ukrainian linguistic decision, labels no held-out material, changes no denominator, and does not authorize Phase 4.

Part of #6375.
