### PR TITLE
test(ci): bound remaining subprocess calls and guard (#5740)

### DIFF
--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -871,7 +871,7 @@ with _discussion_admission(Path(sys.argv[1])):
     completed = subprocess.run(
         [str(python), "-c", code, str(root)],
         cwd=repo_root,
-        check=False,
+        check=False, timeout=30,
     )
 
     assert completed.returncode == 17

--- a/tests/ai_agent_bridge/test_acp_execution.py
+++ b/tests/ai_agent_bridge/test_acp_execution.py
@@ -14,7 +14,7 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         ["git", "-C", str(repo), *args],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
 
 

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -70,7 +70,7 @@ def test_api_child_disables_bytecode_writes(tmp_path: Path, monkeypatch) -> None
         env=environment,
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
     assert json.loads(inherited.stdout) == {"env": "1", "dont_write": True}
 

--- a/tests/api/test_release_snapshot.py
+++ b/tests/api/test_release_snapshot.py
@@ -30,7 +30,7 @@ def _run_git(repo_root: Path, *args: str) -> str:
         capture_output=True,
         check=True,
         env=sanitized_git_env(),
-        text=True,
+        text=True, timeout=30,
     )
     return result.stdout.strip()
 
@@ -42,7 +42,7 @@ def _release_test_sha(repo_root: Path) -> str:
         ["git", "diff", "--cached", "--quiet", "HEAD", "--", "scripts", "schemas"],
         cwd=repo_root,
         check=False,
-        env=sanitized_git_env(),
+        env=sanitized_git_env(), timeout=30,
     )
     if staged.returncode == 0:
         return head
@@ -65,7 +65,7 @@ def _release_test_sha(repo_root: Path) -> str:
         check=True,
         env=environment,
         input="release snapshot staged test\n",
-        text=True,
+        text=True, timeout=30,
     )
     return result.stdout.strip()
 
@@ -245,7 +245,7 @@ def test_git_service_environment_targets_live_checkout(tmp_path: Path) -> None:
         env=environment,
         capture_output=True,
         check=True,
-        text=True,
+        text=True, timeout=30,
     )
     assert "?? live-only.txt" in result.stdout
 

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -202,7 +202,7 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
             capture_output=True,
             text=True,
             cwd=str(PROJECT_ROOT),
-            env=env
+            env=env, timeout=30
         )
 
         assert "WARNING: pid file mismatch" in res.stderr or "WARNING: pid file mismatch" in res.stdout, f"mismatch check failed. returncode={res.returncode}\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
@@ -216,7 +216,7 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
             capture_output=True,
             text=True,
             cwd=str(PROJECT_ROOT),
-            env=env
+            env=env, timeout=30
         )
         assert res_stop.returncode == 0, f"stop failed. returncode={res_stop.returncode}\nstdout:\n{res_stop.stdout}\nstderr:\n{res_stop.stderr}"
         proc.wait(timeout=5)
@@ -225,7 +225,7 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
     finally:
         if proc.poll() is None:
             proc.terminate()
-            proc.wait()
+            proc.wait(timeout=5)
 
     # Scenario B: stale pid file + NO listener -> the removal path CI observed
     api_pid_file.write_text("999999\n", encoding="utf-8")
@@ -236,7 +236,7 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
         capture_output=True,
         text=True,
         cwd=str(PROJECT_ROOT),
-        env=env
+        env=env, timeout=30
     )
     assert "removing stale pid file" in res.stderr or "removing stale pid file" in res.stdout, f"stale pid check failed. returncode={res.returncode}\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
     assert not api_pid_file.exists()
@@ -250,7 +250,7 @@ def test_api_start_delegates_recovery_to_launchd(temp_services_sh, mock_lsof_env
         capture_output=True,
         text=True,
         cwd=str(PROJECT_ROOT),
-        env=env
+        env=env, timeout=30
     )
 
     assert res.returncode == 0, res.stderr
@@ -272,7 +272,7 @@ def test_live_fallback_is_passed_to_launchd_with_a_loud_warning(temp_services_sh
         capture_output=True,
         text=True,
         cwd=str(PROJECT_ROOT),
-        env=env,
+        env=env, timeout=30,
     )
     assert result.returncode == 0, result.stderr
     assert "WARNING: API live mode enabled" in result.stderr
