### PR TITLE
fix(api): derive seminar roster from curriculum manifest

### DIFF
--- a/scripts/api/config.py
+++ b/scripts/api/config.py
@@ -2,6 +2,9 @@
 
 import os
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 # Project root is the immutable code snapshot when the API is release-served.
 # Mutable data remains reachable through the release's explicit symlinks.
@@ -38,44 +41,89 @@ MESSAGE_DB = Path(
 # Dashboards directory (for static file serving)
 DASHBOARDS_DIR = PROJECT_ROOT / "dashboards"
 
-# Levels configuration — keep in sync with:
-#   assess_research.py (TRACKS), batch_dispatcher_config.py (TRACKS), manifest_utils.py (CORE_LEVELS/TRACKS)
-LEVELS = [
-    # Core levels
-    {"id": "a1", "name": "A1 - Beginner", "path": "a1"},
-    {"id": "a2", "name": "A2 - Elementary", "path": "a2"},
-    {"id": "b1", "name": "B1 - Intermediate", "path": "b1"},
-    {"id": "b2", "name": "B2 - Upper Intermediate", "path": "b2"},
-    {"id": "c1", "name": "C1 - Advanced", "path": "c1"},
-    {"id": "c2", "name": "C2 - Mastery", "path": "c2"},
-    # Seminar tracks
-    {"id": "hist", "name": "HIST - History Track", "path": "hist"},
-    {"id": "istorio", "name": "ISTORIO - History Track", "path": "istorio"},
-    {"id": "bio", "name": "BIO - Biography Track", "path": "bio"},
-    {"id": "lit", "name": "LIT - Literature Track", "path": "lit"},
-    {"id": "lit-essay", "name": "LIT-ESSAY - Essays", "path": "lit-essay"},
-    {"id": "lit-hist-fic", "name": "LIT-HIST-FIC - Historical Fiction", "path": "lit-hist-fic"},
-    {"id": "lit-fantastika", "name": "LIT-FANTASTIKA - Fantasy/Sci-Fi", "path": "lit-fantastika"},
-    {"id": "lit-war", "name": "LIT-WAR - War Literature", "path": "lit-war"},
-    {"id": "lit-humor", "name": "LIT-HUMOR - Humor", "path": "lit-humor"},
-    {"id": "lit-youth", "name": "LIT-YOUTH - Youth & YA", "path": "lit-youth"},
-    {"id": "lit-doc", "name": "LIT-DOC - Fact & Testimony", "path": "lit-doc"},
-    {"id": "lit-drama", "name": "LIT-DRAMA - Modern Stage", "path": "lit-drama"},
-    {"id": "lit-crimea", "name": "LIT-CRIMEA - Voices of Crimea", "path": "lit-crimea"},
-    # Historical language tracks
-    {"id": "oes", "name": "OES - Old East Slavic", "path": "oes"},
-    {"id": "ruth", "name": "RUTH - Ruthenian", "path": "ruth"},
-    # Specialized culture tracks
-    {"id": "folk", "name": "FOLK - Folk Culture", "path": "folk"},
-]
-
-# Seminar tracks (require Phase 0 research)
-SEMINAR_TRACK_IDS = {
-    "hist", "istorio", "bio",
-    "lit", "lit-essay", "lit-hist-fic", "lit-fantastika", "lit-war", "lit-humor", "lit-youth",
-    "lit-doc", "lit-drama", "lit-crimea",
-    "oes", "ruth", "folk",
+_KNOWN_LEVEL_NAMES = {
+    "a1": "A1 - Beginner",
+    "a2": "A2 - Elementary",
+    "b1": "B1 - Intermediate",
+    "b2": "B2 - Upper Intermediate",
+    "c1": "C1 - Advanced",
+    "c2": "C2 - Mastery",
+    "hist": "HIST - History Track",
+    "istorio": "ISTORIO - History Track",
+    "bio": "BIO - Biography Track",
+    "lit": "LIT - Literature Track",
+    "lit-essay": "LIT-ESSAY - Essays",
+    "lit-hist-fic": "LIT-HIST-FIC - Historical Fiction",
+    "lit-fantastika": "LIT-FANTASTIKA - Fantasy/Sci-Fi",
+    "lit-war": "LIT-WAR - War Literature",
+    "lit-humor": "LIT-HUMOR - Humor",
+    "lit-youth": "LIT-YOUTH - Youth & YA",
+    "lit-doc": "LIT-DOC - Fact & Testimony",
+    "lit-drama": "LIT-DRAMA - Modern Stage",
+    "lit-crimea": "LIT-CRIMEA - Voices of Crimea",
+    "oes": "OES - Old East Slavic",
+    "ruth": "RUTH - Ruthenian",
+    "folk": "FOLK - Folk Culture",
 }
+
+
+def _read_manifest_levels(repo_root: Path | None = None) -> dict[str, Any] | None:
+    """Read levels mapping directly from curriculum.yaml manifest."""
+    root = repo_root or LIVE_REPO_ROOT
+    manifest_path = root / "curriculum" / "l2-uk-en" / "curriculum.yaml"
+    if not manifest_path.exists():
+        manifest_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
+    if manifest_path.exists():
+        try:
+            data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("levels"), dict):
+                return data["levels"]
+        except Exception:
+            pass
+    return None
+
+
+def load_seminar_track_ids(repo_root: Path | None = None) -> set[str]:
+    """Derive active seminar track IDs from curriculum.yaml manifest."""
+    levels = _read_manifest_levels(repo_root)
+    if levels is not None:
+        return {
+            track_id
+            for track_id, cfg in levels.items()
+            if isinstance(cfg, dict) and cfg.get("type") == "track"
+        }
+    # Fallback if manifest fails to load
+    return {
+        "hist", "istorio", "bio", "lit", "lit-essay", "lit-hist-fic",
+        "lit-fantastika", "lit-war", "lit-humor", "lit-youth", "lit-drama",
+        "oes", "ruth", "folk",
+    }
+
+
+def load_levels(repo_root: Path | None = None) -> list[dict[str, str]]:
+    """Derive active levels and tracks list from curriculum.yaml manifest."""
+    levels = _read_manifest_levels(repo_root)
+    if levels is not None:
+        return [
+            {
+                "id": track_id,
+                "name": _KNOWN_LEVEL_NAMES.get(track_id, f"{track_id.upper()} - {track_id}"),
+                "path": track_id,
+            }
+            for track_id in levels
+        ]
+    return [
+        {"id": k, "name": v, "path": k}
+        for k, v in _KNOWN_LEVEL_NAMES.items()
+    ]
+
+
+
+# Levels configuration — derived from curriculum.yaml
+LEVELS = load_levels()
+
+# Seminar tracks (require Phase 0 research) — derived from curriculum.yaml
+SEMINAR_TRACK_IDS = load_seminar_track_ids()
 
 # Batch state directory
 BATCH_STATE_DIR = PROJECT_ROOT / "batch_state"
@@ -83,3 +131,4 @@ BATCH_STATE_DIR = PROJECT_ROOT / "batch_state"
 # Server settings
 API_HOST = "127.0.0.1"  # nosec B104 — bind to localhost only
 API_PORT = 8765
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -213,8 +213,11 @@ class TestDashboardOverviewEndpoint:
         summary_counts = {track: stats["total"] for track, stats in summary["tracks"].items()}
 
         assert overview_counts == summary_counts
-        assert overview_counts["lit-doc"] == summary_counts["lit-doc"]
-        assert overview_counts["lit-crimea"] == summary_counts["lit-crimea"]
+        # Retired aliases must not reappear once roster is manifest-derived (#5245).
+        assert "lit-doc" not in overview_counts
+        assert "lit-crimea" not in overview_counts
+        assert "hist" in overview_counts
+        assert overview_counts["hist"] == summary_counts["hist"]
 
     def test_overview_reuses_state_summary_cache_and_track_specific_research_metric(self):
         summary = client.get("/api/state/summary?fresh=true").json()

--- a/tests/test_seminar_roster_config.py
+++ b/tests/test_seminar_roster_config.py
@@ -1,10 +1,10 @@
 """Tests for deriving API seminar roster from curriculum.yaml (#5245)."""
 
 from pathlib import Path
-import pytest
+
 import yaml
 
-from scripts.api import config, state_helpers, dashboard_helpers
+from scripts.api import config, state_helpers
 from scripts.orchestration import curriculum_readiness
 
 
@@ -17,7 +17,7 @@ def test_seminar_track_ids_derived_from_curriculum_manifest() -> None:
         if info.get("type") == "track"
     }
 
