### PR TITLE
fix(hooks): parse wrapper flags before guard verbs

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -115,9 +115,9 @@ def _flag_enabled(args: list[str], name: str) -> bool:
 
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
-# so the helpers are copied, not imported. Keep the four copies in
-# guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
-# and guard-pr-merge.py in sync.
+# so the helpers are copied, not imported. Keep the three active copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, and guard-pr-merge.py
+# in sync.
 
 
 def _strip_quotes(token: str) -> str:
@@ -239,13 +239,65 @@ def _is_env_assignment(tok: str) -> bool:
     return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
 
 
-def _skip_command_prefix(seg: list[str], i: int) -> int:
-    """Advance past wrappers / env-assignments / brace-group open so a
-    `env FOO=1 gh pr merge --admin` or `{ gh pr merge --admin; }` is not
-    missed (#4877)."""
+_WRAPPERS = frozenset({"env", "sudo", "time", "nice", "stdbuf", "nohup", "command", "exec"})
+
+_WRAPPER_VALUE_OPTIONS = {
+    "env": frozenset({"-u", "--unset", "-C", "--chdir"}),
+    "sudo": frozenset(
+        {
+            "-u",
+            "--user",
+            "-g",
+            "--group",
+            "-r",
+            "--role",
+            "-t",
+            "--type",
+            "-C",
+            "--close-from",
+            "-c",
+            "--command-timeout",
+            "-T",
+        }
+    ),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
+}
+
+
+def _skip_wrapper_options(wrapper: str, seg: list[str], i: int) -> int:
+    """Return the first command word after one transparent wrapper.
+
+    A missing operand for a recognised value-taking option cannot execute a
+    command, so the scan consumes to the end instead of guessing a verb.
+    """
+    value_options = _WRAPPER_VALUE_OPTIONS.get(wrapper, frozenset())
     while i < len(seg):
         tok = seg[i]
