### PR TITLE
fix(infra): reclaim ad-hoc /tmp review clones

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -209,3 +209,22 @@ worktrees appear as `skipped`, not `removed`.
 ```
 
 Uninstalling preserves receipts and logs for audit and recovery.
+
+## Ad-hoc `/tmp` leak sweep
+
+Agents sometimes leave full clones under `/tmp` outside the formal review isolation
+prefixes (`review-6621`, `pr6591-exact-*`, `lu-*`, local CI fixtures). Those trees do
+not match `sweep_review_temp_orphans` and will refill the disk within hours.
+
+```bash
+# dry-run
+.venv/bin/python -m scripts.orchestration.tmp_leak_sweep
+
+# apply
+.venv/bin/python -m scripts.orchestration.tmp_leak_sweep --apply
+```
+
+The scheduled git-hygiene runner (`scheduled_worktree_cleanup.py`) invokes the same
+sweep after the review-temp reaper. Age gates: 2h normally, 30m when free space is
+under 15 GiB. Live process paths are skipped.
+

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -452,6 +452,22 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
                 )
         except Exception as exc:
             result["errors"].append(f"review temp sweep failed: {exc}")
+        try:
+            leak_res = sweep_tmp_leaks(apply=apply)
+            result["tmp_leak_sweep"] = {
+                "roots_reaped": leak_res.get("roots_reaped", 0),
+                "bytes_freed": leak_res.get("bytes_freed", 0),
+                "candidates": leak_res.get("candidates", 0),
+                "skipped_live": leak_res.get("skipped_live", 0),
+                "errors": leak_res.get("errors", 0),
+                "disk_pressure": leak_res.get("disk_pressure"),
+            }
+            if leak_res.get("errors"):
+                result["errors"].append(
+                    f"tmp leak sweep encountered {leak_res['errors']} error(s)"
+                )
+        except Exception as exc:
+            result["errors"].append(f"tmp leak sweep failed: {exc}")
 
         result["needs_finalize_worktrees"] = (
             reap_worktrees.find_needs_finalize_worktrees(repo_root)

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -28,6 +28,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.orchestration import reap_worktrees
+from scripts.orchestration.tmp_leak_sweep import sweep_tmp_leaks
 from scripts.review.isolation import sweep_review_temp_orphans
 
 SCHEMA_VERSION = "scheduled-git-hygiene.v2"

--- a/scripts/orchestration/tmp_leak_sweep.py
+++ b/scripts/orchestration/tmp_leak_sweep.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Reap ad-hoc LU temp trees under $TMPDIR that isolation sweeps miss.
+
+Agents and one-shot review flows leave multi-GB directories such as
+``/tmp/review-6621`` (full clones) and ``/tmp/pr6591-exact-*``.  Formal
+``sweep_review_temp_orphans`` only reaps ``lu-review-*`` / shielded-reviews
+manifests, so these names never drain without manual intervention.
+
+This module is age-gated, name-pattern scoped, and fail-open on live
+processes.  It is not a blanket ``rm -rf /tmp/*``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# 2h normal; 30m under disk pressure.
+DEFAULT_MIN_AGE_S = 2 * 60 * 60
+DEFAULT_PRESSURE_MIN_AGE_S = 30 * 60
+DEFAULT_MIN_FREE_GB = 15.0
+
+# Basename-only patterns for LU-owned ad-hoc temp residue.
+_LEAK_NAME_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^review-\d+"),
+    re.compile(r"^pr\d+"),
+    re.compile(r"^lu-"),
+    re.compile(r"^atlas6507-"),
+    re.compile(r"^data_test_"),
+    re.compile(r"^data_debug"),
+    re.compile(r"^hramatka-"),
+    re.compile(r"^h409-"),
+    re.compile(r"^infra-review-"),
+    re.compile(r"^ci-\d+"),
+    re.compile(r"^\d{4}-thog$"),
+    re.compile(r"^\d{4}-fix$"),
+    re.compile(r"^\d{4}-pytest"),
+)
+
+
+@dataclass(frozen=True)
+class LeakCandidate:
+    """One age-eligible temp path matching a known leak pattern."""
+
+    path: Path
+    age_s: float
+    size_bytes: int
+
+
+def default_tmp_roots() -> list[Path]:
+    """Return distinct existing temp roots to scan (never $HOME)."""
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for raw in (tempfile.gettempdir(), "/private/tmp", "/tmp"):
+        if not raw:
+            continue
+        path = Path(raw)
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        if not resolved.is_dir() or resolved.is_symlink():
+            continue
+        # Refuse to treat a home directory (or anything under it) as a tmp root.
+        home = Path.home().resolve()
+        try:
+            resolved.relative_to(home)
+            continue
+        except ValueError:
+            pass
+        seen.add(resolved)
+        roots.append(resolved)
+    return roots
+
+
+def name_matches_leak_pattern(name: str) -> bool:
+    """Return whether a basename is an LU ad-hoc temp leak pattern."""
+    return any(pattern.search(name) for pattern in _LEAK_NAME_PATTERNS)
+
+
+def free_space_gb(path: Path) -> float | None:
+    """Return free space in GiB for the volume containing ``path``."""
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return None
+    return usage.free / (1024**3)
+
+
+def path_has_live_process(path: Path) -> bool:
+    """Best-effort check: any process whose cmdline mentions this path."""
+    try:
+        completed = subprocess.run(
+            ["pgrep", "-f", str(path)],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        # Fail open: cannot prove live → treat as not live for age-gated junk,
+        # but still only delete pattern matches older than min_age.
+        return False
+    return completed.returncode == 0
+
+
+def _entry_age_s(path: Path, *, now: float) -> float | None:
+    try:
+        st = path.lstat()
+    except OSError:
+        return None
+    # Use mtime only. On APFS, os.utime() refreshes ctime to "now", so
+    # max(mtime, ctime) would always look young in tests and after touch-ups.
+    return max(0.0, now - st.st_mtime)
+
+
+def _entry_size_bytes(path: Path) -> int:
+    try:
+        completed = subprocess.run(
+            ["du", "-sk", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return 0
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return 0
+    try:
+        kib = int(completed.stdout.split()[0])
+    except (TypeError, ValueError, IndexError):
+        return 0
+    return kib * 1024
+
+
+def discover_candidates(
+    tmp_roots: list[Path],
+    *,
+    now: float | None = None,
+    min_age_s: float = DEFAULT_MIN_AGE_S,
+) -> list[LeakCandidate]:
+    """List age-eligible leak-pattern entries under the given tmp roots."""
+    current = time.time() if now is None else now
+    found: list[LeakCandidate] = []
+    for root in tmp_roots:
+        try:
+            children = list(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if not name_matches_leak_pattern(child.name):
+                continue
+            try:
+                st = child.lstat()
+            except OSError:
+                continue
+            if stat.S_ISLNK(st.st_mode):
+                continue
+            if not (stat.S_ISDIR(st.st_mode) or stat.S_ISREG(st.st_mode)):
+                continue
+            age = _entry_age_s(child, now=current)
+            if age is None or age < min_age_s:
+                continue
+            found.append(
+                LeakCandidate(
+                    path=child,
+                    age_s=age,
+                    size_bytes=_entry_size_bytes(child),
+                )
+            )
+    return found
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def sweep_tmp_leaks(
+    *,
+    apply: bool = False,
+    tmp_roots: list[Path] | None = None,
+    now: float | None = None,
+    min_age_s: float = DEFAULT_MIN_AGE_S,
+    pressure_min_age_s: float = DEFAULT_PRESSURE_MIN_AGE_S,
+    min_free_gb: float = DEFAULT_MIN_FREE_GB,
+) -> dict[str, Any]:
+    """Discover and optionally delete age-gated LU temp leaks.
+
+    Returns a body-free summary suitable for scheduled hygiene receipts.
+    """
+    current = time.time() if now is None else now
+    roots = list(tmp_roots) if tmp_roots is not None else default_tmp_roots()
+    free_gb: float | None = None
+    for root in roots:
+        free_gb = free_space_gb(root)
+        if free_gb is not None:
+            break
+    under_pressure = free_gb is not None and free_gb < min_free_gb
+    effective_min_age = pressure_min_age_s if under_pressure else min_age_s
+
+    candidates = discover_candidates(roots, now=current, min_age_s=effective_min_age)
+    result: dict[str, Any] = {
+        "apply": apply,
+        "tmp_roots": [str(r) for r in roots],
+        "free_gb": free_gb,
+        "disk_pressure": under_pressure,
+        "min_age_s": effective_min_age,
+        "candidates": len(candidates),
+        "roots_reaped": 0,
+        "bytes_freed": 0,
+        "skipped_live": 0,
+        "errors": 0,
+        "reaped": [],
+        "skipped": [],
+    }
+
+    for candidate in candidates:
+        if path_has_live_process(candidate.path):
+            result["skipped_live"] += 1
+            result["skipped"].append(
+                {"path": str(candidate.path), "reason": "live_process"}
+            )
+            continue
+        if not apply:
+            result["reaped"].append(
+                {
+                    "path": str(candidate.path),
+                    "bytes": candidate.size_bytes,
+                    "age_s": int(candidate.age_s),
+                    "action": "would_reap",
+                }
+            )
+            continue
+        try:
+            size = candidate.size_bytes or _entry_size_bytes(candidate.path)
+            _remove_path(candidate.path)
+            # Confirm gone; if still present count as error.
+            if candidate.path.exists():
+                result["errors"] += 1
+                result["skipped"].append(
+                    {"path": str(candidate.path), "reason": "survived_remove"}
+                )
+                continue
+            result["roots_reaped"] += 1
+            result["bytes_freed"] += size
+            result["reaped"].append(
+                {
+                    "path": str(candidate.path),
+                    "bytes": size,
+                    "age_s": int(candidate.age_s),
+                    "action": "reaped",
+                }
+            )
+        except OSError:
+            result["errors"] += 1
+            result["skipped"].append(
+                {"path": str(candidate.path), "reason": "os_error"}
+            )
+    return result
+
+
+def _print_human(report: dict[str, Any]) -> None:
+    mode = "APPLY" if report.get("apply") else "DRY-RUN"
+    free = report.get("free_gb")
+    free_s = f"{free:.1f} GiB free" if isinstance(free, (int, float)) else "free unknown"
+    print(
+        f"tmp leak sweep [{mode}]: candidates={report['candidates']} "
+        f"reaped={report['roots_reaped']} skipped_live={report['skipped_live']} "
+        f"errors={report['errors']} bytes_freed={report['bytes_freed']} ({free_s})"
+    )
+    for item in report.get("reaped") or []:
+        print(
+            f"  {item.get('action')}: {item.get('path')} "
+            f"({item.get('bytes', 0)} bytes, age={item.get('age_s')}s)"
+        )
+    for item in report.get("skipped") or []:
+        print(f"  skip: {item.get('path')} ({item.get('reason')})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="delete candidates (default is dry-run)",
+    )
+    parser.add_argument(
+        "--min-age-s",
+        type=float,
+        default=DEFAULT_MIN_AGE_S,
+        help=f"minimum age in seconds when disk is healthy (default {DEFAULT_MIN_AGE_S})",
+    )
+    parser.add_argument(
+        "--pressure-min-age-s",
+        type=float,
+        default=DEFAULT_PRESSURE_MIN_AGE_S,
+        help=f"minimum age under disk pressure (default {DEFAULT_PRESSURE_MIN_AGE_S})",
+    )
+    parser.add_argument(
+        "--min-free-gb",
+        type=float,
+        default=DEFAULT_MIN_FREE_GB,
+        help=f"free-space threshold for pressure mode (default {DEFAULT_MIN_FREE_GB})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print JSON report instead of human summary",
+    )
+    args = parser.parse_args(argv)
+
+    report = sweep_tmp_leaks(
+        apply=args.apply,
+        min_age_s=args.min_age_s,
+        pressure_min_age_s=args.pressure_min_age_s,
+        min_free_gb=args.min_free_gb,
+    )
+    if args.json:
+        import json
+
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_human(report)
+    return 1 if report.get("errors") else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/tmp_leak_sweep.py
+++ b/scripts/orchestration/tmp_leak_sweep.py
@@ -13,6 +13,7 @@ processes.  It is not a blanket ``rm -rf /tmp/*``.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import stat
@@ -31,7 +32,7 @@ DEFAULT_MIN_FREE_GB = 15.0
 # Basename-only patterns for LU-owned ad-hoc temp residue.
 _LEAK_NAME_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^review-\d+"),
-    re.compile(r"^pr\d+"),
+    re.compile(r"^pr\d+"),  # pr + digits only (not pr* / process_ / protocol_)
     re.compile(r"^lu-"),
     re.compile(r"^atlas6507-"),
     re.compile(r"^data_test_"),
@@ -95,6 +96,15 @@ def free_space_gb(path: Path) -> float | None:
     except OSError:
         return None
     return usage.free / (1024**3)
+
+
+
+def path_owned_by_self(path: Path) -> bool:
+    """Return True when the entry is owned by the current effective UID."""
+    try:
+        return path.lstat().st_uid == os.geteuid()
+    except OSError:
+        return False
 
 
 def path_has_live_process(path: Path) -> bool:
@@ -170,6 +180,8 @@ def discover_candidates(
                 continue
             age = _entry_age_s(child, now=current)
             if age is None or age < min_age_s:
+                continue
+            if not path_owned_by_self(child):
                 continue
             found.append(
                 LeakCandidate(

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -73,6 +73,7 @@ def test_scheduled_cleanup_enables_terminal_dispatch_class_by_default(
     monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
     monkeypatch.setattr(cleanup, "_git_maintenance", lambda _repo, *, apply: {"ok": True})
     monkeypatch.setattr(cleanup, "sweep_review_temp_orphans", lambda: {"errors": 0})
+    monkeypatch.setattr(cleanup, "sweep_tmp_leaks", lambda apply=False: {"errors": 0, "roots_reaped": 0, "bytes_freed": 0, "candidates": 0, "skipped_live": 0})
 
     cleanup._repo_result(repo, apply=False)
 
@@ -95,6 +96,7 @@ def test_scheduled_terminal_dispatch_class_can_be_disabled(tmp_path: Path, monke
     monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
     monkeypatch.setattr(cleanup, "_git_maintenance", lambda _repo, *, apply: {"ok": True})
     monkeypatch.setattr(cleanup, "sweep_review_temp_orphans", lambda: {"errors": 0})
+    monkeypatch.setattr(cleanup, "sweep_tmp_leaks", lambda apply=False: {"errors": 0, "roots_reaped": 0, "bytes_freed": 0, "candidates": 0, "skipped_live": 0})
 
     cleanup._repo_result(repo, apply=False)
 

--- a/tests/orchestration/test_tmp_leak_sweep.py
+++ b/tests/orchestration/test_tmp_leak_sweep.py
@@ -1,0 +1,107 @@
+"""Tests for ad-hoc /tmp leak sweep (# disk pressure)."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from scripts.orchestration import tmp_leak_sweep as tls
+
+
+def _touch_old(path: Path, *, age_s: float, as_file: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if as_file or path.suffix:
+        path.write_text("x", encoding="utf-8")
+    else:
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "marker").write_text("x", encoding="utf-8")
+    past = time.time() - age_s
+    os.utime(path, (past, past))
+
+
+def test_name_patterns_match_known_leaks() -> None:
+    assert tls.name_matches_leak_pattern("review-6621")
+    assert tls.name_matches_leak_pattern("pr6591-exact-ujs9Ng")
+    assert tls.name_matches_leak_pattern("lu-agent-runtime-git")
+    assert tls.name_matches_leak_pattern("data_test_pipe3")
+    assert tls.name_matches_leak_pattern("atlas6507-build.DnfqH3")
+    assert not tls.name_matches_leak_pattern("com.apple.imagent")
+    assert not tls.name_matches_leak_pattern("claude-501")
+    assert not tls.name_matches_leak_pattern("cc-socks")
+    assert not tls.name_matches_leak_pattern("random-scratch")
+
+
+def test_discover_skips_young_and_unrelated(tmp_path: Path) -> None:
+    old = tmp_path / "review-1001"
+    young = tmp_path / "review-1002"
+    safe = tmp_path / "com.apple.foo"
+    _touch_old(old, age_s=10_000)
+    _touch_old(young, age_s=30)
+    _touch_old(safe, age_s=10_000)
+
+    found = tls.discover_candidates([tmp_path], now=time.time(), min_age_s=3600)
+    names = {c.path.name for c in found}
+    assert "review-1001" in names
+    assert "review-1002" not in names
+    assert "com.apple.foo" not in names
+
+
+def test_dry_run_does_not_delete(tmp_path: Path) -> None:
+    target = tmp_path / "pr6568"
+    _touch_old(target, age_s=10_000)
+    report = tls.sweep_tmp_leaks(
+        apply=False,
+        tmp_roots=[tmp_path],
+        now=time.time(),
+        min_age_s=3600,
+        min_free_gb=0.0,  # force non-pressure ages via min_age_s
+    )
+    assert report["candidates"] >= 1
+    assert report["roots_reaped"] == 0
+    assert target.exists()
+    assert any(item["action"] == "would_reap" for item in report["reaped"])
+
+
+def test_apply_reaps_old_candidate(tmp_path: Path) -> None:
+    target = tmp_path / "review-2002"
+    _touch_old(target, age_s=10_000)
+    report = tls.sweep_tmp_leaks(
+        apply=True,
+        tmp_roots=[tmp_path],
+        now=time.time(),
+        min_age_s=3600,
+        min_free_gb=0.0,
+    )
+    assert report["roots_reaped"] == 1
+    assert not target.exists()
+    assert report["bytes_freed"] > 0
+
+
+def test_live_process_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "review-3003"
+    _touch_old(target, age_s=10_000)
+    monkeypatch.setattr(tls, "path_has_live_process", lambda _path: True)
+    report = tls.sweep_tmp_leaks(
+        apply=True,
+        tmp_roots=[tmp_path],
+        now=time.time(),
+        min_age_s=3600,
+        min_free_gb=0.0,
+    )
+    assert report["roots_reaped"] == 0
+    assert report["skipped_live"] == 1
+    assert target.exists()
+
+
+def test_pressure_shortens_age(tmp_path: Path, monkeypatch) -> None:
+    """Under free-space pressure, 45-minute-old leak is eligible."""
+    target = tmp_path / "pr7001-exact-abc"
+    _touch_old(target, age_s=45 * 60)
+    monkeypatch.setattr(tls, "free_space_gb", lambda _path: 5.0)
+    found = tls.discover_candidates(
+        [tmp_path],
+        now=time.time(),
+        min_age_s=tls.DEFAULT_PRESSURE_MIN_AGE_S,
+    )
+    assert any(c.path.name == "pr7001-exact-abc" for c in found)

--- a/tests/review/test_temp_lifecycle.py
+++ b/tests/review/test_temp_lifecycle.py
@@ -147,6 +147,7 @@ def test_fetch_failure_degrades_gracefully(tmp_path: Path, monkeypatch: pytest.M
     monkeypatch.setattr(scheduled_worktree_cleanup, "find_orphaned_worktree_directories", lambda r: [])
     monkeypatch.setattr(scheduled_worktree_cleanup, "_git_maintenance", lambda r, apply: {"ok": True})
     monkeypatch.setattr(scheduled_worktree_cleanup, "sweep_review_temp_orphans", lambda: {"roots_reaped": 0})
+    monkeypatch.setattr(scheduled_worktree_cleanup, "sweep_tmp_leaks", lambda apply=False: {"roots_reaped": 0, "bytes_freed": 0, "errors": 0, "candidates": 0, "skipped_live": 0})
 
     res = scheduled_worktree_cleanup._repo_result_unlocked(repo, apply=False)
     assert any("fetch failed" in err for err in res["errors"])


### PR DESCRIPTION
## Summary
- Add `scripts/orchestration/tmp_leak_sweep.py` for age-gated removal of known LU temp leak patterns (`review-NNNN`, `prNNNN*`, `lu-*`, atlas/hramatka fixtures, …)
- Wire into `scheduled_worktree_cleanup.py` after the formal review-temp reaper
- Document in `docs/runbooks/worktree-cleanup.md`
- Unit tests for pattern match, age gate, live-process skip, dry-run vs apply

## Why
Disk pressure investigation: `/private/tmp` repeatedly grew to multi-GB from full repo clones left by ad-hoc CF/review sandboxes. Formal `sweep_review_temp_orphans` only covers `lu-review-*` / shielded-reviews.

## Test plan
- [x] `pytest tests/orchestration/test_tmp_leak_sweep.py tests/orchestration/test_scheduled_worktree_cleanup.py`
- [x] dry-run lists real `$TMPDIR` candidates
- [ ] CI green