### PR TITLE
ci(deploy): auto-deploy zero-content-drift site changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,7 @@ CI, security, and deploy automation for the learn-ukrainian curriculum.
 | `zizmor.yml` | Static security analysis of all workflow YAML | PR / push / weekly | SARIF → Security tab. Runs `--offline`. |
 | `validate-yaml.yml` | YAML syntax / schema validation | PR / push | |
 | `rules-deployment-check.yml` | Agent-rule deploy idempotency check | PR / push | |
-| `deploy-pages.yml` | Build Site + deploy to GitHub Pages | **Manual** (`workflow_dispatch`) | Auto-deploy on push is intentionally disabled. |
+| `deploy-pages.yml` | Build Site + deploy to GitHub Pages | Manual, plus safe `main` pushes | Pushes deploy only when every changed path since the last successful Pages deployment is approved site code; curriculum, generated site content/data, and unknown paths stay manual. |
 
 ## Supply-chain hardening
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,11 +2,16 @@
 name: Deploy to GitHub Pages
 
 on:
-  # The curriculum lifecycle dispatches this only after production QG reaches
-  # CERTIFIED_FINAL. A push trigger would deploy provisional merged content.
+  # #5356: only deploy a pushed main revision after a fail-closed preflight
+  # proves that no curriculum or generated site content changed since the last
+  # successful Pages deployment.  Manual dispatch remains the certification
+  # route for learner-content changes.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -16,7 +21,60 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  auto-deploy-eligibility:
+    name: Determine automatic deployment eligibility
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.classify.outputs.deploy }}
+    steps:
+      - name: Checkout full main history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Resolve the last successful Pages deployment
+        id: last-deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          runs_json="$(
+            curl --fail --silent --show-error --retry 3 --connect-timeout 10 --max-time 30 \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/${REPOSITORY}/actions/workflows/deploy-pages.yml/runs?branch=main&status=success&per_page=1"
+          )"
+          last_deploy_sha="$(jq --exit-status --raw-output '.workflow_runs[0].head_sha' <<< "$runs_json")"
+          git cat-file -e "${last_deploy_sha}^{commit}"
+          git merge-base --is-ancestor "$last_deploy_sha" "$GITHUB_SHA"
+          printf 'sha=%s\n' "$last_deploy_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Classify all changes since that deployment
+        id: classify
+        env:
+          LAST_DEPLOY_SHA: ${{ steps.last-deploy.outputs.sha }}
+        run: |
+          set -euo pipefail
+          changed_paths="$RUNNER_TEMP/changed-paths.nul"
+          git diff --no-renames --name-only --diff-filter=ACDMRT -z \
+            "$LAST_DEPLOY_SHA" "$GITHUB_SHA" > "$changed_paths"
+          python scripts/deploy/auto_deploy_eligibility.py \
+            --changed-paths "$changed_paths" \
+            --github-output "$GITHUB_OUTPUT"
+
   deploy:
