### PR TITLE
fix(delegate): count private remote deliverables

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1682,20 +1682,23 @@ def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
     return sha or None
 
 
-def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
-    """Return commits on HEAD not reachable from ``base_ref``, or None.
+def _tracking_remote_for_current_branch(worktree: Path) -> str | None:
+    """Return the configured upstream remote for the checked-out branch.
 
-    ``None`` means "cannot count", and a vanished worktree is exactly that: on
-    2026-07-25 a dispatch whose worktree disappeared mid-run raised
-    FileNotFoundError out of here, which killed the finalize path before it
-    could write a terminal status and left the task reading ``running`` with a
-    dead pid — invisible to every settle-loop watching it. The sibling
-    ``_worktree_is_dirty`` already treated OSError as unknown; this is the same
-    contract, and callers already fail closed on ``None``.
+    A reused ``--cwd`` worktree can belong to a private repository whose
+    canonical remote is not named ``origin``.  Its checked-out dispatch branch
+    is the narrowest local source for that repository identity: unlike scanning
+    every configured remote, it cannot accidentally select an unrelated mirror.
     """
     try:
+        branch = _current_branch(worktree)
+    except OSError:
+        return None
+    if not branch or branch == "HEAD":
+        return None
+    try:
         proc = subprocess.run(
-            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+            ["git", "config", "--get", f"branch.{branch}.remote"],
             cwd=worktree,
             capture_output=True,
             text=True,
@@ -1705,27 +1708,72 @@ def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
     except OSError:
         return None
     if proc.returncode != 0:
-        if base_ref.startswith("origin/"):
-            local_ref = base_ref.removeprefix("origin/")
-            try:
-                proc = subprocess.run(
-                    ["git", "rev-list", "--count", f"{local_ref}..HEAD"],
-                    cwd=worktree,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    env=_sanitized_git_env(),
-                )
-            except OSError:
-                return None
-            if proc.returncode != 0:
-                return None
-        else:
-            return None
-    try:
-        return int((proc.stdout or "").strip())
-    except ValueError:
         return None
+    remote = (proc.stdout or "").strip()
+    return remote or None
+
+
+def _commit_count_refs(worktree: Path, base_ref: str) -> tuple[str, ...]:
+    """Return ordered, local-only base-ref candidates for finalization.
+
+    ``origin/<base>`` remains the canonical candidate for ordinary dispatches.
+    If it is unavailable, count against the local base and then the base branch
+    on the checked-out branch's upstream remote.  The last fallback is required
+    for private/secondary remotes, where a pushed dispatch branch may track
+    ``private/<task>`` and the shared checkout intentionally has neither
+    ``origin/<base>`` nor a local ``<base>`` branch.
+    """
+    candidates = [base_ref]
+    _remote, separator, branch = base_ref.partition("/")
+    if separator:
+        candidates.append(branch)
+    else:
+        branch = base_ref
+
+    tracking_remote = _tracking_remote_for_current_branch(worktree)
+    if tracking_remote and branch:
+        candidates.append(f"{tracking_remote}/{branch}")
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
+    """Return commits on HEAD not reachable from an eligible base ref, or None.
+
+    ``None`` means "cannot count", and a vanished worktree is exactly that: on
+    2026-07-25 a dispatch whose worktree disappeared mid-run raised
+    FileNotFoundError out of here, which killed the finalize path before it
+    could write a terminal status and left the task reading ``running`` with a
+    dead pid — invisible to every settle-loop watching it. The sibling
+    ``_worktree_is_dirty`` already treated OSError as unknown; this is the same
+    contract, and callers already fail closed on ``None``.
+    """
+    for candidate in _commit_count_refs(worktree, base_ref):
+        try:
+            proc = subprocess.run(
+                ["git", "rev-list", "--count", f"{candidate}..HEAD"],
+                cwd=worktree,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=_sanitized_git_env(),
+            )
+        except OSError:
+            return None
+        if proc.returncode != 0:
+            continue
+        try:
+            return int((proc.stdout or "").strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _commit_count_base_ref(worktree: Path, base_branch: str) -> str:
+    """Keep an explicit available non-origin remote base for finalization."""
+    explicit_ref = base_branch.removeprefix("refs/remotes/")
+    if "/" in explicit_ref and _resolve_sha(worktree, explicit_ref) is not None:
+        return explicit_ref
+    return _origin_base_ref(base_branch)
 
 
 def _origin_base_ref(base_branch: str) -> str:
@@ -3366,7 +3414,7 @@ def _run_worker(
             # set; the riskier auto-finalize action stays scoped to ``danger``.
             if worktree_path and mode in _WRITE_CAPABLE_MODES:
                 base_branch = str(final_state.get("worktree_base") or "main")
-                base_ref = _origin_base_ref(base_branch)
+                base_ref = _commit_count_base_ref(Path(worktree_path), base_branch)
                 commits_ahead = _count_commits_ahead(
                     Path(worktree_path),
                     base_ref,

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1717,22 +1717,24 @@ def _commit_count_refs(worktree: Path, base_ref: str) -> tuple[str, ...]:
     """Return ordered, local-only base-ref candidates for finalization.
 
     ``origin/<base>`` remains the canonical candidate for ordinary dispatches.
