### PR TITLE
fix(hooks): block compound gh pr merge commands

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -61,6 +61,20 @@ def _decolorize(text: str) -> str:
 ADVISORY_NAME_MARKERS = ("advisory",)
 
 _FAIL_BUCKETS = {"fail", "failure", "error", "cancel", "canceled", "cancelled", "timed_out", "action_required"}
+_FALSE_VALUES = {"false", "f", "0"}
+_VALUE_FLAGS = {
+    "--subject",
+    "-t",
+    "--body",
+    "-b",
+    "--body-file",
+    "-F",
+    "--match-head-commit",
+    "--author-email",
+    "-A",
+    "--repo",
+    "-R",
+}
 
 
 def _is_advisory(name: str) -> bool:
@@ -77,6 +91,26 @@ def _read_payload() -> dict:
 
 def _command(payload: dict) -> str:
     return ((payload.get("tool_input") or {}).get("command") or "").strip()
+
+
+def _flag_enabled(args: list[str], name: str) -> bool:
+    """Whether the last occurrence of a boolean flag enables it."""
+    enabled = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in _VALUE_FLAGS:
+            i += 2
+            continue
+        if arg.startswith("--") and arg.split("=", 1)[0] in _VALUE_FLAGS:
+            i += 1
+            continue
+        if arg == f"--{name}":
+            enabled = True
+        elif arg.startswith(f"--{name}="):
+            enabled = arg.split("=", 1)[1].strip().lower() not in _FALSE_VALUES
+        i += 1
+    return enabled
 
 
 # --- Command segmentation hardened against glued shell operators (#4876). ---
@@ -224,7 +258,7 @@ def _admin_merge_args(seg: list[str]) -> list[str] | None:
     if seg[i : i + 3] != ["gh", "pr", "merge"]:
         return None
     args = seg[i + 3 :]
-    return args if "--admin" in args else None
+    return args if _flag_enabled(args, "admin") else None
 
 
 def _pr_number(args: list[str]) -> str | None:

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -609,10 +609,9 @@ def _merge_args(seg: list[str]) -> list[str] | None:
     Skipped: `--disable-auto` (any spelling), which disarms auto-merge rather than
     merging anything and is exactly the remedy this hook's --auto verdict asks for.
 
