### PR TITLE
fix(delegate): release inactive legacy branch holders

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -126,6 +126,7 @@ if str(_local_repo_root) not in sys.path:
 from scripts.common.repo_root import main_checkout_root as _main_checkout_root  # noqa: F401  # compatibility seam
 from scripts.common.repo_root import resolve_repo_root
 from scripts.config import DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX
+from scripts.orchestration import reaper_lifecycle
 
 _REPO_ROOT = resolve_repo_root(Path(__file__), 1)
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
@@ -1559,15 +1560,17 @@ def _task_status_candidates_for_worktree(path: Path) -> list[str]:
     return out
 
 
-def _task_status_for_worktree(path: Path) -> str | None:
-    """Load batch_state status for a worktree, or None if owner cannot be resolved.
+def _task_state_for_worktree(path: Path) -> tuple[str | None, dict[str, Any] | None]:
+    """Load the path-bound task record for a dispatch worktree.
 
     Resolution order:
     1. Exact ``worktree_path`` match in any task state (authoritative).
     2. Candidate task IDs reconstructed from the dispatch layout.
 
-    Fail closed: callers must not treat ``None`` as releasable for dispatch
-    holders (#5340 CF F001).
+    ``None`` is meaningful to the branch-holder release path: a legacy holder
+    can have no task record, but only a separate known-empty liveness probe may
+    authorize its release.  Never infer a task record from a path component
+    alone.
     """
     resolved = path.resolve()
     # 1) Authoritative: scan states for worktree_path match.
@@ -1586,8 +1589,8 @@ def _task_status_for_worktree(path: Path) -> str | None:
             continue
         try:
             if Path(str(wt)).resolve() == resolved:
-                status = state.get("status")
-                return str(status) if status is not None else None
+                task_id = state.get("task_id")
+                return (str(task_id) if task_id is not None else None), state
         except OSError:
             continue
 
@@ -1606,10 +1609,17 @@ def _task_status_for_worktree(path: Path) -> str | None:
                 continue
         except OSError:
             continue
-        status = state.get("status")
-        if status is not None:
-            return str(status)
-    return None
+        return task_id, state
+    return None, None
+
+
+def _task_status_for_worktree(path: Path) -> str | None:
+    """Return a path-bound worktree owner's recorded status, when present."""
+    _task_id, state = _task_state_for_worktree(path)
+    if state is None:
+        return None
+    status = state.get("status")
+    return str(status) if status is not None else None
 
 
 def _worktree_is_clean(path: Path) -> bool:
@@ -1648,30 +1658,92 @@ _BRANCH_HOLDER_RELEASABLE_STATUSES = frozenset(
         "crashed",
         "cancelled",
         "dry_run",
-        "needs_finalize",
+        "reaped",
         _NO_DELIVERABLE_STATUS,
     }
 )
 
 
+def _branch_holder_activity_reason(
+    path: Path,
+    *,
+    task_id: str | None,
+    task_state: dict[str, Any] | None,
+) -> str | None:
+    """Return why a branch holder cannot be released while activity is possible.
+
+    Unlike scheduled cleanup, a branch hand-off needs to support legacy
+    holders whose task state has already been removed.  That is safe only when
+    both of the reaper's independent liveness probes are available and empty:
+    the active-dispatch API rules out an attached task and ``lsof`` rules out a
+    process still using the checkout.  Probe failure is a refusal, not evidence
+    of inactivity.
+    """
+    candidate_task_ids = [task_id] if task_id is not None else _task_status_candidates_for_worktree(path)
+    if not candidate_task_ids:
+        return "holder is outside the dispatch layout"
+
+    try:
+        from scripts.orchestration import reap_worktrees
+
+        active_ids = reap_worktrees._active_task_ids()
+        live_cwds = reap_worktrees._live_cwd_paths(_REPO_ROOT)
+    except Exception as exc:
+        return f"activity probes unavailable ({type(exc).__name__})"
+    if active_ids is None:
+        return "active-task probe unavailable"
+    if live_cwds is None:
+        return "process-CWD activity probe unavailable"
+    active_task_id = next((candidate for candidate in candidate_task_ids if candidate in active_ids), None)
+    if active_task_id is not None:
+        return f"active dispatch task-id={active_task_id}"
+    if reap_worktrees._task_pid_alive(task_state):
+        return f"live task PID for task-id={candidate_task_ids[0]}"
+
+    worktree = path.resolve()
+    for cwd in live_cwds:
+        try:
+            resolved_cwd = cwd.resolve()
+            resolved_cwd.relative_to(worktree)
+        except (OSError, ValueError):
+            continue
+        return f"live process cwd={cwd}"
+    return None
+
+
 def _stale_branch_holder_releasable(path: Path, branch: str) -> tuple[bool, str]:
     """Return (ok, reason) for auto-releasing a worktree holding ``branch`` (#5340).
 
-    Safe only when clean, fully pushed (HEAD == origin/<branch>), and the
-    owning task is known and terminal. Unresolvable owners fail closed so a
-    running dispatch whose state key does not match the path component cannot
-    be force-removed (CF F001 on PR #5708).
+    Safe only when clean and fully pushed (HEAD == origin/<branch>). A bound
+    task must be terminal or already marked reaped; an absent legacy record is
+    allowed only after known-empty active-task and process-CWD probes prove the
+    holder is not live. Reaper reservations always win to avoid attaching a
+    branch while another cleanup owns its removal.
     """
