### PR TITLE
fix(delegate): fix deliverable commit counting on --cwd reuse worktrees (#6426)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1058,9 +1058,9 @@ def _resolve_cwd_path(raw: str) -> Path:
     return p.resolve()
 
 
-def _is_verified_added_worktree(path: Path) -> bool:
-    """True if ``path`` resolves inside a git-registered worktree that is not the
-    primary checkout.
+def _resolve_verified_worktree_path(path: Path) -> Path | None:
+    """Return canonical Path of the containing registered worktree if ``path`` resolves
+    inside a git-registered worktree that is not the primary checkout, else None.
 
     "Verified" means the containing worktree appears in ``git worktree list``. A
     bare directory that only *looks* like ``.worktrees/**`` but was never
@@ -1073,13 +1073,21 @@ def _is_verified_added_worktree(path: Path) -> bool:
     try:
         main_root = wc.resolve_main_root(start)
     except wc.NotAGitRepositoryError:
-        return False
+        return None
     for worktree in wc.registered_worktrees(main_root):
         if worktree == main_root:
             continue
         if target == worktree or target.is_relative_to(worktree):
-            return True
-    return False
+            return worktree
+    return None
+
+
+def _is_verified_added_worktree(path: Path) -> bool:
+    """True if ``path`` resolves inside a git-registered worktree that is not the
+    primary checkout.
+    """
+    return _resolve_verified_worktree_path(path) is not None
+
 
 
 def _apply_worktree_git_ceiling(worker_env: dict[str, str], worktree_path: Path) -> None:
@@ -1665,7 +1673,23 @@ def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
     except OSError:
         return None
     if proc.returncode != 0:
-        return None
+        if base_ref.startswith("origin/"):
+            local_ref = base_ref.removeprefix("origin/")
+            try:
+                proc = subprocess.run(
+                    ["git", "rev-list", "--count", f"{local_ref}..HEAD"],
+                    cwd=worktree,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=_sanitized_git_env(),
+                )
+            except OSError:
+                return None
+            if proc.returncode != 0:
+                return None
+        else:
+            return None
     try:
         return int((proc.stdout or "").strip())
     except ValueError:
@@ -3281,6 +3305,13 @@ def _run_worker(
         # worktree exited dirty so follow-up reviewers can see at a glance
         # that the dispatched agent left uncommitted changes behind.
         worktree_path = final_state.get("worktree_path")
+        if not worktree_path and final_state.get("cwd"):
+            candidate_cwd = Path(final_state.get("cwd"))
+            resolved_wt = _resolve_verified_worktree_path(candidate_cwd)
+            if resolved_wt:
+                worktree_path = str(resolved_wt)
+                final_state["worktree_path"] = worktree_path
+
         if worktree_path:
             dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
 
@@ -3909,6 +3940,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             except (ValueError, RuntimeError) as exc:
                 print(f"❌ failed to validate branch reuse for {task_id!r}: {exc}", file=sys.stderr)
                 return 1
+        elif args.cwd:
+            candidate_cwd = _resolve_cwd_path(args.cwd)
+            resolved_wt = _resolve_verified_worktree_path(candidate_cwd)
+            if resolved_wt:
+                dry_run_worktree = resolved_wt
+                dry_run_branch = _current_branch(resolved_wt)
+                dry_run_worktree_telemetry["base_sha"] = _resolve_sha(resolved_wt)
 
         try:
             runtime_tmp_root, runtime_tmp_namespace_root = _create_runtime_tmp_lease(task_id)
@@ -4023,6 +4061,21 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         except (ValueError, RuntimeError) as exc:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)
             return 1
+    elif args.cwd:
+        candidate_cwd = _resolve_cwd_path(args.cwd)
+        resolved_wt = _resolve_verified_worktree_path(candidate_cwd)
+        if resolved_wt:
+            worktree_path = resolved_wt
+            worktree_branch = _current_branch(resolved_wt)
+            worktree_telemetry["reused"] = True
+            worktree_telemetry["layout"] = _classify_worktree_layout(resolved_wt)
+            worktree_telemetry["base_sha"] = _resolve_sha(resolved_wt)
+            worktree_telemetry["sparse"] = _apply_dispatch_sparse_checkout(
+                resolved_wt,
+                full_checkout=full_checkout,
+                sparse_include=sparse_include,
+            )
+            _record_worktree_local_venv_warning(resolved_wt, worktree_telemetry)
 
     try:
         runtime_tmp_root, runtime_tmp_namespace_root = _create_runtime_tmp_lease(task_id)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -6033,3 +6033,151 @@ def test_interrupt_fallback_records_the_complete_outcome(
     assert state["returncode"] == 0
     assert state.get("finished_at")
     assert isinstance(state.get("duration_s"), float)
+
+
+# ---------------------------------------------------------------------------
+# Issue #6426: finalizer deliverable counting on --cwd reuse worktrees
+# ---------------------------------------------------------------------------
+
+def test_dispatch_populates_worktree_metadata_on_cwd_reuse(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """Dispatch with --cwd pointing to a registered worktree populates worktree_path and metadata."""
+    main, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    _patch_worker_popen(monkeypatch)
+    args = _write_args(
+        agent="codex",
+        task_id="task-cwd-reuse-meta",
+        mode="workspace-write",
+        cwd=str(dispatch_wt),
+        worktree=None,
+        base="main",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("task-cwd-reuse-meta"))
+    assert state is not None
+    assert state["worktree_path"] == str(dispatch_wt)
+    assert state["worktree_reused"] is True
+    assert state["worktree_branch"] is not None
+
+
+def test_finalize_cwd_reuse_with_pushed_commits_counts_deliverable(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """Reused --cwd worktree with commits ahead of base counts commits_ahead > 0 and settles as done."""
+    main, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+
+    # Add a commit inside the reused worktree
+    (dispatch_wt / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "feature.py"], cwd=dispatch_wt, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "add feature"], cwd=dispatch_wt, check=True, timeout=30)
+
+    state_path = delegate._state_path("task-cwd-commits")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "task-cwd-commits",
+        "agent": "codex",
+        "mode": "workspace-write",
+        "cwd": str(dispatch_wt),
+        "status": "running",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "Implemented feature.",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.6",
+            "effort": "high",
+            "cli_version": "1.0.0",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="task-cwd-commits",
+            agent="codex",
+            prompt="implement feature",
+            mode="workspace-write",
+            cwd_str=str(dispatch_wt),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "done"
+    assert state.get("no_deliverable_reason") is None
+    assert state.get("commits_ahead", 0) > 0
+    assert state["worktree_path"] == str(dispatch_wt)
+
+
+def test_run_worker_falls_back_to_resolving_worktree_from_cwd(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """When worktree_path is missing in state, _run_worker resolves it from cwd if inside a registered worktree."""
+    main, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+
+    (dispatch_wt / "fix.txt").write_text("fix\n", encoding="utf-8")
+    subprocess.run(["git", "add", "fix.txt"], cwd=dispatch_wt, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "fix"], cwd=dispatch_wt, check=True, timeout=30)
+
+    # State file lacks worktree_path but has cwd
+    state_path = delegate._state_path("task-legacy-cwd")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "task-legacy-cwd",
+        "agent": "codex",
+        "mode": "workspace-write",
+        "cwd": str(dispatch_wt),
+        "worktree_path": None,
+        "status": "running",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "Fixed issue.",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.6",
+            "effort": "high",
+            "cli_version": "1.0.0",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="task-legacy-cwd",
+            agent="codex",
+            prompt="fix issue",
+            mode="workspace-write",
+            cwd_str=str(dispatch_wt),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "done"
+    assert state.get("no_deliverable_reason") is None
+    assert state.get("commits_ahead", 0) > 0
+


### PR DESCRIPTION
Fixes #6426

X-Agent: codex/6426-no-deliverable-cwd-reuse

## Summary
- Dispatches using `--cwd` pointing to a verified added worktree were not populating `worktree_path` in the task state dictionary during initial dispatch or dry-run.
- As a result, when `_run_worker` finalized telemetry, `worktree_path` evaluated to `None`, bypassing commit count checks and defaulting `commits_ahead` to `None`, which caused the finalizer to report `no_deliverable (commit_count_unknown)` even when work had been committed and pushed.
- Fixed by:
  1. Resolving `worktree_path` from `--cwd` during dispatch when `--cwd` resolves to a verified added worktree.
  2. Adding fallback resolution in `_run_worker` to resolve `worktree_path` from `cwd` if `worktree_path` is missing in the state dictionary.
  3. Adding fallback in `_count_commits_ahead` to check local base ref if the `origin/` prefixed base ref is unresolvable.
- Added comprehensive unit tests in `tests/test_delegate.py` covering `--cwd` reuse worktree metadata resolution and deliverable commit counting.