### PR TITLE
fix(hygiene): guard destructive worktree removal + RECOVERY.md

### DIFF
--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -1,0 +1,98 @@
+# Recovery after a local checkout or data loss
+
+This runbook records the 2026-07-29 recovery order. It restores a fresh
+checkout and its locally held data without overwriting an active repository,
+inventing missing data, or reactivating stale agent state. It does not install
+an APFS snapshot LaunchAgent.
+
+## Safety boundary
+
+Stop writers for the affected databases before copying anything. Preserve the
+damaged directory as evidence when space permits. Work from a new clone and a
+new empty staging directory; never restore an archive directly over a live
+checkout, its `data/` directory, the repository root, or a home directory.
+
+The published `hramatka-data-releases` assets are the source for recoverable
+database files. Select the asset and database names from the release manifest
+or its checksums, not from memory. If an expected asset is absent or a checksum
+does not match, stop: a partial release is not a substitute for the missing
+database.
+
+## 1. Recreate the checkout and Python environment
+
+```bash
+git clone https://github.com/learn-ukrainian/learn-ukrainian.github.io.git \
+  /absolute/path/to/clean/learn-ukrainian
+cd /absolute/path/to/clean/learn-ukrainian
+git switch main
+git pull --ff-only
+
+PYTHON_CONFIGURE_OPTS="--enable-loadable-sqlite-extensions" pyenv install 3.12.8
+pyenv local 3.12.8
+python -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e .
+```
+
+If `pyenv install` reports that 3.12.8 already exists, retain that interpreter;
+do not substitute another Python version. Add any project dependencies required
+by the checked-out revision using its tracked installation instructions.
+
+## 2. Restore data databases from the release
+
+Download the chosen `hramatka-data-releases` release asset into an empty
+directory outside the checkout. Verify its published checksum before unpacking.
+Then inspect SQLite copies before selectively copying only the verified files
+into the fresh checkout.
+
+```bash
+RELEASE_STAGE=/absolute/path/to/empty/hramatka-data-release-stage
+PROJECT_DIR=/absolute/path/to/clean/learn-ukrainian
+
+mkdir -p "$RELEASE_STAGE"
+# Download the exact reviewed release asset and checksum into $RELEASE_STAGE.
+# Verify the checksum before unpacking; do not use rsync --delete.
+
+sqlite3 "$RELEASE_STAGE/sources.db" 'PRAGMA quick_check;'
+sqlite3 "$RELEASE_STAGE/vesum.db" 'PRAGMA quick_check;'
+cp "$RELEASE_STAGE/sources.db" "$PROJECT_DIR/data/sources.db"
+cp "$RELEASE_STAGE/vesum.db" "$PROJECT_DIR/data/vesum.db"
+```
+
+The two example names are the expected core databases, not a license to copy
+an arbitrary asset set. Copy additional databases only when the selected
+release manifest names them and each file passes its own integrity check.
+Retain the stage until application checks pass.
+
+## 3. Recreate deployed agent configuration
+
+The tracked agent-extension sources regenerate local ignored deployment files:
+
+```bash
+cd /absolute/path/to/clean/learn-ukrainian
+npm ci
+npm run agents:deploy
+```
+
+Do not restore old `.agent/`, `.codex/`, lock, wake, cache, or session-state
+directories wholesale. Deploy from the checked-out sources, then re-trust any
+project hooks through the relevant local tool interface.
+
+## 4. Restore Git identity and prove readiness
+
+Set the identity deliberately for this clone; use the email address associated
+with the account that will sign and push commits. Do not copy another person's
+identity or any credential file.
+
+```bash
+git config user.name "Your name"
+git config user.email "your-verified-email@example.invalid"
+git config --get user.name
+git config --get user.email
+git status --short --branch
+.venv/bin/python -c "import sqlite3; print(sqlite3.sqlite_version)"
+```
+
+Finally run the smallest relevant test or application health check for the
+recovered component. Keep the release stage and the damaged copy until that
+check passes; only then resume writers.

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -50,6 +50,7 @@ RELEASE_STAGE=/absolute/path/to/empty/hramatka-data-release-stage
 PROJECT_DIR=/absolute/path/to/clean/learn-ukrainian
 
 mkdir -p "$RELEASE_STAGE"
+mkdir -p "$PROJECT_DIR/data"
 # Download the exact reviewed release asset and checksum into $RELEASE_STAGE.
 # Verify the checksum before unpacking; do not use rsync --delete.
 

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -142,11 +142,13 @@ def _acp_runtime_root(repo_root: Path) -> Path:
 
 def _is_under_acp_runtime_root(path: Path, repo_root: Path = ROOT) -> bool:
     """True for paths inside .worktrees/dispatch/acp/."""
