### PR TITLE
feat(ci): enforce PR runner-slot budget

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -33,6 +33,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+
+      # This remains in the existing always-on workflow so a PR cannot add a
+      # runner job without checking the complete PR workflow inventory.
+      - name: Enforce CI runner-slot budget (#5818)
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --disable-pip-version-check PyYAML==6.0.3
+          .venv/bin/python -m scripts.ci.slot_inventory --check
+
       - name: Lint workflows
         env:
           # Force the pinned, checksum-verified actionlint build for a

--- a/docs/runbooks/ci-gate.md
+++ b/docs/runbooks/ci-gate.md
@@ -1,0 +1,67 @@
+# CI Gate and runner-slot budget
+
+This runbook documents the CI gate and its runner-slot budget introduced by
+#5818. It is
+an operational guard, not a change to `ci.yml`'s job graph or `CI Gate` needs.
+
+## CI Gate
+
+`CI Gate` is the repository's single required check. It is the final job in
+`.github/workflows/ci.yml` and succeeds only when its unconditional required
+dependencies succeed: pytest planning and all four pytest shards, contracts,
+frontend, and the coverage floor. The workflow remains the authoritative job
+composition; this runbook deliberately does not duplicate its YAML.
+
+The contracts job's BIO preparation validation is load-bearing. In particular,
+an active BIO hold must continue to fail closed (`PREPARATION_HOLD_ACTIVE`),
+and the check refuses a change that would make an active hold pass
+vacuously. Do not remove, path-filter, or move that validation to an advisory
+workflow.
+
+## Runner-slot budget
+
+Run the inventory locally from the repository root:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.ci.slot_inventory --check
+```
+
+The script parses every `.github/workflows/*.yml` that runs on `pull_request`
+or `merge_group`. It counts each top-level job and expands static matrix
+dimensions, exclusions, and additions. It fails closed on an unsupported
+dynamic matrix. The documented pytest-shard runtime matrix is the exception:
+`PYTEST_SHARD_CEILING` is pinned to four and asserts that the static `ci.yml`
+matrix does not exceed that topology.
+
+`CI_SLOT_CEILING = 30` in `scripts/ci/slot_inventory.py` is the only policy
+source. Its baseline is the measured 28 PR runner slots on #5818's main
+baseline, including the four pytest shards; two slots are deliberate headroom.
+The same command runs inside the existing always-on `actionlint` PR workflow,
+so a workflow edit cannot silently bypass the budget and the guard adds no
+runner job of its own.
+
+To raise the ceiling, submit a focused one-line PR changing
+`CI_SLOT_CEILING`, with the inventory's measured before/after output and the
+reason the added concurrency is safe. Do not raise it as a side effect of an
+unrelated workflow change.
+
+Mutation proof: temporarily add a dummy PR job in a local scratch copy of the
+workflow directory whose static matrix raises the total above 30, then run the
+inventory. The unit test models the measured 28-slot baseline plus a three-way
+dummy job and verifies the nonzero exit. Do not commit a dummy job.
+
+## Quarantine convention (documentation only)
+
+If a future CI-capacity exception must be recorded, describe it in the PR or
+issue using this convention; this runbook creates no ledger and does not adopt
+the #5812 implementation list:
+
+```yaml
+reason: why the exception is necessary
+owner: accountable maintainer or team
+exit_condition: measurable condition, expiry date, or tracking issue
+```
+
+Every entry needs all three fields. The `exit_condition` must provide a
+concrete removal path, not an open-ended intention. For incident context, see
+the CI-gate autopsy at `docs/bug-autopsies/2026-07-25-invisible-ci-gate.md`.

--- a/scripts/ci/slot_inventory.py
+++ b/scripts/ci/slot_inventory.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Inventory the GitHub Actions runner slots started by pull-request workflows.
+
+The ceiling is intentionally a constant here: changing it is a visible one-line
+policy change, while the runbook explains why and how to make that change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# #5818: main's measured PR inventory is 28 runner slots (25 top-level jobs,
+# including the four-way pytest matrix). Two slots are deliberate headroom.
+CI_SLOT_CEILING = 30
+
+# CI's planner and its Python job document a four-way pytest topology. This
+# constant is also the fail-closed count for that job should its shard matrix
+# become a runtime expression that static YAML cannot expand.
+PYTEST_SHARD_CEILING = 4
+
+DEFAULT_WORKFLOW_DIR = Path(".github/workflows")
+
+
+@dataclass(frozen=True)
+class WorkflowInventory:
+    """One PR-path workflow and its expanded runner-slot count."""
+
+    path: Path
+    jobs: dict[str, int]
+
+    @property
+    def total(self) -> int:
+        return sum(self.jobs.values())
+
+
+def _mapping(value: Any, *, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{description} must be a mapping")
+    return value
+
+
+def _trigger_config(workflow: Mapping[str, Any]) -> Any:
+    """Return `on`, accounting for YAML 1.1 parsing the word as boolean true."""
+    return workflow.get("on", workflow.get(True))
+
+
+def is_pr_path(workflow: Mapping[str, Any]) -> bool:
+    """Whether a workflow runs for PRs or merge-queue candidates."""
+    triggers = _trigger_config(workflow)
+    if isinstance(triggers, str):
+        return triggers in {"pull_request", "merge_group"}
+    if isinstance(triggers, Sequence) and not isinstance(triggers, (str, bytes)):
+        return bool({"pull_request", "merge_group"} & set(triggers))
+    if isinstance(triggers, Mapping):
+        return bool({"pull_request", "merge_group"} & set(triggers))
+    return False
+
+
+def _static_values(value: Any, *, location: str) -> list[Any]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{location} must be a non-empty static YAML list")
+    if any(isinstance(item, str) and "${{" in item for item in value):
+        raise ValueError(f"{location} contains a dynamic GitHub expression")
+    return value
+
+
+def _matches(candidate: Mapping[str, Any], selector: Mapping[str, Any]) -> bool:
+    return all(candidate.get(key) == value for key, value in selector.items())
+
+
+def _matrix_slots(matrix: Any, *, workflow_name: str, job_name: str) -> int:
+    """Count a documented static matrix; reject unknown runtime expansion."""
+    matrix_map = _mapping(matrix, description=f"{workflow_name}:{job_name} matrix")
+    include = matrix_map.get("include", [])
+    exclude = matrix_map.get("exclude", [])
+    dimensions = {key: value for key, value in matrix_map.items() if key not in {"include", "exclude"}}
+
+    if workflow_name == "ci.yml" and job_name == "python" and isinstance(dimensions.get("shard"), str):
+        shard_expression = dimensions["shard"]
+        if "${{" not in shard_expression:
+            raise ValueError("ci.yml:python shard matrix must be a static list or GitHub expression")
+        if set(dimensions) != {"shard"}:
+            raise ValueError("ci.yml:python dynamic shard matrix may not have other dimensions")
+        return PYTEST_SHARD_CEILING
+
+    values = {
+        key: _static_values(value, location=f"{workflow_name}:{job_name} matrix.{key}")
+        for key, value in dimensions.items()
+    }
+    if not values:
+        combinations: list[dict[str, Any]] = [{}]
+    else:
+        combinations = [dict(zip(values, items, strict=True)) for items in itertools.product(*values.values())]
+
+    for selector in exclude:
+        selector_map = _mapping(selector, description=f"{workflow_name}:{job_name} matrix.exclude entry")
+        combinations = [candidate for candidate in combinations if not _matches(candidate, selector_map)]
+
+    if not isinstance(include, list):
+        raise ValueError(f"{workflow_name}:{job_name} matrix.include must be a list")
+    original_combinations = combinations
+    for entry in include:
+        entry_map = _mapping(entry, description=f"{workflow_name}:{job_name} matrix.include entry")
+        # GitHub augments every original combination that has no conflicting
+        # key. An entry that conflicts with every original combination creates
+        # exactly one additional matrix job.
+        if not any(
+            all(key not in candidate or candidate[key] == value for key, value in entry_map.items())
+            for candidate in original_combinations
+        ):
+            combinations.append(dict(entry_map))
+
+    if workflow_name == "ci.yml" and job_name == "python":
+        shards = values.get("shard")
+        if shards is None:
+            raise ValueError("ci.yml:python must retain its documented shard matrix")
+        if len(shards) > PYTEST_SHARD_CEILING:
+            raise ValueError(
+                f"ci.yml:python has {len(shards)} shards, above PYTEST_SHARD_CEILING={PYTEST_SHARD_CEILING}"
+            )
+    return len(combinations)
+
+
+def job_slots(job: Mapping[str, Any], *, workflow_name: str, job_name: str) -> int:
+    """Return the number of runner jobs produced by one top-level job."""
+    strategy = job.get("strategy")
+    if strategy is None:
+        return 1
+    strategy_map = _mapping(strategy, description=f"{workflow_name}:{job_name} strategy")
+    matrix = strategy_map.get("matrix")
+    return 1 if matrix is None else _matrix_slots(matrix, workflow_name=workflow_name, job_name=job_name)
+
+
+def inventory_workflows(workflow_dir: Path = DEFAULT_WORKFLOW_DIR) -> list[WorkflowInventory]:
+    """Parse and expand every PR or merge-queue workflow in ``workflow_dir``."""
+    inventories: list[WorkflowInventory] = []
+    for path in sorted(workflow_dir.glob("*.yml")):
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ValueError(f"{path}: invalid YAML: {exc}") from exc
+        workflow = _mapping(loaded or {}, description=str(path))
+        if not is_pr_path(workflow):
+            continue
+        raw_jobs = _mapping(workflow.get("jobs", {}), description=f"{path}: jobs")
+        jobs = {
+            job_name: job_slots(_mapping(job, description=f"{path}:{job_name}"), workflow_name=path.name, job_name=job_name)
+            for job_name, job in raw_jobs.items()
+        }
+        inventories.append(WorkflowInventory(path=path, jobs=jobs))
+    return inventories
+
+
+def inventory_report(workflow_dir: Path = DEFAULT_WORKFLOW_DIR) -> dict[str, Any]:
+    """Return a JSON-serializable report for a repository or test fixture."""
+    workflows = inventory_workflows(workflow_dir)
+    total = sum(workflow.total for workflow in workflows)
+    return {
+        "ceiling": CI_SLOT_CEILING,
+        "pass": total <= CI_SLOT_CEILING,
+        "pytest_shard_ceiling": PYTEST_SHARD_CEILING,
+        "total": total,
+        "workflows": [
+            {"jobs": workflow.jobs, "total": workflow.total, "workflow": str(workflow.path)} for workflow in workflows
+        ],
+    }
+
+
+def _print_human(report: Mapping[str, Any]) -> None:
+    print("CI runner-slot inventory")
+    for workflow in report["workflows"]:
+        jobs = ", ".join(f"{name}={count}" for name, count in workflow["jobs"].items())
+        print(f"  {workflow['workflow']}: {workflow['total']} ({jobs})")
+    status = "PASS" if report["pass"] else "FAIL"
+    print(f"{status}: {report['total']} slots / ceiling {report['ceiling']}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow-dir", type=Path, default=DEFAULT_WORKFLOW_DIR, help="workflow directory to inventory")
+    parser.add_argument("--check", action="store_true", help="fail when the inventory exceeds the configured ceiling")
+    parser.add_argument("--json", action="store_true", help="emit JSON only")
+    args = parser.parse_args(argv)
+
+    try:
+        report = inventory_report(args.workflow_dir)
+    except (OSError, ValueError) as exc:
+        print(f"CI runner-slot inventory failed: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        _print_human(report)
+        print(json.dumps(report, sort_keys=True))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_slot_inventory.py
+++ b/tests/test_ci_slot_inventory.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci import slot_inventory
+
+
+def _write_workflow(directory: Path, name: str, text: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / name).write_text(text, encoding="utf-8")
+
+
+def test_inventory_expands_static_matrix_and_ignores_non_pr_workflows(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "pr.yml",
+        """on: pull_request
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+        python: ['3.11', '3.12']
+        exclude:
+          - os: macos
+            python: '3.11'
+        include:
+          - os: windows
+            python: '3.12'
+    runs-on: ${{ matrix.os }}
+""",
+    )
+    _write_workflow(
+        tmp_path,
+        "push.yml",
+        """on: push
+jobs:
+  ignored:
+    runs-on: ubuntu-latest
+""",
+    )
+
+    report = slot_inventory.inventory_report(tmp_path)
+
+    assert report["total"] == 4
+    assert report["workflows"] == [{"workflow": str(tmp_path / "pr.yml"), "jobs": {"test": 4}, "total": 4}]
+
+
+def test_inventory_uses_named_pytest_shard_ceiling_for_runtime_matrix(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """on: [pull_request, merge_group]
+jobs:
+  python:
+    strategy:
+      matrix:
+        shard: ${{ fromJSON(inputs.shards) }}
+    runs-on: ubuntu-latest
+""",
+    )
+
+    report = slot_inventory.inventory_report(tmp_path)
+
+    assert report["total"] == slot_inventory.PYTEST_SHARD_CEILING
+
+
+def test_check_fails_when_dummy_job_expands_past_configured_ceiling(tmp_path: Path, capsys) -> None:
+    _write_workflow(
+        tmp_path,
+        "pr.yml",
+        """on: pull_request
+jobs:
+  baseline:
+    strategy:
+      matrix:
+        lane: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]
+    runs-on: ubuntu-latest
+  dummy:
+    strategy:
+      matrix:
+        lane: [1, 2, 3]
+    runs-on: ubuntu-latest
+""",
+    )
+
+    result = slot_inventory.main(["--workflow-dir", str(tmp_path), "--check", "--json"])
+
+    assert result == 1
+    assert '"pass": false' in capsys.readouterr().out
+
+
+def test_static_pytest_shards_cannot_exceed_named_ceiling(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """on: pull_request
+jobs:
+  python:
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4, 5]
+    runs-on: ubuntu-latest
+""",
+    )
+
+    try:
+        slot_inventory.inventory_report(tmp_path)
+    except ValueError as exc:
+        assert "PYTEST_SHARD_CEILING" in str(exc)
+    else:
+        raise AssertionError("expected an over-ceiling pytest shard matrix to fail")


### PR DESCRIPTION
Closes #5818

## Summary
- inventory every PR/merge-queue workflow, including static matrices and the documented pytest shard ceiling
- enforce the 30-slot ceiling from the existing always-on actionlint workflow without adding a runner job
- document CI Gate, the load-bearing BIO active-hold validation, ceiling changes, and the documentation-only quarantine convention

## Evidence
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_ci_slot_inventory.py tests/test_ci_shard_partition.py -v --tb=short` — 12 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.ci.slot_inventory --check` — 28 slots / ceiling 30
- `bash scripts/audit/check_workflows.sh` — actionlint valid for 14 workflows
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/ci/slot_inventory.py tests/test_ci_slot_inventory.py` — passed

## Mutation proof
The inventory test models the measured 28-slot baseline plus a three-way dummy matrix job (31 slots), and asserts a nonzero guard exit. No dummy workflow is committed.

## Scope
No `ci.yml` job graph, `ci-gate` needs, required checks, BIO gate logic, quarantine ledger, or #5812 implementation list changed.

CF-ready: independent cross-family exact-head review is still required before merge.