### PR TITLE
fix(lexicon): gate full-catalog merge on English-anchor loss, not raw thin-count rise

### DIFF
--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -26,7 +26,10 @@ DEFAULT_PULLED = ROOT / "batch_state" / "full-en-reenrich-pulled" / "manifest.js
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.audit.audit_atlas_thin_enriched import thin_old_gate_entries
+from scripts.audit.audit_atlas_thin_enriched import (
+    has_learner_english_anchor,
+    thin_old_gate_entries,
+)
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT
 from scripts.lexicon.manifest_io import load_manifest, write_manifest
 
@@ -279,6 +282,29 @@ def prove_no_nonempty_en_overwrites(
     return modified
 
 
+def count_anchor_loss(
+    before_by_slug: dict[str, dict[str, Any]],
+    after_by_slug: dict[str, dict[str, Any]],
+) -> int:
+    """Count slugs whose learner English anchor existed before the merge and is gone after.
+
+    This is the binding non-regression invariant. Raw ``thin_old_gate_entries`` counts can
+    rise even on a clean additive merge: a morphology- or layer-only fill gives a
+    previously-unenriched entry its first ``enrichment`` block, which flips it into the old
+    gate's "enriched" bucket without ever adding an English anchor. That inflates the thin
+    count but loses nothing -- the anchor was never there to begin with. Anchor *loss* per
+    slug (had one, now doesn't) is the real signal an additive merge must never produce.
+    """
+    lost = 0
+    for slug, before_entry in before_by_slug.items():
+        if not has_learner_english_anchor(before_entry):
+            continue
+        after_entry = after_by_slug.get(slug)
+        if after_entry is None or not has_learner_english_anchor(after_entry):
+            lost += 1
+    return lost
+
+
 def _read_local_manifest(path: Path) -> dict[str, Any]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
@@ -341,13 +367,19 @@ def main() -> int:
     thin_after = len(thin_old_gate_entries(live))
 
     overwrite_proof = prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug)
+    old_gate_anchor_loss = count_anchor_loss(before_by_slug, after_by_slug)
     old_gate_not_rising = thin_after <= thin_before
 
     payload = stats.as_dict()
     payload["overwrite_proof_modified_nonempty_en"] = overwrite_proof
     payload["old_gate_no_english_anchor_before"] = thin_before
     payload["old_gate_no_english_anchor_after"] = thin_after
+    # Telemetry only: raw thin-gate count naturally rises when a morphology/layer-only fill
+    # gives a previously-unenriched entry its first `enrichment` block (see
+    # count_anchor_loss docstring). It is not the blocking invariant -- old_gate_anchor_loss
+    # below is.
     payload["old_gate_not_rising"] = old_gate_not_rising
+    payload["old_gate_anchor_loss"] = old_gate_anchor_loss
     payload["missing_translation_after"] = sum(
         1 for entry in (live.get("entries") or []) if isinstance(entry, dict) and not entry_has_translation(entry)
     )
