### PR TITLE
fix(bridge): redact opaque secrets in prose

### DIFF
--- a/scripts/secret_redactor.py
+++ b/scripts/secret_redactor.py
@@ -25,7 +25,9 @@ covered, unconditionally.
 
 from __future__ import annotations
 
+import math
 import re
+from collections import Counter
 from collections.abc import Mapping
 from itertools import pairwise
 from typing import Any
@@ -82,6 +84,21 @@ _TOKEN_PATTERNS = (
     ),
 )
 
+# A non-vendor secret can appear inside an OAuth/provider error message without
+# a secret-named key. Restrict the generic detector to long ASCII token runs so
+# natural-language prose is not treated as a credential. Punctuated candidates
+# need substantially more entropy because prose commonly has dates, versions,
+# and hyphenated title case; unpunctuated alphanumeric/letter-only candidates
+# have separate thresholds for their narrower alphabets.
+_OPAQUE_TOKEN_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_+./~=-])(?P<value>[A-Za-z0-9_+./~-]{32,})(?:={1,2})?"
+    r"(?![A-Za-z0-9_+./~=-])"
+)
+_OPAQUE_TOKEN_MIN_ENTROPY = 3.5
+_OPAQUE_ALPHA_TOKEN_MIN_ENTROPY = 4.0
+_OPAQUE_PUNCTUATED_TOKEN_MIN_ENTROPY = 4.5
+_OPAQUE_TOKEN_PUNCTUATION = frozenset("_+./~-")
+
 
 def redact_text(value: str | None) -> str | None:
     """Redact token-looking substrings from text before external egress."""
@@ -98,6 +115,7 @@ def redact_text(value: str | None) -> str | None:
         )
     for pattern in _TOKEN_PATTERNS:
         text = pattern.sub(REDACTION, text)
+    text = _OPAQUE_TOKEN_PATTERN.sub(_redact_opaque_token_match, text)
     return text
 
 
@@ -138,6 +156,33 @@ def _is_secret_key(key: str) -> bool:
 def _is_code_expression(value: str) -> bool:
     """True when an unquoted RHS carries call/subscript/collection punctuation."""
     return any(char in _CODE_EXPRESSION_CHARS for char in value)
+
+
+def _shannon_entropy(value: str) -> float:
+    """Return the per-character Shannon entropy for an ASCII token candidate."""
+    length = len(value)
+    return -sum(
+        (count / length) * math.log2(count / length)
+        for count in Counter(value).values()
+    )
+
+
+def _looks_like_opaque_secret(value: str) -> bool:
+    """True for a high-entropy opaque token rather than ordinary prose."""
+    if not any(char.isalpha() for char in value):
+        return False
+
+    entropy = _shannon_entropy(value)
+    if _OPAQUE_TOKEN_PUNCTUATION.intersection(value):
+        return entropy >= _OPAQUE_PUNCTUATED_TOKEN_MIN_ENTROPY
+    if not any(char.isdigit() for char in value):
+        return entropy >= _OPAQUE_ALPHA_TOKEN_MIN_ENTROPY
+    return entropy >= _OPAQUE_TOKEN_MIN_ENTROPY
+
+
+def _redact_opaque_token_match(match: re.Match[str]) -> str:
+    """Redact only generic candidates that satisfy the entropy detector."""
+    return REDACTION if _looks_like_opaque_secret(match.group("value")) else match.group(0)
 
 
 def _redact_assignment_match(match: re.Match[str]) -> str:

--- a/tests/test_secret_redactor.py
+++ b/tests/test_secret_redactor.py
@@ -93,6 +93,48 @@ def test_redact_text_still_redacts_known_token_shapes_anywhere():
     assert REDACTION in redact_text(f"the token is {jwt} in prose")
 
 
+_OPAQUE_TOKEN = "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c"
+
+
+@pytest.mark.parametrize(
+    ("prose", "opaque_token"),
+    [
+        ('{"detail": "refresh failed for ' + _OPAQUE_TOKEN + '"}', _OPAQUE_TOKEN),
+        ('{"error_description": "token ' + _OPAQUE_TOKEN + ' is expired"}', _OPAQUE_TOKEN),
+        ('{"message": "bad token ' + _OPAQUE_TOKEN + '"}', _OPAQUE_TOKEN),
+        ("refresh failed: " + _OPAQUE_TOKEN + " rejected", _OPAQUE_TOKEN),
+        (
+            "provider returned bW9ja1Rva2VuQWxwaGE5ODc2NTQzMjEwQmV0YQ== in an error",
+            "bW9ja1Rva2VuQWxwaGE5ODc2NTQzMjEwQmV0YQ==",
+        ),
+        (
+            "provider returned AbCdEfGhIjKlMnOpQrSt/UvWxYz0123456789abcdef in an error",
+            "AbCdEfGhIjKlMnOpQrSt/UvWxYz0123456789abcdef",
+        ),
+        (
+            "provider returned aBqLmNwErTyUiOpAsDfGhJkLzXcVbNmQ in an error",
+            "aBqLmNwErTyUiOpAsDfGhJkLzXcVbNmQ",
+        ),
+    ],
+)
+def test_redact_text_redacts_opaque_high_entropy_tokens_embedded_in_prose(prose, opaque_token):
+    """Regression for #5825: unrecognised opaque values must not leak in prose."""
+    redacted = redact_text(prose)
+
+    assert REDACTION in redacted
+    assert opaque_token not in redacted
+
+
+def test_redact_text_preserves_natural_language_and_low_entropy_identifiers():
+    text = (
+        "The pneumonoultramicroscopicsilicovolcanoconiosis lesson covers "
+        "release-2026-08-production-candidate, chapter-2026-08-Production-Candidate, "
+        "and abcabcabcabcabcabcabcabc1234."
+    )
+
+    assert redact_text(text) == text
+
+
 def test_redact_text_redacts_unquoted_passphrase_but_not_code():
     # Documented narrow allowance: a bare whitespace-separated passphrase assigned
     # to a secret-named key is redacted (fail-closed), while code expressions —


### PR DESCRIPTION
## Summary

- redact bounded high-entropy opaque tokens embedded in provider/error prose
- retain deterministic vendor and assignment redaction behavior
- cover JSON prose fields, bare prose, standard/URL-safe token punctuation, and natural-language false-positive guards

## Root cause

`redact_text` only recognized known vendor shapes or whole values associated with secret-named keys, leaving unprefixed opaque tokens in prose unchanged.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_secret_redactor.py tests/test_kimi_oauth_tty_guard.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/secret_redactor.py tests/test_secret_redactor.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Closes #5825.