-    assert config.SEMINAR_TRACK_IDS == expected_seminar
+    assert expected_seminar == config.SEMINAR_TRACK_IDS
     assert "lit-doc" not in config.SEMINAR_TRACK_IDS
     assert "lit-crimea" not in config.SEMINAR_TRACK_IDS
     assert "hist" in config.SEMINAR_TRACK_IDS

--- a/tests/test_seminar_roster_config.py
+++ b/tests/test_seminar_roster_config.py
@@ -1,0 +1,69 @@
+"""Tests for deriving API seminar roster from curriculum.yaml (#5245)."""
+
+from pathlib import Path
+import pytest
+import yaml
+
+from scripts.api import config, state_helpers, dashboard_helpers
+from scripts.orchestration import curriculum_readiness
+
+
+def test_seminar_track_ids_derived_from_curriculum_manifest() -> None:
+    """Verify SEMINAR_TRACK_IDS matches active tracks of type 'track' in curriculum.yaml."""
+    manifest = curriculum_readiness.load_active_manifest(config.LIVE_REPO_ROOT)
+    expected_seminar = {
+        track_id
+        for track_id, info in manifest["tracks"].items()
+        if info.get("type") == "track"
+    }
+
+    assert config.SEMINAR_TRACK_IDS == expected_seminar
+    assert "lit-doc" not in config.SEMINAR_TRACK_IDS
+    assert "lit-crimea" not in config.SEMINAR_TRACK_IDS
+    assert "hist" in config.SEMINAR_TRACK_IDS
+    assert "bio" in config.SEMINAR_TRACK_IDS
+    assert "folk" in config.SEMINAR_TRACK_IDS
+
+
+def test_levels_derived_from_curriculum_manifest() -> None:
+    """Verify LEVELS matches active tracks in order in curriculum.yaml."""
+    manifest = curriculum_readiness.load_active_manifest(config.LIVE_REPO_ROOT)
+    expected_ids = list(manifest["tracks"].keys())
+    actual_ids = [lvl["id"] for lvl in config.LEVELS]
+
+    assert actual_ids == expected_ids
+    assert "a1" in actual_ids
+    assert "c2" in actual_ids
+    assert "hist" in actual_ids
+
+
+def test_roster_loads_from_custom_manifest_root(tmp_path: Path) -> None:
+    """Verify load_seminar_track_ids and load_levels adapt to custom manifest files."""
+    curriculum_dir = tmp_path / "curriculum" / "l2-uk-en"
+    curriculum_dir.mkdir(parents=True)
+    manifest_data = {
+        "version": "1.0",
+        "description": "Test manifest",
+        "levels": {
+            "a1": {"type": "core", "modules": ["m1"]},
+            "custom_seminar": {"type": "track", "modules": ["s1"]},
+        },
+    }
+    (curriculum_dir / "curriculum.yaml").write_text(yaml.safe_dump(manifest_data), encoding="utf-8")
+
+    derived_seminar = config.load_seminar_track_ids(tmp_path)
+    assert derived_seminar == {"custom_seminar"}
+
+    derived_levels = config.load_levels(tmp_path)
+    assert len(derived_levels) == 2
+    assert derived_levels[0]["id"] == "a1"
+    assert derived_levels[1]["id"] == "custom_seminar"
+
+
+def test_profile_map_reflects_derived_seminar_tracks() -> None:
+    """Verify state_helpers.PROFILE_MAP identifies all seminar tracks correctly."""
+    for track_id in config.SEMINAR_TRACK_IDS:
+        assert state_helpers.PROFILE_MAP.get(track_id) == "seminar"
+
+    assert state_helpers.PROFILE_MAP.get("a1") == "core"
+    assert state_helpers.PROFILE_MAP.get("c1") == "core"


### PR DESCRIPTION
## Summary
Derive API seminar track IDs and levels from `curriculum/l2-uk-en/curriculum.yaml` instead of hardcoded rosters (drops retired aliases, picks up new tracks).

Fixes #5245

## Test plan
- `tests/test_seminar_roster_config.py` + related
- X-Agent: agy/5245-seminar-roster