### PR TITLE
fix(bridge): persist ask response provenance

### DIFF
--- a/scripts/agent_runtime/shims/gh
+++ b/scripts/agent_runtime/shims/gh
@@ -67,6 +67,155 @@ _blocks_gh_command() {
   return 1
 }
 
+_is_secondary_rate_limited() {
+  local output="$1"
+
+  # Only retry GitHub's explicit secondary-limit response.  A broad match on
+  # "rate limit" would incorrectly retry provider quotas, malformed commands,
+  # and ordinary GitHub failures. GitHub documents this as a 403/429 together
+  # with a secondary-rate-limit message.
+  printf '%s' "$output" | grep -Eiq '(HTTP|status)[[:space:]:]*(403|429)' \
+    && printf '%s' "$output" | grep -Eiq 'secondary[[:space:]-]+rate[[:space:]-]+limit'
+}
+
+_secondary_rate_limit_http_status() {
+  local output="$1"
+  if printf '%s' "$output" | grep -Eiq '(HTTP[[:space:]]*429|status[[:space:]]*429)'; then
+    printf '429\n'
+  else
+    printf '403\n'
+  fi
+}
+
+_positive_integer_or_default() {
+  local value="$1"
+  local fallback="$2"
+  if [[ "$value" =~ ^[0-9]+$ ]] && (( value > 0 )); then
+    printf '%s\n' "$value"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+_nonnegative_integer_or_default() {
+  local value="$1"
+  local fallback="$2"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+_run_with_secondary_rate_limit_retry() {
+  local real_gh="$1"
+  shift
+
+  # GitHub recommends waiting at least one minute when a secondary-limit
+  # response omits Retry-After, then using exponential backoff and a bounded
+  # number of retries. The env overrides make the shim deterministically
+  # testable without weakening production defaults.
+  local max_retries
+  max_retries="$(_positive_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES:-}" 3)"
+  local base_delay_s
+  base_delay_s="$(_nonnegative_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS:-}" 60)"
+
+  _agent_gh_retry_stdin_file=""
+  _agent_gh_retry_sleep_pid=""
+  _agent_gh_retry_stdout_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdout.XXXXXX")" || return 1
+  _agent_gh_retry_stderr_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stderr.XXXXXX")" || {
+    rm -f "$_agent_gh_retry_stdout_file"
+    return 1
+  }
+  if [[ ! -t 0 ]]; then
+    _agent_gh_retry_stdin_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdin.XXXXXX")" || {
+      rm -f "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
+      return 1
+    }
+    cat >"$_agent_gh_retry_stdin_file" || {
+      rm -f "$_agent_gh_retry_stdin_file" "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
+      return 1
+    }
+  fi
+
+  _cleanup_secondary_retry_tempfiles() {
+    rm -f "$_agent_gh_retry_stdin_file" "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file"
+  }
+
+  _abort_secondary_retry() {
+    local status="$1"
+    trap - EXIT HUP INT TERM
+    if [[ -n "$_agent_gh_retry_sleep_pid" ]]; then
+      kill "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+      wait "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+      _agent_gh_retry_sleep_pid=""
+    fi
+    _cleanup_secondary_retry_tempfiles
+    exit "$status"
+  }
+
+  trap '_cleanup_secondary_retry_tempfiles' EXIT
+  trap '_abort_secondary_retry 129' HUP
+  trap '_abort_secondary_retry 130' INT
+  trap '_abort_secondary_retry 143' TERM
+
+  local attempt=0
+  local exit_status=0
+  local output=""
+  local http_status=""
+  local retries_exhausted=false
+  while :; do
+    if [[ -n "$_agent_gh_retry_stdin_file" ]]; then
+      if "$real_gh" "$@" <"$_agent_gh_retry_stdin_file" >"$_agent_gh_retry_stdout_file" 2>"$_agent_gh_retry_stderr_file"; then
+        exit_status=0
+      else
+        exit_status=$?
+      fi
+    elif "$real_gh" "$@" >"$_agent_gh_retry_stdout_file" 2>"$_agent_gh_retry_stderr_file"; then
+      exit_status=0
+    else
+      exit_status=$?
+    fi
+
+    if (( exit_status == 0 )); then
+      break
+    fi
+
+    output="$(cat "$_agent_gh_retry_stdout_file" "$_agent_gh_retry_stderr_file")"
+    if ! _is_secondary_rate_limited "$output"; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    http_status="$(_secondary_rate_limit_http_status "$output")"
+    if (( attempt > max_retries )); then
+      retries_exhausted=true
+      break
+    fi
+
+    local delay_s=$((base_delay_s * (2 ** (attempt - 1))))
+    printf 'agent-gh-shim: GitHub HTTP %s throttled; retrying gh in %ss (attempt %s/%s).\n' \
+      "$http_status" "$delay_s" "$attempt" "$max_retries" >&2
+    # Bash's wait builtin returns when TERM interrupts it, letting the abort
+    # trap kill the tracked backoff child immediately.
+    sleep "$delay_s" </dev/null >/dev/null 2>&1 &
+    _agent_gh_retry_sleep_pid=$!
+    wait "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+    _agent_gh_retry_sleep_pid=""
+  done
+
+  # Retry attempts stay private: only the final gh invocation's output reaches
+  # the caller. The durable marker is likewise reserved for a truly exhausted
+  # secondary-rate-limit retry budget.
+  cat "$_agent_gh_retry_stdout_file"
+  cat "$_agent_gh_retry_stderr_file" >&2
+  if [[ "$retries_exhausted" == true ]]; then
+    printf 'agent-gh-shim: github_secondary_rate_limited HTTP %s; retries exhausted after %s attempts.\n' \
+      "$http_status" "$max_retries" >&2
+  fi
+  return "$exit_status"
+}
+
 if [[ "${AGENT_NO_MERGE:-}" == "1" ]] && _blocks_gh_command "${1:-}" "${@:2}"; then
   _deny
 fi
