### PR TITLE
fix(runtime): detach intentional session services

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1363,6 +1363,9 @@ Claude, Gemini, and Codex coordinate through distinct primitives. Pick the right
   not a new coordination plane, and fleet-comms/file handoffs remain durable
   authority.
 - Never run a polling loop to check a background task — use `Monitor` or the bash `run_in_background` completion notification.
+- A local service that must intentionally outlive its launching task needs the
+  [detached-session contract](runbooks/background-session-tasks.md); do not
+  weaken process-group cleanup or keep its state in task `$TMPDIR`.
 
 ### Channel bridge — preferred for multi-turn
 

--- a/docs/runbooks/background-session-tasks.md
+++ b/docs/runbooks/background-session-tasks.md
@@ -36,13 +36,13 @@ SERVICE_PID="$SERVICE_ROOT/local-teacher.pid"
   -- /bin/bash "$SERVICE_ROOT/start-local-teacher.sh"
 ```
 
-The command prints the detached PID after the new session is established and
-writes the same PID atomically to `--pid-file`. It redirects standard input to
-`/dev/null`, appends both output streams to `--log-file`, removes task-scoped
-temporary-directory and session-lease variables, resets inherited signal state,
-and closes inherited file descriptors. Do not use a `TemporaryDirectory` owned
-by the launching task for the service database, invite state, logs, PID file, or
-working directory.
+The command prints the detached PID only after the new session has successfully
+executed the command, then writes the same PID atomically to `--pid-file`. It
+redirects standard input to `/dev/null`, appends both output streams to
+`--log-file`, removes task-scoped temporary-directory and session-lease
+variables, resets inherited signal state, and closes inherited file descriptors.
+Do not use a `TemporaryDirectory` owned by the launching task for the service
+database, invite state, logs, PID file, or working directory.
 
 The helper refuses to replace a PID file that names a live process. Verify
 readiness using the service's normal health endpoint or its explicit completion

--- a/docs/runbooks/background-session-tasks.md
+++ b/docs/runbooks/background-session-tasks.md
@@ -1,0 +1,64 @@
+# Intentional background session tasks
+
+Use this pattern only for an operator-owned local service that must outlive the
+agent task that launches it: for example, a local teacher app or a deliberately
+long-lived diagnostic loop. Ordinary builds, reviews, and `delegate.py wait`
+remain harness background tasks and must end with their task.
+
+## Why detachment is required
+
+The dispatch runtime gives each agent invocation a fresh process group. On a
+timeout, cancellation, or runner exception, it kills that group so CLI children
+cannot leak. The runtime-temp orphan sweep is directory-only: it removes only
+dispatcher-owned task leases and never sends a process signal. It must remain
+strict.
+
+An intentional child that stays in the invocation's group can therefore be
+killed together with the invocation, even when no driver issued `TaskStop` for
+that child. The supported escape is a deliberate double-fork plus `setsid`, not
+weakening the orphan cleanup.
+
+## Launch contract
+
+Run the helper from a dispatch worktree or the operator's shell. All three
+lifecycle paths are required and must be outside a dispatch task's `$TMPDIR`:
+
+```bash
+SERVICE_ROOT="/path/to/durable/local-teacher"
+SERVICE_LOG="$SERVICE_ROOT/local-teacher.log"
+SERVICE_PID="$SERVICE_ROOT/local-teacher.pid"
+
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python \
+  scripts/tools/detach_session_task.py \
+  --workdir "$SERVICE_ROOT" \
+  --log-file "$SERVICE_LOG" \
+  --pid-file "$SERVICE_PID" \
+  -- /bin/bash "$SERVICE_ROOT/start-local-teacher.sh"
+```
+
+The command prints the detached PID after the new session is established and
+writes the same PID atomically to `--pid-file`. It redirects standard input to
+`/dev/null`, appends both output streams to `--log-file`, removes task-scoped
+temporary-directory and session-lease variables, resets inherited signal state,
+and closes inherited file descriptors. Do not use a `TemporaryDirectory` owned
+by the launching task for the service database, invite state, logs, PID file, or
+working directory.
+
+The helper refuses to replace a PID file that names a live process. Verify
+readiness using the service's normal health endpoint or its explicit completion
+notification; do not add a polling loop.
+
+## Stop contract
+
+Only stop the exact recorded service PID after checking it is the expected
+process. Remove a stale PID file only after proving the recorded PID is gone.
+
+```bash
+SERVICE_PID="/path/to/durable/local-teacher/local-teacher.pid"
+pid="$(tr -d '[:space:]' < "$SERVICE_PID")"
+ps -p "$pid" -o pid=,command=
+kill -TERM "$pid"
+```
+
+The detached service is intentionally outside harness lifecycle tracking. Its
+operator owns readiness, shutdown, logs, and durable state.

--- a/scripts/tools/detach_session_task.py
+++ b/scripts/tools/detach_session_task.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Launch an intentional local service outside an agent task's process group.
+
+This is deliberately not a general background-task runner.  It exists for
+operator-owned local services that must survive the completion or cancellation
+of the harness task that launched them.  The launcher double-forks and creates
+a new session, so a later process-group cleanup for the task cannot signal the
+service.  It requires explicit durable lifecycle paths: a working directory,
+an append-only log file, and a PID file for deliberate shutdown.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import resource
+import shutil
+import signal
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+_TASK_SCOPED_ENV_KEYS = frozenset(
+    {
+        "AGENT_NO_TELEMETRY_FOOTER",
+        "LU_RUNTIME_INITIATOR",
+        "LU_RUNTIME_INITIATOR_SOURCE",
+        "LU_RUNTIME_TMP_BASE_ROOT",
+        "LU_RUNTIME_TMP_ROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+    }
+)
+
+
+def _absolute_existing_directory(value: str) -> Path:
+    path = Path(value).expanduser().resolve(strict=True)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"not a directory: {path}")
+    return path
+
+
+def _absolute_output_path(value: str) -> Path:
+    path = Path(value).expanduser().resolve()
+    if not path.parent.is_dir():
+        raise argparse.ArgumentTypeError(f"parent directory does not exist: {path.parent}")
+    return path
+
+
+def _command_is_executable(command: Sequence[str]) -> bool:
+    executable = command[0]
+    if "/" in executable:
+        candidate = Path(executable)
+        return candidate.is_file() and os.access(candidate, os.X_OK)
+    return shutil.which(executable) is not None
+
+
+def _pid_is_live(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _refuse_live_pid_file(path: Path) -> None:
+    try:
+        recorded = int(path.read_text(encoding="ascii").strip())
+    except FileNotFoundError:
+        return
+    except (OSError, ValueError):
+        return
+    if recorded > 0 and _pid_is_live(recorded):
+        raise RuntimeError(f"refusing to replace live service PID file: {path}")
+
+
+def _write_pid_file(path: Path, pid: int) -> None:
+    _refuse_live_pid_file(path)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    temporary_path = Path(temporary)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="ascii") as handle:
+            handle.write(f"{pid}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _sanitize_environment() -> None:
+    for key in tuple(os.environ):
+        if key in _TASK_SCOPED_ENV_KEYS or key.startswith("SESSION_STREAM_"):
+            os.environ.pop(key, None)
+
+
+def _reset_signal_state() -> None:
+    if hasattr(signal, "pthread_sigmask"):
+        signal.pthread_sigmask(signal.SIG_SETMASK, set())
+    for signum in signal.valid_signals():
+        if signum in {signal.SIGKILL, signal.SIGSTOP}:
+            continue
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+        except (OSError, RuntimeError, ValueError):
+            continue
+
+
+def _close_inherited_fds(*, preserve: int) -> None:
+    maximum, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    upper_bound = 65_536 if maximum == resource.RLIM_INFINITY else min(maximum, 65_536)
+    for descriptor in range(3, int(upper_bound)):
+        if descriptor != preserve:
+            try:
+                os.close(descriptor)
+            except OSError:
+                continue
+
+
+def _redirect_standard_streams(log_file: Path) -> None:
+    stdin = os.open(os.devnull, os.O_RDONLY)
+    log = os.open(log_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.dup2(stdin, 0)
+        os.dup2(log, 1)
+        os.dup2(log, 2)
+    finally:
+        if stdin > 2:
+            os.close(stdin)
+        if log > 2:
+            os.close(log)
+
+
+def _send_status(descriptor: int, message: str) -> None:
+    try:
+        os.write(descriptor, message.encode("ascii", errors="replace")[:512])
+    finally:
+        os.close(descriptor)
+
+
+def _detach(
+    *,
+    command: Sequence[str],
+    workdir: Path,
+    log_file: Path,
+    pid_file: Path,
+) -> int:
+    read_fd, write_fd = os.pipe()
+    try:
+        first_child = os.fork()
+    except OSError:
+        os.close(read_fd)
+        os.close(write_fd)
+        raise
+
+    if first_child:
+        os.close(write_fd)
+        try:
+            payload = os.read(read_fd, 512).decode("ascii", errors="replace").strip()
+        finally:
+            os.close(read_fd)
+        _pid, status = os.waitpid(first_child, 0)
+        if not payload.startswith("OK ") or not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 0:
+            raise RuntimeError(payload.removeprefix("ERROR ") or "detached child setup failed")
+        try:
+            grandchild_pid = int(payload.removeprefix("OK "))
+        except ValueError as exc:
+            raise RuntimeError("detached child returned an invalid PID") from exc
+        try:
+            _write_pid_file(pid_file, grandchild_pid)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.kill(grandchild_pid, signal.SIGTERM)
+            raise
+        return grandchild_pid
+
+    os.close(read_fd)
+    try:
+        os.setsid()
+        grandchild = os.fork()
+        if grandchild:
+            os._exit(0)
+
+        _sanitize_environment()
+        os.chdir(workdir)
+        os.umask(0o022)
+        _reset_signal_state()
+        _close_inherited_fds(preserve=write_fd)
+        _redirect_standard_streams(log_file)
+    except BaseException as exc:
+        _send_status(write_fd, f"ERROR {type(exc).__name__}: {exc}")
+        os._exit(1)
+    _send_status(write_fd, f"OK {os.getpid()}")
+    try:
+        os.execvp(command[0], list(command))
+    except BaseException as exc:
+        print(f"detach exec failed: {type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+        os._exit(127)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workdir", required=True, type=_absolute_existing_directory)
+    parser.add_argument("--log-file", required=True, type=_absolute_output_path)
+    parser.add_argument("--pid-file", required=True, type=_absolute_output_path)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise SystemExit("a command is required after --")
+    if not _command_is_executable(command):
+        raise SystemExit(f"command is not executable: {command[0]}")
+    try:
+        _refuse_live_pid_file(args.pid_file)
+        pid = _detach(
+            command=command,
+            workdir=args.workdir,
+            log_file=args.log_file,
+            pid_file=args.pid_file,
+        )
+    except (OSError, RuntimeError) as exc:
+        raise SystemExit(f"detach failed: {exc}") from exc
+    print(pid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/detach_session_task.py
+++ b/scripts/tools/detach_session_task.py
@@ -17,7 +17,6 @@ import os
 import resource
 import shutil
 import signal
-import sys
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -47,15 +46,24 @@ def _absolute_output_path(value: str) -> Path:
     path = Path(value).expanduser().resolve()
     if not path.parent.is_dir():
         raise argparse.ArgumentTypeError(f"parent directory does not exist: {path.parent}")
+    if path.is_dir():
+        raise argparse.ArgumentTypeError(f"output path is a directory: {path}")
     return path
 
 
-def _command_is_executable(command: Sequence[str]) -> bool:
+def _resolve_executable(command: Sequence[str]) -> list[str] | None:
     executable = command[0]
     if "/" in executable:
-        candidate = Path(executable)
-        return candidate.is_file() and os.access(candidate, os.X_OK)
-    return shutil.which(executable) is not None
+        candidate = Path(executable).expanduser()
+    else:
+        located = shutil.which(executable)
+        if located is None:
+            return None
+        candidate = Path(located)
+    candidate = candidate.resolve()
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
+        return None
+    return [str(candidate), *command[1:]]
 
 
 def _pid_is_live(pid: int) -> bool:
@@ -154,6 +162,9 @@ def _detach(
 ) -> int:
     read_fd, write_fd = os.pipe()
     try:
+        # The successful exec closes this acknowledgement descriptor.  The
+        # parent therefore does not report a PID until it has observed EOF.
+        os.set_inheritable(write_fd, False)
         first_child = os.fork()
     except OSError:
         os.close(read_fd)
@@ -163,14 +174,25 @@ def _detach(
     if first_child:
         os.close(write_fd)
         try:
-            payload = os.read(read_fd, 512).decode("ascii", errors="replace").strip()
+            chunks = []
+            while chunk := os.read(read_fd, 512):
+                chunks.append(chunk)
+            payload = b"".join(chunks).decode("ascii", errors="replace").strip()
         finally:
             os.close(read_fd)
         _pid, status = os.waitpid(first_child, 0)
-        if not payload.startswith("OK ") or not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 0:
+        if not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 0:
             raise RuntimeError(payload.removeprefix("ERROR ") or "detached child setup failed")
+        records = payload.splitlines()
+        if not records:
+            raise RuntimeError("detached child setup failed")
+        pid_record, *errors = records
+        if pid_record.startswith("ERROR "):
+            raise RuntimeError(pid_record.removeprefix("ERROR "))
+        if errors and errors[0].startswith("ERROR "):
+            raise RuntimeError(errors[0].removeprefix("ERROR "))
         try:
-            grandchild_pid = int(payload.removeprefix("OK "))
+            grandchild_pid = int(pid_record.removeprefix("PID "))
         except ValueError as exc:
             raise RuntimeError("detached child returned an invalid PID") from exc
         try:
@@ -194,14 +216,10 @@ def _detach(
         _reset_signal_state()
         _close_inherited_fds(preserve=write_fd)
         _redirect_standard_streams(log_file)
-    except BaseException as exc:
-        _send_status(write_fd, f"ERROR {type(exc).__name__}: {exc}")
-        os._exit(1)
-    _send_status(write_fd, f"OK {os.getpid()}")
-    try:
+        os.write(write_fd, f"PID {os.getpid()}\n".encode("ascii"))
         os.execvp(command[0], list(command))
     except BaseException as exc:
-        print(f"detach exec failed: {type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+        _send_status(write_fd, f"ERROR {type(exc).__name__}: {exc}")
         os._exit(127)
 
 
@@ -221,12 +239,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         command = command[1:]
     if not command:
         raise SystemExit("a command is required after --")
-    if not _command_is_executable(command):
+    resolved_command = _resolve_executable(command)
+    if resolved_command is None:
         raise SystemExit(f"command is not executable: {command[0]}")
     try:
         _refuse_live_pid_file(args.pid_file)
         pid = _detach(
-            command=command,
+            command=resolved_command,
             workdir=args.workdir,
             log_file=args.log_file,
             pid_file=args.pid_file,

--- a/tests/test_detach_session_task.py
+++ b/tests/test_detach_session_task.py
@@ -1,0 +1,124 @@
+"""Regression coverage for intentional background-session detachment."""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts.tools import detach_session_task
+
+
+def _wait_for_text(path: Path, expected: str) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists() and expected in path.read_text(encoding="utf-8"):
+            return
+        time.sleep(0.02)
+    pytest.fail(f"{path} did not contain {expected!r}")
+
+
+def _stop_process(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.02)
+    os.kill(pid, signal.SIGKILL)
+
+
+def test_detach_creates_independent_session_and_redirects_logs(tmp_path: Path, capsys) -> None:
+    log_file = tmp_path / "service.log"
+    pid_file = tmp_path / "service.pid"
+    ready_file = tmp_path / "ready"
+
+    result = detach_session_task.main(
+        [
+            "--workdir",
+            str(tmp_path),
+            "--log-file",
+            str(log_file),
+            "--pid-file",
+            str(pid_file),
+            "--",
+            "/bin/sh",
+            "-c",
+            f"printf ready > {ready_file}; printf stdout; printf stderr >&2; exec sleep 60",
+        ]
+    )
+
+    assert result == 0
+    pid = int(capsys.readouterr().out.strip())
+    try:
+        assert int(pid_file.read_text(encoding="ascii").strip()) == pid
+        assert os.getsid(pid) != os.getsid(0)
+        assert os.getpgid(pid) != os.getpgid(0)
+        _wait_for_text(ready_file, "ready")
+        _wait_for_text(log_file, "stdout")
+        _wait_for_text(log_file, "stderr")
+    finally:
+        _stop_process(pid)
+
+
+def test_detach_strips_task_scoped_tmpdir(tmp_path: Path, capsys, monkeypatch) -> None:
+    log_file = tmp_path / "service.log"
+    pid_file = tmp_path / "service.pid"
+    observed = tmp_path / "tmpdir.txt"
+    task_tmp = tmp_path / "task-tmp"
+    task_tmp.mkdir()
+    monkeypatch.setenv("TMPDIR", str(task_tmp))
+    monkeypatch.setenv("LU_RUNTIME_TMP_ROOT", str(task_tmp))
+
+    result = detach_session_task.main(
+        [
+            "--workdir",
+            str(tmp_path),
+            "--log-file",
+            str(log_file),
+            "--pid-file",
+            str(pid_file),
+            "--",
+            "/bin/sh",
+            "-c",
+            f"printf '%s' \"${{TMPDIR-unset}}\" > {observed}; exec sleep 60",
+        ]
+    )
+
+    assert result == 0
+    pid = int(capsys.readouterr().out.strip())
+    try:
+        _wait_for_text(observed, "unset")
+        assert observed.read_text(encoding="utf-8") == "unset"
+    finally:
+        _stop_process(pid)
+
+
+def test_detach_refuses_to_replace_a_live_service_pid_file(tmp_path: Path) -> None:
+    log_file = tmp_path / "service.log"
+    pid_file = tmp_path / "service.pid"
+    pid_file.write_text(f"{os.getpid()}\n", encoding="ascii")
+
+    with pytest.raises(SystemExit, match="refusing to replace live service PID file"):
+        detach_session_task.main(
+            [
+                "--workdir",
+                str(tmp_path),
+                "--log-file",
+                str(log_file),
+                "--pid-file",
+                str(pid_file),
+                "--",
+                "/bin/sh",
+                "-c",
+                "exec sleep 60",
+            ]
+        )

--- a/tests/test_detach_session_task.py
+++ b/tests/test_detach_session_task.py
@@ -102,6 +102,84 @@ def test_detach_strips_task_scoped_tmpdir(tmp_path: Path, capsys, monkeypatch) -
         _stop_process(pid)
 
 
+def test_detach_resolves_a_relative_command_before_chdir(tmp_path: Path, capsys, monkeypatch) -> None:
+    command_dir = tmp_path / "command"
+    command_dir.mkdir()
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    observed = tmp_path / "observed"
+    command = command_dir / "service"
+    command.write_text(
+        f"#!/bin/sh\nprintf '%s' \"$PWD\" > {observed}\nexec sleep 60\n",
+        encoding="utf-8",
+    )
+    command.chmod(0o700)
+    monkeypatch.chdir(command_dir)
+
+    result = detach_session_task.main(
+        [
+            "--workdir",
+            str(workdir),
+            "--log-file",
+            str(tmp_path / "service.log"),
+            "--pid-file",
+            str(tmp_path / "service.pid"),
+            "--",
+            "./service",
+        ]
+    )
+
+    assert result == 0
+    pid = int(capsys.readouterr().out.strip())
+    try:
+        _wait_for_text(observed, str(workdir))
+        assert observed.read_text(encoding="utf-8") == str(workdir)
+    finally:
+        _stop_process(pid)
+
+
+def test_detach_does_not_report_a_pid_when_exec_fails(tmp_path: Path, capsys) -> None:
+    log_file = tmp_path / "service.log"
+    pid_file = tmp_path / "service.pid"
+    broken_command = tmp_path / "broken-command"
+    broken_command.write_text("#!/not/a/real/interpreter\n", encoding="utf-8")
+    broken_command.chmod(0o700)
+
+    with pytest.raises(SystemExit, match="detach failed: FileNotFoundError"):
+        detach_session_task.main(
+            [
+                "--workdir",
+                str(tmp_path),
+                "--log-file",
+                str(log_file),
+                "--pid-file",
+                str(pid_file),
+                "--",
+                str(broken_command),
+            ]
+        )
+
+    assert capsys.readouterr().out == ""
+    assert not pid_file.exists()
+
+
+@pytest.mark.parametrize("option", ["--log-file", "--pid-file"])
+def test_detach_rejects_directory_output_paths(tmp_path: Path, option: str) -> None:
+    parser = detach_session_task.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--workdir",
+                str(tmp_path),
+                option,
+                str(tmp_path),
+                "--log-file" if option == "--pid-file" else "--pid-file",
+                str(tmp_path / "output"),
+            ]
+        )
+
+
 def test_detach_refuses_to_replace_a_live_service_pid_file(tmp_path: Path) -> None:
     log_file = tmp_path / "service.log"
     pid_file = tmp_path / "service.pid"


### PR DESCRIPTION
## Summary
- add a double-fork plus `setsid` helper for intentional operator-owned local services
- keep orphan/process-group cleanup strict while isolating opted-in services from task-scoped state
- document launch, readiness, and exact-PID shutdown contracts

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_detach_session_task.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/tools/detach_session_task.py tests/test_detach_session_task.py`
- `node_modules/.bin/markdownlint-cli2 docs/SCRIPTS.md docs/runbooks/background-session-tasks.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

Fixes #5929