+    runtime_root = _acp_runtime_root(repo_root).resolve()
     try:
-        path.resolve().relative_to(_acp_runtime_root(repo_root))
+        resolved_path = path.resolve()
+        resolved_path.relative_to(runtime_root)
     except ValueError:
         return False
-    return True
+    return resolved_path != runtime_root
 
 
 def _is_registered_worktree(path: Path, repo_root: Path) -> bool:

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from scripts.common.repo_root import main_checkout_root
 from scripts.orchestration import reap_worktrees, reaper_lifecycle
+from scripts.path_safety import assert_delete_target
 
 ROOT = main_checkout_root(Path(__file__).resolve().parents[2])
 _TASKS_DIR = ROOT / "batch_state" / "tasks"
@@ -134,10 +135,15 @@ def _is_under_dispatch_worktrees(path: Path) -> bool:
     return rel.parts[:1] != ("acp",)
 
 
-def _is_under_acp_runtime_root(path: Path) -> bool:
+def _acp_runtime_root(repo_root: Path) -> Path:
+    """Return the dedicated ACP-runtime subtree for one repository root."""
+    return repo_root.resolve() / ".worktrees" / "dispatch" / "acp"
+
+
+def _is_under_acp_runtime_root(path: Path, repo_root: Path = ROOT) -> bool:
     """True for paths inside .worktrees/dispatch/acp/."""
     try:
-        path.resolve().relative_to(_ACP_RUNTIME_ROOT)
+        path.resolve().relative_to(_acp_runtime_root(repo_root))
     except ValueError:
         return False
     return True
@@ -242,9 +248,13 @@ def _remove_worktree(path: Path, repo_root: Path) -> tuple[bool, str | None]:
     first establish terminal task ownership, cleanliness, and no live process.
     Regular dispatch worktrees always go through ``reap_worktrees`` instead.
     """
-    if not _is_under_acp_runtime_root(path):
+    if not _is_under_acp_runtime_root(path, repo_root):
         return False, "ACP runtime path is outside .worktrees/dispatch/acp/"
-    cmd = ["worktree", "remove", "--force", str(path)]
+    try:
+        target = assert_delete_target(path, repo_root=repo_root)
+    except ValueError as exc:
+        return False, f"delete guard refused ACP runtime target: {exc}"
+    cmd = ["worktree", "remove", "--force", str(target)]
     proc = _run_git(cmd, cwd=repo_root)
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "git worktree remove failed").strip()
@@ -465,7 +475,7 @@ def _reap_acp_runtime_worktrees(
             )
             continue
 
-        if not _is_under_acp_runtime_root(path):
+        if not _is_under_acp_runtime_root(path, repo_root):
             results.append(
                 {
                     "path": str(path),

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -140,8 +140,8 @@ def build_plan(
         "repo_root": str(primary),
         "archive_root": str(archive_root.expanduser()),
         "policy": {
-            "stale_hours": stale_hours,
-            "build_age_hours": build_age_hours,
+            "stale_hours": float(stale_hours),
+            "build_age_hours": float(build_age_hours),
             "safe_only": safe_only,
             "include_home": include_home,
             "session_stream_history_excluded": True,

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.orchestration import reaper_lifecycle
+from scripts.path_safety import assert_delete_target
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUILD_AGE_HOURS = 6.0
@@ -679,8 +680,12 @@ def _remove_worktree(repo_root: Path, info: WorktreeInfo) -> str | None:
     a worker's ``.venv``. Git still considers that residue when removing a
     worktree, so force is required at this final, guarded deletion boundary.
     """
