### PR TITLE
fix(tests): resolve project Python from worktrees

### DIFF
--- a/tests/audit/test_lint_anti_menu.py
+++ b/tests/audit/test_lint_anti_menu.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from tests.project_python import project_python
+
 SCRIPT = Path("scripts/audit/lint_anti_menu.py")
-PYTHON = Path(".venv/bin/python")
 
 
 def run_linter(path: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [str(PYTHON), str(SCRIPT), "--text", str(path)],
+        [str(project_python()), str(SCRIPT), "--text", str(path)],
         capture_output=True,
         check=False,
         text=True,
@@ -233,7 +234,7 @@ making a concrete recommendation.
 
 def test_stdin_uses_stdin_label_and_informative_snippet() -> None:
     result = subprocess.run(
-        [str(PYTHON), str(SCRIPT), "--stdin"],
+        [str(project_python()), str(SCRIPT), "--stdin"],
         capture_output=True,
         check=False,
         input="Should I merge this now or wait for another review?\n",

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -16,6 +16,7 @@ from scripts.orchestration import task_identity
 from scripts.orchestration.task_family import codex_state, rollover, storage
 from scripts.orchestration.task_family.model import RelationType
 from scripts.orchestration.task_family.storage import TaskFamilyStorage, advisory_lock
+from tests.project_python import project_python
 
 
 def _write_db(path: Path, rows: list[tuple[str, str, str, int, str | None, str]]) -> None:
@@ -240,7 +241,7 @@ def test_advisory_lock_blocks_a_second_process_until_release(tmp_path: Path) -> 
     repo_root = Path(__file__).resolve().parents[3]
     with advisory_lock(lock_path):
         child = subprocess.Popen(
-            [".venv/bin/python", "-c", code, str(lock_path), str(ready_path), str(acquired_path)],
+            [str(project_python()), "-c", code, str(lock_path), str(ready_path), str(acquired_path)],
             cwd=repo_root,
         )
         deadline = time.monotonic() + 5
@@ -270,7 +271,7 @@ def test_advisory_lock_honors_hook_deadline(tmp_path: Path, monkeypatch: pytest.
     environment = os.environ.copy()
     environment.pop("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", None)
     child = subprocess.Popen(
-        [".venv/bin/python", "-c", code, str(lock_path), str(ready_path)],
+        [str(project_python()), "-c", code, str(lock_path), str(ready_path)],
         cwd=repo_root,
         env=environment,
     )

--- a/tests/orchestration/task_family/test_rollover_registry.py
+++ b/tests/orchestration/task_family/test_rollover_registry.py
@@ -10,6 +10,7 @@ import pytest
 from scripts.orchestration import rollover_registry_cli, task_identity
 from scripts.orchestration.task_family import rollover
 from scripts.orchestration.task_family import rollover_registry as registry
+from tests.project_python import project_python
 
 
 def _write_json(path: Path, payload: dict) -> None:
@@ -317,7 +318,7 @@ def test_cli_script_entrypoint_runs_from_repo_root(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     result = subprocess.run(
         [
-            str(repo_root / ".venv/bin/python"),
+            str(project_python()),
             str(repo_root / "scripts/orchestration/rollover_registry_cli.py"),
             "--repo-root",
             str(tmp_path),

--- a/tests/orchestration/test_claudex_supervisor.py
+++ b/tests/orchestration/test_claudex_supervisor.py
@@ -23,9 +23,11 @@ from scripts.orchestration.claudex_supervisor import (
     create_rollover_request,
     load_runtime,
 )
+from tests.project_python import project_python
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_REPO_PYTHON = _REPO_ROOT / ".venv/bin/python"
+def _repo_python() -> Path:
+    return project_python()
 _SUPERVISOR = _REPO_ROOT / "scripts/orchestration/claudex_supervisor.py"
 _SESSION_ID = "official-session-5265"
 _HANDOFF_AGENT = "claude-infra"
@@ -376,7 +378,7 @@ def test_ordinary_child_crash_never_relaunches(tmp_path: Path) -> None:
     )
 
     completed = subprocess.run(
-        [os.fspath(_REPO_PYTHON), os.fspath(_SUPERVISOR), os.fspath(child), *_argv()],
+        [os.fspath(_repo_python()), os.fspath(_SUPERVISOR), os.fspath(child), *_argv()],
         cwd=_REPO_ROOT,
         env=env,
         capture_output=True,
@@ -414,7 +416,7 @@ def test_valid_rollover_relaunches_exact_route_once(
         ANTHROPIC_AUTH_TOKEN="private-token",
     )
     process = subprocess.Popen(
-        [os.fspath(_REPO_PYTHON), os.fspath(_SUPERVISOR), os.fspath(child), *forwarded],
+        [os.fspath(_repo_python()), os.fspath(_SUPERVISOR), os.fspath(child), *forwarded],
         cwd=_REPO_ROOT,
         env=env,
         stdout=subprocess.PIPE,
@@ -485,7 +487,7 @@ def test_relaunch_failure_leaves_handoff_lease_for_manual_recovery(tmp_path: Pat
         SUPERVISOR_CHILD_LOG=os.fspath(child_log),
     )
     process = subprocess.Popen(
-        [os.fspath(_REPO_PYTHON), os.fspath(_SUPERVISOR), os.fspath(child), *_argv()],
+        [os.fspath(_repo_python()), os.fspath(_SUPERVISOR), os.fspath(child), *_argv()],
         cwd=_REPO_ROOT,
         env=env,
         stdout=subprocess.PIPE,

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -18,6 +18,7 @@ from scripts.orchestration import thread_handoff as th
 from scripts.orchestration import thread_handoff_canary as canary
 from scripts.orchestration.task_family import rollover, rollover_registry
 from scripts.orchestration.task_family.storage import TaskFamilyStorage
+from tests.project_python import project_python
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -368,7 +369,7 @@ def test_direct_script_help_from_repository_root():
     env.pop("CODEX_SESSION_ID", None)
 
     completed = subprocess.run(
-        [".venv/bin/python", "scripts/orchestration/thread_handoff.py", "--help"],
+        [str(project_python()), "scripts/orchestration/thread_handoff.py", "--help"],
         cwd=repo_root,
         capture_output=True,
         text=True,

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -22,9 +22,9 @@ from agents_extensions.shared.session_streams.app_lifecycle import VerifiedAppLi
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
 from agents_extensions.shared.session_streams.model import EntryType, HolderKind, LeaseHolder, isoformat_z
 from agents_extensions.shared.session_streams.store import SessionStreamStore
+from tests.project_python import project_python
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-REPO_PYTHON = REPO_ROOT / ".venv/bin/python"
 HANDOFF = REPO_ROOT / "scripts/orchestration/thread_handoff.py"
 HANDOFF_CANARY = REPO_ROOT / "scripts/orchestration/thread_handoff_canary.py"
 CONTEXT_CANARY = REPO_ROOT / "scripts/context_canary.py"
@@ -194,7 +194,7 @@ exec {os.fspath(REPO_ROOT / ".venv" / "bin" / "python")!r} "$@"
 
 def handoff_command(primary: Path, *args: str) -> list[str | Path]:
     return [
-        REPO_PYTHON,
+        project_python(),
         HANDOFF,
         "--repo-root",
         primary,
@@ -542,13 +542,13 @@ def strict_evidence(primary: Path, packet: dict, *, wrong_answer: bool = False) 
     snapshot = semantic_snapshot(lease)
     write_json(snapshot_path, snapshot)
     minted = run(
-        [REPO_PYTHON, CONTEXT_CANARY, "mint", "--snapshot", snapshot_path, "--out", probe_path],
+        [project_python(), CONTEXT_CANARY, "mint", "--snapshot", snapshot_path, "--out", probe_path],
         cwd=primary,
         check=True,
     )
     assert "minted 10 anchors" in minted.stdout
     run(
-        [REPO_PYTHON, CONTEXT_CANARY, "questions", "--probe", probe_path, "--out", questions_path],
+        [project_python(), CONTEXT_CANARY, "questions", "--probe", probe_path, "--out", questions_path],
         cwd=primary,
         check=True,
     )
@@ -565,7 +565,7 @@ def strict_evidence(primary: Path, packet: dict, *, wrong_answer: bool = False) 
     write_json(answers_path, answers)
     scored = run(
         [
-            REPO_PYTHON,
+            project_python(),
             CONTEXT_CANARY,
             "score",
             "--probe",
@@ -593,7 +593,7 @@ def canary_proof(primary: Path, packet: dict, *, challenge: str | None = None) -
     proof_path = primary / replacement["canary_proof_path"]
     run(
         [
-            REPO_PYTHON,
+            project_python(),
             HANDOFF_CANARY,
             "--rollover-id",
             packet["rollover_id"],
@@ -993,7 +993,7 @@ def test_app_style_worktree_bootstrap_deploys_hook_and_discovers_canonical_packe
             "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
             "SESSION_HANDOFF_AGENT": "codex",
             "CODEX_THREAD_ID": "fresh-app-thread",
-            "THREAD_ROLLOVER_PYTHON": str(REPO_PYTHON),
+            "THREAD_ROLLOVER_PYTHON": str(project_python()),
             "THREAD_ROLLOVER_SCRIPT": str(HANDOFF),
         }
     )

--- a/tests/project_python.py
+++ b/tests/project_python.py
@@ -1,0 +1,41 @@
+"""Worktree-aware project interpreter resolution for subprocess tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def project_python() -> Path:
+    """Return the shared project interpreter when tests run in a worktree."""
+    local = _REPO_ROOT / ".venv" / "bin" / "python"
+    if local.is_file():
+        return local
+
+    try:
+        common_dir = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(_REPO_ROOT),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as error:
+        raise RuntimeError("Could not locate the project's Git common directory.") from error
+
+    canonical = Path(common_dir).parent / ".venv" / "bin" / "python"
+    if canonical.is_file():
+        return canonical
+
+    raise RuntimeError(
+        "Project interpreter missing from this checkout and its canonical Git checkout: "
+        f"{local}, {canonical}"
+    )

--- a/tests/test_atlas_entry_model_census.py
+++ b/tests/test_atlas_entry_model_census.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from scripts.audit.atlas_entry_model_census import build_entry_model_census, classify_entry
+from tests.project_python import project_python
 
 
 def _entry(**overrides: object) -> dict:
@@ -123,7 +124,7 @@ def test_cli_emits_json_and_markdown(tmp_path: Path) -> None:
 
     json_result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/atlas_entry_model_census.py",
             "--manifest",
             str(manifest_path),
@@ -139,7 +140,7 @@ def test_cli_emits_json_and_markdown(tmp_path: Path) -> None:
 
     md_result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/atlas_entry_model_census.py",
             "--manifest",
             str(manifest_path),
@@ -160,7 +161,7 @@ def test_cli_can_fail_on_legacy_heuristic(tmp_path: Path) -> None:
 
     result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/atlas_entry_model_census.py",
             "--manifest",
             str(manifest_path),

--- a/tests/test_audit_atlas_poc_richness.py
+++ b/tests/test_audit_atlas_poc_richness.py
@@ -8,6 +8,7 @@ from scripts.audit.audit_atlas_poc_richness import (
     classify_entry,
     rendered_sections,
 )
+from tests.project_python import project_python
 
 
 def _entry(**overrides: object) -> dict:
@@ -146,7 +147,7 @@ def test_audit_cli_runs_as_direct_script(tmp_path) -> None:
 
     result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/audit_atlas_poc_richness.py",
             "--manifest",
             str(manifest_path),
@@ -200,7 +201,7 @@ def test_audit_cli_enforces_explicit_max_counts(tmp_path) -> None:
 
     blocked = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/audit_atlas_poc_richness.py",
             "--manifest",
             str(manifest_path),
@@ -218,7 +219,7 @@ def test_audit_cli_enforces_explicit_max_counts(tmp_path) -> None:
 
     subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/audit_atlas_poc_richness.py",
             "--manifest",
             str(manifest_path),

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from scripts.audit.check_static_practice_assets import check_assets
+from tests.project_python import project_python
 
 DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym", "antonym")
 
@@ -407,7 +408,7 @@ def test_cli_reports_missing_static_shard(tmp_path: Path) -> None:
 
     result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/check_static_practice_assets.py",
             "--daily-pool",
             str(daily_pool),
@@ -680,7 +681,7 @@ def test_cli_prints_coverage_table(tmp_path: Path) -> None:
 
     result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/check_static_practice_assets.py",
             "--daily-pool",
             str(daily_pool),

--- a/tests/test_classify_atlas_source_gaps.py
+++ b/tests/test_classify_atlas_source_gaps.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 
 from scripts.audit.classify_atlas_source_gaps import classify_manifest, rendered_sections
+from tests.project_python import project_python
 
 
 def _entry(**overrides: object) -> dict:
@@ -178,7 +179,7 @@ def test_cli_can_fail_on_unclassified_gaps(tmp_path) -> None:
 
     blocked = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/classify_atlas_source_gaps.py",
             "--manifest",
             str(manifest_path),
@@ -196,7 +197,7 @@ def test_cli_can_fail_on_unclassified_gaps(tmp_path) -> None:
 
     subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/classify_atlas_source_gaps.py",
             "--manifest",
             str(manifest_path),
@@ -220,7 +221,7 @@ def test_cli_emits_machine_readable_formats(tmp_path) -> None:
 
     json_result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/classify_atlas_source_gaps.py",
             "--manifest",
             str(manifest_path),
@@ -241,7 +242,7 @@ def test_cli_emits_machine_readable_formats(tmp_path) -> None:
 
     tsv_result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/classify_atlas_source_gaps.py",
             "--manifest",
             str(manifest_path),
@@ -270,7 +271,7 @@ def test_cli_rejects_negative_unclassified_gap_limit(tmp_path) -> None:
 
     result = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/audit/classify_atlas_source_gaps.py",
             "--manifest",
             str(manifest_path),

--- a/tests/test_cost_report.py
+++ b/tests/test_cost_report.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import scripts.analytics.cost_report as cost_report
+from tests.project_python import project_python
 
 
 def _write_meta(
@@ -209,7 +210,7 @@ def test_json_output_is_valid_json(tmp_path, monkeypatch, capsys):
 
 def test_cost_report_smoke_runs_on_repo_data():
     result = subprocess.run(
-        [".venv/bin/python", "scripts/analytics/cost_report.py", "--all"],
+        [str(project_python()), "scripts/analytics/cost_report.py", "--all"],
         cwd=Path(__file__).resolve().parent.parent,
         capture_output=True,
         text=True,

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -20,6 +20,7 @@ from scripts.orchestration.red_ci_known_failures import (
     load_and_validate_registry,
     main,
 )
+from tests.project_python import project_python
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -711,7 +712,7 @@ def test_direct_lookup_cli_handles_a_stop_action_without_stdout(tmp_path) -> Non
 
     completed = subprocess.run(
         [
-            str(PROJECT_ROOT / ".venv/bin/python"),
+            str(project_python()),
             str(PROJECT_ROOT / "scripts/orchestration/red_ci_known_failures.py"),
             *_lookup_args(registry_path, receipt_path, output_path),
         ],

--- a/tests/test_resume_default.py
+++ b/tests/test_resume_default.py
@@ -2,11 +2,13 @@
 
 import subprocess
 
+from tests.project_python import project_python
+
 
 def test_v7_build_help_lists_no_resume_not_resume() -> None:
     """--resume flag was removed; --no-resume is the new opt-out."""
     out = subprocess.run(
-        [".venv/bin/python", "scripts/build/v7_build.py", "--help"],
+        [str(project_python()), "scripts/build/v7_build.py", "--help"],
         capture_output=True,
         text=True,
         check=True,

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.common.git_context import sanitized_git_env
+from tests.project_python import project_python
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -39,7 +40,7 @@ def _init_repo(tmp_path: Path) -> Path:
 def _run_cli(state_file: Path, *args: str) -> subprocess.CompletedProcess[str]:
     project_root = Path(__file__).resolve().parent.parent
     return subprocess.run(
-        [".venv/bin/python", "-m", "scripts.review.closeout_cli", "--state-file", str(state_file), *args],
+        [str(project_python()), "-m", "scripts.review.closeout_cli", "--state-file", str(state_file), *args],
         cwd=str(project_root),
         capture_output=True,
         text=True,
@@ -240,7 +241,7 @@ def test_behavior_proof_recording_round_trips_into_receipt(tmp_path):
     project_root = Path(__file__).resolve().parent.parent
     verify = subprocess.run(
         [
-            ".venv/bin/python",
+            str(project_python()),
             "scripts/verify_review.py",
             "--review-file",
             str(review_file),


### PR DESCRIPTION
## Summary
- resolve the project interpreter through a dedicated, lazy shared pytest helper when a worktree has no local `.venv`
- update every real test subprocess launch that directly depended on the worktree-relative interpreter
- retain strict failure when neither the checkout nor canonical Git checkout provides the project venv

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -qq` on the 14 affected test modules: 384 passed from this dispatch worktree
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check` on changed tests
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review
- Independent AGY/Gemini review initially found eager collection and `conftest.py` import defects. Commit `6e21d652891e822a28e9e3027a2899fd114b2998` remediated them; exact-head re-review: `PASS`.
- AGY route used the registered `gemini-3.6-flash-high` pin after `gemini-3.1-pro-high` was rejected by the ACP participant.

Closes #4462