@@ -304,7 +304,7 @@ def test_stop_disables_supervision_before_killing_api_listener(temp_services_sh,
             capture_output=True,
             text=True,
             cwd=str(PROJECT_ROOT),
-            env=env
+            env=env, timeout=30
         )
         assert res_stop.returncode == 0, f"stop failed. returncode={res_stop.returncode}\nstdout:\n{res_stop.stdout}\nstderr:\n{res_stop.stderr}"
         assert Path(env["SVC_API_SUPERVISOR_CAPTURE"]).read_text(encoding="utf-8").splitlines() == ["stop"]
@@ -312,9 +312,9 @@ def test_stop_disables_supervision_before_killing_api_listener(temp_services_sh,
     finally:
         if proc.poll() is None:
             proc.terminate()
-            proc.wait()
+            proc.wait(timeout=5)
         # Clean up any started background processes from the start command
-        subprocess.run([str(script_path), "stop", "api"], capture_output=True, cwd=str(PROJECT_ROOT), env=env)
+        subprocess.run([str(script_path), "stop", "api"], capture_output=True, cwd=str(PROJECT_ROOT), env=env, timeout=30)
 
 @pytest.mark.skipif(
     shutil.which("lsof") is None or sys.platform != "darwin",
@@ -360,7 +360,7 @@ def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
             capture_output=True,
             text=True,
             cwd=str(PROJECT_ROOT),
-            env=env,
+            env=env, timeout=30,
         )
 
         assert "WARNING: pid file mismatch" in res.stderr or "WARNING: pid file mismatch" in res.stdout
@@ -374,7 +374,7 @@ def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
             capture_output=True,
             text=True,
             cwd=str(PROJECT_ROOT),
-            env=env,
+            env=env, timeout=30,
         )
 
         # Verify the dummy process was killed
@@ -385,4 +385,4 @@ def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
     finally:
         if proc.poll() is None:
             proc.terminate()
-            proc.wait()
+            proc.wait(timeout=5)

--- a/tests/audit/test_certify_module.py
+++ b/tests/audit/test_certify_module.py
@@ -18,7 +18,7 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         check=True,
         capture_output=True,
         env=env,
-        text=True,
+        text=True, timeout=30,
     )
 
 

--- a/tests/build/test_v7_build_resume.py
+++ b/tests/build/test_v7_build_resume.py
@@ -79,7 +79,7 @@ def _git(cwd: Path, *args: str) -> None:
         ["git", "-C", str(cwd), *args],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
 
 

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -24,7 +24,7 @@ def _git(cwd: Path, *args: str) -> str:
         capture_output=True,
         text=True,
         check=True,
-        env=env,
+        env=env, timeout=30,
     )
     return proc.stdout.strip()
 

--- a/tests/test_backup_data_script.py
+++ b/tests/test_backup_data_script.py
@@ -62,10 +62,10 @@ def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path
         '{"schema_version": 1}\n',
         encoding="utf-8",
     )
-    subprocess.run(["git", "init", "-q", str(project)], check=True)
+    subprocess.run(["git", "init", "-q", str(project)], check=True, timeout=30)
     subprocess.run(
         ["git", "-C", str(project), "add", "README.md", ".gitignore"],
-        check=True,
+        check=True, timeout=30,
     )
     subprocess.run(
         [
@@ -80,7 +80,7 @@ def backup_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path
             "-qm",
             "test fixture",
         ],
-        check=True,
+        check=True, timeout=30,
     )
     password_file.write_text("test-only-password\n", encoding="utf-8")
     password_file.chmod(0o600)
@@ -207,7 +207,7 @@ def _run(
         check=False,
         capture_output=True,
         env=environment,
-        text=True,
+        text=True, timeout=30,
     )
 
 

--- a/tests/test_ci_attribution.py
+++ b/tests/test_ci_attribution.py
@@ -67,7 +67,7 @@ def test_breadcrumb_subprocess_pytest_run(tmp_path: Path) -> None:
             "-o",
             f"cache_dir={tmp_path / '.pytest_cache'}",
         ]
