### PR TITLE
feat(git): add primary ref audit tripwire

### DIFF
--- a/.githooks/reference-transaction
+++ b/.githooks/reference-transaction
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# AUDIT TRIPWIRE ONLY — bypassable (hooksPath=/dev/null etc.); see #5808
+#
+# This hook deliberately records only committed ref updates in the primary
+# checkout. It must never affect the outcome of a Git reference transaction.
+
+set +e
+
+hook_argv="$0 ${1-}"
+
+json_quote() {
+  local value="${1-}"
+
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\b'/\\b}
+  value=${value//$'\f'/\\f}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '"%s"' "$value"
+}
+
+agent_environment_json() {
+  local name value separator=""
+
+  printf '{'
+  while IFS='=' read -r name value; do
+    case "$name" in
+      TASK_ID|X_AGENT|DISPATCH_*|AGENT_*)
+        printf '%s' "$separator"
+        json_quote "$name"
+        printf ':'
+        json_quote "$value"
+        separator=','
+        ;;
+    esac
+  done < <(env)
+  printf '}'
+}
+
+record_update() {
+  local old_sha="$1" new_sha="$2" ref_name="$3"
+  local timestamp cwd cmdline argv agent_environment
+
+  case "$ref_name" in
+    HEAD|refs/heads/*) ;;
+    *) return 0 ;;
+  esac
+
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cwd="$(pwd -P 2>/dev/null)"
+  cmdline="$(ps -o command= -p "$PPID" 2>/dev/null | head -n 1)"
+  argv="$hook_argv"
+  agent_environment="$(agent_environment_json)"
+
+  printf '{"ts":%s,"ref":%s,"old":%s,"new":%s,"pid":%s,"ppid":%s,"argv":%s,"cmdline":%s,"cwd":%s,"agent_env":%s}\n' \
+    "$(json_quote "$timestamp")" \
+    "$(json_quote "$ref_name")" \
+    "$(json_quote "$old_sha")" \
+    "$(json_quote "$new_sha")" \
+    "$(json_quote "$$")" \
+    "$(json_quote "$PPID")" \
+    "$(json_quote "$argv")" \
+    "$(json_quote "$cmdline")" \
+    "$(json_quote "$cwd")" \
+    "$agent_environment" >> "$audit_file" 2>/dev/null || true
+}
+
+record_payload() {
+  local record old_sha new_sha ref_name extra
+
+  # Current Git documents LF-delimited records. Accept NUL-delimited records
+  # too, so this audit hook safely consumes either representation.
+  local saw_nul=0
+  while IFS= read -r -d '' record; do
+    saw_nul=1
+    IFS=' ' read -r old_sha new_sha ref_name extra <<< "$record"
+    [[ -n "$old_sha" && -n "$new_sha" && -n "$ref_name" && -z "$extra" ]] || continue
+    record_update "$old_sha" "$new_sha" "$ref_name"
+  done
+
+  if [[ "$saw_nul" -eq 0 && -n "$record" ]]; then
+    while IFS= read -r record || [[ -n "$record" ]]; do
+      IFS=' ' read -r old_sha new_sha ref_name extra <<< "$record"
+      [[ -n "$old_sha" && -n "$new_sha" && -n "$ref_name" && -z "$extra" ]] || continue
+      record_update "$old_sha" "$new_sha" "$ref_name"
+    done <<< "$record"
+  fi
+}
+
+[[ "${1-}" == "committed" ]] || exit 0
+
+git_dir="$(git rev-parse --path-format=absolute --git-dir 2>/dev/null)"
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+[[ -n "$git_dir" && "$git_dir" == "$common_dir" ]] || exit 0
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+[[ -n "$repo_root" ]] || exit 0
+
+audit_dir="$repo_root/.agent"
+audit_file="$audit_dir/primary-ref-audit.jsonl"
+mkdir -p "$audit_dir" 2>/dev/null || exit 0
+
+record_payload
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,9 @@ temp/
 *.yaml.orig
 *.yml.orig
 .venv
+# Local agent state, including the bypassable primary-ref audit tripwire (#5808).
 .agent/
+.agent/primary-ref-audit.jsonl
 # Local state owned by scripts/deploy_prompts.sh. It records which shared files
 # deploy placed in .agent/ so only those paths can be reaped on a later deploy.
 .deploy-state/

--- a/docs/best-practices/git-hygiene.md
+++ b/docs/best-practices/git-hygiene.md
@@ -14,6 +14,13 @@ accumulates across sessions, silently drifts past merged PRs, and
 eventually produces surprises like "why is this build crashing on an
 import that's clearly in main?"
 
+## Primary-ref audit tripwire
+
+The primary checkout's `reference-transaction` hook records committed `HEAD`
+and local-branch updates in `.agent/primary-ref-audit.jsonl`. This is an audit
+tripwire only, not protection: it is bypassable (for example,
+`core.hooksPath=/dev/null`) and never blocks a Git ref update.
+
 ## Why this is a rule, not a suggestion
 
 Real incident 2026-04-24: a pilot build of `a1/sounds-letters-and-hello`

--- a/tests/test_primary_ref_tripwire.py
+++ b/tests/test_primary_ref_tripwire.py
@@ -1,0 +1,114 @@
+"""End-to-end contract tests for the non-blocking primary-ref audit hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIRECTORY = REPOSITORY_ROOT / ".githooks"
+
+
+def run_git(repository: Path, *arguments: str, hooks_path: Path | None = None) -> subprocess.CompletedProcess[str]:
+    command = ["git"]
+    if hooks_path is not None:
+        command.extend(["-c", f"core.hooksPath={hooks_path}"])
+    command.extend(arguments)
+    return subprocess.run(command, cwd=repository, check=True, capture_output=True, text=True)
+
+
+def initialise_repository(tmp_path: Path) -> tuple[Path, str, str]:
+    repository = tmp_path / "primary"
+    repository.mkdir()
+    run_git(repository, "init")
+    run_git(repository, "config", "user.name", "Tripwire Test")
+    run_git(repository, "config", "user.email", "tripwire@example.test")
+
+    fixture = repository / "fixture.txt"
+    fixture.write_text("first\n", encoding="utf-8")
+    run_git(repository, "add", "fixture.txt")
+    run_git(repository, "commit", "-m", "first")
+    first = run_git(repository, "rev-parse", "HEAD").stdout.strip()
+
+    fixture.write_text("second\n", encoding="utf-8")
+    run_git(repository, "commit", "-am", "second")
+    second = run_git(repository, "rev-parse", "HEAD").stdout.strip()
+    run_git(repository, "update-ref", "refs/heads/audit-target", first)
+    run_git(repository, "config", "core.hooksPath", str(HOOKS_DIRECTORY))
+    return repository, first, second
+
+
+def audit_records(repository: Path) -> list[dict[str, object]]:
+    audit_file = repository / ".agent" / "primary-ref-audit.jsonl"
+    return [json.loads(line) for line in audit_file.read_text(encoding="utf-8").splitlines()]
+
+
+def test_committed_primary_branch_update_is_recorded(tmp_path: Path) -> None:
+    repository, first, second = initialise_repository(tmp_path)
+
+    run_git(repository, "update-ref", "refs/heads/audit-target", second, first)
+
+    record = next(record for record in audit_records(repository) if record["ref"] == "refs/heads/audit-target")
+    assert record["old"] == first
+    assert record["new"] == second
+    assert record["cwd"] == str(repository)
+    assert record["pid"]
+    assert record["argv"]
+
+
+def test_nul_delimited_payload_is_recorded(tmp_path: Path) -> None:
+    repository, first, second = initialise_repository(tmp_path)
+    hook = HOOKS_DIRECTORY / "reference-transaction"
+
+    subprocess.run(
+        [str(hook), "committed"],
+        cwd=repository,
+        check=True,
+        input=f"{first} {second} refs/heads/nul-payload\0",
+        text=True,
+        env=os.environ.copy(),
+    )
+
+    record = next(record for record in audit_records(repository) if record["ref"] == "refs/heads/nul-payload")
+    assert record["old"] == first
+    assert record["new"] == second
+
+
+def test_log_write_failure_does_not_block_a_ref_update(tmp_path: Path) -> None:
+    repository, first, second = initialise_repository(tmp_path)
+    (repository / ".agent").write_text("not a directory\n", encoding="utf-8")
+
+    run_git(repository, "update-ref", "refs/heads/audit-target", second, first)
+
+    assert run_git(repository, "rev-parse", "refs/heads/audit-target").stdout.strip() == second
+
+
+def test_linked_worktree_update_is_not_recorded(tmp_path: Path) -> None:
+    repository, first, second = initialise_repository(tmp_path)
+    linked_worktree = tmp_path / "linked-worktree"
+    run_git(
+        repository,
+        "worktree",
+        "add",
+        "--detach",
+        str(linked_worktree),
+        second,
+        hooks_path=Path("/dev/null"),
+    )
+
+    audit_file = repository / ".agent" / "primary-ref-audit.jsonl"
+    audit_file.unlink(missing_ok=True)
+    run_git(linked_worktree, "update-ref", "refs/heads/audit-target", second, first)
+
+    assert not audit_file.exists()
+    assert run_git(repository, "rev-parse", "refs/heads/audit-target").stdout.strip() == second
+
+
+def test_hooks_path_bypass_succeeds_without_an_audit_record(tmp_path: Path) -> None:
+    repository, first, second = initialise_repository(tmp_path)
+
+    run_git(repository, "update-ref", "refs/heads/audit-target", second, first, hooks_path=Path("/dev/null"))
+
+    assert not (repository / ".agent" / "primary-ref-audit.jsonl").exists()

--- a/tests/test_primary_ref_tripwire.py
+++ b/tests/test_primary_ref_tripwire.py
@@ -16,7 +16,9 @@ def run_git(repository: Path, *arguments: str, hooks_path: Path | None = None) -
     if hooks_path is not None:
         command.extend(["-c", f"core.hooksPath={hooks_path}"])
     command.extend(arguments)
-    return subprocess.run(command, cwd=repository, check=True, capture_output=True, text=True)
+    return subprocess.run(
+        command, cwd=repository, check=True, capture_output=True, text=True, timeout=30
+    )
 
 
 def initialise_repository(tmp_path: Path) -> tuple[Path, str, str]:
@@ -69,6 +71,7 @@ def test_nul_delimited_payload_is_recorded(tmp_path: Path) -> None:
         input=f"{first} {second} refs/heads/nul-payload\0",
         text=True,
         env=os.environ.copy(),
+        timeout=30,
     )
 
     record = next(record for record in audit_records(repository) if record["ref"] == "refs/heads/nul-payload")


### PR DESCRIPTION
## Summary
- add a committed-only, fail-open primary-checkout reference transaction audit hook
- ignore and document the local JSONL audit record
- cover primary recording, NUL input, write failure, linked worktrees, and hooksPath bypass

## Verification
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check tests/test_primary_ref_tripwire.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_primary_ref_tripwire.py tests/test_hooks_executable.py tests/test_git_hooks.py -v (19 passed)

Closes #5808