### PR TITLE
fix(practice): un-bury deck picker above the fold (#6544)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 01025ad5103af70c4937a2bc3f786589c9a8d77206eddda7b1e8f8911f0fe8c3
+  components_sha256: 938d2c23d317f83d0426191fbb7cd46c081f87a3c9a6d74bc81d11b48d7de376
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -263,6 +263,41 @@ test('HARD-2: Ukrainian setup dashboard shows start and resume CTAs without scro
   await assertFirstViewportPracticeCTAs(page, 'uk');
 });
 
+/**
+ * #6544: the active deck must be discoverable above the fold without expanding
+ * the folded Sync & decks panel (#6336 HARD-1/HARD-2 layout). Does not touch
+ * mode-count assertions (those are owned by in-flight #6533).
+ */
+test('A4d: active-deck chip is visible above the fold without opening Sync & decks', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.addInitScript(() => window.localStorage.setItem('lu-chrome-locale', 'en'));
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await page.goto('/words-of-the-day/practice/');
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  const chip = page.getByTestId('practice-active-deck');
+  await expect(chip).toBeVisible();
+  await expect(page.getByTestId('practice-active-deck-chip')).toContainText(/All Words|Всі слова/);
+
+  const secondary = page.getByTestId('practice-secondary-tools');
+  await expect(secondary).toBeVisible();
+  await expect(secondary).not.toHaveAttribute('open');
+
+  const box = await chip.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(768);
+
+  await page.getByTestId('practice-active-deck-chip').click();
+  await expect(page.getByTestId('practice-active-deck-menu')).toBeVisible();
+  await page.getByTestId('practice-deck-option-virtual_teacher_lesson').click();
+  await expect(page.getByTestId('practice-active-deck-chip')).toContainText(/Curated Deck|Відібрана добірка/);
+  await expect(page.getByTestId('practice-daily-deck-title')).toContainText('Curated Deck');
+  // Switching via the above-fold menu must not force-open the bottom panel.
+  await expect(secondary).not.toHaveAttribute('open');
+});
+
 test('practice stress mode renders word-shaped vowel buttons for an N-vowel word', async ({ page }) => {
   await page.goto('/words-of-the-day/practice/');
 
@@ -555,9 +590,8 @@ test('A5: switching level with a session in progress offers a fresh session; acc
   // The A1 setup session is over; deplete A1 so A2's background lower-level merge (which
   // always fetches A1 as a lower level) cannot reintroduce it into the accepted pool.
   fixtures.depleteLowerLevel('A1');
-  // The switch-session-offer this triggers lives inside the same folded panel as
-  // the deck filter, even though the A2 level button itself is above the fold.
-  await openSecondaryTools(page);
+  // #6544: the switch-session offer lives above the fold next to the active-deck chip
+  // (no longer buried inside practice-secondary-tools).
 
   await page.getByRole('button', { name: 'A2' }).click();
 
@@ -626,7 +660,6 @@ test('A5b: declining the switch offer reverts the selection and leaves the sessi
   await context.clearCookies();
   await page.addInitScript(() => window.localStorage.setItem('lu-chrome-locale', 'uk'));
   await prepareResumableMixedSession(page);
-  await openSecondaryTools(page);
 
   await page.getByRole('button', { name: 'A2' }).click();
   await expect(page.getByTestId('practice-switch-session-offer')).toBeVisible();

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1533,6 +1533,7 @@ function LexiconPracticeIsland({
   const [heritageSelectedLabel, setHeritageSelectedLabel] = useState<string | null>(null);
   const [customSets, setCustomSets] = useState<CustomSet[]>(() => readLocalCustomSets());
   const [selectedDeckFilter, setSelectedDeckFilter] = useState<string>('all');
+  const [deckPickerOpen, setDeckPickerOpen] = useState(false);
   const [isDriveSyncing, setIsDriveSyncing] = useState(false);
   const [driveSyncMsg, setDriveSyncMsg] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -1643,6 +1644,7 @@ function LexiconPracticeIsland({
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
   );
   const stageRef = useRef<HTMLDivElement | null>(null);
+  const secondaryToolsRef = useRef<HTMLDetailsElement | null>(null);
   const deckRequestId = useRef(0);
   const sessionStartedAtRef = useRef(Date.now());
   const didInitRef = useRef(false);
@@ -1695,6 +1697,25 @@ function LexiconPracticeIsland({
   const modeDetail = hoveredZnoDeckId
     ? ZNO_MODE_META[hoveredZnoDeckId]
     : MODE_META[hoveredMode ?? 'mixed'];
+
+  // #6544: compact above-fold chip label (keeps Drive/Manage folded per #6336).
+  const activeDeckChipLabel = useMemo(() => {
+    if (selectedDeckFilter === 'virtual_teacher_lesson') {
+      return CHROME_STRINGS[chromeLocale]['practice.deckCurated'];
+    }
+    if (selectedDeckFilter === 'all') {
+      return `${CHROME_STRINGS[chromeLocale]['practice.deckAllWords']} (${learnerLevel})`;
+    }
+    return customSets.find((s) => s.id === selectedDeckFilter)?.title
+      ?? CHROME_STRINGS[chromeLocale]['practice.deckAllWords'];
+  }, [selectedDeckFilter, customSets, chromeLocale, learnerLevel]);
+
+  const activeDeckChipIcon =
+    selectedDeckFilter === 'virtual_teacher_lesson'
+      ? '🎓'
+      : selectedDeckFilter === 'all'
+        ? '🌐'
+        : '⭐';
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
   const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
@@ -2936,12 +2957,25 @@ function LexiconPracticeIsland({
   }
 
   function requestDeckSwitch(nextDeckFilter: string) {
-    if (nextDeckFilter === selectedDeckFilter) return;
+    if (nextDeckFilter === selectedDeckFilter) {
+      setDeckPickerOpen(false);
+      return;
+    }
     if (hasActiveOrResumableSession()) {
       setPendingDeckSwitch({ kind: 'deck', value: nextDeckFilter });
       return;
     }
     setSelectedDeckFilter(nextDeckFilter);
+    setDeckPickerOpen(false);
+  }
+
+  function openSecondaryToolsPanel() {
+    setDeckPickerOpen(false);
+    const panel = secondaryToolsRef.current;
+    if (panel) {
+      panel.open = true;
+      panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
   }
 
   function requestLevelSwitch(nextLevel: CefrLevel) {
@@ -2961,6 +2995,7 @@ function LexiconPracticeIsland({
     if (!pendingDeckSwitch) return;
     const change = pendingDeckSwitch;
     setPendingDeckSwitch(null);
+    setDeckPickerOpen(false);
     setSessionPhase('idle');
     clearResumeSnapshots();
     setClozeLoaded(false);
@@ -3538,6 +3573,108 @@ function LexiconPracticeIsland({
 
             <div className="k3-session" data-testid="practice-dashboard-session">
               <div className="k3-session-overview">
+                {/*
+                 * #6544: surface the active deck above the fold with a compact
+                 * switcher. Full Drive sync + Manage/Import stay folded below
+                 * the mode grid (HARD-1/HARD-2 fold gates from #6336).
+                 */}
+                <div className="k3-active-deck" data-testid="practice-active-deck">
+                  <span className="k3-session-label"><ChromeText k="practice.deckLabel" /></span>
+                  <button
+                    type="button"
+                    className={`k3-active-deck-chip${deckPickerOpen ? ' open' : ''}`}
+                    data-testid="practice-active-deck-chip"
+                    aria-expanded={deckPickerOpen}
+                    aria-controls="practice-active-deck-menu"
+                    onClick={() => setDeckPickerOpen((open) => !open)}
+                  >
+                    <span aria-hidden="true">{activeDeckChipIcon}</span>
+                    <span className="k3-active-deck-name">{activeDeckChipLabel}</span>
+                    <span className="sr-only"><ChromeText k="practice.deckChange" /></span>
+                  </button>
+                  {deckPickerOpen ? (
+                    <div
+                      id="practice-active-deck-menu"
+                      className="k3-active-deck-menu"
+                      data-testid="practice-active-deck-menu"
+                      role="listbox"
+                      aria-label={CHROME_STRINGS[chromeLocale]['practice.deckChange']}
+                    >
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={selectedDeckFilter === 'all'}
+                        className={selectedDeckFilter === 'all' ? 'active' : undefined}
+                        data-testid="practice-deck-option-all"
+                        onClick={() => requestDeckSwitch('all')}
+                      >
+                        {selectedDeckFilter === 'all' ? '✓ ' : ''}🌐{' '}
+                        {chromeLocale === 'uk'
+                          ? `Всі слова (${learnerLevel})`
+                          : `All Words (${learnerLevel})`}
+                      </button>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={selectedDeckFilter === 'virtual_teacher_lesson'}
+                        className={
+                          selectedDeckFilter === 'virtual_teacher_lesson' ? 'active' : undefined
+                        }
+                        data-testid="practice-deck-option-virtual_teacher_lesson"
+                        onClick={() => requestDeckSwitch('virtual_teacher_lesson')}
+                      >
+                        {selectedDeckFilter === 'virtual_teacher_lesson' ? '✓ ' : ''}🎓{' '}
+                        <ChromeText k="practice.deckCurated" />
+                      </button>
+                      {customSets.map((set) => (
+                        <button
+                          key={set.id}
+                          type="button"
+                          role="option"
+                          aria-selected={selectedDeckFilter === set.id}
+                          className={selectedDeckFilter === set.id ? 'active' : undefined}
+                          data-testid={`practice-deck-option-${set.id}`}
+                          onClick={() => requestDeckSwitch(set.id)}
+                        >
+                          {selectedDeckFilter === set.id ? '✓ ' : ''}⭐ {set.title} ({set.lemma_keys.length})
+                        </button>
+                      ))}
+                      <button
+                        type="button"
+                        className="k3-active-deck-manage"
+                        data-testid="practice-deck-open-secondary"
+                        onClick={openSecondaryToolsPanel}
+                      >
+                        <ChromeText k="practice.deckManageMore" />
+                      </button>
+                    </div>
+                  ) : null}
+                  {pendingDeckSwitch ? (
+                    <div className="k3-switch-offer" data-testid="practice-switch-session-offer" role="status">
+                      <span><ChromeText k="practice.switchSessionOffer" /></span>
+                      <div className="k3-switch-offer-actions">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-accent"
+                          data-testid="practice-switch-session-accept"
+                          onClick={() => {
+                            void acceptDeckSwitch();
+                          }}
+                        >
+                          <ChromeText k="practice.switchSessionAccept" />
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm"
+                          data-testid="practice-switch-session-decline"
+                          onClick={declineDeckSwitch}
+                        >
+                          <ChromeText k="practice.switchSessionDecline" />
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
                 <div
                   className="k3-session-size"
                   role="group"
@@ -3738,7 +3875,11 @@ function LexiconPracticeIsland({
            * below the mode grid, behind the same disclosure pattern the page already
            * uses for secondary material.
            */}
-          <details className="k3-practice-sources" data-testid="practice-secondary-tools">
+          <details
+            ref={secondaryToolsRef}
+            className="k3-practice-sources"
+            data-testid="practice-secondary-tools"
+          >
             <summary><ChromeText k="practice.secondaryToolsTitle" /></summary>
             <div className="k3-practice-sources-content">
               <div className="k3-drive-sync-bar" style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -3798,29 +3939,6 @@ function LexiconPracticeIsland({
                     </button>
                   ))}
                 </div>
-                {pendingDeckSwitch ? (
-                  <div className="k3-switch-offer" data-testid="practice-switch-session-offer" role="status">
-                    <span><ChromeText k="practice.switchSessionOffer" /></span>
-                    <div className="k3-switch-offer-actions">
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-accent"
-                        data-testid="practice-switch-session-accept"
-                        onClick={acceptDeckSwitch}
-                      >
-                        <ChromeText k="practice.switchSessionAccept" />
-                      </button>
-                      <button
-                        type="button"
-                        className="btn btn-sm"
-                        data-testid="practice-switch-session-decline"
-                        onClick={declineDeckSwitch}
-                      >
-                        <ChromeText k="practice.switchSessionDecline" />
-                      </button>
-                    </div>
-                  </div>
-                ) : null}
               </div>
 
               {showCreateModal ? (

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -345,6 +345,12 @@ const en = {
   'practice.intervalPrefix': 'in',
   'practice.modeNoExercises': 'No exercises yet',
   'practice.secondaryToolsTitle': 'Sync & decks',
+  // #6544 — above-fold active-deck chip (keeps full picker folded per #6336)
+  'practice.deckLabel': 'Deck',
+  'practice.deckAllWords': 'All Words',
+  'practice.deckCurated': 'Curated Deck',
+  'practice.deckChange': 'Change deck',
+  'practice.deckManageMore': 'Manage decks & sync',
 
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Practice this word →',
@@ -663,6 +669,12 @@ const uk: Record<ChromeKey, string> = {
   'practice.intervalPrefix': 'через',
   'practice.modeNoExercises': 'Немає вправ',
   'practice.secondaryToolsTitle': 'Синхронізація та колоди',
+  // #6544 — above-fold active-deck chip (keeps full picker folded per #6336)
+  'practice.deckLabel': 'Колода',
+  'practice.deckAllWords': 'Всі слова',
+  'practice.deckCurated': 'Відібрана добірка',
+  'practice.deckChange': 'Змінити колоду',
+  'practice.deckManageMore': 'Менеджер колод і синхронізація',
 
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Практикувати це слово →',

--- a/site/src/lib/lexicon/custom-decks.ts
+++ b/site/src/lib/lexicon/custom-decks.ts
@@ -106,8 +106,22 @@ const defaultTeacherLessonVirtualDeck: CustomSet = {
 };
 
 /**
+ * Source tags used by `lexicon-teacher-curated-membership.json` (#6544).
+ * Older filter names (`teacher_lesson` / `private_teacher_lesson`) match zero
+ * members — keep this list aligned with the membership file's real vocabulary.
+ */
+export const TEACHER_CURATED_MEMBERSHIP_SOURCES = ['teacher_inventory', 'homework'] as const;
+
+function isTeacherCuratedMembershipSource(source: string): boolean {
+  return (TEACHER_CURATED_MEMBERSHIP_SOURCES as readonly string[]).includes(source);
+}
+
+/**
  * Returns the built-in, read-only Virtual Special Deck for Teacher Lesson Intake.
  * Its module data is cached — 0 KB extra user storage or hot-path JSON scans.
+ *
+ * TODO(#6544): operator decision — whether the local ~1k practice-admission
+ * subset should be its own selectable deck vs this ~5k Curated Deck union.
  */
 export function getTeacherLessonVirtualDeck(
   entries?: Array<{ lemma: string; sources?: string[] }>,
@@ -115,11 +129,7 @@ export function getTeacherLessonVirtualDeck(
   if (!entries || entries.length === 0) return defaultTeacherLessonVirtualDeck;
 
   const teacherLemmas = entries
-    .filter(
-      (e) =>
-        e.sources &&
-        (e.sources.includes('teacher_lesson') || e.sources.includes('private_teacher_lesson')),
-    )
+    .filter((e) => e.sources?.some(isTeacherCuratedMembershipSource))
     .map((e) => e.lemma);
 
   return {

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1259,6 +1259,87 @@ const frontmatter = {
     align-items: stretch;
     gap: 0.3rem;
   }
+  /*
+   * #6544: compact above-fold deck chip. Closed height must stay small so the
+   * Start/Resume CTAs clear HARD-1/HARD-2 at 1366×768; the full Drive/Manage
+   * panel remains folded below the mode grid (#6336).
+   */
+  :global(.k3-active-deck) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem 0.5rem;
+    min-width: 0;
+  }
+  :global(.k3-active-deck-chip) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 48px;
+    min-width: 0;
+    max-width: 100%;
+    padding: 0 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--lu-primary) 35%, var(--lu-border));
+    border-radius: 999px;
+    background: var(--lu-surface-raised);
+    color: var(--lu-text);
+    font-size: 0.88rem;
+    font-weight: 800;
+    cursor: pointer;
+  }
+  :global(.k3-active-deck-chip.open),
+  :global(.k3-active-deck-chip:hover),
+  :global(.k3-active-deck-chip:focus-visible) {
+    border-color: var(--lu-primary);
+    outline: none;
+  }
+  :global(.k3-active-deck-name) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  :global(.k3-active-deck-menu) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    width: 100%;
+    padding: 0.45rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 12px;
+    background: var(--lu-surface);
+  }
+  :global(.k3-active-deck-menu button) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    min-height: 48px;
+    padding: 0 0.75rem;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--lu-text);
+    font-size: 0.88rem;
+    font-weight: 700;
+    text-align: left;
+    cursor: pointer;
+  }
+  :global(.k3-active-deck-menu button.active) {
+    border-color: #3b82f6;
+    background: color-mix(in srgb, #3b82f6 14%, transparent);
+    font-weight: 800;
+  }
+  :global(.k3-active-deck-menu button:hover),
+  :global(.k3-active-deck-menu button:focus-visible) {
+    background: color-mix(in srgb, var(--lu-primary) 10%, transparent);
+    outline: none;
+  }
+  :global(.k3-active-deck-manage) {
+    margin-top: 0.15rem;
+    border-top: 1px solid var(--lu-border) !important;
+    border-radius: 0 0 10px 10px !important;
+    color: var(--lu-text-muted) !important;
+    font-weight: 800 !important;
+  }
   :global(.k3-session-size) {
     display: flex;
     flex-wrap: nowrap;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -4171,6 +4171,21 @@ describe('LexiconPractice', () => {
   });
 
   describe('Curated Deck & Custom Sets Automated UI Selection Tests', () => {
+    test('exposes the active deck above the fold without opening Sync & decks (#6544)', async () => {
+      document.documentElement.dataset.chromeLocale = 'en';
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={sampleDeck()} autoStart={false} />);
+
+      const chip = await screen.findByTestId('practice-active-deck-chip');
+      expect(chip).toHaveTextContent(/All Words \(A1\)/);
+      expect(screen.getByTestId('practice-secondary-tools')).not.toHaveAttribute('open');
+
+      await user.click(chip);
+      await user.click(screen.getByTestId('practice-deck-option-virtual_teacher_lesson'));
+      expect(screen.getByTestId('practice-active-deck-chip')).toHaveTextContent('Curated Deck');
+      expect(screen.getByTestId('practice-secondary-tools')).not.toHaveAttribute('open');
+    });
+
     test.each([
       ['en', 'Curated Deck'],
       ['uk', 'Відібрана добірка'],

--- a/site/tests/unit/custom-decks-membership.test.ts
+++ b/site/tests/unit/custom-decks-membership.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+import {
+  getTeacherLessonVirtualDeck,
+  TEACHER_CURATED_MEMBERSHIP_SOURCES,
+} from '../../src/lib/lexicon/custom-decks';
+
+const membershipPath = resolve(
+  __dirname,
+  '../../src/data/lexicon-teacher-curated-membership.json',
+);
+
+type MembershipFile = {
+  members: Array<{ lemma: string; sources?: string[] }>;
+};
+
+describe('getTeacherLessonVirtualDeck membership sources (#6544)', () => {
+  const membership = JSON.parse(readFileSync(membershipPath, 'utf8')) as MembershipFile;
+
+  test('pins the real curated-membership source vocabulary', () => {
+    const observed = new Set(
+      membership.members.flatMap((member) => member.sources ?? []),
+    );
+
+    expect([...TEACHER_CURATED_MEMBERSHIP_SOURCES].sort()).toEqual(
+      ['homework', 'teacher_inventory'],
+    );
+    for (const source of TEACHER_CURATED_MEMBERSHIP_SOURCES) {
+      expect(observed.has(source)).toBe(true);
+    }
+    // Dead filter names from the pre-#6544 path — must not reappear as the
+    // membership vocabulary, or the next rename will need an explicit update.
+    expect(observed.has('teacher_lesson')).toBe(false);
+    expect(observed.has('private_teacher_lesson')).toBe(false);
+  });
+
+  test('filters entries with the live source tags instead of the dead ones', () => {
+    const filtered = getTeacherLessonVirtualDeck(membership.members);
+    const expectedLemmas = membership.members
+      .filter((member) =>
+        member.sources?.some((source) =>
+          (TEACHER_CURATED_MEMBERSHIP_SOURCES as readonly string[]).includes(source),
+        ),
+      )
+      .map((member) => member.lemma);
+
+    expect(filtered.lemma_keys.length).toBeGreaterThan(0);
+    expect(filtered.lemma_keys).toEqual(expectedLemmas);
+    expect(filtered.lemma_keys.length).toBe(membership.members.length);
+
+    const deadOnly = getTeacherLessonVirtualDeck([
+      { lemma: 'ghost', sources: ['teacher_lesson', 'private_teacher_lesson'] },
+      { lemma: 'жива', sources: ['teacher_inventory'] },
+      { lemma: 'дзвінок', sources: ['homework'] },
+    ]);
+    expect(deadOnly.lemma_keys).toEqual(['жива', 'дзвінок']);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a compact above-fold **active-deck chip** in the session box so Curated Deck / All Words / custom decks are discoverable without expanding Sync & decks — preserves #6336 HARD-1/HARD-2 fold goals (Drive sync + Manage stay folded below the mode grid).
- Fixes latent `getTeacherLessonVirtualDeck(entries)` filter: now matches real membership sources `teacher_inventory` / `homework` (was dead `teacher_lesson` / `private_teacher_lesson`). Pins vocabulary in a unit test.
- Leaves the ~1k practice-admission subset as an operator decision (`TODO(#6544)` only). Does **not** decide that question.
- e2e `A4d` asserts the chip is visible at 1366×768 without opening the bottom panel; avoids mode-count assertions owned by in-flight #6533.

Refs #6544

## Test plan
- [ ] Visual: `/words-of-the-day/practice/` shows Deck chip above the fold; Curated Deck selectable without opening Sync & decks
- [ ] Visual: HARD fold — Start/Resume still clear the fold at 1366×768
- [ ] Driver verifies before closing (DoD) — do not auto-close

### Local verification (raw)

**vitest** (`custom-decks-membership` + LexiconPractice deck filters):
```
 Test Files  2 passed (2)
      Tests  13 passed | 121 skipped (134)
```

**vitest** (`custom-decks-membership` + `practice-chrome-copy`):
```
 Test Files  2 passed (2)
      Tests  4 passed (4)
```

**playwright** `e2e/atlas-practice.spec.ts` (`CI=1`, fresh preview):
```
  ✓ HARD-1
  ✓ HARD-2
  ✓ A4d: active-deck chip is visible above the fold without opening Sync & decks
  ✓ A5 / A5b / A5c and remaining practice deck/session tests
  32 passed
  2 failed (unrelated atlas word-page routes; build:shell without ATLAS_STATIC_ROUTES — `/lexicon/прапор/` not generated in this sparse worktree)
```

**tsc**: pre-existing errors only; no new errors attributed to this diff.


Made with [Cursor](https://cursor.com)