-    If it is unavailable, count against the local base and then the base branch
-    on the checked-out branch's upstream remote.  The last fallback is required
-    for private/secondary remotes, where a pushed dispatch branch may track
-    ``private/<task>`` and the shared checkout intentionally has neither
-    ``origin/<base>`` nor a local ``<base>`` branch.
+    If it is unavailable, count against the base branch on the checked-out
+    branch's upstream remote before falling back to the local base.  The remote
+    candidate must win because a reused checkout can have a stale local branch.
+    The remote fallback is required for private/secondary remotes, where a
+    pushed dispatch branch may track ``private/<task>`` and the shared checkout
+    intentionally has neither ``origin/<base>`` nor a current local ``<base>``
+    branch.
     """
     candidates = [base_ref]
     _remote, separator, branch = base_ref.partition("/")
-    if separator:
-        candidates.append(branch)
-    else:
+    if not separator:
         branch = base_ref
 
     tracking_remote = _tracking_remote_for_current_branch(worktree)
     if tracking_remote and branch:
         candidates.append(f"{tracking_remote}/{branch}")
+    if separator:
+        candidates.append(branch)
     return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -6126,13 +6126,16 @@ def test_interrupt_fallback_records_the_complete_outcome(
 # Issue #6426: finalizer deliverable counting on --cwd reuse worktrees
 # ---------------------------------------------------------------------------
 
-def _init_private_remote_worktree(tmp_path: Path) -> tuple[Path, Path]:
-    """Create a worktree whose only base is a non-origin private remote.
+def _init_private_remote_worktree(
+    tmp_path: Path, *, stale_local_main: bool = False,
+) -> tuple[Path, Path]:
+    """Create a worktree based on a non-origin private remote.
 
-    The primary checkout is deliberately detached and has no local ``main``
-    branch.  This models a private ``--cwd`` dispatch that pushed its branch to
-    a secondary remote: the finalizer must discover ``private/main`` from the
-    dispatch branch's upstream, not assume ``origin/main`` exists.
+    The primary checkout is detached.  By default it has no local ``main``
+    branch, modeling a private ``--cwd`` dispatch that pushed its branch to a
+    secondary remote.  With ``stale_local_main``, the local branch remains at
+    the clone's initial commit while ``private/main`` advances before the
+    dispatch worktree is created; this models the stale-base ordering bug.
     """
     env = delegate._sanitized_git_env()
 
@@ -6176,7 +6179,14 @@ def _init_private_remote_worktree(tmp_path: Path) -> tuple[Path, Path]:
     _git(primary, "config", "user.email", "test@example.com")
     _git(primary, "config", "user.name", "Test")
     _git(primary, "checkout", "-q", "--detach")
-    _git(primary, "branch", "-D", "main")
+    if stale_local_main:
+        (source / "base-update.txt").write_text("updated base\n", encoding="utf-8")
+        _git(source, "add", "base-update.txt")
+        _git(source, "commit", "-q", "-m", "advance private main")
+        _git(source, "push", "-q", "private", "main")
+        _git(primary, "fetch", "-q", "private")
+    else:
+        _git(primary, "branch", "-D", "main")
 
     dispatch_wt = primary / ".worktrees" / "dispatch" / "codex" / "private-task"
     _git(primary, "worktree", "add", "-q", "-b", "codex/private-task", str(dispatch_wt), "private/main")
