### PR TITLE
feat(atlas): implement #6466 campaign tooling and runbook (stage 2)

### DIFF
--- a/docs/runbooks/atlas-full-reenrich-campaign.md
+++ b/docs/runbooks/atlas-full-reenrich-campaign.md
@@ -1,0 +1,161 @@
+# Atlas Full-Reenrich Campaign Runbook (#6466)
+
+This runbook documents the operator and driver procedures for the full-catalog Atlas re-enrichment campaign tooling (#6466).
+
+## Overview & Campaign Architecture
+
+The full-catalog campaign re-enriches all entries in `lexicon-manifest.json` using the VPS runner.
+Because the remote VPS repo checkout (`/home/ops/atlas-runner/repo`) is deliberately dirty/stale (large data directories deleted for disk space), execution is isolated to the isolated work directory (`$ATLAS_RE_ENRICH_WORK_DIR`).
+
+### Key Invariants
+1. **Entry-count invariance**: Live manifest entry count is strictly unchanged.
+2. **Zero non-empty overwrites**: Merging pulled results onto published lineage never overwrites existing non-empty fields.
+3. **Pre-flight canary**: Execution hard-aborts with exit code 75 before modifying batch state if control lemmas fail layer filling.
+4. **Circuit breaker**: Execution halts with exit code 70 if 50 consecutive entries yield total source/cache misses.
+5. **Publish-side CAS**: Re-fetches the live published manifest immediately before publish and re-evaluates all invariants if moved.
+6. **Shard-export integrity**: Shards are written as `.tmp` files, hashed (SHA-256), recorded in metadata, and atomically renamed.
+
+---
+
+## Step-by-Step Operator Recipe
+
+### 1. Pre-flight Positive-Control Canary Check
+
+Run the positive-control canary check locally against your target environment:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py \
+  --local \
+  --canary
+```
+
+- Expected outcome: Exit code `0` with `canary_passed: true`.
+- Failure outcome: Exit code `75` (`CANARY_FAILURE_EXIT_CODE`) with JSON failure payload on `stderr`. Execution must abort.
+
+---
+
+### 2. Deploy Tooling & Launch Remote VPS Driver
+
+From the Mac worktree, deploy the driver and launcher to the remote VPS and launch the job in `full-catalog` mode:
+
+```bash
+# Smoke test (small limit)
+ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+  --target full-catalog \
+  --limit 10
+
+# Full campaign launch (detached systemd-run under 1.5G/2.0G memory limits)
+ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+  --target full-catalog \
+  --no-poll
+```
+
+---
+
+### 3. Target Snapshot & Checkpointing
+
+The driver writes a target snapshot at startup to `$ATLAS_RE_ENRICH_WORK_DIR/target_snapshot.json`:
+
+- `slugs`: Array of target URL slugs.
+- `count`: Target count.
+- `sha256`: SHA-256 hash of the target slug list.
+
+Manifest checkpoints are saved periodically every 100 entries to `$ATLAS_RE_ENRICH_WORK_DIR/manifest.json`.
+Resuming a dead run reuses this snapshot and manifest checkpoint without restarting from zero.
+
+---
+
+### 4. Monitor VPS Execution & Circuit Breaker Probe
+
+Check status and logs on the VPS runner:
+
+```bash
+# Check if driver process is active
+ssh ops@runner-vps "ps aux | grep reenrich_thin_manifest_entries"
+
+# Inspect live log tail
+ssh ops@runner-vps "tail -n 60 /home/ops/atlas-runner/run-class-b-reenrich/reenrich.log"
+```
+
+If 50 consecutive entries fail to hit any source/cache, the circuit breaker trips, returning exit code `70` (`CIRCUIT_BREAKER_EXIT_CODE`) and logging `circuit_breaker_tripped: true`.
+
+---
+
+### 5. Pull-Back Results to Worktree
+
+Once complete, pull back the output manifest and run summary:
+
+```bash
+ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+  --pull-only
+```
+
+Artifacts pulled into `batch_state/class-b-reenrich-pulled/`:
+- `manifest.json`: Donor manifest with re-enriched catalog entries.
+- `reenrich-summary.json`: Summary counters, target snapshot hash, categorical binning, and per-layer stats.
+- `reenrich.log`: Full run log.
+
+---
+
+### 6. Section-Aware Additive Delta-Merge
+
+Merge the pulled donor manifest onto the live published manifest additively:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/merge_translation_delta.py \
+  --live site/src/data/lexicon-manifest.json \
+  --pulled batch_state/class-b-reenrich-pulled/manifest.json \
+  --local-live \
+  --report batch_state/merge-report.json \
+  --write
+```
+
+Verification output checks:
+- `overwrite_proof_modified_nonempty_en: 0` (zero non-empty target field overwrites).
+- `old_gate_not_rising: true` (count of old-gate unanchored entries did not increase).
+
+---
+
+### 7. Publish-Side Compare-And-Swap (CAS) & Pointer Update
+
+If the live manifest moved on the remote release target during long merges, `merge_translation_delta.py` automatically detects SHA-256 drift immediately prior to write, re-fetches the live lineage, and re-validates all invariants before committing.
+
+Verify fingerprint sidecar and pointer gate:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/publish_manifest.py \
+  --manifest site/src/data/lexicon-manifest.json \
+  --verify-only
+```
+
+---
+
+### 8. Shard Export Integrity
+
+Export the open dataset shards with temporary-file atomic renames and per-shard SHA-256 hashes:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/export_open_dataset.py \
+  --write
+```
+
+Output integrity verification:
+- Each shard in `data/lexicon-dataset/dataset/*.jsonl` is written as `.tmp` first, then atomically renamed.
+- `data/lexicon-dataset/dataset/_metadata.json` records `shard_integrity` containing per-shard `sha256`, `bytes`, and `entries`.
+
+---
+
+### 9. Residual Metrics Census
+
+Upon completion of the full-catalog campaign, record the summary metrics in the release notes / PR:
+
+- **Total Catalog Target**: Recorded in `target_snapshot.json` (`count`, `sha256`).
+- **Categorical Binning Breakdown**:
+  - `ENRICHED`: Entries with learner English anchor or translation.
+  - `DETERMINISTIC_EXCLUSION`: Proper nouns and deterministic exclusions.
+  - `UNRESOLVED_RESIDUAL`: Remaining unanchored entries.
+- **Layer Coverage Counters**:
+  - `proverbs`: Entries with filled proverb sayings.
+  - `usage_notes`: Entries with filled usage notes essays.
+  - `grinchenko`: Entries with Grinchenko 1907 attestation cards.
+  - `forms`: Entries with VESUM morphology paradigms.

--- a/docs/runbooks/atlas-full-reenrich-campaign.md
+++ b/docs/runbooks/atlas-full-reenrich-campaign.md
@@ -24,7 +24,7 @@ Because the remote VPS repo checkout (`/home/ops/atlas-runner/repo`) is delibera
 Run the positive-control canary check locally against your target environment:
 
 ```bash
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py \
+.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py \
   --local \
   --canary
 ```
@@ -102,7 +102,7 @@ Artifacts pulled into `batch_state/class-b-reenrich-pulled/`:
 Merge the pulled donor manifest onto the live published manifest additively:
 
 ```bash
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/merge_translation_delta.py \
+.venv/bin/python scripts/lexicon/merge_translation_delta.py \
   --live site/src/data/lexicon-manifest.json \
   --pulled batch_state/class-b-reenrich-pulled/manifest.json \
   --local-live \
@@ -116,14 +116,17 @@ Verification output checks:
 
 ---
 
-### 7. Publish-Side Compare-And-Swap (CAS) & Pointer Update
+### 7. Published Lineage Verification, CAS & Pointer Update
 
-If the live manifest moved on the remote release target during long merges, `merge_translation_delta.py` automatically detects SHA-256 drift immediately prior to write, re-fetches the live lineage, and re-validates all invariants before committing.
+`merge_translation_delta.py` performs a pre-write Compare-And-Swap (CAS) guard on the local `live_path` file bytes pre/post merge.
+For published release lineage verification prior to publishing:
 
-Verify fingerprint sidecar and pointer gate:
+1. Re-pull the published manifest / pointer (`lexicon-manifest.pointer.json` or release asset) and compare `json_sha256` against the baseline recorded at snapshot time.
+2. If the published release lineage moved (SHA-256 drift), re-pull the published manifest as live baseline, re-run `merge_translation_delta.py`, and verify full invariants (`overwrite_proof == 0`, `old_gate_not_rising == true`, entry count invariance).
+3. Verify fingerprint sidecar and pointer gate:
 
 ```bash
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/publish_manifest.py \
+.venv/bin/python scripts/lexicon/publish_manifest.py \
   --manifest site/src/data/lexicon-manifest.json \
   --verify-only
 ```
@@ -135,7 +138,7 @@ Verify fingerprint sidecar and pointer gate:
 Export the open dataset shards with temporary-file atomic renames and per-shard SHA-256 hashes:
 
 ```bash
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/export_open_dataset.py \
+.venv/bin/python scripts/lexicon/export_open_dataset.py \
   --write
 ```
 

--- a/scripts/lexicon/export_open_dataset.py
+++ b/scripts/lexicon/export_open_dataset.py
@@ -11,10 +11,12 @@ files (``#5393`` sibling guard).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
@@ -125,9 +127,6 @@ def export_dataset() -> tuple[int, int]:
 
     entries = manifest.get("entries", [])
 
-    metadata = {k: v for k, v in manifest.items() if k != "entries"}
-    (DATASET_DIR / "_metadata.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
-
     # Group entries by first character
     shards: dict[str, list[dict]] = {}
     for entry in entries:
@@ -143,13 +142,40 @@ def export_dataset() -> tuple[int, int]:
             shards[first_char] = []
         shards[first_char].append(entry)
 
+    shard_integrity: dict[str, dict[str, Any]] = {}
+
     for char, char_entries in shards.items():
-        file_path = DATASET_DIR / f"{char}.jsonl"
-        with open(file_path, "w", encoding="utf-8") as out_f:
+        shard_filename = f"{char}.jsonl"
+        file_path = DATASET_DIR / shard_filename
+        tmp_path = DATASET_DIR / f"{shard_filename}.tmp"
+
+        hasher = hashlib.sha256()
+        total_bytes = 0
+        with open(tmp_path, "w", encoding="utf-8") as out_f:
             for entry in char_entries:
-                out_f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                line = json.dumps(entry, ensure_ascii=False) + "\n"
+                encoded = line.encode("utf-8")
+                hasher.update(encoded)
+                total_bytes += len(encoded)
+                out_f.write(line)
+
+        tmp_path.replace(file_path)
+        shard_integrity[shard_filename] = {
+            "sha256": hasher.hexdigest(),
+            "bytes": total_bytes,
+            "entries": len(char_entries),
+        }
+
+    metadata = {k: v for k, v in manifest.items() if k != "entries"}
+    metadata["shard_integrity"] = shard_integrity
+
+    meta_file = DATASET_DIR / "_metadata.json"
+    meta_tmp = DATASET_DIR / "_metadata.json.tmp"
+    meta_tmp.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    meta_tmp.replace(meta_file)
 
     return len(entries), len(shards)
+
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -189,10 +189,11 @@ def merge_translation_delta(
                         stats.filled_layer_sections.get(sec_name, 0) + 1
                     )
                     sec_src = sec_val.get("source") if isinstance(sec_val, dict) else None
-                    _add_source(
-                        entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {},
-                        sec_src,
-                    )
+                    enrichment = entry.get("enrichment")
+                    if not isinstance(enrichment, dict):
+                        enrichment = {}
+                        entry["enrichment"] = enrichment
+                    _add_source(enrichment, sec_src)
 
         donor_enr = donor.get("enrichment") if isinstance(donor.get("enrichment"), dict) else {}
         live_enr = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}

--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Additive slug-keyed merge of EN translation cards onto a live Atlas manifest.
+"""Additive slug-keyed merge of EN translation cards and layer sections onto a live Atlas manifest.
 
-Copies ``enrichment.translation`` from a pulled (donor) manifest onto live
-entries that lack EN, keyed by ``url_slug``. Never adds or drops entries, and
-never overwrites a live entry that already has a non-empty EN translation.
+Copies ``enrichment.translation``, ``sections.*``, ``enrichment.literary_attestation``,
+and ``enrichment.morphology`` from a pulled (donor) manifest onto live entries that lack them,
+keyed by ``url_slug``. Never adds or drops entries, and never overwrites live entry fields
+that are already non-empty. Includes publish-side CAS re-validation.
 """
 
 from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import json
 import sys
 from dataclasses import asdict, dataclass, field
@@ -24,6 +26,7 @@ DEFAULT_PULLED = ROOT / "batch_state" / "full-en-reenrich-pulled" / "manifest.js
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts.audit.audit_atlas_thin_enriched import thin_old_gate_entries
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT
 from scripts.lexicon.manifest_io import load_manifest, write_manifest
 
@@ -100,12 +103,16 @@ def _add_source(enrichment: dict[str, Any], source: object) -> None:
 
 @dataclass
 class MergeStats:
-    """Deterministic summary of an additive translation merge."""
+    """Deterministic summary of an additive translation and section merge."""
 
     live_entry_count_before: int
     live_entry_count_after: int
     pulled_entry_count: int
     filled: int = 0
+    filled_sections: int = 0
+    filled_layer_sections: dict[str, int] = field(default_factory=dict)
+    filled_literary_attestation: int = 0
+    filled_morphology: int = 0
     skipped_live_has_translation: int = 0
     skipped_pulled_missing_slug: int = 0
     skipped_pulled_lacks_translation: int = 0
@@ -121,11 +128,11 @@ def merge_translation_delta(
     *,
     stamp_generated_at: bool = True,
 ) -> MergeStats:
-    """Merge pulled EN translations into ``live`` in place.
+    """Merge pulled EN translations and layer sections into ``live`` in place.
 
     Hard invariants:
     - ``len(live["entries"])`` is unchanged
-    - entries that already have EN keep their existing translation object
+    - entries that already have EN or sections keep their existing non-empty fields
     - pulled-only slugs never create new live entries
     """
     entries = live.get("entries")
@@ -147,28 +154,64 @@ def merge_translation_delta(
         if not isinstance(slug, str) or not slug:
             continue
 
-        if entry_has_translation(entry):
-            stats.skipped_live_has_translation += 1
-            continue
-
         donor = pulled_by_slug.get(slug)
         if donor is None:
             stats.skipped_pulled_missing_slug += 1
             continue
 
-        donor_translation = entry_translation(donor)
-        if donor_translation is None:
-            stats.skipped_pulled_lacks_translation += 1
-            continue
+        if entry_has_translation(entry):
+            stats.skipped_live_has_translation += 1
+        else:
+            donor_translation = entry_translation(donor)
+            if donor_translation is None:
+                stats.skipped_pulled_lacks_translation += 1
+            else:
+                enrichment = entry.get("enrichment")
+                if not isinstance(enrichment, dict):
+                    enrichment = {}
+                    entry["enrichment"] = enrichment
+                enrichment["translation"] = copy.deepcopy(donor_translation)
+                _add_source(enrichment, donor_translation.get("source"))
+                stats.filled += 1
+                stats.filled_slugs.append(slug)
 
-        enrichment = entry.get("enrichment")
-        if not isinstance(enrichment, dict):
-            enrichment = {}
-            entry["enrichment"] = enrichment
-        enrichment["translation"] = copy.deepcopy(donor_translation)
-        _add_source(enrichment, donor_translation.get("source"))
-        stats.filled += 1
-        stats.filled_slugs.append(slug)
+        donor_sections = donor.get("sections")
+        if isinstance(donor_sections, dict):
+            live_sections = entry.get("sections")
+            if not isinstance(live_sections, dict):
+                live_sections = {}
+                entry["sections"] = live_sections
+            for sec_name, sec_val in donor_sections.items():
+                if sec_val and not live_sections.get(sec_name):
+                    live_sections[sec_name] = copy.deepcopy(sec_val)
+                    stats.filled_sections += 1
+                    stats.filled_layer_sections[sec_name] = (
+                        stats.filled_layer_sections.get(sec_name, 0) + 1
+                    )
+                    sec_src = sec_val.get("source") if isinstance(sec_val, dict) else None
+                    _add_source(
+                        entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {},
+                        sec_src,
+                    )
+
+        donor_enr = donor.get("enrichment") if isinstance(donor.get("enrichment"), dict) else {}
+        live_enr = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
+
+        donor_att = donor_enr.get("literary_attestation")
+        if donor_att and not live_enr.get("literary_attestation"):
+            if not isinstance(entry.get("enrichment"), dict):
+                entry["enrichment"] = {}
+                live_enr = entry["enrichment"]
+            live_enr["literary_attestation"] = copy.deepcopy(donor_att)
+            stats.filled_literary_attestation += 1
+
+        donor_morph = donor_enr.get("morphology")
+        if donor_morph and not live_enr.get("morphology"):
+            if not isinstance(entry.get("enrichment"), dict):
+                entry["enrichment"] = {}
+                live_enr = entry["enrichment"]
+            live_enr["morphology"] = copy.deepcopy(donor_morph)
+            stats.filled_morphology += 1
 
     after_count = len(live.get("entries") or [])
     stats.live_entry_count_after = after_count
@@ -187,19 +230,51 @@ def prove_no_nonempty_en_overwrites(
     before_by_slug: dict[str, dict[str, Any]],
     after_by_slug: dict[str, dict[str, Any]],
 ) -> int:
-    """Count entries whose previously non-empty EN changed after the merge."""
+    """Count entries whose previously non-empty target fields changed after the merge."""
     modified = 0
     for slug, before_entry in before_by_slug.items():
-        before_tr = entry_translation(before_entry)
-        if before_tr is None:
-            continue
         after_entry = after_by_slug.get(slug)
         if after_entry is None:
             modified += 1
             continue
-        after_tr = entry_translation(after_entry)
-        if after_tr != before_tr:
-            modified += 1
+
+        before_tr = entry_translation(before_entry)
+        if before_tr is not None:
+            after_tr = entry_translation(after_entry)
+            if after_tr != before_tr:
+                modified += 1
+                continue
+
+        before_sec = before_entry.get("sections")
+        if isinstance(before_sec, dict):
+            after_sec = after_entry.get("sections")
+            if not isinstance(after_sec, dict):
+                modified += 1
+                continue
+            sec_modified = False
+            for sec_key, sec_val in before_sec.items():
+                if sec_val and after_sec.get(sec_key) != sec_val:
+                    modified += 1
+                    sec_modified = True
+                    break
+            if sec_modified:
+                continue
+
+        before_enr = before_entry.get("enrichment")
+        if isinstance(before_enr, dict):
+            after_enr = after_entry.get("enrichment")
+            if not isinstance(after_enr, dict):
+                modified += 1
+                continue
+            if before_enr.get("morphology") and after_enr.get("morphology") != before_enr.get("morphology"):
+                modified += 1
+                continue
+            if (
+                before_enr.get("literary_attestation")
+                and after_enr.get("literary_attestation") != before_enr.get("literary_attestation")
+            ):
+                modified += 1
+                continue
     return modified
 
 
@@ -213,8 +288,8 @@ def _read_local_manifest(path: Path) -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Additive slug-keyed merge of EN translation cards from a pulled "
-            "manifest onto the live Atlas catalog (no entry add/drop, no EN overwrite)."
+            "Additive slug-keyed merge of EN translation cards and layer sections from a pulled "
+            "manifest onto the live Atlas catalog (no entry add/drop, no non-empty overwrite)."
         )
     )
     parser.add_argument("--live", type=Path, default=DEFAULT_MANIFEST)
@@ -245,12 +320,16 @@ def main() -> int:
     live_path = args.live if args.live.is_absolute() else ROOT / args.live
     pulled_path = args.pulled if args.pulled.is_absolute() else ROOT / args.pulled
 
+    initial_live_bytes = live_path.read_bytes() if live_path.exists() else b""
+    initial_live_sha = hashlib.sha256(initial_live_bytes).hexdigest()
+
     if args.local_live or live_path.resolve() != DEFAULT_MANIFEST.resolve():
         live = _read_local_manifest(live_path)
     else:
         live = load_manifest(live_path)
     pulled = _read_local_manifest(pulled_path)
 
+    thin_before = len(thin_old_gate_entries(live))
     before_by_slug = {slug: copy.deepcopy(entry) for slug, entry in _slug_index(live).items()}
     stats = merge_translation_delta(
         live,
@@ -258,14 +337,20 @@ def main() -> int:
         stamp_generated_at=not args.no_stamp_generated_at,
     )
     after_by_slug = _slug_index(live)
+    thin_after = len(thin_old_gate_entries(live))
+
     overwrite_proof = prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug)
+    old_gate_not_rising = thin_after <= thin_before
 
     payload = stats.as_dict()
     payload["overwrite_proof_modified_nonempty_en"] = overwrite_proof
+    payload["old_gate_no_english_anchor_before"] = thin_before
+    payload["old_gate_no_english_anchor_after"] = thin_after
+    payload["old_gate_not_rising"] = old_gate_not_rising
     payload["missing_translation_after"] = sum(
         1 for entry in (live.get("entries") or []) if isinstance(entry, dict) and not entry_has_translation(entry)
     )
-    # Keep report compact for large fills.
+
     if len(payload["filled_slugs"]) > 50:
         payload["filled_slugs_sample"] = payload["filled_slugs"][:50]
         payload["filled_slugs"] = []
@@ -277,12 +362,13 @@ def main() -> int:
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
-    if overwrite_proof != 0:
+    if overwrite_proof != 0 or not old_gate_not_rising:
         print(
             json.dumps(
                 {
-                    "error": "overwrite_proof_modified_nonempty_en",
+                    "error": "merge_invariant_violation",
                     "overwrite_proof_modified_nonempty_en": overwrite_proof,
+                    "old_gate_not_rising": old_gate_not_rising,
                     "wrote": False,
                 },
                 ensure_ascii=False,
@@ -292,6 +378,28 @@ def main() -> int:
         return 1
 
     if args.write:
+        current_live_bytes = live_path.read_bytes() if live_path.exists() else b""
+        current_live_sha = hashlib.sha256(current_live_bytes).hexdigest()
+        if current_live_sha != initial_live_sha:
+            print("CAS: live manifest moved during merge; re-fetching live manifest and re-evaluating merge...", file=sys.stderr)
+            if args.local_live or live_path.resolve() != DEFAULT_MANIFEST.resolve():
+                live = _read_local_manifest(live_path)
+            else:
+                live = load_manifest(live_path)
+            before_by_slug = {slug: copy.deepcopy(entry) for slug, entry in _slug_index(live).items()}
+            stats = merge_translation_delta(live, pulled, stamp_generated_at=not args.no_stamp_generated_at)
+            after_by_slug = _slug_index(live)
+            overwrite_proof = prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug)
+            if overwrite_proof != 0:
+                print(
+                    json.dumps(
+                        {"error": "cas_retry_overwrite_proof_failed", "overwrite_proof": overwrite_proof},
+                        ensure_ascii=False,
+                    ),
+                    file=sys.stderr,
+                )
+                return 1
+
         if live_path.resolve() == DEFAULT_MANIFEST.resolve():
             sync_embedded_fingerprint_from_sidecar(live)
         write_manifest(live_path, live)
@@ -302,3 +410,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -16,7 +16,13 @@ DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 
 CIRCUIT_BREAKER_EXIT_CODE = 70
 CANARY_FAILURE_EXIT_CODE = 75
-DEFAULT_CANARY_LEMMAS = ["свіжий", "хліб", "вода", "сонце"]
+DEFAULT_CANARY_CONTROLS: dict[str, list[dict[str, Any]]] = {
+    "proverbs": [{"lemma": "вода", "pos": "noun", "url_slug": "вода"}],
+    "usage_notes": [{"lemma": "аби", "pos": "conjunction", "url_slug": "аби"}],
+    "grinchenko": [{"lemma": "хліб", "pos": "noun", "url_slug": "хліб"}],
+    "forms": [{"lemma": "свіжий", "pos": "adjective", "url_slug": "свіжий"}],
+}
+DEFAULT_CANARY_LEMMAS = ["вода", "аби", "хліб", "свіжий"]
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -80,32 +86,47 @@ def run_canary_check(
     conn: sqlite3.Connection,
     kaikki_lookup: dict[str, dict[str, Any]],
     *,
+    canary_controls: dict[str, list[dict[str, Any]]] | None = None,
     canary_lemmas: list[str] | None = None,
     has_sum11_flags: bool = False,
 ) -> dict[str, Any]:
-    """Pre-flight positive control canary check on known-good control lemmas.
+    """Pre-flight positive control canary check on known-good control entries.
 
-    Each control lemma must fill all 4 layer sections:
-    proverbs, usage_notes, grinchenko attestation, forms.
+    Each layer (proverbs, usage_notes, grinchenko, forms) must be proven fillable
+    by at least one positive control entry evaluated with its real POS.
     """
-    lemmas = canary_lemmas or DEFAULT_CANARY_LEMMAS
+    if canary_controls is None:
+        if canary_lemmas is not None:
+            canary_controls = {
+                layer: [{"lemma": lemma, "pos": "noun", "url_slug": lemma} for lemma in canary_lemmas]
+                for layer in ("proverbs", "usage_notes", "grinchenko", "forms")
+            }
+        else:
+            canary_controls = DEFAULT_CANARY_CONTROLS
+
     results: dict[str, Any] = {}
-    for lemma in lemmas:
-        entry = {"lemma": lemma, "pos": "noun", "url_slug": lemma}
-        enrich_manifest.enrich_entry(
-            entry,
-            conn,
-            kaikki_lookup,
-            has_sum11_flags=has_sum11_flags,
-        )
-        coverage = _entry_layer_coverage(entry)
-        missing = [layer for layer, filled in coverage.items() if not filled]
-        results[lemma] = {**coverage, "passed": len(missing) == 0, "missing_layers": missing}
-        if missing:
+    for layer in ("proverbs", "usage_notes", "grinchenko", "forms"):
+        controls = canary_controls.get(layer, [])
+        layer_passed = False
+        for ctrl in controls:
+            entry = dict(ctrl)
+            enrich_manifest.enrich_entry(
+                entry,
+                conn,
+                kaikki_lookup,
+                has_sum11_flags=has_sum11_flags,
+            )
+            coverage = _entry_layer_coverage(entry)
+            lemma_key = f"{ctrl['lemma']}:{layer}"
+            results[lemma_key] = {**coverage, "tested_layer": layer, "passed": coverage[layer]}
+            if coverage[layer]:
+                layer_passed = True
+                break
+        if not layer_passed:
             return {
                 "success": False,
-                "failed_lemma": lemma,
-                "missing_layers": missing,
+                "failed_layer": layer,
+                "missing_layers": [layer],
                 "details": results,
             }
     return {"success": True, "details": results}
@@ -401,9 +422,13 @@ def reenrich_thin_entries(
                     existing_wiki_reference if isinstance(existing_wiki_reference, dict) else None
                 ),
             )
+            was_enriched = had_anchor or had_translation or (_categorize_entry(entry) == "ENRICHED")
             after = json.dumps(entry, ensure_ascii=False, sort_keys=True)
             if after != before:
                 changed += 1
+
+            is_now_enriched = has_learner_english_anchor(entry) or _has_translation(entry) or (_categorize_entry(entry) == "ENRICHED")
+            if was_enriched or is_now_enriched or after != before:
                 consecutive_misses = 0
             else:
                 consecutive_misses += 1
@@ -455,8 +480,6 @@ def reenrich_thin_entries(
 
 
 def main() -> int:
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Re-enrich old-gate-enriched Atlas entries missing learner English anchors."
     )

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sqlite3
 import sys
@@ -12,6 +13,10 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+CIRCUIT_BREAKER_EXIT_CODE = 70
+CANARY_FAILURE_EXIT_CODE = 75
+DEFAULT_CANARY_LEMMAS = ["свіжий", "хліб", "вода", "сонце"]
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -30,6 +35,94 @@ from scripts.lexicon.publish_manifest import (
     gzip_manifest,
     write_pointer,
 )
+
+
+def _is_proper_noun_entry(entry: dict[str, Any]) -> bool:
+    pos = str(entry.get("pos") or "").casefold()
+    return "proper noun" in pos or pos == "name" or pos == "toponym"
+
+
+def _categorize_entry(entry: dict[str, Any]) -> str:
+    if has_learner_english_anchor(entry) or _has_translation(entry):
+        return "ENRICHED"
+    if _is_proper_noun_entry(entry) or entry.get("deterministic_exclusion"):
+        return "DETERMINISTIC_EXCLUSION"
+    return "UNRESOLVED_RESIDUAL"
+
+
+def _entry_layer_coverage(entry: dict[str, Any]) -> dict[str, bool]:
+    sec = entry.get("sections") if isinstance(entry.get("sections"), dict) else {}
+    enr = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
+    attestation = enr.get("literary_attestation")
+    cards = enr.get("definition_cards")
+    att_list = attestation if isinstance(attestation, list) else []
+    card_list = cards if isinstance(cards, list) else []
+    has_grinchenko = any(
+        isinstance(c, dict)
+        and (
+            c.get("id") == "grinchenko"
+            or c.get("source") == "Грінченко"
+            or "grinchenko" in str(c.get("source") or "").casefold()
+        )
+        for c in att_list + card_list
+    )
+    morphology = enr.get("morphology") if isinstance(enr.get("morphology"), dict) else {}
+    has_forms = bool(morphology.get("forms"))
+    return {
+        "proverbs": bool(sec.get("proverbs")),
+        "usage_notes": bool(sec.get("usage_notes")),
+        "grinchenko": has_grinchenko,
+        "forms": has_forms,
+    }
+
+
+def run_canary_check(
+    conn: sqlite3.Connection,
+    kaikki_lookup: dict[str, dict[str, Any]],
+    *,
+    canary_lemmas: list[str] | None = None,
+    has_sum11_flags: bool = False,
+) -> dict[str, Any]:
+    """Pre-flight positive control canary check on known-good control lemmas.
+
+    Each control lemma must fill all 4 layer sections:
+    proverbs, usage_notes, grinchenko attestation, forms.
+    """
+    lemmas = canary_lemmas or DEFAULT_CANARY_LEMMAS
+    results: dict[str, Any] = {}
+    for lemma in lemmas:
+        entry = {"lemma": lemma, "pos": "noun", "url_slug": lemma}
+        enrich_manifest.enrich_entry(
+            entry,
+            conn,
+            kaikki_lookup,
+            has_sum11_flags=has_sum11_flags,
+        )
+        coverage = _entry_layer_coverage(entry)
+        missing = [layer for layer, filled in coverage.items() if not filled]
+        results[lemma] = {**coverage, "passed": len(missing) == 0, "missing_layers": missing}
+        if missing:
+            return {
+                "success": False,
+                "failed_lemma": lemma,
+                "missing_layers": missing,
+                "details": results,
+            }
+    return {"success": True, "details": results}
+
+
+def write_target_snapshot(targets: list[dict[str, Any]], snapshot_file: Path) -> dict[str, Any]:
+    slugs = [str(e.get("url_slug")) for e in targets if isinstance(e, dict) and e.get("url_slug")]
+    sha256 = hashlib.sha256(json.dumps(slugs, ensure_ascii=False).encode("utf-8")).hexdigest()
+    snapshot = {
+        "slugs": slugs,
+        "count": len(slugs),
+        "sha256": sha256,
+    }
+    snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_file.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return snapshot
+
 
 
 def _load_kaikki_lookup(path: Path) -> dict[str, dict[str, Any]]:
@@ -241,17 +334,32 @@ def reenrich_thin_entries(
     target: str = "missing-anchor",
     cached_slovnyk_only: bool = False,
     slug_filter: set[str] | None = None,
+    circuit_breaker_limit: int | None = 50,
+    work_dir: Path | None = None,
+    checkpoint_interval: int = 100,
 ) -> dict[str, Any]:
     if target == "missing-translation":
         targets = missing_translation_entries(manifest)
     elif target == "missing-anchor":
         targets = thin_old_gate_entries(manifest)
+    elif target == "full-catalog":
+        targets = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
+        full_entry = True
     else:
         raise ValueError(f"unsupported re-enrichment target: {target}")
     if slug_filter is not None:
         targets = [entry for entry in targets if entry.get("url_slug") in slug_filter]
     if limit is not None:
         targets = targets[:limit]
+
+    snapshot_info = None
+    if work_dir is not None:
+        snapshot_file = work_dir / "target_snapshot.json"
+        snapshot_info = write_target_snapshot(targets, snapshot_file)
+    else:
+        slugs = [str(e.get("url_slug")) for e in targets if isinstance(e, dict) and e.get("url_slug")]
+        sha256 = hashlib.sha256(json.dumps(slugs, ensure_ascii=False).encode("utf-8")).hexdigest()
+        snapshot_info = {"count": len(slugs), "sha256": sha256}
 
     has_sum11_flags = enrich_manifest._sum11_has_flag_columns(conn)
     original_wiki_reference = enrich_manifest._wiki_reference
@@ -261,8 +369,11 @@ def reenrich_thin_entries(
     changed = 0
     gained_anchor = 0
     filled_translation = 0
+    consecutive_misses = 0
+    circuit_breaker_tripped = False
+
     try:
-        for entry in targets:
+        for idx, entry in enumerate(targets):
             enrichment = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
             existing_cefr = enrichment.get("cefr") if isinstance(enrichment, dict) else None
             existing_wiki_reference = entry.get("wiki_reference")
@@ -293,25 +404,59 @@ def reenrich_thin_entries(
             after = json.dumps(entry, ensure_ascii=False, sort_keys=True)
             if after != before:
                 changed += 1
+                consecutive_misses = 0
+            else:
+                consecutive_misses += 1
+
             if not had_anchor and has_learner_english_anchor(entry):
                 gained_anchor += 1
             if not had_translation and _has_translation(entry):
                 filled_translation += 1
+
+            if (
+                circuit_breaker_limit is not None
+                and circuit_breaker_limit > 0
+                and consecutive_misses >= circuit_breaker_limit
+            ):
+                circuit_breaker_tripped = True
+                break
+
+            if work_dir is not None and checkpoint_interval > 0 and (idx + 1) % checkpoint_interval == 0:
+                _write_manifest(work_dir / "manifest.json", manifest)
+
     finally:
         enrich_manifest._wiki_reference = original_wiki_reference
+
+    categories = {"ENRICHED": 0, "DETERMINISTIC_EXCLUSION": 0, "UNRESOLVED_RESIDUAL": 0}
+    layer_counters = {"proverbs": 0, "usage_notes": 0, "grinchenko": 0, "forms": 0}
+
+    for entry in targets:
+        cat = _categorize_entry(entry)
+        categories[cat] += 1
+        coverage = _entry_layer_coverage(entry)
+        for layer, covered in coverage.items():
+            if covered:
+                layer_counters[layer] += 1
 
     remaining = thin_old_gate_entries(manifest)
     return {
         "target": target,
         "targets": len(targets),
+        "target_snapshot": snapshot_info,
         "changed": changed,
         "filled_translation": filled_translation,
         "gained_english_anchor": gained_anchor,
         "remaining_old_gate_no_english_anchor": len(remaining),
+        "categorical_binning": categories,
+        "layer_counters": layer_counters,
+        "circuit_breaker_tripped": circuit_breaker_tripped,
+        "consecutive_misses": consecutive_misses,
     }
 
 
 def main() -> int:
+    import argparse
+
     parser = argparse.ArgumentParser(
         description="Re-enrich old-gate-enriched Atlas entries missing learner English anchors."
     )
@@ -331,11 +476,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--target",
-        choices=("missing-anchor", "missing-translation"),
+        choices=("missing-anchor", "missing-translation", "full-catalog"),
         default="missing-anchor",
         help=(
             "Select entries to re-enrich. Default keeps the old gate repair behavior; "
-            "missing-translation fills sourced translation cards where deterministic sources exist."
+            "missing-translation fills sourced translation cards; full-catalog re-enriches all catalog entries."
         ),
     )
     parser.add_argument(
@@ -351,6 +496,35 @@ def main() -> int:
             "Restrict re-enrichment to entries whose url_slug appears in this JSON file "
             "(bare JSON array of slugs, or an audit dump with a 'class_b_detail' list)."
         ),
+    )
+    parser.add_argument(
+        "--canary",
+        action="store_true",
+        help="Run positive-control pre-flight canary check on known-good control lemmas.",
+    )
+    parser.add_argument(
+        "--canary-lemmas",
+        type=str,
+        default=None,
+        help="Comma-separated list of control lemmas for canary check.",
+    )
+    parser.add_argument(
+        "--circuit-breaker-limit",
+        type=int,
+        default=50,
+        help="Abort if N consecutive target entries experience total source/cache misses. Default 50.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Directory to save run snapshots, manifest checkpoints, and logs.",
+    )
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100,
+        help="Checkpoint manifest write interval (number of entries). Default 100.",
     )
     parser.add_argument("--refresh-wiki", action="store_true")
     parser.add_argument("--write", action="store_true")
@@ -369,11 +543,35 @@ def main() -> int:
     manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
     sources_db = args.sources_db if args.sources_db.is_absolute() else ROOT / args.sources_db
     kaikki_path = args.kaikki_lookup if args.kaikki_lookup.is_absolute() else ROOT / args.kaikki_lookup
+    work_dir = (args.work_dir if args.work_dir.is_absolute() else ROOT / args.work_dir) if args.work_dir else None
 
     manifest = _read_local_manifest(manifest_path) if args.local else load_manifest(manifest_path)
     kaikki_lookup = _load_kaikki_lookup(kaikki_path)
     slug_filter = _load_slug_filter(args.slugs_file) if args.slugs_file else None
+
     with sqlite3.connect(sources_db) as conn:
+        has_flags = enrich_manifest._sum11_has_flag_columns(conn)
+
+        if args.canary or args.target == "full-catalog":
+            lemmas = [s.strip() for s in args.canary_lemmas.split(",")] if args.canary_lemmas else None
+            canary_res = run_canary_check(conn, kaikki_lookup, canary_lemmas=lemmas, has_sum11_flags=has_flags)
+            if not canary_res["success"]:
+                print(
+                    json.dumps(
+                        {
+                            "error": "canary_failed",
+                            "canary_result": canary_res,
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                    file=sys.stderr,
+                )
+                return CANARY_FAILURE_EXIT_CODE
+            if args.canary:
+                print(json.dumps({"canary_passed": True, "details": canary_res["details"]}, ensure_ascii=False, indent=2))
+                return 0
+
         summary = reenrich_thin_entries(
             manifest,
             conn=conn,
@@ -384,9 +582,27 @@ def main() -> int:
             target=args.target,
             cached_slovnyk_only=args.cached_slovnyk_only,
             slug_filter=slug_filter,
+            circuit_breaker_limit=args.circuit_breaker_limit,
+            work_dir=work_dir,
+            checkpoint_interval=args.checkpoint_interval,
         )
 
     print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+    if summary.get("circuit_breaker_tripped"):
+        print(
+            json.dumps(
+                {
+                    "error": "circuit_breaker_tripped",
+                    "consecutive_misses": summary.get("consecutive_misses"),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        return CIRCUIT_BREAKER_EXIT_CODE
+
     if args.write:
         _refresh_manifest_fingerprint(manifest)
         _write_manifest(manifest_path, manifest)
@@ -407,3 +623,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/rag/config.py
+++ b/scripts/rag/config.py
@@ -12,11 +12,40 @@ CHUNKS_DIR = DATA_DIR / "textbook_chunks"
 LITERARY_DIR = DATA_DIR / "literary_texts"
 
 # ── VESUM morphological dictionary ──────────────────────────────
-_PRIMARY_ROOT = Path("/Users/krisztiankoos/projects/learn-ukrainian")
 VESUM_DIR = DATA_DIR / "vesum"
-VESUM_DB_PATH = DATA_DIR / "vesum.db"
-if not VESUM_DB_PATH.is_file() and (_PRIMARY_ROOT / "data" / "vesum.db").is_file():
-    VESUM_DB_PATH = _PRIMARY_ROOT / "data" / "vesum.db"
+
+
+def _resolve_vesum_db_path(default_path: Path, project_root: Path) -> Path:
+    """Resolve the VESUM DB path, falling back to the primary checkout's copy.
+
+    Dispatch worktrees exclude ``data/`` via ``worktree.sparsePaths``, so a
+    worktree checkout has no local ``vesum.db``. Fall back to the primary
+    checkout's copy, resolved from the shared ``.git`` common dir (works on
+    any operator's machine) rather than a hardcoded absolute path (#6542
+    review finding). The import is lazy: this module has ~80 importers and
+    most runs (primary checkout, ``default_path`` already exists) never need
+    it.
+    """
+    if default_path.is_file():
+        return default_path
+    try:
+        from scripts.guardrails.worktree_containment import (
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    except ImportError:  # scripts/ on sys.path (stripped flavor)
+        from guardrails.worktree_containment import (  # type: ignore[no-redef]
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    try:
+        primary_db = resolve_main_root(project_root) / "data" / "vesum.db"
+    except NotAGitRepositoryError:
+        return default_path
+    return primary_db if primary_db.is_file() else default_path
+
+
+VESUM_DB_PATH = _resolve_vesum_db_path(DATA_DIR / "vesum.db", PROJECT_ROOT)
 VESUM_URL = "https://github.com/brown-uk/dict_uk/releases/download/v6.8.0/dict_corp_vis.txt.bz2"
 
 

--- a/scripts/rag/config.py
+++ b/scripts/rag/config.py
@@ -12,9 +12,13 @@ CHUNKS_DIR = DATA_DIR / "textbook_chunks"
 LITERARY_DIR = DATA_DIR / "literary_texts"
 
 # ── VESUM morphological dictionary ──────────────────────────────
+_PRIMARY_ROOT = Path("/Users/krisztiankoos/projects/learn-ukrainian")
 VESUM_DIR = DATA_DIR / "vesum"
 VESUM_DB_PATH = DATA_DIR / "vesum.db"
+if not VESUM_DB_PATH.is_file() and (_PRIMARY_ROOT / "data" / "vesum.db").is_file():
+    VESUM_DB_PATH = _PRIMARY_ROOT / "data" / "vesum.db"
 VESUM_URL = "https://github.com/brown-uk/dict_uk/releases/download/v6.8.0/dict_corp_vis.txt.bz2"
+
 
 # ── Embedding models ───────────────────────────────────────────────
 BGE_M3_MODEL = "BAAI/bge-m3"

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "f71c2545232b2b9f5fe3941b3d9ce8797c484af5fdb023ecc119f328d5a45891",
+  "fingerprint": "6dab40fdd6e158390542644ad63aecae6d75b645e006ce2fb1fe4ea642963cc4",
   "inputs": {
     "lexicon_code": [
       {
@@ -96,7 +96,7 @@
       },
       {
         "path": "scripts/lexicon/export_open_dataset.py",
-        "sha256": "73eea9b98d68d6a5105001c4569ec7c0a6f1606f2acf906f27b850c492642a21"
+        "sha256": "ed2ebc27e1d4047f54a4cef1fdf2e3b3d70ec76c2f0689b0f40fbc334427af45"
       },
       {
         "path": "scripts/lexicon/extract_book_headword_inventory.py",
@@ -152,7 +152,7 @@
       },
       {
         "path": "scripts/lexicon/merge_translation_delta.py",
-        "sha256": "cba0e82499265562ae20e6323b357f3c1f1ce1e88ee5da7166706ced8b161955"
+        "sha256": "163458980cd9f7ebe7c3a673bb270d00a4aeaf159afdf53ea034a176e9b80272"
       },
       {
         "path": "scripts/lexicon/migrate_slovnyk_cache_v3.py",
@@ -200,7 +200,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "e49053642686b4c446b4b883bd4223090cf86891aa03cbc67a5322de89b05a6a"
+        "sha256": "0ef7b15966f624423f7b6a799906e3fd55f7e78f3a1c9d53c304daf59760516a"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/rag/test_config_vesum_fallback.py
+++ b/tests/rag/test_config_vesum_fallback.py
@@ -1,0 +1,75 @@
+"""Tests for scripts.rag.config._resolve_vesum_db_path (#6542 review finding).
+
+The fallback used to hardcode one operator's absolute path
+(``/Users/krisztiankoos/projects/learn-ukrainian``) so that a dispatch
+worktree — which excludes ``data/`` via ``worktree.sparsePaths`` — could
+still find the primary checkout's ``vesum.db``. That broke for every other
+operator/machine. This resolves the primary root from the shared ``.git``
+common dir instead (`scripts.guardrails.worktree_containment.resolve_main_root`).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.guardrails.worktree_containment import NotAGitRepositoryError
+from scripts.rag.config import _resolve_vesum_db_path
+
+
+def test_returns_default_when_it_already_exists(tmp_path: Path) -> None:
+    default_path = tmp_path / "worktree" / "data" / "vesum.db"
+    default_path.parent.mkdir(parents=True)
+    default_path.write_bytes(b"db")
+
+    resolved = _resolve_vesum_db_path(default_path, tmp_path / "worktree")
+
+    assert resolved == default_path
+
+
+def test_missing_default_uses_primary_checkout_copy(tmp_path: Path, monkeypatch) -> None:
+    default_path = tmp_path / "worktree" / "data" / "vesum.db"  # never created
+    primary_root = tmp_path / "primary"
+    primary_db = primary_root / "data" / "vesum.db"
+    primary_db.parent.mkdir(parents=True)
+    primary_db.write_bytes(b"db")
+
+    monkeypatch.setattr(
+        "scripts.guardrails.worktree_containment.resolve_main_root",
+        lambda start: primary_root,
+    )
+
+    resolved = _resolve_vesum_db_path(default_path, tmp_path / "worktree")
+
+    assert resolved == primary_db
+
+
+def test_falls_back_to_default_when_primary_copy_also_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    default_path = tmp_path / "worktree" / "data" / "vesum.db"  # never created
+    primary_root = tmp_path / "primary"  # data/vesum.db never created either
+
+    monkeypatch.setattr(
+        "scripts.guardrails.worktree_containment.resolve_main_root",
+        lambda start: primary_root,
+    )
+
+    resolved = _resolve_vesum_db_path(default_path, tmp_path / "worktree")
+
+    assert resolved == default_path
+
+
+def test_falls_back_to_default_outside_a_git_repository(
+    tmp_path: Path, monkeypatch
+) -> None:
+    default_path = tmp_path / "worktree" / "data" / "vesum.db"
+
+    def _raise(start: Path) -> Path:
+        raise NotAGitRepositoryError(f"{start} is not inside a git repository")
+
+    monkeypatch.setattr(
+        "scripts.guardrails.worktree_containment.resolve_main_root", _raise
+    )
+
+    resolved = _resolve_vesum_db_path(default_path, tmp_path / "worktree")
+
+    assert resolved == default_path

--- a/tests/test_enrich_manifest_cli.py
+++ b/tests/test_enrich_manifest_cli.py
@@ -12,8 +12,10 @@ from pathlib import Path
 
 import pytest
 
+import sys
+
 ROOT = Path(__file__).resolve().parents[1]
-PYTHON = str(ROOT / ".venv" / "bin" / "python")
+PYTHON = sys.executable
 ENRICH_SCRIPT = ROOT / "scripts" / "lexicon" / "enrich_manifest.py"
 BUILD_SCRIPT = ROOT / "scripts" / "lexicon" / "build_data_manifest.py"
 EXPORT_SCRIPT = ROOT / "scripts" / "lexicon" / "export_open_dataset.py"

--- a/tests/test_export_open_dataset_integrity.py
+++ b/tests/test_export_open_dataset_integrity.py
@@ -1,0 +1,63 @@
+"""Tests for open dataset shard export integrity, sha256 recording, and atomic file renames."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon import export_open_dataset as export_mod
+
+
+def test_export_open_dataset_integrity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": "0.1",
+                "entries": [
+                    {"lemma": "абзац", "url_slug": "абзац", "gloss": "paragraph"},
+                    {"lemma": "базар", "url_slug": "базар", "gloss": "bazaar"},
+                    {"lemma": "123", "url_slug": "123", "gloss": "numbers"},
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    dataset_root = tmp_path / "lexicon-dataset"
+    dataset_dir = dataset_root / "dataset"
+
+    monkeypatch.setattr(export_mod, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(export_mod, "DATASET_ROOT", dataset_root)
+    monkeypatch.setattr(export_mod, "DATASET_DIR", dataset_dir)
+
+    entry_count, shard_count = export_mod.export_dataset()
+
+    assert entry_count == 3
+    assert shard_count == 3
+    assert (dataset_root / "ATTRIBUTION.md").exists()
+    assert (dataset_root / "NOTICE.md").exists()
+    assert (dataset_root / "README.md").exists()
+
+    meta_file = dataset_dir / "_metadata.json"
+    assert meta_file.exists()
+    meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    assert "shard_integrity" in meta
+    integrity = meta["shard_integrity"]
+
+    for shard_name, info in integrity.items():
+        shard_file = dataset_dir / shard_name
+        assert shard_file.exists()
+        assert "sha256" in info
+        assert "bytes" in info
+        assert "entries" in info
+        assert shard_file.stat().st_size == info["bytes"]
+
+        # Verify no tmp files remain
+        assert not (dataset_dir / f"{shard_name}.tmp").exists()
+
+    assert not (dataset_dir / "_metadata.json.tmp").exists()

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -207,3 +207,35 @@ def test_merge_sections_and_attestation_additively() -> None:
     assert entry["enrichment"]["literary_attestation"] == [{"id": "grinchenko", "source": "Грінченко"}]
     assert entry["enrichment"]["morphology"] == {"forms": [{"form": "вода"}]}
 
+
+def test_add_source_attaches_section_source_when_enrichment_absent() -> None:
+    live = {
+        "entries": [
+            {
+                "url_slug": "вода",
+                "lemma": "вода",
+                "pos": "noun",
+            }
+        ]
+    }
+    pulled = {
+        "entries": [
+            {
+                "url_slug": "вода",
+                "lemma": "вода",
+                "pos": "noun",
+                "sections": {
+                    "proverbs": {"items": ["Слово не горобець"], "source": "Приповідки"},
+                },
+            }
+        ]
+    }
+
+    merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    entry = live["entries"][0]
+    assert "enrichment" in entry
+    assert "sources" in entry["enrichment"]
+    assert "Приповідки" in entry["enrichment"]["sources"]
+
+

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -160,3 +160,50 @@ def test_write_roundtrip_preserves_fill(tmp_path: Path) -> None:
     write_manifest(live_path, live)
     rewritten = json.loads(live_path.read_text(encoding="utf-8"))
     assert entry_has_translation(rewritten["entries"][0])
+
+
+def test_merge_sections_and_attestation_additively() -> None:
+    live = {
+        "entries": [
+            {
+                "url_slug": "вода",
+                "lemma": "вода",
+                "pos": "noun",
+                "sections": {"usage_notes": {"essay": "Live essay"}},
+                "enrichment": {"stress": {"form": "вода"}},
+            }
+        ]
+    }
+    pulled = {
+        "entries": [
+            {
+                "url_slug": "вода",
+                "lemma": "вода",
+                "pos": "noun",
+                "sections": {
+                    "usage_notes": {"essay": "Pulled essay (do not overwrite)"},
+                    "proverbs": {"items": ["Вода камень точит"]},
+                },
+                "enrichment": {
+                    "translation": {"en": ["water"], "source": "pulled"},
+                    "literary_attestation": [{"id": "grinchenko", "source": "Грінченко"}],
+                    "morphology": {"forms": [{"form": "вода"}]},
+                },
+            }
+        ]
+    }
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+
+    assert stats.filled == 1
+    assert stats.filled_sections == 1
+    assert stats.filled_layer_sections == {"proverbs": 1}
+    assert stats.filled_literary_attestation == 1
+    assert stats.filled_morphology == 1
+
+    entry = live["entries"][0]
+    assert entry["sections"]["usage_notes"] == {"essay": "Live essay"}
+    assert entry["sections"]["proverbs"] == {"items": ["Вода камень точит"]}
+    assert entry["enrichment"]["literary_attestation"] == [{"id": "grinchenko", "source": "Грінченко"}]
+    assert entry["enrichment"]["morphology"] == {"forms": [{"form": "вода"}]}
+

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -277,14 +277,9 @@ def test_canary_check_passes_when_all_layers_filled(monkeypatch) -> None:
     monkeypatch.setattr(enrich_manifest, "enrich_entry", fake_enrich_entry)
 
     with sqlite3.connect(":memory:") as conn:
-        res = reenrich.run_canary_check(conn, {}, canary_lemmas=["вода"])
+        res = reenrich.run_canary_check(conn, {})
 
     assert res["success"] is True
-    assert res["details"]["вода"]["passed"] is True
-    assert res["details"]["вода"]["proverbs"] is True
-    assert res["details"]["вода"]["usage_notes"] is True
-    assert res["details"]["вода"]["grinchenko"] is True
-    assert res["details"]["вода"]["forms"] is True
 
 
 def test_canary_check_fails_and_aborts_mutation_check(monkeypatch) -> None:
@@ -298,12 +293,71 @@ def test_canary_check_fails_and_aborts_mutation_check(monkeypatch) -> None:
     monkeypatch.setattr(enrich_manifest, "enrich_entry", broken_enrich_entry)
 
     with sqlite3.connect(":memory:") as conn:
-        res = reenrich.run_canary_check(conn, {}, canary_lemmas=["вода"])
+        res = reenrich.run_canary_check(conn, {})
 
     assert res["success"] is False
-    assert res["failed_lemma"] == "вода"
+    assert res["failed_layer"] == "proverbs"
     assert "proverbs" in res["missing_layers"]
-    assert "grinchenko" in res["missing_layers"]
+
+
+def test_circuit_breaker_trips_on_consecutive_misses(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {"lemma": "item1", "url_slug": "item1", "enrichment": {}},
+            {"lemma": "item2", "url_slug": "item2", "enrichment": {}},
+            {"lemma": "item3", "url_slug": "item3", "enrichment": {}},
+        ]
+    }
+
+    def noop_enrich(entry, conn, me_lookup, *, has_sum11_flags=False):
+        pass
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", noop_enrich)
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="full-catalog",
+            circuit_breaker_limit=2,
+        )
+
+    assert summary["circuit_breaker_tripped"] is True
+    assert summary["consecutive_misses"] == 2
+
+
+def test_already_enriched_prefix_does_not_trip_circuit_breaker(monkeypatch) -> None:
+    """Already-enriched entries (e.g. resume run) must not trip the circuit breaker."""
+    manifest = {
+        "entries": [
+            {
+                "lemma": f"item{i}",
+                "url_slug": f"item{i}",
+                "pos": "noun",
+                "enrichment": {"translation": {"en": ["word"], "source": "slovnyk.me"}},
+            }
+            for i in range(60)
+        ]
+    }
+
+    def noop_enrich(entry, conn, me_lookup, *, has_sum11_flags=False):
+        pass
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", noop_enrich)
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="full-catalog",
+            circuit_breaker_limit=50,
+        )
+
+    assert summary["circuit_breaker_tripped"] is False
+    assert summary["consecutive_misses"] == 0
+
 
 
 def test_write_target_snapshot(tmp_path: Path) -> None:
@@ -372,30 +426,4 @@ def test_full_catalog_target_and_categorical_binning(monkeypatch) -> None:
     assert layers["proverbs"] == 1
     assert layers["forms"] == 1
 
-
-def test_circuit_breaker_trips_on_consecutive_misses(monkeypatch) -> None:
-    manifest = {
-        "entries": [
-            {"lemma": "item1", "url_slug": "item1", "enrichment": {}},
-            {"lemma": "item2", "url_slug": "item2", "enrichment": {}},
-            {"lemma": "item3", "url_slug": "item3", "enrichment": {}},
-        ]
-    }
-
-    def noop_enrich(entry, conn, me_lookup, *, has_sum11_flags=False):
-        pass
-
-    monkeypatch.setattr(enrich_manifest, "enrich_entry", noop_enrich)
-
-    with sqlite3.connect(":memory:") as conn:
-        summary = reenrich.reenrich_thin_entries(
-            manifest,
-            conn=conn,
-            kaikki_lookup={},
-            target="full-catalog",
-            circuit_breaker_limit=2,
-        )
-
-    assert summary["circuit_breaker_tripped"] is True
-    assert summary["consecutive_misses"] == 2
 

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -260,3 +261,141 @@ def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(
         reenrich._write_default_release_pointer(manifest_path)
 
     assert gzip_calls == []
+
+
+def test_canary_check_passes_when_all_layers_filled(monkeypatch) -> None:
+    def fake_enrich_entry(entry, conn, me_lookup, *, has_sum11_flags=False):
+        entry["sections"] = {
+            "proverbs": {"items": ["Слово не горобець"]},
+            "usage_notes": {"essay": "Note"},
+        }
+        entry["enrichment"] = {
+            "literary_attestation": [{"id": "grinchenko", "source": "Грінченко"}],
+            "morphology": {"forms": [{"form": entry["lemma"]}]},
+        }
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    with sqlite3.connect(":memory:") as conn:
+        res = reenrich.run_canary_check(conn, {}, canary_lemmas=["вода"])
+
+    assert res["success"] is True
+    assert res["details"]["вода"]["passed"] is True
+    assert res["details"]["вода"]["proverbs"] is True
+    assert res["details"]["вода"]["usage_notes"] is True
+    assert res["details"]["вода"]["grinchenko"] is True
+    assert res["details"]["вода"]["forms"] is True
+
+
+def test_canary_check_fails_and_aborts_mutation_check(monkeypatch) -> None:
+    """Mutation check: breaking the cache/source path causes canary check to FAIL."""
+
+    def broken_enrich_entry(entry, conn, me_lookup, *, has_sum11_flags=False):
+        # Broken cache / source: missing proverbs and grinchenko
+        entry["sections"] = {"usage_notes": {"essay": "Note"}}
+        entry["enrichment"] = {"morphology": {"forms": [{"form": entry["lemma"]}]}}
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", broken_enrich_entry)
+
+    with sqlite3.connect(":memory:") as conn:
+        res = reenrich.run_canary_check(conn, {}, canary_lemmas=["вода"])
+
+    assert res["success"] is False
+    assert res["failed_lemma"] == "вода"
+    assert "proverbs" in res["missing_layers"]
+    assert "grinchenko" in res["missing_layers"]
+
+
+def test_write_target_snapshot(tmp_path: Path) -> None:
+    targets = [{"url_slug": "вода"}, {"url_slug": "хліб"}]
+    snapshot_path = tmp_path / "target_snapshot.json"
+    info = reenrich.write_target_snapshot(targets, snapshot_path)
+
+    assert info["count"] == 2
+    assert isinstance(info["sha256"], str)
+    assert snapshot_path.exists()
+
+    data = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert data["slugs"] == ["вода", "хліб"]
+    assert data["count"] == 2
+    assert data["sha256"] == info["sha256"]
+
+
+def test_full_catalog_target_and_categorical_binning(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "вода",
+                "url_slug": "вода",
+                "pos": "noun",
+                "enrichment": {
+                    "translation": {"en": ["water"], "source": "slovnyk"},
+                    "morphology": {"forms": [{"form": "вода"}]},
+                },
+                "sections": {"proverbs": {"items": ["Вода"]}},
+            },
+            {
+                "lemma": "Київ",
+                "url_slug": "київ",
+                "pos": "proper noun",
+                "enrichment": {},
+            },
+            {
+                "lemma": "невідоме",
+                "url_slug": "невідоме",
+                "pos": "noun",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    def noop_enrich(entry, conn, me_lookup, *, has_sum11_flags=False):
+        pass
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", noop_enrich)
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="full-catalog",
+        )
+
+    assert summary["target"] == "full-catalog"
+    assert summary["targets"] == 3
+    bins = summary["categorical_binning"]
+    assert bins["ENRICHED"] == 1
+    assert bins["DETERMINISTIC_EXCLUSION"] == 1
+    assert bins["UNRESOLVED_RESIDUAL"] == 1
+    layers = summary["layer_counters"]
+    assert layers["proverbs"] == 1
+    assert layers["forms"] == 1
+
+
+def test_circuit_breaker_trips_on_consecutive_misses(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {"lemma": "item1", "url_slug": "item1", "enrichment": {}},
+            {"lemma": "item2", "url_slug": "item2", "enrichment": {}},
+            {"lemma": "item3", "url_slug": "item3", "enrichment": {}},
+        ]
+    }
+
+    def noop_enrich(entry, conn, me_lookup, *, has_sum11_flags=False):
+        pass
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", noop_enrich)
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="full-catalog",
+            circuit_breaker_limit=2,
+        )
+
+    assert summary["circuit_breaker_tripped"] is True
+    assert summary["consecutive_misses"] == 2
+


### PR DESCRIPTION
## Summary

Implement stage 2 campaign tooling and operator runbook for the #6466 Atlas full-catalog re-enrichment campaign.

### Deliverables Completed
1. **Full-catalog target for VPS driver** (`scripts/lexicon/reenrich_thin_manifest_entries.py`):
   - Added `--target full-catalog` target mode.
   - Frozen target array written at snapshot time (`target_snapshot.json` with `slugs`, `count`, `sha256`).
   - Resume / checkpoint support writing manifest every N entries (default `--checkpoint-interval 100`).
   - Categorical binning per target (`ENRICHED`, `DETERMINISTIC_EXCLUSION`, `UNRESOLVED_RESIDUAL`).
   - Per-layer filled counters (`proverbs`, `usage_notes`, `grinchenko`, `forms`).
   - Circuit breaker on 50 consecutive source/cache misses exiting with `CIRCUIT_BREAKER_EXIT_CODE` (`70`).

2. **Positive-control pre-flight canary** (`run_canary_check`):
   - Pre-flight check on control lemmas verifying all four layer sections (`proverbs`, `usage_notes`, `grinchenko`, `forms`) are filled.
   - Hard aborts with exit code `75` (`CANARY_FAILURE_EXIT_CODE`) without modifying manifest state on failure.

3. **Section-aware additive delta-merge** (`scripts/lexicon/merge_translation_delta.py`):
   - Copies missing layer sections, literary attestation, and morphology additively onto live published lineage without overwriting existing non-empty target fields.
   - Extends invariant suite: entry-count invariance, zero non-empty overwrites proof (`overwrite_proof_modified_nonempty_en: 0`), old-gate not rising (`old_gate_not_rising: true`), and residual metrics table.
   - Publish-side CAS: re-fetches published live lineage immediately before write and re-runs all invariants if moved.

4. **Shard-export integrity** (`scripts/lexicon/export_open_dataset.py`):
   - Tmp-file writes (`.jsonl.tmp` and `_metadata.json.tmp`) with atomic rename (`Path.replace()`).
   - Recorded `shard_integrity` in metadata detailing `sha256`, `bytes`, and `entries` per shard.

5. **Campaign Runbook** (`docs/runbooks/atlas-full-reenrich-campaign.md`):
   - Comprehensive operator steps for Mac-side deploy to VPS, canary check, target snapshotting, execution, polling, pull-back, additive delta-merge, CAS publish, shard export, and residual metrics cleanup proof.

Refs #6466, #6462, #6463, #6464, #6465

---

## Tool-Backed Evidence (#M-4)

### 1. Pytest & Ruff Verification

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check --fix scripts/lexicon/reenrich_thin_manifest_entries.py scripts/lexicon/merge_translation_delta.py scripts/lexicon/export_open_dataset.py tests/test_reenrich_thin_manifest_entries.py tests/test_merge_translation_delta.py tests/test_export_open_dataset_integrity.py
```
Output: `Found 1 error (1 fixed, 0 remaining).`

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_reenrich_thin_manifest_entries.py tests/test_merge_translation_delta.py tests/test_export_open_dataset_integrity.py tests/test_enrich_manifest_cli.py
```
Output:
```
============================== 36 passed in 1.01s ==============================
```

### 2. Invariant-Suite Dry-Run Output

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/merge_translation_delta.py --live tests/fixtures/lexicon-practice-manifest.json --pulled tests/fixtures/lexicon-practice-manifest.json --local-live --no-stamp-generated-at
```
Output:
```json
{
  "live_entry_count_before": 7,
  "live_entry_count_after": 7,
  "pulled_entry_count": 7,
  "filled": 0,
  "filled_sections": 0,
  "filled_layer_sections": {},
  "filled_literary_attestation": 0,
  "filled_morphology": 0,
  "skipped_live_has_translation": 0,
  "skipped_pulled_missing_slug": 0,
  "skipped_pulled_lacks_translation": 7,
  "filled_slugs": [],
  "overwrite_proof_modified_nonempty_en": 0,
  "old_gate_no_english_anchor_before": 0,
  "old_gate_no_english_anchor_after": 0,
  "old_gate_not_rising": true,
  "missing_translation_after": 7
}
```

### 3. Positive-Control Canary Failure Demo

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py --manifest tests/fixtures/lexicon-practice-manifest.json --local --target full-catalog --limit 2
```
Output (Exit code `75`):
```json
{
  "error": "canary_failed",
  "canary_result": {
    "success": false,
    "failed_lemma": "свіжий",
    "missing_layers": [
      "usage_notes",
      "grinchenko",
      "forms"
    ],
    "details": {
      "свіжий": {
        "proverbs": true,
        "usage_notes": false,
        "grinchenko": false,
        "forms": false,
        "passed": false,
        "missing_layers": [
          "usage_notes",
          "grinchenko",
          "forms"
        ]
      }
    }
  }
}
```