### PR TITLE
fix(runtime): recognize startup liveness activity

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -419,8 +419,11 @@ primary is not re-probed immediately.
 
 Eligible trigger classes are deliberately narrow: 401/403 auth failure,
 429/quota exhaustion, 5xx/overloaded, transport failures such as connection
-refused/reset/read timeout, initial-response timeout with no observed output,
-stdout-silence timeout before first stdout, and parsed-but-empty responses.
+refused/reset/read timeout, initial-response timeout with no observable local
+startup activity, stdout-silence timeout before first stdout, and parsed-but-empty
+responses. Startup activity includes stdout/stderr, adapter-declared liveness-file
+updates, and CPU/disk work in the agent process tree. It is intentionally a local
+liveness signal, not proof that a remote provider accepted or completed the task.
 Content-policy refusals, 4xx request-format errors, and mid-stream silence
 timeouts after partial output do not fail over.
 

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -1391,7 +1391,13 @@ def _execute_invocation_plan(
             list(liveness_paths),
             stdout_master_fd=stdout_master_fd,
             stderr_master_fd=stderr_master_fd,
-            track_process_activity=bool(stdout_silence_timeout is not None and stdout_silence_timeout > 0),
+            track_process_activity=bool(
+                (stdout_silence_timeout is not None and stdout_silence_timeout > 0)
+                or (
+                    initial_response_timeout is not None
+                    and initial_response_timeout > 0
+                )
+            ),
             stdout_line_transform=stdout_line_transform,
         )
         capture_repo_raw = None
@@ -1766,7 +1772,8 @@ def _raise_for_kill_reason(
                 or execution.stderr_text[:500]
                 or (
                     f"initial_response_timeout: {agent_name} produced no "
-                    f"stdout/stderr/liveness activity within "
+                    f"observable startup activity (stdout, stderr, liveness "
+                    f"file, or process-tree CPU/disk work) within "
                     f"{initial_response_timeout}s"
                 )
             ),
