### PR TITLE
ci: restore duration-balanced pytest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
 
-# CI Gate reboot (#5762). The prior control plane (4-way pytest sharding +
-# a deterministic-selection planner + JUnit reconstruction + a paths-filtered
-# `changes` job gating every required job) caused four consecutive gate
-# failures and a two-day outage — every failure was in the verification
-# machinery, never in the tests themselves. This file replaces it with four
-# required jobs that always run, plus one aggregator.
+# CI Gate reboot (#5762) made every required job unconditional after the prior
+# paths-filtered control plane caused four consecutive gate failures. #5744
+# restores the proven pytest topology: one deterministic planner, four
+# duration-balanced file shards, and JUnit reconstruction inside CI Gate.
 #
 # Invariant (encodes #3873 #4888 #4936 #5351 #5354): pytest must NEVER be
 # selected or skipped by changed files. Five separate incidents shipped a
@@ -32,14 +30,81 @@ on:
 
 jobs:
   # ---------------------------------------------------------------------
-  # 1. python — the full test suite, one job, no sharding, no path filter.
+  # 1. pytest-plan — collect once, then produce all four LPT file plans from
+  #    one duration dataset restored from a successful main run (#5744).
   # ---------------------------------------------------------------------
-  # Four PARALLEL JOBS, not one xdist session (#5776, 3-seat advisor panel).
-  # Sharding was never the bug — changed-files SELECTION was. This keeps the
-  # reboot's invariant (no test is chosen or skipped by what changed) and
-  # restores the only topology that has ever completed: the single-session
-  # design never finished once, stalling ~94-95% with ~23 minutes of silence on
-  # a DIFFERENT test each run.
+  pytest-plan:
+    name: Pytest plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Restore Atlas lexicon manifest cache
+        id: atlas-manifest-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
+      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        run: |
+          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+
+      - name: Install planner dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt \
+            > "${RUNNER_TEMP}/requirements-ci.txt"
+          .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt"
+          .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
+            torch==2.13.0
+          .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
+
+      - name: Restore successful-main pytest duration dataset
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-artifacts/pytest-durations.json
+          key: pytest-shard-durations-v1-main-${{ github.sha }}
+          restore-keys: |
+            pytest-shard-durations-v1-main-
+
+      - name: Plan all duration-balanced pytest shards
+        run: |
+          .venv/bin/python scripts/ci/pytest_shards.py plan \
+            --durations ci-artifacts/pytest-durations.json \
+            --output-dir ci-artifacts/plans
+
+      - name: Upload pytest plans
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-plans
+          path: ci-artifacts/plans/
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------
+  # 2. python — execute the planner's four unconditional test partitions.
+  # ---------------------------------------------------------------------
+  # The selection still never consults changed files: every collected test runs
+  # exactly once. Four parallel jobs are the topology that completed under the
+  # #5776 hang investigation; one xdist session did not.
   python:
     name: Python (pytest) [${{ matrix.shard }}/4]
     runs-on: ubuntu-latest
@@ -48,6 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
+    needs: [pytest-plan]
     permissions:
       contents: read
     steps:
@@ -148,61 +214,70 @@ jobs:
       - name: Ruff
         run: .venv/bin/python -m ruff check scripts/
 
-      # The playground perf probe is deselected here and run as its own
-      # serial step below — it is the one SERIAL_TESTS entry with a real
-      # isolation claim (a wall-clock latency assertion that is flaky under
-      # parallel resource contention; confirmed locally: it failed inside
-      # the `-n auto` bulk run and passed standalone). The two cache tests
-      # that used to need isolation do not: #2002's autouse fixture already
-      # fixed that class, so they run as ordinary members of the suite.
-      # Coverage is collected only on pushes to `main`, matching the behaviour
-      # this file replaces — it is a trend floor, not a per-PR gate, and
-      # instrumentation costs wall-clock on every PR for no added signal.
-      # QUARANTINE — #5776, one node, temporary, owned.
-      # test_main_cli_encode_flag_wires_ingest_to_manifest HANGS in a full
-      # parallel run: it started at 15:54:23 in run 30163791890 and had produced
-      # nothing 23 minutes later when the new 45-minute cap killed the job. It
-      # passes ALONE in 0.57s and `pytest tests/wiki -n 2` completes in 15s, so
-      # it is an interaction with full-suite state, not a bad test.
-      #
-      # This is a NAMED node with an open issue, not a path filter: it cannot
-      # grow to hide unrelated tests, and it does not reintroduce changed-files
-      # selection (the defect this reboot exists to remove, #3873 #4888 #4936
-      # #5351 #5354). If the cause turns out to be shared global state, the hang
-      # will simply move — and the cap now makes that a bounded, visible failure
-      # rather than a silent six-hour stall.
-      - name: Run pytest
+      - name: Download the single planner's shard plans
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pytest-plans
+          path: ci-artifacts/plans
+
+      # The playground probe is deliberately excluded from the planner's bulk
+      # collection and is run serially on shard 1. It is a named isolation
+      # exception, never a changed-file filter; all other collected tests run
+      # through the file-grouped LPT plan exactly once.
+      - name: Run planned pytest shard
+        id: pytest
+        continue-on-error: true
         timeout-minutes: 25
