### PR TITLE
docs(hooks): document durable thread lease recovery

### DIFF
--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -175,10 +175,20 @@ accumulate past the outer hook deadline. Hook-owned advisory locks use a
 one-second bounded wait; the lock remains fail-safe, while a live but wedged
 owner can no longer stall a new session indefinitely.
 
-A `SIGKILL` can land after `claim-thread-lease` persists the lease but before the
-claim reports back to SessionStart. In that case the session must stop and the
-lease can remain held; do not force-release based only on a claim timeout. The
-lease-lifecycle work in the infrastructure lane is making this recovery explicit.
+A durable thread lease records the harness process PID, process start time, and
+machine identity. A new session reclaims the lease immediately when that exact
+process is dead or the PID has been reused; it never steals from a confirmed-live
+owner, regardless of heartbeat age. `heartbeat_at` is diagnostic only. If process
+liveness cannot be checked, the claim fails closed and prints a CAS-scoped
+`release-thread-lease --force` command bound to the observed owner and generation.
+Use only that exact command after verifying the owner is gone; a confirmed-live
+owner also requires the explicit `--acknowledge-live-owner` flag.
+
+Normal `SessionEnd` runs `release-thread-lease` and leaves a released tombstone so
+the next claim retains a monotonic generation fence. `SIGKILL` can skip that hook,
+and can land after a claim is persisted but before SessionStart receives its
+result. In that case the session must stop; do not force-release based only on a
+claim timeout. A later claim will reclaim a confirmed-dead owner automatically.
 
 Broad curriculum scans, service probes, GitHub issue listings, and governance
 audits were removed from the synchronous hook. The hook now points to


### PR DESCRIPTION
## Summary

- replace the stale runbook statement that lease recovery is still in progress with the exact behavior already landed on `main`
- document PID/start-time/machine liveness, immediate reclaim of confirmed-dead or PID-reused owners, and fail-closed handling for uncheckable owners
- document the identity-fenced `SessionEnd` release tombstone and safe `SIGKILL` recovery posture

The executable fix is already present on `main` through #5758, #5845, and #5896. This PR closes the remaining operator-documentation and issue-linkage gap without duplicating the lease implementation.

## Design

The owner process identity is authoritative: confirmed-live owners are never stolen from, confirmed-dead owners are reclaimed immediately, cooperative release is identity-fenced, and an uncheckable owner requires the exact CAS-scoped operator release instead of a clock-based takeover.

## Validation

- focused lease claim/release/restart and ABA-fencing pytest: 9 passed
- `ruff check scripts/orchestration/thread_handoff.py tests/orchestration/test_thread_handoff.py`: passed
- Markdown lint on `docs/runbooks/codex-hooks.md`: passed
- `git diff --check`: passed
- agent-trailer and OPSEC audits: passed

A broader run of `tests/orchestration/test_thread_handoff.py` reached 148 passed and four unrelated subprocess tests could not execute because they hard-code a worktree-local `.venv/bin/python`; this dispatch worktree intentionally has no `.venv` and all project commands used the shared primary interpreter.

## Residual

When process liveness is genuinely uncheckable, the lease remains fail-closed until an operator runs the exact CAS-scoped release printed by the conflict. This is intentional to preserve anti-double-drive safety.

Fixes #5759