@@ -2597,10 +2604,10 @@ def _invoke_impl(
             seconds. Disabled by default. Uses stdout/stderr, liveness-file
             updates, and process-tree CPU/disk activity.
         initial_response_timeout: Optional startup probe in seconds. When set,
-            the runtime kills the subprocess if it produces no stdout/stderr
-            or liveness-file activity within this window (#2071). Distinct
-            from ``stdout_silence_timeout``, which watches composite activity
-            after startup.
+            the runtime kills the subprocess if it produces no stdout/stderr,
+            liveness-file, or process-tree CPU/disk activity within this
+            window (#2071). Distinct from ``stdout_silence_timeout``, which
+            watches composite activity after startup.
         event_sink: Optional ``event_sink(event_name, **fields)`` callback for
             dispatch JSONL observability events.
         effort: Cross-agent reasoning/effort level. First-class peer of

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -94,6 +94,9 @@ class WatchdogState:
         last_stdout_activity: monotonic timestamp of the most recent stdout
             line. Unlike ``last_activity``, stderr, liveness files, and
             process-tree activity never update this field.
+        observed_io: Whether any startup activity was observed. Despite the
+            historical name, this includes process-tree CPU/disk activity as
+            well as stdout/stderr and liveness-file updates.
         stop: Set to True by the main thread when the watchdog should exit.
         stdout_lines: Accumulated stdout lines captured by the streamer.
             The runner reads this on normal termination to build the final
@@ -413,7 +416,7 @@ def _sleep_until_stop(state: WatchdogState, duration_s: float) -> None:
 
 
 def _process_activity_poller(proc: subprocess.Popen, state: WatchdogState) -> None:
-    """Refresh last_activity while the subprocess tree is doing CPU/disk work."""
+    """Record process-tree CPU/disk work as liveness and startup activity."""
     primed_pids: set[int] = set()
     cpu_baselines: dict[int, float] = {}
     io_baselines: dict[int, tuple[int, int, int, int]] = {}
@@ -428,6 +431,10 @@ def _process_activity_poller(proc: subprocess.Popen, state: WatchdogState) -> No
             io_baselines,
         ):
             state.last_activity = time.monotonic()
+            # ``initial_response_timeout`` must not reject a productive
+            # invocation just because its first user-facing output is delayed.
+            # This covers quiet work such as edits, commits, and PR creation.
+            state.observed_io = True
         _sleep_until_stop(state, _PROCESS_ACTIVITY_POLL_INTERVAL_S)
 
 
@@ -637,8 +644,8 @@ def should_kill(
         None if the process should continue running.
         "hard_timeout" if total runtime exceeded hard_timeout.
         "initial_response_timeout" if the caller enabled startup probing and
-        the subprocess produced no stdout/stderr/liveness activity within that
-        window (#2071 startup hangs with response_chars=0).
+        the subprocess produced no stdout/stderr/liveness/process-tree activity
+        within that window (#2071 startup hangs with response_chars=0).
         "stdout_silence_timeout" if the caller explicitly enabled silence
         detection and no stdout/stderr/liveness/process-tree activity has
         arrived within that window.

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -265,8 +265,9 @@ DEFAULT_HARD_TIMEOUT_S = 7200
 # for build/test/enrich jobs merely because wrapper stdout is expected to be
 # quiet; that recreates the false-kill shape from #3875.
 DEFAULT_SILENCE_TIMEOUT_S = 3600
-# Fail fast when Codex (or any agent) never produces stdout/stderr/liveness
-# activity at startup — distinct from the long silence window above (#2071).
+# Fail fast only when no observable startup activity occurs: stdout/stderr,
+# documented liveness-file updates, or process-tree CPU/disk work. This is
+# distinct from the long silence window above (#2071).
 # 600s: reasoning-heavy models at high/max effort routinely think for minutes
 # before their first token; the old 180s killed healthy workers mid-thought
 # (observed: deepseek review dispatch reaped at 181s, 1s over the limit).
@@ -3200,7 +3201,8 @@ def _run_worker(
             if getattr(exc, "kind", "stall") == "initial_response_timeout":
                 stderr_excerpt = (
                     f"initial_response_timeout fired after {exc.stall_timeout}s "
-                    f"with no first stdout/stderr/liveness activity: {exc} "
+                    f"with no first observable startup activity "
+                    f"(stdout, stderr, liveness file, or process-tree work): {exc} "
                     f"— raise it with --initial-response-timeout "
                     f"(current default {DEFAULT_INITIAL_RESPONSE_TIMEOUT_S}s)"
                 )[:500]
@@ -5072,7 +5074,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
         help=(
             "Startup probe: kill the agent CLI if it produces no "
-            "stdout/stderr/liveness activity within this many seconds "
+            "observable startup activity (stdout, stderr, liveness file, or "
+            "process-tree CPU/disk work) within this many seconds "
             f"(default: {DEFAULT_INITIAL_RESPONSE_TIMEOUT_S}; 0 disables). "
             "Distinct from --silence-timeout, which watches composite "
             "activity after startup (#2071, #3875)."

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -133,6 +133,7 @@ from agent_runtime.runner import (
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
 from agent_runtime.watchdog import (
     WatchdogState,
+    _process_activity_poller,
     _process_tree_has_activity,
     should_kill,
     start_watchdog,
@@ -2714,6 +2715,26 @@ def test_should_kill_silence_timeout_kills_fully_silent_process():
     )
 
 
+def test_initial_response_timeout_accepts_process_tree_activity():
+    """Startup probing treats quiet work as activity, not a missing response."""
+    now = time.monotonic()
+    state = WatchdogState(
+        start_time=now - 120,
+        last_activity=now,
+        observed_io=True,
+    )
+
+    assert (
+        should_kill(
+            state,
+            stall_timeout=180,
+            hard_timeout=3600,
+            initial_response_timeout=60,
+        )
+        is None
+    )
+
+
 def test_process_tree_has_activity_tracks_descendant_cpu(monkeypatch):
     """CPU baselines survive fresh psutil.Process wrappers across polls."""
 
@@ -2751,6 +2772,103 @@ def test_process_tree_has_activity_tracks_descendant_cpu(monkeypatch):
 
     assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is False
     assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is True
+
+
+def test_process_activity_poller_counts_work_as_startup_activity(monkeypatch):
+    """CPU/disk work satisfies the startup probe as well as a silence probe."""
+    import agent_runtime.watchdog as watchdog_module
+
+    state = WatchdogState(start_time=time.monotonic(), last_activity=time.monotonic())
+    proc = SimpleNamespace(poll=lambda: None)
+    monkeypatch.setattr(watchdog_module, "_process_tree_has_activity", lambda *_args: True)
+    monkeypatch.setattr(
+        watchdog_module,
+        "_sleep_until_stop",
+        lambda current_state, _duration: setattr(current_state, "stop", True),
+    )
+
+    _process_activity_poller(proc, state)
+
+    assert state.observed_io is True
+
+
+def test_initial_response_timeout_allows_quiet_process_work(tmp_path, monkeypatch):
+    """The startup probe enables process-tree liveness polling (#6407)."""
+    import agent_runtime.watchdog as watchdog_module
+
+    class FixtureAdapter:
+        def parse_response(self, *, returncode: int, **_kwargs):
+            return ParseResult(ok=returncode == 0, response="done", stderr_excerpt="")
+
+        def liveness_signal_paths(self, _plan):
+            return ()
+
+    monkeypatch.setattr(watchdog_module, "_process_tree_has_activity", lambda *_args: True)
+    execution = _execute_invocation_plan(
+        agent_name="claude",
+        adapter=FixtureAdapter(),
+        plan=InvocationPlan(
+            cmd=[_TEST_PYTHON, "-c", "import time; time.sleep(2.0)"],
+            cwd=tmp_path,
+        ),
+        prompt="fixture",
+        mode="read-only",
+        cwd=tmp_path,
+        model="fixture",
+        task_id="initial-response-process-work",
+        session_id=None,
+        entrypoint="runtime",
+        hard_timeout=30,
+        stall_timeout=30,
+        initial_response_timeout=1,
+    )
+
+    assert execution.kill_reason is None
+    assert execution.parse.ok is True
+
+
+def test_initial_response_timeout_allows_quiet_liveness_file_work(tmp_path, monkeypatch):
+    """A worker can update a documented liveness file before responding (#6407)."""
+    import agent_runtime.watchdog as watchdog_module
+
+    liveness_path = tmp_path / "productive-work.txt"
+
+    class FixtureAdapter:
+        def parse_response(self, *, returncode: int, **_kwargs):
+            return ParseResult(ok=returncode == 0, response="done", stderr_excerpt="")
+
+        def liveness_signal_paths(self, _plan):
+            return (liveness_path,)
+
+    monkeypatch.setattr(watchdog_module, "_MTIME_POLL_INTERVAL_S", 0.02)
+    child = """
+from pathlib import Path
+import time
+
+time.sleep(0.2)
+Path("productive-work.txt").write_text("productive work")
+time.sleep(2.0)
+print("done")
+"""
+    execution = _execute_invocation_plan(
+        agent_name="claude",
+        adapter=FixtureAdapter(),
+        plan=InvocationPlan(cmd=[_TEST_PYTHON, "-c", child], cwd=tmp_path),
+        prompt="fixture",
+        mode="read-only",
+        cwd=tmp_path,
+        model="fixture",
+        task_id="initial-response-productivity",
+        session_id=None,
+        entrypoint="runtime",
+        hard_timeout=30,
+        stall_timeout=30,
+        initial_response_timeout=1,
+    )
+
+    assert execution.kill_reason is None
+    assert execution.parse.ok is True
+    assert liveness_path.exists()
 
 
 def test_tail_liveness_skips_binary_sqlite(tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2797,6 +2797,7 @@ def test_run_worker_initial_response_timeout_still_reaps_silent_startup(
     excerpt = state["stderr_excerpt"] or ""
     assert "initial_response_timeout" in excerpt
     assert "fired after 1s" in excerpt
+    assert "no first observable startup activity" in excerpt
     assert "--initial-response-timeout" in excerpt
 
 


### PR DESCRIPTION
Fixes #6407

## Summary
- Treat process-tree CPU/disk work as startup activity and enable that polling for the startup probe.
- Preserve the timeout for truly silent children and clarify timeout diagnostics.
- Cover process activity, liveness-file updates without stdout, and silent startup timeout behavior.

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/watchdog.py scripts/agent_runtime/runner.py scripts/delegate.py tests/test_agent_runtime.py tests/test_delegate.py`
- Focused pytest: 6 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Auto-merge deliberately not enabled; independent review remains pending.