@@ -6260,6 +6270,57 @@ def test_finalize_private_remote_pushed_commit_is_a_deliverable(
     assert state["status"] == "done"
     assert state["commits_ahead"] == 1
     assert state.get("no_deliverable_reason") is None
+
+
+def test_finalize_private_remote_zero_commits_ignores_stale_local_base(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """A stale local base must not turn a zero-commit dispatch into a delivery."""
+    main, dispatch_wt = _init_private_remote_worktree(tmp_path, stale_local_main=True)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+
+    assert delegate._commit_count_refs(dispatch_wt, "origin/main") == (
+        "origin/main",
+        "private/main",
+        "main",
+    )
+    assert delegate._count_commits_ahead(dispatch_wt, "origin/main") == 0
+
+    state_path = delegate._state_path("private-remote-zero-commits")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "private-remote-zero-commits",
+        "agent": "codex",
+        "mode": "workspace-write",
+        "cwd": str(dispatch_wt),
+        "worktree_path": str(dispatch_wt),
+        "worktree_base": "main",
+        "status": "running",
+    })
+
+    empty_result = _finalize_mock_result()
+    empty_result.response = ""
+    with patch("agent_runtime.runner.invoke", return_value=empty_result):
+        rc = delegate._run_worker(
+            task_id="private-remote-zero-commits",
+            agent="codex",
+            prompt="inspect the requested change",
+            mode="workspace-write",
+            cwd_str=str(dispatch_wt),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    assert rc == 1
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "no_deliverable"
+    assert state["commits_ahead"] == 0
+    assert state["no_deliverable_reason"] == (
+        "write_capable_clean_worktree_zero_commits_short_response"
+    )
+
 
 def test_dispatch_populates_worktree_metadata_on_cwd_reuse(
     tmp_tasks_dir, tmp_path, monkeypatch,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -6126,6 +6126,141 @@ def test_interrupt_fallback_records_the_complete_outcome(
 # Issue #6426: finalizer deliverable counting on --cwd reuse worktrees
 # ---------------------------------------------------------------------------
 
+def _init_private_remote_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a worktree whose only base is a non-origin private remote.
+
+    The primary checkout is deliberately detached and has no local ``main``
+    branch.  This models a private ``--cwd`` dispatch that pushed its branch to
+    a secondary remote: the finalizer must discover ``private/main`` from the
+    dispatch branch's upstream, not assume ``origin/main`` exists.
+    """
+    env = delegate._sanitized_git_env()
+
+    def _git(cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+    remote = tmp_path / "private.git"
+    source = tmp_path / "source"
+    primary = tmp_path / "private-checkout"
+    subprocess.run(["git", "init", "--bare", "-q", str(remote)], check=True, env=env, timeout=30)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(source)],
+        check=True,
+        env=env,
+        timeout=30,
+    )
+    _git(source, "config", "user.email", "test@example.com")
+    _git(source, "config", "user.name", "Test")
+    (source / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(source, "add", "tracked.txt")
+    _git(source, "commit", "-q", "-m", "initial")
+    _git(source, "remote", "add", "private", str(remote))
+    _git(source, "push", "-u", "private", "main")
+    subprocess.run(
+        ["git", "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    subprocess.run(["git", "clone", "-q", str(remote), str(primary)], check=True, env=env, timeout=30)
+    _git(primary, "remote", "rename", "origin", "private")
+    _git(primary, "config", "user.email", "test@example.com")
+    _git(primary, "config", "user.name", "Test")
+    _git(primary, "checkout", "-q", "--detach")
+    _git(primary, "branch", "-D", "main")
+
+    dispatch_wt = primary / ".worktrees" / "dispatch" / "codex" / "private-task"
+    _git(primary, "worktree", "add", "-q", "-b", "codex/private-task", str(dispatch_wt), "private/main")
+    _git(dispatch_wt, "push", "-u", "private", "codex/private-task")
+    return primary.resolve(), dispatch_wt.resolve()
+
+
+def _commit_private_dispatch_delivery(dispatch_wt: Path) -> None:
+    (dispatch_wt / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "feature.py"], cwd=dispatch_wt, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "add feature"], cwd=dispatch_wt, check=True, timeout=30)
+    subprocess.run(
+        ["git", "push", "private", "codex/private-task"],
+        cwd=dispatch_wt,
+        check=True,
+        timeout=30,
+    )
+
+
+def test_count_commits_ahead_uses_private_tracking_remote_without_origin_or_local_base(tmp_path, monkeypatch):
+    """Pushed private-remote commits remain observable when origin/main is absent."""
+    _primary, dispatch_wt = _init_private_remote_worktree(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+
+    assert delegate._count_commits_ahead(dispatch_wt, "origin/main") == 0
+    _commit_private_dispatch_delivery(dispatch_wt)
+
+    assert delegate._count_commits_ahead(dispatch_wt, "origin/main") == 1
+    assert delegate._commit_count_base_ref(dispatch_wt, "private/main") == "private/main"
+
+
+def test_finalize_private_remote_pushed_commit_is_a_deliverable(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """A pushed secondary-remote commit must not settle as commit_count_unknown."""
+    main, dispatch_wt = _init_private_remote_worktree(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    _commit_private_dispatch_delivery(dispatch_wt)
+
+    state_path = delegate._state_path("private-remote-delivery")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "private-remote-delivery",
+        "agent": "codex",
+        "mode": "workspace-write",
+        "cwd": str(dispatch_wt),
+        "worktree_path": str(dispatch_wt),
+        "worktree_base": "main",
+        "status": "running",
+    })
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "Implemented and pushed the private-repository feature.",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.6",
+            "effort": "high",
+            "cli_version": "1.0.0",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="private-remote-delivery",
+            agent="codex",
+            prompt="implement feature",
+            mode="workspace-write",
+            cwd_str=str(dispatch_wt),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["commits_ahead"] == 1
+    assert state.get("no_deliverable_reason") is None
+
 def test_dispatch_populates_worktree_metadata_on_cwd_reuse(
     tmp_tasks_dir, tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
Finalizer counts pushed commits for private/non-origin remotes via the dispatch branch upstream, not only `origin/<base>`. Genuine zero-commit work still no_deliverable.

## Test plan
- 219 focused tests in test_delegate.py
- Ruff, OPSEC, trailer

Fixes #5855

X-Agent: codex/5855-private-no-deliverable