@@ -76,4 +225,4 @@ real_gh="$(_real_gh)" || {
   exit 127
 }
 
-exec "$real_gh" "$@"
+_run_with_secondary_rate_limit_retry "$real_gh" "$@"

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -41,16 +41,28 @@ def require_compat_target(command_target: str) -> str:
         ) from exc
 
 
-def _result_receipt(result: object) -> bytes:
+def _result_receipt(
+    result: object,
+    *,
+    model_requested: str | None = None,
+    effort_requested: str | None = None,
+) -> bytes:
+    actual_model = str(getattr(result, "model", ""))
+    effort_applied = str(getattr(result, "effort", "unknown"))
     payload = {
         "ok": bool(getattr(result, "ok", False)),
         "agent": str(getattr(result, "agent", "")),
-        "model": str(getattr(result, "model", "")),
+        "model": actual_model,
         "response": str(getattr(result, "response", "")),
         "stderr_excerpt": getattr(result, "stderr_excerpt", None),
         "duration_s": float(getattr(result, "duration_s", 0.0)),
         "returncode": getattr(result, "returncode", None),
-        "effort": str(getattr(result, "effort", "unknown")),
+        "effort": effort_applied,
+        "from_model": actual_model,
+        "model_requested": model_requested or actual_model,
+        "effort_requested": effort_requested,
+        "effort_applied": effort_applied if effort_applied != "unknown" else None,
+        "harness": "acp",
         "transport_metadata": getattr(result, "transport_metadata", None),
         "transport_outcome": getattr(result, "transport_outcome", None),
     }
@@ -77,6 +89,18 @@ def _replay_result(raw: bytes) -> object:
             "transport_metadata": payload.get("transport_metadata"),
             "transport_outcome": payload.get("transport_outcome", "error"),
         }
+    actual_model = str(payload.get("from_model") or payload.get("model") or "acp-bridge-error")
+    applied_effort = payload.get("effort_applied")
+    if applied_effort is None and payload.get("effort") not in {None, "unknown"}:
+        applied_effort = payload["effort"]
+    provenance = {
+        "from_model": actual_model,
+        "model_requested": payload.get("model_requested") or actual_model,
+        "effort_requested": payload.get("effort_requested"),
+        "effort_applied": applied_effort,
+        "harness": payload.get("harness") or "acp",
+    }
+    provenance.update({"replayed": True, "transport": "acp"})
     return Result(
         ok=bool(payload["ok"]),
         agent=str(payload["agent"]),
@@ -90,7 +114,7 @@ def _replay_result(raw: bytes) -> object:
         stalled=False,
         returncode=payload.get("returncode"),
         effort=str(payload["effort"]),
-        usage_record={"replayed": True, "transport": "acp"},
+        usage_record=provenance,
         transport_metadata=payload.get("transport_metadata"),
         transport_outcome=payload.get("transport_outcome"),
     )
