### PR TITLE
fix(monitor): expose manifest context for live sessions

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -53,7 +53,9 @@ Text responses append a tail footer:
 ```
 
 JSON responses add a top-level `_telemetry` object instead of changing
-the response text. Pass `?session=<uuid>` or header `X-Session-Id`
+the response text. A session-bound `/api/state/manifest` request always
+includes this measurement, independently of the optional footer setting on
+the long-lived Monitor daemon. Pass `?session=<uuid>` or header `X-Session-Id`
 (query wins) on telemetry-bearing endpoints (`/api/orient`, `/api/rules`,
 `/api/session/current`, `/api/state/manifest`).
 

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -2225,4 +2225,7 @@ async def manifest(request: Request):
     research = research_manifest_component()
     if research is not None:
         body["research"] = research
-    return add_json_telemetry(body, session_id=session_id)
+    # A session-bound manifest is the canonical context-discipline
+    # measurement path. Unlike cosmetic response footers, it must not depend
+    # on an environment variable inherited by the long-lived Monitor daemon.
+    return add_json_telemetry(body, session_id=session_id, force=session_id is not None)

--- a/scripts/api/telemetry/response.py
+++ b/scripts/api/telemetry/response.py
@@ -142,9 +142,18 @@ def _unavailable_session_payload(reason: str) -> dict[str, Any]:
     }
 
 
-def build_telemetry_payload(session_id: str | None = None) -> dict[str, Any] | None:
-    """Build the ``_telemetry`` block for JSON responses."""
-    if not telemetry_footer_enabled():
+def build_telemetry_payload(
+    session_id: str | None = None,
+    *,
+    force: bool = False,
+) -> dict[str, Any] | None:
+    """Build the ``_telemetry`` block for JSON responses.
+
+    ``force`` is reserved for a caller-scoped measurement contract. It keeps
+    that measurement available when the long-lived Monitor daemon did not
+    inherit the optional presentation-footer environment variable.
+    """
+    if not force and not telemetry_footer_enabled():
         return None
 
     if session_id:
@@ -204,9 +213,10 @@ def add_json_telemetry(
     payload: dict[str, Any],
     *,
     session_id: str | None = None,
+    force: bool = False,
 ) -> dict[str, Any]:
     """Add top-level ``_telemetry`` to a JSON-compatible dict when enabled."""
-    telemetry = build_telemetry_payload(session_id)
+    telemetry = build_telemetry_payload(session_id, force=force)
     if telemetry is None:
         return payload
     return {**payload, "_telemetry": telemetry}

--- a/tests/test_api_session_telemetry.py
+++ b/tests/test_api_session_telemetry.py
@@ -89,6 +89,38 @@ def test_session_hit_returns_caller_match_telemetry(
     assert telemetry["source"] == "transcript-jsonl"
 
 
+def test_session_manifest_telemetry_does_not_require_footer_environment(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """The daemon's optional footer setting cannot gate caller context."""
+    project_root = tmp_path / "learn-ukrainian"
+    project_root.mkdir()
+    session_id = "daemon-session-123"
+    transcript = tmp_path / "official transcripts" / "daemon.jsonl"
+    _write_transcript(transcript)
+    update_session(
+        session_id,
+        transcript_path=str(transcript),
+        provenance="SessionStart",
+        state_root=project_root,
+    )
+    monkeypatch.delenv("AGENT_NO_TELEMETRY_FOOTER", raising=False)
+    monkeypatch.delenv("LEARN_UKRAINIAN_TELEMETRY_FOOTER", raising=False)
+    monkeypatch.setattr(telemetry_response, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(
+        transcript_tokens, "canonical_state_root", lambda project_root: project_root
+    )
+
+    response = TestClient(app).get(f"/api/state/manifest?session={session_id}")
+
+    assert response.status_code == 200
+    telemetry = response.json()["_telemetry"]
+    assert telemetry["ctx"] == 187_000
+    assert telemetry["caller_match"] is True
+    assert telemetry["transcript"] == "daemon.jsonl"
+
+
 def test_session_record_drives_capacity_provenance_and_mismatch(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Fixes #5769. A session-bound manifest request was incorrectly gated by the LEARN_UKRAINIAN_TELEMETRY_FOOTER setting, which is evaluated in the long-lived Monitor daemon rather than in the calling agent session. The daemon normally lacks that presentation-only setting, so it omitted the telemetry block even when the validated session record and live transcript were available.

GET /api/state/manifest?session=<id> now always emits the caller-scoped telemetry block. It preserves the optional footer behavior for unbound manifest requests and other endpoints. A missing or invalid session still yields the existing structured absence reason.

## Verification

- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_api_session_telemetry.py tests/test_monitor_api_telemetry.py tests/test_manifest_api.py — 40 passed
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/api/telemetry/response.py scripts/api/state_router.py tests/test_api_session_telemetry.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py
- Independent Gemini 3.6 Flash cross-family review: APPROVE

## Context path

Use GET /api/state/manifest?session=$LEARN_UKRAINIAN_SESSION_ID, or the X-Session-Id header, and read _telemetry.ctx. On a structured absence, use its reason rather than another session transcript.