### PR TITLE
feat(runtime): add dispatch lane self-test

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -250,6 +250,24 @@ fi
 # audits are deliberately absent here. They are optional orientation data and
 # belong behind /api/orient, not on the synchronous session-availability path.
 
+# Dispatch-lane self-test (#4879). Build the active lane's normal adapter
+# invocation, then run only its resolved CLI's --version command. This catches
+# a broken local binary or package shim without sending a model request. Keep
+# it bounded and advisory: a failed probe must surface the unavailable lane,
+# never prevent a SessionStart response from reaching the operator.
+LANE_PROBE_SCRIPT="$PROJECT_DIR/scripts/agent_runtime/lane_probe.py"
+if [ -f "$LANE_PROBE_SCRIPT" ]; then
+  LANE_PROBE_RC=0
+  LANE_PROBE_JSON=$(run_bounded 3 env "PYTHONPATH=$PROJECT_DIR" "$BOUNDED_PYTHON" \
+    -m scripts.agent_runtime.lane_probe --agent "$HANDOFF_AGENT" --cwd "$PROJECT_DIR" --timeout 2 2>/dev/null) || LANE_PROBE_RC=$?
+  if [ "$LANE_PROBE_RC" -ne 0 ]; then
+    LANE_PROBE_REASON=$(printf '%s' "$LANE_PROBE_JSON" | jq -r '.probes[0].reason // "probe did not return a result"' 2>/dev/null || true)
+    ISSUES+=("DISPATCH LANE SELF-TEST FAILED for $HANDOFF_AGENT: $LANE_PROBE_REASON")
+  fi
+  unset LANE_PROBE_RC LANE_PROBE_JSON LANE_PROBE_REASON
+fi
+unset LANE_PROBE_SCRIPT
+
 # 6. Check MEMORY.md line count (truncated at 200 lines by system)
 MEMORY_DIR="$HOME/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian/memory"
 MEMORY_FILE="$MEMORY_DIR/MEMORY.md"

