### PR TITLE
fix(acpx): allow multi-turn advisory asks

### DIFF
--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -119,7 +119,11 @@ CLAUDE_ACP_ADAPTER_COMPATIBILITY_CONTRACT = "installed>=0.64.2<1"
 AGY_CLI_COMPATIBILITY_CONTRACT = "text-plan-sandbox-v1"
 OPENCODE_CLI_COMPATIBILITY_CONTRACT = "native-acp-pure-v1"
 HERMES_CLI_COMPATIBILITY_CONTRACT = "text-oneshot-isolated-v1"
+# Sealed reviewers retain their deliberately constrained baseline unless their
+# adapter derives a reviewed evidence-reading budget. Ordinary advisory asks
+# need enough turns for a model to consult and return a complete response.
 ACPX_DEFAULT_MAX_TURNS = 1
+ACPX_ORDINARY_ASK_MAX_TURNS = 8
 _CLAUDE_ACP_SEALED_READ_CHUNK_BYTES = 24 * 1024
 _CLAUDE_ACP_INLINE_RESULT_CHARS = 48 * 1024
 _CLAUDE_ACP_FALLBACK_READ_CHUNK_BYTES = 8 * 1024
@@ -1629,10 +1633,16 @@ class AcpxAdapter:
             builtin_agent="codex",
         )
 
+        max_turns = (
+            ACPX_DEFAULT_MAX_TURNS
+            if sealed_review_mcp_config is not None
+            else ACPX_ORDINARY_ASK_MAX_TURNS
+        )
         cmd: list[str] = _confinement_prefix_argv(
             binary,
             cwd,
             sealed_review_mcp_config=sealed_review_mcp_config,
+            max_turns=max_turns,
         )
         if model:
             cmd.extend(["--model", model])
@@ -2007,8 +2017,11 @@ class _AcpxDiscussionAdapter:
         return {}
 
     def _max_turns(self, sealed_review_mcp_config: str | None) -> int:
-        _ = sealed_review_mcp_config
-        return ACPX_DEFAULT_MAX_TURNS
+        return (
+            ACPX_DEFAULT_MAX_TURNS
+            if sealed_review_mcp_config is not None
+            else ACPX_ORDINARY_ASK_MAX_TURNS
+        )
 
     def _system_prompt(self, sealed_review_mcp_config: str | None) -> str | None:
         _ = sealed_review_mcp_config
@@ -2158,7 +2171,7 @@ class AcpxClaudeShadowAdapter(_AcpxDiscussionAdapter):
 
     def _max_turns(self, sealed_review_mcp_config: str | None) -> int:
         if sealed_review_mcp_config is None:
-            return ACPX_DEFAULT_MAX_TURNS
+            return ACPX_ORDINARY_ASK_MAX_TURNS
         return _claude_sealed_review_max_turns(sealed_review_mcp_config)
 
     def _system_prompt(self, sealed_review_mcp_config: str | None) -> str | None:
@@ -2424,10 +2437,16 @@ class AcpxGrokShadowAdapter:
             _GROK_SEALED_REVIEW_PROFILE_SHA256 if sealed_review else _GROK_PROFILE_SHA256
         )
         agent_command = _build_grok_agent_command(grok_binary, profile_path)
+        max_turns = (
+            ACPX_DEFAULT_MAX_TURNS
+            if sealed_review_mcp_config is not None
+            else ACPX_ORDINARY_ASK_MAX_TURNS
+        )
         cmd: list[str] = _confinement_prefix_argv(
             acpx_binary,
             cwd,
             sealed_review_mcp_config=sealed_review_mcp_config,
+            max_turns=max_turns,
         )
         # --agent is a single shell-safe command string. Do not combine with a
         # positional agent token (acpx grammar), and never emit built-in

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -712,7 +712,7 @@ def test_build_invocation_argv_is_fully_confined(tmp_path, monkeypatch):
     assert ("--auth-policy", "fail") in pairs
     assert ("--non-interactive-permissions", "fail") in pairs
     assert ("--allowed-tools", "") in pairs
-    assert ("--max-turns", "1") in pairs
+    assert ("--max-turns", "8") in pairs
     assert ("--prompt-retries", "0") in pairs
     assert ("--format", "json") in pairs
     assert "--deny-all" in plan.cmd
@@ -1510,7 +1510,7 @@ def test_grok_build_invocation_fixed_command_and_ordering(tmp_path, monkeypatch)
     assert ("--auth-policy", "fail") in pairs
     assert ("--non-interactive-permissions", "fail") in pairs
     assert ("--allowed-tools", "") in pairs
-    assert ("--max-turns", "1") in pairs
+    assert ("--max-turns", "8") in pairs
     assert ("--prompt-retries", "0") in pairs
     assert "--deny-all" in plan.cmd
     assert "--no-fs" in plan.cmd
@@ -1843,8 +1843,32 @@ def test_claude_sealed_review_turn_budget_is_derived_from_required_chunks(tmp_pa
 
     # Four bounded recovery turns + ToolSearch + four change-evidence chunks + verdict.
     assert acpx_module._claude_sealed_review_max_turns(str(config_path)) == 10
-    assert AcpxClaudeShadowAdapter()._max_turns(None) == 1
+    assert AcpxClaudeShadowAdapter()._max_turns(None) == 8
     assert AcpxClaudeShadowAdapter()._max_turns(str(config_path)) == 10
+
+
+def test_ordinary_claude_advisory_build_invocation_uses_eight_turns(tmp_path, monkeypatch):
+    _stub_binary(monkeypatch, tmp_path)
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+
+    with acpx_module.active_discussion_scope():
+        plan = AcpxClaudeShadowAdapter().build_invocation(
+            prompt="advise on the next infrastructure priority",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-fable-5",
+            task_id="t-claude-advisory",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": "claude",
+                "correlation_id": "corr-claude-advisory",
+                "idempotency_key": "idem-claude-advisory",
+            },
+        )
+
+    pairs = list(zip(plan.cmd, plan.cmd[1:], strict=False))
+    assert ("--max-turns", "8") in pairs
 
 
 @pytest.mark.parametrize("model", ["claude-sonnet-5", "claude-fable-5"])


### PR DESCRIPTION
## Summary

- Raise ordinary ACPX advisory calls to an eight-turn budget.
- Keep sealed-review calls at their existing baseline, with Claude retaining its computed evidence-reading budget.
- Cover ordinary Fable/Claude invocation construction directly.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/agent_runtime/test_acpx_adapter.py -q --tb=line` — 135 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/adapters/acpx.py tests/agent_runtime/test_acpx_adapter.py`

## Canary

The requested Fable advisory transport command completed but returned no response body, so it did not prove the semantic three-bullet outcome. This PR does not weaken fail-closed handling; that residual duplicate-terminal/runtime behavior needs separate diagnosis.

Fixes #6556