### PR TITLE
feat(open-model-data): add protected historical representation

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_historical_representation_v3.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_historical_representation_v3.schema.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_historical_representation_v3.schema.json",
+  "title": "Phase 3 v3 source-grounded historical Ukrainian representation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "source",
+    "historical_context",
+    "text_layers",
+    "alignments",
+    "periodizations",
+    "language_labels",
+    "language_layers",
+    "linguistic_features",
+    "interpretations",
+    "linguistic_analyses",
+    "analysis_provenance",
+    "evidence",
+    "rights",
+    "classification",
+    "safeguards",
+    "provider_calls"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_historical_representation_v3"},
+    "record_id": {"type": "string", "minLength": 1},
+    "source": {"$ref": "#/$defs/source"},
+    "historical_context": {"$ref": "#/$defs/historicalContext"},
+    "text_layers": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/textLayer"}},
+    "alignments": {"type": "array", "items": {"$ref": "#/$defs/alignment"}},
+    "periodizations": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/periodization"}},
+    "language_labels": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/languageLabel"}},
+    "language_layers": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/languageLayer"}},
+    "linguistic_features": {"type": "array", "items": {"$ref": "#/$defs/feature"}},
+    "interpretations": {"type": "array", "items": {"$ref": "#/$defs/interpretation"}},
+    "linguistic_analyses": {"type": "array", "items": {"$ref": "#/$defs/analysis"}},
+    "analysis_provenance": {"$ref": "#/$defs/analysisProvenance"},
+    "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}},
+    "rights": {"$ref": "#/$defs/rights"},
+    "classification": {"$ref": "#/$defs/classification"},
+    "safeguards": {"$ref": "#/$defs/safeguards"},
+    "provider_calls": {"const": false}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "locator": {"type": "object", "minProperties": 1, "additionalProperties": true},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collection_identity",
+        "document_or_edition_identity",
+        "source_record_identity",
+        "frozen_locator",
+        "frozen_locator_sha256",
+        "source_document_bytes_sha256",
+        "source_record_bytes_sha256"
+      ],
+      "properties": {
+        "collection_identity": {"type": "string", "minLength": 1},
+        "document_or_edition_identity": {"type": "string", "minLength": 1},
+        "source_record_identity": {"type": "string", "minLength": 1},
+        "frozen_locator": {"$ref": "#/$defs/locator"},
+        "frozen_locator_sha256": {"$ref": "#/$defs/sha256"},
+        "source_document_bytes_sha256": {"$ref": "#/$defs/sha256"},
+        "source_record_bytes_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "historicalContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "min_year",
+        "max_year",
+        "date_certainty",
+        "region",
+        "polity",
+        "genre",
+        "manuscript_or_inscription_identity",
+        "script",
+        "orthography"
+      ],
+      "properties": {
+        "min_year": {"type": ["integer", "null"]},
+        "max_year": {"type": ["integer", "null"]},
+        "date_certainty": {"enum": ["exact", "range", "approximate", "unknown"]},
+        "region": {"type": ["string", "null"]},
+        "polity": {"type": ["string", "null"]},
+        "genre": {"type": ["string", "null"]},
+        "manuscript_or_inscription_identity": {"type": ["string", "null"]},
+        "script": {"type": ["string", "null"]},
+        "orthography": {"type": ["string", "null"]}
+      }
+    },
+    "normalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nfc", "nfkc", "nfc_sha256", "nfkc_sha256", "source_is_nfc", "source_is_nfkc"],
+      "properties": {
+        "nfc": {"type": "string"},
+        "nfkc": {"type": "string"},
+        "nfc_sha256": {"$ref": "#/$defs/sha256"},
+        "nfkc_sha256": {"$ref": "#/$defs/sha256"},
+        "source_is_nfc": {"type": "boolean"},
+        "source_is_nfkc": {"type": "boolean"}
+      }
+    },
+    "token": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token_id", "kind", "text", "normalized_text", "start", "end", "paragraph_index", "sentence_index"],
+      "properties": {
+        "token_id": {"type": "string", "pattern": "^tok:[0-9]{6}$"},
+        "kind": {"enum": ["word", "punctuation"]},
+        "text": {"type": "string", "minLength": 1},
+        "normalized_text": {"type": "string", "minLength": 1},
+        "start": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 0},
+        "paragraph_index": {"const": 0},
+        "sentence_index": {"const": 0}
+      }
+    },
+    "textLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "layer_id",
+        "text",
+        "text_utf8_sha256",
+        "text_sha256",
+        "offset_basis",
+        "source_layer_preserved",
+        "normalization",
+        "tokens",
+        "authority",
+        "evidence_ids"
+      ],
+      "properties": {
+        "layer_id": {"enum": ["original_diplomatic", "restored_reading", "modern_ukrainian_translation"]},
+        "text": {"type": "string", "minLength": 1},
+        "text_utf8_sha256": {"$ref": "#/$defs/sha256"},
+        "text_sha256": {"$ref": "#/$defs/sha256"},
+        "offset_basis": {"const": "unicode_code_points"},
+        "source_layer_preserved": {"const": true},
+        "normalization": {"$ref": "#/$defs/normalization"},
+        "tokens": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/token"}},
+        "authority": {"enum": ["source_transcription", "qualified_human", "deterministic_derivation", "unresolved"]},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "alignmentSegment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_start", "source_end", "source_text", "target_start", "target_end", "target_text"],
+      "properties": {
+        "source_start": {"type": "integer", "minimum": 0},
+        "source_end": {"type": "integer", "minimum": 0},
+        "source_text": {"type": "string"},
+        "target_start": {"type": "integer", "minimum": 0},
+        "target_end": {"type": "integer", "minimum": 0},
+        "target_text": {"type": "string"}
+      }
+    },
+    "alignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["alignment_id", "from_layer_id", "to_layer_id", "segments", "authority", "evidence_ids", "ambiguity"],
+      "properties": {
+        "alignment_id": {"type": "string", "minLength": 1},
+        "from_layer_id": {"enum": ["original_diplomatic", "restored_reading", "modern_ukrainian_translation"]},
+        "to_layer_id": {"enum": ["original_diplomatic", "restored_reading", "modern_ukrainian_translation"]},
+        "segments": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/alignmentSegment"}},
+        "authority": {"enum": ["source_transcription", "qualified_human", "deterministic_derivation", "unresolved"]},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "periodization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["framework_id", "framework_label", "stage_id", "stage_label", "start_year", "end_year", "status", "attribution", "evidence_ids", "ambiguity"],
+      "properties": {
+        "framework_id": {"type": "string", "minLength": 1},
+        "framework_label": {"type": "string", "minLength": 1},
+        "stage_id": {"type": "string", "minLength": 1},
+        "stage_label": {"type": "string", "minLength": 1},
+        "start_year": {"type": ["integer", "null"]},
+        "end_year": {"type": ["integer", "null"]},
+        "status": {"enum": ["qualified_source_attributed", "provisional", "disputed", "unresolved"]},
+        "attribution": {"type": "string", "minLength": 1},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "languageLabel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "label_kind", "attribution", "scope", "status", "evidence_ids", "ambiguity"],
+      "properties": {
+        "label": {"type": "string", "minLength": 1},
+        "label_kind": {"enum": ["document_era", "modern_scholarly", "corpus_annotation"]},
+        "attribution": {"type": "string", "minLength": 1},
+        "scope": {"type": "string", "minLength": 1},
+        "status": {"enum": ["attested", "attributed", "contested", "unresolved"]},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "languageLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["language_layer_id", "label", "role", "status", "evidence_ids", "ambiguity"],
+      "properties": {
+        "language_layer_id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "role": {"enum": ["primary", "church_slavonic", "chancery_ruthenian", "local_vernacular", "polish", "latin", "russian", "mixed", "other"]},
+        "status": {"enum": ["attested", "attributed", "possible", "unresolved"]},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "text"],
+      "properties": {
+        "start": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 0},
+        "text": {"type": "string"}
+      }
+    },
+    "feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature_id", "domain", "claim", "layer_id", "spans", "status", "attribution", "evidence_ids", "ambiguity"],
+      "properties": {
+        "feature_id": {"type": "string", "minLength": 1},
+        "domain": {"enum": ["script", "orthography", "phonology", "morphology", "syntax", "lexicon"]},
+        "claim": {"type": "string", "minLength": 1},
+        "layer_id": {"enum": ["original_diplomatic", "restored_reading", "modern_ukrainian_translation"]},
+        "spans": {"type": "array", "items": {"$ref": "#/$defs/span"}},
+        "status": {"enum": ["attested", "qualified_source_attributed", "disputed", "unresolved"]},
+        "attribution": {"type": "string", "minLength": 1},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["interpretation_id", "claim", "status", "attribution", "evidence_ids", "alternatives", "ambiguity"],
+      "properties": {
+        "interpretation_id": {"type": "string", "minLength": 1},
+        "claim": {"type": "string", "minLength": 1},
+        "status": {"enum": ["qualified_source_attributed", "disputed", "unresolved"]},
+        "attribution": {"type": "string", "minLength": 1},
+        "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "alternatives": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "analysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["analysis_id", "layer_id", "source_token_id", "source_surface", "token_ids", "lemma", "pos", "morph", "head_analysis_id", "dependency", "ambiguity"],
+      "properties": {
+        "analysis_id": {"type": "string", "minLength": 1},
+        "layer_id": {"enum": ["original_diplomatic", "restored_reading", "modern_ukrainian_translation"]},
+        "source_token_id": {"type": ["string", "null"], "minLength": 1},
+        "source_surface": {"type": "string", "minLength": 1},
+        "token_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^tok:[0-9]{6}$"}},
+        "lemma": {"type": ["string", "null"]},
+        "pos": {"type": ["string", "null"]},
+        "morph": {"type": "object", "additionalProperties": {"type": "string"}},
+        "head_analysis_id": {"type": ["string", "null"]},
+        "dependency": {"type": ["string", "null"]},
+        "ambiguity": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "analysisProvenance": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {"status": {"const": "absent"}}
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "resource_identity", "resource_version", "license", "tokenization_alignment"],
+          "properties": {
+            "status": {"const": "present"},
+            "resource_identity": {"type": "string", "minLength": 1},
+            "resource_version": {"type": "string", "minLength": 1},
+            "license": {"type": "string", "minLength": 1},
+            "tokenization_alignment": {"enum": ["exact", "adapted", "partial"]}
+          }
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_id", "kind", "locator", "locator_sha256", "source_document_bytes_sha256", "evidence_text", "evidence_text_sha256", "text_exposure", "authority", "rights"],
+      "properties": {
+        "evidence_id": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["source_record", "source_metadata", "qualified_scholarship", "aligned_historical_source", "deterministic_derivation"]},
+        "locator": {"$ref": "#/$defs/locator"},
+        "locator_sha256": {"$ref": "#/$defs/sha256"},
+        "source_document_bytes_sha256": {"$ref": "#/$defs/sha256"},
+        "evidence_text": {"type": "string", "minLength": 1},
+        "evidence_text_sha256": {"$ref": "#/$defs/sha256"},
+        "text_exposure": {"enum": ["verbatim", "paraphrase", "metadata_only"]},
+        "authority": {"enum": ["source_transcription", "qualified_human", "deterministic_derivation", "unresolved"]},
+        "rights": {"$ref": "#/$defs/rights"}
+      }
+    },
+    "rights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "license", "reuse_scope", "attribution_required"],
+      "properties": {
+        "status": {"enum": ["admitted", "private_inspection_only", "restricted", "unresolved", "excluded"]},
+        "license": {"type": "string", "minLength": 1},
+        "reuse_scope": {"enum": ["public_training", "research_only", "private_inspection_only", "excluded"]},
+        "attribution_required": {"type": "boolean"}
+      }
+    },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_role_id", "claim_type", "consumer_views", "derived_bundles", "derived_bundle_rights", "evidence_grade"],
+      "properties": {
+        "primary_role_id": {"enum": ["explicit_rule", "correct_example", "incorrect_example", "corrected_example", "editing_exercise", "answer_key", "distractor", "quotation", "historical_or_literary_excerpt", "metalinguistic_mention", "ordinary_narration", "ambiguous_or_ocr"]},
+        "claim_type": {"enum": ["prescriptive_rule", "human_correction_pair", "style_preference", "acceptable_variant", "historical_advice", "attestation_only", "unresolved"]},
+        "consumer_views": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["supervised_pair", "preference", "protection", "filtering", "review", "automatic", "research_only"]}},
+        "derived_bundles": {"type": "array", "uniqueItems": true, "items": {"enum": ["historical_recognition", "historical_alignment", "periodization", "language_label_disambiguation", "language_change_explanation"]}},
+        "derived_bundle_rights": {"type": "array", "items": {"$ref": "#/$defs/bundleRights"}},
+        "evidence_grade": {"type": "string", "minLength": 1}
+      }
+    },
+    "bundleRights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundle_id", "rights"],
+      "properties": {
+        "bundle_id": {"enum": ["historical_recognition", "historical_alignment", "periodization", "language_label_disambiguation", "language_change_explanation"]},
+        "rights": {"$ref": "#/$defs/rights"}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["historical_forms_protected", "modern_correction_eligible", "russkyi_auto_mapped_to_modern_russian", "old_east_slavic_is_modern_russian", "scalar_language_age_claim_allowed"],
+      "properties": {
+        "historical_forms_protected": {"const": true},
+        "modern_correction_eligible": {"const": false},
+        "russkyi_auto_mapped_to_modern_russian": {"const": false},
+        "old_east_slavic_is_modern_russian": {"const": false},
+        "scalar_language_age_claim_allowed": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/projects/open_model_data/phase3_historical_representation.py
+++ b/scripts/projects/open_model_data/phase3_historical_representation.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Deterministic, non-correction representation for historical Ukrainian data.
+
+The representation preserves attributed historical layers and uncertainty.  It
+never promotes a historical form into modern correction gold and never treats
+model output as linguistic authority.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import unicodedata
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data.phase3_linguistic_representation import (
+    CLAIM_TYPES,
+    CONSUMER_VIEWS,
+    PRIMARY_ROLE_IDS,
+    canonical_json,
+    sha256_bytes,
+    sha256_text,
+    sha256_value,
+    tokenize,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_historical_representation_v3.schema.json"
+SCHEMA_VERSION = "phase3_historical_representation_v3"
+
+TEXT_LAYER_IDS = frozenset({"original_diplomatic", "restored_reading", "modern_ukrainian_translation"})
+HISTORICAL_PRIMARY_ROLES = frozenset(
+    {"historical_or_literary_excerpt", "quotation", "metalinguistic_mention", "ambiguous_or_ocr"}
+)
+HISTORICAL_CLAIM_TYPES = frozenset({"historical_advice", "attestation_only", "unresolved"})
+DERIVED_BUNDLES = frozenset(
+    {
+        "historical_recognition",
+        "historical_alignment",
+        "periodization",
+        "language_label_disambiguation",
+        "language_change_explanation",
+    }
+)
+
+
+class HistoricalRepresentationError(ValueError):
+    """The historical representation is structurally inconsistent."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise HistoricalRepresentationError(message)
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _schema_validator() -> Draft202012Validator:
+    try:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HistoricalRepresentationError(f"cannot read historical representation schema: {SCHEMA_PATH}") from exc
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _validate_schema(value: Mapping[str, Any]) -> None:
+    errors = sorted(_schema_validator().iter_errors(value), key=lambda item: list(item.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "packet"
+        raise HistoricalRepresentationError(f"schema violation at {location}: {errors[0].message}")
+
+
+def _normalization(text: str) -> dict[str, Any]:
+    nfc = unicodedata.normalize("NFC", text)
+    nfkc = unicodedata.normalize("NFKC", text)
+    return {
+        "nfc": nfc,
+        "nfkc": nfkc,
+        "nfc_sha256": sha256_text(nfc),
+        "nfkc_sha256": sha256_text(nfkc),
+        "source_is_nfc": text == nfc,
+        "source_is_nfkc": text == nfkc,
+    }
+
+
+def _normalize_text_layer(raw: Mapping[str, Any]) -> dict[str, Any]:
+    _require(
+        set(raw) == {"layer_id", "text", "authority", "evidence_ids"},
+        "text layer input fields must be exact",
+    )
+    layer_id = raw["layer_id"]
+    text = raw["text"]
+    _require(layer_id in TEXT_LAYER_IDS, "unknown historical text layer")
+    _require(isinstance(text, str) and text, "historical text layer must contain complete text")
+    span = {"start": 0, "end": len(text)}
+    return {
+        "layer_id": layer_id,
+        "text": text,
+        "text_utf8_sha256": sha256_bytes(text.encode("utf-8")),
+        "text_sha256": sha256_text(text),
+        "offset_basis": "unicode_code_points",
+        "source_layer_preserved": True,
+        "normalization": _normalization(text),
+        "tokens": tokenize(text, paragraph_span=span, sentence_span=span),
+        "authority": raw["authority"],
+        "evidence_ids": list(raw["evidence_ids"]),
+    }
+
+
+def _normalize_evidence(raw: Mapping[str, Any]) -> dict[str, Any]:
+    expected = {
+        "evidence_id",
+        "kind",
+        "locator",
+        "source_document_bytes_sha256",
+        "evidence_text",
+        "text_exposure",
+        "authority",
+        "rights",
+    }
+    _require(set(raw) == expected, "evidence input fields must be exact")
+    locator = raw["locator"]
+    text = raw["evidence_text"]
+    _require(isinstance(locator, Mapping) and locator, "evidence locator is required")
+    _require(isinstance(text, str) and text, "evidence text is required")
+    return {
+        "evidence_id": raw["evidence_id"],
+        "kind": raw["kind"],
+        "locator": dict(locator),
+        "locator_sha256": sha256_value(locator),
+        "source_document_bytes_sha256": raw["source_document_bytes_sha256"],
+        "evidence_text": text,
+        "evidence_text_sha256": sha256_text(text),
+        "text_exposure": raw["text_exposure"],
+        "authority": raw["authority"],
+        "rights": dict(raw["rights"]),
+    }
+
+
+def _normalize_alignment(raw: Mapping[str, Any], layers: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    expected = {
+        "alignment_id",
+        "from_layer_id",
+        "to_layer_id",
+        "segments",
+        "authority",
+        "evidence_ids",
+        "ambiguity",
+    }
+    _require(set(raw) == expected, "alignment input fields must be exact")
+    source_id, target_id = raw["from_layer_id"], raw["to_layer_id"]
+    _require(source_id in layers and target_id in layers, "alignment refers to an unknown text layer")
+    source_text, target_text = layers[source_id]["text"], layers[target_id]["text"]
+    segments: list[dict[str, Any]] = []
+    for segment in raw["segments"]:
+        _require(
+            set(segment) == {"source_start", "source_end", "target_start", "target_end"},
+            "alignment segment input fields must be exact",
+        )
+        source_start, source_end = segment["source_start"], segment["source_end"]
+        target_start, target_end = segment["target_start"], segment["target_end"]
+        _require(
+            all(isinstance(item, int) for item in (source_start, source_end, target_start, target_end)),
+            "alignment offsets must be integers",
+        )
+        _require(0 <= source_start <= source_end <= len(source_text), "source alignment offset is outside layer")
+        _require(0 <= target_start <= target_end <= len(target_text), "target alignment offset is outside layer")
+        segments.append(
+            {
+                "source_start": source_start,
+                "source_end": source_end,
+                "source_text": source_text[source_start:source_end],
+                "target_start": target_start,
+                "target_end": target_end,
+                "target_text": target_text[target_start:target_end],
+            }
+        )
+    return {
+        "alignment_id": raw["alignment_id"],
+        "from_layer_id": source_id,
+        "to_layer_id": target_id,
+        "segments": segments,
+        "authority": raw["authority"],
+        "evidence_ids": list(raw["evidence_ids"]),
+        "ambiguity": list(raw["ambiguity"]),
+    }
+
+
+def _normalize_feature(raw: Mapping[str, Any], layers: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    expected = {
+        "feature_id",
+        "domain",
+        "claim",
+        "layer_id",
+        "spans",
+        "status",
+        "attribution",
+        "evidence_ids",
+        "ambiguity",
+    }
+    _require(set(raw) == expected, "linguistic feature input fields must be exact")
+    layer_id = raw["layer_id"]
+    _require(layer_id in layers, "linguistic feature refers to an unknown text layer")
+    text = layers[layer_id]["text"]
+    spans: list[dict[str, Any]] = []
+    for span in raw["spans"]:
+        _require(set(span) == {"start", "end"}, "feature span input fields must be exact")
+        start, end = span["start"], span["end"]
+        _require(isinstance(start, int) and isinstance(end, int), "feature offsets must be integers")
+        _require(0 <= start <= end <= len(text), "feature offset is outside text layer")
+        spans.append({"start": start, "end": end, "text": text[start:end]})
+    return {
+        "feature_id": raw["feature_id"],
+        "domain": raw["domain"],
+        "claim": raw["claim"],
+        "layer_id": layer_id,
+        "spans": spans,
+        "status": raw["status"],
+        "attribution": raw["attribution"],
+        "evidence_ids": list(raw["evidence_ids"]),
+        "ambiguity": list(raw["ambiguity"]),
+    }
+
+
+def build_historical_representation(
+    *,
+    record_id: str,
+    collection_identity: str,
+    document_or_edition_identity: str,
+    source_record_identity: str,
+    frozen_locator: Mapping[str, Any],
+    source_document_bytes_sha256: str,
+    source_record_bytes_sha256: str,
+    historical_context: Mapping[str, Any],
+    text_layers: Sequence[Mapping[str, Any]],
+    alignments: Sequence[Mapping[str, Any]],
+    periodizations: Sequence[Mapping[str, Any]],
+    language_labels: Sequence[Mapping[str, Any]],
+    language_layers: Sequence[Mapping[str, Any]],
+    linguistic_features: Sequence[Mapping[str, Any]],
+    interpretations: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+    rights: Mapping[str, Any],
+    derived_bundle_rights: Sequence[Mapping[str, Any]],
+    primary_role_id: str = "historical_or_literary_excerpt",
+    claim_type: str = "attestation_only",
+    consumer_views: Sequence[str] = ("protection", "research_only"),
+    derived_bundles: Sequence[str] = ("historical_recognition",),
+    evidence_grade: str = "source_grounded_historical",
+    linguistic_analyses: Sequence[Mapping[str, Any]] = (),
+    analysis_provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate one immutable historical source record."""
+    for label, value in (
+        ("record id", record_id),
+        ("collection identity", collection_identity),
+        ("document identity", document_or_edition_identity),
+        ("source record identity", source_record_identity),
+    ):
+        _require(isinstance(value, str) and value, f"{label} is required")
+    _require(isinstance(frozen_locator, Mapping) and frozen_locator, "frozen locator is required")
+    _require(_is_sha256(source_document_bytes_sha256), "source document bytes SHA-256 is required")
+    _require(_is_sha256(source_record_bytes_sha256), "source record bytes SHA-256 is required")
+    _require(primary_role_id in PRIMARY_ROLE_IDS, "primary role is not frozen v2 vocabulary")
+    _require(claim_type in CLAIM_TYPES, "claim type is not frozen v2 vocabulary")
+    _require(set(consumer_views) <= CONSUMER_VIEWS, "consumer view is not frozen v2 vocabulary")
+    _require(set(derived_bundles) <= DERIVED_BUNDLES, "unknown derived historical bundle")
+
+    normalized_layers = [_normalize_text_layer(item) for item in text_layers]
+    layers_by_id = {item["layer_id"]: item for item in normalized_layers}
+    _require(len(layers_by_id) == len(normalized_layers), "duplicate historical text layer")
+    normalized_evidence = [_normalize_evidence(item) for item in evidence]
+    packet: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "record_id": record_id,
+        "source": {
+            "collection_identity": collection_identity,
+            "document_or_edition_identity": document_or_edition_identity,
+            "source_record_identity": source_record_identity,
+            "frozen_locator": dict(frozen_locator),
+            "frozen_locator_sha256": sha256_value(frozen_locator),
+            "source_document_bytes_sha256": source_document_bytes_sha256,
+            "source_record_bytes_sha256": source_record_bytes_sha256,
+        },
+        "historical_context": dict(historical_context),
+        "text_layers": normalized_layers,
+        "alignments": [_normalize_alignment(item, layers_by_id) for item in alignments],
+        "periodizations": [dict(item) for item in periodizations],
+        "language_labels": [dict(item) for item in language_labels],
+        "language_layers": [dict(item) for item in language_layers],
+        "linguistic_features": [_normalize_feature(item, layers_by_id) for item in linguistic_features],
+        "interpretations": [dict(item) for item in interpretations],
+        "linguistic_analyses": [dict(item) for item in linguistic_analyses],
+        "analysis_provenance": dict(analysis_provenance or {"status": "absent"}),
+        "evidence": normalized_evidence,
+        "rights": dict(rights),
+        "classification": {
+            "primary_role_id": primary_role_id,
+            "claim_type": claim_type,
+            "consumer_views": list(consumer_views),
+            "derived_bundles": list(derived_bundles),
+            "derived_bundle_rights": [
+                {"bundle_id": item["bundle_id"], "rights": dict(item["rights"])}
+                for item in derived_bundle_rights
+            ],
+            "evidence_grade": evidence_grade,
+        },
+        "safeguards": {
+            "historical_forms_protected": True,
+            "modern_correction_eligible": False,
+            "russkyi_auto_mapped_to_modern_russian": False,
+            "old_east_slavic_is_modern_russian": False,
+            "scalar_language_age_claim_allowed": False,
+        },
+        "provider_calls": False,
+    }
+    validate_historical_representation(packet)
+    return packet
+
+
+build_packet = build_historical_representation
+
+
+def _assert_evidence_references(items: Sequence[Mapping[str, Any]], evidence_ids: set[str], label: str) -> None:
+    for item in items:
+        _require(set(item["evidence_ids"]) <= evidence_ids, f"{label} refers to unknown evidence")
+
+
+def _validate_rights(rights: Mapping[str, Any], label: str) -> None:
+    if rights["reuse_scope"] == "public_training":
+        _require(rights["status"] == "admitted", f"{label} public training requires admitted rights")
+        _require(rights["license"].casefold() not in {"unknown", "unresolved"}, f"{label} requires a license")
+
+
+def _reachable_layers(alignments: Sequence[Mapping[str, Any]]) -> set[str]:
+    reachable = {"original_diplomatic"}
+    changed = True
+    while changed:
+        changed = False
+        for alignment in alignments:
+            if alignment["from_layer_id"] in reachable and alignment["to_layer_id"] not in reachable:
+                reachable.add(alignment["to_layer_id"])
+                changed = True
+    return reachable
+
+
+def validate_historical_representation(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate hashes, offsets, evidence, rights, and historical safeguards."""
+    packet = copy.deepcopy(dict(value))
+    _validate_schema(packet)
+    _require(packet["provider_calls"] is False, "provider calls are forbidden")
+
+    source = packet["source"]
+    _require(source["frozen_locator_sha256"] == sha256_value(source["frozen_locator"]), "stale frozen locator hash")
+    _require(_is_sha256(source["source_document_bytes_sha256"]), "invalid source document bytes hash")
+    _require(_is_sha256(source["source_record_bytes_sha256"]), "invalid source record bytes hash")
+
+    layers = packet["text_layers"]
+    layer_ids = [item["layer_id"] for item in layers]
+    _require(len(layer_ids) == len(set(layer_ids)), "duplicate historical text layer")
+    _require(layer_ids.count("original_diplomatic") == 1, "exactly one original diplomatic layer is required")
+    layers_by_id = {item["layer_id"]: item for item in layers}
+    original = layers_by_id["original_diplomatic"]
+    _require(original["authority"] == "source_transcription", "original layer must retain source authority")
+    for layer in layers:
+        text = layer["text"]
+        _require(layer["text_utf8_sha256"] == sha256_bytes(text.encode("utf-8")), "stale text UTF-8 hash")
+        _require(layer["text_sha256"] == sha256_text(text), "stale text hash")
+        _require(layer["normalization"] == _normalization(text), "stale text normalization facts")
+        span = {"start": 0, "end": len(text)}
+        _require(
+            layer["tokens"] == tokenize(text, paragraph_span=span, sentence_span=span),
+            "historical tokens do not round-trip Unicode offsets",
+        )
+
+    evidence = packet["evidence"]
+    evidence_ids = [item["evidence_id"] for item in evidence]
+    _require(len(evidence_ids) == len(set(evidence_ids)), "duplicate evidence id")
+    evidence_id_set = set(evidence_ids)
+    evidence_by_id = {item["evidence_id"]: item for item in evidence}
+    for item in evidence:
+        _require(item["locator_sha256"] == sha256_value(item["locator"]), "stale evidence locator hash")
+        _require(item["evidence_text_sha256"] == sha256_text(item["evidence_text"]), "stale evidence text hash")
+        _validate_rights(item["rights"], "evidence")
+        if item["rights"]["reuse_scope"] != "public_training":
+            _require(item["text_exposure"] != "verbatim", "non-public evidence cannot expose verbatim text")
+    _require(
+        any(
+            item["kind"] == "source_record"
+            and item["source_document_bytes_sha256"] == source["source_document_bytes_sha256"]
+            and item["evidence_text_sha256"] == source["source_record_bytes_sha256"]
+            and original["text"] in item["evidence_text"]
+            for item in evidence
+        ),
+        "original text is not bound to source-record evidence",
+    )
+
+    _assert_evidence_references(layers, evidence_id_set, "text layer")
+    alignment_ids = [item["alignment_id"] for item in packet["alignments"]]
+    _require(len(alignment_ids) == len(set(alignment_ids)), "duplicate alignment id")
+    for alignment in packet["alignments"]:
+        _require(
+            alignment["from_layer_id"] in layers_by_id and alignment["to_layer_id"] in layers_by_id,
+            "alignment refers to an unknown text layer",
+        )
+        _require(alignment["from_layer_id"] != alignment["to_layer_id"], "alignment cannot target its own layer")
+        source_text = layers_by_id[alignment["from_layer_id"]]["text"]
+        target_text = layers_by_id[alignment["to_layer_id"]]["text"]
+        previous_source_end = previous_target_end = -1
+        for segment in alignment["segments"]:
+            _require(segment["source_start"] >= previous_source_end, "alignment source segments overlap or reorder")
+            _require(segment["target_start"] >= previous_target_end, "alignment target segments overlap or reorder")
+            _require(
+                source_text[segment["source_start"] : segment["source_end"]] == segment["source_text"],
+                "stale source alignment offset",
+            )
+            _require(
+                target_text[segment["target_start"] : segment["target_end"]] == segment["target_text"],
+                "stale target alignment offset",
+            )
+            previous_source_end, previous_target_end = segment["source_end"], segment["target_end"]
+    _assert_evidence_references(packet["alignments"], evidence_id_set, "alignment")
+    _require(set(layer_ids) <= _reachable_layers(packet["alignments"]), "derived text layer is not aligned to original")
+
+    context = packet["historical_context"]
+    min_year, max_year = context["min_year"], context["max_year"]
+    _require((min_year is None) == (max_year is None), "historical date bounds must be both present or both absent")
+    if min_year is not None:
+        _require(min_year <= max_year, "historical date range is reversed")
+    if context["date_certainty"] == "unknown":
+        _require(min_year is None, "unknown historical date cannot assert bounds")
+    if context["date_certainty"] == "exact":
+        _require(min_year is not None and min_year == max_year, "exact historical date must have one year")
+
+    period_keys: set[tuple[str, str]] = set()
+    for item in packet["periodizations"]:
+        key = (item["framework_id"], item["stage_id"])
+        _require(key not in period_keys, "duplicate periodization framework stage")
+        period_keys.add(key)
+        start_year, end_year = item["start_year"], item["end_year"]
+        _require((start_year is None) == (end_year is None), "periodization bounds must be both present or absent")
+        if start_year is not None:
+            _require(start_year <= end_year, "periodization range is reversed")
+            if min_year is not None:
+                _require(start_year <= min_year and max_year <= end_year, "periodization stage excludes record date")
+    _assert_evidence_references(packet["periodizations"], evidence_id_set, "periodization")
+    _assert_evidence_references(packet["language_labels"], evidence_id_set, "language label")
+    _assert_evidence_references(packet["language_layers"], evidence_id_set, "language layer")
+    _assert_evidence_references(packet["interpretations"], evidence_id_set, "interpretation")
+
+    for feature in packet["linguistic_features"]:
+        _require(feature["layer_id"] in layers_by_id, "linguistic feature refers to an unknown text layer")
+        text = layers_by_id[feature["layer_id"]]["text"]
+        for span in feature["spans"]:
+            _require(text[span["start"] : span["end"]] == span["text"], "stale linguistic feature offset")
+    _assert_evidence_references(packet["linguistic_features"], evidence_id_set, "linguistic feature")
+
+    analyses = packet["linguistic_analyses"]
+    provenance = packet["analysis_provenance"]
+    _require(
+        (not analyses and provenance["status"] == "absent") or (analyses and provenance["status"] == "present"),
+        "analysis provenance status disagrees with analyses",
+    )
+    token_positions_by_layer = {
+        layer_id: {token["token_id"]: index for index, token in enumerate(layer["tokens"])}
+        for layer_id, layer in layers_by_id.items()
+    }
+    analysis_by_id = {analysis["analysis_id"]: analysis for analysis in analyses}
+    _require(len(analysis_by_id) == len(analyses), "duplicate linguistic analysis id")
+    for analysis in analyses:
+        layer_id = analysis["layer_id"]
+        _require(layer_id in token_positions_by_layer, "analysis refers to an unknown text layer")
+        token_positions = token_positions_by_layer[layer_id]
+        _require(set(analysis["token_ids"]) <= set(token_positions), "analysis refers to an unknown token")
+        positions = [token_positions[token_id] for token_id in analysis["token_ids"]]
+        _require(
+            positions == list(range(positions[0], positions[0] + len(positions))),
+            "analysis tokens must be contiguous and source ordered",
+        )
+        layer_tokens = layers_by_id[layer_id]["tokens"]
+        start, end = layer_tokens[positions[0]]["start"], layer_tokens[positions[-1]]["end"]
+        _require(
+            layers_by_id[layer_id]["text"][start:end] == analysis["source_surface"],
+            "analysis source surface does not round-trip token offsets",
+        )
+        head = analysis["head_analysis_id"]
+        _require(
+            head is None or head in analysis_by_id,
+            "analysis head refers to an unknown analysis",
+        )
+        if head is not None:
+            _require(analysis_by_id[head]["layer_id"] == layer_id, "analysis head crosses text layers")
+
+    classification = packet["classification"]
+    _require(classification["primary_role_id"] in HISTORICAL_PRIMARY_ROLES, "non-historical primary role is forbidden")
+    _require(classification["claim_type"] in HISTORICAL_CLAIM_TYPES, "correction claim is forbidden for historical data")
+    _require(set(classification["consumer_views"]) <= CONSUMER_VIEWS, "invalid frozen consumer view")
+    _require("protection" in classification["consumer_views"], "historical data requires the protection view")
+    _require(set(classification["derived_bundles"]) <= DERIVED_BUNDLES, "unknown derived historical bundle")
+    bundle_rights = {item["bundle_id"]: item["rights"] for item in classification["derived_bundle_rights"]}
+    _require(
+        len(bundle_rights) == len(classification["derived_bundle_rights"])
+        and set(bundle_rights) == set(classification["derived_bundles"]),
+        "derived bundle rights must cover every bundle exactly once",
+    )
+    bundle_sources = {
+        "historical_recognition": layers,
+        "historical_alignment": packet["alignments"],
+        "periodization": packet["periodizations"],
+        "language_label_disambiguation": [*packet["language_labels"], *packet["language_layers"]],
+        "language_change_explanation": [*packet["linguistic_features"], *packet["interpretations"]],
+    }
+    for bundle_id, bundle_policy in bundle_rights.items():
+        _validate_rights(bundle_policy, "derived bundle")
+        if packet["rights"]["reuse_scope"] != "public_training":
+            _require(bundle_policy["reuse_scope"] != "public_training", "derived bundle exceeds source rights")
+        referenced = {
+            evidence_id
+            for item in bundle_sources[bundle_id]
+            for evidence_id in item["evidence_ids"]
+        }
+        if any(evidence_by_id[evidence_id]["rights"]["reuse_scope"] != "public_training" for evidence_id in referenced):
+            _require(bundle_policy["reuse_scope"] != "public_training", "derived bundle exceeds evidence rights")
+    rights = packet["rights"]
+    _validate_rights(rights, "historical source")
+    if rights["reuse_scope"] != "public_training":
+        _require("research_only" in classification["consumer_views"], "non-public rights require research-only view")
+        _require(
+            not {"supervised_pair", "preference", "automatic"} & set(classification["consumer_views"]),
+            "non-public historical data cannot enter learning views",
+        )
+
+    safeguards = packet["safeguards"]
+    _require(safeguards["historical_forms_protected"] is True, "historical forms are not protected")
+    _require(safeguards["modern_correction_eligible"] is False, "historical text entered modern correction gold")
+    _require(
+        safeguards["russkyi_auto_mapped_to_modern_russian"] is False,
+        "historical руський cannot be auto-mapped to modern Russian",
+    )
+    _require(
+        safeguards["old_east_slavic_is_modern_russian"] is False,
+        "Old East Slavic cannot be equated with modern Russian",
+    )
+    _require(safeguards["scalar_language_age_claim_allowed"] is False, "unsupported scalar age claim is enabled")
+    return packet
+
+
+__all__ = [
+    "SCHEMA_PATH", "SCHEMA_VERSION", "HistoricalRepresentationError",
+    "build_historical_representation", "build_packet", "canonical_json", "validate_historical_representation",
+]

--- a/tests/test_open_model_phase3_historical_representation.py
+++ b/tests/test_open_model_phase3_historical_representation.py
@@ -1,0 +1,586 @@
+"""Hermetic canaries for the Phase 3 historical, non-correction layer."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from scripts.projects.open_model_data.phase3_historical_representation import (
+    HistoricalRepresentationError,
+    build_historical_representation,
+    validate_historical_representation,
+)
+from scripts.projects.open_model_data.phase3_linguistic_representation import sha256_text
+
+ORIGINAL = "Во имя Отца и С[ы]на и с[вя]т[о]го Д[у]ха. амин[ь]."
+RESTORED = "Во имя Отца и Сына и святого Духа. аминь."
+SOURCE_BLOCK = "\n".join(
+    (
+        "# newdoc = uk__shaxm_krym__zudech1413",
+        "# lang = orv-uk",
+        "# created = 1413",
+        "# title = Зудечівська розгранична грамота 1413 року",
+        "# sent_id = uk__shaxm_krym__zudech1413-4",
+        f"# text = {ORIGINAL}",
+    )
+)
+PERIODIZATION_EVIDENCE = (
+    "Qualified Ukrainian secondary sources attribute overlapping historical stages "
+    "to the periodization frameworks of Vasyl Nimchuk and George Shevelov."
+)
+# Exact acquired-file hashes from the Wave H and Wave G retrieval receipts.
+SOURCE_DOCUMENT_SHA = "fc13f73dc71e5fac95938eba424b3d5236bfa8edd8ce7bd0e28db2d28a2f9680"
+PERIODIZATION_DOCUMENT_SHA = "31a3c97bc512d72aeb0278b6683ee75215f073d0ded414ed09efd13b9659e9b6"
+
+
+def _build_kwargs() -> dict:
+    source_locator = {
+        "repository": "UniversalDependencies/UD_Old_East_Slavic-Ruthenian",
+        "commit": "05a029e00ccf1a374c91a22d17fb6310e646d628",
+        "path": "orv_ruthenian-ud-train.conllu",
+        "newdoc": "uk__shaxm_krym__zudech1413",
+        "sent_id": "uk__shaxm_krym__zudech1413-4",
+    }
+    source_evidence_id = "evidence:ud-source-record"
+    metadata_evidence_id = "evidence:ud-source-metadata"
+    periodization_evidence_id = "evidence:qualified-periodization"
+    restoration_evidence_id = "evidence:bracket-restoration"
+    public_source_rights = {
+        "status": "admitted",
+        "license": "CC BY-SA 4.0",
+        "reuse_scope": "public_training",
+        "attribution_required": True,
+    }
+    private_scholarship_rights = {
+        "status": "private_inspection_only",
+        "license": "copyright retained; repository open access",
+        "reuse_scope": "private_inspection_only",
+        "attribution_required": True,
+    }
+    return {
+        "record_id": "historical:ud-orv-uk:zudech1413:4",
+        "collection_identity": "UD_Old_East_Slavic-Ruthenian@05a029e00ccf",
+        "document_or_edition_identity": "Зудечівська розгранична грамота 1413 року",
+        "source_record_identity": "uk__shaxm_krym__zudech1413-4",
+        "frozen_locator": source_locator,
+        "source_document_bytes_sha256": SOURCE_DOCUMENT_SHA,
+        "source_record_bytes_sha256": sha256_text(SOURCE_BLOCK),
+        "historical_context": {
+            "min_year": 1413,
+            "max_year": 1413,
+            "date_certainty": "exact",
+            "region": "historical Ukrainian territory; source metadata does not encode a normalized region",
+            "polity": None,
+            "genre": "boundary charter",
+            "manuscript_or_inscription_identity": "Зудечівська розгранична грамота 1413 року",
+            "script": "Cyrillic transcription",
+            "orthography": "historical source orthography with editorial bracket restorations",
+        },
+        "text_layers": [
+            {
+                "layer_id": "original_diplomatic",
+                "text": ORIGINAL,
+                "authority": "source_transcription",
+                "evidence_ids": [source_evidence_id],
+            },
+            {
+                "layer_id": "restored_reading",
+                "text": RESTORED,
+                "authority": "deterministic_derivation",
+                "evidence_ids": [source_evidence_id, restoration_evidence_id],
+            },
+        ],
+        "alignments": [
+            {
+                "alignment_id": "alignment:original-to-restored",
+                "from_layer_id": "original_diplomatic",
+                "to_layer_id": "restored_reading",
+                "segments": [
+                    {
+                        "source_start": 0,
+                        "source_end": len(ORIGINAL),
+                        "target_start": 0,
+                        "target_end": len(RESTORED),
+                    }
+                ],
+                "authority": "deterministic_derivation",
+                "evidence_ids": [source_evidence_id, restoration_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        "periodizations": [
+            {
+                "framework_id": "nimchuk-five-stage",
+                "framework_label": "Five-stage synthesis attributed to Vasyl Nimchuk",
+                "stage_id": "stage-iv-middle-ukrainian-rus",
+                "stage_label": "Middle Ukrainian / Rus period",
+                "start_year": 1300,
+                "end_year": 1699,
+                "status": "qualified_source_attributed",
+                "attribution": "Vasyl Nimchuk framework as reproduced by qualified UzhNU scholarship",
+                "evidence_ids": [periodization_evidence_id],
+                "ambiguity": ["The published boundary is expressed as XIV/XV century, not one exact year."],
+            },
+            {
+                "framework_id": "shevelov-detailed-periodization",
+                "framework_label": "Detailed periodization attributed to George Shevelov",
+                "stage_id": "early-middle-ukrainian",
+                "stage_label": "Early Middle Ukrainian",
+                "start_year": None,
+                "end_year": None,
+                "status": "qualified_source_attributed",
+                "attribution": "George Shevelov framework as reproduced by qualified UzhNU scholarship",
+                "evidence_ids": [periodization_evidence_id],
+                "ambiguity": ["This canary preserves the attributed label without forcing exact numeric bounds."],
+            },
+        ],
+        "language_labels": [
+            {
+                "label": "orv-uk",
+                "label_kind": "corpus_annotation",
+                "attribution": "UD Old East Slavic-Ruthenian treebank",
+                "scope": "this explicitly tagged source document",
+                "status": "attested",
+                "evidence_ids": [metadata_evidence_id],
+                "ambiguity": [],
+            },
+            {
+                "label": "Old Ukrainian",
+                "label_kind": "modern_scholarly",
+                "attribution": "qualified Ukrainian historical-linguistic periodization",
+                "scope": "historical stage interpretation, not a modern-language identity assertion",
+                "status": "attributed",
+                "evidence_ids": [periodization_evidence_id],
+                "ambiguity": ["Historical umbrella labels vary across scholarly frameworks."],
+            },
+        ],
+        "language_layers": [
+            {
+                "language_layer_id": "layer:primary-orv-uk",
+                "label": "source-tagged Ukrainian Ruthenian record",
+                "role": "primary",
+                "status": "attested",
+                "evidence_ids": [source_evidence_id, metadata_evidence_id],
+                "ambiguity": ["The corpus-wide Ruthenian collection includes other regional language tags."],
+            }
+        ],
+        "linguistic_features": [
+            {
+                "feature_id": "feature:editorial-bracket-restoration",
+                "domain": "orthography",
+                "claim": "Square brackets mark editorially supplied letters in the source transcription.",
+                "layer_id": "original_diplomatic",
+                "spans": [{"start": ORIGINAL.index("[ы]"), "end": ORIGINAL.index("[ы]") + 3}],
+                "status": "attested",
+                "attribution": "UD source transcription",
+                "evidence_ids": [source_evidence_id, restoration_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        "interpretations": [
+            {
+                "interpretation_id": "interpretation:periodization-overlap",
+                "claim": "The 1413 record is retained under multiple attributed historical frameworks.",
+                "status": "qualified_source_attributed",
+                "attribution": "qualified UzhNU historical-linguistic scholarship",
+                "evidence_ids": [periodization_evidence_id],
+                "alternatives": ["Middle Ukrainian / Rus period", "Early Middle Ukrainian"],
+                "ambiguity": ["Framework names and boundaries are not collapsed into one chronology."],
+            }
+        ],
+        "evidence": [
+            {
+                "evidence_id": source_evidence_id,
+                "kind": "source_record",
+                "locator": source_locator,
+                "source_document_bytes_sha256": SOURCE_DOCUMENT_SHA,
+                "evidence_text": SOURCE_BLOCK,
+                "text_exposure": "verbatim",
+                "authority": "source_transcription",
+                "rights": public_source_rights,
+            },
+            {
+                "evidence_id": metadata_evidence_id,
+                "kind": "source_metadata",
+                "locator": {**source_locator, "fields": ["lang", "created", "title"]},
+                "source_document_bytes_sha256": SOURCE_DOCUMENT_SHA,
+                "evidence_text": "lang=orv-uk; created=1413; title=Зудечівська розгранична грамота 1413 року",
+                "text_exposure": "metadata_only",
+                "authority": "source_transcription",
+                "rights": public_source_rights,
+            },
+            {
+                "evidence_id": periodization_evidence_id,
+                "kind": "qualified_scholarship",
+                "locator": {
+                    "institutional_repository": "Uzhhorod National University",
+                    "item_uuid": "04a0fdb3-1203-4855-8d8f-d6d3beb16a9b",
+                    "bitstream_uuid": "8a86d15d-9534-441e-92c9-561fd8098a39",
+                    "file": "uzhnu-historical-grammar-timko-ditko-yusyp-yakymovych-2017.pdf",
+                    "evidence_pages": [28, 29, 30, 31],
+                },
+                "source_document_bytes_sha256": PERIODIZATION_DOCUMENT_SHA,
+                "evidence_text": PERIODIZATION_EVIDENCE,
+                "text_exposure": "paraphrase",
+                "authority": "qualified_human",
+                "rights": private_scholarship_rights,
+            },
+            {
+                "evidence_id": restoration_evidence_id,
+                "kind": "deterministic_derivation",
+                "locator": {**source_locator, "derivation": "remove editorial square brackets, retain contents"},
+                "source_document_bytes_sha256": SOURCE_DOCUMENT_SHA,
+                "evidence_text": "The restored-reading fixture removes square brackets and retains bracket contents.",
+                "text_exposure": "paraphrase",
+                "authority": "deterministic_derivation",
+                "rights": public_source_rights,
+            },
+        ],
+        "rights": {
+            "status": "admitted",
+            "license": "CC BY-SA 4.0",
+            "reuse_scope": "public_training",
+            "attribution_required": True,
+        },
+        "derived_bundle_rights": [
+            {"bundle_id": "historical_recognition", "rights": public_source_rights},
+            {"bundle_id": "historical_alignment", "rights": public_source_rights},
+            {"bundle_id": "periodization", "rights": private_scholarship_rights},
+            {"bundle_id": "language_label_disambiguation", "rights": private_scholarship_rights},
+        ],
+        "primary_role_id": "historical_or_literary_excerpt",
+        "claim_type": "attestation_only",
+        "consumer_views": ("protection", "automatic"),
+        "derived_bundles": (
+            "historical_recognition",
+            "historical_alignment",
+            "periodization",
+            "language_label_disambiguation",
+        ),
+        "evidence_grade": "source_record_plus_qualified_periodization",
+        "linguistic_analyses": [
+            {
+                "analysis_id": "analysis:ud:1",
+                "layer_id": "original_diplomatic",
+                "source_token_id": "1",
+                "source_surface": "Во",
+                "token_ids": ["tok:000001"],
+                "lemma": "во",
+                "pos": "ADP",
+                "morph": {},
+                "head_analysis_id": "analysis:ud:2",
+                "dependency": "case",
+                "ambiguity": [],
+            },
+            {
+                "analysis_id": "analysis:ud:2",
+                "layer_id": "original_diplomatic",
+                "source_token_id": "2",
+                "source_surface": "имя",
+                "token_ids": ["tok:000002"],
+                "lemma": "имя",
+                "pos": "NOUN",
+                "morph": {"Case": "Acc", "Gender": "Neut", "Number": "Sing"},
+                "head_analysis_id": None,
+                "dependency": "root",
+                "ambiguity": [],
+            },
+            {
+                "analysis_id": "analysis:ud:3",
+                "layer_id": "original_diplomatic",
+                "source_token_id": "3",
+                "source_surface": "Отца",
+                "token_ids": ["tok:000003"],
+                "lemma": "отецъ",
+                "pos": "NOUN",
+                "morph": {"Case": "Gen", "Gender": "Masc", "Number": "Sing"},
+                "head_analysis_id": "analysis:ud:2",
+                "dependency": "nmod",
+                "ambiguity": [],
+            },
+            {
+                "analysis_id": "analysis:ud:5",
+                "layer_id": "original_diplomatic",
+                "source_token_id": "5",
+                "source_surface": "С[ы]на",
+                "token_ids": ["tok:000005", "tok:000006", "tok:000007", "tok:000008", "tok:000009"],
+                "lemma": "сынъ",
+                "pos": "NOUN",
+                "morph": {"Case": "Gen", "Gender": "Masc", "Number": "Sing"},
+                "head_analysis_id": "analysis:ud:3",
+                "dependency": "conj",
+                "ambiguity": ["One UD token spans five deterministic tokens because editorial brackets are explicit."],
+            },
+        ],
+        "analysis_provenance": {
+            "status": "present",
+            "resource_identity": "UD_Old_East_Slavic-Ruthenian",
+            "resource_version": "05a029e00ccf1a374c91a22d17fb6310e646d628",
+            "license": "CC BY-SA 4.0",
+            "tokenization_alignment": "adapted",
+        },
+    }
+
+
+def _packet(**overrides):
+    kwargs = _build_kwargs()
+    kwargs.update(overrides)
+    return build_historical_representation(**kwargs)
+
+
+def _private_bundle_rights():
+    rights = {
+        "status": "private_inspection_only",
+        "license": "copyright retained",
+        "reuse_scope": "private_inspection_only",
+        "attribution_required": True,
+    }
+    return [{"bundle_id": bundle_id, "rights": rights} for bundle_id in _build_kwargs()["derived_bundles"]]
+
+
+def test_source_grounded_canary_round_trips_all_text_offsets():
+    packet = _packet()
+
+    assert packet["text_layers"][0]["text"] == ORIGINAL
+    assert packet["text_layers"][1]["text"] == RESTORED
+    assert "[ы]" in [token["text"] for token in packet["text_layers"][0]["tokens"]] or any(
+        token["text"] == "ы" for token in packet["text_layers"][0]["tokens"]
+    )
+    for layer in packet["text_layers"]:
+        for token in layer["tokens"]:
+            assert layer["text"][token["start"] : token["end"]] == token["text"]
+    bracketed_analysis = next(
+        item for item in packet["linguistic_analyses"] if item["source_token_id"] == "5"
+    )
+    assert bracketed_analysis["token_ids"] == [
+        "tok:000005",
+        "tok:000006",
+        "tok:000007",
+        "tok:000008",
+        "tok:000009",
+    ]
+    assert validate_historical_representation(packet) == packet
+
+
+def test_competing_periodization_frameworks_are_preserved_without_collapse():
+    packet = _packet()
+
+    assert [(item["framework_id"], item["stage_label"]) for item in packet["periodizations"]] == [
+        ("nimchuk-five-stage", "Middle Ukrainian / Rus period"),
+        ("shevelov-detailed-periodization", "Early Middle Ukrainian"),
+    ]
+
+
+def test_each_derived_bundle_has_rights_bounded_by_its_evidence():
+    packet = _packet()
+    bundle_rights = {
+        item["bundle_id"]: item["rights"]["reuse_scope"]
+        for item in packet["classification"]["derived_bundle_rights"]
+    }
+
+    assert bundle_rights == {
+        "historical_recognition": "public_training",
+        "historical_alignment": "public_training",
+        "periodization": "private_inspection_only",
+        "language_label_disambiguation": "private_inspection_only",
+    }
+
+
+def test_historical_record_is_mechanically_excluded_from_modern_correction_gold():
+    packet = _packet()
+
+    assert packet["safeguards"] == {
+        "historical_forms_protected": True,
+        "modern_correction_eligible": False,
+        "russkyi_auto_mapped_to_modern_russian": False,
+        "old_east_slavic_is_modern_russian": False,
+        "scalar_language_age_claim_allowed": False,
+    }
+    assert "protection" in packet["classification"]["consumer_views"]
+    assert "supervised_pair" not in packet["classification"]["consumer_views"]
+
+
+def test_unresolved_language_annotation_remains_unresolved_without_inference():
+    language_labels = copy.deepcopy(_build_kwargs()["language_labels"])
+    language_labels[0] = {
+        "label": "unresolved",
+        "label_kind": "corpus_annotation",
+        "attribution": "missing source metadata",
+        "scope": "one untagged adjacent document",
+        "status": "unresolved",
+        "evidence_ids": ["evidence:ud-source-metadata"],
+        "ambiguity": ["No language tag is present; regional identity must not be inferred."],
+    }
+
+    packet = _packet(language_labels=language_labels)
+
+    assert packet["language_labels"][0]["label"] == "unresolved"
+    assert packet["language_labels"][0]["status"] == "unresolved"
+
+
+def test_rejects_stale_text_hash():
+    packet = _packet()
+    packet["text_layers"][0]["text_sha256"] = "0" * 64
+
+    with pytest.raises(HistoricalRepresentationError, match="stale text hash"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_source_record_hash_not_bound_to_exact_evidence_bytes():
+    packet = _packet()
+    packet["source"]["source_record_bytes_sha256"] = "0" * 64
+
+    with pytest.raises(HistoricalRepresentationError, match="not bound to source-record evidence"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_missing_original_diplomatic_layer():
+    packet = _packet()
+    packet["text_layers"] = [item for item in packet["text_layers"] if item["layer_id"] != "original_diplomatic"]
+
+    with pytest.raises(HistoricalRepresentationError, match="original diplomatic"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_stale_alignment_offsets():
+    packet = _packet()
+    packet["alignments"][0]["segments"][0]["source_text"] = "stale"
+
+    with pytest.raises(HistoricalRepresentationError, match="stale source alignment"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_derived_layer_without_path_from_original():
+    packet = _packet()
+    packet["alignments"] = []
+
+    with pytest.raises(HistoricalRepresentationError, match="not aligned to original"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_unknown_evidence_reference():
+    packet = _packet()
+    packet["language_labels"][0]["evidence_ids"] = ["evidence:missing"]
+
+    with pytest.raises(HistoricalRepresentationError, match="unknown evidence"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_model_output_as_evidence_authority():
+    packet = _packet()
+    packet["evidence"][0]["authority"] = "model_output"
+
+    with pytest.raises(HistoricalRepresentationError, match="schema violation"):
+        validate_historical_representation(packet)
+
+
+def test_rejects_verbatim_exposure_from_non_public_evidence():
+    evidence = copy.deepcopy(_build_kwargs()["evidence"])
+    evidence[2]["text_exposure"] = "verbatim"
+
+    with pytest.raises(HistoricalRepresentationError, match="cannot expose verbatim"):
+        _packet(evidence=evidence)
+
+
+def test_rejects_derived_bundle_that_exceeds_evidence_rights():
+    bundle_rights = copy.deepcopy(_build_kwargs()["derived_bundle_rights"])
+    bundle_rights[2]["rights"] = {
+        "status": "admitted",
+        "license": "CC BY 4.0",
+        "reuse_scope": "public_training",
+        "attribution_required": True,
+    }
+
+    with pytest.raises(HistoricalRepresentationError, match="exceeds evidence rights"):
+        _packet(derived_bundle_rights=bundle_rights)
+
+
+def test_rejects_correction_claim_for_historical_record():
+    with pytest.raises(HistoricalRepresentationError, match="correction claim"):
+        _packet(claim_type="human_correction_pair")
+
+
+def test_rejects_non_public_record_in_learning_view():
+    rights = {
+        "status": "private_inspection_only",
+        "license": "copyright retained",
+        "reuse_scope": "private_inspection_only",
+        "attribution_required": True,
+    }
+
+    with pytest.raises(HistoricalRepresentationError, match="cannot enter learning views"):
+        _packet(
+            rights=rights,
+            derived_bundle_rights=_private_bundle_rights(),
+            consumer_views=("protection", "research_only", "automatic"),
+        )
+
+
+def test_accepts_private_inspection_record_only_in_protected_research_view():
+    rights = {
+        "status": "private_inspection_only",
+        "license": "copyright retained",
+        "reuse_scope": "private_inspection_only",
+        "attribution_required": True,
+    }
+
+    packet = _packet(
+        rights=rights,
+        derived_bundle_rights=_private_bundle_rights(),
+        consumer_views=("protection", "research_only"),
+    )
+
+    assert packet["rights"]["reuse_scope"] == "private_inspection_only"
+
+
+def test_rejects_public_training_without_resolved_license():
+    rights = {
+        "status": "admitted",
+        "license": "unknown",
+        "reuse_scope": "public_training",
+        "attribution_required": False,
+    }
+
+    with pytest.raises(HistoricalRepresentationError, match="requires a license"):
+        _packet(rights=rights)
+
+
+def test_rejects_analysis_for_unknown_token():
+    analyses = copy.deepcopy(_build_kwargs()["linguistic_analyses"])
+    analyses[0]["token_ids"] = ["tok:999999"]
+
+    with pytest.raises(HistoricalRepresentationError, match="unknown token"):
+        _packet(linguistic_analyses=analyses)
+
+
+def test_rejects_analysis_head_for_unknown_source_analysis():
+    analyses = copy.deepcopy(_build_kwargs()["linguistic_analyses"])
+    analyses[0]["head_analysis_id"] = "analysis:ud:missing"
+
+    with pytest.raises(HistoricalRepresentationError, match="unknown analysis"):
+        _packet(linguistic_analyses=analyses)
+
+
+def test_rejects_analysis_with_noncontiguous_token_mapping():
+    analyses = copy.deepcopy(_build_kwargs()["linguistic_analyses"])
+    analyses[3]["token_ids"] = ["tok:000005", "tok:000007", "tok:000009"]
+
+    with pytest.raises(HistoricalRepresentationError, match="contiguous and source ordered"):
+        _packet(linguistic_analyses=analyses)
+
+
+def test_rejects_analysis_surface_that_does_not_round_trip_offsets():
+    analyses = copy.deepcopy(_build_kwargs()["linguistic_analyses"])
+    analyses[3]["source_surface"] = "Сына"
+
+    with pytest.raises(HistoricalRepresentationError, match="source surface"):
+        _packet(linguistic_analyses=analyses)
+
+
+def test_schema_rejects_untracked_fields():
+    packet = _packet()
+    packet["historical_context"]["modernized_guess"] = "forbidden"
+
+    with pytest.raises(HistoricalRepresentationError, match="schema violation"):
+        validate_historical_representation(packet)


### PR DESCRIPTION
## Summary

- add a strict Phase 3 v3 representation for historical Ukrainian source records, separate from modern correction packets
- preserve immutable source identity, original/restored/modern text layers, Unicode offsets and tokens, alignments, periodizations, language labels/layers, linguistic features, analyses, interpretations, rights, and evidence
- preserve one-to-many analysis alignment when one historical UD surface token spans multiple deterministic Unicode tokens (for example editorial bracket restorations)
- mechanically forbid modern-correction eligibility, automatic `руський` -> modern Russian mapping, Old East Slavic -> modern Russian equivalence, unsupported scalar language-age claims, model authority, and non-public material entering learning views
- bind rights separately for the primary record, every evidence item, and every derived bundle; non-public evidence may expose only metadata or paraphrase and cannot authorize a public derived bundle
- add a source-grounded public canary from the explicitly tagged `orv-uk` UD Ruthenian subset, while testing that an untagged document remains unresolved

This implements the dedicated historical layer required by the reviewed Phase 3 reboot contract without changing the frozen v2 role or consumer-view vocabulary. Phase 4 remains blocked.

Reviewed prompt SHA-256: `5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d`

## Verification

- `pytest -p no:cacheprovider tests/test_open_model_phase3_historical_representation.py tests/test_open_model_phase3_linguistic_representation.py -q` -> 42 passed
- `ruff check scripts/projects/open_model_data/phase3_historical_representation.py tests/test_open_model_phase3_historical_representation.py` -> passed
- both historical and modern schemas validated as JSON Schema Draft 2020-12
- `git diff --check` -> clean

Part of #6375.