-        # The predicate is evaluated by the expression engine and reaches the
-        # shell as the literal string "true"/"false" via env — `github.ref` is
-        # never spliced into `run:`, so a hostile branch name cannot inject.
         env:
           IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           SHARD: ${{ matrix.shard }}
           PYTEST_BREADCRUMB_DIR: .pytest_breadcrumbs
         run: |
+          set -o pipefail
+          mkdir -p ci-artifacts
+          cp "ci-artifacts/plans/pytest-shard-${SHARD}/plan.json" ci-artifacts/plan.json
+          cp "ci-artifacts/plans/pytest-shard-${SHARD}/test-nodeids.txt" ci-artifacts/test-nodeids.txt
+          if grep -q '^tests/agent_runtime/test_acp_text_agent.py::' ci-artifacts/test-nodeids.txt; then
+            npm ci --ignore-scripts
+          fi
           cov_args=""
           if [ "$IS_MAIN_PUSH" = "true" ]; then
             cov_args="--cov=scripts --cov-report="
           fi
-          # Round-robin over SORTED test files. Deterministic, depends only on the
-          # file list, and every file lands in exactly one shard — so the union is
-          # always the whole suite. Nothing here consults the diff.
-          split_py="import pathlib,sys;fs=sorted(str(p) for p in pathlib.Path('tests').rglob('test_*.py'));print(chr(10).join(fs[int(sys.argv[1])-1::4]))"
-          mapfile -t shard_files < <(.venv/bin/python -c "$split_py" "$SHARD")
-          echo "shard $SHARD: ${#shard_files[@]} test files"
-          if [ "${#shard_files[@]}" -eq 0 ]; then echo "::error::empty shard"; exit 1; fi
-          # The text ACP protocol test executes the project-owned Node server,
-          # which imports the exact SDK pinned in package-lock.json. Install
-          # Node dependencies only in the shard that owns that test file.
-          if printf '%s\n' "${shard_files[@]}" | grep -Fxq \
-            'tests/agent_runtime/test_acp_text_agent.py'; then
-            npm ci --ignore-scripts
-          fi
           # shellcheck disable=SC2086  # cov_args is a deliberate word-split argument list
-          .venv/bin/python -m pytest "${shard_files[@]}" -n auto --strict-markers \
-            --timeout=120 --timeout-method=thread --durations=25 $cov_args \
-            --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast
+          .venv/bin/python scripts/ci/pytest_shards.py run --nodeids ci-artifacts/test-nodeids.txt -- \
+            -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread \
+            --junitxml=ci-artifacts/main-junit.xml --durations=0 $cov_args \
+            2>&1 | tee ci-artifacts/main.log
+
+      - name: Playground perf probe (serial, shard 1 only)
+        id: playground
+        if: matrix.shard == 1
+        continue-on-error: true
+        run: |
+          for attempt in 1 2 3; do
+            echo "playground smoke attempt ${attempt}/3"
+            if .venv/bin/python -m pytest \
+              tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+              -v --tb=short --junitxml=ci-artifacts/playground-junit.xml; then
+              exit 0
+            fi
+            sleep 3
+          done
+          exit 1
+
+      - name: Upload pytest shard plan and results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-shard-${{ matrix.shard }}
+          path: ci-artifacts/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Fail after preserving pytest evidence
+        if: steps.pytest.outcome != 'success' || (matrix.shard == 1 && steps.playground.outcome != 'success')
+        run: exit 1
 
       - name: Upload test breadcrumbs
         if: always()
@@ -220,15 +295,10 @@ jobs:
       # its removal as a P1: without it a green CI Gate could accompany an
       # arbitrarily large coverage regression.
       #
