### PR TITLE
fix(lexicon): sync VPS enrichment package

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -14,6 +14,8 @@
 #   - reenrich_thin_manifest_entries.py   driver copy with --slugs-file
 #     support, IF the in-repo checkout at $REPO is still stale (no
 #     --slugs-file flag). The in-repo driver is preferred once it catches up.
+#   - scripts/lexicon/... and its supporting imports, synced from the Mac
+#     worktree so the driver never imports stale enrichment code from $REPO.
 #
 # Does NOT finalize, publish, or pin-flip. This mutates a *work-dir copy* of
 # the manifest only (snapshotted once from the live checkout, then re-used
@@ -27,6 +29,7 @@
 #
 # Env overrides:
 #   ATLAS_RUN_ROOT, ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
+#   ATLAS_RE_ENRICH_CODE_ROOT,
 #   ATLAS_RE_ENRICH_UNIT, ATLAS_RE_ENRICH_DRIVER, ATLAS_RE_ENRICH_SLUGS_FILE,
 #   ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON, ATLAS_LIVE_MANIFEST
 set -euo pipefail
@@ -34,6 +37,7 @@ set -euo pipefail
 RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
 REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
+CODE_ROOT="${ATLAS_RE_ENRICH_CODE_ROOT:-$WORK_DIR}"
 UNIT="${ATLAS_RE_ENRICH_UNIT:-atlas-class-b-reenrich.service}"
 LOG="$WORK_DIR/reenrich.log"
 PID_FILE="$WORK_DIR/reenrich-driver.pid"
@@ -98,6 +102,10 @@ if [[ ! -f "$DRIVER" ]]; then
   echo "reenrich driver not found: $DRIVER" >&2
   exit 1
 fi
+if [[ ! -f "$CODE_ROOT/scripts/lexicon/enrich_manifest.py" ]]; then
+  echo "synced enrichment package not found: $CODE_ROOT/scripts/lexicon/enrich_manifest.py" >&2
+  exit 1
+fi
 if ! grep -q -- '--slugs-file' "$DRIVER" 2>/dev/null; then
   echo "reenrich driver at $DRIVER lacks --slugs-file support; scp the #6398 driver into $WORKDIR_DRIVER or update the checkout" >&2
   exit 1
@@ -156,12 +164,9 @@ fi
 # into its own artifact without fighting systemd-run's StandardOutput
 # property. stderr still folds into the shared log.
 #
-# PYTHONPATH=$REPO is required when DRIVER is the work-dir copy: that file's
-# own `sys.path` bootstrap assumes it lives 2 levels under the real repo
-# root (scripts/lexicon/<file>.py -> parents[2] == repo root) to import its
-# sibling `scripts.audit.*` / `scripts.lexicon.*` packages. A flat work-dir
-# copy breaks that assumption; PYTHONPATH makes the real package tree
-# resolvable regardless of where the file itself was invoked from.
+# PYTHONPATH puts the synced work-dir package before the stale VPS checkout.
+# The driver then imports the exact enrichment code deployed by the Mac-side
+# wrapper, while $REPO remains available for its hydrated data files and venv.
 # systemd-run --user starts units with a fresh environment (it does not
 # inherit the launching shell's exports), so this must be set inside the
 # wrapped command, not via `export` before systemd-run.
@@ -174,7 +179,7 @@ run_cmd() {
     printf '%q ' "${EXTRA_ARGS[@]}"
   fi
 }
