### PR TITLE
fix(cursor): attribute resolved model in dispatch state

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -25,6 +25,7 @@ import json
 import logging
 import re
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 
 from ..result import ParseResult
@@ -45,6 +46,37 @@ _RATE_LIMIT_PATTERNS = (
     r"\b429\b",
 )
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+# Cursor's automatic route is a selector, not an attributable model. Keep
+# this boundary structural: assistant prose, tool input, and arbitrary log
+# text must never become model evidence merely because they contain the word
+# "model".
+_NON_CONCRETE_MODEL_VALUES = frozenset({"", "auto", "default", "unknown", "none", "null", "n/a"})
+_MODEL_KEYS = frozenset(
+    {
+        "model",
+        "modelid",
+        "model_id",
+        "actualmodel",
+        "actual_model",
+        "resolvedmodel",
+        "resolved_model",
+    }
+)
+_MODEL_CONTAINER_KEYS = frozenset(
+    {
+        "data",
+        "info",
+        "meta",
+        "metadata",
+        "message",
+        "result",
+        "response",
+        "run",
+        "session",
+    }
+)
+_MODEL_ID_KEYS = ("id", "modelId", "model_id", "name")
 
 
 class CursorAdapter:
@@ -322,7 +354,6 @@ class CursorAdapter:
     ) -> ParseResult:
         """Parse cursor-agent JSONL output into a ParseResult."""
         _ = output_file
-        _ = plan
         _ = call_start_time
 
         # Parse JSONL events
@@ -331,9 +362,11 @@ class CursorAdapter:
 
         # Detect the session ID of the current run
         session_id = None
+        session_id_source: str | None = None
         for event in events:
             if "sessionId" in event or "session_id" in event:
                 session_id = str(event.get("sessionId") or event.get("session_id"))
+                session_id_source = "cursor-stream-json"
                 break
 
         # If not found in stdout events, scan the filesystem for a new transcript
@@ -350,26 +383,48 @@ class CursorAdapter:
                     if candidates:
                         newest = max(candidates, key=lambda p: p.stat().st_mtime)
                         session_id = newest.name
+                        session_id_source = "cursor-new-transcript"
                 except OSError:
                     pass
 
         # If still not found, check the disk generally for the newest one
         if not session_id and getattr(self, "_workspace", None):
             session_id = self._find_session_id_on_disk(self._workspace)
+            if session_id:
+                # This may be an older, unrelated session. It can preserve the
+                # adapter's existing response fallback, but it is not evidence
+                # for the model used by this invocation.
+                session_id_source = "cursor-existing-transcript"
 
         # The final response is usually the last 'content' or 'text' event
         # in the stream. parse_json_events + normalize_tool_calls handles
         # most of this, but we need to extract the assistant's final prose.
         response = _extract_response_from_events(events)
-        if not response and session_id and getattr(self, "_workspace", None):
-            transcript_events = self._read_session_transcript_events(
-                self._workspace,
-                session_id,
-            )
+        resolved_model = _extract_concrete_model_from_events(events)
+        resolved_model_source = "cursor-stream-json" if resolved_model else None
+        transcript_events: list[dict] = []
+        if session_id and getattr(self, "_workspace", None) and (not response or not resolved_model):
+            transcript_events = self._read_session_transcript_events(self._workspace, session_id)
             transcript_response = _extract_response_from_events(transcript_events)
-            if transcript_response:
+            if not response and transcript_response:
                 response = transcript_response
                 tool_calls = normalize_tool_calls(transcript_events)
+            if not resolved_model and session_id_source in {
+                "cursor-stream-json",
+                "cursor-new-transcript",
+            }:
+                resolved_model = _extract_concrete_model_from_events(transcript_events)
+                if resolved_model:
+                    resolved_model_source = "cursor-transcript"
+
+        # Some Cursor versions put structured metadata on stderr while the
+        # assistant stream remains on stdout. Parse only JSON events here;
+        # never infer a model from free-form diagnostics.
+        if not resolved_model and stderr:
+            stderr_events = parse_json_events(stderr, source="cursor-stderr", logger=_logger)
+            resolved_model = _extract_concrete_model_from_events(stderr_events)
+            if resolved_model:
+                resolved_model_source = "cursor-stderr-json"
 
         # Cursor's stream-json stdout contains much more than the assistant's
         # response: it can echo the user prompt and tool output verbatim. Those
@@ -390,6 +445,22 @@ class CursorAdapter:
         if not ok:
             stderr_excerpt = (stderr or stdout).strip()[:500]
 