-        res = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, cwd=str(repo_root))
+        res = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, cwd=str(repo_root), timeout=30)
         assert res.returncode == 0, f"stdout: {res.stdout}\nstderr: {res.stderr}"
 
         breadcrumb_file = bdir / "breadcrumb_gw1.txt"

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -26,7 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PRIMARY_ROOT = Path(
     subprocess.check_output(
         ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        text=True,
+        text=True, timeout=30,
     ).strip()
 ).parent
 HOOKS_CONFIG = REPO_ROOT / "agents_extensions" / "codex" / "hooks.json"

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -805,7 +805,7 @@ def test_dashboard_routing_html_renders_unavailable_explicitly():
 
     console.log(innerHTML);
     """
-    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
     out = res.stdout
     assert "0.0%" not in out, f"Dashboard rendered 0.0% for unavailable state: {out}"
     assert "style=\"width:0%\"" not in out, f"Dashboard rendered 0-width bar for unavailable state: {out}"

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -3844,10 +3844,10 @@ def test_branch_reuse_real_worktree_head_matches_fetched_origin(tmp_tasks_dir, t
             check=True,
             capture_output=True,
             text=True,
-            env=env,
+            env=env, timeout=30,
         )
 
-    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, env=env)
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, env=env, timeout=30)
     source.mkdir()
     git(source, "init", "-b", "main")
     git(source, "config", "user.email", "test@example.com")
@@ -3859,7 +3859,7 @@ def test_branch_reuse_real_worktree_head_matches_fetched_origin(tmp_tasks_dir, t
     git(source, "switch", "-c", "claude/predeploy-visibility")
     git(source, "commit", "--allow-empty", "-m", "remote branch head")
     git(source, "push", "-u", "origin", "claude/predeploy-visibility")
-    subprocess.run(["git", "clone", str(remote), str(client)], check=True, capture_output=True, env=env)
+    subprocess.run(["git", "clone", str(remote), str(client)], check=True, capture_output=True, env=env, timeout=30)
     git(client, "branch", "claude/predeploy-visibility", "origin/main")
 
     monkeypatch.setattr(delegate, "_REPO_ROOT", client.resolve())

--- a/tests/test_entire_context_live.py
+++ b/tests/test_entire_context_live.py
@@ -35,7 +35,7 @@ def _run_git(repo: Path, *args: str) -> str:
         ["git", "-C", str(repo), *args],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
     return completed.stdout.strip()
 

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -108,7 +108,7 @@ def git(repo: Path, *args: str) -> str:
         ["git", "-C", str(repo), *args],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
     return completed.stdout.strip()
 

--- a/tests/test_fleet_hramatka_hygiene_check.py
+++ b/tests/test_fleet_hramatka_hygiene_check.py
@@ -32,7 +32,7 @@ CLEAN_BODY = (
 
 
 def _run(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=check)
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=check, timeout=30)
 
 
 def _init_repo(repo_root: Path) -> None:
@@ -294,7 +294,7 @@ def test_zombie_detection_not_detectable_when_git_worktree_list_fails(hermetic_r
     def fake_run(args, **kwargs):
         if args[:2] == ["git", "worktree"]:
             return subprocess.CompletedProcess(args, 1, stdout="", stderr="boom")
-        return subprocess.run(args, **kwargs)
+        return subprocess.run(args, timeout=30, **kwargs)
 
     monkeypatch.setattr(hygiene.subprocess, "run", fake_run)
 

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -66,7 +66,7 @@ def _run(args: list[str], cwd: Path, check: bool = True) -> subprocess.Completed
         cwd=cwd,
         capture_output=True,
         text=True,
-        check=check,
+        check=check, timeout=30,
     )
 
 

--- a/tests/test_git_shim_guard.py
+++ b/tests/test_git_shim_guard.py
@@ -58,7 +58,7 @@ def shim_fixture(tmp_path: Path) -> dict[str, Path]:
     subprocess.run(
         ["git", "init", "-q", str(workdir)],
         check=True,
-        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin", "HOME": str(tmp_path)},
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin", "HOME": str(tmp_path)}, timeout=30,
     )
 
     return {"shim": shim_copy, "workdir": workdir, "log": tmp_path / ".venv" / "guard-invocations.log"}

--- a/tests/test_health_20k_runner.py
+++ b/tests/test_health_20k_runner.py
@@ -17,7 +17,7 @@ def _run_probe(*, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         env={**os.environ, **env},
         capture_output=True,
         text=True,
-        check=False,
+        check=False, timeout=30,
     )
 
 

--- a/tests/test_makefile_practice_admit.py
+++ b/tests/test_makefile_practice_admit.py
@@ -14,7 +14,7 @@ def test_curated_admit_dry_run_consumes_only_the_local_practice_overlay() -> Non
         cwd=ROOT,
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
 
     output = result.stdout
@@ -34,7 +34,7 @@ def test_gold_slice_dry_run_uses_bounded_local_static_shards_without_cloze() -> 
         cwd=ROOT,
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
 
     output = result.stdout

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -275,7 +275,7 @@ def test_acp_page_groups_duplicate_fanout_and_keeps_protocol_order():
       withoutSynthesis: groupTranscript(messages.filter(message => message.kind !== 'synthesis'))
     }}));
     """