@@ -363,12 +395,13 @@ def main() -> int:
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
-    if overwrite_proof != 0 or not old_gate_not_rising:
+    if overwrite_proof != 0 or old_gate_anchor_loss != 0:
         print(
             json.dumps(
                 {
                     "error": "merge_invariant_violation",
                     "overwrite_proof_modified_nonempty_en": overwrite_proof,
+                    "old_gate_anchor_loss": old_gate_anchor_loss,
                     "old_gate_not_rising": old_gate_not_rising,
                     "wrote": False,
                 },

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -159,7 +159,7 @@
       },
       {
         "path": "scripts/lexicon/merge_translation_delta.py",
-        "sha256": "163458980cd9f7ebe7c3a673bb270d00a4aeaf159afdf53ea034a176e9b80272"
+        "sha256": "ea68d272a2fb0df30ebda5d434a540ee9ee9fda45a680c617ba7566f0533236f"
       },
       {
         "path": "scripts/lexicon/migrate_slovnyk_cache_v3.py",

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from scripts.lexicon.merge_translation_delta import (
+    count_anchor_loss,
     entry_has_translation,
     entry_translation,
     merge_translation_delta,
@@ -206,6 +207,51 @@ def test_merge_sections_and_attestation_additively() -> None:
     assert entry["sections"]["proverbs"] == {"items": ["Вода камень точит"]}
     assert entry["enrichment"]["literary_attestation"] == [{"id": "grinchenko", "source": "Грінченко"}]
     assert entry["enrichment"]["morphology"] == {"forms": [{"form": "вода"}]}
+
+
+def test_morphology_only_fill_on_empty_enrichment_does_not_trip_anchor_loss() -> None:
+    """A morphology-only fill onto a previously-unenriched entry must not read as anchor loss.
+
+    It gives the entry its first `enrichment` block (so the old thin-gate's raw count can
+    rise -- it now counts as "enriched but thin"), but no English anchor existed before and
+    none was removed, so old_gate_anchor_loss must stay 0.
+    """
+    live = {
+        "entries": [
+            {"url_slug": "гора", "lemma": "гора", "pos": "noun"},
+        ]
+    }
+    before_by_slug = {e["url_slug"]: copy.deepcopy(e) for e in live["entries"]}
+    pulled = {
+        "entries": [
+            {
+                "url_slug": "гора",
+                "lemma": "гора",
+                "pos": "noun",
+                "enrichment": {"morphology": {"forms": [{"form": "гора"}]}},
+            }
+        ]
+    }
+
+    stats = merge_translation_delta(live, pulled, stamp_generated_at=False)
+    after_by_slug = {e["url_slug"]: e for e in live["entries"]}
+
+    assert stats.filled_morphology == 1
+    assert live["entries"][0]["enrichment"]["morphology"] == {"forms": [{"form": "гора"}]}
+    assert prove_no_nonempty_en_overwrites(before_by_slug, after_by_slug) == 0
+    assert count_anchor_loss(before_by_slug, after_by_slug) == 0
+
+
+def test_stripping_english_anchor_trips_anchor_loss() -> None:
+    """Mutation check: an entry that loses its EN anchor must be caught, no matter the cause."""
+    before_by_slug = {
+        "kiwi": _entry("kiwi", "ківі", en=["kiwi 2"], source="live-balla"),
+    }
+    stripped = copy.deepcopy(before_by_slug["kiwi"])
+    stripped["enrichment"]["translation"]["en"] = []
+    after_by_slug = {"kiwi": stripped}
+
+    assert count_anchor_loss(before_by_slug, after_by_slug) == 1
 
 
 def test_add_source_attaches_section_source_when_enrichment_absent() -> None:


### PR DESCRIPTION
## What broke

The full-catalog reenrich (VPS batch, artifacts in `batch_state/class-b-reenrich-pulled/`)
finished successfully — targets=19203, ENRICHED=16676, UNRESOLVED_RESIDUAL=2527,
filled_translation=7124, gained_english_anchor=5131, layer fills: proverbs=552,
usage_notes=52, grinchenko=9843, forms=17410 — but the dry-run merge failed the
`old_gate_not_rising` gate.

Root cause: that gate compared raw `thin_old_gate_entries` counts before/after. Adding
morphology/literary-layer fills gives a previously-**unenriched** entry its first
`enrichment` block, which flips it into the old gate's "enriched but thin" bucket even
though no English anchor was ever removed. On the real donor this moved the raw thin
count 118 → 2295 while `overwrite_proof_modified_nonempty_en` stayed 0 the whole time —
an honest, purely additive layer-fill blocked by a metric that doesn't distinguish "never
had an anchor" from "lost an anchor."

## Fix

`scripts/lexicon/merge_translation_delta.py`: replaced the blocking check with
`old_gate_anchor_loss` — a per-slug count of entries that had a learner English anchor
(`has_learner_english_anchor`) before the merge and don't have one after. That's the real
invariant an additive merge must never violate. `merge_translation_delta` never removes
`translation`/`gloss` data, so this is zero by construction for any merge that stays
additive; a mutation test (`test_stripping_english_anchor_trips_anchor_loss`) proves the
check still fires if that ever changes. Raw `old_gate_not_rising` stays in the report as
telemetry, no longer as a blocker. `overwrite_proof` stays strict (unchanged).

Tests added in `tests/test_merge_translation_delta.py`:
- `test_morphology_only_fill_on_empty_enrichment_does_not_trip_anchor_loss` — the exact
  regression shape above: morphology-only fill onto an empty-enrichment entry succeeds
  even though the raw thin count would rise.
- `test_stripping_english_anchor_trips_anchor_loss` — mutation check that an entry losing
  its EN anchor is still caught.

All 12 tests in the file pass; ruff clean.

## Proof on real artifacts

Dry-run against the live manifest (hydrated primary, 20053 entries) and the pulled
full-catalog-reenrich donor:

```
live_entry_count_before = 20053
live_entry_count_after  = 20053
pulled_entry_count      = 19203
filled                   = 1224   (new EN translation cards)
filled_sections          = 13521
filled_layer_sections     = {form_notes: 6819, synonyms: 3711, proverbs: 552,
                              usage_notes: 52, idioms: 1636, antonyms: 179,
                              homonyms: 569, paronyms: 3}
filled_literary_attestation = 10696
filled_morphology         = 10015
overwrite_proof_modified_nonempty_en = 0
old_gate_no_english_anchor_before = 118
old_gate_no_english_anchor_after  = 2295
old_gate_not_rising  = false   (telemetry only now)
old_gate_anchor_loss = 0        <- blocking check, passes
missing_translation_after = 3814
```

Exit code 0 — no `merge_invariant_violation`. A `--write` roundtrip against a scratch copy
of the live manifest also succeeded: all 20053 entries preserved, spot-checked filled slug
(`аби-то` → `{"en": ["If only"], ...}`) roundtrips correctly through `write_manifest`.

`lexicon-manifest.json` is gitignored / pointer-based
(`site/src/data/lexicon-manifest.json` in `.gitignore`), so this PR is **code + tests
only**. The merge itself is proven above but not published — no `publish_manifest` call,
no deploy. The operator runs the real write + publish from the hydrated primary tree when
ready.

## Non-goals (out of scope for this PR)
- No VPS relaunch
- No deploy / no `publish_manifest`
- No acceptance-threshold changes that skip the 2527 residual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