-WRAPPED="cd $(printf '%q' "$REPO") && PYTHONPATH=$(printf '%q' "$REPO") exec /usr/bin/nice -n 10 /usr/bin/ionice -c3 $(run_cmd) 2>>$(printf '%q' "$LOG") | tee -a $(printf '%q' "$LOG") > $(printf '%q' "$SUMMARY_FILE")"
+WRAPPED="cd $(printf '%q' "$REPO") && PYTHONPATH=$(printf '%q' "$CODE_ROOT"):\$PYTHONPATH:$(printf '%q' "$REPO") exec /usr/bin/nice -n 10 /usr/bin/ionice -c3 $(run_cmd) 2>>$(printf '%q' "$LOG") | tee -a $(printf '%q' "$LOG") > $(printf '%q' "$SUMMARY_FILE")"
 
 if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run >/dev/null 2>&1; then
   rm -f "$PID_FILE" "$WRAPPER_PID_FILE"

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -22,12 +22,16 @@
 # Env overrides:
 #   ATLAS_RUNNER_HOST (default vps), ATLAS_RUN_ROOT, ATLAS_REPO,
 #   ATLAS_RE_ENRICH_WORK_DIR, ATLAS_RE_ENRICH_RESIDUAL (local slugs dump),
+#   ATLAS_LOCAL_VESUM_DB, ATLAS_LOCAL_SLOVNYK_CACHE
+#   (local enrichment data for the work-dir overlay),
+#   ATLAS_RE_ENRICH_PYTHON (default shared project interpreter),
 #   ATLAS_RE_ENRICH_OUT_DIR (local pull-back dir),
 #   ATLAS_RE_ENRICH_POLL_TIMEOUT_S (default 900),
 #   ATLAS_RE_ENRICH_POLL_INTERVAL_S (default 15)
 set -euo pipefail
 
 WORKTREE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python}"
 
 HOST="${ATLAS_RUNNER_HOST:-vps}"
 RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
@@ -38,6 +42,11 @@ LOCAL_RESIDUAL="${ATLAS_RE_ENRICH_RESIDUAL:-$WORKTREE/batch_state/atlas-6369-cla
 LOCAL_OUT_DIR="${ATLAS_RE_ENRICH_OUT_DIR:-$WORKTREE/batch_state/class-b-reenrich-pulled}"
 LOCAL_DRIVER="$WORKTREE/scripts/lexicon/reenrich_thin_manifest_entries.py"
 LOCAL_LAUNCHER="$WORKTREE/scripts/lexicon/runner/launch_reenrich_class_b.sh"
+# The driver imports ``scripts.lexicon.enrich_manifest`` and its supporting
+# modules. The VPS checkout is deliberately allowed to stay stale, so deploy
+# the current scripts package tree into the work-dir instead of trying to
+# maintain a brittle transitive-import allowlist against $REMOTE_REPO.
+LOCAL_SCRIPTS_PACKAGE="$WORKTREE/scripts"
 
 POLL_TIMEOUT_S="${ATLAS_RE_ENRICH_POLL_TIMEOUT_S:-900}"
 POLL_INTERVAL_S="${ATLAS_RE_ENRICH_POLL_INTERVAL_S:-15}"
@@ -68,6 +77,12 @@ done
 
 ssh_q() { ssh -o BatchMode=yes -o ConnectTimeout=10 -- "$HOST" "$@"; }
 scp_q() { scp -o BatchMode=yes -o ConnectTimeout=10 -- "$@"; }
+rsync_q() { rsync -a --delete -e "ssh -o BatchMode=yes -o ConnectTimeout=10" -- "$@"; }
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "shared project Python not executable: $PYTHON_BIN" >&2
+  exit 1
+fi
 
 if ! ssh_q "true" 2>/dev/null; then
   echo "cannot reach $HOST over SSH (BatchMode); check ~/.ssh/config" >&2
@@ -99,9 +114,36 @@ if [[ ! -e "$LOCAL_SOURCES_DB_CANDIDATE" ]]; then
     exit 1
   fi
 fi
-LOCAL_SOURCES_DB="$(python3 -c "import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())" "$LOCAL_SOURCES_DB_CANDIDATE")"
+LOCAL_SOURCES_DB="$("$PYTHON_BIN" -c "import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())" "$LOCAL_SOURCES_DB_CANDIDATE")"
 if [[ ! -f "$LOCAL_SOURCES_DB" ]]; then
   echo "resolved local sources.db is not a regular file: $LOCAL_SOURCES_DB" >&2