-    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
     output = json.loads(result.stdout)
     grouped = output["grouped"]
 

--- a/tests/test_open_model_phase3_audit_entropy.py
+++ b/tests/test_open_model_phase3_audit_entropy.py
@@ -17,7 +17,7 @@ from scripts.projects.open_model_data import phase3_functional_roles as function
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.run(
-        ["git", "-C", str(repo), *args], check=True, stdout=subprocess.PIPE, text=True,
+        ["git", "-C", str(repo), *args], check=True, stdout=subprocess.PIPE, text=True, timeout=30,
     ).stdout.strip()
 
 

--- a/tests/test_open_model_phase3_disposition_audit.py
+++ b/tests/test_open_model_phase3_disposition_audit.py
@@ -260,7 +260,7 @@ def test_entropy_receipt_rejects_every_alternative_derivation(frozen: tuple[dict
 
 
 def _git_run(repo: Any, *arguments: str) -> str:
-    return subprocess.run(["git", "-C", str(repo), *arguments], check=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run(["git", "-C", str(repo), *arguments], check=True, capture_output=True, text=True, timeout=30).stdout.strip()
 
 
 @pytest.mark.parametrize("subject, accepted", [("feat: land freeze (#123)", True), ("feat: manual landing", False)])

--- a/tests/test_open_model_phase3_evaluation_reproduction.py
+++ b/tests/test_open_model_phase3_evaluation_reproduction.py
@@ -51,7 +51,7 @@ def _action(
 
 def _run_git(*args: str, cwd: Path) -> str:
     return subprocess.run(
-        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True, timeout=30
     ).stdout.strip()
 
 

--- a/tests/test_open_model_phase3_rule_author_packets.py
+++ b/tests/test_open_model_phase3_rule_author_packets.py
@@ -770,7 +770,7 @@ def test_cli_synthetic_build_and_verify_smoke(tmp_path: Path) -> None:
         cwd=packets.ROOT,
         check=False,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
     assert build.returncode == 0, build.stdout
     verify = subprocess.run(
@@ -797,7 +797,7 @@ def test_cli_synthetic_build_and_verify_smoke(tmp_path: Path) -> None:
         cwd=packets.ROOT,
         check=False,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     )
     assert verify.returncode == 0, verify.stdout
     assert json.loads(verify.stdout)["ok"] is True

--- a/tests/test_open_model_phase3_source_universe_freeze_validator.py
+++ b/tests/test_open_model_phase3_source_universe_freeze_validator.py
@@ -25,7 +25,7 @@ def _script_binding() -> tuple[str, str]:
         ["git", "-C", str(verifier.ROOT), "rev-parse", "origin/main"],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     ).stdout.strip()
     script = subprocess.run(
         [
@@ -33,7 +33,7 @@ def _script_binding() -> tuple[str, str]:
             f"{merged_main_sha}:scripts/projects/open_model_data/phase3_source_universe.py",
         ],
         check=True,
-        capture_output=True,
+        capture_output=True, timeout=30,
     ).stdout
     return merged_main_sha, verifier.sha256_bytes(script)
 

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -104,7 +104,7 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         check=True,
         capture_output=True,
         text=True,
-        env=_clean_git_env(),
+        env=_clean_git_env(), timeout=30,
     )
 
 
@@ -116,7 +116,7 @@ def _init_orient_git_repo(tmp_path: Path) -> Path:
         check=True,
         capture_output=True,
         text=True,
-        env=_clean_git_env(),
+        env=_clean_git_env(), timeout=30,
     )
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test")

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -20,7 +20,7 @@ GIT_COMMON_DIR = Path(
         capture_output=True,
         check=True,
         cwd=REPO_ROOT,
-        text=True,
+        text=True, timeout=30,
     ).stdout.strip()
 )
 if not GIT_COMMON_DIR.is_absolute():

