### PR TITLE
fix(cursor): retry GitHub secondary limits

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -47,6 +47,14 @@ _RATE_LIMIT_PATTERNS = (
 )
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 
+# This marker is emitted only by our GH shim after it has recognized a
+# GitHub-side secondary-limit response. It must not trip Cursor's provider
+# cooldown: the Cursor model is still available, and the worker can succeed
+# after the shim's bounded retry. If retries are exhausted, preserve the
+# distinct failure for delegate recovery rather than calling it a provider
+# rate limit.
+_GITHUB_SECONDARY_RATE_LIMIT_MARKER = "agent-gh-shim: github_secondary_rate_limited"
+
 # Cursor's automatic route is a selector, not an attributable model. Keep
 # this boundary structural: assistant prose, tool input, and arbitrary log
 # text must never become model evidence merely because they contain the word
@@ -437,7 +445,14 @@ class CursorAdapter:
         # stderr diagnostic is rate-limited.
         usable_response = bool(response)
         failed_call = returncode != 0 or not usable_response
-        rate_limited = failed_call and bool(_RATE_LIMIT_RE.search(stderr or ""))
+        github_secondary_rate_limited = (
+            failed_call and _GITHUB_SECONDARY_RATE_LIMIT_MARKER in (stderr or "")
+        )
+        rate_limited = (
+            failed_call
+            and not github_secondary_rate_limited
+            and bool(_RATE_LIMIT_RE.search(stderr or ""))
+        )
 
         ok = returncode == 0 and bool(response) and not rate_limited
 
@@ -469,6 +484,9 @@ class CursorAdapter:
             session_id=session_id,
             tool_calls=tool_calls,
             substitution=model_attribution,