+    try:
+        target = assert_delete_target(info.path, repo_root=repo_root)
+    except ValueError as exc:
+        return f"delete guard refused worktree target: {exc}"
     proc = _run(
-        ["git", "worktree", "remove", "--force", str(info.path)],
+        ["git", "worktree", "remove", "--force", str(target)],
         cwd=repo_root,
     )
     if proc.returncode != 0:

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -27,7 +27,7 @@ from scripts.orchestration import reaper_lifecycle
 from scripts.path_safety import assert_delete_target
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_BUILD_AGE_HOURS = 6.0
+DEFAULT_BUILD_AGE_HOURS = 6
 
 _GIT_ENV_DENYLIST = {
     "GIT_DIR",

--- a/scripts/path_safety.py
+++ b/scripts/path_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from pathlib import Path
 
 # Dual-flavor import: several consumers load this module as top-level
@@ -151,3 +152,56 @@ def trusted_join(base: Path, *parts: str | Path) -> Path:
     if common != abs_base:
         raise ValueError("Path escapes the configured root")
     return Path(target)
+
+
+def assert_delete_target(
+    target: str | Path,
+    *,
+    repo_root: Path,
+    approved_temp_roots: Iterable[Path] = (),
+) -> Path:
+    """Return a resolved deletion target only when it is safely allowlisted.
+
+    Destructive callers must use this immediately before deleting a tree.  It
+    accepts only descendants (never the allowlist root itself) of the
+    repository's ``.worktrees/`` or ``batch_state/tmp/`` directories, the
+    process ``$TMPDIR`` (when configured), or an explicitly supplied approved
+    temporary root.  The repository root, the user's home directory, empty
+    shell expansions, and symlink escapes are all rejected.
+
+    ``approved_temp_roots`` is for a narrow, caller-owned temporary directory;
+    it is not a mechanism to approve a broad parent such as a repository or
+    home directory.
+    """
+    raw_target = str(target)
+    if raw_target.strip() in {"", "."}:
+        raise ValueError("delete target is empty or the current directory")
+    if "$" in raw_target:
+        raise ValueError("delete target contains an unexpanded shell variable")
+
+    resolved_target = Path(raw_target).resolve()
+    resolved_repo_root = repo_root.resolve()
+    home_root = Path.home().resolve()
+    if resolved_target == resolved_repo_root:
+        raise ValueError("delete target is the repository root")
+    if resolved_target == home_root:
+        raise ValueError("delete target is the home directory")
+
+    allowed_roots = [
+        resolved_repo_root / ".worktrees",
+        resolved_repo_root / "batch_state" / "tmp",
+    ]
+    tmpdir = os.environ.get("TMPDIR")
+    if tmpdir:
+        allowed_roots.append(Path(tmpdir).resolve())
+    allowed_roots.extend(Path(root).resolve() for root in approved_temp_roots)
+
+    for root in allowed_roots:
+        if root in {resolved_repo_root, home_root}:
+            raise ValueError("approved deletion root must not be the repository or home directory")
+        if resolved_target == root:
+            raise ValueError("delete target must be below an approved root, not the root itself")
+        if _is_within(root, resolved_target):
+            return resolved_target
+
+    raise ValueError("delete target is outside approved deletion roots")

--- a/scripts/path_safety.py
+++ b/scripts/path_safety.py
@@ -197,6 +197,8 @@ def assert_delete_target(
     allowed_roots.extend(Path(root).resolve() for root in approved_temp_roots)
 
     for root in allowed_roots:
+        if root.parent == root:
+            raise ValueError("approved deletion root must not be the filesystem root")
         if root in {resolved_repo_root, home_root}:
             raise ValueError("approved deletion root must not be the repository or home directory")
         if resolved_target == root:

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -208,6 +208,14 @@ def test_acp_runtime_remove_is_force_limited_to_its_dedicated_subtree(
     assert len(commands) == 1
 
 
+def test_acp_runtime_root_is_not_a_removable_runtime_descendant(tmp_path: Path) -> None:
+    """The dedicated ACP directory is a boundary, never a runtime target."""
+    runtime_root = post_task_reap._acp_runtime_root(tmp_path)
+
+    assert post_task_reap._is_under_acp_runtime_root(runtime_root, tmp_path) is False
+    assert post_task_reap._is_under_acp_runtime_root(runtime_root / "runtime-task", tmp_path) is True
+
+
 def _raw_worktree_remove_callers(project_root: Path) -> dict[str, set[str]]:
     """Return production functions constructing a literal ``worktree remove`` command."""
     actual: dict[str, set[str]] = {}

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -163,6 +163,16 @@ def test_merged_worktree_with_only_untracked_venv_is_force_removed_after_guards(
     assert_main_checkout_unchanged(repo)
 
 
+def test_final_worktree_delete_hand_refuses_the_repository_root(tmp_path: Path) -> None:
+    """The last deletion boundary cannot turn a bad path into a root removal."""
+    repo = init_repo(tmp_path)
+    info = rw.WorktreeInfo(path=repo, branch="codex/bad-path", head="deadbeef")
+
+    error = rw._remove_worktree(repo, info)
+
+    assert error == "delete guard refused worktree target: delete target is the repository root"
+
+
 def test_post_task_reap_routes_regular_dispatch_deletion_through_p0_reaper() -> None:
     """Regular dispatch worktrees have one automatic deletion hand: P0."""
     source = inspect.getsource(post_task_reap._reap_main_worktree)
@@ -183,7 +193,7 @@ def test_acp_runtime_remove_is_force_limited_to_its_dedicated_subtree(
         return subprocess.CompletedProcess(args, 0, "", "")
 
     monkeypatch.setattr(post_task_reap, "_run_git", fake_run_git)
-    runtime = post_task_reap._ACP_RUNTIME_ROOT / "p2b-runtime"
+    runtime = tmp_path / ".worktrees" / "dispatch" / "acp" / "p2b-runtime"
 
     ok, error = post_task_reap._remove_worktree(runtime, tmp_path)
 

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,66 @@
+"""Regression tests for the shared destructive-path guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.path_safety import assert_delete_target
+
+
+def test_delete_guard_allows_descendants_of_standard_and_approved_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = repo_root / ".worktrees" / "dispatch" / "codex" / "task"
+    batch_temp = repo_root / "batch_state" / "tmp" / "render"
+    approved_temp = tmp_path / "approved-temp" / "staging"
+    tmpdir = tmp_path / "process-tmp"
+    monkeypatch.setenv("TMPDIR", str(tmpdir))
+
+    assert assert_delete_target(worktree, repo_root=repo_root) == worktree.resolve()
+    assert assert_delete_target(batch_temp, repo_root=repo_root) == batch_temp.resolve()
+    assert assert_delete_target(tmpdir / "payload", repo_root=repo_root) == (tmpdir / "payload").resolve()
+    assert (
+        assert_delete_target(
+            approved_temp,
+            repo_root=repo_root,
+            approved_temp_roots=(tmp_path / "approved-temp",),
+        )
+        == approved_temp.resolve()
+    )
+
+
+@pytest.mark.parametrize(
+    ("target_factory", "message"),
+    [
+        (lambda repo_root: "", "empty"),
+        (lambda repo_root: ".", "current directory"),
+        (lambda repo_root: "$TMPDIR", "unexpanded shell variable"),
+        (lambda repo_root: repo_root, "repository root"),
+        (lambda repo_root: repo_root / ".worktrees", "not the root itself"),
+        (lambda repo_root: Path.home(), "home directory"),
+        (lambda repo_root: Path("/etc"), "outside approved"),
+    ],
+)
+def test_delete_guard_refuses_catastrophic_or_unapproved_targets(
+    tmp_path: Path,
+    target_factory,
+    message: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+
+    with pytest.raises(ValueError, match=message):
+        assert_delete_target(target_factory(repo_root), repo_root=repo_root)
+
+
+def test_symlink_escape_is_blocked(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    worktrees = repo_root / ".worktrees"
+    worktrees.mkdir(parents=True)
+    (worktrees / "escape").symlink_to(Path("/etc"), target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside approved"):
+        assert_delete_target(worktrees / "escape", repo_root=repo_root)

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -64,3 +64,32 @@ def test_symlink_escape_is_blocked(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="outside approved"):
         assert_delete_target(worktrees / "escape", repo_root=repo_root)
+
+
+@pytest.mark.parametrize(
+    ("tmpdir", "approved_temp_roots"),
+    [
+        ("/", ()),
+        (None, (Path("/"),)),
+    ],
+)
+def test_delete_guard_refuses_filesystem_root_as_a_temp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmpdir: str | None,
+    approved_temp_roots: tuple[Path, ...],
+) -> None:
+    """Neither $TMPDIR nor an explicit root can allow arbitrary deletion."""
+    repo_root = tmp_path / "repo"
+    arbitrary_target = tmp_path / "arbitrary-target"
+    if tmpdir is None:
+        monkeypatch.delenv("TMPDIR", raising=False)
+    else:
+        monkeypatch.setenv("TMPDIR", tmpdir)
+
+    with pytest.raises(ValueError, match="filesystem root"):
+        assert_delete_target(
+            arbitrary_target,
+            repo_root=repo_root,
+            approved_temp_roots=approved_temp_roots,
+        )


### PR DESCRIPTION
## Summary
- Fail-closed path guard for destructive worktree removal (allowlist under `.worktrees/` / approved temps; refuse repo root, home, empty expansions, symlink escapes).
- Wire into worktree reaper hands.
- `docs/RECOVERY.md` for the 2026-07-29 restore sequence (no APFS LaunchAgent — operator GO remains).

## Non-goals
Hourly APFS localsnapshot LaunchAgent (operator GO).

## Test plan
- 9 path-safety + 41 reaper + 23 post-task-reaper tests
- Ruff, markdownlint, OPSEC, trailer

Refs #6013 (residual; leaves APFS item open)

X-Agent: codex/6013-root-guard-recovery-docs