--- a/tests/test_preparation_api.py
+++ b/tests/test_preparation_api.py
@@ -47,7 +47,7 @@ def _git(repo: Path, *args: str) -> str:
         check=True,
         capture_output=True,
         text=True,
-        env=_git_env(),
+        env=_git_env(), timeout=30,
     )
     return result.stdout.strip()
 
@@ -59,7 +59,7 @@ def _repo(path: Path, *, remote: str) -> Path:
         check=True,
         capture_output=True,
         text=True,
-        env=_git_env(),
+        env=_git_env(), timeout=30,
     )
     _git(path, "config", "user.email", "test@example.com")
     _git(path, "config", "user.name", "Test")

--- a/tests/test_rag_ingestion.py
+++ b/tests/test_rag_ingestion.py
@@ -474,7 +474,7 @@ class TestTextbookExtractionReadiness:
         rendered = subprocess.run(
             ["cupsfilter", "-m", "application/pdf", str(source)],
             check=True,
-            capture_output=True,
+            capture_output=True, timeout=30,
         )
         pdf.write_bytes(rendered.stdout)
 
@@ -492,7 +492,7 @@ class TestTextbookExtractionReadiness:
             ],
             check=True,
             capture_output=True,
-            text=True,
+            text=True, timeout=30,
         )
         text = json.loads(completed.stdout)["pages"][0]["text"]
 

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -718,7 +718,7 @@ def test_direct_lookup_cli_handles_a_stop_action_without_stdout(tmp_path) -> Non
         ],
         capture_output=True,
         check=False,
-        text=True,
+        text=True, timeout=30,
     )
 
     assert completed.returncode == 0

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -145,7 +145,7 @@ def _git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         check=True,
         capture_output=True,
         text=True,
-        env=_git_fixture_env(),
+        env=_git_fixture_env(), timeout=30,
     )
 
 
@@ -865,7 +865,7 @@ def test_codex_parent_owned_sealed_reader_lists_reads_and_blocks_escape(
         input=requests + "\n",
         capture_output=True,
         text=True,
-        check=True,
+        check=True, timeout=30,
     )
     responses = [json.loads(line) for line in completed.stdout.splitlines()]
     assert {tool["name"] for tool in responses[1]["result"]["tools"]} == {
@@ -932,7 +932,7 @@ def test_sealed_reader_bounds_escaped_claude_tool_result(tmp_path: Path) -> None
         input=json.dumps(request) + "\n",
         capture_output=True,
         text=True,
-        check=True,
+        check=True, timeout=30,
     )
 
     response = json.loads(completed.stdout)
@@ -977,7 +977,7 @@ def test_codex_sealed_reader_returns_bounded_hash_bound_chunks(tmp_path: Path) -
         input=requests + "\n",
         capture_output=True,
         text=True,
-        check=True,
+        check=True, timeout=30,
     )
     payloads = [
         json.loads(json.loads(line)["result"]["content"][0]["text"])

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -28,7 +28,7 @@ def _canonical_python() -> Path:
         cwd=_REPO_ROOT,
         capture_output=True,
         check=True,
-        text=True,
+        text=True, timeout=30,
     )
     return Path(result.stdout.strip()).parent / ".venv" / "bin" / "python"
 