@@ -354,7 +378,7 @@ def _run_compat_ask_impl(
                         {
                             "ok": False,
                             "agent": participant,
-                            "model": model or "",
+                            "model": model or f"{participant}-bridge-error",
                             "response": "",
                             "stderr_excerpt": (
                                 f"{type(exc).__name__}: terminal ACP invocation failed"
@@ -362,6 +386,11 @@ def _run_compat_ask_impl(
                             "duration_s": 0.0,
                             "returncode": 1,
                             "effort": effort or "unknown",
+                            "from_model": model or f"{participant}-bridge-error",
+                            "model_requested": model or f"{participant}-bridge-error",
+                            "effort_requested": effort,
+                            "effort_applied": None,
+                            "harness": "acp",
                             "transport_metadata": None,
                             "transport_outcome": "error",
                         },
@@ -381,7 +410,11 @@ def _run_compat_ask_impl(
                     worker_id=worker_id,
                     fence_token=lease.fence_token,
                     state="complete" if bool(getattr(result, "ok", False)) else "failed",
-                    result=_result_receipt(result),
+                    result=_result_receipt(
+                        result,
+                        model_requested=model,
+                        effort_requested=effort,
+                    ),
                     failure=(
                         None
                         if bool(getattr(result, "ok", False))

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -101,8 +101,26 @@ def _replay_result(raw: bytes) -> object:
         "harness": payload.get("harness") or "acp",
     }
     provenance.update({"replayed": True, "transport": "acp"})
+    if not payload["ok"]:
+        return Result(
+            ok=False,
+            agent=str(payload["agent"]),
+            model=str(payload["model"]),
+            mode="read-only",
+            response=str(payload["response"]),
+            stderr_excerpt=payload.get("stderr_excerpt"),
+            duration_s=float(payload["duration_s"]),
+            session_id=None,
+            rate_limited=payload.get("transport_outcome") == "rate_limited",
+            stalled=False,
+            returncode=payload.get("returncode"),
+            effort=str(payload["effort"]),
+            usage_record=provenance,
+            transport_metadata=payload.get("transport_metadata"),
+            transport_outcome=payload.get("transport_outcome"),
+        )
     return Result(
-        ok=bool(payload["ok"]),
+        ok=True,
         agent=str(payload["agent"]),
         model=str(payload["model"]),
         mode="read-only",

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -48,7 +48,13 @@ def _result_receipt(
     effort_requested: str | None = None,
 ) -> bytes:
     actual_model = str(getattr(result, "model", ""))
-    effort_applied = str(getattr(result, "effort", "unknown"))
+    raw_effort = getattr(result, "effort", None)
+    if raw_effort is None or raw_effort == "unknown":
+        effort_applied = None
+        effort_str = "unknown"
+    else:
+        effort_applied = str(raw_effort)
+        effort_str = effort_applied
     payload = {
         "ok": bool(getattr(result, "ok", False)),
         "agent": str(getattr(result, "agent", "")),
@@ -57,11 +63,11 @@ def _result_receipt(
         "stderr_excerpt": getattr(result, "stderr_excerpt", None),
         "duration_s": float(getattr(result, "duration_s", 0.0)),
         "returncode": getattr(result, "returncode", None),
-        "effort": effort_applied,
+        "effort": effort_str,
         "from_model": actual_model,
         "model_requested": model_requested or actual_model,
         "effort_requested": effort_requested,
-        "effort_applied": effort_applied if effort_applied != "unknown" else None,
+        "effort_applied": effort_applied,
         "harness": "acp",
         "transport_metadata": getattr(result, "transport_metadata", None),
         "transport_outcome": getattr(result, "transport_outcome", None),

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -90,9 +90,12 @@ def _replay_result(raw: bytes) -> object:
             "transport_outcome": payload.get("transport_outcome", "error"),
         }
     actual_model = str(payload.get("from_model") or payload.get("model") or "acp-bridge-error")
-    applied_effort = payload.get("effort_applied")
-    if applied_effort is None and payload.get("effort") not in {None, "unknown"}:
+    if "effort_applied" in payload:
+        applied_effort = payload["effort_applied"]
+    elif payload.get("effort") not in {None, "unknown"}:
         applied_effort = payload["effort"]
+    else:
+        applied_effort = None
     provenance = {
         "from_model": actual_model,
         "model_requested": payload.get("model_requested") or actual_model,

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -389,12 +389,19 @@ def _extract_target_model(msg: dict) -> str | None:
 def _handle_agy_error(msg: dict, message_id: int, reason: str) -> None:
     """Record an Agy failure as a response message and acknowledge."""
     print(f"\n❌ Agy error for message #{message_id}: {reason}")
+    from ._ask_contract import failed_response_provenance
+
+    data, from_model = failed_response_provenance(
+        msg, bridge_model="agy-bridge-error", harness="agy"
+    )
     send_message(
         content=f"[Agy error] {reason}",
         task_id=msg["task_id"],
         msg_type="error",
         from_llm="agy",
         to_llm=msg["from"],
+        data=data,
+        from_model=from_model,
     )
     acknowledge(message_id)
     record_ask_failure(

--- a/scripts/ai_agent_bridge/_ask_contract.py
+++ b/scripts/ai_agent_bridge/_ask_contract.py
@@ -91,3 +91,19 @@ def response_provenance(
     if effort_reason:
         metadata["effort_reason"] = effort_reason
     return json.dumps(metadata, sort_keys=True), actual_model
+
+
+def failed_response_provenance(
+    message: Mapping[str, Any],
+    *,
+    bridge_model: str,
+    harness: str,
+) -> tuple[str, str]:
+    """Stamp a terminal bridge error without inventing an applied effort."""
+    return response_provenance(
+        message,
+        actual_model=bridge_model,
+        harness=harness,
+        effort_applied=None,
+        effort_reason="bridge execution failed before the requested effort could be applied",
+    )

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -30,6 +30,7 @@ from agent_runtime.runner import invoke as runtime_invoke
 from secret_redactor import redact_text
 
 from ._ask_contract import (
+    failed_response_provenance,
     resolve_model_selection,
     response_provenance,
     unsupported_effort_note,
@@ -56,6 +57,11 @@ from ._review_worktree import (
 VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 CLAUDE_DEFAULT_ASK_MODEL = "claude-sonnet-5"
 CLAUDE_ADVISORY_MODEL = "claude-opus-5"
+
+
+def _claude_error_provenance(msg: dict, bridge_model: str) -> tuple[str, str]:
+    """Return the uniform provenance required for a terminal Claude error."""
+    return failed_response_provenance(msg, bridge_model=bridge_model, harness="claude")
 
 
 def resolve_claude_ask_model(msg_type: str, to_model: str | None) -> str:
@@ -330,11 +336,14 @@ def _run_claude_sync_via_runtime(
 
     except RateLimitedError as exc:
         print(f"\n⏳ Claude rate limited: {exc}")
+        provenance_data, from_model = _claude_error_provenance(
+            msg, "claude-bridge-rate-limited"
+        )
         send_message(
             content=f"[Bridge Error] Claude rate limited: {exc}",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
-            from_model="claude-bridge-rate-limited",
+            data=provenance_data, from_model=from_model,
         )
         _response_sent = True
         acknowledge(message_id)
@@ -342,6 +351,7 @@ def _run_claude_sync_via_runtime(
     except (AgentStalledError, AgentTimeoutError) as exc:
         timeout_mins = timeout_val // 60
         print(f"\n❌ Claude CLI timed out ({timeout_mins} min sync limit): {exc}")
+        provenance_data, from_model = _claude_error_provenance(msg, "claude-bridge-timeout")
         send_message(
             content=(
                 f"[Bridge Error] Claude CLI timed out after {timeout_mins} minutes. "
@@ -349,28 +359,32 @@ def _run_claude_sync_via_runtime(
             ),
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
-            from_model="claude-bridge-timeout",
+            data=provenance_data, from_model=from_model,
         )
         _response_sent = True
         acknowledge(message_id)
         record_ask_failure(message_id, str(exc), timed_out=True)
     except AgentUnavailableError:
         print("❌ claude CLI not found. Is it installed?")
+        provenance_data, from_model = _claude_error_provenance(msg, "claude-bridge-not-found")
         send_message(
             content="[Bridge Error] Claude CLI not found on system",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
-            from_model="claude-bridge-not-found",
+            data=provenance_data, from_model=from_model,
         )
         _response_sent = True
         acknowledge(message_id)  # Must ack incoming msg to prevent stuck queue
         record_ask_failure(message_id, "Claude CLI not found")
     except ReviewWorktreeError as exc:
+        provenance_data, from_model = _claude_error_provenance(
+            msg, "claude-bridge-review-checkout"
+        )
         send_message(
             content=f"[Bridge Error] Claude review checkout failed: {exc}",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
-            from_model="claude-bridge-review-checkout",
+            data=provenance_data, from_model=from_model,
         )
         _response_sent = True
         acknowledge(message_id)
@@ -517,10 +531,11 @@ def _handle_claude_error(msg, message_id, stderr):
     print(f"\n❌ Claude CLI error: {error_msg[:500]}")
     sys.stdout.flush()
 
+    provenance_data, from_model = _claude_error_provenance(msg, "claude-bridge-error")
     send_message(
         content=f"[Bridge Error] Claude CLI failed:\n{error_msg[:500]}",
         task_id=msg['task_id'], msg_type="error",
-        from_llm="claude", to_llm=msg['from'], from_model="claude-bridge-error"
+        from_llm="claude", to_llm=msg['from'], data=provenance_data, from_model=from_model
     )
     acknowledge(message_id)
     record_ask_failure(message_id, error_msg)
@@ -530,10 +545,11 @@ def _handle_claude_error(msg, message_id, stderr):
 def _send_claude_fallback_error(msg, message_id):
     """Send fallback error when Claude process fails without sending a response."""
     try:
+        provenance_data, from_model = _claude_error_provenance(msg, "claude-bridge-error")
         send_message(
             content=f"[Bridge Error] Claude process failed unexpectedly for message #{message_id}. Check logs.",
             task_id=msg['task_id'], msg_type="error",
-            from_llm="claude", to_llm=msg['from'], from_model="claude-bridge-error"
+            from_llm="claude", to_llm=msg['from'], data=provenance_data, from_model=from_model
         )
         acknowledge(message_id)
         record_ask_failure(message_id, "Claude process failed unexpectedly")

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -488,13 +488,19 @@ def _extract_effort(msg: dict) -> str | None:
 def _handle_codex_error(msg: dict, message_id: int, error_msg: str) -> None:
     """Send bridge error back to sender."""
     print(f"\n❌ Codex CLI error: {error_msg[:500]}")
+    from ._ask_contract import failed_response_provenance
+
+    data, from_model = failed_response_provenance(
+        msg, bridge_model="codex-bridge-error", harness="codex"
+    )
     send_message(
         content=f"[Bridge Error] Codex CLI failed:\n{error_msg[:500]}",
         task_id=msg["task_id"],
         msg_type="error",
         from_llm="codex",
         to_llm=msg["from"],
-        from_model="codex-bridge-error",
+        data=data,
+        from_model=from_model,
     )
     acknowledge(message_id)
     record_ask_failure(
@@ -508,6 +514,11 @@ def _handle_codex_rate_limited(msg: dict, message_id: int, reason: str) -> None:
     """Defer a rate-limited message without acknowledging the inbound row."""
     print(f"\n⛔ Codex rate limited - message {message_id} deferred")
     print(f"   Reason: {reason}")
+    from ._ask_contract import failed_response_provenance
+
+    data, from_model = failed_response_provenance(
+        msg, bridge_model="codex-bridge-rate-limited", harness="codex"
+    )
     send_message(
         content=(
             "[Codex rate limited] Usage limit hit.\n"
@@ -520,7 +531,8 @@ def _handle_codex_rate_limited(msg: dict, message_id: int, reason: str) -> None:
         msg_type="error",
         from_llm="codex",
         to_llm=msg["from"],
-        from_model="codex-bridge-rate-limited",
+        data=data,
+        from_model=from_model,
     )
     record_ask_failure(message_id, reason)
 

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -604,12 +604,19 @@ Standing rules for bridge Q&A:
 def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
     """Record a Grok Build failure as a response message and acknowledge."""
     print(f"\nGrok Build error for message #{message_id}: {reason}")
+    from ._ask_contract import failed_response_provenance
+
+    data, from_model = failed_response_provenance(
+        msg, bridge_model="grok-bridge-error", harness="grok"
+    )
     send_message(
         content=f"[Grok Build error] {reason}",
         task_id=msg["task_id"],
         msg_type="error",
         from_llm="grok-build",
         to_llm=msg["from"],
+        data=data,
+        from_model=from_model,
     )
     acknowledge(message_id)
     record_ask_failure(

--- a/scripts/ai_agent_bridge/_kimi.py
+++ b/scripts/ai_agent_bridge/_kimi.py
@@ -183,9 +183,14 @@ def _build_kimi_prompt(
 
 def _handle_kimi_error(msg: dict, message_id: int, reason: str) -> None:
     """Persist a terminal Kimi failure and unblock the original ask."""
+    from ._ask_contract import failed_response_provenance
+
+    data, from_model = failed_response_provenance(
+        msg, bridge_model="kimi-bridge-error", harness="kimi"
+    )
     send_message(
         content=f"[Kimi error] {reason}", task_id=msg["task_id"], msg_type="error",
-        from_llm="kimi", to_llm=msg["from"],
+        from_llm="kimi", to_llm=msg["from"], data=data, from_model=from_model,
     )
     acknowledge(message_id)
     record_ask_failure(message_id, reason, timed_out="timeout" in reason.lower() or "stalled" in reason.lower())

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -108,7 +108,7 @@ def test_terminal_failure_replays_without_invoking_provider_again(
         "from_model": "gemini-3.6-flash-high",
         "model_requested": "gemini-3.6-flash-high",
         "effort_requested": "high",
-        "effort_applied": "high",
+        "effort_applied": None,
         "harness": "acp",
         "replayed": True,
         "transport": "acp",
@@ -372,6 +372,27 @@ def test_acp_result_receipt_and_replay_preserve_response_provenance() -> None:
         "replayed": True,
         "transport": "acp",
     }
+
+
+def test_acp_replay_preserves_explicit_none_effort_applied() -> None:
+    result = SimpleNamespace(
+        ok=True,
+        agent="agy",
+        model="gemini-3.6-flash-high",
+        response="answer",
+        stderr_excerpt=None,
+        duration_s=1.0,
+        returncode=0,
+        effort="high",
+        transport_metadata=None,
+        transport_outcome="ok",
+    )
+    payload = json.loads(_acp_compat._result_receipt(result))
+    payload["effort_applied"] = None
+
+    replay = _acp_compat._replay_result(json.dumps(payload).encode("utf-8"))
+
+    assert replay.usage_record["effort_applied"] is None
 
 
 def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> None:

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -104,11 +104,14 @@ def test_terminal_failure_replays_without_invoking_provider_again(
 
     assert replay.ok is False
     assert replay.transport_outcome == "error"
-    assert replay.usage_record["replayed"] is True
-    assert replay.usage_record["transport"] == "acp"
-    assert set(replay.usage_record) == {
-        "from_model", "model_requested", "effort_requested", "effort_applied",
-        "harness", "replayed", "transport",
+    assert replay.usage_record == {
+        "from_model": "gemini-3.6-flash-high",
+        "model_requested": "gemini-3.6-flash-high",
+        "effort_requested": "high",
+        "effort_applied": "high",
+        "harness": "acp",
+        "replayed": True,
+        "transport": "acp",
     }
     assert invoke.call_count == 1
 

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -395,6 +395,26 @@ def test_acp_replay_preserves_explicit_none_effort_applied() -> None:
     assert replay.usage_record["effort_applied"] is None
 
 
+def test_acp_failed_result_receipt_serializes_none_effort_as_unapplied() -> None:
+    result = SimpleNamespace(
+        ok=False,
+        agent="agy",
+        model="gemini-3.6-flash-high",
+        response="",
+        stderr_excerpt="provider failed",
+        duration_s=1.0,
+        returncode=1,
+        effort=None,
+        transport_metadata=None,
+        transport_outcome="error",
+    )
+
+    payload = json.loads(_acp_compat._result_receipt(result))
+
+    assert payload["effort"] == "unknown"
+    assert payload["effort_applied"] is None
+
+
 def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> None:
     """Native grok ask prompt includes NATIVE_ASK_TOOL_CONTRACT when not review-provisioned; absent on review-provisioned, reverted builders, and full drivers (#5893)."""
     from ai_agent_bridge._ask_contract import NATIVE_ASK_TOOL_CONTRACT

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from ai_agent_bridge import _acp_compat, _cli
 from ai_agent_bridge._ask_contract import (
     EFFORT_CHOICES,
+    failed_response_provenance,
     resolve_model_selection,
     response_provenance,
     unsupported_effort_note,
@@ -103,7 +104,12 @@ def test_terminal_failure_replays_without_invoking_provider_again(
 
     assert replay.ok is False
     assert replay.transport_outcome == "error"
-    assert replay.usage_record == {"replayed": True, "transport": "acp"}
+    assert replay.usage_record["replayed"] is True
+    assert replay.usage_record["transport"] == "acp"
+    assert set(replay.usage_record) == {
+        "from_model", "model_requested", "effort_requested", "effort_applied",
+        "harness", "replayed", "transport",
+    }
     assert invoke.call_count == 1
 
 
@@ -219,7 +225,10 @@ def test_claim_race_to_terminal_replays_without_invoking_provider(
     )
 
     assert result.response == "durably completed response"
-    assert result.usage_record == {"replayed": True, "transport": "acp"}
+    assert result.usage_record["replayed"] is True
+    assert result.usage_record["transport"] == "acp"
+    assert result.usage_record["from_model"] == "gemini-3.6-flash-high"
+    assert result.usage_record["harness"] == "acp"
     assert invoke.call_count == 0
 
 
@@ -304,6 +313,61 @@ def test_every_response_provenance_shape_has_required_fields(harness: str) -> No
         "from_model": "actual",
         "harness": harness,
         "model_requested": "requested",
+    }
+
+
+def test_failed_response_provenance_preserves_request_and_marks_unapplied_effort() -> None:
+    data, from_model = failed_response_provenance(
+        {"data": json.dumps({"to_model": "requested", "effort": "xhigh"})},
+        bridge_model="agy-bridge-error",
+        harness="agy",
+    )
+
+    assert from_model == "agy-bridge-error"
+    assert json.loads(data) == {
+        "effort_applied": None,
+        "effort_reason": "bridge execution failed before the requested effort could be applied",
+        "effort_requested": "xhigh",
+        "from_model": "agy-bridge-error",
+        "harness": "agy",
+        "model_requested": "requested",
+    }
+
+
+def test_acp_result_receipt_and_replay_preserve_response_provenance() -> None:
+    result = SimpleNamespace(
+        ok=True,
+        agent="agy",
+        model="gemini-3.6-flash-high",
+        response="answer",
+        stderr_excerpt=None,
+        duration_s=1.0,
+        returncode=0,
+        effort="high",
+        transport_metadata=None,
+        transport_outcome="ok",
+    )
+
+    receipt = _acp_compat._result_receipt(
+        result, model_requested="gemini-3.6-flash-high", effort_requested="high"
+    )
+    payload = json.loads(receipt)
+    assert {key: payload[key] for key in ("from_model", "model_requested", "effort_requested", "effort_applied", "harness")} == {
+        "from_model": "gemini-3.6-flash-high",
+        "model_requested": "gemini-3.6-flash-high",
+        "effort_requested": "high",
+        "effort_applied": "high",
+        "harness": "acp",
+    }
+    replay = _acp_compat._replay_result(receipt)
+    assert replay.usage_record == {
+        "from_model": "gemini-3.6-flash-high",
+        "model_requested": "gemini-3.6-flash-high",
+        "effort_requested": "high",
+        "effort_applied": "high",
+        "harness": "acp",
+        "replayed": True,
+        "transport": "acp",
     }
 
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import select
 import subprocess
 import sys
 import time
@@ -4366,6 +4367,187 @@ def test_gh_shim_allows_pr_merge_with_opt_in(tmp_path):
     assert proc.stdout.strip() == "real-gh pr merge 1234"
 
 
+def test_gh_shim_retries_mocked_secondary_rate_limit_and_replays_stdin(tmp_path):
+    """A GitHub 403 secondary limit retries without losing a PR/comment body."""
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "count=$((count + 1))\n"
+        "printf '%s' \"$count\" >\"$attempts\"\n"
+        "if [[ \"$count\" == 1 ]]; then\n"
+        "  printf 'retry-output-should-not-leak\\n'\n"
+        "  printf 'HTTP 403: You have exceeded a secondary rate limit.\\n' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "printf 'real-gh %s stdin=%s\\n' \"$*\" \"$(cat)\"\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "issue", "comment", "5146", "-F", "-"],
+        input="preserved comment body\n",
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0
+    assert attempts.read_text(encoding="utf-8") == "2"
+    assert proc.stdout.strip() == "real-gh issue comment 5146 -F - stdin=preserved comment body"
+    assert "retry-output-should-not-leak" not in proc.stdout
+    assert "You have exceeded a secondary rate limit" not in proc.stderr
+    assert "GitHub HTTP 403 throttled; retrying gh in 0s (attempt 1/2)." in proc.stderr
+    assert "github_secondary_rate_limited" not in proc.stderr
+
+
+def test_gh_shim_emits_only_final_attempt_output_and_exhaustion_marker(tmp_path):
+    """Intermediate secondary-limit output stays private until retries exhaust."""
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "count=$((count + 1))\n"
+        "printf '%s' \"$count\" >\"$attempts\"\n"
+        "printf 'attempt-%s-stdout\\n' \"$count\"\n"
+        "printf 'HTTP 403: secondary rate limit on attempt %s\\n' \"$count\" >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "issue", "comment", "5146"],
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 1
+    assert attempts.read_text(encoding="utf-8") == "3"
+    assert proc.stdout == "attempt-3-stdout\n"
+    assert "attempt-1-stdout" not in proc.stdout
+    assert "attempt-2-stdout" not in proc.stdout
+    assert "secondary rate limit on attempt 1" not in proc.stderr
+    assert "secondary rate limit on attempt 2" not in proc.stderr
+    assert proc.stderr.count("github_secondary_rate_limited") == 1
+
+
+def test_gh_shim_cleans_retry_tempfiles_on_sigterm(tmp_path):
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    ready = tmp_path / "ready"
+    temp_dir = tmp_path / "shim-temp"
+    temp_dir.mkdir()
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"ready={ready!s}\n"
+        "printf 'ready' >\"$ready\"\n"
+        "printf 'HTTP 403: secondary rate limit.\\n' >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.Popen(
+        [str(shim), "issue", "comment", "5146"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "30",
+            "PATH": os.environ.get("PATH", ""),
+            "TMPDIR": str(temp_dir),
+        },
+    )
+    for _ in range(100):
+        if ready.exists():
+            break
+        time.sleep(0.01)
+    assert ready.exists()
+    readable, _, _ = select.select([proc.stderr], [], [], 2)
+    assert readable, "shim did not enter secondary-rate-limit backoff"
+    # The retry diagnostic is emitted immediately before the delay starts.
+    # Give the shell a scheduling turn so SIGTERM reaches active backoff code.
+    time.sleep(0.05)
+
+    proc.terminate()
+    _, stderr = proc.communicate(timeout=2)
+
+    assert proc.returncode == 143
+    assert "retrying gh in 30s" in stderr
+    assert list(temp_dir.iterdir()) == []
+
+
+def test_gh_shim_requires_an_explicit_http_status_for_secondary_limit_retry(tmp_path):
+    shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "gh"
+    fake_gh = tmp_path / "real-gh"
+    attempts = tmp_path / "attempts"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"attempts={attempts!s}\n"
+        "count=0\n"
+        "[[ -f \"$attempts\" ]] && count=$(cat \"$attempts\")\n"
+        "printf '%s' \"$((count + 1))\" >\"$attempts\"\n"
+        "printf 'secondary rate limit incident #403\\n' >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(shim), "pr", "create"],
+        capture_output=True,
+        text=True,
+        env={
+            "AGENT_NO_MERGE": "1",
+            "AGENT_REAL_GH": str(fake_gh),
+            "AGENT_GH_SECONDARY_RATE_LIMIT_RETRIES": "2",
+            "AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS": "0",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        check=False,
+        timeout=15,
+    )
+
+    assert proc.returncode == 1
+    assert attempts.read_text(encoding="utf-8") == "1"
+    assert "throttled; retrying" not in proc.stderr
+
+
 def test_git_shim_blocks_push_to_main_without_opt_in(tmp_path):
     shim = Path(__file__).resolve().parent.parent / "scripts" / "agent_runtime" / "shims" / "git"
     fake_git = tmp_path / "real-git"
@@ -4624,6 +4806,7 @@ def test_acp_routes_share_a_bounded_protocol_envelope(agent_name):
             "acp_review_evidence_too_large",
         ),
         ("error", False, False, "acp_adapter_missing", None, "acp_adapter_missing"),
+        ("error", False, False, "github_secondary_rate_limited", 1, "github_secondary_rate_limited"),
         ("error", False, False, None, 1, "transport_error"),
         ("rate_limited", True, False, None, 1, "rate_limited"),
     ],


### PR DESCRIPTION
## Summary

Persists the full ask provenance contract in ACP terminal receipts and replay results, and stamps legacy background error replies with the same fields.

This prevents a completed or replayed response from losing its answering-model, requested model/effort, applied effort, and harness attribution.

Refs #5761

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/ai_agent_bridge/test_ask_contract.py tests/ai_agent_bridge/test_claude_advisory_routing.py tests/test_codex_bridge.py tests/test_kimi_integration.py tests/test_model_catalog.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check …`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

`swarm_used: true` — one read-only internal audit identified the ACP receipt and background-error gaps; no worker edits.