### PR TITLE
fix(tests): isolate telemetry fixtures (#6419)

### DIFF
--- a/tests/test_api_telemetry_footer.py
+++ b/tests/test_api_telemetry_footer.py
@@ -104,8 +104,20 @@ def test_current_context_telemetry_skips_newest_transcript_without_usage(
     tmp_path,
     monkeypatch,
 ) -> None:
-    projects = tmp_path / ".claude" / "projects"
-    project_dir = projects / "-tmp-learn-ukrainian"
+    # Exclusive server/test hooks must not leak into this fixture — when set,
+    # resolve_transcript_paths returns only that path and never scans HOME.
+    monkeypatch.delenv("LEARN_UKRAINIAN_TRANSCRIPT_PATH", raising=False)
+    monkeypatch.delenv("CLAUDE_TRANSCRIPT_PATH", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    project_root = tmp_path / "learn-ukrainian"
+    project_root.mkdir()
+    # Match scripts.api.telemetry.transcript_tokens._claude_project_dir_name
+    # (resolved path with "/" → "-") so candidates come from the exact dir,
+    # not the *learn-ukrainian* fallback glob.
+    project_dir = (
+        tmp_path / ".claude" / "projects" / str(project_root.resolve()).replace("/", "-")
+    )
     project_dir.mkdir(parents=True)
     older = project_dir / "older.jsonl"
     older.write_text(
@@ -130,9 +142,8 @@ def test_current_context_telemetry_skips_newest_transcript_without_usage(
         encoding="utf-8",
     )
     newer.touch()
-    monkeypatch.setenv("HOME", str(tmp_path))
 
-    telemetry = current_context_telemetry(tmp_path / "learn-ukrainian")
+    telemetry = current_context_telemetry(project_root)
 
     assert telemetry is not None
     assert telemetry.transcript_path == older

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import yaml
 
 from scripts.build import linear_pipeline
 from scripts.common.thresholds import QG_DIMS
@@ -18,6 +19,38 @@ def _event_sink(events: list[dict[str, Any]]):
         events.append({"event": event, "ts": "2026-05-05T00:00:00+00:00", **fields})
 
     return sink
+
+
+def _qg_fixture_plan(tmp_path: Path) -> Path:
+    """Minimal plan for run_python_qg unit tests (no curriculum/ checkout required)."""
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        yaml.safe_dump(
+            {
+                "module": "a1-020",
+                "level": "A1",
+                "sequence": 20,
+                "slug": "my-morning",
+                "title": "Мій ранок",
+                "subtitle": "Зворотні дієслова",
+                "word_target": 89,
+                "content_outline": [
+                    {
+                        "section": "Діалоги",
+                        "words": 89,
+                        "points": ["Introduce a morning dialogue."],
+                    }
+                ],
+                "references": [
+                    {"title": "Караман Grade 10, p.176", "verbatim_required": False}
+                ],
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return plan_path
 
 
 def _writer_prompt() -> str:
@@ -363,7 +396,7 @@ def test_writer_rule_fired_event_emitted_on_known_failure_class(tmp_path: Path) 
 
     linear_pipeline.run_python_qg(
         module_dir,
-        linear_pipeline.plan_path_for("a1", "my-morning"),
+        _qg_fixture_plan(tmp_path),
         verify_words_fn=verify_words,
         event_sink=_event_sink(events),
     )
@@ -397,7 +430,7 @@ def test_python_qg_surface_policy_scans_yaml_sidecars(tmp_path: Path) -> None:
 
     report = linear_pipeline.run_python_qg(
         module_dir,
-        linear_pipeline.plan_path_for("a1", "my-morning"),
+        _qg_fixture_plan(tmp_path),
         verify_words_fn=verify_words,
     )
 


### PR DESCRIPTION
## Summary
- `test_current_context_telemetry_skips_newest_transcript_without_usage` failed when `LEARN_UKRAINIAN_TRANSCRIPT_PATH` / `CLAUDE_TRANSCRIPT_PATH` leaked into the process (exclusive hooks skip HOME scan → `None`). Clear those env vars and place transcripts under the resolved Claude project dir name.
- `test_writer_rule_fired_event_emitted_on_known_failure_class` and `test_python_qg_surface_policy_scans_yaml_sidecars` called `plan_path_for("a1", "my-morning")`, which requires `curriculum/` on disk. Sparse agent worktrees (and any checkout without that tree) raised `FileNotFoundError`. Use a temp plan fixture instead; product gates unchanged.

Fixes #6419

## Root cause per test
1. **Footer skip-newest**: fixture isolation gap vs intentional exclusive env hooks in `resolve_transcript_paths` (related live symptom: `_telemetry.ctx: null` when hooks point at usage-less transcripts — #5769 sibling, not redesigned here).
2. **writer_rule_fired**: test env assumption (curriculum path), not a product regression in rule emission.
3. **surface_policy YAML sidecars**: same curriculum path assumption; gate logic already correct on full trees.

## Test plan
- [x] `LEARN_UKRAINIAN_TRANSCRIPT_PATH=/tmp/no-usage.jsonl .venv/bin/python -m pytest tests/test_api_telemetry_footer.py tests/test_linear_pipeline_telemetry.py -q` (17 passed in sparse worktree)
- [x] ruff on changed files
- [x] `git diff --check`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)