### PR TITLE
docs(agents): dedupe static instruction digest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,15 @@ non-skippable:
   bounded search before prioritization or dispatch. Treat results as body-free,
   supplemental locators; record use only when a verified locator informed work.
 - Before delegation, classify role, task family, track, and owned paths for the
-  Project Research Registry. Give helpers disjoint paths and bounded authority;
-  same-family helpers do not satisfy the cross-family review gate.
+  Project Research Registry. Before every `delegate.py dispatch`, the accountable
+  orchestrator records a scoped classification using `--research-role`,
+  `--research-task-family`, `--research-track`, and `--research-owned-path`, or
+  deliberately classifies it as genuinely generic or unknown and omits all
+  `--research-*` flags. A surfaced pointer is not proof of consumption; verify
+  attributed consumption before final disposition. Full contract:
+  `agents_extensions/shared/rules/workflow.md` § Project Research Registry.
+  Give helpers disjoint paths and bounded authority; same-family helpers do not
+  satisfy the cross-family review gate.
 
 ## Completion
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,550 +1,98 @@
-# AGENTS.md - Rules for AI Coding Agents
+# AGENTS.md - Compact Rules for AI Coding Agents
 
-> Shared source of truth for non-provider-specific repository rules.
-> Codex prompts read this file only as runtime instructions; do not load `CLAUDE.md` or `GEMINI.md` for normal Codex startup.
-> `CLAUDE.md` and `GEMINI.md` contain provider-specific context and may defer here for shared rules.
+> This is the non-skippable static digest for Codex-family consumers. It is
+> deliberately compact: full policy lives in the rules API and the listed local
+> sources. Do not load `CLAUDE.md` or `GEMINI.md` during normal Codex startup.
 
----
+## Read the current rule set
+
+When the local Monitor API is available, read `GET /api/rules?format=markdown`
+before consequential work; it is the canonical, complete ruleset. It is served
+with the operator contract first and supports hash-based cache checks.
+
+When that API is unavailable, read
+`agents_extensions/shared/rules/_load-via-api.md`, then its ordered local
+fallback list. Do not invent an alternative policy or treat an unavailable API
+as permission to skip rules. The full sources include the operator contract,
+critical and non-negotiable rules, workflow, fleet-comms coordination,
+worktree, CLI, and model-assignment rules.
 
 ## Operator Contract (binding for ALL agents — read before acting)
 