--- a/tests/test_subprocess_timeout_guard.py
+++ b/tests/test_subprocess_timeout_guard.py
@@ -1,0 +1,181 @@
+"""Anti-rot guard for #5740 — every test subprocess call must be bounded.
+
+Background: a timeout-less ``subprocess.*`` hang held a CI runner for 357 minutes
+(run ``30109965086``) because three guards were missing at once: call-site
+``timeout=``, job ``timeout-minutes``, and ``pytest-timeout``. Job caps landed in
+PR #5735; ``pytest-timeout`` is pinned in ``requirements*.txt`` and enforced via
+``pyproject.toml`` (``timeout = 120``, ``timeout_method = "thread"``) plus the
+CI pytest invocation. This module keeps the *call-site* fence from regrowing and
+proves a hang fails fast *and names the test*.
+
+``subprocess.Popen`` cannot take ``timeout=`` at construction; callers must bound
+``.wait()`` / ``.communicate()`` (or an equivalent deadline). The AST guard below
+covers ``run`` / ``check_output`` / ``call`` / ``check_call`` only.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+from tests.project_python import project_python
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+_BOUNDED_FUNCS = frozenset({"run", "check_output", "call", "check_call"})
+
+# Documented per-test budget (must stay aligned with pyproject + ci.yml).
+_EXPECTED_PYTEST_TIMEOUT_SECONDS = 120
+_EXPECTED_TIMEOUT_METHOD = "thread"
+
+
+def _subprocess_aliases(tree: ast.AST) -> dict[str, str | None]:
+    """Map local names to subprocess attrs (None => the module itself)."""
+    aliases: dict[str, str | None] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    aliases[alias.asname or "subprocess"] = None
+    return aliases
+
+
+def _timeout_less_calls(path: Path) -> list[tuple[int, str]]:
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(path))
+    aliases = _subprocess_aliases(tree)
+    found: list[tuple[int, str]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            name: str | None = None
+            if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+                base = node.func.value.id
+                if base in aliases and aliases[base] is None and node.func.attr in _BOUNDED_FUNCS:
+                    name = f"subprocess.{node.func.attr}"
+            elif isinstance(node.func, ast.Name) and node.func.id in aliases:
+                attr = aliases[node.func.id]
+                if attr in _BOUNDED_FUNCS:
+                    name = f"subprocess.{attr}"
+            if name is not None:
+                kwargs = {kw.arg for kw in node.keywords if kw.arg}
+                if "timeout" not in kwargs:
+                    found.append((node.lineno, name))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return found
+
+
+def test_pytest_timeout_budget_is_documented_in_pyproject() -> None:
+    """The 120s per-test budget must stay explicit in tool.pytest.ini_options."""
+    # Avoid importing tomllib only for this — pyproject is small; parse lightly.
+    text = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert "timeout = 120" in text or 'timeout = 120' in text
+    assert 'timeout_method = "thread"' in text or "timeout_method = 'thread'" in text
+    assert "pytest-timeout" in (_REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    lock = (_REPO_ROOT / "requirements-lock.txt").read_text(encoding="utf-8")
+    assert "pytest-timeout==" in lock
+
+
+def test_ci_pytest_invokes_timeout_flags() -> None:
+    ci = (_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "--timeout=120" in ci
+    assert "--timeout-method=thread" in ci
+
+
+def test_no_timeout_less_subprocess_calls_under_tests() -> None:
+    """Fail CI when a new ``subprocess.run``/``check_*``/``call`` lacks ``timeout=``."""
+    offenders: list[str] = []
+    for path in sorted(_TESTS_ROOT.rglob("*.py")):
+        if path.name == Path(__file__).name:
+            # This file deliberately constructs a hanging child; its own
+            # subprocess.run calls carry timeout=.
+            pass
+        try:
+            hits = _timeout_less_calls(path)
+        except SyntaxError as exc:
+            offenders.append(f"{path}: syntax error while scanning ({exc})")
+            continue
+        for lineno, name in hits:
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}:{lineno} {name}")
+
+    assert not offenders, (
+        "Timeout-less subprocess calls under tests/ (issue #5740). "
+        "Pass an explicit timeout= (typically 30 for git fixtures, 60–120 for "
+        "heavier scripts). Popen must bound wait()/communicate() instead.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_deliberately_hanging_test_is_named_by_pytest_timeout(tmp_path: Path) -> None:
+    """Prove pytest-timeout fails fast and names the hanging nodeid (#5740 AC).
+
+    Runs an isolated child pytest so the hang cannot stall this suite. The child
+    uses a 2-second budget; we allow a generous outer bound so flake from
+    process startup does not become another hang.
+    """
+    hang_dir = tmp_path / "hang_suite"
+    hang_dir.mkdir()
+    hang_test = hang_dir / "test_intentional_hang.py"
+    hang_test.write_text(
+        textwrap.dedent(
+            """\
+            import time
+
+            def test_intentional_forever_sleep():
+                time.sleep(3600)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PYTEST_") and key not in {"PYTEST_CURRENT_TEST", "PYTEST_ADDOPTS"}
+    }
+
+    completed = subprocess.run(
+        [
+            str(project_python()),
+            "-m",
+            "pytest",
+            str(hang_test),
+            "-p",
+            "no:xdist",
+            "-p",
+            "timeout",
+            "--timeout=2",
+            f"--timeout-method={_EXPECTED_TIMEOUT_METHOD}",
+            "-o",
+            "addopts=",
+            "-q",
+            "--tb=line",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode != 0, (
+        "hanging test must fail under pytest-timeout, not pass/skip:\n" + combined
+    )
+    assert "test_intentional_forever_sleep" in combined, (
+        "pytest-timeout must name the hanging test in its output "
+        f"(budget={_EXPECTED_PYTEST_TIMEOUT_SECONDS}s documented; child used 2s):\n"
+        + combined
+    )
+    # Either Failed: Timeout / +++ Timeout / Failed: Timeout >… depending on version.
+    assert "timeout" in combined.lower(), (
+        "expected a timeout failure signal in child pytest output:\n" + combined
+    )

--- a/tests/test_ua_eval_heldout_manifest.py
+++ b/tests/test_ua_eval_heldout_manifest.py
@@ -58,16 +58,16 @@ def _write_upstream(root: Path) -> str:
         + "\n",
         encoding="utf-8",
     )
-    subprocess.run(["git", "init", "-q", str(root)], check=True)
-    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
-    subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
-    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
-    subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True, timeout=30)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True, timeout=30)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True, timeout=30)
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True, timeout=30)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True, timeout=30)
     return subprocess.run(
         ["git", "-C", str(root), "rev-parse", "HEAD"],
         check=True,
         capture_output=True,
-        text=True,
+        text=True, timeout=30,
     ).stdout.strip()
 
 

