### PR TITLE
fix(ci): guard negated closing references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,12 @@
 
 ## Related Issues
 
-<!-- Link to related issues: Fixes #NNN, Relates to #NNN -->
+<!--
+Choose wording deliberately because GitHub parses closing references lexically.
+
+- Full issue closeout owned here: Closes #NNN, Fixes #NNN, or Resolves #NNN.
+- Related issue that remains open: Refs #NNN or This PR leaves #NNN open.
+
+Do not pair a negative expression with a closing action and an issue reference.
+See docs/best-practices/pr-issue-references.md.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,7 +694,28 @@ jobs:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
 
   # ---------------------------------------------------------------------
-  # 5. CI Gate — the sole required check. Every job above is unconditional,
+  # 5. pr-body-references — GitHub parses closing references lexically, so a
+  # negated phrase can still close an issue. This job deliberately reads the
+  # event body rather than repository files and runs on PR body edits.
+  # ---------------------------------------------------------------------
+  pr-body-references:
+    name: PR body issue-reference guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Reject negated closing references
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: |
+          printf '%s' "$PR_BODY" | python scripts/audit/lint_pr_closing_references.py --stdin
+
+  # ---------------------------------------------------------------------
+  # 6. CI Gate — the sole required check. Every job above is unconditional,
   #    so `skipped` is as much a failure as `failure`/`cancelled`: there is
   #    no legitimate reason for any of them to not report `success`.
   # ---------------------------------------------------------------------
@@ -749,6 +770,7 @@ jobs:
       - contracts
       - frontend
       - security
+      - pr-body-references
       - coverage-floor
     steps:
       - name: Report required-job results

--- a/docs/best-practices/pr-issue-references.md
+++ b/docs/best-practices/pr-issue-references.md
@@ -1,0 +1,23 @@
+# Pull-request issue references
+
+GitHub parses closing references lexically. Negating a closing action does not
+make an issue reference safe.
+
+When a pull request leaves an issue open, use one of these forms:
+
+- `Refs #123`
+- `This PR leaves #123 open.`
+
+Use `Closes #123`, `Fixes #123`, or `Resolves #123` only when the pull request
+owns the issue's complete closeout. Do not put a negative expression beside a
+closing action and an issue reference.
+
+The required CI job runs this deterministic check on PR creation, updates, and
+body edits. To exercise it locally with a disposable body, run:
+
+```bash
+printf '%s' 'Refs #123' | .venv/bin/python scripts/audit/lint_pr_closing_references.py --stdin
+```
+
+Before auto-merge, the task lifecycle also compares GitHub's authoritative
+closing-reference list with the lifecycle's declared remaining-scope status.