+        requested_model = _requested_model_from_plan(plan, default=self.default_model)
+        model_attribution = {
+            "requested_provider": "cursor",
+            "requested_model": requested_model,
+            "actual_provider": "cursor",
+            # Keep the raw actual value empty when no trusted model was
+            # reported. The dispatch layer adds the human-readable
+            # ``resolved_model: unknown`` companion field without turning
+            # unknown into a fake provider/model route.
+            "actual_model": resolved_model,
+            "actual_model_known": bool(resolved_model),
+            "substituted": bool(resolved_model and resolved_model != requested_model),
+            "source": resolved_model_source or "unknown",
+            "marker": None,
+        }
+
         return ParseResult(
             ok=ok,
             response=response,
@@ -397,6 +468,7 @@ class CursorAdapter:
             rate_limited=rate_limited,
             session_id=session_id,
             tool_calls=tool_calls,
+            substitution=model_attribution,
         )
 
     def _read_session_transcript_events(
@@ -471,3 +543,81 @@ def _extract_text_content(content: object) -> str:
     if isinstance(content, str):
         return content
     return ""
+
+
+def _requested_model_from_plan(plan: InvocationPlan | None, *, default: str) -> str:
+    """Read Cursor's requested selector without treating it as actual output."""
+    if plan is not None:
+        metadata = plan.metadata
+        if isinstance(metadata, Mapping):
+            fleet = metadata.get("entire_fleet")
+            if isinstance(fleet, Mapping):
+                requested = fleet.get("requested_model")
+                if isinstance(requested, str) and requested.strip():
+                    return requested.strip()
+        try:
+            model_index = plan.cmd.index("--model")
+            requested = plan.cmd[model_index + 1]
+        except (ValueError, IndexError):
+            requested = None
+        if isinstance(requested, str) and requested.strip():
+            return requested.strip()
+    return default
+
+
+def _concrete_model_value(value: object) -> str | None:
+    """Return a concrete model ID from a structured scalar/object value."""
+    if isinstance(value, str):
+        candidate = value.strip()
+    elif isinstance(value, Mapping):
+        for key in _MODEL_ID_KEYS:
+            nested = value.get(key)
+            if not isinstance(nested, str) or not nested.strip():
+                continue
+            candidate = nested.strip()
+            if candidate.casefold() not in _NON_CONCRETE_MODEL_VALUES:
+                return candidate
+        return None
+    else:
+        return None
+
+    if candidate.casefold() in _NON_CONCRETE_MODEL_VALUES:
+        return None
+    return candidate or None
+
+
+def _concrete_model_from_structured(value: object, *, depth: int = 0) -> str | None:
+    """Find a model only through known metadata containers.
+
+    In particular, ``content``, ``text``, ``input``, and tool arguments are
+    not traversed. That boundary prevents a prompt or assistant response from
+    being mistaken for provider metadata.
+    """
+    if depth > 4:
+        return None
+    if isinstance(value, Mapping):
+        for raw_key, nested in value.items():
+            key = str(raw_key).replace("-", "_").casefold()
+            if key in _MODEL_KEYS:
+                candidate = _concrete_model_value(nested)
+                if candidate:
+                    return candidate
+            elif key in _MODEL_CONTAINER_KEYS and isinstance(nested, (Mapping, list)):
+                candidate = _concrete_model_from_structured(nested, depth=depth + 1)
+                if candidate:
+                    return candidate
+    elif isinstance(value, list):
+        for nested in value:
+            candidate = _concrete_model_from_structured(nested, depth=depth + 1)
+            if candidate:
+                return candidate
+    return None
+
+
+def _extract_concrete_model_from_events(events: list[dict]) -> str | None:
+    """Extract the first concrete model reported by Cursor's structured data."""
+    for event in events:
+        candidate = _concrete_model_from_structured(event)
+        if candidate:
+            return candidate
+    return None

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -36,6 +36,9 @@ State files live at ``batch_state/tasks/<task-id>.json``. Format:
         "task_id": str,
         "agent": str,
         "model": str,
+        "resolved_model": str,  # Cursor's concrete model, or "unknown"
+        "resolved_model_known": bool,
+        "resolved_model_source": str,
         "effort": str,
         "cli_version": str,
         "mode": str,
@@ -912,6 +915,62 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
 
 _WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
 _NO_DELIVERABLE_STATUS = "no_deliverable"
+_CURSOR_UNKNOWN_MODEL = "unknown"
+_NON_CONCRETE_MODEL_VALUES = frozenset({"", "auto", "default", "unknown", "none", "null", "n/a"})
+
+
+def _cursor_model_state(
+    *,
+    agent: str,
+    result: Any | None = None,
+    substitution: dict[str, Any] | None = None,
+    initial: bool = False,
+) -> dict[str, Any]:
+    """Return a truthful Cursor model-attribution companion for task state.
+
+    ``model`` remains the requested selector unless the runtime supplied a
+    concrete Cursor model. The separate ``resolved_model`` field makes an
+    unresolved Auto run explicit without promoting ``auto`` to family proof.
+    """
+    if agent != "cursor":
+        return {}
+
+    if initial:
+        return {
+            "resolved_model": _CURSOR_UNKNOWN_MODEL,
+            "resolved_model_known": False,
+            "resolved_model_source": "pending",
+        }
+
+    actual_model: object = None
+    source = "unknown"
+    known_raw: object = None
+    if isinstance(substitution, dict):
+        actual_model = substitution.get("actual_model")
+        known_raw = substitution.get("actual_model_known")
+        source_value = substitution.get("source")
+        if isinstance(source_value, str) and source_value.strip():
+            source = source_value.strip()
+
+    concrete = actual_model.strip() if isinstance(actual_model, str) else ""
+    is_concrete = bool(concrete) and concrete.casefold() not in _NON_CONCRETE_MODEL_VALUES
+    explicitly_unknown = str(known_raw).strip().casefold() in {"false", "0", "no"}
+    resolved_model = concrete if is_concrete and not explicitly_unknown else _CURSOR_UNKNOWN_MODEL
+    known = resolved_model != _CURSOR_UNKNOWN_MODEL
+
+    state = {
+        "resolved_model": resolved_model,
+        "resolved_model_known": known,
+        "resolved_model_source": source,
+    }
+    if result is not None and known:
+        # Keep the legacy ``model`` field useful to consumers that only read
+        # one field, while leaving it at the requested ``auto`` selector when
+        # attribution is unknown.
+        state["model"] = resolved_model
+    return state
+
+
 _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON = "commit_count_unknown"
 _NO_DELIVERABLE_SHORT_RESPONSE_REASON = "write_capable_clean_worktree_zero_commits_short_response"
 _NO_DELIVERABLE_INVALID_DECLARATION_REASON = "invalid_delivery_declaration"
@@ -3027,6 +3086,9 @@ def _emit_terminal_dispatch_event(
                 "task_id": task_id,
                 "agent": agent,
                 "model": model,
+                "resolved_model": final_state.get("resolved_model"),
+                "resolved_model_known": final_state.get("resolved_model_known"),
+                "resolved_model_source": final_state.get("resolved_model_source"),
                 "effort": final_state.get("effort"),
                 "branch": final_state.get("worktree_branch"),
                 "worktree": final_state.get("worktree_path"),
@@ -3538,6 +3600,11 @@ def _run_worker(
         substitution = result_substitution
     if substitution is None and isinstance(usage_record, dict):
         substitution = usage_record.get("substitution")
+    cursor_model_state = _cursor_model_state(
+        agent=agent,
+        result=result,
+        substitution=substitution,
+    )
 
     final_state.update(
         {
@@ -3546,6 +3613,7 @@ def _run_worker(
             # reader between the two writes never sees the status change.
             **core_terminal_state,
             "model": getattr(result, "model", final_state.get("model")),
+            **cursor_model_state,
             "effort": getattr(result, "effort", final_state.get("effort")),
             "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
             "substitution": substitution,
@@ -3968,6 +4036,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "attribution_source": attribution.source,
             "agent": dispatch_agent,
             "model": start_telemetry.model,
+            **_cursor_model_state(agent=dispatch_agent, initial=True),
             "effort": start_telemetry.effort,
             "cli_version": start_telemetry.cli_version,
             "mode": args.mode,
@@ -4123,6 +4192,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "attribution_source": attribution.source,
         "agent": dispatch_agent,
         "model": start_telemetry.model,
+        **_cursor_model_state(agent=dispatch_agent, initial=True),
         "effort": start_telemetry.effort,
         "cli_version": start_telemetry.cli_version,
         "allow_merge": bool(getattr(args, "allow_merge", False)),

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -244,6 +244,116 @@ def test_cursor_adapter_parse_response_success(adapter):
     assert result.tool_calls[0]["name"] == "mcp__sources__search_text"
 
 
+def test_cursor_adapter_attributes_concrete_model_from_stream_metadata(adapter):
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": "cursor-session-model",
+                    "model": "auto",
+                }
+            ),
+            json.dumps({"type": "text", "content": "Completed."}),
+            json.dumps({"type": "result", "model": "composer-2.5"}),
+        ]
+    )
+
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.substitution is not None
+    assert result.substitution["requested_model"] == "auto"
+    assert result.substitution["actual_model"] == "composer-2.5"
+    assert result.substitution["actual_model_known"] is True
+    assert result.substitution["source"] == "cursor-stream-json"
+
+
+def test_cursor_adapter_does_not_infer_model_from_assistant_text(adapter):
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "system", "subtype": "init", "model": "auto"}),
+            json.dumps(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "The model is composer-2.5, but this is only prose.",
+                }
+            ),
+        ]
+    )
+
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.substitution is not None
+    assert result.substitution["actual_model"] is None
+    assert result.substitution["actual_model_known"] is False
+    assert result.substitution["source"] == "unknown"
+
+
+def test_cursor_adapter_reads_concrete_model_from_session_transcript(adapter, monkeypatch):
+    adapter._workspace = "/tmp/cursor-model-test"
+    monkeypatch.setattr(
+        adapter,
+        "_read_session_transcript_events",
+        lambda _workspace, _session_id: [
+            {"type": "result", "model_id": "claude-sonnet-4-5"},
+        ],
+    )
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "system", "session_id": "cursor-session-transcript"}),
+            json.dumps({"type": "text", "content": "Completed."}),
+        ]
+    )
+
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.substitution is not None
+    assert result.substitution["actual_model"] == "claude-sonnet-4-5"
+    assert result.substitution["actual_model_known"] is True
+    assert result.substitution["source"] == "cursor-transcript"
+
+
+def test_cursor_adapter_does_not_use_unrelated_existing_transcript_model(adapter, monkeypatch):
+    adapter._workspace = "/tmp/cursor-model-test"
+    monkeypatch.setattr(adapter, "_find_session_id_on_disk", lambda _workspace: "old-session")
+    monkeypatch.setattr(
+        adapter,
+        "_read_session_transcript_events",
+        lambda _workspace, _session_id: [{"type": "result", "model": "composer-2.5"}],
+    )
+
+    result = adapter.parse_response(
+        stdout=json.dumps({"type": "text", "content": "Completed."}),
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.substitution is not None
+    assert result.substitution["actual_model"] is None
+    assert result.substitution["actual_model_known"] is False
+    assert result.substitution["source"] == "unknown"
+
+
 def test_cursor_adapter_successful_echoed_rate_limit_text_is_not_rate_limited(adapter):
     """Prompt/tool text is part of stream-json stdout, not a provider signal."""
     stdout = "\n".join(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1413,6 +1413,115 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["returncode_reason"] is None
 
 
+def test_run_worker_persists_cursor_resolved_model_companion(tmp_tasks_dir, tmp_path):
+    state_path = delegate._state_path("cursor-resolved-model")
+    delegate._write_state_atomic(
+        state_path,
+        {
+            "task_id": "cursor-resolved-model",
+            "agent": "cursor",
+            "model": "auto",
+        },
+    )
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "auto",
+            "effort": "unknown",
+            "cli_version": "2026.08.04",
+            "substitution": {
+                "requested_model": "auto",
+                "actual_model": "composer-2.5",
+                "actual_model_known": True,
+                "source": "cursor-stream-json",
+                "substituted": True,
+            },
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="cursor-resolved-model",
+            agent="cursor",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["model"] == "composer-2.5"
+    assert state["resolved_model"] == "composer-2.5"
+    assert state["resolved_model_known"] is True
+    assert state["resolved_model_source"] == "cursor-stream-json"
+
+
+def test_run_worker_records_unknown_cursor_model_without_inventing_selector(
+    tmp_tasks_dir,
+    tmp_path,
+):
+    state_path = delegate._state_path("cursor-unknown-model")
+    delegate._write_state_atomic(
+        state_path,
+        {
+            "task_id": "cursor-unknown-model",
+            "agent": "cursor",
+            "model": "auto",
+        },
+    )
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "auto",
+            "effort": "unknown",
+            "cli_version": "2026.08.04",
+            "substitution": {
+                "requested_model": "auto",
+                "actual_model": None,
+                "actual_model_known": False,
+                "source": "unknown",
+                "substituted": False,
+            },
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="cursor-unknown-model",
+            agent="cursor",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["model"] == "auto"
+    assert state["resolved_model"] == "unknown"
+    assert state["resolved_model_known"] is False
+    assert state["resolved_model_source"] == "unknown"
+
+
 def test_run_worker_surfaces_instant_exit_stderr_in_task_state_and_log(
     tmp_tasks_dir,
     tmp_path,
@@ -6122,6 +6231,7 @@ def test_finalize_cwd_reuse_with_pushed_commits_counts_deliverable(
     assert state["status"] == "done"
     assert state.get("no_deliverable_reason") is None
     assert state.get("commits_ahead", 0) > 0
+
     assert state["worktree_path"] == str(dispatch_wt)
 
 
@@ -6181,4 +6291,3 @@ def test_run_worker_falls_back_to_resolving_worktree_from_cwd(
     assert state["status"] == "done"
     assert state.get("no_deliverable_reason") is None
     assert state.get("commits_ahead", 0) > 0
-


### PR DESCRIPTION
## Summary
Cursor dispatches no longer leave only `model: auto`. Resolved model is recorded as `resolved_model` (+ known/source), and legacy `model` is updated when concrete. Unresolved stays honest: `resolved_model: unknown` without fabricating a model id.

## Test plan
- 263 tests passed
- Ruff, OPSEC, trailer checks

Fixes #6546

X-Agent: codex/6546-cursor-model-attribution