-      # Simpler than what it replaces: the four shards ran as separate JOBS, so
-      # main had to upload four `.coverage.shard-*` artifacts and `coverage
-      # combine` them. One job with `-n auto` means pytest-cov combines the
-      # xdist workers itself, and `coverage report` just reads the result.
-      # The floor moves to its own job: with four shards no single one sees the
-      # whole suite, so enforcing per-shard would measure a quarter and pass
-      # vacuously. Each shard publishes its data; `coverage-floor` combines.
+      # Each matrix shard publishes its xdist-combined data. The floor stays in
+      # its own job because no individual shard observes the whole suite.
       - name: Upload shard coverage data
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pytest.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-shard-${{ matrix.shard }}
@@ -237,24 +307,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      # Wall-clock perf probe. Kept serial, after the main body, with its
-      # existing retry-on-flake: /api/rag/search_text can 500 on an FTS
-      # rebuild race under load.
-      - name: Playground perf probe (serial)
-        run: |
-          for attempt in 1 2 3; do
-            echo "playground smoke attempt ${attempt}/3"
-            if .venv/bin/python -m pytest \
-              tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
-              -v --tb=short; then
-              exit 0
-            fi
-            sleep 3
-          done
-          exit 1
-
   # ---------------------------------------------------------------------
-  # 2. contracts — deterministic drift/artifact checks. Unconditional:
+  # 3. contracts — deterministic drift/artifact checks. Unconditional:
   #    every check here diffs against origin/main or a committed file
   #    itself, so an untouched input is a fast no-op, not a skip.
   # ---------------------------------------------------------------------
@@ -555,7 +609,7 @@ jobs:
           printf '%s' "$PR_BODY" | .venv/bin/python scripts/audit/lint_pr_closing_references.py --stdin
 
   # ---------------------------------------------------------------------
-  # 3. frontend — build + vitest. Unconditional.
+  # 4. frontend — build + vitest. Unconditional.
   # ---------------------------------------------------------------------
   frontend:
     name: Frontend (build + vitest)
@@ -695,10 +749,58 @@ jobs:
         run: npx playwright test
 
   # ---------------------------------------------------------------------
+  # ---------------------------------------------------------------------
   # 4. Coverage floor + CI Gate. Secret scanning and the PR-body reference
   #    guard live inside `contracts` (#4811 slot cut). Every remaining
   #    required job above is unconditional, so `skipped` is as much a
   #    failure as `failure`/`cancelled`.
+
+  # Duration data is intentionally published only after every matrix member of
+  # a push to main succeeds. PRs and failed main runs can consume a prior main
+  # dataset but can never overwrite it.
+  pytest-duration-publish:
+    name: Publish pytest durations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.python.result == 'success'
+    needs: [python]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+      - name: Restore prior successful-main duration dataset
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-artifacts/pytest-durations.json
+          key: pytest-shard-durations-v1-main-${{ github.sha }}
+          restore-keys: |
+            pytest-shard-durations-v1-main-
+      - name: Download pytest shard results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pytest-shard-*
+          path: ci-artifacts
+      - name: Publish successful-main durations and p95 summary
+        run: |
+          python scripts/ci/pytest_shards.py publish-durations \
+            --log ci-artifacts/pytest-shard-1/main.log \
+            --log ci-artifacts/pytest-shard-2/main.log \
+            --log ci-artifacts/pytest-shard-3/main.log \
+            --log ci-artifacts/pytest-shard-4/main.log \
+            --previous ci-artifacts/pytest-durations.json \
+            --output ci-artifacts/pytest-durations.json \
+            --summary "${GITHUB_STEP_SUMMARY}"
+      - name: Save successful-main duration dataset
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-artifacts/pytest-durations.json
+          key: pytest-shard-durations-v1-main-${{ github.sha }}
+
   # ---------------------------------------------------------------------
   # Enforces the 35% floor ONCE, over the combined four-shard data. Restores the
   # guarantee cross-family review flagged as a P1 when the reboot dropped it.
@@ -747,11 +849,25 @@ jobs:
     timeout-minutes: 10
     if: always()
     needs:
+      - pytest-plan
       - python
       - contracts
       - frontend
       - coverage-floor
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+      - name: Download pytest plans and JUnit results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pytest-shard-*
+          path: ci-artifacts
+      - name: Verify pytest shard completeness
+        run: python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir ci-artifacts
       - name: Report required-job results
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}

