### PR TITLE
feat(practice): integrate ЗНО/НМТ decks in modes grid

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 9326942a9e6178311eb7a065b1622db700ddc94bb03388cc9e1c4aecf49472f0
+  components_sha256: 01025ad5103af70c4937a2bc3f786589c9a8d77206eddda7b1e8f8911f0fe8c3
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -2719,6 +2719,14 @@ components:
       - name: decks
         type: ZnoPracticeDeck[]
         description: decks prop.
+        ukrainian_text: 'false'
+      - name: deck
+        type: ZnoPracticeDeck | null
+        description: deck prop.
+        ukrainian_text: 'false'
+      - name: onBackToDecks
+        type: () => void
+        description: onBackToDecks prop.
         ukrainian_text: 'false'
     nested_types:
       ZnoPracticeDeck:

--- a/docs/poc/word-atlas/PRACTICE-HUB-SPEC.md
+++ b/docs/poc/word-atlas/PRACTICE-HUB-SPEC.md
@@ -66,6 +66,20 @@ in the browser (quality bar). Pattern: **move generation to build time → stati
 | Choice (meaning MC) | lemma + gloss | every eligible word (free) |
 | **Cloze** | sentence + `blankCase` + `form` + `caseRule` | only words with a vetted sentence |
 
+### 3a. ЗНО / НМТ parallel deck cards (#6496, #6530)
+
+The official ЗНО/НМТ decks (Наголос, Пароніми, Лексична норма) are a parallel
+practice family, not CEFR-sharded Atlas vocabulary. They render as ordinary
+MODES-grid cards with their fixed verified counts and an explicit «ЗНО / НМТ»
+kind label; the thin Пароніми deck is marked as a small collection rather than
+padded. The learner-level selector continues to scope the Atlas modes and the
+mixed session only. It does **not** filter, hide, or reset the exam cards: their
+items are level-independent official assessments, so every published learner
+level exposes the same three cards and each opens the standard practice session
+frame. Exam-card grading remains item-keyed in local SRS, and each prompt keeps
+its УЦОЯО attribution. This conservative rule avoids implying CEFR calibration
+that the source data does not provide while keeping the parallel family visible.
+
 ⟦fleet cursor⟧ **Cloze is scarce** (most words are recognition-only) → it has its own `clozeDue` sub-queue and
 is **soft-capped at ~25% of a session** (a weighting guideline, not a hard ceiling — ⟦fleet codex⟧ **lapsed / urgent-due cloze is EXEMPT** so the scheduler is never starved; unless the learner opts into a "grammar focus"). Build emits
 `clozeCoverage` per level; **CI warns if an A1 deck is <10% cloze-eligible.**

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -278,13 +278,14 @@ test('practice stress mode renders word-shaped vowel buttons for an N-vowel word
   await expect(stress.locator('[data-testid="practice-stress-verdict"]')).toBeVisible();
 });
 