+  exit 1
+fi
+
+# Current enrichment also needs VESUM for morphology and to verify dictionary
+# content before learner-facing sections are admitted. The VPS intentionally
+# keeps only sources.db in its stale repo checkout, so materialize VESUM in the
+# disposable work-dir overlay rather than changing that checkout.
+LOCAL_VESUM_DB_CANDIDATE="${ATLAS_LOCAL_VESUM_DB:-$WORKTREE/data/vesum.db}"
+if [[ ! -e "$LOCAL_VESUM_DB_CANDIDATE" ]]; then
+  if [[ -e "/Users/krisztiankoos/projects/learn-ukrainian/data/vesum.db" ]]; then
+    LOCAL_VESUM_DB_CANDIDATE="/Users/krisztiankoos/projects/learn-ukrainian/data/vesum.db"
+  else
+    echo "local vesum.db not found (tried worktree + primary checkout)" >&2
+    exit 1
+  fi
+fi
+LOCAL_VESUM_DB="$("$PYTHON_BIN" -c "import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())" "$LOCAL_VESUM_DB_CANDIDATE")"
+if [[ ! -f "$LOCAL_VESUM_DB" ]]; then
+  echo "resolved local vesum.db is not a regular file: $LOCAL_VESUM_DB" >&2
+  exit 1
+fi
+LOCAL_SLOVNYK_CACHE="${ATLAS_LOCAL_SLOVNYK_CACHE:-$WORKTREE/data/lexicon/slovnyk_cache}"
+if [[ ! -d "$LOCAL_SLOVNYK_CACHE" ]]; then
+  LOCAL_SLOVNYK_CACHE="/Users/krisztiankoos/projects/learn-ukrainian/data/lexicon/slovnyk_cache"
+fi
+if [[ ! -d "$LOCAL_SLOVNYK_CACHE" ]]; then
+  echo "local slovnyk cache not found (tried worktree + primary checkout)" >&2
   exit 1
 fi
 
@@ -148,19 +190,47 @@ if [[ "$do_sync_and_launch" == "1" ]]; then
     fi
   fi
 
