### PR TITLE
fix(delegate): pin worker virtualenv

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1943,6 +1943,47 @@ def _sanitized_git_env() -> dict[str, str]:
     }
 
 
+def _is_virtualenv_bin_path(entry: str) -> bool:
+    """Return whether a PATH entry is a conventional Python virtualenv bin."""
+    path = Path(entry)
+    return path.name == "bin" and path.parent.name in {".venv", "venv"}
+
+
+def _pinned_worker_venv_env(source: dict[str, str]) -> dict[str, str]:
+    """Pin a detached worker to this repository's venv, never an inherited one.
+
+    A dispatch worker can run arbitrary project commands.  If its parent was
+    launched from a different checkout's activated virtualenv, retaining that
+    ``VIRTUAL_ENV`` or its ``bin`` directory in ``PATH`` lets ``pip`` rewrite
+    that other environment's console scripts.  The worker always receives the
+    canonical project venv path; its explicit ``.venv/bin/python`` spawn
+    command has no fallback if that interpreter is unavailable.
+    """
+    venv_root = _REPO_ROOT / ".venv"
+    venv_bin = venv_root / "bin"
+    pinned = dict(source)
+    inherited_path = source.get("PATH", "")
+    inherited_venv = source.get("VIRTUAL_ENV")
+    inherited_venv_bin = (
+        os.path.normpath(str(Path(inherited_venv) / "bin"))
+        if inherited_venv
+        else None
+    )
+    path_entries = [
+        entry
+        for entry in inherited_path.split(os.pathsep)
+        if entry
+        and not _is_virtualenv_bin_path(entry)
+        and os.path.normpath(entry) != inherited_venv_bin
+    ]
+    pinned["PATH"] = os.pathsep.join((str(venv_bin), *path_entries))
+    pinned["VIRTUAL_ENV"] = str(venv_root)
+    # PYTHONHOME can override the interpreter's calculated prefix and make a
+    # correctly pinned venv behave like an unrelated Python installation.
+    pinned.pop("PYTHONHOME", None)
+    return pinned
+
+
 @dataclass(frozen=True)
 class AutoFinalizeResult:
     ok: bool
@@ -4489,10 +4530,10 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # Pipe the prompt via stdin so it doesn't hit argv length limits.
     # start_new_session=True detaches from our process group — the
     # worker survives our exit, which is what we want.
-    # Explicit env=os.environ.copy() — makes the inherited env
-    # explicit rather than implicit. Callers that want to scrub
-    # secrets from the worker's env can override this here.
-    worker_env = os.environ.copy()
+    # Pin the worker to this checkout's venv before it can invoke a CLI.  Do
+    # not retain a parent process's activated venv: pip can otherwise rewrite
+    # console scripts in that foreign checkout (#5134).
+    worker_env = _pinned_worker_venv_env(os.environ)
     worker_env["LU_RUNTIME_INITIATOR"] = attribution.initiator
     worker_env["LU_RUNTIME_INITIATOR_SOURCE"] = attribution.source
     _inject_gh_token_for_agent(worker_env, dispatch_agent)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -97,6 +97,37 @@ def test_sanitized_git_env_keeps_benign_git_transport_env(monkeypatch):
     assert "PRE_COMMIT_HOME" not in env
 
 
+def test_pinned_worker_venv_env_replaces_foreign_virtualenv(monkeypatch):
+    project_venv = delegate._REPO_ROOT / ".venv"
+    foreign_venv = "/tmp/foreign-repo/virtualenv"
+    monkeypatch.setattr(delegate, "_REPO_ROOT", Path(project_venv).parent)
+
+    env = delegate._pinned_worker_venv_env(
+        {
+            "PATH": os.pathsep.join(
+                (f"{foreign_venv}/bin", "/usr/local/bin", "/usr/bin")
+            ),
+            "VIRTUAL_ENV": foreign_venv,
+            "PYTHONHOME": "/tmp/foreign-python-home",
+        }
+    )
+
+    assert env["VIRTUAL_ENV"] == str(project_venv)
+    assert env["PATH"] == os.pathsep.join(
+        (str(project_venv / "bin"), "/usr/local/bin", "/usr/bin")
+    )
+    assert "PYTHONHOME" not in env
+
+
+def test_pinned_worker_venv_env_uses_canonical_path_even_before_venv_exists(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate, "_REPO_ROOT", tmp_path)
+
+    env = delegate._pinned_worker_venv_env({"PATH": "/usr/bin"})
+
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+    assert env["PATH"] == os.pathsep.join((str(tmp_path / ".venv" / "bin"), "/usr/bin"))
+
+
 # ---------------------------------------------------------------------------
 # State file helpers
 # ---------------------------------------------------------------------------
@@ -3382,6 +3413,52 @@ def test_dispatch_defaults_worker_env_to_no_merge(tmp_tasks_dir, monkeypatch):
     env = recorded["env"]
     assert env["AGENT_NO_MERGE"] == "1"
     assert "AGENT_ALLOW_MERGE" not in env
+
+
+def test_dispatch_worker_env_pins_project_venv(tmp_tasks_dir, monkeypatch):
+    import argparse
+
+    recorded: dict[str, object] = {}
+    foreign_venv = "/tmp/foreign-repo/.venv"
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24680
+        stdin = _FakeStdin()
+
+    def fake_popen(*args, **kwargs):
+        recorded["env"] = kwargs.get("env", {})
+        return _FakeProc()
+
+    monkeypatch.setenv("PATH", f"{foreign_venv}/bin{os.pathsep}/usr/bin")
+    monkeypatch.setenv("VIRTUAL_ENV", foreign_venv)
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+    args = argparse.Namespace(
+        agent="codex",
+        task_id="pinned-worker-venv",
+        prompt="test",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=None,
+        hard_timeout=3600,
+        allow_merge=False,
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    env = recorded["env"]
+    assert env["VIRTUAL_ENV"] == str(delegate._REPO_ROOT / ".venv")
+    assert env["PATH"] == os.pathsep.join(
+        (str(delegate._REPO_ROOT / ".venv" / "bin"), "/usr/bin")
+    )
 
 
 def test_dispatch_records_runtime_tmp_lease_and_injects_worker_env(


### PR DESCRIPTION
## Summary
- pin each detached delegate worker to the canonical repository virtualenv
- remove inherited virtualenv PATH entries and Python home overrides
- cover foreign-venv and dispatch handoff regressions

Fixes #5134

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py -k "pinned_worker_venv_env or dispatch_worker_env_pins_project_venv" -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/delegate.py tests/test_delegate.py`
- staged OPSEC scan and `git diff --check`

No merge requested; PR is intentionally left open for independent cross-family review.