### PR TITLE
fix(services): reconcile listener PID on Linux

### DIFF
--- a/services.sh
+++ b/services.sh
@@ -163,7 +163,7 @@ _cmdline_for_pid() {
     # does not depend on procps personality or command-width formatting, both
     # of which can alter the string used for our service identity match.
     # macOS has no procfs equivalent, so it retains the established ps path.
-    if [ -s "/proc/$pid/cmdline" ] && cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null); then
+    if cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) && [ -n "$cmdline" ]; then
         # The kernel terminates every argv element with NUL, including argv[0].
         # Remove only the terminal separator introduced by ``tr``.
         printf '%s\n' "${cmdline% }"

--- a/services.sh
+++ b/services.sh
@@ -157,6 +157,19 @@ _pid_on_port() {
 
 _cmdline_for_pid() {
     local pid="$1"
+    local cmdline
+
+    # Linux exposes the argv vector directly.  Unlike ``ps -o args=``, this
+    # does not depend on procps personality or command-width formatting, both
+    # of which can alter the string used for our service identity match.
+    # macOS has no procfs equivalent, so it retains the established ps path.
+    if [[ -r "/proc/$pid/cmdline" ]] && cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null); then
+        # The kernel terminates every argv element with NUL, including argv[0].
+        # Remove only the terminal separator introduced by ``tr``.
+        printf '%s\n' "${cmdline% }"
+        return 0
+    fi
+
     ps -p "$pid" -o args= 2>/dev/null
 }
 

--- a/services.sh
+++ b/services.sh
@@ -163,7 +163,7 @@ _cmdline_for_pid() {
     # does not depend on procps personality or command-width formatting, both
     # of which can alter the string used for our service identity match.
     # macOS has no procfs equivalent, so it retains the established ps path.
-    if [[ -r "/proc/$pid/cmdline" ]] && cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null); then
+    if [ -s "/proc/$pid/cmdline" ] && cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null); then
         # The kernel terminates every argv element with NUL, including argv[0].
         # Remove only the terminal separator introduced by ``tr``.
         printf '%s\n' "${cmdline% }"

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -17,9 +17,10 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SERVICES_SH = PROJECT_ROOT / "services.sh"
 PIDS_DIR = PROJECT_ROOT / ".pids"
 LOGS_DIR = PROJECT_ROOT / "logs"
-# Service commands must use the repository virtual environment, matching the
-# production launcher contract.
-VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
+# Service commands use the repository virtual environment in normal CI.  The
+# explicit override lets a dispatch worktree use the shared project interpreter
+# without creating a worktree-local virtual environment.
+VENV_PYTHON = Path(os.environ.get("SERVICES_TEST_PYTHON", PROJECT_ROOT / ".venv" / "bin" / "python"))
 
 def find_free_port() -> int:
     """Find a free TCP port on localhost."""
@@ -175,12 +176,6 @@ def cleanup_pids_and_logs():
     elif api_start_file.exists():
         api_start_file.unlink()
 
-@pytest.mark.skipif(
-    sys.platform != "darwin",
-    reason="services.sh is macOS-targeted local-ops tooling; its process-lifecycle "
-    "behavior diverges on Linux CI (issue #4930 tracks the divergence). The "
-    "platform-neutral logic tests (preload, guards, missing-lsof) run everywhere.",
-)
 def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
     """Test stale pid file / listener interactions hermetically."""
     script_path, port = temp_services_sh
@@ -284,12 +279,6 @@ def test_live_fallback_is_passed_to_launchd_with_a_loud_warning(temp_services_sh
     calls = Path(env["SVC_API_SUPERVISOR_CAPTURE"]).read_text(encoding="utf-8").splitlines()
     assert calls == ["start", "--repo-root", str(PROJECT_ROOT), "--live"]
 
-@pytest.mark.skipif(
-    sys.platform != "darwin",
-    reason="services.sh is macOS-targeted local-ops tooling; its process-lifecycle "
-    "behavior diverges on Linux CI (issue #4930 tracks the divergence). The "
-    "platform-neutral logic tests (preload, guards, missing-lsof) run everywhere.",
-)
 def test_stop_disables_supervision_before_killing_api_listener(temp_services_sh, mock_lsof_env):
     """A deliberate stop asks launchd to disable before touching the listener."""
     script_path, port = temp_services_sh


### PR DESCRIPTION
## Summary
- read Linux process argv from `/proc/<pid>/cmdline` before the existing macOS `ps` fallback
- re-enable hermetic lifecycle reconciliation and stop tests on Ubuntu
- allow dispatch-worktree test runs to select the shared project interpreter without creating a local venv

## Root cause
The lsof shim returned the expected PID on Ubuntu, but its subsequent service-identity check used `ps -o args=`. That rendered command line was not a stable contract across the Ubuntu/macOS process tools, so reconcile rejected the shim PID as not belonging to the API. Linux now uses its raw NUL-delimited argv source; macOS retains the existing `ps` behavior.

## Verification
- `SERVICES_TEST_PYTHON=/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/api/test_services_ops.py -q` (4 passed, 1 skipped on macOS)
- `bash -n services.sh`
- `ruff check tests/api/test_services_ops.py`
- `scripts/audit/lint_agent_trailer.py`
- `scripts/audit/lint_opsec_leaks.py`

Closes #4930