-The operator's working contract is `agents_extensions/shared/rules/operator-expectations.md`
-(deploy copies: `.codex/rules/` · `.agent/rules/` · `.gemini/rules/`; served FIRST at
-`GET http://localhost:8765/api/rules`). Its items are the tie-breakers when instructions
-conflict. Digest — read the full file for the binding wording:
-**1** Quality: no shortcuts, no threshold-lowering, no "for now" · **2** Best practices +
-root-cause fixes · **3** Git/GitHub hygiene (**layout A**): primary non-bare on `main`
-(human + services); agents only in `.worktrees/dispatch/<agent>/<task>/`; bare primary =
-heal-as-bug; PRs + `X-Agent` · **4** Use the whole fleet; review gate = independent
-**cross-family** reviewer (discussion ≠ review) · **5** Route by model × harness fit ·
-**6** Limits: substitute lanes, NOTE substitutions · **7** Tool-backed claims only;
-outcome validity precedes paid execution (semantic canary, explicit success/stop criteria;
-transport/shape/cost are not outcome proof); UA word/stress/morphology VESUM/`sources`-verified · **8** Clean code + current docs ·
-**9** Max UA immersion EXCEPT A1 · **10** Drive within approved scope · **11** Repo hard
-gates bind · **12** **Advisor/operator approval gate**: no architecture, layout, or
-process decisions without present-tense **operator** or designated **advisor** approval
-(current advisors: **Fable**, **Sol** — roster may change; check `/api/rules`) · **13**
-Adversarial quality · **14**
-**Pre-dispatch outcome adequacy**: before presentation or dispatch, substantive phase/epic prompts freeze SHA-256 plus
-user outcome, denominator, non-goals, role map, independent held-out evaluation,
-stop/residual policy, and completion terms; live-routed critics review and re-review
-material drift. Prompt review is not exact-head implementation or cross-family PR review;
-engine proof is not product completion.
-
-### Fleet-comms mid-cutover (binding for standalone TUI/UI drivers; #5512 / #5632)
-
-Full text: `agents_extensions/shared/rules/fleet-comms-coordination.md` (also in
-`GET /api/rules`). Method: skill **`drive-epic`**; operator seats:
-`docs/runbooks/epic-orchestrator-roster.md` + `./start-<model>-drive.sh <epic>`.
-Digest: prefer `.venv/bin/python -m scripts.fleet_comms plane-status` +
-`review-pr <PR_NUMBER>` / `publish-review-verdict` for topology and formal CF.
-Plane modes are only `off|shadow|dual_write` — **file dual-write stays authoritative
-in every mode** (`dual_write` is shadow/mirror, not authority cutover). Do not invent
-a competing design or flip plane / retention apply / `formal_review_eligible` without
-operator/advisor GO. Codex is a review/coding seat, **not** an epic-driver loop.
-Stream leases are already claimed by launchers.
-
----
-
-## Entire context recall — automatic intake (binding; ADR-018)
-
-**Do not wait for the operator to mention Entire / entire.io.** Skill
-`entire-context` (`agents_extensions/shared/skills/entire-context/SKILL.md`).
-
-On non-trivial work, before prioritization or dispatch:
-
-```bash
-.venv/bin/python -m scripts.entire_context status
-.venv/bin/python -m scripts.entire_context search --query "<task keywords>"
-# if locators inform the plan:
-.venv/bin/python -m scripts.entire_context record-use \
-  --task-id <task> --consumer <harness> --purpose <planning|handoff|review|debug> \
-  --locator-id <clink_…>
-```
-
-Body-free only; no load-bearing `entire` CLI network search; supplemental to GH /
-Fleet Comms / Monitor / formal CF. Skip only pure one-liners or when the module is
-missing/disabled (state once). Grok seats also load a stronger always-on copy of
-this duty from `~/.grok/Agents.md`.
-
----
-
-## Project Research Registry — Orchestrator Duty (binding)
-
-Before every delegated task, the accountable orchestrator must deliberately classify
-its functional role, task family, track, and owned paths. For scoped work, pass every
-known dimension through `--research-role`, `--research-task-family`,
-`--research-track`, and repeatable `--research-owned-path`; never infer them from the
-provider or agent name. A genuinely generic or unknown task omits all research flags
-and remains pointer-free. A surfaced pointer is not proof of consumption: research
-claimed as used requires an attributed record fetch while the task is active. Registry
-delivery remains fail-open, but forgetting this classification is not an acceptable
-generic-task classification. Full contract and examples:
-`agents_extensions/shared/rules/workflow.md` § Project Research Registry.
-
----
-
-## Work Intake — Stream Epics (binding for ALL orchestrators; #4708)
-
-Every open GH issue belongs to **exactly one stream epic** — registry:
-`scripts/config/issue_streams.yaml` (streams → epic numbers). Your work queue is YOUR
-stream's epic, not the global issue list. Codex UI track drivers: your curriculum-track
-work hangs off its stream epic (seminars-folk #2836, seminars-bio #4431, core-quality
-#4274, …) — pick up from there, and link every issue you create to its stream epic at
-creation (native sub-issue preferred; `#N` checklist line in the epic body accepted).
-Unlinked issues are flagged as ORPHANS at every agent's cold start (session-setup 11b)
-and at `GET /api/issues/streams`. When a PR fixes an issue, close it with evidence —
-and if scope remains, split it into a new linked issue BEFORE the auto-close keyword
-eats it. Full protocol: `agents_extensions/shared/rules/workflow.md` § Work intake
-(served at `/api/rules`).
-
-## Global Codex Operating Rules
-
-- Start every task at the repository root and run `git status --short --branch` before editing. **This is a read-only preflight/orientation step only.** Do not use this as permission to implement from the primary checkout.
-- **The primary checkout is strictly read-only.** Do not drop scratch files, test scripts, or command outputs into its root directory under any circumstances. If you need a temporary file for discovery or testing, put it in your assigned worktree or an ignored scratch directory (like `batch_state/`).
-- **Any implementation edit, branch work, commit, or PR MUST happen from a worktree (`.worktrees/dispatch/<agent>/<task>/`)** unless the user explicitly authorizes an exception. This prose rule is a reminder/backstop; mechanical enforcement is tracked in #4444-#4450.
-- Preserve user and unrelated changes; do not revert, delete, or clean up work outside the task.
-- Use multi-agent delegation for non-trivial work that can run in parallel without shared-file contention.
-- Keep worker scopes disjoint, and explicitly tell agents not to revert or overwrite others' changes.
-- Use `apply_patch` for manual edits.
-- Keep changes scoped to the requested files and behavior.
-- Run relevant verification before finalizing, or state why verification was not run.
-- Final reports must include changed files, verification performed, and final `git status --short --branch`.
-- New material blocking, mutating, network-dependent, or always-loaded guardrails must follow
-  `docs/best-practices/guardrail-lifecycle.md`; do not blanket-retrofit historical controls.
-
----
-
-## MANDATORY PRE-SUBMIT CHECKLIST
-
-**Before creating a PR, verify EVERY item. If ANY check fails, fix it BEFORE submitting.**
-
-- [ ] `.python-version` is unchanged (must be `3.12.8`)
-- [ ] `.yamllint` is unchanged (zero modifications)
-- [ ] `.markdownlint.json` is unchanged (zero modifications)
-- [ ] No `status/*.json` files in the diff
-- [ ] No `audit/*-review.md` files in the diff
-- [ ] No `review/*-review.md` files in the diff
-- [ ] No `data/telemetry/**` files in the diff
-- [ ] No `sys.executable` anywhere in code (use `.venv/bin/python`)
-- [ ] No `@pytest.mark.skip` with empty `pass` bodies
-- [ ] No assertions weakened (e.g., `is True` → `isinstance(..., bool)`)
-- [ ] Every changed file is directly related to the task
-- [ ] Total files changed < 20 (if more, you likely included artifacts)
-- [ ] Code runs without `NameError`, `KeyError`, or `ImportError`
-- [ ] OPSEC check passed: zero raw IP addresses, SSH keys, or infrastructure secrets in diff (`.venv/bin/python scripts/audit/lint_opsec_leaks.py`)
-
-**If you cannot check every box, your PR WILL be rejected.**
-
----
-
-## Non-Negotiable Rules
-
-These rules are ABSOLUTE. Violating ANY of them results in immediate PR rejection.
-**100% of recent PRs violated these rules. Read carefully.**
-
-### 1. NEVER Change `.python-version`
-
-The file `.python-version` is set to `3.12.8`. This version is compiled via pyenv with `--enable-loadable-sqlite-extensions` for sqlite-vec support. Changing it to 3.12.12 or any other version breaks every developer's environment.
-
-**Do not touch this file. Not even to "upgrade" it.**
-
-### 2. NEVER Modify Linter Configs
-
-`.markdownlint.json` and `.yamllint` contain intentional style rules.
-
-**If your code fails linting:**
-- **Fix the source files**, not the linter config
-- Do NOT disable rules to make CI pass
-- Do NOT set rules to `false` or `disable`
-- Do NOT add `key-duplicates: disable` (duplicate YAML keys silently overwrite data)
-
-**This is the #1 reason PRs get rejected.** Every single PR in the last batch gutted linter configs. "Fix source, not symptoms" is a core project principle.
-
-### 3. NEVER Use `sys.executable`
-
-```bash
-# CORRECT — in shell commands
-.venv/bin/python scripts/audit_module.py path/to/module.md
-
-# CORRECT — in Python subprocess calls
-subprocess.run(['.venv/bin/python', 'scripts/audit_module.py', path])
-
-# WRONG — uses system Python, missing deps
-python3 scripts/audit_module.py path/to/module.md
-subprocess.run([sys.executable, 'scripts/audit_module.py', path])
-```
-
-`sys.executable` may point to the system Python or a different interpreter that lacks sqlite-vec and other venv dependencies. **Always use `.venv/bin/python` explicitly.**
-
-### 4. NEVER Include Auto-Generated Files in Code PRs
-
-These files are auto-generated and MUST NOT appear in PRs that change code/scripts:
-
-- `curriculum/l2-uk-en/**/status/*.json` — audit cache files
-- `curriculum/l2-uk-en/**/audit/*-review.md` — auto-generated reviews
-- `curriculum/l2-uk-en/**/review/*-review.md` — review files
-- `docs/*-STATUS.md` — level status reports
-- `data/telemetry/**` — local runtime telemetry state
-
-**Why this is critical:**
-- Creates massive diffs (one PR had 296 artifact files out of 301 total)
-- Overwrites hand-crafted reviews with generic machine output
-- Introduces data regressions (e.g., `"plan": null` in status JSONs)
-- Makes code review impossible (real changes buried in noise)
-
-**Rule of thumb:** If your PR touches more than 20 files, you almost certainly included artifacts. Check your diff.
-
-### 5. NEVER Weaken Tests
-
-- Do NOT add `@pytest.mark.skip` with empty `pass` bodies
-- Do NOT change `assert result['passed'] is True` to `assert isinstance(result['passed'], bool)`
-- Do NOT stub imports with `try/except` that silently return empty results
-- Do NOT comment out assertions
-- Do NOT use double `@pytest.mark.skip` decorators (copy-paste error)
-
-If tests fail, **fix the underlying code** or properly rewrite the tests. Dead tests are worse than no tests.
-
-### 6. NEVER Fabricate Documentation
-
-Do NOT invent:
-- Error codes that don't exist in the codebase
-- Phases/workflows that don't exist
-- Screenshots or assets that don't exist
-- API endpoints that don't exist
-- Review documents at the repo root (e.g., `CODEBASE_QUALITY_REVIEW.md`)
-
-**Read the actual source code first.** Reference real function names, real file paths, real workflows.
-
-### 7. NEVER Delete Files Without Explicit Instructions
-
-Do not remove scripts, utilities, or debug tools unless the task specifically asks for it. Files that exist in the repo exist for a reason. One failed session deleted 21 scripts — all were needed.
-
-### 8. ALWAYS Test Your Code Before Submitting
-
-Run the scripts you modified. Check for:
-- `NameError` — variables referenced but not defined in scope
-- `KeyError` — dictionary keys assumed but not present
-- `ImportError` — modules imported but not installed
-- Variable scoping bugs in multiprocessing/threading code
-- `lru_cache` on functions that return mutable data (stale results)
-- Temp files created with `delete=False` but never cleaned up
-
-### 9. Scope Your PRs
-
-One PR = one concern. Do NOT:
-- Change linter configs in a "performance optimization" PR
-- Change `.python-version` in a "test suite" PR
-- Delete files in a "fix docs" PR
-- Add unrelated CI changes in a "monitoring" PR
-- Regenerate all audit/status files in a "code change" PR
-
-If you find something unrelated that needs fixing, create a separate issue.
-
-### 10. ALWAYS Use the Worktree Subtree Layout (layout A)
-
-**Mental model (Fable 2026-07-21):** *Root is the human's and the services'; agents live under `.worktrees/`.*
-
-| Who | Path | Notes |
-| --- | --- | --- |
-| **Human + services** | repo root (`~/projects/learn-ukrainian`) | Normal **non-bare** checkout, pinned to **`main`**. `git status` works. |
-| **Agents** | `.worktrees/dispatch/<agent>/<task>/` | All implementation. Never commit on primary. |
-
-Primary `core.bare=true` is a **bug** (heal with `git config core.bare false`; keep `extensions.worktreeConfig=true`). Do not invent alternate human homes (e.g. `.worktrees/main`) or layout helpers without **operator or advisor** approval.
-
-When you create a worktree (orchestrator or self), use the **subtree layout**:
-
-```
-.worktrees/dispatch/<agent>/<task>/
-```
-
-Concrete examples:
-- `.worktrees/dispatch/codex/1877-verify-quote/`
-- `.worktrees/dispatch/gemini/1878-fixtures-update/`
-- `.worktrees/dispatch/claude/1657-adr-010/`
-
-The branch name aligns: `<agent>/<task>` (e.g. `codex/1877-verify-quote`).
-
-**Why this matters:**
-- Cleaner cleanup — `rm -rf .worktrees/dispatch/codex/` nukes all your leftovers at once instead of grepping names.
-- Aligned branch + path makes `git worktree list` readable as the directory fills up.
-- `scripts/delegate.py` emits a `⚠️ DEPRECATED flat worktree layout` warning on the old `.worktrees/<name>/` form.
-
-**When the orchestrator dispatches you:** the runtime auto-derives the subtree path when invoked with bare `--worktree` (no path). Trust it.
-
-**When you set up a worktree yourself (no orchestrator):** use the subtree layout manually:
-
-```bash
-git worktree add -b codex/<issue>-<topic> .worktrees/dispatch/codex/<issue>-<topic> origin/main
-cd .worktrees/dispatch/codex/<issue>-<topic>
-```
-
-After the PR merges, clean up:
-
-```bash
-git worktree remove .worktrees/dispatch/<agent>/<task>
-git branch -d <agent>/<task>
-```
-
-The flat `.worktrees/<name>/` layout still works for back-compat but is being phased out. Do not create new flat worktrees.
-
-### 11. ALWAYS Add an `X-Agent` Trailer to Every Commit
-
-Every commit you create MUST include an `X-Agent` trailer identifying which agent + task produced it. This is the ONLY way to distinguish Codex / Gemini / Claude-headless / orchestrator-inline work — the git `committer` field is the user's local config and is identical across all locally-dispatched agents.
-
-**Format:**
-
-```
-X-Agent: <agent>/<task-id>
-```
-
-Where `<agent>` ∈ {`claude-inline`, `claude`, `codex`, `gemini`, `dependabot`} and `<task-id>` is your dispatch task identifier OR the literal `orchestrator` / `inline` for orchestrator-side commits.
-
-**Examples:**
-
-```
-X-Agent: codex/1879-fix-ci-and-wikipedia
-X-Agent: claude/1657-adr-010
-X-Agent: gemini/1787-15-handoff-verifier
-X-Agent: claude-inline/orchestrator
-```
-
-**How to add it:**
-
-```bash
-# Preferred: use --trailer on commit (auto-formats)
-git commit -m "feat(foo): bar" --trailer "X-Agent: codex/1879-fix-ci-and-wikipedia"
-
-# Or include it directly in the commit message body (separated by blank line):
-git commit -m "$(cat <<EOF
-feat(foo): bar
-
-Implementation details here.
-
-X-Agent: codex/1879-fix-ci-and-wikipedia
-EOF
-)"
-```
-
-**Enforcement:**
-
-`scripts/audit/lint_agent_trailer.py` checks every commit in `origin/main..HEAD` for the trailer. Run it before pushing:
-
-```bash
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-```
-
-Dependabot squash-merges are auto-skipped (recognized by subject `deps: ...` / `Bump ...` or `dependabot` in committer/author). Merge commits are skipped via `git log --no-merges`.
-
-### 12. NEVER Use Container Paths
-
-This project runs **locally with pyenv**, NOT in Docker. Do not use:
-- `/app/curriculum/...` — use relative paths or real local paths
-- `localhost:8765` — use relative URLs (`/api/...`)
-
-### 13. Use Current Agent Tooling
-
-Gemini CLI and Gemini Code Assist are not supported or restorable routes for
-this project. For Gemini-family work, use AGY through the project bridge or
-dispatch runtime.
-
-Do not tell agents to run bare `ab ...` commands. On the user's machine `ab`
-resolves to ApacheBench (`/usr/sbin/ab`), so bare `ab ask-*`, `ab post`, and
-`ab discuss` instructions are brittle. Use explicit project entry points:
-
-```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - \
-  --task-id review-123 \
-  --to-model gemini-3.1-pro-high
-
-scripts/delegate.py dispatch --agent agy --brief docs/dispatch-briefs/task.md --worktree
-```
-
-Direct `agy --model` calls use display labels from `agy models`, such as
-`Gemini 3.1 Pro (High)` and `Gemini 3.5 Flash (High)`. The bridge/runtime may
-map slugs such as `gemini-3.1-pro-high` to those labels.
-
-### 14. Do Not Leave PRs In Limbo
-
-Do not leave draft PRs or open PRs in limbo after checks are green. Every PR you
-create must end the task in one of these states: merged, closed with a reason,
-or explicitly handed off with the blocker, owner, and next action.
-
-Before the final response, check PR state, checks, mergeability, and whether the
-branch/worktree needs cleanup. If a PR remains open, the final response must say
-exactly why and what action is required. Leaving PRs in review hell wastes CI,
-agent, and human attention.
-
-**Arm auto-merge at review-gate-pass (#4703, user directive 2026-07-07).** The repo
-setting `allow_auto_merge` is enabled. The moment a PR's review gate passes
-(cross-family review evidence, no requested changes), the responsible
-orchestrator/reviewer runs `gh pr merge <N> --auto --squash --delete-branch` —
-GitHub merges when CI settles, nobody babysits. Dispatched agents do NOT
-self-enable auto-merge (the review gate comes first — unchanged). `--auto` waits
-for green and never bypasses blocking checks.
-
-**Out-of-lane pickup threshold (user directive 2026-07-07).** A PR belonging to
-another lane/track is hands-off for every other orchestrator — no shepherding,
-review-routing, or auto-merge arming — unless it has sat GREEN (CI passing +
-review gate passed) idle for MORE THAN 1 HOUR. Only then does the orchestrator
-sweep backstop pick it up. Fresh out-of-lane PRs belong to their lane.
-
----
-
-## Economical Multi-Agent Delegation
-
-When Codex multi-agent support is enabled, the user explicitly authorizes the main Codex agent to use lower-cost routine subagents for bounded work that can run in parallel without lowering quality. The main agent stays responsible for planning, integration, final review, PR creation, independent review routing, and merge decisions.
-
-Native V2 is the intra-Codex execution graph, not a context-compaction or
-durability layer. Codex runtime compaction remains authoritative. Fleet streams
-and file shadow diaries carry durable cross-session state; the external fleet
-provides cross-provider specialization, quota substitution, and independent
-review. Compose them under one accountable root, and never duplicate a healthy
-lane across V2 and the fleet.
-
-Prefer `explorer` subagents for read-only investigation and validation. Use `worker` subagents only for mechanical edits with a clearly owned file set and no ambiguity.
-
-Routine subagent model routing:
-
-- Use `gpt-5.6-luna` at `max` for clearly bounded repo search, summaries,
-  docs/index checks, focused implementation, test/log triage, small refactors,
-  and targeted validation. Every Luna task must name its owned paths and an
-  objective scope ceiling; Luna does not make consequential decisions or the
-  final disposition.
-- Use `gpt-5.3-codex-spark` only as a separate-quota fallback for the same
-  bounded work when Luna is unavailable or the Codex lane is hot. Use
-  `gpt-5.6-terra` at `high` when the scope ceiling is missing, integration is
-  broader, or consequential ambiguity remains.
-
-Use routine subagents for:
-
-- finding where a feature, config, route, test, or workflow is defined
-- summarizing a small file set before the main agent edits it
-- checking whether docs, indexes, tests, or scripts reference a changed file
-- running simple validation such as `bash -n`, YAML/JSON parsing, `git diff --check`, or targeted tests
-- making mechanical edits in a clearly owned file set
-- updating straightforward documentation or generated indexes when explicitly in scope
-- verifying a narrow behavior while the main agent keeps implementing elsewhere
-
-Do not use routine subagents for architecture decisions, security-sensitive judgment, ambiguous debugging, broad refactors, PR creation, independent review routing, merges, destructive actions, or work that blocks the main agent's next immediate step. Give each subagent a narrow task, a clear file ownership boundary when edits are allowed, and instructions not to revert unrelated changes. The main agent must review every routine-subagent diff before finalizing or presenting the work as complete.
-
-Cost controls:
-
-- Use local deterministic tools before model calls: `rg`, `git diff --check`, `bash -n`, `.venv/bin/ruff`, targeted tests, JSON/YAML parsers, and local API endpoints.
-- Route bounded Codex work to `gpt-5.6-luna` at `max`; use
-  `gpt-5.3-codex-spark` only as the separate-quota fallback, and move to
-  `gpt-5.6-terra` at `high` for broader autonomous integration. The accountable
-  root retains judgment and final disposition.
-- Do not spawn a subagent for work the main agent can finish faster than delegation overhead.
-- Keep routine delegation to one to three subagents at a time unless the user explicitly asks for a larger sweep.
-- Do not let subagents read secrets, source `.envrc`, call `gh`, request reviews, or merge PRs.
-- Do not delegate independent review requirement. Internal GPT helper swarms Codex self-review do not satisfy external gate. Request one read-only review through an independent non-Codex route and treat unresolved findings as blockers. The reviewer must come from OUTSIDE the author's model family (cross-family; discussion/panel input does not satisfy this gate). Current lanes and per-task routing: `agents_extensions/shared/rules/model-assignment.md` (served at `/api/rules`) — the harness-vs-model table there explains which models each harness (hermes, opencode, native CLIs) can reach; never block on a single unavailable lane (Claude/Codex budget buckets at near_cap substitute per `scripts/config/agent_fallback_substitutions.yaml`; other lanes reroute via the harness table, noting the substitution). If AGY is used as that route, call it through the explicit bridge, example `printf '%s\n' "<review prompt>" | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id review-<id> --to-model gemini-3.1-pro-high --review`.
-
-### Native Codex multi-agent V2 prompt contract
-
-When the operator asks any repository agent to create, write, or improve a
-Codex delegation/orchestration prompt, produce a native multi-agent V2 prompt
-by default unless the operator names another harness or explicitly asks for a
-single-agent prompt. This default applies to agent-work prompts, not unrelated
-prompts such as lesson copy, image generation, or learner exercises.
-
-Every V2 prompt must:
-
-- appoint exactly one accountable root orchestrator that owns scope,
-  sequencing, integration, validation, and the final disposition
-- tell the root to call `list_agents` before spawning and again after all
-  requested agents reach terminal states
-- give each child a unique `task_name`, an explicit functional role, task
-  family, track when applicable, owned paths, read/write authority, inputs,
-  constraints, expected evidence, and return contract
-- default to `fork_turns="none"` with a self-contained child brief; inherit
-  conversation turns only when the child materially needs them
-- parallelize only independent work, prohibit duplicate lanes and shared-file
-  contention, and keep useful critical-path work with the root
-- keep no more than three non-root agents active across the entire tree at
-  once; nested descendants consume the same shared child capacity, so the root
-  must reserve their required slots before starting a nested parent or delay
-  conflicting siblings
-- require the root to wait for every requested result, inspect worker output
-  and diffs, reconcile disagreements, run integrated verification, and report
-  canonical agent paths plus final statuses from a requested-agent ledger,
-  including failures, cancellations, or missing descendants
-- use nested parent → grandchild delegation only when a bounded sub-workstream
-  needs its own coordinator; the parent must receive explicit spawn authority,
-  wait for all descendants, and return their status to the root
-- preserve the repository's worktree, research-classification, quota-routing,
-  tool-backed-evidence, and cross-family review requirements
-
-Native Codex children are same-family helpers. Their review or consensus never
-satisfies the independent cross-family review gate. The canonical copy/paste
-template and examples live in
-[`docs/best-practices/agent-cooperation.md`](docs/best-practices/agent-cooperation.md#native-codex-multi-agent-v2).
-
-Module-build PRs must persist token telemetry through
-`POST /api/telemetry/module-builds` and include the same summary in the PR body
-or final orchestration note. Every record must explicitly say whether a swarm
-was used (`swarm_used: true/false`) and include a `swarm_note`; solo runs still
-need a note such as "solo run; no swarm used". See
-`docs/runbooks/module-build-token-telemetry.md`. The SQLite database under
-`data/telemetry/` is local runtime state and must not be committed.
-
-
-## Project Architecture
-
-```
-curriculum/l2-uk-en/
-├── plans/{level}/{slug}.yaml     # SOURCE OF TRUTH (immutable)
-├── {level}/meta/{slug}.yaml      # Build config (mutable)
-├── {level}/{num}-{slug}.md       # Lesson content
-├── {level}/activities/{slug}.yaml # Activities (V1 bare list or V2 inline/workbook)
-├── {level}/vocabulary/{slug}.yaml # Vocabulary
-├── {level}/status/{slug}.json    # AUTO-GENERATED — never include in PRs
-└── {level}/audit/{slug}-review.md # AUTO-GENERATED — never include in PRs
-```
-
-**Key facts:**
-- Activity YAML may be V1 bare list at root for simple modules, or V2 object with `inline:` and `workbook:` lists when Lesson-tab activities must be separated from Workbook/Activities-tab practice; never wrap the list in an `activities:` key
-- Word targets in plans are MINIMUMS, not maximums
-- Dependencies: `pyproject.toml` (NOT `requirements.txt` — it doesn't exist)
-- Repo: `learn-ukrainian/learn-ukrainian.github.io`
-- Python: pyenv 3.12.8 (NOT 3.10, NOT 3.12.12)
-- All documentation goes in `docs/`, not repo root
-- Only `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `README.md` belong at root
-
-## Common Anti-Patterns (All Seen in Recent PRs)
-
-| Anti-Pattern | Frequency | What to Do Instead |
-| --- | --- | --- |
-| Disable/gut `.yamllint` rules | 100% of PRs | Fix the source files that fail linting |
-| Disable/gut `.markdownlint.json` rules | 80% of PRs | Fix the markdown files |
-| Change `.python-version` to 3.12.12 | 60% of PRs | Don't. It must stay 3.12.8 |
-| Include 50-300 regenerated artifacts | 60% of PRs | Only include files you actually changed |
-| Use `sys.executable` in subprocess | 40% of PRs | Use `.venv/bin/python` |
-| Skip tests with `@skip` + `pass` | 40% of PRs | Fix the code or rewrite the test |
-| Ship code with `NameError` at runtime | 40% of PRs | Run your code before submitting |
-| Scope creep (unrelated changes) | 80% of PRs | One PR = one concern |
-| Use `/app/` container paths | 20% of PRs | Use real local paths or relative paths |
-| Reference `requirements.txt` | seen | Use `pyproject.toml` |
-| Delete existing scripts/files | seen | Don't delete without explicit instructions |
-| Create root-level doc files | seen | Put documentation in `docs/` |
-
----
-
-## Multi-Agent Deliberation Protocol (added 2026-05-02 — issue #1639)
-
-You will sometimes be invoked via `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` for design / framing / pedagogy / architecture decisions. **This is NOT a quorum** — Claude/AGY/Codex have correlated training-data priors. What we DO get from deliberation: more angles, adversarial pressure, written record.
-
-**When you participate in multi-agent discussion through `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`:**
-
-1. **End with `[AGREE]`** if you genuinely agree with the prior round's converging position. This short-circuits the discussion.
-2. **Surface options with explicit labels** — Option A / Option B / Option C. Don't bury alternatives in prose.
-3. **State your rationale, not just your verdict.** "I prefer A because X" — not just "I prefer A."
-4. **Push back on correlated-prior risks.** If the discussion is converging on a position that smells like training-data bias (Russian-imperial framings on Ukrainian topics, Western centrism on decolonization, etc.), explicitly flag it. You may be the only check.
-
-**When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card.** It means user input is needed. Don't try to resolve it on your side; the orchestrator routes it to inline chat / `docs/decisions/pending/` / GH issue depending on user availability.
-
-**High-risk-track override:** On sensitive tracks (FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
-
-**Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** If you're starting work in a worktree and that directory has files, surface them in your initial response and check the field before assuming a decision blocks your work.
-
-Full protocol: `docs/best-practices/agent-cooperation.md` "Multi-Agent Deliberation" section.
+The binding wording is in
+`agents_extensions/shared/rules/operator-expectations.md` (served first by
+`/api/rules`). Its items decide conflicts. This inline digest is intentionally
+non-skippable:
+
+1. Quality: no shortcuts, threshold-lowering, or “for now”.
+2. Use established best practice and fix root causes.
+3. Preserve Git/GitHub hygiene: layout A, dispatch worktrees, PRs, and
+   `X-Agent` attribution.
+4. Use the fleet; the review gate is an independent **cross-family** review,
+   not discussion.
+5. Route by model × harness fit.
+6. Substitute a constrained lane and record that substitution.
+7. Make tool-backed claims only; outcome validity precedes paid execution:
+   define semantic success and stop criteria; transport, shape, and cost are
+   not proof. Verify Ukrainian word, stress, and morphology claims with
+   VESUM/`sources`.
+8. Keep code and documentation current and clean.
+9. Maximize Ukrainian immersion, **EXCEPT A1**.
+10. Drive decided work within approved scope.
+11. Repository hard gates bind.
+12. Do not make architecture, layout, process, or policy decisions without
+    present-tense operator or designated-advisor approval.
+13. Apply adversarial quality: lead with failure modes and missing evidence.
+14. **Pre-dispatch outcome adequacy:** before presenting or dispatching a
+    substantive phase/epic, freeze the SHA-256, user outcome, denominator,
+    non-goals, role map, independent held-out evaluation, stop/residual policy,
+    and completion terms. Prompt review never replaces exact-head
+    implementation or cross-family PR review.
+
+## Non-skippable offline execution guardrails
+
+- The primary checkout belongs to the human and services and is read-only for
+  agents. Make every implementation edit, branch, commit, and PR only from a
+  dispatch worktree at `.worktrees/dispatch/<agent>/<task>/`; never switch the
+  primary checkout’s branch.
+- For changed agent-rule deploy copies, edit `agents_extensions/` first and
+  run the repository deployment check or command required by the full rules;
+  never hand-edit deployed `.claude/`, `.codex/`, `.agent/`, or `.gemini/`
+  copies.
+- Use the project interpreter prescribed by the task/worktree contract; never use bare `python`,
+  `python3`, or `sys.executable` for project commands.
+- Never modify `.python-version`, `.yamllint`, or `.markdownlint.json` to make
+  work pass. Fix source instead. Do not commit generated status, audit, review,
+  or telemetry artifacts; keep one PR to one concern and under the file cap.
+- Do not delete existing files without explicit authorization. Do not weaken, skip, stub, or comment out tests.
+  Run the affected checks and report their actual output; distinguish sandbox or harness limits from product failures.
+- Never print or commit secrets, credentials, infrastructure details, raw IP
+  addresses, or private transcripts. Use only approved, privacy-safe evidence.
+- Every commit has an `X-Agent: <agent>/<task-id>` trailer. Change tasks end in
+  a pushed PR with CI; never push directly to `main`. Workers neither merge nor
+  arm auto-merge. Before merge, required CI and an independent cross-family
+  exact-head review must both pass; resolve material findings and re-review.
+- Treat unavailable telemetry as unknown, not policy proof. Do not close
+  partial work: state verified outcome, denominator, residual gap, and owner.
+
+## Fleet, context, and delegation
+
+- For standalone TUI/UI drivers, read
+  `agents_extensions/shared/rules/fleet-comms-coordination.md`; file
+  dual-write remains authoritative in every plane mode. Use `plane-status` and
+  the `drive-epic` skill; Codex is a coding or review seat, not an epic-driver
+  loop. Do not change plane, retention, or formal-review eligibility without
+  operator/advisor GO.
+- On non-trivial work, use the `entire-context` skill: run status and one
+  bounded search before prioritization or dispatch. Treat results as body-free,
+  supplemental locators; record use only when a verified locator informed work.
+- Before delegation, classify role, task family, track, and owned paths for the
+  Project Research Registry. Give helpers disjoint paths and bounded authority;
+  same-family helpers do not satisfy the cross-family review gate.
+
+## Completion
+
+Before claiming completion, inspect the exact diff and status, run proportionate
+verification, and report changed files, commands/results, final branch status,
+the user-visible outcome, and any residual. Follow the full rules for issue
+linkage, PR state, review routing, merge ownership, and cleanup.

--- a/docs/decisions/2026-08-10-static-instruction-dedupe.md
+++ b/docs/decisions/2026-08-10-static-instruction-dedupe.md
@@ -1,0 +1,48 @@
+# Design Note: Static instruction dedupe for agent cold starts
+
+- **Date:** 2026-08-10
+- **Issue:** #6449
+- **Status:** implemented
+- **Scope:** `AGENTS.md` static injection for Codex-family consumers only
+
+## Context
+
+`AGENTS.md` was 30,863 UTF-8 bytes (550 lines) and is injected before Codex
+work. The full canonical policy is already served at `/api/rules` and remains
+available as ordered local fallback sources. Duplicating the full rule layer in
+the static file spends context without improving the source of truth.
+
+`CLAUDE.md` is deliberately out of scope: headless `claude -p` may not fetch
+the rules API, and its existing inline operator-contract digest remains intact.
+
+## Decision
+
+Use a tiered static digest for `AGENTS.md` with a hard 9 KiB UTF-8 budget. Keep
+the 14-item operator-contract digest and the minimum non-skippable safeguards
+needed by AGENTS-only/offline Codex consumers: worktree isolation, deployment
+source order, interpreter, protected configuration, generated-artifact and
+test integrity, secret handling, attribution, PR/cross-family review, Entire
+recall, and bounded delegation.
+
+The digest names both the live `GET /api/rules?format=markdown` source and the
+local `agents_extensions/shared/rules/_load-via-api.md` fallback. Detailed or
+dynamic policy remains in the rules API and its ordered sources; this change
+does not create a second complete rule system.
+
+## Alternatives rejected
+
+- **Generated digest:** unnecessary build and deployment surface for this
+  bounded reduction; the byte ceiling and required-clause test catch drift.
+- **Pointer-only file:** unsafe for AGENTS-only consumers when the API is
+  unavailable, because critical negative constraints become skippable.
+- **Per-harness redesign:** outside this issue and would affect headless Claude
+  and other launchers without evidence that their injection behavior changes.
+
+## Review and verification plan
+
+The deterministic wiring test enforces the UTF-8 byte ceiling and required live,
+offline, and safety clauses. The existing contract tests continue to require the
+operator digest. An independent Gemini-family design critique selected the same
+tiered approach; the requested Gemini 3.1 Pro lane was unavailable through ACP,
+so the documented Gemini 3.6 Flash substitution was used. Exact-head
+cross-family PR review remains required before any merge.

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -62,6 +62,29 @@ def test_agents_md_carries_binding_digest() -> None:
     assert "independent held-out evaluation" in body, "digest lost held-out proof requirement"
 
 
+def test_agents_md_is_a_bounded_offline_digest() -> None:
+    """#6449: Codex injects AGENTS.md before work, so keep a tested compact
+    safety digest while retaining both live and local paths to full policy."""
+    path = REPO / "AGENTS.md"
+    body = path.read_text(encoding="utf-8")
+
+    assert len(path.read_bytes()) <= 9 * 1024, "AGENTS.md exceeded its 9 KiB static-injection budget"
+    for required in (
+        "GET /api/rules?format=markdown",
+        "agents_extensions/shared/rules/_load-via-api.md",
+        "primary checkout belongs to the human and services",
+        "agents_extensions/` first",
+        "never use bare `python`",
+        "Never modify `.python-version`, `.yamllint`, or `.markdownlint.json`",
+        "Do not weaken, skip, stub, or comment out tests",
+        "X-Agent: <agent>/<task-id>",
+        "independent cross-family",
+        "Never print or commit secrets",
+        "entire-context",
+    ):
+        assert required in body, f"AGENTS.md lost required offline guardrail: {required}"
+
+
 def test_gemini_md_carries_binding_digest() -> None:
     """agy/gemini one-shots boot from GEMINI.md, not AGENTS.md — proven by the
     2026-07-05 live canary (agy answered NOT LOADED before this digest)."""


### PR DESCRIPTION
Closes #6449

## Summary
- reduce auto-injected `AGENTS.md` from 30,863 to 5,541 UTF-8 bytes while retaining an inline operator-contract and offline safety digest
- point Codex consumers to the live `/api/rules` policy and ordered local fallback
- add a design note and regression coverage for the 9 KiB budget plus mandatory offline clauses

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_operator_contract_wiring.py tests/test_fleet_comms_launcher_awareness.py -q` (19 passed)
- `npx markdownlint-cli2 AGENTS.md docs/decisions/2026-08-10-static-instruction-dedupe.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check tests/test_operator_contract_wiring.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

## Design and review routing
- Gemini-family design critique selected the tiered digest. ACP pins AGY to Gemini 3.6 Flash, so it substituted for the unavailable requested Gemini 3.1 Pro lane; the design note records this.
- Exact-head cross-family PR review is still pending; per dispatch instruction, this PR is not merged.

Swarm used: true
Swarm note: one read-only Luna reconnaissance helper mapped the instruction surface; root performed all edits and validation.