### PR TITLE
fix(lexicon): sync live manifest before reenrich

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -18,9 +18,11 @@
 #     worktree so the driver never imports stale enrichment code from $REPO.
 #
 # Does NOT finalize, publish, or pin-flip. This mutates a *work-dir copy* of
-# the manifest only (snapshotted once from the live checkout, then re-used
-# across resumes) — never the live $REPO/site/src/data/lexicon-manifest.json.
-# Pulling the result back for the PR / publish gate is
+# the manifest only. The Mac-side wrapper refreshes that copy from its live
+# catalog before each normal launch; this script retains a live-checkout
+# snapshot fallback only for direct VPS invocation. It never mutates
+# $REPO/site/src/data/lexicon-manifest.json. Pulling the result back for the
+# PR / publish gate is
 # launch_reenrich_class_b_remote.sh's job, run from the Mac-side worktree.
 #
 # Usage (on the VPS):
@@ -126,10 +128,9 @@ if [[ ! -f "$REPO/.venv/bin/python" ]]; then
   exit 1
 fi
 
-# Snapshot the live hydrated manifest into the work-dir exactly once. Resumes
-# reuse this same copy so a prior run's fills are not thrown away — the
-# missing-translation target predicate already skips entries that got filled,
-# so a resumed run only touches what's still outstanding.
+# Direct VPS invocation snapshots the live hydrated manifest into the work-dir
+# only when the Mac-side wrapper did not already sync one. Normal remote runs
+# receive a fresh Mac live-manifest sync before this launcher starts.
 if [[ ! -f "$WORK_MANIFEST" ]]; then
   if [[ ! -f "$LIVE_MANIFEST" ]]; then
     echo "live manifest not found: $LIVE_MANIFEST (nothing to snapshot)" >&2

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -9,8 +9,8 @@
 # checkout untouched. This is the "OR scp the script from PR branch" fallback
 # from the #6369 dispatch brief.
 #
-# Steps: sync (residual slugs + driver + launcher) -> launch (detached,
-# idempotent, memory-capped) -> optional poll -> pull manifest + log +
+# Steps: sync (live manifest + residual slugs + driver + launcher) -> launch
+# (detached, idempotent, memory-capped) -> optional poll -> pull manifest + log +
 # summary back into this worktree for the PR / publish gate.
 #
 # Usage:
@@ -42,6 +42,13 @@ LOCAL_RESIDUAL="${ATLAS_RE_ENRICH_RESIDUAL:-$WORKTREE/batch_state/atlas-6369-cla
 LOCAL_OUT_DIR="${ATLAS_RE_ENRICH_OUT_DIR:-$WORKTREE/batch_state/class-b-reenrich-pulled}"
 LOCAL_DRIVER="$WORKTREE/scripts/lexicon/reenrich_thin_manifest_entries.py"
 LOCAL_LAUNCHER="$WORKTREE/scripts/lexicon/runner/launch_reenrich_class_b.sh"
+# Full-catalog runs must begin from the Mac's live catalog, not the stale
+# manifest retained in the VPS checkout. Prefer the dispatched worktree when
+# it contains the large catalog; sparse worktrees normally fall back to the
+# operator's primary checkout.
+LOCAL_LIVE_MANIFEST_CANDIDATE="$WORKTREE/site/src/data/lexicon-manifest.json"
+PRIMARY_LIVE_MANIFEST="/Users/krisztiankoos/projects/learn-ukrainian/site/src/data/lexicon-manifest.json"
+MIN_LIVE_MANIFEST_BYTES=1048576
 # The driver imports ``scripts.lexicon.enrich_manifest`` and its supporting
 # modules. The VPS checkout is deliberately allowed to stay stale, so deploy
 # the current scripts package tree into the work-dir instead of trying to
@@ -179,6 +186,16 @@ fi
 echo "sources.db OK (sizes match)"
 
 if [[ "$do_sync_and_launch" == "1" ]]; then
+  LOCAL_LIVE_MANIFEST=""
+  if [[ -f "$LOCAL_LIVE_MANIFEST_CANDIDATE" ]] && (( $(_local_sz "$LOCAL_LIVE_MANIFEST_CANDIDATE") >= MIN_LIVE_MANIFEST_BYTES )); then
+    LOCAL_LIVE_MANIFEST="$LOCAL_LIVE_MANIFEST_CANDIDATE"
+  elif [[ -f "$PRIMARY_LIVE_MANIFEST" ]] && (( $(_local_sz "$PRIMARY_LIVE_MANIFEST") >= MIN_LIVE_MANIFEST_BYTES )); then
+    LOCAL_LIVE_MANIFEST="$PRIMARY_LIVE_MANIFEST"
+  else
+    echo "live lexicon manifest not found or too small (tried worktree + primary checkout)" >&2
+    exit 1
+  fi
+
   if [[ "$TARGET" == "missing-translation" ]]; then
     if [[ ! -f "$LOCAL_RESIDUAL" ]]; then
       echo "local residual dump not found: $LOCAL_RESIDUAL" >&2
@@ -192,6 +209,18 @@ if [[ "$do_sync_and_launch" == "1" ]]; then
 
   echo "syncing driver + current enrichment package -> $HOST:$REMOTE_WORK_DIR (target=$TARGET)"
   ssh_q "mkdir -p $(printf '%q' "$REMOTE_WORK_DIR/scripts")"