+    needs: auto-deploy-eligibility
+    if: >-
+      always() && (github.event_name == 'workflow_dispatch' ||
+      needs.auto-deploy-eligibility.outputs.deploy == 'true')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -582,9 +582,11 @@ of a second server:
 ./services.sh rebuild astro     # clean then build
 ```
 
-> Public deploy is separate and **manual**: the `deploy-pages.yml` GitHub Actions
-> workflow (`workflow_dispatch`) — auto-deploy on push to `main` is disabled.
-> Running services locally never touches the live site.
+> Public deploy is separate: the `deploy-pages.yml` GitHub Actions workflow retains
+> manual `workflow_dispatch` for certified content, and automatically deploys a
+> `main` push only when the diff since the last successful Pages deployment contains
+> approved site code and no content drift. Running services locally never touches the
+> live site.
 
 ### Key Files
 

--- a/scripts/deploy/auto_deploy_eligibility.py
+++ b/scripts/deploy/auto_deploy_eligibility.py
@@ -1,0 +1,101 @@
+"""Fail-closed eligibility decision for Pages auto-deploys (#5356).
+
+Curriculum certification remains authoritative for learner-facing content.  This
+module permits the Pages workflow to redeploy a main revision automatically only
+when *every* path since the last successful deployment is known site code.  The
+denylist takes precedence over the site allowlist and an unknown path is drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# These paths can change published learner content even though two of them live
+# under ``site/``.  Keep this list explicit: a new content surface must be added
+# here before an automatic deployment can cross it.
+CONTENT_PATH_PREFIXES = (
+    "curriculum/",
+    "site/src/content/",
+    "site/src/data/",
+)
+
+# This is deliberately broad enough for regular Astro UI, style, asset, and
+# dependency changes, but it does not grant permission to any path outside the
+# site tree.  ``CONTENT_PATH_PREFIXES`` is always evaluated first.
+SITE_CODE_PATH_PREFIXES = ("site/",)
+
+
+@dataclass(frozen=True)
+class AutoDeployDecision:
+    """A machine-readable result safe to write to ``GITHUB_OUTPUT``."""
+
+    deploy: bool
+    reason: str
+
+
+def _has_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def decide_auto_deploy(changed_paths: Iterable[str]) -> AutoDeployDecision:
+    """Classify a NUL-safe git path sequence with a deny-by-default policy."""
+    paths = tuple(changed_paths)
+    if not paths:
+        return AutoDeployDecision(deploy=False, reason="no_changed_paths")
+
+    for path in paths:
+        if _has_prefix(path, CONTENT_PATH_PREFIXES):
+            return AutoDeployDecision(deploy=False, reason="content_drift")
+        if not _has_prefix(path, SITE_CODE_PATH_PREFIXES):
+            return AutoDeployDecision(deploy=False, reason="unknown_path")
+
+    return AutoDeployDecision(deploy=True, reason="site_code_only")
+
+
+def read_nul_delimited_paths(path: Path) -> tuple[str, ...]:
+    """Read ``git diff --name-only -z`` output without misparsing odd filenames."""
+    raw_paths = path.read_bytes().split(b"\0")
+    return tuple(
+        raw_path.decode("utf-8", errors="surrogateescape")
+        for raw_path in raw_paths
+        if raw_path
+    )
+
+
+def write_github_output(path: Path, decision: AutoDeployDecision) -> None:
+    """Append fixed-format action outputs; never interpolate repository paths."""
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"deploy={'true' if decision.deploy else 'false'}\n")
+        output.write(f"reason={decision.reason}\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-paths",
+        type=Path,
+        required=True,
+        help="NUL-delimited path list produced by git diff --name-only -z.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        required=True,
+        help="GitHub Actions output file to append.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    decision = decide_auto_deploy(read_nul_delimited_paths(args.changed_paths))
+    write_github_output(args.github_output, decision)
+    print(f"auto-deploy eligibility: {decision.reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import yaml
 
+from scripts.deploy.auto_deploy_eligibility import decide_auto_deploy, read_nul_delimited_paths
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-pages.yml"
 REQUIREMENTS_LOCK = REPO_ROOT / "requirements-lock.txt"
@@ -66,3 +68,47 @@ def test_pages_deploy_vendors_atlas_tree_after_build_before_size_gate() -> None:
     assert steps.index(build_site) < steps.index(vendor)
     assert steps.index(vendor) < steps.index(size_gate)
     assert steps.index(size_gate) < steps.index(upload)
+
+
+def test_auto_deploy_accepts_only_site_code_since_last_successful_deployment(tmp_path: Path) -> None:
+    """#5356: content drift and unknown paths must keep Pages manual-only."""
+    assert decide_auto_deploy(["site/src/components/Practice.tsx"]).deploy is True
+    assert decide_auto_deploy(["site/src/content/docs/a1/hello.mdx"]).reason == "content_drift"
+    assert decide_auto_deploy(["site/src/data/lexicon-manifest.json"]).reason == "content_drift"
+    assert decide_auto_deploy(["curriculum/l2-uk-en/a1/01-hello.md"]).reason == "content_drift"
+    assert decide_auto_deploy(["scripts/build/site.py"]).reason == "unknown_path"
+    assert decide_auto_deploy([]).reason == "no_changed_paths"
+
+    changed_paths = tmp_path / "changed-paths.nul"
+    changed_paths.write_bytes(b"site/src/components/Practice.tsx\0site/src/styles/app.css\0")
+    assert read_nul_delimited_paths(changed_paths) == (
+        "site/src/components/Practice.tsx",
+        "site/src/styles/app.css",
+    )
+
+
+def test_pages_workflow_uses_fail_closed_auto_deploy_preflight() -> None:
+    """The manual certification route remains available beside the push preflight."""
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    trigger_block = workflow_text.split("on:\n", 1)[1].split("permissions:\n", 1)[0]
+    workflow = yaml.safe_load(workflow_text)
+
+    assert "push:\n    branches: [main]" in trigger_block
+    assert "workflow_dispatch:" in trigger_block
+    assert workflow["permissions"]["actions"] == "read"
+
+    eligibility = workflow["jobs"]["auto-deploy-eligibility"]
+    assert eligibility["if"] == "github.event_name == 'push'"
+    assert eligibility["outputs"]["deploy"] == "${{ steps.classify.outputs.deploy }}"
+
+    deploy = workflow["jobs"]["deploy"]
+    assert deploy["needs"] == "auto-deploy-eligibility"
+    assert "workflow_dispatch" in deploy["if"]
+    assert "outputs.deploy == 'true'" in deploy["if"]
+
+    preflight = "\n".join(step.get("run", "") for step in eligibility["steps"])
+    assert "actions/workflows/deploy-pages.yml/runs" in preflight
+    assert "git cat-file -e" in preflight
+    assert "git merge-base --is-ancestor" in preflight
+    assert "git diff --no-renames --name-only --diff-filter=ACDMRT -z" in preflight
+    assert "scripts/deploy/auto_deploy_eligibility.py" in preflight

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -2204,4 +2204,4 @@ def test_pages_deploy_installs_schema_runtime_and_emits_exact_head_marker() -> N
     assert "learn-ukrainian-deployment-${GITHUB_SHA}.txt" in workflow
     assert "printf '%s\\n' \"$GITHUB_SHA\"" in workflow
     assert "workflow_dispatch:" in trigger_block
-    assert "push:" not in trigger_block
+    assert "push:" in trigger_block


### PR DESCRIPTION
## Summary

- add a fail-closed Pages preflight that compares each main push with the last successful Pages deployment
- auto-deploy only site-only diffs; curriculum, generated site content/data, unknown paths, missing API data, and divergent history stop the automatic route
- retain manual dispatch as the curriculum-certification deployment route

Closes #5356

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_deploy_pages_workflow.py tests/test_track_completion.py::test_pages_deploy_installs_schema_runtime_and_emits_exact_head_marker -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/deploy/auto_deploy_eligibility.py tests/test_deploy_pages_workflow.py`
- `bash scripts/audit/check_workflows.sh .github/workflows/deploy-pages.yml`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No deploy or merge was performed.