-    A bare `--admin` is also seen by ``guard-admin-merge.py``, but it remains visible
-    here: P6 rail authorization must have no ``--admin`` bypass. The duplicate status
-    read is conservative; the command is already an explicit protection bypass and an
-    unreadable rail decision must refuse.
+    `--admin` (including its explicit true/false spelling) belongs exclusively to
+    ``guard-admin-merge.py``. Returning None here prevents both PreToolUse hooks from
+    judging the same command; a disabled `--admin=false` remains a normal merge.
     """
     i, via_xargs = _invoked_start(seg)
     if seg[i : i + 3] == ["gh", "pr", "merge"]:
@@ -636,6 +635,8 @@ def _merge_args(seg: list[str]) -> list[str] | None:
         # another; refuse instead.
         args = [*args, _UNREADABLE_MARKER]
     flags, _ = _classify(args)
+    if _flag_enabled(flags, "admin"):
+        return None
     # `gh pr merge --help` prints help and merges nothing — reading the manual is not
     # the offence this guard is for. --help is a bool like any other, so it gets the same
     # spelling treatment (`--help=true`) rather than a bare-token check.

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -54,6 +54,9 @@ def _run(monkeypatch, command: str, *, pr: str | None = "5", failing=()) -> int:
     "seg,is_admin",
     [
         (["gh", "pr", "merge", "--admin"], True),
+        (["gh", "pr", "merge", "123", "--admin=true"], True),
+        (["gh", "pr", "merge", "123", "--admin=false"], False),
+        (["gh", "pr", "merge", "123", "--subject", "--admin"], False),
         (["gh", "pr", "merge", "123", "--admin", "--squash"], True),
         (["sudo", "gh", "pr", "merge", "--admin"], True),
         (["gh", "pr", "merge", "--squash"], False),
@@ -93,6 +96,10 @@ def test_unrelated_command_is_untouched(monkeypatch):
 
 def test_admin_with_failing_required_check_blocked(monkeypatch):
     assert _run(monkeypatch, "gh pr merge 5 --admin", failing=["Test (pytest)"]) == 2
+
+
+def test_admin_equals_true_with_failing_required_check_blocked(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --admin=true", failing=["Test (pytest)"]) == 2
 
 
 def test_admin_with_only_green_or_advisory_allowed(monkeypatch):

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -99,8 +99,8 @@ def _run(
         (["gh", "pr", "merge", "123", "--squash", "--delete-branch"], True),
         (["gh", "pr", "merge", "--auto", "--squash"], True),
         (["sudo", "gh", "pr", "merge", "5"], True),
-        # Admin merges remain visible to draft/check protections.
-        (["gh", "pr", "merge", "5", "--admin"], True),
+        # Admin merges belong to guard-admin-merge and are not double-judged here.
+        (["gh", "pr", "merge", "5", "--admin"], False),
         # Disarms auto-merge rather than merging; it is the remedy, not the offence.
         (["gh", "pr", "merge", "5", "--disable-auto"], False),
         (["gh", "pr", "view", "5"], False),
@@ -157,8 +157,33 @@ def test_unrelated_command_is_untouched(monkeypatch):
     assert _run(monkeypatch, "git push origin main") == 0
 
 
-def test_admin_merge_does_not_bypass_failed_checks(monkeypatch):
-    assert _run(monkeypatch, "gh pr merge 5 --admin", checks=(["Test (pytest)"], [])) == 2
+def test_admin_merge_is_deferred_to_admin_guard(monkeypatch):
+    judged: list[list[str]] = []
+    monkeypatch.setattr(guard, "_judge", lambda args, cwd=None: judged.append(args) or "blocked")
+    assert _run(monkeypatch, "gh pr merge 5 --admin", checks=(["Test (pytest)"], [])) == 0
+    assert judged == []
+
+
+@pytest.mark.parametrize(
+    "command,checks,protected",
+    [
+        ("gh pr merge 5 --auto --squash", ([], []), False),
+        ("gh pr comment 5 --body note && gh pr merge --auto 5 --squash", ([], []), False),
+        ("gh pr comment 5 --body note; gh pr merge 5 --squash", (["boundary-and-tests"], []), False),
+        ("printf ready | gh pr merge 5 --squash", ([], ["Test (pytest)"]), False),
+        ("gh pr comment 5 --body note\ngh pr merge 5 --squash", ([], ["Test (pytest)"]), False),
+    ],
+)
+def test_compound_merge_segments_are_judged(monkeypatch, command, checks, protected):
+    assert _run(monkeypatch, command, checks=checks, protected=protected) == 2
+
+
+def test_compound_admin_merge_is_deferred_without_double_judging(monkeypatch):
+    judged: list[list[str]] = []
+    monkeypatch.setattr(guard, "_judge", lambda args, cwd=None: judged.append(args) or "blocked")
+    command = "gh pr comment 5 --body note && gh pr merge 5 --admin"
+    assert _run(monkeypatch, command, checks=(["boundary-and-tests"], [])) == 0
+    assert judged == []
 
 
 def test_disable_auto_is_not_a_merge(monkeypatch):
@@ -391,11 +416,11 @@ def test_disable_auto_equals_true_is_not_a_merge(monkeypatch):
     )
 
 
-def test_admin_equals_true_is_judged_here(monkeypatch):
-    # guard-admin-merge.py matches the exact token "--admin" only, so `--admin=true`
-    # is invisible to it. Judging it here closes the gap between the two hooks rather
-    # than letting a red admin merge fall between them. P6 also judges bare --admin.
-    assert _run(monkeypatch, "gh pr merge 5 --admin=true", checks=(["Test (pytest)"], [])) == 2
+def test_admin_equals_true_is_deferred_to_admin_guard(monkeypatch):
+    judged: list[list[str]] = []
+    monkeypatch.setattr(guard, "_judge", lambda args, cwd=None: judged.append(args) or "blocked")
+    assert _run(monkeypatch, "gh pr merge 5 --admin=true", checks=(["Test (pytest)"], [])) == 0
+    assert judged == []
 
 
 @pytest.mark.parametrize(
@@ -644,7 +669,7 @@ def test_flag_looking_value_does_not_force_auto_path():
 
 def test_real_control_flags_still_recognized():
     assert guard._merge_args(["gh", "pr", "merge", "5", "--disable-auto"]) is None
-    assert guard._merge_args(["gh", "pr", "merge", "5", "--admin"]) == ["5", "--admin"]
+    assert guard._merge_args(["gh", "pr", "merge", "5", "--admin"]) is None
     assert guard._flag_enabled(guard._classify(["5", "--auto"])[0], "auto")
 
 


### PR DESCRIPTION
## Summary

- Keep compound-command regression coverage for &&, semicolon, pipeline, and newline gh pr merge segments.
- Keep --admin ownership exclusively in guard-admin-merge, including explicit boolean spellings, so the two hooks do not double-judge.
- Preserve fail-closed merge decisions for red, pending, draft, and unverifiable state.

Fixes #6479

## Verification

- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest -q tests/test_guard_pr_merge.py tests/test_guard_admin_merge.py tests/test_hooks_executable.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check agents_extensions/shared/hooks/guard-admin-merge.py agents_extensions/shared/hooks/guard-pr-merge.py tests/test_guard_admin_merge.py tests/test_guard_pr_merge.py
- git diff --check
- OPSEC lint and X-Agent trailer lint

No auto-merge enabled.