-  echo "syncing driver + launcher -> $HOST:$REMOTE_WORK_DIR (target=$TARGET)"
-  ssh_q "mkdir -p $(printf '%q' "$REMOTE_WORK_DIR")"
+  echo "syncing driver + current enrichment package -> $HOST:$REMOTE_WORK_DIR (target=$TARGET)"
+  ssh_q "mkdir -p $(printf '%q' "$REMOTE_WORK_DIR/scripts")"
+  # Modules deployed under $REMOTE_WORK_DIR derive their project root from
+  # that directory. Materialize a work-dir-only data overlay: the live repo
+  # remains read-only, while VESUM sits next to the synced code.
+  ssh_q "if test -L $(printf '%q' "$REMOTE_WORK_DIR/data"); then data_target=\$(readlink -f $(printf '%q' "$REMOTE_WORK_DIR/data")); if test \"\$data_target\" != $(printf '%q' "$REMOTE_REPO/data"); then echo 'refusing to replace unexpected work-dir data symlink' >&2; exit 1; fi; rm $(printf '%q' "$REMOTE_WORK_DIR/data"); mkdir -p $(printf '%q' "$REMOTE_WORK_DIR/data"); ln -s $(printf '%q' "$REMOTE_REPO/data/sources.db") $(printf '%q' "$REMOTE_WORK_DIR/data/sources.db"); ln -s $(printf '%q' "$REMOTE_REPO/data/lexicon") $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon"); elif test ! -d $(printf '%q' "$REMOTE_WORK_DIR/data"); then echo 'work-dir data path is not a directory' >&2; exit 1; fi"
+  # Slovnyk is deliberately offline during VPS runs. Materialize only its
+  # cache directory locally in the overlay, while all other lexicon artifacts
+  # remain linked to the hydrated VPS repo data.
+  ssh_q "if test -L $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon"); then lexicon_target=\$(readlink -f $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon")); if test \"\$lexicon_target\" != $(printf '%q' "$REMOTE_REPO/data/lexicon"); then echo 'refusing to replace unexpected work-dir lexicon symlink' >&2; exit 1; fi; rm $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon"); mkdir -p $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon"); for source_path in $(printf '%q' "$REMOTE_REPO/data/lexicon")/*; do name=\$(basename \"\$source_path\"); if test \"\$name\" != slovnyk_cache; then ln -s \"\$source_path\" $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon")/\"\$name\"; fi; done; elif test ! -d $(printf '%q' "$REMOTE_WORK_DIR/data/lexicon"); then echo 'work-dir lexicon path is not a directory' >&2; exit 1; fi"
+  echo "syncing Slovnyk cache into work-dir overlay"
+  rsync_q "$LOCAL_SLOVNYK_CACHE/" "$HOST:$REMOTE_WORK_DIR/data/lexicon/slovnyk_cache/"
+  REMOTE_VESUM_DB="$REMOTE_WORK_DIR/data/vesum.db"
+  local_vesum_sz="$(_local_sz "$LOCAL_VESUM_DB")"
+  remote_vesum_sz="$(ssh_q "if test -f $(printf '%q' "$REMOTE_VESUM_DB"); then stat -L -c '%s' $(printf '%q' "$REMOTE_VESUM_DB"); else echo 0; fi")"
+  echo "vesum.db preflight local=$local_vesum_sz remote=$remote_vesum_sz path=$REMOTE_VESUM_DB"
+  if [[ "$local_vesum_sz" != "$remote_vesum_sz" ]]; then
+    echo "syncing vesum.db into work-dir overlay"
+    rsync -a --partial "$LOCAL_VESUM_DB" "$HOST:$REMOTE_VESUM_DB"
+    remote_vesum_sz="$(ssh_q "stat -L -c '%s' $(printf '%q' "$REMOTE_VESUM_DB")")"
+    echo "vesum.db after rsync local=$local_vesum_sz remote=$remote_vesum_sz"
+    if [[ "$local_vesum_sz" != "$remote_vesum_sz" ]]; then
+      echo "FAIL CLOSED: vesum.db still mismatched after rsync (local=$local_vesum_sz remote=$remote_vesum_sz)" >&2
+      exit 1
+    fi
+  fi
   if [[ "$TARGET" == "missing-translation" ]]; then
     scp_q "$LOCAL_RESIDUAL" "$HOST:$REMOTE_WORK_DIR/class-b-no-en.json"
   fi
   scp_q "$LOCAL_DRIVER" "$HOST:$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py"
   scp_q "$LOCAL_LAUNCHER" "$HOST:$REMOTE_WORK_DIR/launch_reenrich_class_b.sh"
+  # Keep every direct and lazy transitive import current.  The package is
+  # small enough to sync cheaply, and this avoids rerunning a new driver
+  # against a mixture of Mac-current and VPS-stale helper modules.
+  rsync_q "$LOCAL_SCRIPTS_PACKAGE/" "$HOST:$REMOTE_WORK_DIR/scripts/"
   ssh_q "chmod +x $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
 
   echo "launching on $HOST"
   # ATLAS_RE_ENRICH_DRIVER pins the work-dir copy explicitly so a stale
   # in-repo checkout on the VPS can never win the launcher's auto-detection.
-  remote_cmd="ATLAS_RUN_ROOT=$(printf '%q' "$RUN_ROOT") ATLAS_REPO=$(printf '%q' "$REMOTE_REPO") ATLAS_RE_ENRICH_WORK_DIR=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_DRIVER=$(printf '%q' "$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py") bash $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
+  remote_cmd="ATLAS_RUN_ROOT=$(printf '%q' "$RUN_ROOT") ATLAS_REPO=$(printf '%q' "$REMOTE_REPO") ATLAS_RE_ENRICH_WORK_DIR=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_CODE_ROOT=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_DRIVER=$(printf '%q' "$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py") bash $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
   # macOS ships bash 3.2, where "${arr[@]}" on a zero-element array throws
   # "unbound variable" under `set -u` (fixed upstream in bash 4.4+) — guard
   # the iteration instead of relying on the expansion alone.