+    if reaper_lifecycle.is_reap_pending(_REPO_ROOT, path):
+        return False, "reaper lifecycle reservation is pending"
     if not _worktree_is_clean(path):
         return False, "dirty"
     if not _worktree_matches_origin_branch(path, branch):
         return False, "HEAD != origin/<branch>"
-    status = _task_status_for_worktree(path)
-    if status is None:
-        return False, "owner task unresolvable (fail-closed)"
+    task_id, task_state = _task_state_for_worktree(path)
+    activity = _branch_holder_activity_reason(
+        path,
+        task_id=task_id,
+        task_state=task_state,
+    )
+    if activity is not None:
+        return False, activity
+    status = (
+        str(task_state.get("status"))
+        if task_state and task_state.get("status") is not None
+        else None
+    )
+    if task_state is None:
+        return True, "clean+synced; task record absent; activity probes empty"
     if status in _BRANCH_HOLDER_RELEASABLE_STATUSES:
         return True, f"clean+synced; task status={status}"
-    return False, f"task still active (status={status})"
+    return False, f"task still active or invalid status (status={status})"
 
 
 def _release_stale_branch_holders(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4054,6 +4054,7 @@ def test_branch_reuse_releases_clean_terminal_holder_then_attaches(
         return base_stub(cmd, **kwargs)
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate, "_branch_holder_activity_reason", lambda *_args, **_kwargs: None)
     # Owning task is terminal (done review).
     delegate._write_state_atomic(
         delegate._state_path("review-5338-deepseek"),
@@ -4106,6 +4107,11 @@ def test_branch_reuse_refuses_clean_holder_with_active_task(
         return base_stub(cmd, **kwargs)
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        delegate,
+        "_branch_holder_activity_reason",
+        lambda *_args, **_kwargs: "active dispatch task-id=atlas-5230-runner-pr1-delta",
+    )
     delegate._write_state_atomic(
         delegate._state_path("atlas-5230-runner-pr1-delta"),
         {
@@ -4125,8 +4131,10 @@ def test_branch_reuse_refuses_clean_holder_with_active_task(
         )
 
 
-def test_branch_reuse_fail_closed_when_owner_unresolvable(tmp_path, monkeypatch, tmp_tasks_dir):
-    """#5340 CF F001: clean synced holder without resolvable task must refuse."""
+def test_branch_reuse_releases_clean_holder_with_absent_task_record(
+    tmp_path, monkeypatch, tmp_tasks_dir
+):
+    """#5340: legacy holder without state releases after empty activity probes."""
     target = tmp_path / "target"
     occupied = (
         Path(delegate._REPO_ROOT)
@@ -4136,28 +4144,149 @@ def test_branch_reuse_fail_closed_when_owner_unresolvable(tmp_path, monkeypatch,
         / "foo"
     )
     branch = "codex/foo"
-    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    calls, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    list_hits = {"n": 0}
+    removes: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
         if cmd[:3] == ["git", "worktree", "list"]:
+            list_hits["n"] += 1
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n",
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n" if list_hits["n"] == 1 else "",
                 "",
             )
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            removes.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == f"refs/heads/{branch}":
+            return subprocess.CompletedProcess(cmd, 0, "same-sha", "")
+        calls.pop()
         return base_stub(cmd, **kwargs)
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
-    # No batch_state entry at all — fail closed.
+    from scripts.orchestration import reap_worktrees
 
-    with pytest.raises(delegate.WorktreeBranchMismatch, match="already checked out"):
-        delegate._ensure_worktree(
-            agent="cursor",
-            task_id="follow-up",
-            raw_path=str(target),
-            branch=branch,
-        )
+    monkeypatch.setattr(reap_worktrees, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    # No batch_state entry at all; a known-empty activity probe permits release.
+
+    _, actual_branch, telemetry = delegate._ensure_worktree(
+        agent="cursor",
+        task_id="follow-up",
+        raw_path=str(target),
+        branch=branch,
+    )
+
+    assert actual_branch == branch
+    assert telemetry["reused"] is False
+    assert removes and str(occupied) in removes[0]
+
+
+def test_branch_holder_rejects_reaper_reservation(tmp_path, monkeypatch, tmp_tasks_dir):
+    """A reaper reservation prevents branch hand-off during removal."""
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "reserved"
+    branch = "codex/reserved"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    monkeypatch.setattr(delegate.subprocess, "run", base_stub)
+    monkeypatch.setattr(delegate.reaper_lifecycle, "is_reap_pending", lambda *_args: True)
+
+    releasable, reason = delegate._stale_branch_holder_releasable(occupied, branch)
+
+    assert releasable is False
+    assert reason == "reaper lifecycle reservation is pending"
+
+
+def test_branch_holder_releases_reaped_task_after_empty_activity_probes(
+    tmp_path, monkeypatch, tmp_tasks_dir
+):
+    """A reaped task record is terminal but still requires empty probes."""
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "reaped"
+    branch = "codex/reaped"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    monkeypatch.setattr(delegate.subprocess, "run", base_stub)
+    monkeypatch.setattr(delegate, "_branch_holder_activity_reason", lambda *_args, **_kwargs: None)
+    delegate._write_state_atomic(
+        delegate._state_path("reaped"),
+        {"task_id": "reaped", "status": "reaped", "worktree_path": str(occupied)},
+    )
+
+    releasable, reason = delegate._stale_branch_holder_releasable(occupied, branch)
+
+    assert releasable is True
+    assert reason == "clean+synced; task status=reaped"
+
+
+def test_branch_holder_refuses_needs_finalize_task(tmp_path, monkeypatch, tmp_tasks_dir):
+    """A task awaiting finalization remains mounted for its owner."""
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "finalize"
+    branch = "codex/finalize"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    monkeypatch.setattr(delegate.subprocess, "run", base_stub)
+    monkeypatch.setattr(delegate, "_branch_holder_activity_reason", lambda *_args, **_kwargs: None)
+    delegate._write_state_atomic(
+        delegate._state_path("finalize"),
+        {"task_id": "finalize", "status": "needs_finalize", "worktree_path": str(occupied)},
+    )
+
+    releasable, reason = delegate._stale_branch_holder_releasable(occupied, branch)
+
+    assert releasable is False
+    assert reason == "task still active or invalid status (status=needs_finalize)"
+
+
+def test_branch_holder_refuses_task_state_without_status(tmp_path, monkeypatch, tmp_tasks_dir):
+    """A corrupted task record is not equivalent to an absent record."""
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "incomplete"
+    branch = "codex/incomplete"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    monkeypatch.setattr(delegate.subprocess, "run", base_stub)
+    monkeypatch.setattr(delegate, "_branch_holder_activity_reason", lambda *_args, **_kwargs: None)
+    delegate._write_state_atomic(
+        delegate._state_path("incomplete"),
+        {"task_id": "incomplete", "worktree_path": str(occupied)},
+    )
+
+    releasable, reason = delegate._stale_branch_holder_releasable(occupied, branch)
+
+    assert releasable is False
+    assert reason == "task still active or invalid status (status=None)"
+
+
+def test_branch_holder_absent_task_refuses_live_process_cwd(tmp_path, monkeypatch, tmp_tasks_dir):
+    """Missing state is never enough when a process still uses the holder."""
+    from scripts.orchestration import reap_worktrees
+
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "legacy"
+    monkeypatch.setattr(reap_worktrees, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(reap_worktrees, "_live_cwd_paths", lambda _repo: {occupied / "scripts"})
+
+    reason = delegate._branch_holder_activity_reason(
+        occupied,
+        task_id=None,
+        task_state=None,
+    )
+
+    assert reason == f"live process cwd={occupied / 'scripts'}"
+
+
+def test_branch_holder_absent_task_checks_every_layout_task_id(tmp_path, monkeypatch, tmp_tasks_dir):
+    """Legacy paths may encode the active task with an agent-prefixed ID."""
+    from scripts.orchestration import reap_worktrees
+
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "legacy"
+    monkeypatch.setattr(reap_worktrees, "_active_task_ids", lambda: {"codex-legacy"})
+    monkeypatch.setattr(reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+
+    reason = delegate._branch_holder_activity_reason(
+        occupied,
+        task_id=None,
+        task_state=None,
+    )
+
+    assert reason == "active dispatch task-id=codex-legacy"
 
 
 def test_branch_reuse_resolves_owner_via_worktree_path_when_ids_diverge(
@@ -4196,6 +4325,7 @@ def test_branch_reuse_resolves_owner_via_worktree_path_when_ids_diverge(
         return base_stub(cmd, **kwargs)
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate, "_branch_holder_activity_reason", lambda *_args, **_kwargs: None)
     # State file is slash-sanitized original task id, not path component alone.
     delegate._write_state_atomic(
         delegate._state_path("codex/foo"),


### PR DESCRIPTION
Summary: release a clean, origin-synced dispatch holder with an absent task record only after active-task and process-CWD probes are both available and empty. Recognize reaped records; retain needs-finalize or malformed records; honor pending reaper reservations. Tests cover the release and refusal paths, including all encoded task-ID candidates.

Verification: pytest tests/test_delegate.py tests/orchestration/test_reap_worktrees (270 passed); Ruff; git diff --check; OPSEC and X-Agent checks passed.

Cross-family advisory review: AGY Gemini 3.6 Flash High approved after its first-round liveness finding was fixed. The requested Gemini 3.1 Pro pin was unavailable on that bridge.

Closes #5340.