+            failure_code=(
+                "github_secondary_rate_limited" if github_secondary_rate_limited else None
+            ),
         )
 
     def _read_session_transcript_events(

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -162,6 +162,7 @@ _SAFE_ACP_FAILURE_CODES = frozenset(
         "acp_review_evidence_too_large",
         "acp_session_create_timeout",
         "acp_turn_limit",
+        "github_secondary_rate_limited",
         "adapter_refused",
         "protocol_output_limit",
         "provider_unavailable",

--- a/scripts/agent_runtime/shims/gh
+++ b/scripts/agent_runtime/shims/gh
@@ -67,6 +67,143 @@ _blocks_gh_command() {
   return 1
 }
 
+_is_secondary_rate_limited() {
+  local output="$1"
+
+  # Only retry GitHub's explicit secondary-limit response.  A broad match on
+  # "rate limit" would incorrectly retry provider quotas, malformed commands,
+  # and ordinary GitHub failures. GitHub documents this as a 403/429 together
+  # with a secondary-rate-limit message.
+  printf '%s' "$output" | grep -Eiq '(HTTP|status)[[:space:]:]*(403|429)' \
+    && printf '%s' "$output" | grep -Eiq 'secondary[[:space:]-]+rate[[:space:]-]+limit'
+}
+
+_secondary_rate_limit_http_status() {
+  local output="$1"
+  if printf '%s' "$output" | grep -Eiq '(HTTP[[:space:]]*429|status[[:space:]]*429)'; then
+    printf '429\n'
+  else
+    printf '403\n'
+  fi
+}
+
+_positive_integer_or_default() {
+  local value="$1"
+  local fallback="$2"
+  if [[ "$value" =~ ^[0-9]+$ ]] && (( value > 0 )); then
+    printf '%s\n' "$value"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+_nonnegative_integer_or_default() {
+  local value="$1"
+  local fallback="$2"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+_run_with_secondary_rate_limit_retry() {
+  local real_gh="$1"
+  shift
+
+  # GitHub recommends waiting at least one minute when a secondary-limit
+  # response omits Retry-After, then using exponential backoff and a bounded
+  # number of retries. The env overrides make the shim deterministically
+  # testable without weakening production defaults.
+  local max_retries
+  max_retries="$(_positive_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES:-}" 3)"
+  local base_delay_s
+  base_delay_s="$(_nonnegative_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS:-}" 60)"
+
+  local stdin_file=""
+  local stdout_file
+  local stderr_file
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdout.XXXXXX")" || return 1
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stderr.XXXXXX")" || {
+    rm -f "$stdout_file"
+    return 1
+  }
+  if [[ ! -t 0 ]]; then
+    stdin_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdin.XXXXXX")" || {
+      rm -f "$stdout_file" "$stderr_file"
+      return 1
+    }
+    cat >"$stdin_file" || {
+      rm -f "$stdin_file" "$stdout_file" "$stderr_file"
+      return 1
+    }
+  fi
+
+  _cleanup_secondary_retry_tempfiles() {
+    rm -f "$stdin_file" "$stdout_file" "$stderr_file"
+    trap - HUP INT TERM
+  }
+
+  _abort_secondary_retry() {
+    local status="$1"
+    _cleanup_secondary_retry_tempfiles
+    exit "$status"
+  }
+
+  trap '_abort_secondary_retry 129' HUP
+  trap '_abort_secondary_retry 130' INT
+  trap '_abort_secondary_retry 143' TERM
+
+  local attempt=0
+  local exit_status=0
+  local output=""
+  local http_status=""
+  while :; do
+    if [[ -n "$stdin_file" ]]; then
+      if "$real_gh" "$@" <"$stdin_file" >"$stdout_file" 2>"$stderr_file"; then
+        exit_status=0
+      else
+        exit_status=$?
+      fi
+    elif "$real_gh" "$@" >"$stdout_file" 2>"$stderr_file"; then
+      exit_status=0
+    else
+      exit_status=$?
+    fi
+
+    if (( exit_status == 0 )); then
+      cat "$stdout_file"
+      cat "$stderr_file" >&2
+      _cleanup_secondary_retry_tempfiles
+      return 0
+    fi
+
+    output="$(cat "$stdout_file" "$stderr_file")"
+    if ! _is_secondary_rate_limited "$output"; then
+      cat "$stdout_file"
+      cat "$stderr_file" >&2
+      _cleanup_secondary_retry_tempfiles
+      return "$exit_status"
+    fi
+
+    attempt=$((attempt + 1))
+    http_status="$(_secondary_rate_limit_http_status "$output")"
+    if (( attempt > max_retries )); then
+      cat "$stdout_file"
+      cat "$stderr_file" >&2
+      printf 'agent-gh-shim: github_secondary_rate_limited HTTP %s; retries exhausted after %s attempts.\n' \
+        "$http_status" "$max_retries" >&2
+      _cleanup_secondary_retry_tempfiles
+      return "$exit_status"
+    fi
+
+    local delay_s=$((base_delay_s * (2 ** (attempt - 1))))
+    printf 'agent-gh-shim: GitHub HTTP %s throttled; retrying gh in %ss (attempt %s/%s).\n' \
+      "$http_status" "$delay_s" "$attempt" "$max_retries" >&2
+    sleep "$delay_s"
+  done
+}
+
 if [[ "${AGENT_NO_MERGE:-}" == "1" ]] && _blocks_gh_command "${1:-}" "${@:2}"; then
   _deny
 fi
@@ -76,4 +213,4 @@ real_gh="$(_real_gh)" || {
   exit 127
 }
 
-exec "$real_gh" "$@"
+_run_with_secondary_rate_limit_retry "$real_gh" "$@"

--- a/scripts/agent_runtime/shims/gh
+++ b/scripts/agent_runtime/shims/gh
@@ -120,36 +120,35 @@ _run_with_secondary_rate_limit_retry() {
   local base_delay_s
   base_delay_s="$(_nonnegative_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS:-}" 60)"
 
-  local stdin_file=""
-  local stdout_file
-  local stderr_file
-  stdout_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdout.XXXXXX")" || return 1
-  stderr_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stderr.XXXXXX")" || {
-    rm -f "$stdout_file"
+  _agent_gh_retry_stdin_file=""
+  _agent_gh_retry_stdout_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdout.XXXXXX")" || return 1
+  _agent_gh_retry_stderr_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stderr.XXXXXX")" || {
+    rm -f "$_agent_gh_retry_stdout_file"
     return 1
   }
   if [[ ! -t 0 ]]; then
-    stdin_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdin.XXXXXX")" || {
-      rm -f "$stdout_file" "$stderr_file"
+    _agent_gh_retry_stdin_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdin.XXXXXX")" || {
+      rm -f "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
       return 1
     }
-    cat >"$stdin_file" || {
-      rm -f "$stdin_file" "$stdout_file" "$stderr_file"
+    cat >"$_agent_gh_retry_stdin_file" || {
+      rm -f "$_agent_gh_retry_stdin_file" "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
       return 1
     }
   fi
 
   _cleanup_secondary_retry_tempfiles() {
-    rm -f "$stdin_file" "$stdout_file" "$stderr_file"
-    trap - HUP INT TERM
+    rm -f "$_agent_gh_retry_stdin_file" "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
   }
 
   _abort_secondary_retry() {
     local status="$1"
+    trap - EXIT HUP INT TERM
     _cleanup_secondary_retry_tempfiles
     exit "$status"
   }
 
+  trap '_cleanup_secondary_retry_tempfiles' EXIT
   trap '_abort_secondary_retry 129' HUP
   trap '_abort_secondary_retry 130' INT
   trap '_abort_secondary_retry 143' TERM
@@ -158,43 +157,34 @@ _run_with_secondary_rate_limit_retry() {
   local exit_status=0
   local output=""
   local http_status=""
+  local retries_exhausted=false
   while :; do
-    if [[ -n "$stdin_file" ]]; then
-      if "$real_gh" "$@" <"$stdin_file" >"$stdout_file" 2>"$stderr_file"; then
+    if [[ -n "$_agent_gh_retry_stdin_file" ]]; then
+      if "$real_gh" "$@" <"$_agent_gh_retry_stdin_file" >"$_agent_gh_retry_stdout_file" 2>"$_agent_gh_retry_stderr_file"; then
         exit_status=0
       else
         exit_status=$?
       fi
-    elif "$real_gh" "$@" >"$stdout_file" 2>"$stderr_file"; then
+    elif "$real_gh" "$@" >"$_agent_gh_retry_stdout_file" 2>"$_agent_gh_retry_stderr_file"; then
       exit_status=0
     else
       exit_status=$?
     fi
 
     if (( exit_status == 0 )); then
-      cat "$stdout_file"
-      cat "$stderr_file" >&2
-      _cleanup_secondary_retry_tempfiles
-      return 0
+      break
     fi
 
-    output="$(cat "$stdout_file" "$stderr_file")"
+    output="$(cat "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file")"
     if ! _is_secondary_rate_limited "$output"; then
-      cat "$stdout_file"
-      cat "$stderr_file" >&2
-      _cleanup_secondary_retry_tempfiles
-      return "$exit_status"
+      break
     fi
 
     attempt=$((attempt + 1))
     http_status="$(_secondary_rate_limit_http_status "$output")"
     if (( attempt > max_retries )); then
-      cat "$stdout_file"
-      cat "$stderr_file" >&2
-      printf 'agent-gh-shim: github_secondary_rate_limited HTTP %s; retries exhausted after %s attempts.\n' \
-        "$http_status" "$max_retries" >&2
-      _cleanup_secondary_retry_tempfiles
-      return "$exit_status"
+      retries_exhausted=true
+      break
     fi
 
     local delay_s=$((base_delay_s * (2 ** (attempt - 1))))
@@ -202,6 +192,17 @@ _run_with_secondary_rate_limit_retry() {
       "$http_status" "$delay_s" "$attempt" "$max_retries" >&2
     sleep "$delay_s"
   done
+
+  # Retry attempts stay private: only the final gh invocation's output reaches
+  # the caller. The durable marker is likewise reserved for a truly exhausted
+  # secondary-rate-limit retry budget.
+  cat "$_agent_gh_retry_stdout_file"
+  cat "$_agent_gh_retry_stderr_file" >&2
+  if [[ "$retries_exhausted" == true ]]; then
+    printf 'agent-gh-shim: github_secondary_rate_limited HTTP %s; retries exhausted after %s attempts.\n' \
+      "$http_status" "$max_retries" >&2
+  fi
+  return "$exit_status"
 }
 
 if [[ "${AGENT_NO_MERGE:-}" == "1" ]] && _blocks_gh_command "${1:-}" "${@:2}"; then

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -437,6 +437,22 @@ def test_cursor_adapter_parse_response_rate_limited(adapter):
     assert "429" in result.stderr_excerpt
 
 
+def test_cursor_adapter_secondary_github_limit_is_not_a_cursor_provider_limit(adapter):
+    result = adapter.parse_response(
+        stdout="",
+        stderr=(
+            "HTTP 403: You have exceeded a secondary rate limit.\n"
+            "agent-gh-shim: github_secondary_rate_limited HTTP 403; retries exhausted after 3 attempts."
+        ),
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.rate_limited is False
+    assert result.failure_code == "github_secondary_rate_limited"
+
+
 def test_cursor_adapter_parse_response_message_format(adapter):
     stdout = """
 {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "Hello world"}]}

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4366,6 +4366,90 @@ def test_gh_shim_allows_pr_merge_with_opt_in(tmp_path):
     assert proc.stdout.strip() == "real-gh pr merge 1234"
 
 
+def test_gh_shim_retries_mocked_secondary_rate_limit_and_replays_stdin(tmp_path):
+    """A GitHub 403 secondary limit retries without losing a PR/comment body."""
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "count=$((count + 1))\n"
+        "printf '%s' \"$count\" >\"$attempts\"\n"
+        "if [[ \"$count\" == 1 ]]; then\n"
+        "  printf 'retry-output-should-not-leak\\n'\n"
+        "  printf 'HTTP 403: You have exceeded a secondary rate limit.\\n' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "printf 'real-gh %s stdin=%s\\n' \"$*\" \"$(cat)\"\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "issue", "comment", "5146", "-F", "-"],
+        input="preserved comment body\n",
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0
+    assert attempts.read_text(encoding="utf-8") == "2"
+    assert proc.stdout.strip() == "real-gh issue comment 5146 -F - stdin=preserved comment body"
+    assert "retry-output-should-not-leak" not in proc.stdout
+    assert "You have exceeded a secondary rate limit" not in proc.stderr
+    assert "GitHub HTTP 403 throttled; retrying gh in 0s (attempt 1/2)." in proc.stderr
+
+
+def test_gh_shim_requires_an_explicit_http_status_for_secondary_limit_retry(tmp_path):
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "printf '%s' \"$((count + 1))\" >\"$attempts\"\n"
+        "printf 'secondary rate limit incident #403\\n' >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "pr", "create"],
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 1
+    assert attempts.read_text(encoding="utf-8") == "1"
+    assert "throttled; retrying" not in proc.stderr
+
+
 def test_git_shim_blocks_push_to_main_without_opt_in(tmp_path):
     shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "git"
     fake_git = tmp_path / "real-git"
@@ -4624,6 +4708,7 @@ def test_acp_routes_share_a_bounded_protocol_envelope(agent_name):
             "acp_review_evidence_too_large",
         ),
         ("error", False, False, "acp_adapter_missing", None, "acp_adapter_missing"),
+        ("error", False, False, "github_secondary_rate_limited", 1, "github_secondary_rate_limited"),
         ("error", False, False, None, 1, "transport_error"),
         ("rate_limited", True, False, None, 1, "rate_limited"),
     ],

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -4411,6 +4411,97 @@ def test_gh_shim_retries_mocked_secondary_rate_limit_and_replays_stdin(tmp_path)
     assert "retry-output-should-not-leak" not in proc.stdout
     assert "You have exceeded a secondary rate limit" not in proc.stderr
     assert "GitHub HTTP 403 throttled; retrying gh in 0s (attempt 1/2)." in proc.stderr
+    assert "github_secondary_rate_limited" not in proc.stderr
+
+
+def test_gh_shim_emits_only_final_attempt_output_and_exhaustion_marker(tmp_path):
+    """Intermediate secondary-limit output stays private until retries exhaust."""
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "count=$((count + 1))\n"
+        "printf '%s' \"$count\" >\"$attempts\"\n"
+        "printf 'attempt-%s-stdout\\n' \"$count\"\n"
+        "printf 'HTTP 403: secondary rate limit on attempt %s\\n' \"$count\" >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "issue", "comment", "5146"],
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 1
+    assert attempts.read_text(encoding="utf-8") == "3"
+    assert proc.stdout == "attempt-3-stdout\n"
+    assert "attempt-1-stdout" not in proc.stdout
+    assert "attempt-2-stdout" not in proc.stdout
+    assert "secondary rate limit on attempt 1" not in proc.stderr
+    assert "secondary rate limit on attempt 2" not in proc.stderr
+    assert proc.stderr.count("github_secondary_rate_limited") == 1
+
+
+def test_gh_shim_cleans_retry_tempfiles_on_sigterm(tmp_path):
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    ready = tmp_path / "ready"
+    temp_dir = tmp_path / "shim-temp"
+    temp_dir.mkdir()
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"ready={ready!s}\n"
+        "printf 'ready' >\"$ready\"\n"
+        "printf 'HTTP 403: secondary rate limit.\\n' >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.Popen(
+        [str(shim), "issue", "comment", "5146"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "30",
+            "PATH": os.environ.get("PATH", ""),
+            "TMPDIR": str(temp_dir),
+        },
+    )
+    for _ in range(100):
+        if ready.exists():
+            break
+        time.sleep(0.01)
+    assert ready.exists()
+
+    proc.terminate()
+    proc.communicate(timeout=15)
+
+    assert proc.returncode == 143
+    assert list(temp_dir.iterdir()) == []
 
 
 def test_gh_shim_requires_an_explicit_http_status_for_secondary_limit_retry(tmp_path):


### PR DESCRIPTION
## Summary

- retry explicit GitHub HTTP 403/429 secondary-rate-limit responses through the existing agent `gh` shim with bounded exponential backoff
- preserve stdin across retries and emit a distinct GitHub secondary-limit marker
- keep exhausted GitHub limits out of Cursor provider cooldown classification

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/agent_runtime/adapters/test_cursor_adapter.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_agent_runtime.py -k "not usage_attribution_detects_codex_desktop"`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/adapters/cursor.py scripts/agent_runtime/runner.py tests/test_agent_runtime.py tests/agent_runtime/adapters/test_cursor_adapter.py`
- `bash -n scripts/agent_runtime/shims/gh`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main...HEAD`

Closes #5146