### PR TITLE
feat(open-model-data): add historical corpus canary materializer

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_historical_materialization_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_historical_materialization_receipt_v1.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_historical_materialization_receipt_v1.schema.json",
+  "title": "Phase 3 historical canary materialization text-free receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "mode", "text_free", "inputs", "denominators", "selection", "outputs", "projection", "residuals", "safeguards"],
+  "properties": {
+    "schema_version": {"const": "phase3_historical_materialization_receipt_v1"},
+    "mode": {"const": "canary"},
+    "text_free": {"const": true},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ud", "plug2"],
+      "properties": {
+        "ud": {"$ref": "#/$defs/udInput"},
+        "plug2": {"$ref": "#/$defs/plug2Input"}
+      }
+    },
+    "denominators": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ud_explicit_orv_uk", "ud_other_or_unresolved_sentences", "plug2", "plug2_original_counts", "plug2_orthography_counts", "plug2_candidate_uk_token_sum"],
+      "properties": {
+        "ud_explicit_orv_uk": {"$ref": "#/$defs/udDenominator"},
+        "ud_other_or_unresolved_sentences": {"type": "integer", "minimum": 0},
+        "plug2": {"$ref": "#/$defs/plug2Denominator"},
+        "plug2_original_counts": {"$ref": "#/$defs/languageCounts"},
+        "plug2_orthography_counts": {"$ref": "#/$defs/orthographyCounts"},
+        "plug2_candidate_uk_token_sum": {"type": "integer", "minimum": 1}
+      }
+    },
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "ud_fraction", "ud_selected_sentences", "ud_selection_sha256", "plug2_fraction", "plug2_selected_documents", "plug2_selection_sha256"],
+      "properties": {
+        "algorithm": {"type": "string", "minLength": 1},
+        "ud_fraction": {"type": "number", "exclusiveMinimum": 0, "maximum": 0.01},
+        "ud_selected_sentences": {"type": "integer", "minimum": 1},
+        "ud_selection_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "plug2_fraction": {"type": "number", "exclusiveMinimum": 0, "maximum": 0.01},
+        "plug2_selected_documents": {"type": "integer", "minimum": 1},
+        "plug2_selection_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ud", "plug2"],
+      "properties": {
+        "ud": {"$ref": "#/$defs/output"},
+        "plug2": {"$ref": "#/$defs/output"}
+      }
+    },
+    "projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ud_compressed_gib", "plug2_compressed_gib", "total_compressed_gib", "ceiling_gib", "within_ceiling"],
+      "properties": {
+        "ud_compressed_gib": {"type": "number", "minimum": 0},
+        "plug2_compressed_gib": {"type": "number", "minimum": 0},
+        "total_compressed_gib": {"type": "number", "minimum": 0, "maximum": 5},
+        "ceiling_gib": {"const": 5.0},
+        "within_ceiling": {"const": true}
+      }
+    },
+    "residuals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ud_untagged_or_other_excluded", "plug2_non_uk_or_unknown_excluded", "unlabeled_orthography_not_inferred", "periodization_unresolved_pending_qualified_evidence", "full_materialization_authorized"],
+      "properties": {
+        "ud_untagged_or_other_excluded": {"const": true},
+        "plug2_non_uk_or_unknown_excluded": {"const": true},
+        "unlabeled_orthography_not_inferred": {"const": true},
+        "periodization_unresolved_pending_qualified_evidence": {"const": true},
+        "full_materialization_authorized": {"const": false}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["historical_forms_protected", "modern_correction_eligible", "provider_calls", "phase4_authorized"],
+      "properties": {
+        "historical_forms_protected": {"const": true},
+        "modern_correction_eligible": {"const": false},
+        "provider_calls": {"const": false},
+        "phase4_authorized": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "nonnegativeCounts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"type": "integer", "minimum": 0}
+    },
+    "languageCounts": {
+      "allOf": [
+        {"$ref": "#/$defs/nonnegativeCounts"},
+        {"propertyNames": {"pattern": "^(UNKNOWN|[A-Z]{2,3})$"}}
+      ]
+    },
+    "orthographyCounts": {
+      "allOf": [
+        {"$ref": "#/$defs/nonnegativeCounts"},
+        {"propertyNames": {"enum": ["CONT", "LUKR", "SKRY", "ZHEL", "unlabeled"]}}
+      ]
+    },
+    "udInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dataset_id", "commit_sha", "file_sha256"],
+      "properties": {
+        "dataset_id": {"const": "ud-old-east-slavic-ruthenian-05a029e00ccf"},
+        "commit_sha": {"const": "05a029e00ccf1a374c91a22d17fb6310e646d628"},
+        "file_sha256": {"type": "object", "minProperties": 1, "additionalProperties": {"$ref": "#/$defs/sha256"}}
+      }
+    },
+    "plug2Input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dataset_id", "doi", "archive_sha256", "metadata_sha256"],
+      "properties": {
+        "dataset_id": {"const": "plug2-zenodo-19482961"},
+        "doi": {"const": "10.5281/zenodo.19482961"},
+        "archive_sha256": {"$ref": "#/$defs/sha256"},
+        "metadata_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "udDenominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documents", "sentences", "token_rows"],
+      "properties": {
+        "documents": {"type": "integer", "minimum": 1},
+        "sentences": {"type": "integer", "minimum": 1},
+        "token_rows": {"type": "integer", "minimum": 1}
+      }
+    },
+    "plug2Denominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documents", "token_sum", "uk_documents", "non_uk_or_unknown_documents"],
+      "properties": {
+        "documents": {"type": "integer", "minimum": 1},
+        "token_sum": {"type": "integer", "minimum": 1},
+        "uk_documents": {"type": "integer", "minimum": 1},
+        "non_uk_or_unknown_documents": {"type": "integer", "minimum": 0}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "records", "bytes", "sha256"],
+      "properties": {
+        "filename": {"type": "string", "pattern": "^[^/]+\\.jsonl\\.gz$"},
+        "records": {"type": "integer", "minimum": 1},
+        "bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    }
+  }
+}

