### PR TITLE
feat(review): dual-family quorum fallback for unattested cursor:auto authors

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -28,6 +28,15 @@ Cost never lowers the quality floor. An `unhealthy` route is unavailable; `degra
 only break ties inside a quality rung. `cursor:auto` is never an acceptable formal-review identity;
 Composer is eligible only with its concrete `composer-2.5` model identity.
 
+**Unattested-harness AUTHORS (Cursor Auto) — dual-family quorum (#6489):** when the author ran
+`cursor:auto` (harness attests no pinned model), the resolver returns a **dual-family quorum**
+instead of failing closed: two independent, exact-head PASS verdicts from **distinct** attested,
+formal-review-eligible families — whichever family the hidden author was, at least one verdict is
+necessarily cross-family. A declared `author_family` against an auto attestation is a fail-closed
+conflict, and an explicit reviewer pin cannot substitute for the quorum. Resolved-model attestation
+(or pinned `composer-2.5` authorship) remains the primary provenance path; the quorum is the
+fallback for already-authored Auto work.
+
 **Fable transport order (user directive 2026-07-20):** always dispatch the exact
 `claude-fable-5` model through the native Claude harness first:
 `.venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-fable-5`.

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -375,6 +375,8 @@ def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
         json.dumps(
             {
                 "selected": asdict(resolution.selected) if resolution.selected else None,
+                "quorum": [asdict(q) for q in resolution.quorum],
+                "quorum_rule": resolution.quorum_rule,
                 "advisory": [asdict(a) for a in resolution.advisory],
                 "trace": [asdict(t) for t in resolution.trace],
                 "substitution_note": resolution.substitution_note,
@@ -386,7 +388,13 @@ def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
             indent=2,
         )
     )
-    return 1 if resolution.fail_closed_reason or resolution.selected is None else 0
+    if resolution.fail_closed_reason:
+        return 1
+    # A dual-family quorum plan (unattested-harness author) is a successful
+    # resolution: no single reviewer of record, both seats must PASS.
+    if len(resolution.quorum) >= 2:
+        return 0
+    return 1 if resolution.selected is None else 0
 
 
 def _cmd_finding(args: argparse.Namespace) -> int:

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -87,13 +87,27 @@ _VALID_CONCRETE_FAMILIES: frozenset[str] = frozenset(
 # Fail-closed author-identity outcomes: none of these is a real model family,
 # and a caller must never treat one as matching (or not matching) any
 # candidate's family — resolve_reviewer refuses to select a formal reviewer
-# for any of them.
+# for any of them. The unattested-harness sentinel is still unresolved (no
+# single-reviewer selection is possible against it), but unlike the others it
+# resolves to a dual-family quorum plan instead of a bare refusal.
 UNKNOWN_AUTHOR_FAMILY = "unknown"
 AMBIGUOUS_AUTHOR_FAMILY = "ambiguous"
 CONFLICTING_AUTHOR_FAMILY = "conflict"
+UNATTESTED_AUTHOR_FAMILY = "unattested-harness"
 UNRESOLVED_AUTHOR_FAMILIES: frozenset[str] = frozenset(
-    {UNKNOWN_AUTHOR_FAMILY, AMBIGUOUS_AUTHOR_FAMILY, CONFLICTING_AUTHOR_FAMILY}
+    {UNKNOWN_AUTHOR_FAMILY, AMBIGUOUS_AUTHOR_FAMILY, CONFLICTING_AUTHOR_FAMILY, UNATTESTED_AUTHOR_FAMILY}
 )
+
+# A multi-model harness session that positively attests it ran WITHOUT a
+# pinned model (Cursor Auto records model="auto", resolved_model=null). This
+# differs from a bare ambiguous harness: "ambiguous" means the record is
+# silent about which model ran, so a validated external override may fill the
+# gap; "unattested" means the harness explicitly recorded that no single
+# model was pinned, so no caller-asserted family can be corroborated — a
+# declared author_family against an auto attestation is a fail-closed
+# conflict, never a disambiguation.
+UNATTESTED_MODEL_TOKENS: frozenset[str] = frozenset({"auto"})
+UNATTESTED_HARNESS_SEATS: frozenset[str] = frozenset({"cursor-auto"})
 
 
 def resolve_author_family(author_model: str, author_family: str | None = None) -> str:
@@ -114,7 +128,11 @@ def resolve_author_family(author_model: str, author_family: str | None = None) -
     - ``"ambiguous"`` — a multi-model harness with no concrete model and no
       valid override to disambiguate it.
     - ``"conflict"`` — the embedded/resolved model family and an explicit
-      ``author_family`` override disagree.
+      ``author_family`` override disagree, or an override was declared
+      against a positive no-pinned-model (auto) attestation.
+    - ``"unattested-harness"`` — the harness positively attests no pinned
+      model (Cursor Auto). Not selectable as a single-reviewer identity;
+      :func:`resolve_reviewer` answers it with a dual-family quorum plan.
 
     Callers (:func:`resolve_reviewer`) must never select a formal reviewer
     against a fail-closed sentinel — an unresolved author identity is not
@@ -126,8 +144,15 @@ def resolve_author_family(author_model: str, author_family: str | None = None) -
         override = None  # an invalid/unrecognized override does not count as validated
 
     harness_token, sep, embedded = normalized.partition(":")
-    if sep and harness_token in AMBIGUOUS_HARNESS_SEATS and embedded.strip():
-        resolved = resolve_family(embedded.strip())
+    embedded_token = embedded.strip()
+    if (sep and harness_token in AMBIGUOUS_HARNESS_SEATS and embedded_token in UNATTESTED_MODEL_TOKENS) or (
+        normalized in UNATTESTED_HARNESS_SEATS
+    ):
+        # The harness attests the model was NOT pinned; a caller-asserted
+        # single family contradicts that attestation instead of resolving it.
+        return CONFLICTING_AUTHOR_FAMILY if override else UNATTESTED_AUTHOR_FAMILY
+    if sep and harness_token in AMBIGUOUS_HARNESS_SEATS and embedded_token:
+        resolved = resolve_family(embedded_token)
     elif normalized in AMBIGUOUS_HARNESS_SEATS or (normalize_seat(normalized) or "") in AMBIGUOUS_HARNESS_SEATS:
         resolved = None  # bare ambiguous harness, no embedded concrete model
     else:
@@ -474,6 +499,22 @@ class ReviewerResolution:
     # reviewer selected, since there is nothing reliable to diff a
     # candidate's family against.
     fail_closed_reason: str | None = None
+    # Dual-family quorum plan for an unattested-harness author (Cursor Auto:
+    # the harness attests no pinned model). ``selected`` stays None — there
+    # is no single reviewer of record; BOTH quorum seats must independently
+    # return an exact-head PASS verdict. Because the seats are from distinct
+    # attested families and the hidden author is at most one family, at
+    # least one quorum verdict is necessarily cross-family.
+    quorum: tuple[CandidateResult, ...] = ()
+    quorum_rule: str | None = None
+
+
+_DUAL_FAMILY_QUORUM_RULE = (
+    "unattested-harness author (harness attests no pinned model): the formal gate "
+    "requires two independent exact-head PASS verdicts from distinct attested, "
+    "formal-review-eligible families; whichever family the hidden author actually "
+    "was, at least one verdict is necessarily cross-family"
+)
 
 
 def _health_of(candidate: ReviewerCandidate, snapshot: Mapping[str, str] | None) -> str | None:
@@ -725,6 +766,26 @@ def evaluate_candidate(
     )
 
 
+def _best_eligible(
+    eligible_by_fit_and_tier: dict[tuple[int, int], list[tuple[ReviewerCandidate, CandidateResult, int]]],
+    *,
+    exclude_families: frozenset[str] = frozenset(),
+) -> tuple[ReviewerCandidate, CandidateResult, int] | None:
+    """Pick the best eligible entry: best (suitability, tier) group first,
+    deterministic selection_score inside it. ``exclude_families`` lets the
+    dual-family quorum path pick a second seat outside the first seat's
+    family without relaxing the fit-before-pressure ordering."""
+    filtered = {
+        fit_key: kept
+        for fit_key, entries in eligible_by_fit_and_tier.items()
+        if (kept := [item for item in entries if item[0].family not in exclude_families])
+    }
+    if not filtered:
+        return None
+    best_fit_and_tier = min(filtered)
+    return min(filtered[best_fit_and_tier], key=lambda item: item[1].selection_score or ())
+
+
 def resolve_reviewer(
     inputs: ResolverInputs,
     ladder: tuple[tuple[ReviewerCandidate, ...], ...] | None = None,
@@ -743,6 +804,13 @@ def resolve_reviewer(
     unrecognized identity, a bare ambiguous-model harness with no
     disambiguation, or a conflicting override). See
     :func:`resolve_author_family`.
+
+    Exception: an ``unattested-harness`` author (Cursor Auto — the harness
+    positively attests no pinned model) resolves to a **dual-family quorum**
+    instead of a bare refusal: ``selected`` stays ``None`` and ``quorum``
+    carries two seats from distinct attested, formal-review-eligible
+    families, each of which must independently PASS at the same exact head.
+    Fewer than two eligible distinct families still fails closed.
     """
     if runtime_state is not None:
         # The state owner injects a transaction-consistent snapshot. This
@@ -817,7 +885,22 @@ def resolve_reviewer(
         )
 
     author_family = resolve_author_family(inputs.author_model, inputs.author_family)
-    if author_family in UNRESOLVED_AUTHOR_FAMILIES:
+    quorum_required = author_family == UNATTESTED_AUTHOR_FAMILY
+    if quorum_required and inputs.pinned_candidate:
+        return ReviewerResolution(
+            selected=None,
+            advisory=(),
+            trace=(),
+            substitution_note=None,
+            policy_version=_SCHEDULER_POLICY_VERSION,
+            catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+            resolved_risk=risk,
+            fail_closed_reason=(
+                "explicit reviewer pin cannot satisfy the dual-family quorum required "
+                "for an unattested-harness author — two distinct-family seats must be resolved"
+            ),
+        )
+    if author_family in UNRESOLVED_AUTHOR_FAMILIES and not quorum_required:
         reason = {
             UNKNOWN_AUTHOR_FAMILY: (
                 f"author identity unknown — cannot resolve a model family from author_model={inputs.author_model!r}"
@@ -896,6 +979,50 @@ def resolve_reviewer(
                 fit_key = (result.suitability_rank or 0, tier_for_candidate[candidate.name])
                 eligible_by_fit_and_tier.setdefault(fit_key, []).append((candidate, result, rung_index))
 
+    if quorum_required:
+        first = _best_eligible(eligible_by_fit_and_tier)
+        if first is None:
+            quorum_failure = (
+                "dual-family quorum unsatisfiable: no eligible formal-review candidate "
+                "for an unattested-harness author"
+            )
+        else:
+            second = _best_eligible(eligible_by_fit_and_tier, exclude_families=frozenset({first[0].family}))
+            quorum_failure = (
+                f"dual-family quorum unsatisfiable: only one eligible family ({first[0].family!r}) — "
+                "two distinct attested, formal-review-eligible families are required"
+            ) if second is None else None
+        if quorum_failure is not None:
+            return ReviewerResolution(
+                selected=None,
+                advisory=tuple(advisory),
+                trace=tuple(trace),
+                substitution_note=None,
+                policy_version=_SCHEDULER_POLICY_VERSION,
+                catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+                resolved_risk=risk,
+                fail_closed_reason=quorum_failure,
+            )
+        quorum_results: list[CandidateResult] = []
+        for _, seat_result, _ in (first, second):
+            promoted = replace(seat_result, status="selected")
+            for i, entry in enumerate(trace):
+                if entry is seat_result:
+                    trace[i] = promoted
+                    break
+            quorum_results.append(promoted)
+        return ReviewerResolution(
+            selected=None,
+            advisory=tuple(advisory),
+            trace=tuple(trace),
+            substitution_note=None,
+            policy_version=_SCHEDULER_POLICY_VERSION,
+            catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+            resolved_risk=risk,
+            quorum=tuple(quorum_results),
+            quorum_rule=_DUAL_FAMILY_QUORUM_RULE,
+        )
+
     if inputs.pinned_candidate:
         pinned = [
             item for entries in eligible_by_fit_and_tier.values() for item in entries if item[0].name == inputs.pinned_candidate
@@ -914,11 +1041,7 @@ def resolve_reviewer(
         candidate, best, selected_rung_index = pinned[0]
         selected = best
     elif eligible_by_fit_and_tier:
-        best_fit_and_tier = min(eligible_by_fit_and_tier)
-        candidate, best, selected_rung_index = min(
-            eligible_by_fit_and_tier[best_fit_and_tier],
-            key=lambda item: item[1].selection_score or (),
-        )
+        candidate, best, selected_rung_index = _best_eligible(eligible_by_fit_and_tier)
         selected = best
 
     if selected is not None:

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -157,6 +157,25 @@ def test_resolve_reviewer_cli_rejects_invalid_risk_and_fail_closed_identity(tmp_
     assert json.loads(unknown_author.stdout)["selected"] is None
 
 
+def test_resolve_reviewer_cli_returns_dual_family_quorum_for_cursor_auto(tmp_path):
+    state_file = tmp_path / "state.json"
+    quorum_proc = _run_cli(
+        state_file,
+        "resolve-reviewer",
+        "--author-model",
+        "cursor-auto",
+    )
+    # A satisfiable dual-family quorum is a successful resolution (exit 0)
+    # even though no single reviewer of record is selected.
+    assert quorum_proc.returncode == 0, quorum_proc.stderr
+    payload = json.loads(quorum_proc.stdout)
+    assert payload["fail_closed_reason"] is None
+    assert payload["selected"] is None
+    assert len(payload["quorum"]) == 2
+    assert len({seat["family"] for seat in payload["quorum"]}) == 2
+    assert "exact-head" in payload["quorum_rule"]
+
+
 def test_resolve_reviewer_cli_rejects_learner_semantic_profile_before_dispatch(tmp_path):
     state_file = tmp_path / "state.json"
     unsupported = _run_cli(

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -24,6 +24,7 @@ from scripts.review.reviewer_resolver import (
     REVIEW_CANDIDATES,
     REVIEW_LADDERS,
     TERRA,
+    UNATTESTED_AUTHOR_FAMILY,
     UNKNOWN_AUTHOR_FAMILY,
     ResolverInputs,
     evaluate_candidate,
@@ -96,6 +97,77 @@ def test_cursor_requires_concrete_model_identity():
     assert resolve_author_family("cursor:claude-opus-4-8") == "anthropic"
     assert resolve_author_family("cursor:composer-2.5") == "moonshot"
     assert resolve_author_family("cursor", author_family="anthropic") == "anthropic"
+
+
+def test_cursor_auto_is_unattested_not_unknown():
+    # Cursor Auto positively attests no pinned model (model="auto",
+    # resolved_model=null) — distinct from a silent/bare harness record.
+    assert resolve_author_family("cursor:auto") == UNATTESTED_AUTHOR_FAMILY
+    assert resolve_author_family("cursor-auto") == UNATTESTED_AUTHOR_FAMILY
+    assert resolve_author_family("cursor-tools:auto") == UNATTESTED_AUTHOR_FAMILY
+    assert resolve_author_family("Cursor:AUTO") == UNATTESTED_AUTHOR_FAMILY
+
+
+def test_author_family_override_against_auto_attestation_is_a_conflict():
+    # The harness attests the model was NOT pinned; a caller-asserted single
+    # family cannot be corroborated and must not dodge the quorum.
+    assert resolve_author_family("cursor:auto", author_family="openai") == CONFLICTING_AUTHOR_FAMILY
+    assert resolve_author_family("cursor-auto", author_family="anthropic") == CONFLICTING_AUTHOR_FAMILY
+    resolution = resolve_reviewer(ResolverInputs(author_model="cursor:auto", author_family="openai"))
+    assert resolution.selected is None
+    assert resolution.quorum == ()
+    assert resolution.fail_closed_reason
+
+
+def test_unattested_author_resolves_a_dual_family_quorum():
+    resolution = resolve_reviewer(ResolverInputs(author_model="cursor-auto", risk="medium"))
+    assert resolution.fail_closed_reason is None
+    # No single reviewer of record — the quorum is the formal gate.
+    assert resolution.selected is None
+    assert len(resolution.quorum) == 2
+    families = {seat.family for seat in resolution.quorum}
+    assert len(families) == 2
+    assert all(seat.status == "selected" for seat in resolution.quorum)
+    assert "exact-head" in resolution.quorum_rule
+    # Both seats are promoted in the trace, like a single selection would be.
+    selected_in_trace = [entry for entry in resolution.trace if entry.status == "selected"]
+    assert {entry.name for entry in selected_in_trace} == {seat.name for seat in resolution.quorum}
+
+
+def test_unattested_quorum_holds_at_every_risk():
+    for risk in ("low", "medium", "high", "critical"):
+        resolution = resolve_reviewer(ResolverInputs(author_model="cursor:auto", risk=risk))
+        assert resolution.fail_closed_reason is None, risk
+        assert len(resolution.quorum) == 2, risk
+        assert len({seat.family for seat in resolution.quorum}) == 2, risk
+
+
+def test_unattested_author_with_single_eligible_family_fails_closed():
+    # A ladder that only offers one family cannot satisfy the quorum.
+    anthropic_only = (
+        (REVIEW_CANDIDATES["claude-sonnet-5"],),
+        (REVIEW_CANDIDATES["claude-fable-5"],),
+    )
+    resolution = resolve_reviewer(
+        ResolverInputs(author_model="cursor-auto", risk="medium"),
+        ladder=anthropic_only,
+    )
+    assert resolution.selected is None
+    assert resolution.quorum == ()
+    assert "dual-family quorum unsatisfiable" in resolution.fail_closed_reason
+
+
+def test_unattested_author_rejects_explicit_reviewer_pin():
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="cursor-auto",
+            pinned_candidate="gpt-5.6-terra",
+            pressure_override_reason="operator request",
+        )
+    )
+    assert resolution.selected is None
+    assert resolution.quorum == ()
+    assert "pin cannot satisfy the dual-family quorum" in resolution.fail_closed_reason
 
 
 def test_invalid_or_conflicting_author_identity_fails_closed():


### PR DESCRIPTION
Fixes #6489

## Design one-liner

An author whose harness positively attests **no pinned model** (Cursor Auto: `model="auto"`, `resolved_model=null`) is a new `unattested-harness` identity class: instead of failing closed, the resolver returns a **dual-family quorum plan** — two independent, exact-head PASS verdicts from **distinct** attested, formal-review-eligible families. Whichever family the hidden author actually was, at least one verdict is necessarily cross-family (Sol advisory, 2026-08-08).

## The quorum rule (contract)

- `cursor:auto` / `cursor-auto` / `cursor-tools:auto` → `unattested-harness` (NOT `unknown`).
- `resolve_reviewer` walks the normal risk ladder with all hard gates (formal eligibility, egress, domain, health, circuit) intact; no same-family exclusion is possible against the sentinel. Seat 1 = normal best selection; seat 2 = best eligible **outside seat 1's family**. Both are promoted to `selected`; `ReviewerResolution.selected` stays `None` — there is no single reviewer of record, BOTH seats must PASS at the same exact head.
- Fail-closed is preserved where it should be:
  - a declared `--author-family` against an auto attestation is a **conflict** (an unverifiable claim must not dodge the quorum) — unlike a bare `cursor` record, where a validated override still disambiguates;
  - fewer than two eligible distinct families → fail closed;
  - an explicit reviewer pin cannot substitute for the quorum.
- `closeout_cli resolve-reviewer` emits `quorum` + `quorum_rule` and exits 0 on a satisfiable quorum. Never self-seals: the plan is executed via the lightweight direct ask + PR-posted verdicts (sealed formal machinery stays retired); no plane-mode changes.
- Operator contract recorded in `model-assignment.md` next to the existing reviewer-side `cursor:auto` ban.

Example resolution (medium risk): Terra (openai) + Sonnet 5 (anthropic). Critical: Fable 5 (anthropic) + Sol frontier (openai).

## Verification

- `pytest tests/test_review_reviewer_resolver.py tests/ai_agent_bridge/test_review_pr.py tests/ai_agent_bridge/test_review_pr_pins.py tests/review/test_bench_health.py tests/test_codexbar_usage.py` — 141 passed.
- End-to-end CLI: `closeout_cli resolve-reviewer --author-model cursor-auto` → exit 0, quorum `[gpt-5.6-terra/openai, claude-sonnet-5/anthropic]`, `fail_closed_reason=null`.
- `ruff check` clean on all touched files; `lint_model_catalog.py` ok.
- Note: `tests/test_review_closeout_cli.py` subprocess tests fail in the sparse dispatch worktree on a clean tree too (`_run_cli` spawns a relative `.venv/bin/python`, absent by dispatch policy) — environmental, passes in CI.

## Residuals

- Attestation-first capture (issue item 2): the cursor adapter still reports `actual_model_known: "false"`; capturing the resolved model from the stream when the API exposes it is separate adapter work.
- Open question (issue item 3): whether Cursor Auto can switch models mid-task. If yes, per the Sol advisory even dual review is insufficient and pinned authorship / per-contribution attestation becomes mandatory for formal-reviewed work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)