### PR TITLE
fix(hooks): regenerate lesson schema before commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -187,11 +187,17 @@ repos:
         name: lesson schema drift gate
         entry: >-
           bash -c 'bash scripts/pre_commit/project_python.sh
-          scripts/build/generate_lesson_schema.py && git diff --exit-code
+          scripts/pre_commit/regen_lesson_schema.py && git diff --exit-code
           docs/lesson-schema.yaml'
         language: system
         pass_filenames: false
-        files: ^(site/src/components/.*\.(tsx|astro)|scripts/pipeline/config_tables\.py|docs/lesson-contract\.md)$
+        files: >-
+          (?x)^(
+            site/src/components/.*\.(tsx|astro)|
+            scripts/build/(generate_lesson_schema\.py|lesson_schema_extractor\.mjs)|
+            scripts/pipeline/config_tables\.py|
+            docs/lesson-contract\.md
+          )$
         stages: [pre-commit]
 
       # Atlas lexicon code-fingerprint must stay in sync with scripts/lexicon/*.py.

--- a/scripts/pre_commit/regen_lesson_schema.py
+++ b/scripts/pre_commit/regen_lesson_schema.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Pre-commit: regenerate the lesson component schema.
+
+``docs/lesson-schema.yaml`` is a committed representation of the public lesson
+component interfaces.  It must be refreshed whenever one of its source
+components changes; otherwise the contracts checks fail only after a PR reaches
+CI.  The matching pre-commit entry invokes this helper and then requires the
+refreshed schema to be staged, following the Atlas lexicon fingerprint pattern.
+
+The generator remains the single implementation of schema construction.  This
+small wrapper gives the local guard a stable, testable entry point and prints a
+clear confirmation of the file it refreshed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.build import generate_lesson_schema
+
+
+def main() -> int:
+    """Regenerate the committed lesson schema through its canonical generator."""
+    result = generate_lesson_schema.main()
+    if result == 0:
+        print("Lesson schema written: docs/lesson-schema.yaml")
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_regen_lesson_schema_hook.py
+++ b/tests/test_regen_lesson_schema_hook.py
@@ -1,0 +1,62 @@
+"""Coverage for the lesson-schema pre-commit regeneration path."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.build import generate_lesson_schema
+from scripts.pre_commit import regen_lesson_schema
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _lesson_schema_hook() -> dict[str, object]:
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    for repo in config["repos"]:
+        for hook in repo["hooks"]:
+            if hook["id"] == "lesson-schema-drift":
+                return hook
+    raise AssertionError("lesson-schema-drift hook is missing")
+
+
+def test_regen_lesson_schema_uses_canonical_generator(monkeypatch, capsys):
+    calls: list[tuple[object, ...]] = []
+
+    def fake_main() -> int:
+        calls.append(())
+        return 0
+
+    monkeypatch.setattr(regen_lesson_schema.generate_lesson_schema, "main", fake_main)
+
+    assert regen_lesson_schema.main() == 0
+    assert calls == [()]
+    assert capsys.readouterr().out == "Lesson schema written: docs/lesson-schema.yaml\n"
+
+
+def test_lesson_schema_hook_regenerates_for_all_schema_inputs():
+    hook = _lesson_schema_hook()
+
+    assert hook["pass_filenames"] is False
+    assert hook["stages"] == ["pre-commit"]
+    assert "scripts/pre_commit/regen_lesson_schema.py" in hook["entry"]
+    assert "git diff --exit-code docs/lesson-schema.yaml" in hook["entry"]
+
+    pattern = hook["files"]
+    schema_inputs = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in generate_lesson_schema.discover_components(generate_lesson_schema.COMPONENTS_DIR)
+    ]
+    schema_inputs.extend(
+        [
+            "scripts/build/generate_lesson_schema.py",
+            "scripts/build/lesson_schema_extractor.mjs",
+            "scripts/pipeline/config_tables.py",
+            "docs/lesson-contract.md",
+        ]
+    )
+
+    assert all(re.fullmatch(pattern, path) for path in schema_inputs)
+    assert not re.fullmatch(pattern, "site/src/pages/index.astro")


### PR DESCRIPTION
Closes #6554

## Summary
- add a dedicated, canonical lesson-schema regeneration pre-commit helper
- trigger it for component and generator input changes, then require the refreshed schema to be staged
- cover helper delegation and complete trigger-path coverage with pytest

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pre-commit run lesson-schema-drift --files site/src/components/Quiz.tsx`
- isolated-index stale-schema probe: hook refreshed the working file and rejected the stale staged schema
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_regen_lesson_schema_hook.py tests/test_lesson_schema.py tests/test_lesson_schema_filter_coverage.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/pre_commit/regen_lesson_schema.py tests/test_regen_lesson_schema_hook.py`
- `pre-commit run check-yaml --files .pre-commit-config.yaml`
- `git diff --check` and `scripts/audit/lint_opsec_leaks.py`

## Review routing
Cross-family review requested through AGY using its registered `gemini-3.6-flash-high` pin (the configured `gemini-3.1-pro-high` route was rejected as incompatible).