### PR TITLE
fix(lexicon): stop full-catalog VPS runs silently narrowing to old residual slugs

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -59,6 +59,8 @@ TARGET="missing-translation"
 for ((_i = 0; _i < ${#EXTRA_ARGS[@]}; _i++)); do
   if [[ "${EXTRA_ARGS[_i]}" == "--target" && $((_i + 1)) -lt ${#EXTRA_ARGS[@]} ]]; then
     TARGET="${EXTRA_ARGS[_i + 1]}"
+  elif [[ "${EXTRA_ARGS[_i]}" == --target=* ]]; then
+    TARGET="${EXTRA_ARGS[_i]#--target=}"
   fi
 done
 

--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -49,6 +49,28 @@ WORK_MANIFEST="$WORK_DIR/manifest.json"
 IN_REPO_DRIVER="$REPO/scripts/lexicon/reenrich_thin_manifest_entries.py"
 WORKDIR_DRIVER="$WORK_DIR/reenrich_thin_manifest_entries.py"
 
+EXTRA_ARGS=("$@")
+
+# Effective target: default missing-translation (this launcher's original,
+# residual-slug-scoped behavior), but a caller-supplied --target in
+# EXTRA_ARGS (e.g. #6466 full-catalog campaigns) overrides it. Mirrors
+# argparse's own last-value-wins semantics for a repeated flag.
+TARGET="missing-translation"
+for ((_i = 0; _i < ${#EXTRA_ARGS[@]}; _i++)); do
+  if [[ "${EXTRA_ARGS[_i]}" == "--target" && $((_i + 1)) -lt ${#EXTRA_ARGS[@]} ]]; then
+    TARGET="${EXTRA_ARGS[_i + 1]}"
+  fi
+done
+
+# Test/debug hook: print the resolved target and exit before any
+# filesystem/systemd side effect (tests/test_launch_reenrich_target_detection.py).
+for arg in "${EXTRA_ARGS[@]-}"; do
+  if [[ "$arg" == "--print-target" ]]; then
+    printf '%s\n' "$TARGET"
+    exit 0
+  fi
+done
+
 mkdir -p "$WORK_DIR"
 cd "$REPO"
 
@@ -78,7 +100,10 @@ if ! grep -q -- '--slugs-file' "$DRIVER" 2>/dev/null; then
   echo "reenrich driver at $DRIVER lacks --slugs-file support; scp the #6398 driver into $WORKDIR_DRIVER or update the checkout" >&2
   exit 1
 fi
-if [[ ! -f "$SLUGS_FILE" ]]; then
+# --slugs-file (and its residual-dump prerequisite) only applies to the
+# missing-translation target — see the guarded COMMON_ARGS block below for
+# why stacking it onto full-catalog would be wrong, not just redundant.
+if [[ "$TARGET" == "missing-translation" && ! -f "$SLUGS_FILE" ]]; then
   echo "residual slugs file not found: $SLUGS_FILE (sync it from the Mac worktree first)" >&2
   exit 1
 fi
@@ -103,16 +128,24 @@ if [[ ! -f "$WORK_MANIFEST" ]]; then
   cp "$LIVE_MANIFEST" "$WORK_MANIFEST"
 fi
 
-EXTRA_ARGS=("$@")
-
 COMMON_ARGS=(
   --manifest "$WORK_MANIFEST"
   --local
-  --target missing-translation
-  --slugs-file "$SLUGS_FILE"
+  --target "$TARGET"
   --sources-db "$SOURCES_DB"
   --write
 )
+# --slugs-file restricts re-enrichment to a residual slug allowlist (see
+# reenrich_thin_manifest_entries.py::reenrich_thin_entries). That's correct
+# for missing-translation (this launcher's original purpose) but WRONG for
+# full-catalog: full-catalog already selects every manifest entry, and
+# stacking a stale --slugs-file on top would silently narrow it back down to
+# whatever residual set happened to be synced to $SLUGS_FILE, defeating the
+# whole point of a full-catalog run while still exiting 0 and looking done.
+# (Existence of $SLUGS_FILE for this target was already validated above.)
+if [[ "$TARGET" == "missing-translation" ]]; then
+  COMMON_ARGS+=(--slugs-file "$SLUGS_FILE")
+fi
 if [[ -f "$KAIKKI_JSON" ]]; then
   COMMON_ARGS+=(--kaikki-lookup "$KAIKKI_JSON")
 fi

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -53,6 +53,17 @@ for arg in "$@"; do
   esac
 done
 
+# Effective target (see launch_reenrich_class_b.sh for the same detection):
+# the class-b residual slug dump is only meaningful for missing-translation
+# runs. A #6466 full-catalog run has no use for it, so don't require or sync
+# a residual file that has nothing to do with the requested target.
+TARGET="missing-translation"
+for ((_i = 0; _i < ${#EXTRA_ARGS[@]}; _i++)); do
+  if [[ "${EXTRA_ARGS[_i]}" == "--target" && $((_i + 1)) -lt ${#EXTRA_ARGS[@]} ]]; then
+    TARGET="${EXTRA_ARGS[_i + 1]}"
+  fi
+done
+
 ssh_q() { ssh -o BatchMode=yes -o ConnectTimeout=10 -- "$HOST" "$@"; }
 scp_q() { scp -o BatchMode=yes -o ConnectTimeout=10 -- "$@"; }
 
@@ -124,18 +135,22 @@ fi
 echo "sources.db OK (sizes match)"
 
 if [[ "$do_sync_and_launch" == "1" ]]; then
-  if [[ ! -f "$LOCAL_RESIDUAL" ]]; then
-    echo "local residual dump not found: $LOCAL_RESIDUAL" >&2
-    exit 1
-  fi
-  if ! grep -q -- '--slugs-file' "$LOCAL_DRIVER"; then
-    echo "local driver at $LOCAL_DRIVER lacks --slugs-file support; this worktree is out of date" >&2
-    exit 1
+  if [[ "$TARGET" == "missing-translation" ]]; then
+    if [[ ! -f "$LOCAL_RESIDUAL" ]]; then
+      echo "local residual dump not found: $LOCAL_RESIDUAL" >&2
+      exit 1
+    fi
+    if ! grep -q -- '--slugs-file' "$LOCAL_DRIVER"; then
+      echo "local driver at $LOCAL_DRIVER lacks --slugs-file support; this worktree is out of date" >&2
+      exit 1
+    fi
   fi
 
-  echo "syncing residual + driver + launcher -> $HOST:$REMOTE_WORK_DIR"
+  echo "syncing driver + launcher -> $HOST:$REMOTE_WORK_DIR (target=$TARGET)"
   ssh_q "mkdir -p $(printf '%q' "$REMOTE_WORK_DIR")"
-  scp_q "$LOCAL_RESIDUAL" "$HOST:$REMOTE_WORK_DIR/class-b-no-en.json"
+  if [[ "$TARGET" == "missing-translation" ]]; then
+    scp_q "$LOCAL_RESIDUAL" "$HOST:$REMOTE_WORK_DIR/class-b-no-en.json"
+  fi
   scp_q "$LOCAL_DRIVER" "$HOST:$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py"
   scp_q "$LOCAL_LAUNCHER" "$HOST:$REMOTE_WORK_DIR/launch_reenrich_class_b.sh"
   ssh_q "chmod +x $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -61,6 +61,8 @@ TARGET="missing-translation"
 for ((_i = 0; _i < ${#EXTRA_ARGS[@]}; _i++)); do
   if [[ "${EXTRA_ARGS[_i]}" == "--target" && $((_i + 1)) -lt ${#EXTRA_ARGS[@]} ]]; then
     TARGET="${EXTRA_ARGS[_i + 1]}"
+  elif [[ "${EXTRA_ARGS[_i]}" == --target=* ]]; then
+    TARGET="${EXTRA_ARGS[_i]#--target=}"
   fi
 done
 

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -1,0 +1,123 @@
+"""Target-detection regression test for the #6466 campaign launcher scripts.
+
+Root cause covered: both launcher scripts used to hardcode
+``--target missing-translation`` + ``--slugs-file <residual dump>``
+unconditionally. A caller passing ``--target full-catalog`` (the #6466
+runbook's own documented invocation) would still get the stale residual
+slugs-file filter applied on top, silently narrowing a "full catalog" run
+down to whatever small residual set happened to be on disk -- exit 0, looks
+done, campaign result is wrong. These scripts have no existing pytest
+coverage (they are VPS-side bash, not imported Python), so this drives them
+via subprocess with a ``--print-target`` debug hook that exits before any
+filesystem/systemd side effect.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_LAUNCHER = ROOT / "scripts" / "lexicon" / "runner" / "launch_reenrich_class_b.sh"
+REMOTE_LAUNCHER = ROOT / "scripts" / "lexicon" / "runner" / "launch_reenrich_class_b_remote.sh"
+
+
+def _run_local_launcher(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "ATLAS_REPO": str(tmp_path),
+        "ATLAS_RUN_ROOT": str(tmp_path),
+    }
+    return subprocess.run(
+        ["bash", str(LOCAL_LAUNCHER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize(
+    "args,expected_target",
+    [
+        ((), "missing-translation"),
+        (("--limit", "5"), "missing-translation"),
+        (("--target", "full-catalog"), "full-catalog"),
+        (("--target", "full-catalog", "--limit", "10"), "full-catalog"),
+        (("--target", "missing-anchor"), "missing-anchor"),
+    ],
+)
+def test_local_launcher_resolves_target(tmp_path: Path, args: tuple[str, ...], expected_target: str) -> None:
+    proc = _run_local_launcher(tmp_path, *args, "--print-target")
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == expected_target
+
+
+def test_full_catalog_does_not_carry_slugs_file(tmp_path: Path) -> None:
+    """The bug this test guards: --target full-catalog must never also
+    inject --slugs-file into the driver invocation (see reenrich_thin_entries
+    -- a slug_filter silently narrows an already-selected target list)."""
+    proc = _run_local_launcher(tmp_path, "--target", "full-catalog", "--print-target")
+    assert proc.returncode == 0, proc.stderr
+    # The print-target hook exits before COMMON_ARGS is built, so this test
+    # also asserts the source directly reflects the guard, since the
+    # constructed argv itself is not observable via --print-target alone.
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    guard = 'if [[ "$TARGET" == "missing-translation" ]]; then'
+    slugs_line = 'COMMON_ARGS+=(--slugs-file "$SLUGS_FILE")'
+    assert guard in source
+    assert slugs_line in source
+    # The slugs-file append must be textually inside the missing-translation
+    # guard block, not unconditional at COMMON_ARGS construction time.
+    guard_idx = source.index(guard)
+    unconditional_common_args = 'COMMON_ARGS=(\n  --manifest "$WORK_MANIFEST"\n  --local\n  --target "$TARGET"\n  --sources-db "$SOURCES_DB"\n  --write\n)'
+    assert unconditional_common_args in source
+    assert source.index(slugs_line) > guard_idx
+
+
+@pytest.mark.parametrize(
+    "args,expected_target",
+    [
+        ([], "missing-translation"),
+        (["--limit", "10"], "missing-translation"),
+        (["--target", "full-catalog"], "full-catalog"),
+        (["--target", "full-catalog", "--limit", "10"], "full-catalog"),
+    ],
+)
+def test_remote_target_detection(args: list[str], expected_target: str) -> None:
+    """The remote wrapper's own TARGET detection (used to gate the residual
+    slugs-file sync/require) must resolve identically to the local
+    launcher's for the same argv -- verified by sourcing just the detection
+    block so this doesn't require a real SSH host."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    start = source.index('TARGET="missing-translation"')
+    end = source.index("\n\n", start)
+    detection_block = source[start:end]
+    script = (
+        'EXTRA_ARGS=("$@")\n'
+        f"{detection_block}\n"
+        'printf "%s\\n" "$TARGET"\n'
+    )
+    proc = subprocess.run(
+        ["bash", "-c", script, "--", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == expected_target
+
+
+def test_remote_wrapper_skips_residual_requirement_for_full_catalog() -> None:
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    assert 'if [[ "$TARGET" == "missing-translation" ]]; then' in source
+    # The residual-dump existence check and its scp must both be nested
+    # inside that guard, not unconditional.
+    guard_idx = source.index('if [[ "$TARGET" == "missing-translation" ]]; then')
+    residual_check_idx = source.index("local residual dump not found")
+    residual_scp_idx = source.index('scp_q "$LOCAL_RESIDUAL"')
+    assert residual_check_idx > guard_idx
+    assert residual_scp_idx > guard_idx

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -45,7 +45,12 @@ def _run_local_launcher(tmp_path: Path, *args: str) -> subprocess.CompletedProce
         ((), "missing-translation"),
         (("--limit", "5"), "missing-translation"),
         (("--target", "full-catalog"), "full-catalog"),
+        (("--target=full-catalog",), "full-catalog"),
         (("--target", "full-catalog", "--limit", "10"), "full-catalog"),
+        (
+            ("--target=missing-anchor", "--target", "full-catalog"),
+            "full-catalog",
+        ),
         (("--target", "missing-anchor"), "missing-anchor"),
     ],
 )
@@ -59,7 +64,7 @@ def test_full_catalog_does_not_carry_slugs_file(tmp_path: Path) -> None:
     """The bug this test guards: --target full-catalog must never also
     inject --slugs-file into the driver invocation (see reenrich_thin_entries
     -- a slug_filter silently narrows an already-selected target list)."""
-    proc = _run_local_launcher(tmp_path, "--target", "full-catalog", "--print-target")
+    proc = _run_local_launcher(tmp_path, "--target=full-catalog", "--print-target")
     assert proc.returncode == 0, proc.stderr
     # The print-target hook exits before COMMON_ARGS is built, so this test
     # also asserts the source directly reflects the guard, since the
@@ -83,7 +88,9 @@ def test_full_catalog_does_not_carry_slugs_file(tmp_path: Path) -> None:
         ([], "missing-translation"),
         (["--limit", "10"], "missing-translation"),
         (["--target", "full-catalog"], "full-catalog"),
+        (["--target=full-catalog"], "full-catalog"),
         (["--target", "full-catalog", "--limit", "10"], "full-catalog"),
+        (["--target=missing-anchor", "--target", "full-catalog"], "full-catalog"),
     ],
 )
 def test_remote_target_detection(args: list[str], expected_target: str) -> None:


### PR DESCRIPTION
## Summary

Found while preparing to launch the #6466 full-catalog VPS campaign per the just-merged
runbook (`docs/runbooks/atlas-full-reenrich-campaign.md`, #6542): the two VPS launcher
scripts under `scripts/lexicon/runner/` were never updated for the new `--target
full-catalog` mode #6542 added to `reenrich_thin_manifest_entries.py`.

## The bug (silent, would have burned ~5h of VPS compute on a wrong result)

Both `launch_reenrich_class_b.sh` and `launch_reenrich_class_b_remote.sh` unconditionally
hardcoded `--target missing-translation` + `--slugs-file <old class-b residual dump>`.
Per the runbook, launching a full-catalog campaign is:

```bash
scripts/lexicon/runner/launch_reenrich_class_b_remote.sh --target full-catalog --limit 10
```

Passing `--target full-catalog` would coexist with the hardcoded `--slugs-file` (argparse
takes the *target* override fine, last-value-wins, but there's no way to "unset" a
slugs-file already passed). Per `reenrich_thin_entries()`:

```python
elif target == "full-catalog":
    targets = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
    ...
if slug_filter is not None:
    targets = [entry for entry in targets if entry.get("url_slug") in slug_filter]
```

a full-catalog run would get its already-selected ~20K-entry target list silently
filtered back down to whichever ~6.5K old residual slugs happened to be on disk from a
prior `missing-translation` campaign — while exiting 0 and printing a summary that reads
as a complete run.

## Fix

Both launchers now detect the effective `--target` from argv (mirroring argparse's own
last-value-wins semantics) and only apply/require/sync the residual slugs file when the
target is actually `missing-translation`. Existing default behavior (no `--target` passed)
is unchanged.

## Evidence

```
$ shellcheck scripts/lexicon/runner/launch_reenrich_class_b.sh scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
(clean, exit 0)

$ .venv/bin/python -m pytest tests/test_launch_reenrich_target_detection.py -v
11 passed
```

Mutation-checked: reverted the guard back to unconditional `--slugs-file` locally,
confirmed `test_full_catalog_does_not_carry_slugs_file` fails, then restored the fix and
confirmed all 11 pass again.

## Scope

Infra/tooling fix, not curriculum content. Blocks nothing else — the #6466 campaign
(queue item 2 on the atlas driver handoff) should not launch against `--target
full-catalog` until this merges.