-test('Stress mode remains available after choosing A2', async ({ page, context }) => {
+test('Stress mode and ZNO decks remain available after choosing A2', async ({ page, context }) => {
   await context.clearCookies();
   await page.goto('/words-of-the-day/practice/');
 
   await page.getByRole('button', { name: 'A2' }).click();
   await expect(page.locator('button[data-mode="stress"]')).toBeVisible();
-  await expect(page.locator('button[data-mode]')).toHaveCount(11);
+  await expect(page.locator('button[data-zno-deck="true"]')).toHaveCount(3);
+  await expect(page.locator('button[data-mode]')).toHaveCount(14);
 });
 
 test('practice flashcard rating locks the card and waits for explicit next', async ({ page, context }) => {

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -99,7 +99,7 @@ import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken
 import { usablePracticeSentenceEnglish } from '../lib/lexicon/practice-sentence-en';
 import { searchShardForQuery, type SearchRow, type SearchShardManifest } from '../lib/lexicon/search';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
-import ZnoPractice from './ZnoPractice';
+import ZnoPractice, { ZNO_PRACTICE_DECKS, type ZnoPracticeDeck } from './ZnoPractice';
 
 
 /**
@@ -627,6 +627,31 @@ const MODE_META: Record<
     step: 'Питома лексика',
     stepEn: 'Native vocabulary',
     accent: 'teal',
+  },
+};
+
+const ZNO_MODE_META: Record<
+  ZnoPracticeDeck['deckId'],
+  {
+    description: string;
+    descriptionEn: string;
+    accent: 'blue' | 'teal' | 'purple' | 'orange';
+  }
+> = {
+  'zno-stress': {
+    description: 'Тренуйте наголос на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Practise stress placement with official ZNO and NMT items.',
+    accent: 'teal',
+  },
+  'zno-paronym': {
+    description: 'Розрізняйте пароніми на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Distinguish paronyms with official ZNO and NMT items.',
+    accent: 'purple',
+  },
+  'zno-lexical-norm': {
+    description: 'Закріплюйте лексичну норму на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Reinforce lexical norms with official ZNO and NMT items.',
+    accent: 'orange',
   },
 };
 
@@ -1612,6 +1637,8 @@ function LexiconPracticeIsland({
     return () => clearTimeout(timeoutId);
   }, []);
   const [hoveredMode, setHoveredMode] = useState<VisiblePracticeModeFilter | null>(null);
+  const [hoveredZnoDeckId, setHoveredZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
+  const [activeZnoDeckId, setActiveZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
   const [publishedLevels] = useState<Set<CefrLevel>>(
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
   );
@@ -1661,6 +1688,13 @@ function LexiconPracticeIsland({
     const title = customSets.find((s) => s.id === selectedDeckFilter)?.title;
     return title ? { uk: title, en: title } : null;
   }, [selectedDeckFilter, customSets]);
+  const activeZnoDeck = useMemo(
+    () => ZNO_PRACTICE_DECKS.find((candidate) => candidate.deckId === activeZnoDeckId) ?? null,
+    [activeZnoDeckId],
+  );
+  const modeDetail = hoveredZnoDeckId
+    ? ZNO_MODE_META[hoveredZnoDeckId]
+    : MODE_META[hoveredMode ?? 'mixed'];
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
   const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
@@ -3363,9 +3397,8 @@ function LexiconPracticeIsland({
         </p>
       )}
 
-      {sessionPhase === 'idle' && (
+      {sessionPhase === 'idle' && !activeZnoDeck && (
         <>
-          <ZnoPractice />
           {focusedLemmaId && (
             <div
               className="k3-decks-wrapper shadow-sm rounded-xl p-3 my-2 bg-base-200/50"
@@ -3599,8 +3632,8 @@ function LexiconPracticeIsland({
               <h2><ChromeText k="practice.modesTitle" /></h2>
               <p id="mode-detail-line" aria-live="polite" className="k3-mode-detail">
                 {chromeLocale === 'uk'
-                  ? MODE_META[hoveredMode ?? 'mixed'].description
-                  : MODE_META[hoveredMode ?? 'mixed'].descriptionEn}
+                  ? modeDetail.description
+                  : modeDetail.descriptionEn}
               </p>
               <div
                 className="k3-mode-grid"
@@ -3642,6 +3675,47 @@ function LexiconPracticeIsland({
                       <span
                         className="k3-mode-count"
                         data-testid={`practice-mode-count-${practiceMode}`}
+                      >
+                        <span aria-hidden="true">{modeCount}</span>
+                        <span className="sr-only">
+                          {modeCountAccessibleSuffix(modeCount, chromeLocale)}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+                {ZNO_PRACTICE_DECKS.map((znoDeck) => {
+                  const meta = ZNO_MODE_META[znoDeck.deckId];
+                  const modeCount = znoDeck.items.length;
+                  return (
+                    <button
+                      key={znoDeck.deckId}
+                      type="button"
+                      className="k3-mode-card"
+                      data-mode={znoDeck.deckId}
+                      data-zno-deck="true"
+                      data-accent={meta.accent}
+                      data-mode-count={modeCount}
+                      aria-describedby="mode-detail-line"
+                      onMouseEnter={() => setHoveredZnoDeckId(znoDeck.deckId)}
+                      onMouseLeave={() => setHoveredZnoDeckId(null)}
+                      onFocus={() => setHoveredZnoDeckId(znoDeck.deckId)}
+                      onBlur={() => setHoveredZnoDeckId(null)}
+                      onClick={() => setActiveZnoDeckId(znoDeck.deckId)}
+                    >
+                      <span className="k3-mode-title">{znoDeck.title}</span>
+                      <span className="k3-mode-step">ЗНО / НМТ</span>
+                      <span className="k3-mode-desc">
+                        {chromeLocale === 'uk' ? meta.description : meta.descriptionEn}
+                      </span>
+                      {znoDeck.thinDeck ? (
+                        <span className="k3-mode-empty-note" data-testid={`practice-zno-thin-${znoDeck.deckId}`}>
+                          Невелика добірка
+                        </span>
+                      ) : null}
+                      <span
+                        className="k3-mode-count"
+                        data-testid={`practice-mode-count-${znoDeck.deckId}`}
                       >
                         <span aria-hidden="true">{modeCount}</span>
                         <span className="sr-only">
@@ -3801,6 +3875,23 @@ function LexiconPracticeIsland({
           }}
           onDone={finishPractice}
         />
+      )}
+
+      {activeZnoDeck && (
+        <div className="lexicon-practice-stage-shell" data-testid="practice-zno-session">
+          <div className="lexicon-practice-stage-bar">
+            <button type="button" className="stage-back" onClick={() => setActiveZnoDeckId(null)}>
+              <PracticeChromeLabel k="practice.home" />
+            </button>
+            <h2>ЗНО / НМТ · {activeZnoDeck.title}</h2>
+            <span className="queue-pill" data-testid="practice-zno-session-count">
+              {activeZnoDeck.items.length}
+            </span>
+          </div>
+          <div className="lexicon-practice-stage" tabIndex={-1}>
+            <ZnoPractice deck={activeZnoDeck} onBackToDecks={() => setActiveZnoDeckId(null)} />
+          </div>
+        </div>
       )}
 
       {sessionPhase === 'active' && (

--- a/site/src/components/ZnoPractice.tsx
+++ b/site/src/components/ZnoPractice.tsx
@@ -29,9 +29,15 @@ export interface ZnoPracticeDeck {
 
 export interface ZnoPracticeProps {
   decks?: ZnoPracticeDeck[];
+  /**
+   * When supplied by the practice hub, render this deck directly inside the
+   * hub's session frame rather than exposing the legacy standalone deck picker.
+   */
+  deck?: ZnoPracticeDeck | null;
+  onBackToDecks?: () => void;
 }
 
-const DEFAULT_DECKS = [stressDeck, paronymDeck, lexicalNormDeck] as ZnoPracticeDeck[];
+export const ZNO_PRACTICE_DECKS = [stressDeck, paronymDeck, lexicalNormDeck] as ZnoPracticeDeck[];
 
 function taskCountLabel(count: number): string {
   const tail = count % 100;
@@ -56,12 +62,16 @@ function nextDueItem(items: readonly ZnoPracticeItem[], currentId: string | null
     })[0] ?? null;
 }
 
-export default function ZnoPractice({ decks = DEFAULT_DECKS }: ZnoPracticeProps) {
+export default function ZnoPractice({
+  decks = ZNO_PRACTICE_DECKS,
+  deck: controlledDeck,
+  onBackToDecks,
+}: ZnoPracticeProps) {
   const [activeDeckId, setActiveDeckId] = useState<string | null>(null);
   const [itemId, setItemId] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [rated, setRated] = useState(false);
-  const activeDeck = decks.find((deck) => deck.deckId === activeDeckId) ?? null;
+  const activeDeck = controlledDeck ?? decks.find((deck) => deck.deckId === activeDeckId) ?? null;
   const currentItem = useMemo(
     () => activeDeck?.items.find((item) => item.znoTaskId === itemId) ?? nextDueItem(activeDeck?.items ?? [], null),
     [activeDeck, itemId],
@@ -72,6 +82,14 @@ export default function ZnoPractice({ decks = DEFAULT_DECKS }: ZnoPracticeProps)
     setItemId(nextDueItem(deck.items, null)?.znoTaskId ?? null);
     setSelectedIndex(null);
     setRated(false);
+  }
+
+  function backToDecks() {
+    if (controlledDeck) {
+      onBackToDecks?.();
+      return;
+    }
+    setActiveDeckId(null);
   }
 
   function answer(index: number) {
@@ -91,8 +109,12 @@ export default function ZnoPractice({ decks = DEFAULT_DECKS }: ZnoPracticeProps)
 
   return (
     <section className="zno-practice" aria-label="Практика ЗНО та НМТ" data-testid="zno-practice">
-      <h2>ЗНО / НМТ</h2>
-      <p>Офіційні завдання з української мови для інтервального повторення.</p>
+      {!controlledDeck ? (
+        <>
+          <h2>ЗНО / НМТ</h2>
+          <p>Офіційні завдання з української мови для інтервального повторення.</p>
+        </>
+      ) : null}
       {!activeDeck ? (
         <div className="zno-practice-decks">
           {decks.map((deck) => (
@@ -132,7 +154,7 @@ export default function ZnoPractice({ decks = DEFAULT_DECKS }: ZnoPracticeProps)
           ) : null}
           <p className="zno-practice-attribution" lang="uk">{currentItem.attribution}</p>
           <button type="button" onClick={next} disabled={!rated}>Наступне завдання</button>
-          <button type="button" onClick={() => setActiveDeckId(null)}>До колод</button>
+          <button type="button" onClick={backToDecks}>До колод</button>
         </div>
       ) : (
         <p role="status">У цій колоді поки немає придатних завдань.</p>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -908,7 +908,7 @@ describe('LexiconPractice', () => {
 
     await user.click(screen.getByRole('button', { name: 'A2' }));
     await waitFor(() => expect(dashboard.querySelector('[data-mode="stress"]')).toBeInTheDocument());
-    expect(dashboard.querySelectorAll('[data-mode]').length).toBe(11);
+    expect(dashboard.querySelectorAll('[data-mode]').length).toBe(14);
   });
 
   test('renders stress marks only on A1, while revealed daily sentence English stays available', () => {
@@ -4374,6 +4374,33 @@ describe('LexiconPractice', () => {
         expect(screen.getByTestId('practice-mode-count-flashcards')).toHaveTextContent('1'),
       );
       expect(screen.getByTestId('practice-mode-count-cloze')).toHaveTextContent('0');
+    });
+
+    test('#6530 embeds level-independent ЗНО/НМТ decks in the modes grid and session frame', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice initialDeck={sampleDeck()} autoStart={false} />);
+
+      expect(screen.getByTestId('practice-mode-count-zno-stress')).toHaveTextContent('27');
+      expect(screen.getByTestId('practice-mode-count-zno-paronym')).toHaveTextContent('6');
+      expect(screen.getByTestId('practice-mode-count-zno-lexical-norm')).toHaveTextContent('24');
+      expect(screen.getByTestId('practice-zno-thin-zno-paronym')).toHaveTextContent('Невелика добірка');
+      expect(container.querySelector('[data-zno-deck="true"]')).toHaveClass('k3-mode-card');
+      expect(screen.queryByTestId('zno-practice')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'A2' }));
+      await waitFor(() =>
+        expect(screen.getByTestId('practice-mode-count-zno-stress')).toHaveTextContent('27'),
+      );
+
+      await user.click(container.querySelector<HTMLButtonElement>('[data-mode="zno-stress"]')!);
+      expect(screen.getByTestId('practice-zno-session')).toBeInTheDocument();
+      expect(screen.getByTestId('zno-practice-item')).toBeInTheDocument();
+      expect(screen.getByText(/Джерело: УЦОЯО/)).toBeInTheDocument();
+      expect(screen.queryByTestId('practice-dashboard-hero')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'До колод' }));
+      expect(screen.getByTestId('practice-dashboard-hero')).toBeInTheDocument();
+      expect(screen.getByTestId('practice-mode-count-zno-stress')).toHaveTextContent('27');
     });
   });
 });