@@ -195,7 +265,7 @@ scp_q "$HOST:$REMOTE_WORK_DIR/reenrich-summary.json" "$LOCAL_OUT_DIR/reenrich-su
 
 if [[ -f "$LOCAL_OUT_DIR/reenrich-summary.json" ]]; then
   echo "--- summary ---"
-  python3 -c "
+  "$PYTHON_BIN" -c "
 import json, sys
 try:
     data = json.load(open('$LOCAL_OUT_DIR/reenrich-summary.json'))

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -128,3 +128,27 @@ def test_remote_wrapper_skips_residual_requirement_for_full_catalog() -> None:
     residual_scp_idx = source.index('scp_q "$LOCAL_RESIDUAL"')
     assert residual_check_idx > guard_idx
     assert residual_scp_idx > guard_idx
+
+
+def test_remote_wrapper_syncs_current_enrichment_package() -> None:
+    """The work-dir driver must not import its enrichment code from stale $REPO."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+
+    assert 'LOCAL_SCRIPTS_PACKAGE="$WORKTREE/scripts"' in source
+    assert 'rsync_q "$LOCAL_SCRIPTS_PACKAGE/" "$HOST:$REMOTE_WORK_DIR/scripts/"' in source
+    assert 'ATLAS_LOCAL_VESUM_DB' in source
+    assert 'REMOTE_VESUM_DB="$REMOTE_WORK_DIR/data/vesum.db"' in source
+    assert 'ATLAS_LOCAL_SLOVNYK_CACHE' in source
+    assert 'rsync_q "$LOCAL_SLOVNYK_CACHE/" "$HOST:$REMOTE_WORK_DIR/data/lexicon/slovnyk_cache/"' in source
+    assert "refusing to replace unexpected work-dir data symlink" in source
+    assert "syncing vesum.db into work-dir overlay" in source
+    assert 'ATLAS_RE_ENRICH_CODE_ROOT=$(printf \'%q\' "$REMOTE_WORK_DIR")' in source
+
+
+def test_local_launcher_prefers_synced_package_on_systemd_import_path() -> None:
+    """The service command resolves ``scripts.*`` from the work-dir first."""
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+
+    assert 'CODE_ROOT="${ATLAS_RE_ENRICH_CODE_ROOT:-$WORK_DIR}"' in source
+    assert '"$CODE_ROOT/scripts/lexicon/enrich_manifest.py"' in source
+    assert 'PYTHONPATH=$(printf \'%q\' "$CODE_ROOT"):\\$PYTHONPATH:$(printf \'%q\' "$REPO")' in source


### PR DESCRIPTION
## Summary

- Sync the full current `scripts` package into the disposable VPS work-dir, keeping it first in the systemd command's `PYTHONPATH`.
- Add a work-dir-only data overlay for VESUM and the current offline Slovnyk cache; the stale VPS repository remains untouched.
- Preserve the #6577 target and slug-filter behavior, with launcher source coverage.

## Root cause

The remote wrapper copied only the driver while `PYTHONPATH=$REPO` loaded `scripts.lexicon.enrich_manifest` from the stale VPS checkout. Its full-catalog canary therefore produced empty layer coverage.

## Verification

- `bash -n scripts/lexicon/runner/launch_reenrich_class_b_remote.sh`
- `bash -n scripts/lexicon/runner/launch_reenrich_class_b.sh`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_launch_reenrich_target_detection.py tests/test_reenrich_thin_manifest_entries.py -q` — 33 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged` — passed
- VPS full-catalog smoke: source DB `1956089856` bytes and VESUM `967602176` bytes matched local; run advanced past the fail-closed canary and reported `target: full-catalog`, `targets: 10`, `categorical_binning: ENRICHED: 10`, and layer counters `proverbs: 1`, `usage_notes: 1`, `grinchenko: 3`, `forms: 9`.

No VPS `git pull`, reset, or checkout was performed.