### PR TITLE
fix(agent-runtime): auto-approve Grok write dispatches

### DIFF
--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -15,8 +15,13 @@ injected — HOME (already allow-listed by env_sanitize) is sufficient.
 
 Mode → ``--permission-mode``:
 - ``read-only``       → ``plan``               (analysis only, no mutations)
-- ``workspace-write`` → ``acceptEdits``        (auto-accept file edits, headless)
-- ``danger``          → ``bypassPermissions``  (full autonomy)
+- ``workspace-write`` → ``acceptEdits`` + ``--always-approve``
+  (unattended edits and Bash within the dispatch worktree)
+- ``danger``          → ``bypassPermissions`` + ``--always-approve``
+  (unattended full autonomy within the dispatch worktree)
+
+Trail and review isolation use their own explicit tool/deny policies; they do
+not inherit the ordinary write-dispatch approval grant.
 
 ``resume_policy`` is ``never`` in the registry: the CLI's ``--resume`` +
 cross-session memory risk worktree contamination — the same footgun as Codex.
@@ -57,6 +62,12 @@ _MODE_PERMISSION: dict[str, str] = {
     "workspace-write": "acceptEdits",
     "danger": "bypassPermissions",
 }
+
+# Native Grok separates file-edit acceptance from approval for shell/tool
+# executions. Dispatch worktrees are the write boundary, so non-isolated
+# write-capable dispatches must grant both for ``git push`` / ``gh pr create``
+# to complete without a human approval prompt.
+_UNATTENDED_WRITE_MODES: frozenset[str] = frozenset({"workspace-write", "danger"})
 
 # MCP servers that are safe to run under an execution-capable permission mode
 # (read-only data lookups, no mutations). ONLY these may trigger the plan→exec
@@ -237,8 +248,9 @@ class GrokBuildAdapter:
             permission_mode = "bypassPermissions" if mcp_read_only else _MODE_PERMISSION[mode]
         cmd.extend(["--permission-mode", permission_mode])
         cmd.extend(["--cwd", str(execution_cwd)])
-        if mcp_read_only and not review_isolation:
+        if (mcp_read_only or mode in _UNATTENDED_WRITE_MODES) and not review_isolation and not trail_isolation:
             cmd.append("--always-approve")
+        if mcp_read_only and not review_isolation:
             cmd.append("--no-plan")
             cmd.append("--disable-web-search")
             for rule in _MCP_REVIEW_DENY_RULES:

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -74,6 +74,62 @@ def test_mode_permission_mapping(tmp_path):
         assert _val(plan.cmd, "--permission-mode") == perm
 
 
+@pytest.mark.parametrize("mode", ["workspace-write", "danger"])
+def test_write_capable_modes_auto_approve_headless_tool_execution(tmp_path, mode):
+    plan = _build("commit and push", tmp_path, mode=mode)
+
+    assert "--always-approve" in plan.cmd
+
+
+def test_read_only_mode_does_not_auto_approve_tool_execution(tmp_path):
+    plan = _build("inspect only", tmp_path, mode="read-only")
+
+    assert _val(plan.cmd, "--permission-mode") == "plan"
+    assert "--always-approve" not in plan.cmd
+
+
+def test_trail_isolation_does_not_inherit_write_approval(tmp_path):
+    tool_config = {
+        "trail_isolation": True,
+        "allowed_tools": "Read,Grep,Glob",
+        "mcp_config_path": str(tmp_path / ".mcp.json"),
+        "setting_sources": "",
+        "strict_mcp_config": True,
+        "tools": "Read,Grep,Glob",
+        "trail_isolation_cwd": str(tmp_path),
+    }
+    with patch(
+        "agent_runtime.adapters.grok_build.assert_trail_isolation_config",
+        return_value=tmp_path,
+    ):
+        plan = _build("inspect trail", tmp_path, mode="read-only", tool_config=tool_config)
+
+    assert _val(plan.cmd, "--permission-mode") == "default"
+    assert "--always-approve" not in plan.cmd
+    assert "Bash" in [plan.cmd[index + 1] for index, item in enumerate(plan.cmd) if item == "--deny"]
+
+
+def test_review_isolation_keeps_its_existing_approval_and_denies(tmp_path):
+    review_root = tmp_path / "review"
+    for child in ("tmp", "home", "exec"):
+        (review_root / child).mkdir(parents=True, exist_ok=True)
+    tool_config = {
+        "review_isolation": True,
+        "review_engine_binary": "/usr/bin/true",
+    }
+    with patch(
+        "scripts.review.isolation.validated_review_write_root",
+        return_value=review_root,
+    ):
+        plan = _build("review evidence", tmp_path, mode="read-only", tool_config=tool_config)
+
+    assert _val(plan.cmd, "--permission-mode") == "bypassPermissions"
+    assert "--always-approve" in plan.cmd
+    denied = [plan.cmd[index + 1] for index, item in enumerate(plan.cmd) if item == "--deny"]
+    assert "Bash" in denied
+    assert {"Write", "Edit", "MultiEdit", "NotebookEdit"} <= set(denied)
+
+
 def test_unsupported_mode_raises(tmp_path):
     with pytest.raises(ValueError, match="unsupported mode"):
         _build("x", tmp_path, mode="bogus")


### PR DESCRIPTION
## Summary

- add `--always-approve` to ordinary native Grok `workspace-write` and `danger` invocation plans
- keep read-only, trail isolation, and review isolation policies distinct and covered by tests

## Root cause

`workspace-write` used `acceptEdits`, which auto-approved file edits but still left shell tool execution awaiting human approval; dispatches therefore could commit and then stall at `git push` or `gh pr create`.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/adapters/grok_build.py tests/test_grok_build_adapter.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_grok_build_adapter.py -q` (31 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_review_isolation.py -k grok_adapter_uses_sealed_prompt_file_for_large_review_evidence -q` (1 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `git diff --check FETCH_HEAD..HEAD`

Fixes #6522