--- a/scripts/agent_runtime/lane_probe.py
+++ b/scripts/agent_runtime/lane_probe.py
@@ -1,0 +1,215 @@
+"""No-cost dispatch-lane self-test.
+
+The probe exercises the same adapter selection and invocation construction as
+``delegate.py``, then runs only the resolved CLI's ``--version`` command.  It
+does not submit a prompt, create a delegate task, or make a provider request.
+
+It is intentionally useful both as an operator diagnostic and from
+SessionStart, where a single active lane can be checked inside the bounded
+startup budget.  See #4879.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from .registry import AGENTS, get_agent_entry
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+# Several legacy adapters retain top-level imports such as ``ai_llm`` and
+# ``ai_agent_bridge``. Delegate adds this same source root before loading them;
+# SessionStart runs this probe as ``scripts.agent_runtime`` and needs the
+# compatibility import root too.
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_PROBE_PROMPT = "Dispatch adapter health probe; do not execute this prompt."
+_DEFAULT_TIMEOUT_SECONDS = 3
+_MAX_TIMEOUT_SECONDS = 30
+
+
+def _mode_for_probe(adapter: Any) -> str:
+    """Choose a supported mode without executing an agent request."""
+    supported = getattr(adapter, "supported_modes", frozenset())
+    if "read-only" in supported and getattr(adapter, "name", "") != "kimi":
+        return "read-only"
+    if "workspace-write" in supported:
+        return "workspace-write"
+    if "danger" in supported:
+        return "danger"
+    raise ValueError("adapter declares no supported invocation mode")
+
+
+def _load_adapter(agent: str) -> Any:
+    """Load the registered adapter without importing the full task runner.
+
+    SessionStart imports this module as ``scripts.agent_runtime.lane_probe``.
+    The normal runner also supports legacy ``agent_runtime`` top-level imports,
+    but loading it here would make a binary-only health check depend on the
+    runner's optional bridge-only imports.
+    """
+    entry = get_agent_entry(agent)
+    module_name, class_name = entry["adapter"].split(":", 1)
+    adapter_class = getattr(importlib.import_module(module_name), class_name)
+    return adapter_class()
+
+
+def _version_command(invocation: list[str]) -> list[str]:
+    """Reduce an adapter command to its zero-cost CLI version invocation.
+
+    Most adapters start with their executable.  Claude's retained fallback is
+    ``npx <package>``, whose package token is part of the executable prefix;
+    keeping it is essential for catching another broken npm shim rather than
+    merely proving Node itself is installed.
+    """
+    if not invocation or not isinstance(invocation[0], str) or not invocation[0]:
+        raise ValueError("adapter produced no executable command")
+    executable = Path(invocation[0]).name.lower()
+    if executable in {"npx", "npx.cmd"}:
+        if len(invocation) < 2 or not isinstance(invocation[1], str) or not invocation[1]:
+            raise ValueError("npx adapter command omitted its package")
+        return [invocation[0], invocation[1], "--version"]
+    return [invocation[0], "--version"]
+
+
+def _probe_environment(plan: Any) -> dict[str, str]:
+    """Apply the plan's child-only environment exactly as the runner would."""
+    environment = os.environ.copy()
+    for key in getattr(plan, "env_unsets", ()):
+        environment.pop(key, None)
+    environment.update(getattr(plan, "env_overrides", {}))
+    return environment
+
+
+def _cleanup_probe_output(plan: Any | None) -> None:
+    """Remove the Codex output file created solely by this synthetic plan."""
+    output_file = getattr(plan, "output_file", None)
+    if not isinstance(output_file, Path) or not output_file.name.startswith("codex-runtime-lane-health-probe-"):
+        return
+    try:
+        temp_root = Path(tempfile.gettempdir()).resolve()
+        if output_file.resolve().is_relative_to(temp_root):
+            output_file.unlink(missing_ok=True)
+    except OSError:
+        # Cleanup is best-effort. A failed probe must still report its real
+        # adapter/binary verdict rather than turn into a false healthy signal.
+        return
+
+
+def probe_lane(agent: str, *, cwd: Path, timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Return one machine-readable health result for a runtime lane."""
+    started = time.monotonic()
+    result: dict[str, Any] = {"agent": agent, "status": "unhealthy"}
+    try:
+        entry = get_agent_entry(agent)
+    except KeyError:
+        result["reason"] = "agent is not registered"
+        result["duration_ms"] = round((time.monotonic() - started) * 1000)
+        return result
+
+    if not entry["cli_available"]:
+        result.update({"status": "skipped", "reason": "lane is disabled in the runtime registry"})
+        result["duration_ms"] = round((time.monotonic() - started) * 1000)
+        return result
+
+    plan: Any | None = None
+    try:
+        adapter = _load_adapter(agent)
+        mode = _mode_for_probe(adapter)
+        plan = adapter.build_invocation(
+            prompt=_PROBE_PROMPT,
+            mode=mode,
+            cwd=cwd,
+            model=None,
+            task_id="lane-health-probe",
+            session_id=None,
+            tool_config=None,
+        )
+        command = _version_command(plan.cmd)
+        completed = subprocess.run(
+            command,
+            cwd=plan.cwd,
+            env=_probe_environment(plan),
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        result["reason"] = f"version command exceeded {timeout_seconds}s"
+    except Exception as exc:
+        result["reason"] = f"{type(exc).__name__} while building or spawning the adapter"
+    else:
+        if completed.returncode == 0:
+            result["status"] = "healthy"
+        else:
+            result["reason"] = f"version command exited {completed.returncode}"
+    finally:
+        _cleanup_probe_output(plan)
+        result["duration_ms"] = round((time.monotonic() - started) * 1000)
+    return result
+
+
+def probe_lanes(agents: list[str], *, cwd: Path, timeout_seconds: int) -> dict[str, Any]:
+    """Probe the requested lanes and return a stable JSON document."""
+    results = [probe_lane(agent, cwd=cwd, timeout_seconds=timeout_seconds) for agent in agents]
+    return {
+        "schema_version": "agent_runtime_lane_probe.v1",
+        "probes": results,
+        "summary": {
+            "healthy": sum(result["status"] == "healthy" for result in results),
+            "unhealthy": sum(result["status"] == "unhealthy" for result in results),
+            "skipped": sum(result["status"] == "skipped" for result in results),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--agent", help="One registered runtime lane to probe")
+    selection.add_argument("--all", action="store_true", help="Probe every runtime registry lane")
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path.cwd(),
+        help="Directory passed to adapter build_invocation (default: current directory)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help=f"Per-version-command timeout in seconds (1-{_MAX_TIMEOUT_SECONDS}; default: {_DEFAULT_TIMEOUT_SECONDS})",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.cwd.is_dir():
+        print(f"error: --cwd is not a directory: {args.cwd}", file=sys.stderr)
+        return 2
+    if not 1 <= args.timeout <= _MAX_TIMEOUT_SECONDS:
+        print(f"error: --timeout must be between 1 and {_MAX_TIMEOUT_SECONDS}", file=sys.stderr)
+        return 2
+
+    agents = list(AGENTS) if args.all else [args.agent]
+    payload = probe_lanes(agents, cwd=args.cwd.resolve(), timeout_seconds=args.timeout)
+    json.dump(payload, sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 1 if payload["summary"]["unhealthy"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent_runtime/test_lane_probe.py
+++ b/tests/agent_runtime/test_lane_probe.py
@@ -1,0 +1,166 @@
+"""Regression coverage for the no-cost dispatch-lane self-test (#4879)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.agent_runtime import lane_probe
+from scripts.agent_runtime.adapters.base import InvocationPlan
+
+
+class _FakeAdapter:
+    name = "fake"
+    supported_modes = frozenset({"read-only", "workspace-write"})
+
+    def __init__(self, command: list[str]) -> None:
+        self.command = command
+        self.calls: list[dict[str, object]] = []
+
+    def build_invocation(self, **kwargs: object) -> InvocationPlan:
+        self.calls.append(kwargs)
+        return InvocationPlan(cmd=self.command, cwd=Path(str(kwargs["cwd"])))
+
+
+def _registered_lane(monkeypatch, name: str = "fake") -> None:
+    monkeypatch.setitem(
+        lane_probe.AGENTS,
+        name,
+        {
+            "adapter": "tests.fake:Adapter",
+            "default_model": None,
+            "cost_tier": "low",
+            "capabilities": frozenset(),
+            "cli_available": True,
+            "resume_policy": "never",
+        },
+    )
+
+
+def test_probe_builds_adapter_then_runs_plain_binary_version(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch)
+    adapter = _FakeAdapter(["fake-cli", "run", "ignored"])
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: adapter)
+
+    def fake_run(command, **kwargs):
+        calls.append({"command": command, **kwargs})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(lane_probe.subprocess, "run", fake_run)
+
+    result = lane_probe.probe_lane("fake", cwd=tmp_path, timeout_seconds=2)
+
+    assert result["status"] == "healthy"
+    assert adapter.calls[0]["mode"] == "read-only"
+    assert calls[0]["command"] == ["fake-cli", "--version"]
+    assert calls[0]["timeout"] == 2
+    assert calls[0]["check"] is False
+    assert calls[0]["stdin"] is lane_probe.subprocess.DEVNULL
+
+
+def test_probe_keeps_npx_package_in_version_command(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch)
+    adapter = _FakeAdapter(["npx", "@anthropic-ai/claude-code@latest", "-p", "ignored"])
+    commands: list[list[str]] = []
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: adapter)
+    monkeypatch.setattr(
+        lane_probe.subprocess,
+        "run",
+        lambda command, **_kwargs: commands.append(command) or SimpleNamespace(returncode=0),
+    )
+
+    result = lane_probe.probe_lane("fake", cwd=tmp_path)
+
+    assert result["status"] == "healthy"
+    assert commands == [["npx", "@anthropic-ai/claude-code@latest", "--version"]]
+
+
+def test_probe_reports_build_failure_without_running_a_command(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch)
+
+    class FailingAdapter(_FakeAdapter):
+        def build_invocation(self, **kwargs: object) -> InvocationPlan:
+            raise RuntimeError("broken adapter")
+
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: FailingAdapter([]))
+    monkeypatch.setattr(lane_probe.subprocess, "run", lambda *_args, **_kwargs: AssertionError("must not run"))
+
+    result = lane_probe.probe_lane("fake", cwd=tmp_path)
+
+    assert result["status"] == "unhealthy"
+    assert result["reason"] == "RuntimeError while building or spawning the adapter"
+
+
+def test_probe_reports_nonzero_version_exit(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch)
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: _FakeAdapter(["fake-cli"]))
+    monkeypatch.setattr(lane_probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(returncode=23))
+
+    result = lane_probe.probe_lane("fake", cwd=tmp_path)
+
+    assert result["status"] == "unhealthy"
+    assert result["reason"] == "version command exited 23"
+
+
+def test_probe_uses_write_mode_for_kimi_without_executing_a_prompt(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch, "kimi")
+    adapter = _FakeAdapter(["kimi", "-p", "ignored"])
+    adapter.name = "kimi"
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: adapter)
+    monkeypatch.setattr(lane_probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(returncode=0))
+
+    result = lane_probe.probe_lane("kimi", cwd=tmp_path)
+
+    assert result["status"] == "healthy"
+    assert adapter.calls[0]["mode"] == "workspace-write"
+
+
+def test_disabled_lane_is_reported_as_skipped(monkeypatch, tmp_path):
+    monkeypatch.setitem(
+        lane_probe.AGENTS,
+        "disabled",
+        {
+            "adapter": "tests.fake:Adapter",
+            "default_model": None,
+            "cost_tier": "low",
+            "capabilities": frozenset(),
+            "cli_available": False,
+            "resume_policy": "never",
+        },
+    )
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: AssertionError("must not load"))
+
+    result = lane_probe.probe_lane("disabled", cwd=tmp_path)
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "lane is disabled in the runtime registry"
+    assert isinstance(result["duration_ms"], int)
+
+
+def test_probe_removes_codex_temp_output_created_by_synthetic_plan(monkeypatch, tmp_path):
+    _registered_lane(monkeypatch)
+    output_file = tmp_path / "codex-runtime-lane-health-probe-123.txt"
+    output_file.write_text("synthetic", encoding="utf-8")
+    adapter = _FakeAdapter(["fake-cli"])
+
+    def build_with_output(**kwargs: object) -> InvocationPlan:
+        return InvocationPlan(cmd=adapter.command, cwd=Path(str(kwargs["cwd"])), output_file=output_file)
+
+    monkeypatch.setattr(adapter, "build_invocation", build_with_output)
+    monkeypatch.setattr(lane_probe, "_load_adapter", lambda _agent: adapter)
+    monkeypatch.setattr(lane_probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(lane_probe.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    result = lane_probe.probe_lane("fake", cwd=tmp_path)
+
+    assert result["status"] == "healthy"
+    assert not output_file.exists()
+
+
+def test_session_start_wires_the_active_lane_probe() -> None:
+    hook = Path("agents_extensions/shared/hooks/session-setup.sh").read_text(encoding="utf-8")
+
+    assert "scripts.agent_runtime.lane_probe" in hook
+    assert '--agent "$HANDOFF_AGENT"' in hook
+    assert "--timeout 2" in hook


### PR DESCRIPTION
## Summary

- add a no-provider-cost adapter health probe that builds the normal dispatch invocation and runs only the resolved CLI `--version` command
- invoke the active lane probe from SessionStart inside the existing bounded command budget, reporting failures without blocking startup
- cover command-prefix handling, failures, Kimi mode selection, disabled lanes, temp cleanup, and hook wiring

Closes #4879

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/agent_runtime/test_lane_probe.py tests/api/test_lane_health.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/agent_runtime/lane_probe.py tests/agent_runtime/test_lane_probe.py`
- `bash -n agents_extensions/shared/hooks/session-setup.sh`
- live `codex` lane probe passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`