--- a/scripts/audit/lint_pr_closing_references.py
+++ b/scripts/audit/lint_pr_closing_references.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Reject negated GitHub closing references in pull-request prose.
+
+GitHub closing-reference parsing is lexical.  This linter therefore does not
+try to infer intent: it rejects a negation placed before a closing keyword and
+an issue reference, and leaves deliberate closing references untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One unsafe closing-reference phrase."""
+
+    line_number: int
+    phrase: str
+
+
+_NEGATED_CLOSING_REFERENCE = re.compile(
+    r"\b(?:do(?:es)?\s+not|did\s+not|will\s+not|won['’]t|cannot|can['’]t|without|not)"
+    r"(?:\s+[A-Za-z]+){0,3}?\s+"
+    r"(?:clos(?:e|es|ed|ing)|fix(?:es|ed|ing)?|resolv(?:e|es|ed|ing))\s+#(?P<issue>[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+
+
+def scan_text(text: str) -> list[Violation]:
+    """Return every negated closing reference, with its one-based line."""
+
+    return [
+        Violation(line_number, match.group(0))
+        for line_number, line in enumerate(text.splitlines(), start=1)
+        for match in _NEGATED_CLOSING_REFERENCE.finditer(line)
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    inputs = parser.add_mutually_exclusive_group(required=True)
+    inputs.add_argument("--text", type=Path, help="UTF-8 PR-body fixture to scan")
+    inputs.add_argument("--stdin", action="store_true", help="Read a PR body from standard input")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.stdin:
+        label = "<stdin>"
+        text = sys.stdin.read()
+    else:
+        label = str(args.text)
+        try:
+            text = args.text.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            print(f"{label}: not utf-8", file=sys.stderr)
+            return 2
+
+    violations = scan_text(text)
+    for violation in violations:
+        print(
+            f"{label}:{violation.line_number}: negated GitHub closing reference: "
+            f"{violation.phrase!r}; use 'Refs #{_issue_number(violation.phrase)}' "
+            "or 'leaves #N open' instead"
+        )
+    return 1 if violations else 0
+
+
+def _issue_number(phrase: str) -> str:
+    match = _NEGATED_CLOSING_REFERENCE.search(phrase)
+    if match is None:  # pragma: no cover - callers pass a regex match phrase.
+        raise ValueError("phrase is not a negated closing reference")
+    return match.group("issue")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -173,7 +173,8 @@ class GhGitHubAdapter:
                 repository,
                 "--json",
                 "number,url,state,isDraft,headRefOid,headRefName,mergeCommit,mergedAt,"
-                "autoMergeRequest,reviewDecision,reviews,statusCheckRollup,body",
+                "autoMergeRequest,reviewDecision,reviews,statusCheckRollup,body,"
+                "closingIssuesReferences",
             ]
         )
         checks: list[dict[str, Any]] = []
@@ -200,6 +201,15 @@ class GhGitHubAdapter:
                 )
         auto = pr.get("autoMergeRequest") or {}
         merge_commit = pr.get("mergeCommit") or {}
+        closing_references = pr.get("closingIssuesReferences")
+        if not isinstance(closing_references, list):
+            raise task_lifecycle.LifecycleError("GitHub PR closing-reference response is not a list")
+        closing_issue_numbers: list[int] = []
+        for reference in closing_references:
+            number = reference.get("number") if isinstance(reference, dict) else None
+            if not isinstance(number, int) or number < 1:
+                raise task_lifecycle.LifecycleError("GitHub PR closing reference lacks a valid issue number")
+            closing_issue_numbers.append(number)
         return {
             "number": pr.get("number"),
             "url": pr.get("url"),
@@ -215,6 +225,7 @@ class GhGitHubAdapter:
             "reviews": pr.get("reviews") or [],
             "checks": checks,
             "body": pr.get("body") or "",
+            "closing_issue_numbers": sorted(set(closing_issue_numbers)),
         }
 
     def _comments(self, repository: str, pr_number: int) -> list[dict[str, Any]]:
@@ -348,6 +359,7 @@ class GhGitHubAdapter:
             "reviews": [],
             "checks": [],
             "body": "",
+            "closing_issue_numbers": [],
         }
         comments: list[dict[str, Any]] = []
         deployments: list[dict[str, Any]] = []
@@ -534,6 +546,7 @@ def _assert_mutation_ready(
         if fatal:
             raise task_lifecycle.LifecycleError("AC sync blocked: " + "; ".join(fatal))
     elif action == "arm-auto-merge":
+        _assert_closing_references_match_disposition(ledger, observation)
         if hard:
             raise task_lifecycle.LifecycleError("auto-merge blocked: " + "; ".join(hard))
         if task_lifecycle.STATE_RANK.get(evaluation["last_success_state"], -1) < task_lifecycle.STATE_RANK[
@@ -559,6 +572,32 @@ def _assert_mutation_ready(
         if ledger["remaining_scope"]["status"] == "open":
             raise task_lifecycle.LifecycleError("issue close is blocked by untransferred remaining scope")
     return evaluation
+
+
+def _assert_closing_references_match_disposition(
+    ledger: Mapping[str, Any], observation: Mapping[str, Any]
+) -> None:
+    """Fail closed when GitHub closing references contradict retained scope."""
+
+    raw_numbers = observation["github"]["pr"].get("closing_issue_numbers")
+    if not isinstance(raw_numbers, list) or any(
+        not isinstance(number, int) or number < 1 for number in raw_numbers
+    ):
+        raise task_lifecycle.LifecycleError("authoritative PR closing references are unavailable or malformed")
+    closing_numbers = set(raw_numbers)
+    remaining_scope = ledger["remaining_scope"]["status"]
+    expected = (
+        {int(ledger["identity"]["github_issue_number"])}
+        if remaining_scope == "none"
+        else set()
+    )
+    unexpected = sorted(closing_numbers - expected)
+    if unexpected:
+        rendered = ", ".join(f"#{number}" for number in unexpected)
+        raise task_lifecycle.LifecycleError(
+            "GitHub closing references contradict the declared remaining-scope disposition: "
+            f"{rendered}"
+        )
 
 
 def _record_failed_mutation(

--- a/tests/audit/test_lint_pr_closing_references.py
+++ b/tests/audit/test_lint_pr_closing_references.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from scripts.audit import lint_pr_closing_references
+
+
+@pytest.mark.parametrize(
+    "body, issue",
+    [
+        ("This PR does not close #42.", "42"),
+        ("Do not close #43 until the follow-up completes.", "43"),
+        ("This won't close #44.", "44"),
+        ("The migration ships without closing #45.", "45"),
+    ],
+)
+def test_negated_closing_references_are_rejected(body: str, issue: str) -> None:
+    violations = lint_pr_closing_references.scan_text(body)
+
+    assert len(violations) == 1
+    assert f"#{issue}" in violations[0].phrase
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Refs #42.",
+        "This PR leaves #42 open.",
+        "Closes #42 after the acceptance criteria are complete.",
+        "The change does not close the browser window.",
+    ],
+)
+def test_safe_or_non_reference_prose_is_accepted(body: str) -> None:
+    assert lint_pr_closing_references.scan_text(body) == []
+
+
+def test_stdin_guard_fails_for_a_disposable_pr_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("This PR does not close #42."))
+
+    assert lint_pr_closing_references.main(["--stdin"]) == 1
+    assert "negated GitHub closing reference" in capsys.readouterr().out

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -140,6 +140,7 @@ def _observation(
                     {"name": "CI Gate", "status": "COMPLETED", "conclusion": "SUCCESS"}
                 ],
                 "body": pr_body,
+                "closing_issue_numbers": [],
             },
             "comments": [{"url": REVIEW_URL, "body": "PASS", "created_at": NOW}],
             "deployments": [],
@@ -296,6 +297,53 @@ def test_auto_merge_is_blocked_until_current_head_review(tmp_path: Path) -> None
     assert "outside-family review" in ledger["mutation_receipts"][-1]["detail"]
 
 
+def test_auto_merge_rejects_closing_reference_when_scope_is_retained(tmp_path: Path) -> None:
+    path, ledger = _ledger(tmp_path)
+    ledger = task_lifecycle.set_remaining_scope(
+        ledger,
+        status="open",
+        summary="A follow-up is still required.",
+        now=NOW,
+    )
+    task_lifecycle.write_lifecycle(path, ledger)
+    observation = _observation()
+    observation["github"]["pr"]["closing_issue_numbers"] = [42]
+    adapter = FakeAdapter(observation)
+
+    with pytest.raises(task_lifecycle.LifecycleError, match="closing references contradict"):
+        task_closeout.perform_mutation(
+            path,
+            adapter,
+            action="arm-auto-merge",
+            authorized_by="codex/6096-close-keyword-guard",
+            branch="codex/42-closeout",
+            worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+            now=NOW,
+        )
+
+    assert adapter.calls == []
+
+
+def test_auto_merge_allows_declared_lifecycle_issue_closing_reference(tmp_path: Path) -> None:
+    path, _ = _ledger(tmp_path)
+    observation = _observation()
+    observation["github"]["pr"]["closing_issue_numbers"] = [42]
+    adapter = FakeAdapter(observation)
+
+    result = task_closeout.perform_mutation(
+        path,
+        adapter,
+        action="arm-auto-merge",
+        authorized_by="codex/6096-close-keyword-guard",
+        branch="codex/42-closeout",
+        worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+        now=NOW,
+    )
+
+    assert result["remote_mutation_performed"] is True
+    assert adapter.calls == ["arm-auto-merge"]
+
+
 def test_missing_authorization_is_durable_and_nonmutating(tmp_path: Path) -> None:
     path, _ = _ledger(tmp_path)
 
@@ -382,6 +430,7 @@ def test_github_adapter_normalizes_parent_pr_checks_and_deployments(tmp_path: Pa
                         }
                     ],
                     "body": "Refs #42",
+                    "closingIssuesReferences": [],
                 }
             )
         if "issues/77/comments" in command:


### PR DESCRIPTION
## Summary

Adds a deterministic PR-body guard for lexical GitHub closing references and documents the safe alternatives.

- rejects negation next to a closing action and `#N` in the required CI Gate
- compares GitHub `closingIssuesReferences` to declared lifecycle remaining scope before auto-merge
- updates the PR template and agent-facing reference guidance

## Safe wording

- `Refs #N`
- `This PR leaves #N open.`

Use `Closes #N`, `Fixes #N`, or `Resolves #N` only for full issue closeout.

## Verification

- `28 passed` — focused lint and lifecycle tests
- Ruff, actionlint, staged OPSEC audit, and `git diff --check` passed
- disposable body: safe reference exits 0; guarded reference exits 1

## Guardrail proposal

https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6096#issuecomment-5232755764

Closes #6096