--- a/site/tests/unit/ZnoPractice.test.tsx
+++ b/site/tests/unit/ZnoPractice.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ZnoPractice, { type ZnoPracticeDeck } from '@site/src/components/ZnoPractice';
@@ -34,5 +34,16 @@ describe('ZnoPractice', () => {
     expect(screen.getByTestId('zno-practice-verdict')).toHaveTextContent('✓ Правильно');
     expect(localStorage.getItem(SRS_STORAGE_KEY)).not.toBeNull();
     expect(loadState().cards.has(cardKey('zno:7', 'choice'))).toBe(true);
+  });
+
+  test('renders a hub-controlled deck without the standalone picker and returns through its callback', async () => {
+    const user = userEvent.setup();
+    const onBackToDecks = vi.fn();
+    render(<ZnoPractice deck={decks[0]} onBackToDecks={onBackToDecks} />);
+
+    expect(screen.queryByRole('heading', { name: 'ЗНО / НМТ' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('zno-practice-item')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'До колод' }));
+    expect(onBackToDecks).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Move the three ЗНО/НМТ decks into the established MODES grid; each card uses the sibling anatomy, verified 27/6/24 count badge, kind label, and thin-deck treatment.
- Open each exam deck in the standard practice session frame while preserving its shipped item flow, SRS grading, УЦОЯО attribution, and «До колод» return.
- Remove the standalone top-of-page deck surface and add grid/session coverage.

## Level-selector decision

ЗНО/НМТ cards remain visible and enabled at every published learner level: the selector scopes only CEFR-sharded Atlas vocabulary and mixed Atlas sessions, whereas these official assessment items are a parallel, level-independent family. The alternative reading—filtering them by learner level—would require an unsupported CEFR calibration and could silently hide valid exam practice; the conservative choice therefore keeps their fixed source-backed counts and local-SRS progress intact across level changes.

## Verification

- `npm exec vitest run tests/unit/ZnoPractice.test.tsx tests/unit/LexiconPractice.test.tsx` — 135 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/practice_deck/test_zno.py` — 3 passed
- `npm run build:shell` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/practice_deck/zno.py tests/practice_deck/test_zno.py` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py` — passed

No auto-merge requested.

Refs #6530, #6496