### PR TITLE
fix(runtime): interrupt gh retry backoff on SIGTERM

### DIFF
--- a/scripts/agent_runtime/shims/gh
+++ b/scripts/agent_runtime/shims/gh
@@ -121,6 +121,7 @@ _run_with_secondary_rate_limit_retry() {
   base_delay_s="$(_nonnegative_integer_or_default "${AGENT_GH_SECONDARY_RATE_LIMIT_BACKOFF_SECONDS:-}" 60)"
 
   _agent_gh_retry_stdin_file=""
+  _agent_gh_retry_sleep_pid=""
   _agent_gh_retry_stdout_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stdout.XXXXXX")" || return 1
   _agent_gh_retry_stderr_file="$(mktemp "${TMPDIR:-/tmp}/agent-gh.stderr.XXXXXX")" || {
     rm -f "$_agent_gh_retry_stdout_file"
@@ -144,6 +145,11 @@ _run_with_secondary_rate_limit_retry() {
   _abort_secondary_retry() {
     local status="$1"
     trap - EXIT HUP INT TERM
+    if [[ -n "$_agent_gh_retry_sleep_pid" ]]; then
+      kill "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+      wait "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+      _agent_gh_retry_sleep_pid=""
+    fi
     _cleanup_secondary_retry_tempfiles
     exit "$status"
   }
@@ -190,7 +196,16 @@ _run_with_secondary_rate_limit_retry() {
     local delay_s=$((base_delay_s * (2 ** (attempt - 1))))
     printf 'agent-gh-shim: GitHub HTTP %s throttled; retrying gh in %ss (attempt %s/%s).\n' \
       "$http_status" "$delay_s" "$attempt" "$max_retries" >&2
-    sleep "$delay_s"
+    # Bash can defer TERM's trap while it waits for a foreground command. Keep
+    # the full backoff in a tracked child and only make short foreground waits,
+    # so the abort trap kills the backoff child within one polling interval.
+    sleep "$delay_s" </dev/null >/dev/null 2>&1 &
+    _agent_gh_retry_sleep_pid=$!
+    while kill -0 "$_agent_gh_retry_sleep_pid" 2>/dev/null; do
+      sleep 0.2
+    done
+    wait "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
+    _agent_gh_retry_sleep_pid=""
   done
 
   # Retry attempts stay private: only the final gh invocation's output reaches

--- a/scripts/agent_runtime/shims/gh
+++ b/scripts/agent_runtime/shims/gh
@@ -196,14 +196,10 @@ _run_with_secondary_rate_limit_retry() {
     local delay_s=$((base_delay_s * (2 ** (attempt - 1))))
     printf 'agent-gh-shim: GitHub HTTP %s throttled; retrying gh in %ss (attempt %s/%s).\n' \
       "$http_status" "$delay_s" "$attempt" "$max_retries" >&2
-    # Bash can defer TERM's trap while it waits for a foreground command. Keep
-    # the full backoff in a tracked child and only make short foreground waits,
-    # so the abort trap kills the backoff child within one polling interval.
+    # Bash's wait builtin returns when TERM interrupts it, letting the abort
+    # trap kill the tracked backoff child immediately.
     sleep "$delay_s" </dev/null >/dev/null 2>&1 &
     _agent_gh_retry_sleep_pid=$!
-    while kill -0 "$_agent_gh_retry_sleep_pid" 2>/dev/null; do
-      sleep 0.2
-    done
     wait "$_agent_gh_retry_sleep_pid" 2>/dev/null || true
     _agent_gh_retry_sleep_pid=""
   done

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import select
 import subprocess
 import sys
 import time
@@ -4496,11 +4497,17 @@ def test_gh_shim_cleans_retry_tempfiles_on_sigterm(tmp_path):
             break
         time.sleep(0.01)
     assert ready.exists()
+    readable, _, _ = select.select([proc.stderr], [], [], 2)
+    assert readable, "shim did not enter secondary-rate-limit backoff"
+    # The retry diagnostic is emitted immediately before the delay starts.
+    # Give the shell a scheduling turn so SIGTERM reaches active backoff code.
+    time.sleep(0.05)
 
     proc.terminate()
-    proc.communicate(timeout=15)
+    _, stderr = proc.communicate(timeout=2)
 
     assert proc.returncode == 143
+    assert "retrying gh in 30s" in stderr
     assert list(temp_dir.iterdir()) == []
 
 


### PR DESCRIPTION
## Summary
- interrupt and reap the shim-owned secondary-rate-limit backoff delay on TERM/HUP/INT
- make the SIGTERM cleanup test wait for confirmed retry mode and require prompt completion
- retain live 403/429 retry delays and stdin replay behavior

## Verification
- `bash -n scripts/agent_runtime/shims/gh`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_agent_runtime.py -k gh_shim -q` (6 passed)
- 20 consecutive runs of `test_gh_shim_cleans_retry_tempfiles_on_sigterm` (all passed; 0.90s-1.31s)
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_opsec_leaks.py`

## Known environment residual
The full `tests/test_agent_runtime.py` run is blocked outside this diff: `test_usage_attribution_detects_codex_desktop` sees the live `grok-infra` runtime as the initiator.

## Independent review
Cross-family review remains required. Attempts through AGY, Kimi, Pool, and DeepSeek routes yielded no usable review payload, quota exhaustion, or ACP replay errors; none are counted as approval.