### PR TITLE
feat(orchestration): support capped stream parents (#5912)

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -62,7 +62,7 @@ is the single source of truth for membership (auditor:
 | atlas-practice | #4387, #4700, #5331 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378, #5224 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
-| infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
+| infra-harness | #4707, #5880, #5885 | Infra & fleet reliability (hooks, dispatch, routing). #4707 is capped at GitHub's 100-sub-issue limit; #5880 and #5885 are program membership roots. |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
 | open-model-data | #6321 (successor to closed #6164 and #6056) | Build evidence-bearing prepared Ukrainian data products on the completed Foundry engine. Community usefulness is primary; adoption is secondary evidence, not a gate. Every shipped artifact names a concrete consumer decision/use case. Current truth: #6375 is the active Phase 3 v2.1 functional-role and runtime rebinding task; #6333 is historical `ENGINE_READY` evidence only and establishes no linguistic, source, consumer, or completion status; Phase 4 remains blocked. |

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -9,6 +9,10 @@
 # - New issues link their stream epic at creation time.
 # - Epics themselves (and their child drive boards) are exempt from membership.
 schema_version: 1
+capped_epics:
+  4707:
+    reason: "GitHub 100-sub-issue hard cap (#5912)"
+    max_native: 100
 streams:
   atlas-practice:
     title: "Word Atlas + Practice Hub product"
@@ -21,7 +25,7 @@ streams:
     epics: [4706]
   infra-harness:
     title: "Infra & fleet reliability (hooks, dispatch, routing)"
-    epics: [4707]
+    epics: [4707, 5880, 5885]  # capped umbrella + fleet taxonomy + weak-driver trails
   devops:
     title: "DevOps automation, CI, release & launcher reliability"
     epics: [5703]

--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -1,8 +1,9 @@
 """Issue-stream auditor — every open GH issue must belong to exactly one stream epic.
 
 Registry: scripts/config/issue_streams.yaml (streams → epic issue numbers).
-Membership: native GitHub sub-issue of a stream epic, OR (fallback while the
-native migration is pending) a ``#N`` reference in a stream epic's body.
+Membership: native GitHub sub-issue of a stream epic, OR a ``#N`` reference in
+a stream epic's body. Body references normally await native migration, except
+for explicitly capped parent epics where they are an accepted fallback.
 
 Usage:
   .venv/bin/python -m scripts.orchestration.issue_stream_audit           # human summary
@@ -36,6 +37,7 @@ import time
 from collections.abc import Callable
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -590,19 +592,78 @@ def _run_refresh_worker(run_id: str) -> int:
         _release_lock(fd)
 
 
-def load_registry(path: Path = REGISTRY_PATH) -> dict[str, list[int]]:
-    """Return {stream_key: [epic_numbers]}."""
+class IssueStreamRegistry(dict[str, list[int]]):
+    """Stream-to-epic mapping with validated, opt-in parent-cap metadata.
+
+    It deliberately remains a ``dict`` subclass so existing registry consumers
+    can continue to use ``.items()``, ``.values()``, and mapping equality.
+    """
+
+    def __init__(self, streams: dict[str, list[int]], capped_epics: dict[int, dict[str, Any]]):
+        super().__init__(streams)
+        self.capped_epics = capped_epics
+
+
+def _capped_epic_specs(registry: dict[str, list[int]]) -> dict[int, dict[str, Any]]:
+    """Return validated cap metadata when supplied by ``load_registry``."""
+    raw = getattr(registry, "capped_epics", {})
+    return raw if isinstance(raw, dict) else {}
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> IssueStreamRegistry:
+    """Load the registry, rejecting unknown keys and malformed cap metadata."""
     doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise ValueError("issue_streams.yaml must contain a mapping")
+    unknown_top_level = set(doc) - {"schema_version", "streams", "capped_epics"}
+    if unknown_top_level:
+        raise ValueError(f"issue_streams.yaml has unknown keys: {sorted(unknown_top_level)}")
+    schema_version = doc.get("schema_version", 1)
+    if schema_version != 1:
+        raise ValueError(f"unsupported issue-streams schema_version: {schema_version!r}")
     streams = doc.get("streams") or {}
+    if not isinstance(streams, dict):
+        raise ValueError("issue_streams.yaml streams must be a mapping")
     registry: dict[str, list[int]] = {}
     for key, spec in streams.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("issue-streams stream keys must be non-empty strings")
+        if not isinstance(spec, dict):
+            raise ValueError(f"stream {key!r} must be a mapping")
+        unknown_stream_keys = set(spec) - {"title", "epics"}
+        if unknown_stream_keys:
+            raise ValueError(f"stream {key!r} has unknown keys: {sorted(unknown_stream_keys)}")
         epics = [int(n) for n in (spec.get("epics") or [])]
         if not epics:
             raise ValueError(f"stream {key!r} has no epics")
         registry[key] = epics
     if not registry:
         raise ValueError("issue_streams.yaml defines no streams")
-    return registry
+    registered_epics = {epic for epics in registry.values() for epic in epics}
+    raw_capped_epics = doc.get("capped_epics") or {}
+    if not isinstance(raw_capped_epics, dict):
+        raise ValueError("capped_epics must be a mapping")
+    capped_epics: dict[int, dict[str, Any]] = {}
+    for raw_epic, spec in raw_capped_epics.items():
+        try:
+            epic = int(raw_epic)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"capped epic key is not an issue number: {raw_epic!r}") from exc
+        if epic not in registered_epics:
+            raise ValueError(f"capped epic #{epic} is not registered in any stream")
+        if not isinstance(spec, dict):
+            raise ValueError(f"capped epic #{epic} must be a mapping")
+        unknown_cap_keys = set(spec) - {"reason", "max_native"}
+        if unknown_cap_keys:
+            raise ValueError(f"capped epic #{epic} has unknown keys: {sorted(unknown_cap_keys)}")
+        reason = spec.get("reason")
+        max_native = spec.get("max_native")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"capped epic #{epic} requires a non-empty reason")
+        if isinstance(max_native, bool) or not isinstance(max_native, int) or max_native < 1:
+            raise ValueError(f"capped epic #{epic} requires positive integer max_native")
+        capped_epics[epic] = {"reason": reason, "max_native": max_native}
+    return IssueStreamRegistry(registry, capped_epics)
 
 
 def _table_cells(line: str) -> list[str]:
@@ -904,6 +965,7 @@ def classify(
 ) -> dict:
     """Pure classification — unit-testable without network."""
     epic_numbers = {e for epics in registry.values() for e in epics}
+    capped_epics = _capped_epic_specs(registry)
     stream_of_epic = {e: key for key, epics in registry.items() for e in epics}
 
     native_epics: dict[int, set[int]] = {}
@@ -939,6 +1001,12 @@ def classify(
         n for n in open_numbers
         if n not in epic_numbers and owning_epics.get(n) and n not in native_linked
     )
+    pending_native_link = sorted(
+        n for n in body_only if not (owning_epics[n] & set(capped_epics))
+    )
+    accepted_capped_fallback = sorted(
+        n for n in body_only if owning_epics[n] & set(capped_epics)
+    )
     missing_epics = sorted(e for e in epic_numbers if e not in open_numbers)
 
     return {
@@ -954,7 +1022,8 @@ def classify(
             }
             for n in multi_homed
         ],
-        "pending_native_link": body_only,
+        "pending_native_link": pending_native_link,
+        "accepted_capped_fallback": accepted_capped_fallback,
         "closed_or_missing_epics": missing_epics,
         # The invariant is EXACTLY ONE EFFECTIVE EPIC — multi-homed violates it
         # (codex F1), including two epics that happen to share one stream.
@@ -1258,6 +1327,7 @@ def migrate(report: dict) -> int:
     winner order-dependent instead of deliberate. Resolve them manually.
     """
     registry = load_registry()
+    capped_epics = _capped_epic_specs(registry)
     ambiguous = {m["number"] for m in report.get("multi_homed", [])}
     if ambiguous:
         print(
@@ -1268,6 +1338,14 @@ def migrate(report: dict) -> int:
     created = 0
     for stream_key, epics in registry.items():
         for epic in epics:
+            cap = capped_epics.get(epic)
+            if cap is not None:
+                print(
+                    f"skipping capped epic #{epic}: {cap['reason']} "
+                    f"(max_native={cap['max_native']}); body fallback is accepted",
+                    file=sys.stderr,
+                )
+                continue
             native, refs = fetch_epic_membership(epic)
             pending = sorted(
                 refs - native - ambiguous
@@ -1313,6 +1391,11 @@ def human_summary(report: dict) -> str:
         lines.append(
             f"pending native sub-issue link: {len(report['pending_native_link'])}"
             " (run --migrate)"
+        )
+    if report.get("accepted_capped_fallback"):
+        lines.append(
+            f"accepted capped-parent body fallback: "
+            f"{len(report['accepted_capped_fallback'])} (no migration required)"
         )
     if report["closed_or_missing_epics"]:
         lines.append(f"⚠️ stream epics not open: {report['closed_or_missing_epics']}")

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -139,8 +139,17 @@ def test_unknown_selector_fails_closed() -> None:
 def test_devops_epic_is_registered_separately_from_infra() -> None:
     registry = yaml.safe_load(_ISSUE_STREAMS.read_text(encoding="utf-8"))["streams"]
 
-    assert registry["infra-harness"]["epics"] == [4707]
+    infra_epics = registry["infra-harness"]["epics"]
+    devops_epics = registry["devops"]["epics"]
+
+    assert 4707 in infra_epics
+    assert 5880 in infra_epics
+    assert 5885 in infra_epics
+    assert 5703 not in infra_epics
     assert registry["devops"]["epics"] == [5703]
+    assert 4707 not in devops_epics
+    assert 5880 not in devops_epics
+    assert 5885 not in devops_epics
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -80,6 +80,82 @@ def test_body_reference_counts_but_flags_pending_migration(registry):
     )
     assert report["orphans"] == []
     assert report["pending_native_link"] == [7]
+    assert report["accepted_capped_fallback"] == []
+
+
+def test_body_reference_on_capped_epic_is_accepted_fallback(tmp_path):
+    path = tmp_path / "issue_streams.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            schema_version: 1
+            capped_epics:
+              100:
+                reason: "GitHub sub-issue limit"
+                max_native: 100
+            streams:
+              infra:
+                title: "Infra"
+                epics: [100, 101]
+            """
+        ),
+        encoding="utf-8",
+    )
+    registry = load_registry(path)
+
+    report = classify(
+        _issues(100, 101, 7),
+        registry,
+        {100: (set(), {7}), 101: (set(), set())},
+    )
+
+    assert registry["infra"] == [100, 101]
+    assert registry.capped_epics == {
+        100: {"reason": "GitHub sub-issue limit", "max_native": 100}
+    }
+    assert report["pending_native_link"] == []
+    assert report["accepted_capped_fallback"] == [7]
+    assert report["ok"] is True
+    summary = issue_stream_audit.human_summary(report)
+    assert "accepted capped-parent body fallback: 1 (no migration required)" in summary
+    assert "run --migrate" not in summary
+
+
+def test_project_registry_declares_capped_infra_parent_and_program_epics():
+    registry = load_registry(issue_stream_audit.REGISTRY_PATH)
+
+    assert registry["infra-harness"] == [4707, 5880, 5885]
+    assert registry.capped_epics[4707] == {
+        "reason": "GitHub 100-sub-issue hard cap (#5912)",
+        "max_native": 100,
+    }
+
+
+def test_migrate_skips_marked_capped_parent(monkeypatch, capsys):
+    registry = issue_stream_audit.IssueStreamRegistry(
+        {"infra": [100]},
+        {100: {"reason": "GitHub sub-issue limit", "max_native": 100}},
+    )
+    monkeypatch.setattr(issue_stream_audit, "load_registry", lambda: registry)
+    monkeypatch.setattr(
+        issue_stream_audit,
+        "fetch_epic_membership",
+        lambda _epic: pytest.fail("capped parent must not be queried for migration"),
+    )
+
+    assert issue_stream_audit.migrate({"pending_native_link": [7]}) == 0
+    assert "skipping capped epic #100" in capsys.readouterr().err
+
+
+def test_registry_rejects_unknown_capped_epic_keys(tmp_path):
+    path = tmp_path / "issue_streams.yaml"
+    path.write_text(
+        "streams:\n  infra:\n    title: Infra\n    epics: [100]\n"
+        "capped_epics:\n  100:\n    reason: cap\n    max_native: 100\n    typo: nope\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unknown keys"):
+        load_registry(path)
 
 
 def test_multi_homed_across_streams_flagged(registry):


### PR DESCRIPTION
Implements auditor+registry half of #5912; re-parenting continues in follow-up.

- registers #5880 and #5885 as infra program roots
- records #4707 as a capped native-sub-issue parent
- reports body-only children of a capped parent as accepted and skips native migration

Validation:
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_issue_stream_audit.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/orchestration/issue_stream_audit.py tests/test_issue_stream_audit.py`

X-Agent: codex/5912-capped-parent-split