--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Plan and verify duration-balanced pytest shards for the CI Gate.
+
+The planner collects the selected suite exactly once, groups every selected
+node ID by test file, then uses deterministic longest-processing-time (LPT)
+assignment.  Workers execute only the planner-produced node-ID list; CI Gate
+reconstructs and verifies the complete partition from their JUnit artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import statistics
+import sys
+import xml.etree.ElementTree as element_tree
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+SHARD_COUNT = 4
+PLAYGROUND_PERF_TEST = "tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast"
+SERIAL_TESTS = (PLAYGROUND_PERF_TEST,)
+COMMON_ARGS = ("tests/", f"--deselect={PLAYGROUND_PERF_TEST}")
+_DURATION_LINE = re.compile(r"^\s*(?P<seconds>\d+(?:\.\d+)?)s\s+(?:call|setup|teardown)\s+(?P<nodeid>\S+)")
+_DATASET_VERSION = 1
+_P95_HISTORY_LIMIT = 40
+
+
+def _digest(nodeids: Iterable[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(nodeids)).encode("utf-8")).hexdigest()
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+class _NodeidCollector:
+    def __init__(self) -> None:
+        self.nodeids: list[str] = []
+
+    def pytest_collection_finish(self, session: Any) -> None:
+        self.nodeids = [item.nodeid for item in session.items]
+
+
+def collect_nodeids(args: Sequence[str] = COMMON_ARGS) -> list[str]:
+    """Collect the exact selection executed by the matrix workers."""
+    import pytest
+
+    collector = _NodeidCollector()
+    exit_code = pytest.main([*args, "--collect-only", "-q"], plugins=[collector])
+    if exit_code != pytest.ExitCode.OK:
+        raise RuntimeError(f"pytest collection failed with exit code {exit_code}")
+    if not collector.nodeids:
+        raise RuntimeError("pytest collection selected zero tests")
+    if len(set(collector.nodeids)) != len(collector.nodeids):
+        raise RuntimeError("pytest collection returned duplicate node IDs")
+    return collector.nodeids
+
+
+def load_durations(path: Path | None) -> dict[str, float]:
+    """Load only valid node timings from a main-only duration dataset."""
+    if path is None or not path.exists():
+        return {}
+    raw = _read_json(path)
+    if not isinstance(raw, dict):
+        raise ValueError(f"duration file {path} must be a JSON object")
+    source = raw.get("node_durations", raw)
+    if not isinstance(source, dict):
+        raise ValueError(f"duration file {path} has invalid node_durations")
+    return {
+        nodeid: float(duration)
+        for nodeid, duration in source.items()
+        if isinstance(nodeid, str) and isinstance(duration, (int, float)) and duration > 0
+    }
+
+
+def _file_nodeids(nodeids: Sequence[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    for nodeid in nodeids:
+        groups.setdefault(nodeid.split("::", 1)[0], []).append(nodeid)
+    return groups
+
+
+def _file_weights(nodeids: Sequence[str], durations: dict[str, float]) -> dict[str, float]:
+    """Return file weights; files without history use the median known file weight."""
+    groups = _file_nodeids(nodeids)
+    known = {
+        filename: sum(durations[nodeid] for nodeid in members if nodeid in durations)
+        for filename, members in groups.items()
+    }
+    observed = sorted(weight for weight in known.values() if weight > 0)
+    fallback = statistics.median(observed) if observed else 1.0
+    return {filename: weight if weight > 0 else fallback for filename, weight in known.items()}
+
+
+def assign_shards(nodeids: Sequence[str], shard_count: int, durations: dict[str, float]) -> list[list[str]]:
+    """Use deterministic file-grouped LPT scheduling; assign each node ID once."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    if len(set(nodeids)) != len(nodeids):
+        raise ValueError("nodeids must be unique before sharding")
+    groups = _file_nodeids(nodeids)
+    weights = _file_weights(nodeids, durations)
+    weighted_groups = sorted(groups, key=lambda filename: (-weights[filename], filename))
+    shard_groups: list[list[str]] = [[] for _ in range(shard_count)]
+    totals = [0.0] * shard_count
+    for filename in weighted_groups:
+        shard_index = min(range(shard_count), key=lambda index: (totals[index], index))
+        shard_groups[shard_index].extend(groups[filename])
+        totals[shard_index] += weights[filename]
+    return shard_groups
+
+
+def write_plans(*, durations_path: Path | None, output_dir: Path, shard_count: int = SHARD_COUNT) -> None:
+    """Collect once and write every matrix-worker plan from one duration dataset."""
+    nodeids = collect_nodeids()
+    durations = load_durations(durations_path)
+    shards = assign_shards(nodeids, shard_count, durations)
+    if any(not assigned for assigned in shards):
+        empty = [index + 1 for index, assigned in enumerate(shards) if not assigned]
+        raise RuntimeError(f"planner produced empty shard(s): {empty}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    weights = _file_weights(nodeids, durations)
+    for shard_id, assigned in enumerate(shards, start=1):
+        shard_dir = output_dir / f"pytest-shard-{shard_id}"
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        (shard_dir / "test-nodeids.txt").write_text("\n".join(assigned) + "\n", encoding="utf-8")
+        assigned_files = sorted({nodeid.split("::", 1)[0] for nodeid in assigned})
+        _write_json(
+            shard_dir / "plan.json",
+            {
+                "assigned_digest": _digest(assigned),
+                "assigned_nodeids": assigned,
+                "collected_count": len(nodeids),
+                "collected_digest": _digest(nodeids),
+                "estimated_seconds": sum(weights[filename] for filename in assigned_files),
+                "grouping": "file",
+                "partition_mode": "lpt-durations",
+                "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
+                "shard_count": shard_count,
+                "shard_id": shard_id,
+            },
+        )
+
+
+def _junit_count(path: Path) -> int:
+    root = element_tree.parse(path).getroot()
+    if root.tag == "testsuite":
+        return int(root.attrib.get("tests", "0"))
+    return sum(int(suite.attrib.get("tests", "0")) for suite in root.iter("testsuite"))
+
+
+def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
+    """Fail closed unless plan, execution count, and partition all agree."""
+    plans: list[dict[str, Any]] = []
+    for shard_id in range(1, shard_count + 1):
+        shard_dir = artifact_dir / f"pytest-shard-{shard_id}"
+        plan_path = shard_dir / "plan.json"
+        main_junit = shard_dir / "main-junit.xml"
+        if not plan_path.exists() or not main_junit.exists():
+            raise RuntimeError(f"missing plan or main JUnit artifact for shard {shard_id}")
+        plan = _read_json(plan_path)
+        if plan.get("shard_id") != shard_id or plan.get("shard_count") != shard_count:
+            raise RuntimeError(f"invalid shard identity in {plan_path}")
+        assigned = plan.get("assigned_nodeids")
+        if not isinstance(assigned, list) or not all(isinstance(nodeid, str) for nodeid in assigned):
+            raise RuntimeError(f"invalid assigned node IDs in {plan_path}")
+        if _digest(assigned) != plan.get("assigned_digest"):
+            raise RuntimeError(f"assigned node ID digest mismatch in {plan_path}")
+        if plan.get("partition_mode") != "lpt-durations" or plan.get("grouping") != "file":
+            raise RuntimeError(f"invalid planner mode in {plan_path}")
+        if _junit_count(main_junit) != len(assigned):
+            raise RuntimeError(f"main JUnit count does not match plan for shard {shard_id}")
+        serial = plan.get("serial_nodeids")
+        if shard_id == 1:
+            playground_junit = shard_dir / "playground-junit.xml"
+            if serial != list(SERIAL_TESTS) or not playground_junit.exists():
+                raise RuntimeError("shard 1 must execute the documented serial tests")
+            if _junit_count(playground_junit) != len(SERIAL_TESTS):
+                raise RuntimeError("serial JUnit count does not match the documented serial tests")
+        elif serial or (shard_dir / "playground-junit.xml").exists():
+            raise RuntimeError(f"only shard 1 may contain serial tests (found shard {shard_id})")
+        plans.append(plan)
+
+    counts = {plan["collected_count"] for plan in plans}
+    digests = {plan["collected_digest"] for plan in plans}
+    if len(counts) != 1 or len(digests) != 1:
+        raise RuntimeError("shards disagree about the collected selection")
+    assigned = [nodeid for plan in plans for nodeid in plan["assigned_nodeids"]]
+    if len(assigned) != len(set(assigned)):
+        raise RuntimeError("a collected test was assigned to more than one shard")
+    if set(assigned).intersection(SERIAL_TESTS):
+        raise RuntimeError("a serial test was also assigned to a parallel shard")
+    if len(assigned) != counts.pop() or _digest(assigned) != digests.pop():
+        raise RuntimeError("shards do not form a complete partition of the collected selection")
+
+
+def parse_durations(log_paths: Sequence[Path]) -> dict[str, float]:
+    durations: dict[str, float] = {}
+    for path in log_paths:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            match = _DURATION_LINE.match(line)
+            if match:
+                nodeid = match.group("nodeid")
+                durations[nodeid] = durations.get(nodeid, 0.0) + float(match.group("seconds"))
+    if not durations:
+        raise RuntimeError("no pytest duration lines found in shard logs")
+    return durations
+
+
+def _nearest_rank_p95(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("cannot calculate p95 of an empty history")
+    ordered = sorted(values)
+    return ordered[max(0, (95 * len(ordered) + 99) // 100 - 1)]
+
+
+def publish_durations(*, log_paths: Sequence[Path], previous: Path | None, output: Path, summary: Path) -> None:
+    """Publish successful-main timings and quote rolling slowest-shard p95."""
+    node_durations = parse_durations(log_paths)
+    prior: dict[str, Any] = _read_json(previous) if previous and previous.exists() else {}
+    history = prior.get("slowest_shard_seconds", []) if isinstance(prior, dict) else []
+    if not isinstance(history, list) or not all(isinstance(value, (int, float)) and value > 0 for value in history):
+        raise ValueError("previous duration dataset has invalid slowest_shard_seconds")
+    shard_totals = [sum(parse_durations([path]).values()) for path in log_paths]
+    slowest = max(shard_totals)
+    history = [*map(float, history), slowest][-_P95_HISTORY_LIMIT:]
+    p95 = _nearest_rank_p95(history)
+    _write_json(
+        output,
+        {
+            "node_durations": node_durations,
+            "schema_version": _DATASET_VERSION,
+            "slowest_shard_seconds": history,
+        },
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        "## Pytest shard duration record\n\n"
+        f"Successful main run shard test durations: {', '.join(f'{total:.2f}s' for total in shard_totals)}.\n\n"
+        f"Slowest-shard p95: **{p95:.2f}s** across {len(history)} successful main run(s).\n",
+        encoding="utf-8",
+    )
+
+
+def run_nodeids(nodeids_path: Path, pytest_args: Sequence[str]) -> int:
+    """Invoke pytest with a planner-produced node-ID list (not shell @file)."""
+    import pytest
+
+    nodeids = [line.strip() for line in nodeids_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not nodeids:
+        raise RuntimeError(f"node-id file {nodeids_path} is empty")
+    if len(set(nodeids)) != len(nodeids):
+        raise RuntimeError(f"node-id file {nodeids_path} contains duplicates")
+    args = list(pytest_args)
+    if args and args[0] == "--":
+        args = args[1:]
+    return int(pytest.main([*args, *nodeids]))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan")
+    plan.add_argument("--durations", type=Path)
+    plan.add_argument("--output-dir", type=Path, required=True)
+    plan.add_argument("--shard-count", type=int, default=SHARD_COUNT)
+    verify = commands.add_parser("verify-artifacts")
+    verify.add_argument("--artifact-dir", type=Path, required=True)
+    verify.add_argument("--shard-count", type=int, default=SHARD_COUNT)
+    publish = commands.add_parser("publish-durations")
+    publish.add_argument("--log", type=Path, action="append", required=True)
+    publish.add_argument("--previous", type=Path)
+    publish.add_argument("--output", type=Path, required=True)
+    publish.add_argument("--summary", type=Path, required=True)
+    run = commands.add_parser("run")
+    run.add_argument("--nodeids", type=Path, required=True)
+    run.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "plan":
+            write_plans(durations_path=args.durations, output_dir=args.output_dir, shard_count=args.shard_count)
+        elif args.command == "verify-artifacts":
+            verify_artifacts(args.artifact_dir, args.shard_count)
+        elif args.command == "publish-durations":
+            publish_durations(log_paths=args.log, previous=args.previous, output=args.output, summary=args.summary)
+        elif args.command == "run":
+            return run_nodeids(args.nodeids, args.pytest_args)
+    except (OSError, RuntimeError, ValueError, element_tree.ParseError) as error:
+        print(f"pytest shard error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -47,6 +47,7 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     assert "trufflesecurity/trufflehog@" in contracts_steps
     assert "lint_pr_closing_references.py" in contracts_steps
     assert set(jobs["ci-gate"]["needs"]) == {
+        "pytest-plan",
         "python",
         "contracts",
         "frontend",

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -1,97 +1,167 @@
-"""The CI shard split must be a PARTITION of the test suite.
-
-Sharding is how the gate runs at all (#5776: the single-session design never
-completed once). But a sharding bug is invisible in the worst way — every shard
-goes green while some tests simply never ran. That is the exact failure class the
-gate reboot exists to end (#3873 #4888 #4936 #5351 #5354, all "a required check
-passed while pytest was skipped").
-
-So the split expression is extracted from `.github/workflows/ci.yml` and executed
-here. If someone edits the shard logic in YAML and breaks coverage of the suite,
-this fails — the workflow is not a place where logic can hide from tests.
-"""
+"""Regression tests for CI Gate's duration-balanced pytest partition."""
 
 from __future__ import annotations
 
-import pathlib
-import re
-import subprocess
-import sys
+import json
+from pathlib import Path
 
 import pytest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
-WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
-SHARD_COUNT = 4
+from scripts.ci import pytest_shards
 
 
-def _split_expression() -> str:
-    """The one-liner the workflow feeds to `python -c`, read from the YAML itself."""
-    text = WORKFLOW.read_text(encoding="utf-8")
-    match = re.search(r'split_py="(?P<expr>[^"]+)"', text)
-    assert match, "shard split expression not found in ci.yml — did the shard job change shape?"
-    return match.group("expr")
+def _write_junit(path: Path, count: int) -> None:
+    path.write_text(f'<testsuite tests="{count}" />', encoding="utf-8")
 
 
-def _shard_files(shard: int) -> list[str]:
-    out = subprocess.run(
-        [sys.executable, "-c", _split_expression(), str(shard)],
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-        timeout=60,
-        check=True,
+def _write_complete_artifacts(root: Path, selected: list[str]) -> None:
+    digest = pytest_shards._digest(selected)
+    for shard_id, nodeid in enumerate(selected, start=1):
+        shard = root / f"pytest-shard-{shard_id}"
+        shard.mkdir()
+        plan = {
+            "assigned_digest": pytest_shards._digest([nodeid]),
+            "assigned_nodeids": [nodeid],
+            "collected_count": len(selected),
+            "collected_digest": digest,
+            "grouping": "file",
+            "partition_mode": "lpt-durations",
+            "serial_nodeids": list(pytest_shards.SERIAL_TESTS) if shard_id == 1 else [],
+            "shard_count": len(selected),
+            "shard_id": shard_id,
+        }
+        (shard / "plan.json").write_text(json.dumps(plan), encoding="utf-8")
+        _write_junit(shard / "main-junit.xml", 1)
+        if shard_id == 1:
+            _write_junit(shard / "playground-junit.xml", len(pytest_shards.SERIAL_TESTS))
+
+
+def test_assign_shards_is_complete_disjoint_balanced_and_file_grouped() -> None:
+    nodeids = [
+        "tests/test_heavy.py::test_a",
+        "tests/test_heavy.py::test_b",
+        "tests/test_medium.py::test_a",
+        "tests/test_small_a.py::test_a",
+        "tests/test_small_b.py::test_a",
+        "tests/test_small_c.py::test_a",
+    ]
+    durations = {
+        "tests/test_heavy.py::test_a": 6.0,
+        "tests/test_heavy.py::test_b": 6.0,
+        "tests/test_medium.py::test_a": 8.0,
+        "tests/test_small_a.py::test_a": 4.0,
+        "tests/test_small_b.py::test_a": 4.0,
+        "tests/test_small_c.py::test_a": 4.0,
+    }
+
+    shards = pytest_shards.assign_shards(nodeids, 3, durations)
+
+    assert sorted(nodeid for shard in shards for nodeid in shard) == sorted(nodeids)
+    assert len({nodeid for shard in shards for nodeid in shard}) == len(nodeids)
+    assert any({"tests/test_heavy.py::test_a", "tests/test_heavy.py::test_b"}.issubset(shard) for shard in shards)
+    totals = [sum(durations[nodeid] for nodeid in shard) for shard in shards]
+    assert max(totals) - min(totals) == 4.0
+
+
+def test_unknown_file_uses_median_known_file_weight() -> None:
+    nodeids = [
+        "tests/test_fast.py::test_a",
+        "tests/test_medium.py::test_a",
+        "tests/test_slow.py::test_a",
+        "tests/test_unknown.py::test_a",
+    ]
+    weights = pytest_shards._file_weights(
+        nodeids,
+        {
+            "tests/test_fast.py::test_a": 1.0,
+            "tests/test_medium.py::test_a": 3.0,
+            "tests/test_slow.py::test_a": 9.0,
+        },
     )
-    return [line for line in out.stdout.splitlines() if line.strip()]
+
+    assert weights["tests/test_unknown.py"] == 3.0
 
 
-@pytest.fixture(scope="module")
-def shards() -> list[list[str]]:
-    return [_shard_files(i) for i in range(1, SHARD_COUNT + 1)]
+def test_write_plans_collects_once_and_marks_duration_lpt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(8)]
+    collected = 0
+
+    def fake_collect() -> list[str]:
+        nonlocal collected
+        collected += 1
+        return selected
+
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", fake_collect)
+    durations = tmp_path / "durations.json"
+    durations.write_text(json.dumps({"node_durations": {selected[0]: 100.0}}), encoding="utf-8")
+
+    pytest_shards.write_plans(durations_path=durations, output_dir=tmp_path / "plans")
+
+    assert collected == 1
+    plans = [json.loads((tmp_path / "plans" / f"pytest-shard-{index}" / "plan.json").read_text()) for index in range(1, 5)]
+    assert {plan["partition_mode"] for plan in plans} == {"lpt-durations"}
+    assert {plan["grouping"] for plan in plans} == {"file"}
+    assert sorted(nodeid for plan in plans for nodeid in plan["assigned_nodeids"]) == selected
 
 
-def test_shards_cover_every_test_file(shards: list[list[str]]) -> None:
-    """Union of all shards == every test file. A dropped file is a silent hole."""
-    expected = sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "tests").rglob("test_*.py"))
-    union = sorted(f for shard in shards for f in shard)
-    missing = sorted(set(expected) - set(union))
-    assert not missing, f"{len(missing)} test file(s) belong to NO shard and would never run: {missing[:10]}"
-    assert union == expected
+def test_verify_artifacts_accepts_complete_partition(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+
+    pytest_shards.verify_artifacts(tmp_path, 4)
 
 
-def test_shards_do_not_overlap(shards: list[list[str]]) -> None:
-    """A file in two shards wastes a runner and double-counts coverage."""
-    union = [f for shard in shards for f in shard]
-    duplicates = sorted({f for f in union if union.count(f) > 1})
-    assert not duplicates, f"file(s) in more than one shard: {duplicates[:10]}"
+def test_verify_artifacts_rejects_mispartitioned_plan(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+    plan_path = tmp_path / "pytest-shard-4" / "plan.json"
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    plan["assigned_nodeids"] = []
+    plan["assigned_digest"] = pytest_shards._digest([])
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    _write_junit(tmp_path / "pytest-shard-4" / "main-junit.xml", 0)
+
+    with pytest.raises(RuntimeError, match="complete partition"):
+        pytest_shards.verify_artifacts(tmp_path, 4)
 
 
-def test_no_shard_is_empty(shards: list[list[str]]) -> None:
-    """An empty shard means the split silently collapsed — the job would pass trivially."""
-    empty = [i + 1 for i, shard in enumerate(shards) if not shard]
-    assert not empty, f"shard(s) {empty} are empty; the gate would pass without running them"
+def test_publish_durations_writes_main_dataset_and_rolling_p95(tmp_path: Path) -> None:
+    logs = []
+    for shard_id, seconds in enumerate((1.0, 2.0, 3.0, 4.0), start=1):
+        path = tmp_path / f"shard-{shard_id}.log"
+        path.write_text(f"  {seconds:.2f}s call     tests/test_{shard_id}.py::test_case\n", encoding="utf-8")
+        logs.append(path)
+    previous = tmp_path / "previous.json"
+    previous.write_text(json.dumps({"slowest_shard_seconds": [2.0, 8.0]}), encoding="utf-8")
+    output = tmp_path / "dataset.json"
+    summary = tmp_path / "summary.md"
+
+    pytest_shards.publish_durations(log_paths=logs, previous=previous, output=output, summary=summary)
+
+    dataset = json.loads(output.read_text(encoding="utf-8"))
+    assert dataset["node_durations"]["tests/test_4.py::test_case"] == 4.0
+    assert dataset["slowest_shard_seconds"] == [2.0, 8.0, 4.0]
+    assert "Slowest-shard p95: **8.00s** across 3 successful main run(s)." in summary.read_text(encoding="utf-8")
 
 
-def test_shards_are_balanced_within_one_file(shards: list[list[str]]) -> None:
-    """Round-robin over a sorted list; sizes must differ by at most one."""
-    sizes = [len(shard) for shard in shards]
-    assert max(sizes) - min(sizes) <= 1, f"unbalanced shard sizes {sizes}"
+def test_run_nodeids_passes_exact_planner_output_to_pytest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    nodeids = tmp_path / "nodeids.txt"
+    nodeids.write_text("tests/test_a.py::test_a\ntests/test_b.py::test_b\n", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    import pytest as real_pytest
+
+    monkeypatch.setattr(real_pytest, "main", lambda args: captured.append(list(args)) or 0)
+
+    assert pytest_shards.run_nodeids(nodeids, ["--", "-q", "--dist=loadfile"]) == 0
+    assert captured == [["-q", "--dist=loadfile", "tests/test_a.py::test_a", "tests/test_b.py::test_b"]]
 
 
-def test_split_is_deterministic() -> None:
-    """Two invocations must agree, or reruns would test a different subset."""
-    assert _shard_files(1) == _shard_files(1)
+def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
+    workflow = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-
-def test_split_does_not_consult_the_diff() -> None:
-    """The invariant the whole reboot exists to protect.
-
-    Five main-breaking regressions shipped because a required check chose tests
-    from the changed-file set. The split may depend on the FILE LIST and nothing
-    else — no git, no diff, no base ref.
-    """
-    expr = _split_expression()
-    for forbidden in ("git", "diff", "GITHUB_BASE_REF", "changed", "HEAD", "origin/"):
-        assert forbidden not in expr, (
-            f"shard split references {forbidden!r}; it must depend only on the test file list"
-        )
+    assert "pytest-plan:" in workflow
+    assert "pytest_shards.py plan" in workflow
+    assert workflow.count("pytest_shards.py plan") == 1
+    assert "pytest_shards.py verify-artifacts" in workflow
+    assert "--dist=loadfile" in workflow


### PR DESCRIPTION
## Summary

- Restore a single duration-aware pytest planner that assigns file-grouped LPT plans to four workers.
- Verify plan/JUnit completeness inside the sole required CI Gate and retain a failing mispartition regression test.
- Publish node durations and a rolling slowest-shard p95 only after successful main runs.

## Root cause

The CI reboot retained four matrix jobs but replaced the shared planner and artifact verifier with round-robin file slicing, so duration balance and execution-completeness proof were lost.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_ci_shard_partition.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/ci/pytest_shards.py tests/test_ci_shard_partition.py`
- `actionlint .github/workflows/ci.yml`
- OPSEC and X-Agent trailer gates

Closes #5744