### PR TITLE
fix(acp): serialize schema migration race under concurrent reservations (#6483)

### DIFF
--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -609,15 +609,17 @@ def _ensure_migration_table(conn: sqlite3.Connection) -> None:
     )
 
 
-def apply_migrations(conn: sqlite3.Connection) -> int:
-    """Apply each known migration atomically and refuse unknown future versions."""
-    _ensure_migration_table(conn)
-    conn.commit()
-    known = {migration.version: migration for migration in MIGRATIONS}
-    applied = {
+def _applied_migrations(conn: sqlite3.Connection) -> dict[int, tuple[str, str]]:
+    return {
         int(row[0]): (str(row[1]), str(row[2]))
         for row in conn.execute("SELECT version, name, checksum FROM comms_schema_migrations")
     }
+
+
+def _validate_applied_migrations(
+    applied: dict[int, tuple[str, str]],
+    known: dict[int, Migration],
+) -> None:
     unknown = set(applied).difference(known)
     if unknown:
         raise CommsMigrationError(f"Unsupported future communications schema version(s): {sorted(unknown)}")
@@ -628,11 +630,28 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
         )
         if name != expected.name or checksum not in compatible:
             raise CommsMigrationError(f"Communications migration {version} has an unexpected checksum")
+
+
+def apply_migrations(conn: sqlite3.Connection) -> int:
+    """Apply each known migration atomically and refuse unknown future versions."""
+    _ensure_migration_table(conn)
+    conn.commit()
+    known = {migration.version: migration for migration in MIGRATIONS}
+    applied = _applied_migrations(conn)
+    _validate_applied_migrations(applied, known)
     for migration in MIGRATIONS:
         if migration.version in applied:
             continue
         try:
             conn.execute("BEGIN IMMEDIATE")
+            # A concurrent opener may have committed this version while this
+            # connection waited for the write lock. Re-read only after the
+            # lock is held; the pre-lock snapshot is not safe for INSERTs.
+            applied = _applied_migrations(conn)
+            _validate_applied_migrations(applied, known)
+            if migration.version in applied:
+                conn.commit()
+                continue
             _ensure_delivery_contract_columns(conn)
             for statement in migration.statements:
                 conn.execute(statement)
@@ -641,6 +660,7 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
                 (migration.version, migration.name, migration.checksum, datetime.now(UTC).isoformat()),
             )
             conn.commit()
+            applied[migration.version] = (migration.name, migration.checksum)
         except Exception:
             conn.rollback()
             raise

--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -668,4 +668,4 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
         except Exception:
             conn.rollback()
             raise
-    return MIGRATIONS[-1].version if MIGRATIONS else 0
+    return max(applied.keys(), default=0)

--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -639,6 +639,10 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
     known = {migration.version: migration for migration in MIGRATIONS}
     applied = _applied_migrations(conn)
     _validate_applied_migrations(applied, known)
+    # Finish the optimistic read before acquiring a write transaction below.
+    # Some connection configurations retain that read transaction, in which
+    # case SQLite rejects a nested ``BEGIN IMMEDIATE``.
+    conn.commit()
     for migration in MIGRATIONS:
         if migration.version in applied:
             continue

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -14,6 +14,7 @@ import pytest
 from scripts.agent_runtime import acpx_discuss
 from scripts.agent_runtime.errors import AgentTimeoutError
 from scripts.agent_runtime.result import Result
+from scripts.fleet_comms import migrations
 from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.authority import AuthorityService
 from scripts.fleet_comms.message_plane import default_plane_root
