### PR TITLE
fix(hooks): sanction safe squash-merge branch -D (#4674)

### DIFF
--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -24,7 +24,7 @@ Blocked in a protected PRIMARY checkout:
   - git checkout <non-main-branch>          (when target is a branch, not a path)
   - git branch -M <current-branch>          (force-rename HEAD)
   - git branch -f <name>                    (force-move a branch ref)
-  - git branch -D <protected|checked-out|live-remote+unpushed>
+  - git branch -D <protected|checked-out|never-pushed|live-remote+unpushed>
 
 Allowed in the MAIN worktree:
   - git checkout main / master / HEAD / HEAD~N
@@ -39,9 +39,10 @@ Allowed in the MAIN worktree:
 Sanctioned ``git branch -D`` / ``--delete --force`` (#4674 / #M-10a):
   Squash-merged tips are never ancestors of main, so ``-d`` refuses. Force-
   delete is allowed from the primary only when the target is none of:
-  protected (main/master), checked out in any worktree, or carrying a live
-  upstream with unpushed local commits. Gone-upstream, never-pushed, and
-  fully-pushed live remotes may be force-deleted.
+  protected (main/master), checked out in any worktree, never-pushed (no
+  upstream / no remote backup), or carrying a live upstream with unpushed
+  local commits. Gone-upstream and fully-pushed live remotes may be
+  force-deleted. Never-pushed locals need merge proof or push-then-gone.
 """
 from __future__ import annotations
 
@@ -350,11 +351,47 @@ def _checked_out_branches(repo_root: Path) -> set[str]:
     return checked
 
 
+def _branch_is_never_pushed(repo_root: Path, branch: str) -> bool:
+    """True when ``branch`` has no upstream configured (no remote backup).
+
+    Distinct from gone-upstream: after a remote tip delete, ``@{upstream}``
+    fails to resolve even though ``branch.<name>.remote`` / ``.merge`` remain
+    set. Never-pushed has no tracking config at all, so ``-D`` would
+    permanently discard local-only commits (#4674 CF).
+    """
+    try:
+        remote = subprocess.run(
+            ["git", "config", "--get", f"branch.{branch}.remote"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_git_probe_env(),
+        )
+        merge = subprocess.run(
+            ["git", "config", "--get", f"branch.{branch}.merge"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_git_probe_env(),
+        )
+    except FileNotFoundError:
+        return False
+    return (
+        remote.returncode != 0
+        or merge.returncode != 0
+        or not remote.stdout.strip()
+        or not merge.stdout.strip()
+    )
+
+
 def _branch_has_live_remote_with_unpushed(repo_root: Path, branch: str) -> bool:
     """True when ``branch`` tracks a still-present upstream and is ahead of it.
 
-    Squash-merge cleanup (#4674): gone upstream or no upstream → safe to
-    force-delete. A live upstream with local-only commits must refuse.
+    Squash-merge cleanup (#4674): gone upstream (tracking set, tip missing)
+    is safe to force-delete. A live upstream with local-only commits must
+    refuse. Never-pushed is handled separately by ``_branch_is_never_pushed``.
     """
     try:
         upstream = subprocess.run(
@@ -422,6 +459,11 @@ def _force_delete_target_reason(
         return (
             f"git branch -D {branch} force-deletes a branch checked out in a "
             "worktree"
+        )
+    if _branch_is_never_pushed(repo_root, branch):
+        return (
+            f"git branch -D {branch} would permanently discard a never-pushed "
+            "local branch with no remote backup"
         )
     if _branch_has_live_remote_with_unpushed(repo_root, branch):
         return (
@@ -839,8 +881,8 @@ def main() -> int:
             "  # ...edits, commits, push, PR...\n"
             "  # back in the main project dir:\n"
             "  git worktree remove .worktrees/<purpose>/<branch-name>\n"
-            "  git branch -D <branch-name>  # sanctioned when not checked "
-            "out and not live+unpushed (#4674)\n\n"
+            "  git branch -D <branch-name>  # sanctioned when gone-upstream "
+            "or fully-pushed; never-pushed stays blocked (#4674)\n\n"
             "Hook source: .claude/hooks/guard-branch-switch-in-main.py\n"
         )
         return 2

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -22,17 +22,26 @@ Blocked in a protected PRIMARY checkout:
   - git switch -c <name>
   - git switch <non-main-branch>
   - git checkout <non-main-branch>          (when target is a branch, not a path)
-  - git branch -D / -M <current-branch>     (force-delete / force-rename HEAD)
+  - git branch -M <current-branch>          (force-rename HEAD)
   - git branch -f <name>                    (force-move a branch ref)
+  - git branch -D <protected|checked-out|live-remote+unpushed>
 
 Allowed in the MAIN worktree:
   - git checkout main / master / HEAD / HEAD~N
   - git checkout -- <path>                  (file-level discard / restore)
   - git branch -d / -m <name>               (safe delete-if-merged / rename)
+  - git branch -D <name>                    (sanctioned force-delete; see below)
   - git branch <name>                       (create; does not switch)
   - git status / git log / git worktree add / ...
   - non-git commands
   - git commit -m "...body mentioning git checkout -b... / git branch -D..."
+
+Sanctioned ``git branch -D`` / ``--delete --force`` (#4674 / #M-10a):
+  Squash-merged tips are never ancestors of main, so ``-d`` refuses. Force-
+  delete is allowed from the primary only when the target is none of:
+  protected (main/master), checked out in any worktree, or carrying a live
+  upstream with unpushed local commits. Gone-upstream, never-pushed, and
+  fully-pushed live remotes may be force-deleted.
 """
 from __future__ import annotations
 
@@ -53,6 +62,9 @@ SWITCH_VERBS = frozenset({"checkout", "switch"})
 # NEVER list ``--detach`` / ``--orphan`` here — bare ``git checkout --detach``
 # leaves target=None and was previously allowed (#4857 recurrence class).
 SAFE_TARGETS = frozenset({"main", "master", "HEAD", "-"})
+
+# Never force-delete these from a protected primary, even when not HEAD.
+PROTECTED_BRANCHES = frozenset({"main", "master"})
 
 # Full-length or abbreviated object names (SHA-1/SHA-256 hex) that would
 # detach HEAD when used as ``git checkout <sha>``.
@@ -316,44 +328,176 @@ def _segments_with_following_operator(command: str) -> list[tuple[list[str], str
     return segments
 
 
-def _branch_force_reason(args: list[str], current_branch: str | None) -> str | None:
-    """Reason string if a `git branch` invocation force-deletes/force-renames.
+def _checked_out_branches(repo_root: Path) -> set[str]:
+    """Return local branch names currently checked out in any worktree."""
+    try:
+        out = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=_git_probe_env(),
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return set()
+    checked: set[str] = set()
+    for line in out.splitlines():
+        if line.startswith("branch "):
+            ref = line[len("branch ") :].strip()
+            if ref.startswith("refs/heads/"):
+                checked.add(ref[len("refs/heads/") :])
+    return checked
 
-    Blocks only force operations which affect the currently checked-out branch:
-      - `git branch -D <current>`     (force delete, == --delete --force)
-      - `git branch -M <current> <new>` / `git branch -M <new>`
-      - `git branch -f <name> <ref>`  / `--force` (force-move a ref)
-      - any combined short cluster carrying D/M/f (e.g. `-Df`)
+
+def _branch_has_live_remote_with_unpushed(repo_root: Path, branch: str) -> bool:
+    """True when ``branch`` tracks a still-present upstream and is ahead of it.
+
+    Squash-merge cleanup (#4674): gone upstream or no upstream → safe to
+    force-delete. A live upstream with local-only commits must refuse.
+    """
+    try:
+        upstream = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_git_probe_env(),
+        )
+    except FileNotFoundError:
+        return False
+    if upstream.returncode != 0:
+        return False
+    upstream_name = upstream.stdout.strip()
+    if not upstream_name:
+        return False
+
+    # Gone upstream after prune: tracking ref remains configured but missing.
+    exists = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{branch}@{{upstream}}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_git_probe_env(),
+    )
+    if exists.returncode != 0:
+        return False
+
+    ahead = subprocess.run(
+        ["git", "rev-list", "--count", f"{branch}@{{upstream}}..{branch}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_git_probe_env(),
+    )
+    if ahead.returncode != 0:
+        # Fail closed when we cannot prove the tip is fully pushed.
+        return True
+    try:
+        return int((ahead.stdout or "0").strip() or "0") > 0
+    except ValueError:
+        return True
+
+
+def _force_delete_target_reason(
+    branch: str,
+    *,
+    current_branch: str | None,
+    repo_root: Path | None,
+) -> str | None:
+    """Return a block reason for force-deleting ``branch``, else None."""
+    if branch in PROTECTED_BRANCHES:
+        return (
+            f"git branch -D {branch} force-deletes a protected trunk branch "
+            "in the main worktree"
+        )
+    if current_branch and branch == current_branch:
+        return "git branch -D force-deletes the checked-out branch in the main worktree"
+    if repo_root is None:
+        return None
+    if branch in _checked_out_branches(repo_root):
+        return (
+            f"git branch -D {branch} force-deletes a branch checked out in a "
+            "worktree"
+        )
+    if _branch_has_live_remote_with_unpushed(repo_root, branch):
+        return (
+            f"git branch -D {branch} would discard unpushed commits while a "
+            "live upstream still exists"
+        )
+    return None
+
+
+def _branch_force_reason(
+    args: list[str],
+    current_branch: str | None,
+    repo_root: Path | None = None,
+) -> str | None:
+    """Reason string if a `git branch` invocation is a blocked force op.
+
+    Force-delete (``-D`` / ``--delete --force`` / ``-d --force`` / ``-Df``) is
+    the sanctioned #M-10a cleanup path for squash-merged locals. It is
+    allowed only when every named target passes
+    ``_force_delete_target_reason``. Force-rename of HEAD and force-move of
+    any ref stay blocked.
 
     Intentionally ALLOWED (non-destructive): `-d` (delete-if-merged),
     `-m` (rename), plain `git branch` (list), `git branch <name>` (create).
-    Uppercase D/M and lowercase `f` are the force indicators; their
-    lowercase counterparts `d`/`m` are the safe ops, so a simple
-    character-membership test discriminates correctly.
     """
     force_delete = False
     force_rename = False
+    force_move = False
+    saw_delete = False
     positions: list[str] = []
     for a in args:
         if a == "--force":
-            return "git branch --force rewrites/force-deletes a branch ref in the main worktree"
-        # Single-dash short flag cluster (e.g. -D, -M, -f, -Df). Long flags
-        # (`--`) other than --force are not force ops and fall through.
+            force_move = True
+            continue
+        if a == "--delete":
+            saw_delete = True
+            continue
+        # Single-dash short flag cluster (e.g. -D, -M, -f, -Df).
         if len(a) >= 2 and a[0] == "-" and a[1] != "-":
             flags = a[1:]
+            if "D" in flags:
+                force_delete = True
+            if "d" in flags:
+                saw_delete = True
+            if "M" in flags:
+                force_rename = True
             if "f" in flags:
-                return f"git branch {a} force-moves a branch ref in the main worktree"
-            force_delete = force_delete or "D" in flags
-            force_rename = force_rename or "M" in flags
+                force_move = True
         elif not a.startswith("-"):
             positions.append(a)
 
-    if force_delete and current_branch and current_branch in positions:
-        return "git branch -D force-deletes the checked-out branch in the main worktree"
+    # ``-d --force`` / ``--delete --force`` / ``-Df`` are force-delete, not
+    # force-move. Bare ``-f`` / ``--force`` without a delete flag stays blocked.
+    if force_delete or (saw_delete and force_move):
+        force_delete = True
+        force_move = False
+
+    if force_move:
+        return (
+            "git branch --force/-f force-moves a branch ref in the main worktree"
+        )
+
     if force_rename and current_branch and (
         len(positions) == 1 or positions[0] == current_branch
     ):
         return "git branch -M force-renames the checked-out branch in the main worktree"
+
+    if force_delete:
+        for branch in positions:
+            reason = _force_delete_target_reason(
+                branch,
+                current_branch=current_branch,
+                repo_root=repo_root,
+            )
+            if reason:
+                return reason
     return None
 
 
@@ -515,7 +659,9 @@ def _cd_target(seg: list[str], effective_cwd: Path) -> Path | None:
 
 
 def _segment_is_dangerous(
-    seg: list[str], current_branch: str | None = "main"
+    seg: list[str],
+    current_branch: str | None = "main",
+    repo_root: Path | None = None,
 ) -> str | None:
     """Return a human-readable reason string if seg is a dangerous git op,
     else None."""
@@ -527,8 +673,9 @@ def _segment_is_dangerous(
     # `git branch -D/-M/-f` force-deletes or force-renames a branch ref —
     # destructive and irreversible in the MAIN worktree. Safe variants
     # (`-d` delete-if-merged, `-m` rename, plain list/create) are allowed.
+    # Sanctioned `-D` of a non-checked-out squash-merged tip is allowed (#4674).
     if verb == "branch":
-        return _branch_force_reason(args, current_branch)
+        return _branch_force_reason(args, current_branch, repo_root)
 
     if verb not in SWITCH_VERBS:
         return None
@@ -662,7 +809,11 @@ def _command_danger_reason(command: str, session_cwd: Path | None = None) -> str
         # allowed. Ask git rather than relying only on the path spelling.
         if not _in_main_worktree(repo_root):
             continue
-        reason = _segment_is_dangerous(segment, _checked_out_branch(repo_root))
+        reason = _segment_is_dangerous(
+            segment,
+            _checked_out_branch(repo_root),
+            repo_root,
+        )
         if reason:
             return reason
     return None
@@ -676,21 +827,23 @@ def main() -> int:
 
     reason = _command_danger_reason(command)
     if reason:
-            sys.stderr.write(
-                f"BLOCKED by guard-branch-switch-in-main: {reason}.\n\n"
-                "A protected PRIMARY worktree must stay on `main`. "
-                "All feature work happens in added worktrees so the main\n"
-                "tree is always reviewable.\n\n"
-                "Use this pattern instead (from the main project dir):\n\n"
-                "  git worktree add .worktrees/<purpose>/<branch-name> "
-                "-b <branch-name>\n"
-                "  cd .worktrees/<purpose>/<branch-name>\n"
-                "  # ...edits, commits, push, PR...\n"
-                "  # back in the main project dir:\n"
-                "  git worktree remove .worktrees/<purpose>/<branch-name>\n\n"
-                "Hook source: .claude/hooks/guard-branch-switch-in-main.py\n"
-            )
-            return 2
+        sys.stderr.write(
+            f"BLOCKED by guard-branch-switch-in-main: {reason}.\n\n"
+            "A protected PRIMARY worktree must stay on `main`. "
+            "All feature work happens in added worktrees so the main\n"
+            "tree is always reviewable.\n\n"
+            "Use this pattern instead (from the main project dir):\n\n"
+            "  git worktree add .worktrees/<purpose>/<branch-name> "
+            "-b <branch-name>\n"
+            "  cd .worktrees/<purpose>/<branch-name>\n"
+            "  # ...edits, commits, push, PR...\n"
+            "  # back in the main project dir:\n"
+            "  git worktree remove .worktrees/<purpose>/<branch-name>\n"
+            "  git branch -D <branch-name>  # sanctioned when not checked "
+            "out and not live+unpushed (#4674)\n\n"
+            "Hook source: .claude/hooks/guard-branch-switch-in-main.py\n"
+        )
+        return 2
 
     return 0
 

--- a/docs/best-practices/git-hygiene.md
+++ b/docs/best-practices/git-hygiene.md
@@ -175,6 +175,35 @@ branch/worktree needs cleanup. If a PR remains open, the final response must say
 exactly why and what action is required. Leaving PRs in review hell wastes CI,
 agent, and human attention.
 
+## Post-merge local branch cleanup (#4674 / #M-10a)
+
+Squash-merged branch tips are never ancestors of `main`, so
+`git branch -d` correctly refuses. After the worktree is gone, force-delete
+the local ref from the primary checkout:
+
+```bash
+git worktree remove .worktrees/dispatch/<agent>/<task>
+git branch -D <agent>/<task>
+```
+
+`guard-branch-switch-in-main` allows that `-D` only when the target is:
+
++ not `main` / `master`
++ not checked out in any worktree
++ not carrying a **live** upstream with **unpushed** local commits
+
+Gone-upstream (typical post-squash remote delete), never-pushed locals, and
+fully-pushed live remotes may be force-deleted. Force-rename (`-M`) and
+force-move (`-f` / bare `--force`) stay blocked on the primary.
+
+Scheduled gone-upstream pruning (`scripts/orchestration/scheduled_worktree_cleanup.py`)
+and the post-merge auto-prune hook remain complementary paths; they do not
+replace this sanctioned interactive cleanup.
+
+Stale-ref sweep (follow-up): if `git branch` still lists leftovers from prior
+sessions, delete each with the same `-D` rules above — do not broaden the
+guard or skip the live-remote+unpushed check.
+
 ## Monitor API surface
 
 `GET /api/git/hygiene` (planned, GH #TBD) returns a structured view:

--- a/docs/best-practices/git-hygiene.md
+++ b/docs/best-practices/git-hygiene.md
@@ -190,11 +190,14 @@ git branch -D <agent>/<task>
 
 + not `main` / `master`
 + not checked out in any worktree
++ not **never-pushed** (no upstream configured — no remote backup)
 + not carrying a **live** upstream with **unpushed** local commits
 
-Gone-upstream (typical post-squash remote delete), never-pushed locals, and
-fully-pushed live remotes may be force-deleted. Force-rename (`-M`) and
-force-move (`-f` / bare `--force`) stay blocked on the primary.
+Gone-upstream (typical post-squash remote delete) and fully-pushed live
+remotes may be force-deleted. Never-pushed locals stay blocked: push first
+(then delete after gone-upstream), or keep the merge/PR proof path — do not
+`-D` a tip that exists only on disk. Force-rename (`-M`) and force-move
+(`-f` / bare `--force`) stay blocked on the primary.
 
 Scheduled gone-upstream pruning (`scripts/orchestration/scheduled_worktree_cleanup.py`)
 and the post-merge auto-prune hook remain complementary paths; they do not
@@ -202,7 +205,7 @@ replace this sanctioned interactive cleanup.
 
 Stale-ref sweep (follow-up): if `git branch` still lists leftovers from prior
 sessions, delete each with the same `-D` rules above — do not broaden the
-guard or skip the live-remote+unpushed check.
+guard or skip the never-pushed / live-remote+unpushed checks.
 
 ## Monitor API surface
 

--- a/docs/best-practices/gitflow.md
+++ b/docs/best-practices/gitflow.md
@@ -167,7 +167,7 @@ Never run these without explicit user instruction:
 - `git clean -f`
 - `git branch -D {branch}` — except the sanctioned post-squash-merge
   cleanup documented in [`git-hygiene.md`](git-hygiene.md#post-merge-local-branch-cleanup-4674--m-10a)
-  (not checked out; not live-upstream+unpushed)
+  (gone-upstream or fully-pushed; never-pushed stays blocked)
 - `git commit --amend` (on published commits)
 - `git rebase -i` (interactive rebase)
 

--- a/docs/best-practices/gitflow.md
+++ b/docs/best-practices/gitflow.md
@@ -165,7 +165,9 @@ Never run these without explicit user instruction:
 - `git reset --hard`
 - `git checkout .` or `git restore .`
 - `git clean -f`
-- `git branch -D {branch}`
+- `git branch -D {branch}` — except the sanctioned post-squash-merge
+  cleanup documented in [`git-hygiene.md`](git-hygiene.md#post-merge-local-branch-cleanup-4674--m-10a)
+  (not checked out; not live-upstream+unpushed)
 - `git commit --amend` (on published commits)
 - `git rebase -i` (interactive rebase)
 

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -261,14 +261,15 @@ def _add_bare_origin(repo: Path, remote_path: Path) -> None:
     _git(repo, "remote", "add", "origin", str(remote_path))
 
 
-def test_issue_4674_force_delete_never_pushed_is_allowed(repos):
+def test_issue_4674_force_delete_never_pushed_is_blocked(repos):
     public = repos["public"]
     _git(public, "branch", "local-only")
     reason = guard._command_danger_reason(
         "git branch -D local-only",
         session_cwd=public,
     )
-    assert reason is None
+    assert reason is not None
+    assert "never-pushed" in reason
 
 
 def test_issue_4674_force_delete_upstream_gone_is_allowed(repos, tmp_path):
@@ -495,8 +496,15 @@ def test_protected_primary_current_branch_force_ops_block(repos, root_key, opera
     assert guard._command_danger_reason(f"git -C {root} {operation}", repos["other"]) is not None
 
 
-def test_private_non_current_branch_pruning_is_allowed(repos):
-    command = f"git -C {repos['private']} branch -D merged-feature"
+def test_private_non_current_branch_pruning_is_allowed(repos, tmp_path):
+    """Private primary may still -D a sanctioned (fully-pushed) non-HEAD tip."""
+    private = repos["private"]
+    _add_bare_origin(private, tmp_path / "private-origin.git")
+    _git(private, "checkout", "-b", "merged-feature")
+    _git(private, "commit", "--allow-empty", "-m", "feature")
+    _git(private, "push", "-u", "origin", "merged-feature")
+    _git(private, "checkout", "main")
+    command = f"git -C {private} branch -D merged-feature"
     assert guard._command_danger_reason(command, repos["public"]) is None
 
 

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -232,6 +232,10 @@ def test_quoted_git_in_commit_message_not_blocked(cmd):
 def test_branch_force_reason_unit():
     assert guard._branch_force_reason(["-D", "feature"], "feature") is not None
     assert guard._branch_force_reason(["-D", "feature"], "main") is None
+    assert guard._branch_force_reason(["-D", "main"], "feature") is not None
+    assert guard._branch_force_reason(["-d", "--force", "feature"], "main") is None
+    assert guard._branch_force_reason(["--delete", "--force", "feature"], "main") is None
+    assert guard._branch_force_reason(["-Df", "feature"], "main") is None
     assert guard._branch_force_reason(["-M", "old", "new"], "old") is not None
     assert guard._branch_force_reason(["-M", "new"], "main") is not None
     assert guard._branch_force_reason(["-f", "feature", "ref"], "main") is not None
@@ -240,6 +244,104 @@ def test_branch_force_reason_unit():
     assert guard._branch_force_reason(["-m", "old", "new"], "main") is None
     assert guard._branch_force_reason(["feature"], "main") is None
     assert guard._branch_force_reason([], "main") is None
+
+
+# --- #4674: sanctioned squash-merge force-delete -----------------------------
+
+
+def _add_bare_origin(repo: Path, remote_path: Path) -> None:
+    remote_path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "--bare", str(remote_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    _git(repo, "remote", "add", "origin", str(remote_path))
+
+
+def test_issue_4674_force_delete_never_pushed_is_allowed(repos):
+    public = repos["public"]
+    _git(public, "branch", "local-only")
+    reason = guard._command_danger_reason(
+        "git branch -D local-only",
+        session_cwd=public,
+    )
+    assert reason is None
+
+
+def test_issue_4674_force_delete_upstream_gone_is_allowed(repos, tmp_path):
+    public = repos["public"]
+    _add_bare_origin(public, tmp_path / "origin.git")
+    _git(public, "checkout", "-b", "squash-merged")
+    _git(public, "commit", "--allow-empty", "-m", "feature")
+    _git(public, "push", "-u", "origin", "squash-merged")
+    _git(public, "checkout", "main")
+    _git(public, "push", "origin", "--delete", "squash-merged")
+    reason = guard._command_danger_reason(
+        "git branch -D squash-merged",
+        session_cwd=public,
+    )
+    assert reason is None
+
+
+def test_issue_4674_force_delete_fully_pushed_live_remote_is_allowed(repos, tmp_path):
+    public = repos["public"]
+    _add_bare_origin(public, tmp_path / "origin.git")
+    _git(public, "checkout", "-b", "fully-pushed")
+    _git(public, "commit", "--allow-empty", "-m", "feature")
+    _git(public, "push", "-u", "origin", "fully-pushed")
+    _git(public, "checkout", "main")
+    reason = guard._command_danger_reason(
+        "git branch -D fully-pushed",
+        session_cwd=public,
+    )
+    assert reason is None
+
+
+def test_issue_4674_force_delete_live_remote_with_unpushed_is_blocked(repos, tmp_path):
+    public = repos["public"]
+    _add_bare_origin(public, tmp_path / "origin.git")
+    _git(public, "checkout", "-b", "unpushed-wip")
+    _git(public, "commit", "--allow-empty", "-m", "pushed")
+    _git(public, "push", "-u", "origin", "unpushed-wip")
+    _git(public, "commit", "--allow-empty", "-m", "local-only")
+    _git(public, "checkout", "main")
+    reason = guard._command_danger_reason(
+        "git branch -D unpushed-wip",
+        session_cwd=public,
+    )
+    assert reason is not None
+    assert "unpushed" in reason
+
+
+def test_issue_4674_force_delete_checked_out_in_worktree_is_blocked(repos):
+    public = repos["public"]
+    reason = guard._command_danger_reason(
+        "git branch -D topic",
+        session_cwd=public,
+    )
+    assert reason is not None
+    assert "worktree" in reason
+
+
+def test_issue_4674_delete_force_spellings_follow_same_policy(repos, tmp_path):
+    public = repos["public"]
+    _add_bare_origin(public, tmp_path / "origin.git")
+    _git(public, "checkout", "-b", "spell-check")
+    _git(public, "commit", "--allow-empty", "-m", "pushed")
+    _git(public, "push", "-u", "origin", "spell-check")
+    _git(public, "commit", "--allow-empty", "-m", "local-only")
+    _git(public, "checkout", "main")
+    for command in (
+        "git branch -d --force spell-check",
+        "git branch --delete --force spell-check",
+        "git branch -Df spell-check",
+    ):
+        reason = guard._command_danger_reason(command, session_cwd=public)
+        assert reason is not None, command
+        assert "unpushed" in reason
 
 
 # --- #4876: glued-operator evasion class ------------------------------------


### PR DESCRIPTION
## Summary
- Teach `guard-branch-switch-in-main` a sanctioned `git branch -D` path for #M-10a squash-merge cleanup: allow when the target is not protected, not checked out in any worktree, and not live-upstream+unpushed.
- Keep force-rename (`-M` of HEAD) and force-move (`-f` / bare `--force`) blocked; treat `-d --force` / `--delete --force` / `-Df` as force-delete under the same policy.
- Document the cleanup recipe in `git-hygiene.md` (and cross-link from `gitflow.md`).

## Test plan
- [x] `.venv/bin/pytest -q tests/test_guard_branch_switch_in_main.py` (105 passed)
- [x] `ruff check` on the hook + tests
- [ ] Confirm CI green on this PR
- [ ] After merge: `npm run agents:deploy` (or local hook copy) so the deployed PreToolUse hook picks up the change

Fixes #4674

Made with [Cursor](https://cursor.com)