--- a/scripts/projects/open_model_data/phase3_historical_materialization.py
+++ b/scripts/projects/open_model_data/phase3_historical_materialization.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+"""Stream a bounded historical-corpus canary into the protected v3 model.
+
+Only explicitly ``orv-uk`` UD documents and PluG2 rows whose source-language
+metadata is exactly ``UK`` enter the candidate output.  Historical text is
+written to a caller-supplied private directory; the receipt is text-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import stat
+import tempfile
+import zipfile
+from collections import Counter
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data.phase3_historical_representation import (
+    build_historical_representation,
+)
+from scripts.projects.open_model_data.phase3_linguistic_representation import (
+    canonical_json,
+    sha256_bytes,
+    sha256_text,
+    sha256_value,
+    tokenize,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+RECEIPT_SCHEMA_PATH = (
+    ROOT / "data/projects/open_model_data/contracts/phase3_historical_materialization_receipt_v1.schema.json"
+)
+
+UD_COLLECTION_ID = "ud-old-east-slavic-ruthenian-05a029e00ccf"
+UD_COMMIT = "05a029e00ccf1a374c91a22d17fb6310e646d628"
+UD_EXPECTED_SHA256 = {
+    "orv_ruthenian-ud-dev.conllu": "a2047c4c734dab0a5b68f888979a3ca14670d217d7dcc11bb12b775f2dbbfd1d",
+    "orv_ruthenian-ud-test.conllu": "f34964cee7d6a38b3dd39ceb4dbde38a4fd9aacd8512272c19318027e044ea0d",
+    "orv_ruthenian-ud-train.conllu": "fc13f73dc71e5fac95938eba424b3d5236bfa8edd8ce7bd0e28db2d28a2f9680",
+}
+UD_EXPECTED_DENOMINATOR = {"documents": 82, "sentences": 1311, "token_rows": 35081}
+
+PLUG2_COLLECTION_ID = "plug2-zenodo-19482961"
+PLUG2_DOI = "10.5281/zenodo.19482961"
+PLUG2_ARCHIVE_SHA256 = "ff1ff139049539fc7c9ab69b006c12444567989758738baa948cfa0837aabe23"
+PLUG2_METADATA_SHA256 = "a9f79149606b570ebd6895020292eb06016d883e5c75dcb38a6e2cfd15378494"
+PLUG2_EXPECTED_DENOMINATOR = {
+    "documents": 56245,
+    "token_sum": 74497787,
+    "uk_documents": 56080,
+    "non_uk_or_unknown_documents": 165,
+}
+
+MAX_CANARY_FRACTION = 0.01
+OUTPUT_CEILING_GIB = 5.0
+RECEIPT_SCHEMA_VERSION = "phase3_historical_materialization_receipt_v1"
+
+
+class HistoricalMaterializationError(ValueError):
+    """An input identity, role boundary, or deterministic invariant failed."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise HistoricalMaterializationError(message)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_hash(path: Path, expected: str) -> None:
+    _require(path.is_file(), f"missing input: {path}")
+    actual = file_sha256(path)
+    _require(actual == expected, f"SHA-256 mismatch for {path.name}: expected {expected}, got {actual}")
+
+
+def _rights(license_name: str) -> dict[str, Any]:
+    return {
+        "status": "admitted",
+        "license": license_name,
+        "reuse_scope": "public_training",
+        "attribution_required": True,
+    }
+
+
+def _select_canary(keys: Sequence[str], fraction: float, *, salt: str) -> list[str]:
+    _require(0 < fraction <= MAX_CANARY_FRACTION, "canary fraction must be in (0, 0.01]")
+    _require(bool(keys), "cannot select a canary from an empty denominator")
+    count = max(1, math.ceil(len(keys) * fraction))
+    return sorted(keys, key=lambda key: (sha256_text(f"{salt}:{key}"), key))[:count]
+
+
+@dataclass(frozen=True)
+class UdToken:
+    token_id: str
+    form: str
+    lemma: str | None
+    upos: str | None
+    feats: dict[str, str]
+    head: str | None
+    deprel: str | None
+    misc: str
+
+
+@dataclass(frozen=True)
+class UdSentence:
+    source_file: str
+    source_file_sha256: str
+    document_id: str
+    language: str | None
+    created: str | None
+    title: str | None
+    sent_id: str
+    source_comment_text: str | None
+    tokens: tuple[UdToken, ...]
+
+
+def _parse_feats(value: str) -> dict[str, str]:
+    if value == "_":
+        return {}
+    pairs: dict[str, str] = {}
+    for item in value.split("|"):
+        _require("=" in item, f"malformed CoNLL-U feature: {item}")
+        key, raw_value = item.split("=", 1)
+        _require(key not in pairs, f"duplicate CoNLL-U feature: {key}")
+        pairs[key] = raw_value
+    return pairs
+
+
+def parse_conllu(path: Path, *, source_file_sha256: str) -> list[UdSentence]:
+    document: dict[str, str | None] = {"id": None, "lang": None, "created": None, "title": None}
+    sentence_meta: dict[str, str | None] = {"sent_id": None, "text": None}
+    token_rows: list[UdToken] = []
+    sentences: list[UdSentence] = []
+
+    def flush() -> None:
+        nonlocal sentence_meta, token_rows
+        if not token_rows:
+            sentence_meta = {"sent_id": None, "text": None}
+            return
+        _require(bool(document["id"]), f"sentence without document id in {path.name}")
+        _require(bool(sentence_meta["sent_id"]), f"sentence without sent_id in {path.name}")
+        token_ids = [token.token_id for token in token_rows]
+        _require(len(token_ids) == len(set(token_ids)), f"duplicate CoNLL-U token id in {sentence_meta['sent_id']}")
+        sentences.append(
+            UdSentence(
+                source_file=path.name,
+                source_file_sha256=source_file_sha256,
+                document_id=str(document["id"]),
+                language=document["lang"],
+                created=document["created"],
+                title=document["title"],
+                sent_id=str(sentence_meta["sent_id"]),
+                source_comment_text=sentence_meta["text"],
+                tokens=tuple(token_rows),
+            )
+        )
+        sentence_meta = {"sent_id": None, "text": None}
+        token_rows = []
+
+    with path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\n\r")
+            if not line:
+                flush()
+                continue
+            if line.startswith("# ") and "=" in line:
+                key, value = (part.strip() for part in line[2:].split("=", 1))
+                if key in {"newdoc", "newdoc id", "newdoc_id"}:
+                    flush()
+                    document = {"id": value, "lang": None, "created": None, "title": None}
+                elif key == "lang":
+                    document["lang"] = value
+                elif key == "created":
+                    document["created"] = value
+                elif key == "title":
+                    document["title"] = value
+                elif key == "sent_id":
+                    sentence_meta["sent_id"] = value
+                elif key == "text":
+                    sentence_meta["text"] = value
+                continue
+            if line.startswith("#"):
+                continue
+            columns = line.split("\t")
+            _require(len(columns) == 10, f"malformed CoNLL-U row in {path.name}")
+            raw_id = columns[0]
+            if "-" in raw_id or "." in raw_id:
+                continue
+            _require(raw_id.isdigit(), f"non-integer CoNLL-U token id: {raw_id}")
+            token_rows.append(
+                UdToken(
+                    token_id=raw_id,
+                    form=columns[1],
+                    lemma=None if columns[2] == "_" else columns[2],
+                    upos=None if columns[3] == "_" else columns[3],
+                    feats=_parse_feats(columns[5]),
+                    head=None if columns[6] in {"_", "0"} else columns[6],
+                    deprel=None if columns[7] == "_" else columns[7],
+                    misc=columns[9],
+                )
+            )
+    flush()
+    return sentences
+
+
+def _ud_surface(sentence: UdSentence) -> tuple[str, list[tuple[int, int]]]:
+    parts: list[str] = []
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for index, token in enumerate(sentence.tokens):
+        start = cursor
+        parts.append(token.form)
+        cursor += len(token.form)
+        spans.append((start, cursor))
+        if index < len(sentence.tokens) - 1 and "SpaceAfter=No" not in token.misc.split("|"):
+            parts.append(" ")
+            cursor += 1
+    text = "".join(parts)
+    comment = sentence.source_comment_text
+    if comment and comment != "[Omitted long context line]":
+        _require(comment == text, f"CoNLL-U # text does not round-trip token rows: {sentence.sent_id}")
+    return text, spans
+
+
+def _ud_analyses(sentence: UdSentence, text: str, spans: Sequence[tuple[int, int]]) -> list[dict[str, Any]]:
+    deterministic = tokenize(
+        text,
+        paragraph_span={"start": 0, "end": len(text)},
+        sentence_span={"start": 0, "end": len(text)},
+    )
+    analyses: list[dict[str, Any]] = []
+    analysis_id_by_token = {
+        token.token_id: f"ud-analysis:{sentence.sent_id}:{token.token_id}" for token in sentence.tokens
+    }
+    heads = {token.token_id: token.head for token in sentence.tokens}
+    for token_id in heads:
+        seen = {token_id}
+        head = heads[token_id]
+        while head is not None:
+            _require(head in heads, f"UD dependency head is unknown: {sentence.sent_id}:{head}")
+            _require(head not in seen, f"UD dependency cycle: {sentence.sent_id}:{head}")
+            seen.add(head)
+            head = heads[head]
+    claimed_token_ids: set[str] = set()
+    for source_token, (start, end) in zip(sentence.tokens, spans, strict=True):
+        token_ids = [item["token_id"] for item in deterministic if item["start"] >= start and item["end"] <= end]
+        _require(bool(token_ids), f"UD token has no deterministic mapping: {sentence.sent_id}:{source_token.token_id}")
+        mapped = [item for item in deterministic if item["token_id"] in token_ids]
+        _require(
+            mapped[0]["start"] == start and mapped[-1]["end"] == end,
+            f"UD token mapping does not cover its source surface: {sentence.sent_id}:{source_token.token_id}",
+        )
+        _require(
+            claimed_token_ids.isdisjoint(token_ids),
+            f"UD analyses overlap deterministic tokens: {sentence.sent_id}:{source_token.token_id}",
+        )
+        claimed_token_ids.update(token_ids)
+        analyses.append(
+            {
+                "analysis_id": analysis_id_by_token[source_token.token_id],
+                "layer_id": "original_diplomatic",
+                "source_token_id": source_token.token_id,
+                "source_surface": source_token.form,
+                "token_ids": token_ids,
+                "lemma": source_token.lemma,
+                "pos": source_token.upos,
+                "morph": source_token.feats,
+                "head_analysis_id": (None if source_token.head is None else analysis_id_by_token[source_token.head]),
+                "dependency": source_token.deprel,
+                "ambiguity": [],
+            }
+        )
+    return analyses
+
+
+def _unresolved_periodization(evidence_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "framework_id": "materialization-unresolved",
+            "framework_label": "No periodization inferred during source materialization",
+            "stage_id": "unresolved",
+            "stage_label": "Unresolved pending qualified historical adjudication",
+            "start_year": None,
+            "end_year": None,
+            "status": "unresolved",
+            "attribution": "Phase 3 deterministic materializer",
+            "evidence_ids": [evidence_id],
+            "ambiguity": ["Competing scholarly periodizations remain separate downstream evidence."],
+        }
+    ]
+
+
+def _year_context(raw_year: str | None) -> tuple[int | None, int | None, str]:
+    if raw_year and re.fullmatch(r"[0-9]{4}", raw_year):
+        year = int(raw_year)
+        return year, year, "exact"
+    return None, None, "unknown"
+
+
+def build_ud_record(sentence: UdSentence) -> dict[str, Any]:
+    text, spans = _ud_surface(sentence)
+    locator = {
+        "dataset_id": UD_COLLECTION_ID,
+        "commit_sha": UD_COMMIT,
+        "source_file": sentence.source_file,
+        "newdoc_id": sentence.document_id,
+        "sent_id": sentence.sent_id,
+    }
+    metadata = {
+        "newdoc_id": sentence.document_id,
+        "lang": sentence.language,
+        "created": sentence.created,
+        "title": sentence.title,
+    }
+    source_evidence_id = "ud-source-record"
+    metadata_evidence_id = "ud-source-metadata"
+    rights = _rights("CC BY-SA 4.0")
+    min_year, max_year, certainty = _year_context(sentence.created)
+    analyses = _ud_analyses(sentence, text, spans)
+    return build_historical_representation(
+        record_id=f"ud-orv-uk:{sha256_value(locator)[:24]}",
+        collection_identity=f"{UD_COLLECTION_ID}@{UD_COMMIT}",
+        document_or_edition_identity=sentence.document_id,
+        source_record_identity=sentence.sent_id,
+        frozen_locator=locator,
+        source_document_bytes_sha256=sentence.source_file_sha256,
+        source_record_bytes_sha256=sha256_text(text),
+        historical_context={
+            "min_year": min_year,
+            "max_year": max_year,
+            "date_certainty": certainty,
+            "region": None,
+            "polity": None,
+            "genre": None,
+            "manuscript_or_inscription_identity": sentence.title,
+            "script": "Cyrillic",
+            "orthography": None,
+        },
+        text_layers=[
+            {
+                "layer_id": "original_diplomatic",
+                "text": text,
+                "authority": "source_transcription",
+                "evidence_ids": [source_evidence_id],
+            }
+        ],
+        alignments=[],
+        periodizations=_unresolved_periodization(metadata_evidence_id),
+        language_labels=[
+            {
+                "label": "orv-uk",
+                "label_kind": "corpus_annotation",
+                "attribution": "Universal Dependencies Old East Slavic-Ruthenian",
+                "scope": sentence.document_id,
+                "status": "attested",
+                "evidence_ids": [metadata_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        language_layers=[
+            {
+                "language_layer_id": "ud-primary-orv-uk",
+                "label": "orv-uk",
+                "role": "primary",
+                "status": "attested",
+                "evidence_ids": [metadata_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        linguistic_features=[],
+        interpretations=[],
+        linguistic_analyses=analyses,
+        analysis_provenance={
+            "status": "present",
+            "resource_identity": "Universal Dependencies Old East Slavic-Ruthenian",
+            "resource_version": UD_COMMIT,
+            "license": "CC BY-SA 4.0",
+            "tokenization_alignment": "adapted",
+        },
+        evidence=[
+            {
+                "evidence_id": source_evidence_id,
+                "kind": "source_record",
+                "locator": locator,
+                "source_document_bytes_sha256": sentence.source_file_sha256,
+                "evidence_text": text,
+                "text_exposure": "verbatim",
+                "authority": "source_transcription",
+                "rights": rights,
+            },
+            {
+                "evidence_id": metadata_evidence_id,
+                "kind": "source_metadata",
+                "locator": {**locator, "component": "document_comments"},
+                "source_document_bytes_sha256": sentence.source_file_sha256,
+                "evidence_text": canonical_json(metadata),
+                "text_exposure": "metadata_only",
+                "authority": "source_transcription",
+                "rights": rights,
+            },
+        ],
+        rights=rights,
+        derived_bundles=("historical_recognition", "language_label_disambiguation"),
+        derived_bundle_rights=[
+            {"bundle_id": "historical_recognition", "rights": rights},
+            {"bundle_id": "language_label_disambiguation", "rights": rights},
+        ],
+    )
+
+
+def _safe_member_path(name: str) -> PurePosixPath:
+    raw_parts = name.split("/")
+    _require(all(part not in {"", ".", ".."} for part in raw_parts), f"unsafe ZIP member: {name}")
+    path = PurePosixPath(name)
+    _require(not path.is_absolute(), f"unsafe absolute ZIP member: {name}")
+    _require("\\" not in name, f"unsafe ZIP member separator: {name}")
+    return path
+
+
+def load_plug2_metadata(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="|", quotechar='"')
+        _require(reader.fieldnames is not None and "path" in reader.fieldnames, "PluG2 metadata lacks path")
+        rows = [dict(row) for row in reader]
+    paths = [row["path"] for row in rows]
+    _require(len(paths) == len(set(paths)), "duplicate PluG2 metadata path")
+    for name in paths:
+        _safe_member_path(name)
+    return rows
+
+
+def _metadata_nonnegative_int(row: Mapping[str, str], key: str) -> int:
+    raw_value = row.get(key)
+    try:
+        value = int(raw_value) if raw_value is not None else -1
+    except ValueError as exc:
+        raise HistoricalMaterializationError(f"invalid PluG2 integer field {key}: {raw_value!r}") from exc
+    _require(value >= 0, f"invalid PluG2 nonnegative field {key}: {raw_value!r}")
+    return value
+
+
+def inspect_plug2_archive(path: Path) -> dict[str, zipfile.ZipInfo]:
+    files: dict[str, zipfile.ZipInfo] = {}
+    with zipfile.ZipFile(path) as archive:
+        for info in archive.infolist():
+            member = _safe_member_path(info.filename[:-1] if info.is_dir() else info.filename)
+            if info.is_dir():
+                continue
+            unix_mode = info.external_attr >> 16
+            _require(not stat.S_ISLNK(unix_mode), f"unsafe ZIP symlink member: {info.filename}")
+            _require(member.parts[0] == "PLuG2_texts", f"unexpected PluG2 ZIP root: {info.filename}")
+            relative = PurePosixPath(*member.parts[1:]).as_posix()
+            _require(relative not in files, f"duplicate PluG2 ZIP member: {relative}")
+            files[relative] = info
+    return files
+
+
+def paragraph_units(text: str) -> list[tuple[int, int, str]]:
+    units: list[tuple[int, int, str]] = []
+    for match in re.finditer(r"[^\r\n]+", text):
+        value = match.group(0)
+        if value.strip():
+            units.append((match.start(), match.end(), value))
+    return units
+
+
+def build_plug2_record(
+    *,
+    row: Mapping[str, str],
+    member_bytes: bytes,
+    paragraph_index: int,
+    paragraph_start: int,
+    paragraph_end: int,
+    paragraph_text: str,
+    archive_sha256: str = PLUG2_ARCHIVE_SHA256,
+    metadata_sha256: str = PLUG2_METADATA_SHA256,
+) -> dict[str, Any]:
+    _require(row.get("doc.original") == "UK", "non-UK PluG2 row cannot enter Ukrainian candidate output")
+    document_sha256 = sha256_bytes(member_bytes)
+    locator = {
+        "dataset_id": PLUG2_COLLECTION_ID,
+        "doi": PLUG2_DOI,
+        "archive_sha256": archive_sha256,
+        "member_path": row["path"],
+        "paragraph_index": paragraph_index,
+        "paragraph_start": paragraph_start,
+        "paragraph_end": paragraph_end,
+        "offset_basis": "unicode_code_points",
+    }
+    source_evidence_id = "plug2-source-record"
+    metadata_evidence_id = "plug2-source-metadata"
+    rights = _rights("CC BY 4.0")
+    min_year, max_year, certainty = _year_context(row.get("doc.date"))
+    genre_parts = [value for value in (row.get("doc.style"), row.get("doc.genre")) if value]
+    return build_historical_representation(
+        record_id=f"plug2-uk:{sha256_value(locator)[:24]}",
+        collection_identity=f"{PLUG2_COLLECTION_ID}:{PLUG2_DOI}",
+        document_or_edition_identity=row["path"],
+        source_record_identity=f"{row['path']}#paragraph={paragraph_index}",
+        frozen_locator=locator,
+        source_document_bytes_sha256=document_sha256,
+        source_record_bytes_sha256=sha256_text(paragraph_text),
+        historical_context={
+            "min_year": min_year,
+            "max_year": max_year,
+            "date_certainty": certainty,
+            "region": row.get("doc.authorLocCode") or None,
+            "polity": None,
+            "genre": "+".join(genre_parts) or None,
+            "manuscript_or_inscription_identity": row.get("doc.name") or row["path"],
+            "script": "Cyrillic",
+            "orthography": row.get("doc.orthography") or None,
+        },
+        text_layers=[
+            {
+                "layer_id": "original_diplomatic",
+                "text": paragraph_text,
+                "authority": "source_transcription",
+                "evidence_ids": [source_evidence_id],
+            }
+        ],
+        alignments=[],
+        periodizations=_unresolved_periodization(metadata_evidence_id),
+        language_labels=[
+            {
+                "label": "UK",
+                "label_kind": "corpus_annotation",
+                "attribution": "PluG2 metadata",
+                "scope": row["path"],
+                "status": "attested",
+                "evidence_ids": [metadata_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        language_layers=[
+            {
+                "language_layer_id": "plug2-primary-uk",
+                "label": "UK",
+                "role": "primary",
+                "status": "attested",
+                "evidence_ids": [metadata_evidence_id],
+                "ambiguity": [],
+            }
+        ],
+        linguistic_features=[],
+        interpretations=[],
+        evidence=[
+            {
+                "evidence_id": source_evidence_id,
+                "kind": "source_record",
+                "locator": locator,
+                "source_document_bytes_sha256": document_sha256,
+                "evidence_text": paragraph_text,
+                "text_exposure": "verbatim",
+                "authority": "source_transcription",
+                "rights": rights,
+            },
+            {
+                "evidence_id": metadata_evidence_id,
+                "kind": "source_metadata",
+                "locator": {**locator, "component": "PluG2_metadata.psv"},
+                "source_document_bytes_sha256": metadata_sha256,
+                "evidence_text": canonical_json(dict(row)),
+                "text_exposure": "metadata_only",
+                "authority": "source_transcription",
+                "rights": rights,
+            },
+        ],
+        rights=rights,
+        derived_bundles=("historical_recognition", "language_label_disambiguation"),
+        derived_bundle_rights=[
+            {"bundle_id": "historical_recognition", "rights": rights},
+            {"bundle_id": "language_label_disambiguation", "rights": rights},
+        ],
+    )
+
+
+def _write_jsonl_gzip(path: Path, records: Iterable[Mapping[str, Any]]) -> tuple[int, int, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    count = 0
+    try:
+        with (
+            temporary.open("wb") as raw_handle,
+            gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as gzip_handle,
+        ):
+            for record in records:
+                gzip_handle.write(canonical_json(record).encode("utf-8") + b"\n")
+                count += 1
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return count, path.stat().st_size, file_sha256(path)
+
+
+def _validate_receipt(receipt: Mapping[str, Any]) -> None:
+    schema = json.loads(RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(receipt), key=lambda item: list(item.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "receipt"
+        raise HistoricalMaterializationError(f"receipt schema violation at {location}: {errors[0].message}")
+
+
+def _write_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    _validate_receipt(receipt)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _projection_gib(output_bytes: int, selected_tokens: int, denominator_tokens: int) -> float:
+    _require(selected_tokens > 0, "selected token denominator must be positive")
+    projected = output_bytes * denominator_tokens / selected_tokens
+    return projected / (1024**3)
+
+
+def _inside_git_checkout(path: Path) -> bool:
+    return any((candidate / ".git").exists() for candidate in (path, *path.parents))
+
+
+def materialize_canary(
+    *,
+    ud_dir: Path,
+    plug2_archive: Path,
+    plug2_metadata: Path,
+    private_output_dir: Path,
+    receipt_output: Path,
+    ud_fraction: float = 0.01,
+    plug2_fraction: float = 0.001,
+    expected_ud_sha256: Mapping[str, str] = UD_EXPECTED_SHA256,
+    expected_plug2_archive_sha256: str = PLUG2_ARCHIVE_SHA256,
+    expected_plug2_metadata_sha256: str = PLUG2_METADATA_SHA256,
+    expected_ud_denominator: Mapping[str, int] = UD_EXPECTED_DENOMINATOR,
+    expected_plug2_denominator: Mapping[str, int] = PLUG2_EXPECTED_DENOMINATOR,
+) -> dict[str, Any]:
+    """Audit complete denominators and materialize deterministic bounded samples."""
+    _require(
+        not _inside_git_checkout(private_output_dir.resolve()),
+        "private text output cannot be inside a Git checkout",
+    )
+    _require(
+        receipt_output.parent.resolve() == private_output_dir.resolve(),
+        "receipt must be written inside the immutable canary output directory",
+    )
+    _require(not private_output_dir.exists(), "immutable canary output directory already exists")
+    for filename, expected_hash in expected_ud_sha256.items():
+        _verify_hash(ud_dir / filename, expected_hash)
+    _verify_hash(plug2_archive, expected_plug2_archive_sha256)
+    _verify_hash(plug2_metadata, expected_plug2_metadata_sha256)
+
+    all_ud: list[UdSentence] = []
+    for filename in sorted(expected_ud_sha256):
+        all_ud.extend(parse_conllu(ud_dir / filename, source_file_sha256=expected_ud_sha256[filename]))
+    ud_candidates = [item for item in all_ud if item.language == "orv-uk"]
+    ud_documents = {item.document_id for item in ud_candidates}
+    ud_token_rows = sum(len(item.tokens) for item in ud_candidates)
+    actual_ud_denominator = {
+        "documents": len(ud_documents),
+        "sentences": len(ud_candidates),
+        "token_rows": ud_token_rows,
+    }
+    _require(actual_ud_denominator == dict(expected_ud_denominator), "UD candidate denominator drift")
+    ud_by_id = {item.sent_id: item for item in ud_candidates}
+    _require(len(ud_by_id) == len(ud_candidates), "duplicate UD candidate sent_id")
+    selected_ud_ids = _select_canary(sorted(ud_by_id), ud_fraction, salt=UD_COLLECTION_ID)
+    selected_ud = [ud_by_id[item] for item in selected_ud_ids]
+    selected_ud_token_rows = sum(len(item.tokens) for item in selected_ud)
+
+    rows = load_plug2_metadata(plug2_metadata)
+    archive_files = inspect_plug2_archive(plug2_archive)
+    metadata_paths = {row["path"] for row in rows}
+    _require(metadata_paths == set(archive_files), "PluG2 metadata/archive path-set mismatch")
+    original_counts = Counter((row.get("doc.original") or "UNKNOWN") for row in rows)
+    orthography_counts = Counter((row.get("doc.orthography") or "unlabeled") for row in rows)
+    token_sum = sum(_metadata_nonnegative_int(row, "doc.tokenCount") for row in rows)
+    uk_rows = {row["path"]: row for row in rows if row.get("doc.original") == "UK"}
+    actual_plug2_denominator = {
+        "documents": len(rows),
+        "token_sum": token_sum,
+        "uk_documents": len(uk_rows),
+        "non_uk_or_unknown_documents": len(rows) - len(uk_rows),
+    }
+    _require(actual_plug2_denominator == dict(expected_plug2_denominator), "PluG2 denominator drift")
+    selected_plug2_paths = _select_canary(sorted(uk_rows), plug2_fraction, salt=PLUG2_COLLECTION_ID)
+    selected_plug2_tokens = sum(
+        _metadata_nonnegative_int(uk_rows[path], "doc.tokenCount") for path in selected_plug2_paths
+    )
+    candidate_plug2_tokens = sum(_metadata_nonnegative_int(row, "doc.tokenCount") for row in uk_rows.values())
+
+    plug2_record_counter = 0
+
+    def plug2_records() -> Iterator[Mapping[str, Any]]:
+        nonlocal plug2_record_counter
+        with zipfile.ZipFile(plug2_archive) as archive:
+            for member_path in selected_plug2_paths:
+                info = archive_files[member_path]
+                raw_bytes = archive.read(info)
+                try:
+                    document_text = raw_bytes.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise HistoricalMaterializationError(f"PluG2 member is not UTF-8: {member_path}") from exc
+                units = paragraph_units(document_text)
+                _require(bool(units), f"PluG2 document has no non-empty paragraphs: {member_path}")
+                for paragraph_index, (start, end, value) in enumerate(units):
+                    plug2_record_counter += 1
+                    yield build_plug2_record(
+                        row=uk_rows[member_path],
+                        member_bytes=raw_bytes,
+                        paragraph_index=paragraph_index,
+                        paragraph_start=start,
+                        paragraph_end=end,
+                        paragraph_text=value,
+                        archive_sha256=expected_plug2_archive_sha256,
+                        metadata_sha256=expected_plug2_metadata_sha256,
+                    )
+
+    private_output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(
+        tempfile.mkdtemp(
+            prefix=f".{private_output_dir.name}.staging-",
+            dir=private_output_dir.parent,
+        )
+    )
+    try:
+        ud_output = staging_dir / "ud-orv-uk-canary.jsonl.gz"
+        ud_record_count, ud_output_bytes, ud_output_sha256 = _write_jsonl_gzip(
+            ud_output, (build_ud_record(item) for item in selected_ud)
+        )
+        plug2_output = staging_dir / "plug2-uk-canary.jsonl.gz"
+        plug2_record_count, plug2_output_bytes, plug2_output_sha256 = _write_jsonl_gzip(plug2_output, plug2_records())
+        _require(plug2_record_count == plug2_record_counter, "PluG2 record counter drift")
+
+        ud_projection = _projection_gib(ud_output_bytes, selected_ud_token_rows, actual_ud_denominator["token_rows"])
+        plug2_projection = _projection_gib(plug2_output_bytes, selected_plug2_tokens, candidate_plug2_tokens)
+        total_projection = ud_projection + plug2_projection
+        _require(total_projection <= OUTPUT_CEILING_GIB, "projected compressed output exceeds 5 GiB ceiling")
+
+        receipt: dict[str, Any] = {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "mode": "canary",
+            "text_free": True,
+            "inputs": {
+                "ud": {
+                    "dataset_id": UD_COLLECTION_ID,
+                    "commit_sha": UD_COMMIT,
+                    "file_sha256": dict(expected_ud_sha256),
+                },
+                "plug2": {
+                    "dataset_id": PLUG2_COLLECTION_ID,
+                    "doi": PLUG2_DOI,
+                    "archive_sha256": expected_plug2_archive_sha256,
+                    "metadata_sha256": expected_plug2_metadata_sha256,
+                },
+            },
+            "denominators": {
+                "ud_explicit_orv_uk": actual_ud_denominator,
+                "ud_other_or_unresolved_sentences": len(all_ud) - len(ud_candidates),
+                "plug2": actual_plug2_denominator,
+                "plug2_original_counts": dict(sorted(original_counts.items())),
+                "plug2_orthography_counts": dict(sorted(orthography_counts.items())),
+                "plug2_candidate_uk_token_sum": candidate_plug2_tokens,
+            },
+            "selection": {
+                "algorithm": "sha256(dataset_id + ':' + immutable_unit_id), ascending",
+                "ud_fraction": ud_fraction,
+                "ud_selected_sentences": len(selected_ud_ids),
+                "ud_selection_sha256": sha256_value(selected_ud_ids),
+                "plug2_fraction": plug2_fraction,
+                "plug2_selected_documents": len(selected_plug2_paths),
+                "plug2_selection_sha256": sha256_value(selected_plug2_paths),
+            },
+            "outputs": {
+                "ud": {
+                    "filename": ud_output.name,
+                    "records": ud_record_count,
+                    "bytes": ud_output_bytes,
+                    "sha256": ud_output_sha256,
+                },
+                "plug2": {
+                    "filename": plug2_output.name,
+                    "records": plug2_record_count,
+                    "bytes": plug2_output_bytes,
+                    "sha256": plug2_output_sha256,
+                },
+            },
+            "projection": {
+                "ud_compressed_gib": ud_projection,
+                "plug2_compressed_gib": plug2_projection,
+                "total_compressed_gib": total_projection,
+                "ceiling_gib": OUTPUT_CEILING_GIB,
+                "within_ceiling": True,
+            },
+            "residuals": {
+                "ud_untagged_or_other_excluded": True,
+                "plug2_non_uk_or_unknown_excluded": True,
+                "unlabeled_orthography_not_inferred": True,
+                "periodization_unresolved_pending_qualified_evidence": True,
+                "full_materialization_authorized": False,
+            },
+            "safeguards": {
+                "historical_forms_protected": True,
+                "modern_correction_eligible": False,
+                "provider_calls": False,
+                "phase4_authorized": False,
+            },
+        }
+        _write_receipt(staging_dir / receipt_output.name, receipt)
+        os.replace(staging_dir, private_output_dir)
+        return receipt
+    finally:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ud-dir", type=Path, required=True)
+    parser.add_argument("--plug2-archive", type=Path, required=True)
+    parser.add_argument("--plug2-metadata", type=Path, required=True)
+    parser.add_argument("--private-output-dir", type=Path, required=True)
+    parser.add_argument("--receipt-output", type=Path, required=True)
+    parser.add_argument("--ud-fraction", type=float, default=0.01)
+    parser.add_argument("--plug2-fraction", type=float, default=0.001)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        receipt = materialize_canary(
+            ud_dir=args.ud_dir,
+            plug2_archive=args.plug2_archive,
+            plug2_metadata=args.plug2_metadata,
+            private_output_dir=args.private_output_dir,
+            receipt_output=args.receipt_output,
+            ud_fraction=args.ud_fraction,
+            plug2_fraction=args.plug2_fraction,
+        )
+    except HistoricalMaterializationError as exc:
+        print(canonical_json({"status": "blocked", "error": str(exc)}))
+        return 2
+    print(canonical_json({"status": "canary_complete", "receipt_sha256": sha256_value(receipt)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_open_model_phase3_historical_materialization.py
+++ b/tests/test_open_model_phase3_historical_materialization.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import json
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_historical_materialization as materialization
+from scripts.projects.open_model_data.phase3_historical_materialization import (
+    HistoricalMaterializationError,
+    build_ud_record,
+    file_sha256,
+    materialize_canary,
+    paragraph_units,
+    parse_conllu,
+)
+
+UD_FIXTURE = """# newdoc = uk__fixture__1413
+# lang = orv-uk
+# created = 1413
+# title = Fixture charter
+# sent_id = uk__fixture__1413-1
+# text = Во имя Отца и С[ы]на.
+1\tВо\tво\tADP\t_\t_\t2\tcase\t_\t_
+2\tимя\tимя\tNOUN\t_\tCase=Acc\t0\troot\t_\t_
+3\tОтца\tотецъ\tNOUN\t_\tCase=Gen\t2\tnmod\t_\t_
+4\tи\tи\tCCONJ\t_\t_\t5\tcc\t_\t_
+5\tС[ы]на\tсынъ\tNOUN\t_\tCase=Gen\t3\tconj\t_\tSpaceAfter=No
+6\t.\t.\tPUNCT\t_\t_\t2\tpunct\t_\t_
+
+# newdoc = adjacent__unresolved
+# sent_id = adjacent__unresolved-1
+# text = Не класифікувати.
+1\tНе\tне\tPART\t_\t_\t2\tadvmod\t_\t_
+2\tкласифікувати\tкласифікувати\tVERB\t_\tVerbForm=Inf\t0\troot\t_\tSpaceAfter=No
+3\t.\t.\tPUNCT\t_\t_\t2\tpunct\t_\t_
+"""
+
+PLUG_HEADERS = [
+    "path",
+    "doc.name",
+    "doc.date",
+    "doc.publicationYear",
+    "doc.tokenCount",
+    "doc.sentenceCount",
+    "doc.original",
+    "doc.style",
+    "doc.genre",
+    "doc.source",
+    "doc.orthography",
+    "doc.mediaName",
+    "doc.author",
+    "doc.authorSex",
+    "doc.authorBorn",
+    "doc.authorLocCode",
+    "doc.translator",
+    "doc.translatorSex",
+    "doc.translatorBorn",
+    "doc.translatorLocCode",
+    "doc.publication",
+    "doc.publicationCity",
+    "doc.publisher",
+]
+
+
+def _make_inputs(tmp_path: Path, *, unsafe_member: bool = False) -> tuple[Path, Path, Path]:
+    ud_dir = tmp_path / "ud"
+    ud_dir.mkdir()
+    ud_file = ud_dir / "fixture.conllu"
+    ud_file.write_text(UD_FIXTURE, encoding="utf-8")
+
+    metadata = tmp_path / "metadata.psv"
+    rows = [
+        {
+            "path": "A/uk.txt",
+            "doc.name": "Ukrainian fixture",
+            "doc.date": "1913",
+            "doc.publicationYear": "",
+            "doc.tokenCount": "8",
+            "doc.sentenceCount": "2",
+            "doc.original": "UK",
+            "doc.style": "FIC",
+            "doc.genre": "",
+            "doc.source": "PRI",
+            "doc.orthography": "",
+            "doc.mediaName": "",
+            "doc.author": "Fixture",
+            "doc.authorSex": "",
+            "doc.authorBorn": "",
+            "doc.authorLocCode": "UA-X",
+            "doc.translator": "",
+            "doc.translatorSex": "",
+            "doc.translatorBorn": "",
+            "doc.translatorLocCode": "",
+            "doc.publication": "",
+            "doc.publicationCity": "",
+            "doc.publisher": "",
+        },
+        {
+            "path": "B/context.txt",
+            "doc.name": "Context fixture",
+            "doc.date": "1914",
+            "doc.publicationYear": "",
+            "doc.tokenCount": "3",
+            "doc.sentenceCount": "1",
+            "doc.original": "PL",
+            "doc.style": "",
+            "doc.genre": "",
+            "doc.source": "PRI",
+            "doc.orthography": "ZHEL",
+            "doc.mediaName": "",
+            "doc.author": "Fixture",
+            "doc.authorSex": "",
+            "doc.authorBorn": "",
+            "doc.authorLocCode": "",
+            "doc.translator": "",
+            "doc.translatorSex": "",
+            "doc.translatorBorn": "",
+            "doc.translatorLocCode": "",
+            "doc.publication": "",
+            "doc.publicationCity": "",
+            "doc.publisher": "",
+        },
+    ]
+    with metadata.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=PLUG_HEADERS, delimiter="|", quotechar='"', quoting=csv.QUOTE_ALL)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    archive = tmp_path / "texts.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        handle.writestr("PLuG2_texts/", "")
+        handle.writestr("PLuG2_texts/A/", "")
+        handle.writestr("PLuG2_texts/B/", "")
+        handle.writestr("PLuG2_texts/A/uk.txt", "Перший рядок.\n\nДругий рядок.")
+        handle.writestr("PLuG2_texts/B/context.txt", "Nie kandydat.")
+        if unsafe_member:
+            handle.writestr("../escape.txt", "forbidden")
+    return ud_dir, archive, metadata
+
+
+def _fixture_arguments(
+    *,
+    ud_dir: Path,
+    archive: Path,
+    metadata: Path,
+    output: Path,
+    expected_ud_denominator: dict[str, int] | None = None,
+    expected_plug2_denominator: dict[str, int] | None = None,
+) -> dict[str, object]:
+    return {
+        "ud_dir": ud_dir,
+        "plug2_archive": archive,
+        "plug2_metadata": metadata,
+        "private_output_dir": output,
+        "receipt_output": output / "receipt.json",
+        "ud_fraction": 0.01,
+        "plug2_fraction": 0.01,
+        "expected_ud_sha256": {"fixture.conllu": file_sha256(ud_dir / "fixture.conllu")},
+        "expected_plug2_archive_sha256": file_sha256(archive),
+        "expected_plug2_metadata_sha256": file_sha256(metadata),
+        "expected_ud_denominator": expected_ud_denominator or {"documents": 1, "sentences": 1, "token_rows": 6},
+        "expected_plug2_denominator": expected_plug2_denominator
+        or {
+            "documents": 2,
+            "token_sum": 11,
+            "uk_documents": 1,
+            "non_uk_or_unknown_documents": 1,
+        },
+    }
+
+
+def _run(tmp_path: Path, *, unsafe_member: bool = False):
+    ud_dir, archive, metadata = _make_inputs(tmp_path, unsafe_member=unsafe_member)
+    output = tmp_path / "private"
+    receipt_path = output / "receipt.json"
+    ud_hash = file_sha256(ud_dir / "fixture.conllu")
+    receipt = materialize_canary(
+        ud_dir=ud_dir,
+        plug2_archive=archive,
+        plug2_metadata=metadata,
+        private_output_dir=output,
+        receipt_output=receipt_path,
+        ud_fraction=0.01,
+        plug2_fraction=0.01,
+        expected_ud_sha256={"fixture.conllu": ud_hash},
+        expected_plug2_archive_sha256=file_sha256(archive),
+        expected_plug2_metadata_sha256=file_sha256(metadata),
+        expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+        expected_plug2_denominator={
+            "documents": 2,
+            "token_sum": 11,
+            "uk_documents": 1,
+            "non_uk_or_unknown_documents": 1,
+        },
+    )
+    return receipt, output, receipt_path
+
+
+def test_conllu_analysis_maps_one_source_token_to_many_unicode_tokens(tmp_path: Path) -> None:
+    ud_dir, _, _ = _make_inputs(tmp_path)
+    source_hash = file_sha256(ud_dir / "fixture.conllu")
+    sentences = parse_conllu(ud_dir / "fixture.conllu", source_file_sha256=source_hash)
+    record = build_ud_record(sentences[0])
+    analysis = next(item for item in record["linguistic_analyses"] if item["source_surface"] == "С[ы]на")
+    assert len(analysis["token_ids"]) == 5
+    assert record["safeguards"]["modern_correction_eligible"] is False
+    assert record["provider_calls"] is False
+
+
+def test_rejects_cyclic_ud_dependency_graph(tmp_path: Path) -> None:
+    ud_dir, _, _ = _make_inputs(tmp_path)
+    path = ud_dir / "fixture.conllu"
+    path.write_text(
+        UD_FIXTURE.replace(
+            "2\tимя\tимя\tNOUN\t_\tCase=Acc\t0\troot",
+            "2\tимя\tимя\tNOUN\t_\tCase=Acc\t5\troot",
+        ),
+        encoding="utf-8",
+    )
+    sentences = parse_conllu(path, source_file_sha256=file_sha256(path))
+    with pytest.raises(HistoricalMaterializationError, match="dependency cycle"):
+        build_ud_record(sentences[0])
+
+
+def test_rejects_unknown_ud_dependency_head(tmp_path: Path) -> None:
+    ud_dir, _, _ = _make_inputs(tmp_path)
+    path = ud_dir / "fixture.conllu"
+    path.write_text(
+        UD_FIXTURE.replace(
+            "2\tимя\tимя\tNOUN\t_\tCase=Acc\t0\troot",
+            "2\tимя\tимя\tNOUN\t_\tCase=Acc\t99\troot",
+        ),
+        encoding="utf-8",
+    )
+    sentences = parse_conllu(path, source_file_sha256=file_sha256(path))
+    with pytest.raises(HistoricalMaterializationError, match="dependency head is unknown"):
+        build_ud_record(sentences[0])
+
+
+def test_rejects_duplicate_ud_token_id(tmp_path: Path) -> None:
+    ud_dir, _, _ = _make_inputs(tmp_path)
+    path = ud_dir / "fixture.conllu"
+    path.write_text(
+        UD_FIXTURE.replace(
+            "3\tОтца\tотецъ\tNOUN\t_\tCase=Gen\t2\tnmod",
+            "2\tОтца\tотецъ\tNOUN\t_\tCase=Gen\t2\tnmod",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(HistoricalMaterializationError, match="duplicate CoNLL-U token id"):
+        parse_conllu(path, source_file_sha256=file_sha256(path))
+
+
+def test_ud_overlap_is_rejected(tmp_path: Path) -> None:
+    ud_dir, _, _ = _make_inputs(tmp_path)
+    path = ud_dir / "fixture.conllu"
+    sentence = parse_conllu(path, source_file_sha256=file_sha256(path))[0]
+    text, spans = materialization._ud_surface(sentence)
+    overlapping_spans = list(spans)
+    overlapping_spans[1] = overlapping_spans[0]
+    with pytest.raises(HistoricalMaterializationError, match="overlap deterministic tokens"):
+        materialization._ud_analyses(sentence, text, overlapping_spans)
+
+
+def test_canary_is_deterministic_text_private_and_receipt_text_free(tmp_path: Path) -> None:
+    receipt, output, receipt_path = _run(tmp_path)
+    first_hashes = {path.name: file_sha256(path) for path in output.iterdir()}
+    second_output = tmp_path / "private-second"
+    second_receipt = second_output / "receipt.json"
+    ud_dir = tmp_path / "ud"
+    materialize_canary(
+        ud_dir=ud_dir,
+        plug2_archive=tmp_path / "texts.zip",
+        plug2_metadata=tmp_path / "metadata.psv",
+        private_output_dir=second_output,
+        receipt_output=second_receipt,
+        ud_fraction=0.01,
+        plug2_fraction=0.01,
+        expected_ud_sha256={"fixture.conllu": file_sha256(ud_dir / "fixture.conllu")},
+        expected_plug2_archive_sha256=file_sha256(tmp_path / "texts.zip"),
+        expected_plug2_metadata_sha256=file_sha256(tmp_path / "metadata.psv"),
+        expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+        expected_plug2_denominator={
+            "documents": 2,
+            "token_sum": 11,
+            "uk_documents": 1,
+            "non_uk_or_unknown_documents": 1,
+        },
+    )
+    assert first_hashes == {path.name: file_sha256(path) for path in output.iterdir()}
+    assert receipt == json.loads(second_receipt.read_text(encoding="utf-8"))
+    receipt_text = receipt_path.read_text(encoding="utf-8")
+    assert "Перший рядок" not in receipt_text
+    assert "Во имя" not in receipt_text
+    assert receipt["denominators"]["plug2_original_counts"] == {"PL": 1, "UK": 1}
+    assert receipt["residuals"]["plug2_non_uk_or_unknown_excluded"] is True
+    with gzip.open(output / "plug2-uk-canary.jsonl.gz", "rt", encoding="utf-8") as handle:
+        records = [json.loads(line) for line in handle]
+    assert len(records) == 2
+    assert all(item["historical_context"]["orthography"] is None for item in records)
+
+
+def test_paragraph_unitization_preserves_exact_offsets() -> None:
+    source = "  Перший.  \r\n\r\nДругий.\n"
+    units = paragraph_units(source)
+    assert [(start, end) for start, end, _ in units] == [(0, 11), (15, 22)]
+    assert all(source[start:end] == text for start, end, text in units)
+
+
+def test_rejects_canary_fraction_above_one_percent(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    with pytest.raises(HistoricalMaterializationError, match="canary fraction"):
+        materialize_canary(
+            ud_dir=ud_dir,
+            plug2_archive=archive,
+            plug2_metadata=metadata,
+            private_output_dir=tmp_path / "private",
+            receipt_output=tmp_path / "private" / "receipt.json",
+            ud_fraction=0.02,
+            expected_ud_sha256={"fixture.conllu": file_sha256(ud_dir / "fixture.conllu")},
+            expected_plug2_archive_sha256=file_sha256(archive),
+            expected_plug2_metadata_sha256=file_sha256(metadata),
+            expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+            expected_plug2_denominator={
+                "documents": 2,
+                "token_sum": 11,
+                "uk_documents": 1,
+                "non_uk_or_unknown_documents": 1,
+            },
+        )
+
+
+def test_rejects_private_output_inside_any_git_checkout(tmp_path: Path) -> None:
+    checkout = tmp_path / "other-checkout"
+    (checkout / ".git").mkdir(parents=True)
+    output = checkout / "private-output"
+    with pytest.raises(HistoricalMaterializationError, match="inside a Git checkout"):
+        materialize_canary(
+            ud_dir=tmp_path / "missing-ud",
+            plug2_archive=tmp_path / "missing.zip",
+            plug2_metadata=tmp_path / "missing.psv",
+            private_output_dir=output,
+            receipt_output=output / "receipt.json",
+        )
+
+
+def test_rejects_existing_immutable_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    output = tmp_path / "private"
+    output.mkdir()
+    with pytest.raises(HistoricalMaterializationError, match="already exists"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+
+
+def test_rejects_hash_drift_before_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    with pytest.raises(HistoricalMaterializationError, match="SHA-256 mismatch"):
+        materialize_canary(
+            ud_dir=ud_dir,
+            plug2_archive=archive,
+            plug2_metadata=metadata,
+            private_output_dir=tmp_path / "private",
+            receipt_output=tmp_path / "private" / "receipt.json",
+            expected_ud_sha256={"fixture.conllu": "0" * 64},
+            expected_plug2_archive_sha256=file_sha256(archive),
+            expected_plug2_metadata_sha256=file_sha256(metadata),
+            expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+            expected_plug2_denominator={
+                "documents": 2,
+                "token_sum": 11,
+                "uk_documents": 1,
+                "non_uk_or_unknown_documents": 1,
+            },
+        )
+    assert not (tmp_path / "private").exists()
+
+
+def test_rejects_projection_above_ceiling_without_promotion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    output = tmp_path / "private"
+    monkeypatch.setattr(materialization, "OUTPUT_CEILING_GIB", 0.0)
+    with pytest.raises(HistoricalMaterializationError, match="exceeds 5 GiB ceiling"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+    assert not output.exists()
+    assert not list(tmp_path.glob(".private.staging-*"))
+
+
+def test_rejects_unsafe_zip_member(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path, unsafe_member=True)
+    with pytest.raises(HistoricalMaterializationError, match="unsafe ZIP member"):
+        materialize_canary(
+            ud_dir=ud_dir,
+            plug2_archive=archive,
+            plug2_metadata=metadata,
+            private_output_dir=tmp_path / "private",
+            receipt_output=tmp_path / "private" / "receipt.json",
+            expected_ud_sha256={"fixture.conllu": file_sha256(ud_dir / "fixture.conllu")},
+            expected_plug2_archive_sha256=file_sha256(archive),
+            expected_plug2_metadata_sha256=file_sha256(metadata),
+            expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+            expected_plug2_denominator={
+                "documents": 2,
+                "token_sum": 11,
+                "uk_documents": 1,
+                "non_uk_or_unknown_documents": 1,
+            },
+        )
+    assert not (tmp_path / "private").exists()
+
+
+def test_rejects_zip_symlink_member_before_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    symlink = zipfile.ZipInfo("PLuG2_texts/link.txt")
+    symlink.create_system = 3
+    symlink.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(archive, "a") as handle:
+        handle.writestr(symlink, "A/uk.txt")
+    output = tmp_path / "private"
+    with pytest.raises(HistoricalMaterializationError, match="unsafe ZIP symlink member"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+    assert not output.exists()
+
+
+def test_rejects_unexpected_zip_root_before_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    with zipfile.ZipFile(archive, "a") as handle:
+        handle.writestr("WrongRoot/extra.txt", "forbidden")
+    output = tmp_path / "private"
+    with pytest.raises(HistoricalMaterializationError, match="unexpected PluG2 ZIP root"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+    assert not output.exists()
+
+
+def test_rejects_duplicate_zip_member_before_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    with zipfile.ZipFile(archive, "a") as handle, pytest.warns(UserWarning, match="Duplicate name"):
+        handle.writestr("PLuG2_texts/A/uk.txt", "duplicate")
+    output = tmp_path / "private"
+    with pytest.raises(HistoricalMaterializationError, match="duplicate PluG2 ZIP member"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("denominator", "expected_message"),
+    [
+        ("ud", "UD candidate denominator drift"),
+        ("plug2", "PluG2 denominator drift"),
+    ],
+)
+def test_rejects_denominator_drift_before_output(
+    tmp_path: Path,
+    denominator: str,
+    expected_message: str,
+) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    output = tmp_path / "private"
+    arguments = _fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output)
+    if denominator == "ud":
+        arguments["expected_ud_denominator"] = {"documents": 2, "sentences": 1, "token_rows": 6}
+    else:
+        arguments["expected_plug2_denominator"] = {
+            "documents": 3,
+            "token_sum": 11,
+            "uk_documents": 1,
+            "non_uk_or_unknown_documents": 1,
+        }
+    with pytest.raises(HistoricalMaterializationError, match=expected_message):
+        materialize_canary(**arguments)
+    assert not output.exists()
+
+
+def test_rejects_malformed_metadata_integer_before_output(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    metadata.write_text(metadata.read_text(encoding="utf-8").replace('"8"', '"not-an-int"', 1), encoding="utf-8")
+    output = tmp_path / "private"
+    with pytest.raises(HistoricalMaterializationError, match="invalid PluG2 integer field"):
+        materialize_canary(**_fixture_arguments(ud_dir=ud_dir, archive=archive, metadata=metadata, output=output))
+    assert not output.exists()
+
+
+def test_receipt_schema_rejects_unbounded_count_keys(tmp_path: Path) -> None:
+    receipt, _, _ = _run(tmp_path)
+    receipt["denominators"]["plug2_original_counts"] = {"raw prose": 1}
+    with pytest.raises(HistoricalMaterializationError, match="receipt schema violation"):
+        materialization._validate_receipt(receipt)
+
+
+def test_rejects_metadata_archive_path_mismatch(tmp_path: Path) -> None:
+    ud_dir, archive, metadata = _make_inputs(tmp_path)
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        handle.writestr("PLuG2_texts/A/uk.txt", "Перший рядок.")
+    with pytest.raises(HistoricalMaterializationError, match="path-set mismatch"):
+        materialize_canary(
+            ud_dir=ud_dir,
+            plug2_archive=archive,
+            plug2_metadata=metadata,
+            private_output_dir=tmp_path / "private",
+            receipt_output=tmp_path / "private" / "receipt.json",
+            expected_ud_sha256={"fixture.conllu": file_sha256(ud_dir / "fixture.conllu")},
+            expected_plug2_archive_sha256=file_sha256(archive),
+            expected_plug2_metadata_sha256=file_sha256(metadata),
+            expected_ud_denominator={"documents": 1, "sentences": 1, "token_rows": 6},
+            expected_plug2_denominator={
+                "documents": 2,
+                "token_sum": 11,
+                "uk_documents": 1,
+                "non_uk_or_unknown_documents": 1,
+            },
+        )


### PR DESCRIPTION
## What changed

- add a deterministic, streaming Phase 3 historical-corpus canary materializer
- freeze a strict, text-free receipt schema
- add adversarial tests for input hashes, denominator drift, unsafe ZIP paths, dependency cycles, Unicode token mapping, immutable atomic output, and language-role separation

## Why

Phase 3 now has a protected historical representation, but the open historical corpora still need a safe bridge into that representation. This PR adds that bridge without bulk extraction, a second raw-corpus copy, provider calls, or any route into modern correction gold.

Only explicitly tagged `orv-uk` UD documents and PluG2 rows with `doc.original=UK` enter candidate shards. Untagged/other UD data, non-UK/unknown PluG2 rows, and blank orthography labels remain explicit residuals.

## Live canary

The exact code materialized a private Drive canary after auditing the complete pinned inputs:

- UD denominator: 82 documents / 1,311 sentences / 35,081 token rows
- PluG2 denominator: 56,245 documents / 74,497,787 metadata tokens
- candidate lane: 56,080 `UK` documents / 71,802,066 metadata tokens
- sample: 14 UD sentences and 57 PluG2 documents
- output: 14 UD records and 521 PluG2 paragraph records
- compressed full-run projection: 1.8482 GiB, below the frozen 5 GiB ceiling
- every one of the 535 emitted records passed the historical representation validator
- all output files and the checksum manifest report uploaded in Google Drive with no upload error

The receipt stays text-free; source-bearing JSONL is written only to the caller-supplied private directory.

## Validation

```text
72 passed in 3.25s
Ruff: All checks passed
receipt schema: valid Draft 2020-12 JSON Schema
git diff --check: clean
live output gzip/checksum/record validation: passed
```

## Boundaries

- full materialization remains unauthorized until exact-head review and CI pass
- periodization remains unresolved unless linked to qualified historical evidence
- historical forms remain protected and ineligible for modern correction gold
- Phase 4 and provider calls remain blocked

Closes part of #6375. Epic: #6321.