-        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(tok):
+        if tok == "--":
+            return i + 1
+        if not tok.startswith("-") or tok == "-":
+            return i
+        i += 1
+        if tok in value_options:
+            if i >= len(seg):
+                return len(seg)
+            i += 1
+    return i
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past wrappers (and their flags), assignments, and ``{``.
+
+    Thus `sudo -u root gh pr merge --admin` reaches `gh`, rather than stopping
+    on the wrapper option (#4878).
+    """
+    while i < len(seg):
+        tok = seg[i]
+        if tok in _WRAPPERS:
+            i = _skip_wrapper_options(tok, seg, i + 1)
+        elif tok == "{" or _is_env_assignment(tok):
             i += 1
         else:
             break

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -142,8 +142,8 @@ def _in_main_worktree(project_root: Path) -> bool:
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py (the reference parser among the
 # Bash guards). Hooks are standalone by design, so the helpers are copied,
-# not imported. Keep the four copies in guard-branch-switch-in-main.py,
-# guard-admin-merge.py, guard-push-pytest.py, and guard-pr-merge.py in sync.
+# not imported. Keep the three active copies in guard-branch-switch-in-main.py,
+# guard-admin-merge.py, and guard-pr-merge.py in sync.
 
 
 def _strip_quotes(token: str) -> str:
@@ -363,16 +363,69 @@ def _is_env_assignment(tok: str) -> bool:
     return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
 
 
-def _skip_command_prefix(seg: list[str], i: int) -> int:
-    """Advance past transparent leading tokens so we land on the real command
-    word: wrappers (`sudo`/`time`/`env`/`nohup`/`command`/`exec`), env
-    assignments (`FOO=1`), and a brace-group opener (`{`). Without this a
-    `env FOO=1 git branch -D x` or `{ git branch -D x; }` hid the verb (#4877)."""
+_WRAPPERS = frozenset({"env", "sudo", "time", "nice", "stdbuf", "nohup", "command", "exec"})
+
+# Only options whose value is a separate token are listed. Attached values
+# (``-u root`` versus ``-uroot`` and ``--user=root``) deliberately need no
+# special treatment: the latter two already carry their operand in one token.
+_WRAPPER_VALUE_OPTIONS = {
+    "env": frozenset({"-u", "--unset", "-C", "--chdir"}),
+    "sudo": frozenset(
+        {
+            "-u",
+            "--user",
+            "-g",
+            "--group",
+            "-r",
+            "--role",
+            "-t",
+            "--type",
+            "-C",
+            "--close-from",
+            "-c",
+            "--command-timeout",
+            "-T",
+        }
+    ),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
+}
+
+
+def _skip_wrapper_options(wrapper: str, seg: list[str], i: int) -> int:
+    """Return the first command word after one transparent wrapper.
+
+    A wrapper's flags are not the wrapped command: ``sudo -u root git`` and
+    ``nice -n 10 git`` both execute ``git``.  A recognised value-taking flag
+    without its operand cannot execute a command, so consume to the end rather
+    than guessing that a missing command is harmless.
+    """
+    value_options = _WRAPPER_VALUE_OPTIONS.get(wrapper, frozenset())
     while i < len(seg):
         tok = seg[i]
-        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
-            tok
-        ):
+        if tok == "--":
+            return i + 1
+        if not tok.startswith("-") or tok == "-":
+            return i
+        i += 1
+        if tok in value_options:
+            if i >= len(seg):
+                return len(seg)
+            i += 1
+    return i
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past transparent leading tokens so we land on the real command
+    word: wrappers (including their flags), env assignments (`FOO=1`), and a
+    brace-group opener (`{`). Without this, `sudo -u root git branch -D x`
+    stops at `-u` and hides the verb (#4878)."""
+    while i < len(seg):
+        tok = seg[i]
+        if tok in _WRAPPERS:
+            i = _skip_wrapper_options(tok, seg, i + 1)
+        elif tok == "{" or _is_env_assignment(tok):
             i += 1
         else:
             break

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -124,9 +124,9 @@ def _command(payload: dict) -> str:
 
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
-# so the helpers are copied, not imported. Keep the four copies in
-# guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
-# and guard-pr-merge.py in sync.
+# so the helpers are copied, not imported. Keep the three active copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, and guard-pr-merge.py
+# in sync.
 #
 # This copy alone splits the tokenizer into _scope_events() with _segments() derived from
 # it: only this hook cares WHERE a subshell begins and ends, because only this hook tracks
@@ -362,12 +362,65 @@ def _is_env_assignment(tok: str) -> bool:
     return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
 
 
-def _skip_command_prefix(seg: list[str], i: int) -> int:
-    """Advance past wrappers / env-assignments / brace-group open so a
-    `env FOO=1 gh pr merge` or `{ gh pr merge; }` is not missed (#4877)."""
+_WRAPPERS = frozenset({"env", "sudo", "time", "nice", "stdbuf", "nohup", "command", "exec"})
+
+_WRAPPER_VALUE_OPTIONS = {
+    "env": frozenset({"-u", "--unset", "-C", "--chdir"}),
+    "sudo": frozenset(
+        {
+            "-u",
+            "--user",
+            "-g",
+            "--group",
+            "-r",
+            "--role",
+            "-t",
+            "--type",
+            "-C",
+            "--close-from",
+            "-c",
+            "--command-timeout",
+            "-T",
+        }
+    ),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
+}
+
+
+def _skip_wrapper_options(wrapper: str, seg: list[str], i: int) -> int:
+    """Return the first command word after one transparent wrapper.
+
+    A missing operand for a recognised value-taking option cannot execute a
+    command, so the scan consumes to the end instead of guessing a verb.
+    """
+    value_options = _WRAPPER_VALUE_OPTIONS.get(wrapper, frozenset())
     while i < len(seg):
         tok = seg[i]
-        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(tok):
+        if tok == "--":
+            return i + 1
+        if not tok.startswith("-") or tok == "-":
+            return i
+        i += 1
+        if tok in value_options:
+            if i >= len(seg):
+                return len(seg)
+            i += 1
+    return i
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past wrappers (and their flags), assignments, and ``{``.
+
+    Thus `nice -n 10 gh pr merge` reaches `gh`, rather than stopping on the
+    wrapper option (#4878).
+    """
+    while i < len(seg):
+        tok = seg[i]
+        if tok in _WRAPPERS:
+            i = _skip_wrapper_options(tok, seg, i + 1)
+        elif tok == "{" or _is_env_assignment(tok):
             i += 1
         else:
             break

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -202,6 +202,24 @@ def test_wrapper_assignment_brace_admin_detected(cmd):
     assert _any_admin(cmd)
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env -i gh pr merge 5 --admin",
+        "env -i FOO=1 gh pr merge 5 --admin",
+        "env -u FOO gh pr merge 5 --admin",
+        "sudo -u root gh pr merge 5 --admin",
+        "sudo --preserve-env gh pr merge 5 --admin",
+        "sudo -E gh pr merge 5 --admin",
+        "time -p gh pr merge 5 --admin",
+        "nice -n 10 gh pr merge 5 --admin",
+        "stdbuf -oL gh pr merge 5 --admin",
+    ],
+)
+def test_wrapper_options_do_not_hide_admin_merge_verb(cmd):
+    assert _any_admin(cmd)
+
+
 def test_unclosed_heredoc_does_not_hide_admin():
     assert _any_admin("cat <<'NOEND'\nnote\ngh pr merge 5 --admin")
 

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -314,6 +314,24 @@ def test_wrapper_and_assignment_prefixes_still_inspected(cmd):
     assert _dangerous(cmd) is not None
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env -i git branch -D main",
+        "env -i FOO=1 git branch -D main",
+        "env -u FOO git branch -D main",
+        "sudo -u root git branch -D main",
+        "sudo --preserve-env git branch -D main",
+        "sudo -E git branch -D main",
+        "time -p git branch -D main",
+        "nice -n 10 git branch -D main",
+        "stdbuf -oL git branch -D main",
+    ],
+)
+def test_wrapper_options_do_not_hide_branch_verb(cmd):
+    assert _dangerous(cmd) is not None
+
+
 def test_unclosed_heredoc_does_not_hide_trailing_danger():
     # A never-closing marker must NOT drop the real command after it (#4877
     # fail-open): the buffered lines were not a real heredoc body.

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -437,6 +437,28 @@ def test_wrapper_with_options_is_still_judged(cmd):
     assert _any_merge(cmd)
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env -i gh pr merge 5 --squash",
+        "env -i FOO=1 gh pr merge 5 --squash",
+        "env -u FOO gh pr merge 5 --squash",
+        "sudo -u root gh pr merge 5 --squash",
+        "sudo --preserve-env gh pr merge 5 --squash",
+        "sudo -E gh pr merge 5 --squash",
+        "time -p gh pr merge 5 --squash",
+        "nice -n 10 gh pr merge 5 --squash",
+        "stdbuf -oL gh pr merge 5 --squash",
+    ],
+)
+def test_wrapper_options_land_on_pr_merge_verb(cmd):
+    seg = guard._segments(cmd)[0]
+    i, via_xargs = guard._invoked_start(seg)
+    assert not via_xargs
+    assert seg[i : i + 3] == ["gh", "pr", "merge"]
+    assert _any_merge(cmd)
+
+
 def test_unwrapped_mention_is_not_a_merge():
     # The wrapper scan must not turn any stray token run into a merge.
     assert not _any_merge("echo gh pr merge 5")


### PR DESCRIPTION
Fixes #4878.

## Summary

- Consume recognised wrapper flags and value operands before matching the protected verb.
- Cover `env`, `sudo`, `time`, `nice`, and `stdbuf` forms across the active Bash guards.
- Leave the Git pre-push pytest hook unchanged: it receives Git-resolved ref updates rather than a shell command.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_guard_branch_switch_in_main.py tests/test_guard_admin_merge.py tests/test_guard_pr_merge.py -q` (359 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check agents_extensions/shared/hooks/guard-branch-switch-in-main.py agents_extensions/shared/hooks/guard-admin-merge.py agents_extensions/shared/hooks/guard-pr-merge.py tests/test_guard_branch_switch_in_main.py tests/test_guard_admin_merge.py tests/test_guard_pr_merge.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Ready for independent cross-family review; do not merge from this dispatch.