@@ -1178,8 +1179,21 @@ def test_next_admitted_discussion_recovers_expired_reservation_before_new_calls(
 
 def test_racing_reservations_never_expose_a_conversation_without_created_event(tmp_path, monkeypatch):
     barrier = threading.Barrier(2)
+    migration_read_barrier = threading.Barrier(2)
+    migration_read_state = threading.local()
     returned: list[tuple[str, dict | None]] = []
     errors: list[BaseException] = []
+
+    original_applied_migrations = migrations._applied_migrations
+
+    def synchronize_initial_migration_read(conn):
+        applied = original_applied_migrations(conn)
+        if not getattr(migration_read_state, "initial_read_complete", False):
+            migration_read_state.initial_read_complete = True
+            migration_read_barrier.wait(timeout=2)
+        return applied
+
+    monkeypatch.setattr(migrations, "_applied_migrations", synchronize_initial_migration_read)
 
     def reserve():
         barrier.wait(timeout=2)
@@ -1192,7 +1206,7 @@ def test_racing_reservations_never_expose_a_conversation_without_created_event(t
                     task_digest="a", correlation_digest="b", idempotency_digest="same-key", rounds=1,
                     deadline_at="2099-01-01T00:00:00Z",
                 ))
-            except acpx_discuss.AcpxDiscussionError as exc:
+            except BaseException as exc:
                 errors.append(exc)
         finally:
             controller.close()
@@ -1202,8 +1216,10 @@ def test_racing_reservations_never_expose_a_conversation_without_created_event(t
         thread.start()
     for thread in threads:
         thread.join(timeout=3)
+    assert not any(thread.is_alive() for thread in threads)
     assert len(returned) == 1
     assert len(errors) == 1
+    assert isinstance(errors[0], acpx_discuss.AcpxDiscussionError)
     assert "still in progress" in str(errors[0])
     conversation_ids = {item[0] for item in returned}
     assert len(conversation_ids) == 1

--- a/tests/ai_agent_bridge/test_fleet_comms_migration.py
+++ b/tests/ai_agent_bridge/test_fleet_comms_migration.py
@@ -62,7 +62,9 @@ def test_apply_migrations_closes_prelock_read_transaction_and_returns_version(
 
     monkeypatch.setattr(migrations, "_applied_migrations", retain_initial_read_transaction)
     try:
-        assert migrations.apply_migrations(conn) == MIGRATIONS[-1].version
+        applied_version = migrations.apply_migrations(conn)
+        assert isinstance(applied_version, int)
+        assert applied_version == MIGRATIONS[-1].version
         assert conn.in_transaction is False
     finally:
         conn.close()

--- a/tests/ai_agent_bridge/test_fleet_comms_migration.py
+++ b/tests/ai_agent_bridge/test_fleet_comms_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 
 from scripts.ai_agent_bridge import _db
+from scripts.fleet_comms import migrations
 from scripts.fleet_comms.migrations import MIGRATIONS
 
 
@@ -41,3 +42,27 @@ def test_bridge_upgrades_legacy_copy_without_mutating_legacy_rows(tmp_path, monk
         }.issubset(tables)
     finally:
         migrated.close()
+
+
+def test_apply_migrations_closes_prelock_read_transaction_and_returns_version(
+    tmp_path, monkeypatch
+) -> None:
+    """A transaction retained by the optimistic read must not nest BEGIN IMMEDIATE."""
+    conn = sqlite3.connect(tmp_path / "messages.db")
+    original_applied_migrations = migrations._applied_migrations
+    calls = 0
+
+    def retain_initial_read_transaction(connection: sqlite3.Connection):
+        nonlocal calls
+        applied = original_applied_migrations(connection)
+        if calls == 0:
+            calls += 1
+            connection.execute("BEGIN")
+        return applied
+
+    monkeypatch.setattr(migrations, "_applied_migrations", retain_initial_read_transaction)
+    try:
+        assert migrations.apply_migrations(conn) == MIGRATIONS[-1].version
+        assert conn.in_transaction is False
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
Fixes flaky ACP UNIQUE race on schema migrations under concurrent reservations.

## Test plan
- 40 ACPX + 72 fleet-comms focused tests
- 30× xdist race runs on the named test
- Ruff, OPSEC, trailer

Fixes #6483

X-Agent: codex/6483-acp-racing-unique