--- a/tests/trails/test_rb2_rb5_v11.py
+++ b/tests/trails/test_rb2_rb5_v11.py
@@ -188,7 +188,7 @@ def _run_rb2_shell_step(
         env={**os.environ, **environment},
         check=False,
         text=True,
-        capture_output=True,
+        capture_output=True, timeout=30,
     )
 
 


### PR DESCRIPTION
## Summary
- Finish the #5740 call-site sweep: add explicit `timeout=` to the remaining timeout-less `subprocess.run` / `check_output` / `call` / `check_call` sites under `tests/` (66 sites across 35 files), and bound leftover `Popen.wait()` cleanups in `tests/api/test_services_ops.py`.
- Add `tests/test_subprocess_timeout_guard.py`: AST anti-rot guard (fails on reintroduction), asserts the documented 120s / `thread` budget in `pyproject.toml` + CI flags, and demonstrates that a deliberately hanging test fails fast **and is named** by `pytest-timeout`.
- `pytest-timeout` itself was already installed and enforced (`requirements*.txt`, `pyproject.toml` `timeout = 120` / `timeout_method = "thread"`, `ci.yml --timeout=120`); this PR closes the remaining acceptance criteria.

## Notes
- `subprocess.Popen` cannot take constructor `timeout=`; the guard covers the timeout-bearing APIs. Popen callers must bound `.wait()` / `.communicate()`.
- Companion to earlier partial batches (#5747 / #5748 / #5753) and job caps in #5735.

## Test plan
- [x] `pytest tests/test_subprocess_timeout_guard.py` — 4 passed (includes named hang demo)
- [x] Sample suite of rewritten files — 162 passed (1 unrelated env flake on session-setup Python version)
- [x] AST inventory: 0 remaining timeout-less `run`/`check_*`/`call` under `tests/`
- [x] `ruff check` on key edited files
- [ ] CI green on this PR

Refs #5740

Made with [Cursor](https://cursor.com)