+  # Always replace the work-dir input before launch. The VPS checkout's
+  # catalog is deliberately allowed to be stale, but the local launcher uses
+  # this work-dir path as its --manifest input for every target.
+  local_manifest_sz="$(_local_sz "$LOCAL_LIVE_MANIFEST")"
+  echo "syncing live manifest local=$local_manifest_sz path=$LOCAL_LIVE_MANIFEST -> $REMOTE_WORK_DIR/manifest.json"
+  rsync -a --copy-links --partial "$LOCAL_LIVE_MANIFEST" "$HOST:$REMOTE_WORK_DIR/manifest.json"
+  remote_manifest_sz="$(ssh_q "stat -L -c '%s' $(printf '%q' "$REMOTE_WORK_DIR/manifest.json")")"
+  if [[ "$local_manifest_sz" != "$remote_manifest_sz" ]]; then
+    echo "FAIL CLOSED: live manifest still mismatched after rsync (local=$local_manifest_sz remote=$remote_manifest_sz)" >&2
+    exit 1
+  fi
+  echo "live manifest OK (sizes match)"
   # Modules deployed under $REMOTE_WORK_DIR derive their project root from
   # that directory. Materialize a work-dir-only data overlay: the live repo
   # remains read-only, while VESUM sits next to the synced code.

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4054,9 +4054,10 @@ def test_branch_reuse_existing_pr_worktree_with_merge_refuses_staleness_without_
             capture_output=True,
             text=True,
             env=env,
+            timeout=30,
         )
 
-    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, env=env)
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, env=env, timeout=30)
     source.mkdir()
     git(source, "init", "-b", "main")
     git(source, "config", "user.email", "test@example.com")
@@ -4069,7 +4070,7 @@ def test_branch_reuse_existing_pr_worktree_with_merge_refuses_staleness_without_
     git(source, "commit", "--allow-empty", "-m", "PR base")
     git(source, "push", "-u", "origin", branch)
 
-    subprocess.run(["git", "clone", str(remote), str(client)], check=True, capture_output=True, env=env)
+    subprocess.run(["git", "clone", str(remote), str(client)], check=True, capture_output=True, env=env, timeout=30)
     git(client, "config", "user.email", "test@example.com")
     git(client, "config", "user.name", "Test")
     git(client, "config", "core.hooksPath", "/dev/null")

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -145,10 +145,22 @@ def test_remote_wrapper_syncs_current_enrichment_package() -> None:
     assert 'ATLAS_RE_ENRICH_CODE_ROOT=$(printf \'%q\' "$REMOTE_WORK_DIR")' in source
 
 
+def test_remote_wrapper_syncs_live_manifest_to_work_dir_before_launch() -> None:
+    """Full-catalog must never inherit the stale manifest in the VPS repo."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+
+    assert 'LOCAL_LIVE_MANIFEST_CANDIDATE="$WORKTREE/site/src/data/lexicon-manifest.json"' in source
+    assert "PRIMARY_LIVE_MANIFEST=" in source
+    assert 'rsync -a --copy-links --partial "$LOCAL_LIVE_MANIFEST" "$HOST:$REMOTE_WORK_DIR/manifest.json"' in source
+    assert 'stat -L -c \'%s\' $(printf \'%q\' "$REMOTE_WORK_DIR/manifest.json")' in source
+    assert source.index('rsync -a --copy-links --partial "$LOCAL_LIVE_MANIFEST"') < source.index('remote_cmd=')
+
+
 def test_local_launcher_prefers_synced_package_on_systemd_import_path() -> None:
     """The service command resolves ``scripts.*`` from the work-dir first."""
     source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
 
     assert 'CODE_ROOT="${ATLAS_RE_ENRICH_CODE_ROOT:-$WORK_DIR}"' in source
+    assert 'WORK_MANIFEST="$WORK_DIR/manifest.json"' in source
     assert '"$CODE_ROOT/scripts/lexicon/enrich_manifest.py"' in source
     assert 'PYTHONPATH=$(printf \'%q\' "$CODE_ROOT"):\\$PYTHONPATH:$(printf \'%q\' "$REPO")' in source


### PR DESCRIPTION
Fixes #6466.

## What changed

- Sync the Mac live lexicon manifest into the VPS work-dir before every re-enrichment launch.
- Prefer the dispatched worktree catalog when it is substantial; otherwise use the operator Mac primary catalog.
- Verify the remote work-dir manifest size after rsync; fail closed on a mismatch.
- Preserve work-dir-first `PYTHONPATH` and the `missing-translation` residual-slug guard.

## Evidence

The live Mac catalog measured 19,203 entries and 102,569,555 bytes. The launcher passes `$WORK_DIR/manifest.json` to the driver, and the new remote rsync writes that exact work-dir path before the remote launch command.

## Validation

- `bash -n scripts/lexicon/runner/launch_reenrich_class_b_remote.sh scripts/lexicon/runner/launch_reenrich_class_b.sh`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_launch_reenrich_target_detection.py -q` (18 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check tests/test_launch_reenrich_target_detection.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No merge was initiated. Next gate: independent cross-family PR review.