### PR TITLE
feat(open-model-data): gate Phase 3 university source admission

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_university_source_admission_gate_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_admission_gate_v1.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_university_source_admission_gate_v1.schema.json",
+  "title": "Phase 3 university source-admission gate v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "text_free",
+    "bindings",
+    "transport",
+    "denominator_count",
+    "denominator",
+    "disposition_counts",
+    "topic_counts",
+    "scope_review_finding_counts",
+    "rights_and_exactness_residual_count",
+    "complete_residual_count",
+    "decisions",
+    "scope_review_ready",
+    "policy_generation_ready",
+    "database_ingest_authorized",
+    "source_freeze_ready",
+    "phase3_complete",
+    "phase4_blocked",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_university_source_admission_gate_v1"},
+    "text_free": {"const": true},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256",
+        "university_source_matrix_v3_sha256",
+        "tracked_university_policy_v3_sha256",
+        "university_corpus_reconciliation_v3_sha256",
+        "final_drive_backup_receipt_sha256",
+        "review_sha256",
+        "scope_review_sha256"
+      ],
+      "properties": {
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_recovery_prompt_v2_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_matrix_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "tracked_university_policy_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "university_corpus_reconciliation_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "final_drive_backup_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "review_sha256": {"$ref": "#/$defs/sha256"},
+        "scope_review_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ukrainian_review", "scope_review"],
+      "properties": {
+        "ukrainian_review": {"$ref": "#/$defs/transportReceipt"},
+        "scope_review": {"$ref": "#/$defs/transportReceipt"}
+      }
+    },
+    "denominator_count": {"const": 11},
+    "denominator": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "disposition_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["admit_scoped", "contextual_only", "quarantine", "needs_more_evidence"],
+      "properties": {
+        "admit_scoped": {"type": "integer", "minimum": 0},
+        "contextual_only": {"type": "integer", "minimum": 0},
+        "quarantine": {"type": "integer", "minimum": 0},
+        "needs_more_evidence": {"type": "integer", "minimum": 0}
+      }
+    },
+    "topic_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sufficient", "partial", "missing", "total"],
+      "properties": {
+        "sufficient": {"type": "integer", "minimum": 0},
+        "partial": {"type": "integer", "minimum": 0},
+        "missing": {"type": "integer", "minimum": 0},
+        "total": {"const": 26}
+      }
+    },
+    "scope_review_finding_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["material", "minor"],
+      "properties": {
+        "material": {"type": "integer", "minimum": 0},
+        "minor": {"type": "integer", "minimum": 0}
+      }
+    },
+    "rights_and_exactness_residual_count": {"type": "integer", "minimum": 0},
+    "complete_residual_count": {"type": "integer", "minimum": 0},
+    "decisions": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_id",
+          "final_disposition",
+          "source_state",
+          "allowed_lanes",
+          "orthography_regime",
+          "rights_capability",
+          "primary_source_roles",
+          "claim_types",
+          "supported_uses",
+          "prohibited_uses",
+          "exactness_status",
+          "evidence_hashes",
+          "missing_evidence"
+        ],
+        "properties": {
+          "source_id": {"type": "string", "minLength": 1},
+          "final_disposition": {
+            "enum": ["admit_scoped", "contextual_only", "quarantine", "needs_more_evidence"]
+          },
+          "source_state": {"enum": ["db_resident", "staged_not_ingested"]},
+          "allowed_lanes": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"]
+            }
+          },
+          "orthography_regime": {"enum": ["pre_2019", "post_2019", "mixed_or_not_applicable"]},
+          "rights_capability": {
+            "enum": [
+              "cc_by_4_0",
+              "cc_by_nc_4_0_noncommercial_only",
+              "internal_research_only",
+              "rights_scope_requires_confirmation"
+            ]
+          },
+          "primary_source_roles": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "claim_types": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "supported_uses": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "prohibited_uses": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "exactness_status": {
+            "enum": ["verified_for_scoped_use", "context_only", "failed", "insufficient"]
+          },
+          "evidence_hashes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/sha256"}
+          },
+          "missing_evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "scope_review_ready": {"const": true},
+    "policy_generation_ready": {"const": true},
+    "database_ingest_authorized": {"const": false},
+    "source_freeze_ready": {"const": false},
+    "phase3_complete": {"const": false},
+    "phase4_blocked": {"const": true},
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "transportReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["task_id", "normalized_status", "exit_code", "raw_result_sha256", "semantic_result_sha256", "normalization", "metadata_only_mutation_paths"],
+      "properties": {
+        "task_id": {"type": "string", "minLength": 1},
+        "normalized_status": {"enum": ["done", "failed_metadata_only"]},
+        "exit_code": {"const": 0},
+        "raw_result_sha256": {"$ref": "#/$defs/sha256"},
+        "semantic_result_sha256": {"$ref": "#/$defs/sha256"},
+        "normalization": {"enum": ["direct_json", "stripped_non_json_prefix"]},
+        "metadata_only_mutation_paths": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_university_source_admission_gate_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_admission_gate_v1.schema.json
@@ -158,8 +158,18 @@
             "uniqueItems": true,
             "items": {"type": "string", "minLength": 1}
           },
-          "supported_uses": {"type": "array", "items": {"type": "string", "minLength": 1}},
-          "prohibited_uses": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "supported_uses": {
+            "type": "array",
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/textFreeToken"}
+          },
+          "prohibited_uses": {
+            "type": "array",
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/textFreeToken"}
+          },
           "exactness_status": {
             "enum": ["verified_for_scoped_use", "context_only", "failed", "insufficient"]
           },
@@ -169,7 +179,12 @@
             "uniqueItems": true,
             "items": {"$ref": "#/$defs/sha256"}
           },
-          "missing_evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+          "missing_evidence": {
+            "type": "array",
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/textFreeToken"}
+          }
         }
       }
     },
@@ -183,6 +198,7 @@
   },
   "$defs": {
     "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "textFreeToken": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_]{0,95}$"},
     "transportReceipt": {
       "type": "object",
       "additionalProperties": false,

--- a/data/projects/open_model_data/contracts/phase3_university_source_admission_review_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_admission_review_v1.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_university_source_admission_review_v1.schema.json",
+  "title": "Phase 3 university source-admission review v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "reviewer_identity",
+    "role",
+    "verified_inputs",
+    "denominator",
+    "decisions",
+    "findings",
+    "complete_residuals",
+    "review_disposition",
+    "policy_generation_authorized",
+    "database_ingest_authorized",
+    "source_freeze_authorized",
+    "phase3_complete",
+    "phase4_blocked"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_v3_final_source_admission_review_v1"},
+    "reviewer_identity": {"const": "controller_phase3_ukrainian_reviewer_01"},
+    "role": {"const": "ukrainian_source_reviewer"},
+    "verified_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256",
+        "university_source_matrix_v3_sha256",
+        "tracked_university_policy_v3_sha256",
+        "university_corpus_reconciliation_v3_sha256",
+        "final_drive_backup_receipt_sha256",
+        "prior_reviews_verified"
+      ],
+      "properties": {
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_recovery_prompt_v2_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_matrix_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "tracked_university_policy_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "university_corpus_reconciliation_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "final_drive_backup_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "prior_reviews_verified": {"const": true}
+      }
+    },
+    "denominator": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "decisions": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": {"$ref": "#/$defs/decision"}
+    },
+    "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+    "complete_residuals": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "review_disposition": {"enum": ["APPROVE_POLICY_GENERATION", "CHANGES_REQUIRED"]},
+    "policy_generation_authorized": {"type": "boolean"},
+    "database_ingest_authorized": {"const": false},
+    "source_freeze_authorized": {"const": false},
+    "phase3_complete": {"const": false},
+    "phase4_blocked": {"const": true}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "sourceRole": {
+      "enum": [
+        "explicit_rule",
+        "correct_example",
+        "incorrect_example",
+        "corrected_example",
+        "editing_exercise",
+        "answer_key",
+        "distractor",
+        "quotation",
+        "historical_or_literary_excerpt",
+        "metalinguistic_mention",
+        "ordinary_narration",
+        "ambiguous_or_ocr"
+      ]
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "final_disposition",
+        "source_state",
+        "audience_class",
+        "allowed_lanes",
+        "orthography_regime",
+        "rights_capability",
+        "primary_source_roles",
+        "claim_types",
+        "supported_uses",
+        "prohibited_uses",
+        "exactness_status",
+        "evidence_hashes",
+        "missing_evidence",
+        "reason"
+      ],
+      "properties": {
+        "source_id": {"type": "string", "pattern": "^uni-ukrmova-"},
+        "final_disposition": {
+          "enum": ["admit_scoped", "contextual_only", "quarantine", "needs_more_evidence"]
+        },
+        "source_state": {"enum": ["db_resident", "staged_not_ingested"]},
+        "audience_class": {"const": "A_ukrainian_university_audience"},
+        "allowed_lanes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"]
+          }
+        },
+        "orthography_regime": {"enum": ["pre_2019", "post_2019", "mixed_or_not_applicable"]},
+        "rights_capability": {
+          "enum": [
+            "cc_by_4_0",
+            "cc_by_nc_4_0_noncommercial_only",
+            "internal_research_only",
+            "rights_scope_requires_confirmation"
+          ]
+        },
+        "primary_source_roles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/sourceRole"}
+        },
+        "claim_types": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "prescriptive_rule",
+              "human_correction_pair",
+              "style_preference",
+              "acceptable_variant",
+              "historical_advice",
+              "attestation_only",
+              "unresolved"
+            ]
+          }
+        },
+        "supported_uses": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "prohibited_uses": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "exactness_status": {
+          "enum": ["verified_for_scoped_use", "context_only", "failed", "insufficient"]
+        },
+        "evidence_hashes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "missing_evidence": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "reason": {"type": "string", "minLength": 1}
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "source_id", "finding", "required_action"],
+      "properties": {
+        "severity": {"enum": ["material", "minor"]},
+        "source_id": {"type": ["string", "null"]},
+        "finding": {"type": "string", "minLength": 1},
+        "required_action": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_university_source_admission_review_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_admission_review_v1.schema.json
@@ -156,11 +156,15 @@
         },
         "supported_uses": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/textFreeToken"}
         },
         "prohibited_uses": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/textFreeToken"}
         },
         "exactness_status": {
           "enum": ["verified_for_scoped_use", "context_only", "failed", "insufficient"]
@@ -173,11 +177,14 @@
         },
         "missing_evidence": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/textFreeToken"}
         },
         "reason": {"type": "string", "minLength": 1}
       }
     },
+    "textFreeToken": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_]{0,95}$"},
     "finding": {
       "type": "object",
       "additionalProperties": false,

--- a/data/projects/open_model_data/contracts/phase3_university_source_scope_review_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_scope_review_v1.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_university_source_scope_review_v1.schema.json",
+  "title": "Phase 3 university source scope and circularity review v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "reviewer_identity",
+    "role",
+    "verified_inputs",
+    "source_set_check",
+    "source_disposition_corrections",
+    "topic_matrix",
+    "topic_counts",
+    "rights_and_exactness_residuals",
+    "findings",
+    "complete_residuals",
+    "matrix_disposition",
+    "source_admission_matrix_ready",
+    "database_ingest_authorized",
+    "source_freeze_authorized",
+    "phase3_complete",
+    "phase4_blocked"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_university_source_scope_review_v1"},
+    "reviewer_identity": {"const": "controller_phase3_scope_critic_01"},
+    "role": {"const": "scope_circularity_critic"},
+    "verified_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256",
+        "university_source_matrix_v3_sha256",
+        "university_source_admission_review_sha256",
+        "university_source_admission_gate_sha256",
+        "university_corpus_reconciliation_v3_sha256",
+        "final_drive_backup_receipt_sha256"
+      ],
+      "properties": {
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_recovery_prompt_v2_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_matrix_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_admission_review_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_admission_gate_sha256": {"$ref": "#/$defs/sha256"},
+        "university_corpus_reconciliation_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "final_drive_backup_receipt_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "source_set_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_unique_sources",
+        "admit_scoped_count",
+        "contextual_only_count",
+        "quarantine_count",
+        "no_extras",
+        "no_omissions",
+        "no_duplicate_credit",
+        "quarantines_preserved"
+      ],
+      "properties": {
+        "total_unique_sources": {"const": 30},
+        "admit_scoped_count": {"const": 11},
+        "contextual_only_count": {"const": 15},
+        "quarantine_count": {"const": 4},
+        "no_extras": {"const": true},
+        "no_omissions": {"const": true},
+        "no_duplicate_credit": {"const": true},
+        "quarantines_preserved": {"const": true}
+      }
+    },
+    "source_disposition_corrections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_id", "from", "to", "reason"],
+        "properties": {
+          "source_id": {"type": "string", "minLength": 1},
+          "from": {"enum": ["admit_scoped", "contextual_only", "quarantine"]},
+          "to": {"enum": ["admit_scoped", "contextual_only", "quarantine", "needs_more_evidence"]},
+          "reason": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "topic_matrix": {
+      "type": "array",
+      "minItems": 26,
+      "maxItems": 26,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["area", "status", "bounded_scope", "supporting_source_ids", "residual"],
+        "properties": {
+          "area": {"type": "string", "minLength": 1},
+          "status": {"enum": ["sufficient", "partial", "missing"]},
+          "bounded_scope": {"type": "string", "minLength": 1},
+          "supporting_source_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "residual": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "topic_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sufficient", "partial", "missing", "total"],
+      "properties": {
+        "sufficient": {"type": "integer", "minimum": 0},
+        "partial": {"type": "integer", "minimum": 0},
+        "missing": {"type": "integer", "minimum": 0},
+        "total": {"const": 26}
+      }
+    },
+    "rights_and_exactness_residuals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_id", "residual", "effect"],
+        "properties": {
+          "source_id": {"type": "string", "minLength": 1},
+          "residual": {"type": "string", "minLength": 1},
+          "effect": {"enum": ["scope_restriction", "context_only", "quarantine", "blocks_complete_source_freeze"]}
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "finding", "required_action"],
+        "properties": {
+          "severity": {"enum": ["material", "minor"]},
+          "finding": {"type": "string", "minLength": 1},
+          "required_action": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "complete_residuals": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "matrix_disposition": {"enum": ["APPROVE_ADMISSION_MATRIX", "CHANGES_REQUIRED"]},
+    "source_admission_matrix_ready": {"type": "boolean"},
+    "database_ingest_authorized": {"const": false},
+    "source_freeze_authorized": {"const": false},
+    "phase3_complete": {"const": false},
+    "phase4_blocked": {"const": true}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_university_source_scope_review_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_university_source_scope_review_v1.schema.json
@@ -63,14 +63,14 @@
         "quarantines_preserved"
       ],
       "properties": {
-        "total_unique_sources": {"const": 30},
-        "admit_scoped_count": {"const": 11},
-        "contextual_only_count": {"const": 15},
-        "quarantine_count": {"const": 4},
-        "no_extras": {"const": true},
-        "no_omissions": {"const": true},
-        "no_duplicate_credit": {"const": true},
-        "quarantines_preserved": {"const": true}
+        "total_unique_sources": {"type": "integer", "minimum": 0},
+        "admit_scoped_count": {"type": "integer", "minimum": 0},
+        "contextual_only_count": {"type": "integer", "minimum": 0},
+        "quarantine_count": {"type": "integer", "minimum": 0},
+        "no_extras": {"type": "boolean"},
+        "no_omissions": {"type": "boolean"},
+        "no_duplicate_credit": {"type": "boolean"},
+        "quarantines_preserved": {"type": "boolean"}
       }
     },
     "source_disposition_corrections": {

--- a/scripts/projects/open_model_data/phase3_university_source_admission.py
+++ b/scripts/projects/open_model_data/phase3_university_source_admission.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Validate the reviewed Phase 3 university source-admission boundary.
+
+The module is deliberately non-semantic.  It cannot admit a source by itself;
+it checks an exact Ukrainian-reviewer result and emits a text-free gate receipt
+that keeps database ingest, the complete source freeze, and Phase 4 blocked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+DATA = ROOT / "data/projects/open_model_data"
+REVIEW_SCHEMA_PATH = DATA / "contracts/phase3_university_source_admission_review_v1.schema.json"
+GATE_SCHEMA_PATH = DATA / "contracts/phase3_university_source_admission_gate_v1.schema.json"
+
+SOURCE_IDS = (
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+    "uni-ukrmova-lexicology-filon-khomik-2010",
+    "uni-ukrmova-morphology-volkova-maslo-2012",
+    "uni-ukrmova-orthography-strokal-2021",
+    "uni-ukrmova-phonetics-komarova-2015",
+    "uni-ukrmova-prof-haluzynska-2006",
+    "uni-ukrmova-punctuation-marynenko-2021",
+    "uni-ukrmova-stylistics-sharapa-tytarenko-2025",
+    "uni-ukrmova-syntax-herman-2021",
+    "uni-ukrmova-text-linguistics-shevel-bilyk-2024",
+)
+DB_RESIDENT_IDS = frozenset(
+    {
+        "uni-ukrmova-lexicology-filon-khomik-2010",
+        "uni-ukrmova-orthography-strokal-2021",
+        "uni-ukrmova-phonetics-komarova-2015",
+        "uni-ukrmova-prof-haluzynska-2006",
+        "uni-ukrmova-punctuation-marynenko-2021",
+        "uni-ukrmova-stylistics-sharapa-tytarenko-2025",
+        "uni-ukrmova-syntax-herman-2021",
+    }
+)
+STAGED_IDS = frozenset(SOURCE_IDS) - DB_RESIDENT_IDS
+CONTEXTUAL_ONLY_IDS = frozenset(
+    {
+        "khpi-ukrainian-morphological-tagging-petrasova-et-al-2017",
+        "lang-uk-tokenize-uk",
+        "naukma-ukrainian-tokenization-stemming-hlybovets-tochytskyi-2017",
+        "uni-istoriya-kalynichenko-olianych-2025",
+        "uni-istoriya-levytska-2015",
+        "uni-mystetstvo-levytska-2015",
+        "uni-mystetstvo-petutina-2012",
+        "uni-ukrlit-dvulychanska-2017",
+        "uni-ukrlit-kalinichenko-2024",
+        "uni-ukrmova-computational-linguistics-vakhovska-2023",
+        "uni-ukrmova-dialectology-torchynska-2017",
+        "uni-ukrmova-error-typology-minchak-2023",
+        "uni-ukrmova-historical-grammar-kupchynska-piletskyi-2024",
+        "uni-ukrmova-morphology-kobchenko-2025",
+        "uni-ukrmova-sociolinguistics-masenko-2010",
+    }
+)
+QUARANTINE_IDS = frozenset(
+    {
+        "uni-ukrmova-glukhovtseva-2021",
+        "uni-ukrmova-morphology-aleksiienko-2014",
+        "uni-ukrmova-syntax-didkivska-shvets-2020",
+        "uni-ukrmova-vlasova-2023",
+    }
+)
+FULL_SOURCE_IDS = frozenset(SOURCE_IDS) | CONTEXTUAL_ONLY_IDS | QUARANTINE_IDS
+TOPIC_AREAS = (
+    "phonetics",
+    "phonology",
+    "orthoepy",
+    "accentology",
+    "graphics",
+    "orthography",
+    "morphemics",
+    "word formation",
+    "lexicology",
+    "semantics",
+    "phraseology",
+    "morphology",
+    "syntax",
+    "punctuation",
+    "government/valency",
+    "text linguistics",
+    "discourse/pragmatics",
+    "stylistics",
+    "culture of language",
+    "dialectology",
+    "sociolinguistics",
+    "language contact",
+    "historical grammar",
+    "history of the literary language",
+    "corpus linguistics",
+    "Ukrainian-specific computational linguistics/tokenization",
+)
+EXPECTED_INPUT_HASHES = {
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "phase3_recovery_prompt_v2_sha256": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b",
+    "university_source_matrix_v3_sha256": "e2e82934ec26b7d98002cdf87f5326b84fb2d3d7900fe675920ba99e84d190de",
+    "tracked_university_policy_v3_sha256": "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d",
+    "university_corpus_reconciliation_v3_sha256": "3a4abb3883ad06db3fea1f994a5b51bc22cbdd6ab3e8d3adaf72c180bc42dd65",
+    "final_drive_backup_receipt_sha256": "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a",
+}
+EXPECTED_SCOPE_INPUT_HASHES = {
+    "phase3_reboot_prompt_v3_sha256": EXPECTED_INPUT_HASHES["phase3_reboot_prompt_v3_sha256"],
+    "phase3_recovery_prompt_v2_sha256": EXPECTED_INPUT_HASHES["phase3_recovery_prompt_v2_sha256"],
+    "university_source_matrix_v3_sha256": EXPECTED_INPUT_HASHES["university_source_matrix_v3_sha256"],
+    "university_source_admission_review_sha256": "8267f65aefdd8d14d24f1255c7bda4b7b92bc06f62f4c6e234696f39bd9ad22a",
+    "university_source_admission_gate_sha256": "71a22c5159a21709d0eacd777c3b1a9c33bca041ca8436defed494722a75440c",
+    "university_corpus_reconciliation_v3_sha256": EXPECTED_INPUT_HASHES["university_corpus_reconciliation_v3_sha256"],
+    "final_drive_backup_receipt_sha256": EXPECTED_INPUT_HASHES["final_drive_backup_receipt_sha256"],
+}
+DISPOSITIONS = ("admit_scoped", "contextual_only", "quarantine", "needs_more_evidence")
+METADATA_ONLY_MUTATION_PREFIXES = (".agent/sessions/", ".entire/", "batch_state/api_usage/usage_")
+SOURCE_ROLES = frozenset(
+    {
+        "explicit_rule",
+        "correct_example",
+        "incorrect_example",
+        "corrected_example",
+        "editing_exercise",
+        "answer_key",
+        "distractor",
+        "quotation",
+        "historical_or_literary_excerpt",
+        "metalinguistic_mention",
+        "ordinary_narration",
+        "ambiguous_or_ocr",
+    }
+)
+CLAIM_TYPES = frozenset(
+    {
+        "prescriptive_rule",
+        "human_correction_pair",
+        "style_preference",
+        "acceptable_variant",
+        "historical_advice",
+        "attestation_only",
+        "unresolved",
+    }
+)
+
+
+class SourceAdmissionError(ValueError):
+    """The reviewed source-admission boundary is incomplete or unsafe."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SourceAdmissionError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SourceAdmissionError(f"cannot read JSON artifact: {path}") from exc
+    require(isinstance(value, dict), f"JSON artifact must be an object: {path}")
+    return value
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    """Publish one complete UTF-8 receipt without exposing a partial file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    require(not path.is_symlink(), f"refusing symlink output: {path}")
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def read_review_result(path: Path) -> tuple[dict[str, Any], str, str, str]:
+    """Read direct JSON or strip one non-JSON commentary prefix losslessly."""
+    path = Path(path)
+    try:
+        raw_bytes = path.read_bytes()
+        raw_text = raw_bytes.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SourceAdmissionError(f"cannot read UTF-8 review result: {path}") from exc
+    raw_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+    try:
+        value = json.loads(raw_text)
+    except json.JSONDecodeError:
+        start = raw_text.find("{")
+        require(start > 0, f"review result has no recoverable JSON object: {path}")
+        require("{" not in raw_text[:start], f"review result prefix contains an ambiguous JSON opener: {path}")
+        try:
+            value, consumed = json.JSONDecoder().raw_decode(raw_text[start:])
+        except json.JSONDecodeError as exc:
+            raise SourceAdmissionError(f"review result JSON payload is malformed: {path}") from exc
+        require(not raw_text[start + consumed :].strip(), f"review result has non-whitespace trailing content: {path}")
+        semantic_text = raw_text[start : start + consumed]
+        normalization = "stripped_non_json_prefix"
+    else:
+        semantic_text = raw_text
+        normalization = "direct_json"
+    require(isinstance(value, dict), f"review result must contain one JSON object: {path}")
+    semantic_sha256 = hashlib.sha256(semantic_text.encode("utf-8")).hexdigest()
+    return value, raw_sha256, semantic_sha256, normalization
+
+
+def _validate_schema(value: Mapping[str, Any], schema_path: Path, label: str) -> None:
+    schema = read_json(schema_path)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(value),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    require(not errors, f"{label} schema violation: {errors[0].message if errors else ''}")
+
+
+def _contains_marker(values: list[str], *markers: str) -> bool:
+    lowered = [value.casefold() for value in values]
+    return any(all(marker in value for marker in markers) for value in lowered)
+
+
+def validate_review(review: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one exact 11-source Ukrainian-reviewer response."""
+    _validate_schema(review, REVIEW_SCHEMA_PATH, "source-admission review")
+    verified_inputs = dict(review["verified_inputs"])
+    prior_reviews_verified = verified_inputs.pop("prior_reviews_verified")
+    require(prior_reviews_verified is True, "prior university reviews were not verified")
+    require(verified_inputs == EXPECTED_INPUT_HASHES, "review input hashes do not match the frozen audit inputs")
+    require(review["denominator"] == list(SOURCE_IDS), "review denominator is not the exact sorted 11-source set")
+
+    decisions = review["decisions"]
+    decision_ids = [decision["source_id"] for decision in decisions]
+    require(decision_ids == list(SOURCE_IDS), "review decisions are missing, duplicated, or out of canonical order")
+    for decision in decisions:
+        source_id = decision["source_id"]
+        expected_state = "db_resident" if source_id in DB_RESIDENT_IDS else "staged_not_ingested"
+        require(decision["source_state"] == expected_state, f"{source_id}: source-state drift")
+        require(set(decision["primary_source_roles"]) <= SOURCE_ROLES, f"{source_id}: unsupported primary role")
+        require(set(decision["claim_types"]) <= CLAIM_TYPES, f"{source_id}: unsupported claim type")
+        require(
+            decision["allowed_lanes"] == sorted(set(decision["allowed_lanes"])),
+            f"{source_id}: allowed lanes must be sorted and unique",
+        )
+
+        disposition = decision["final_disposition"]
+        lanes = set(decision["allowed_lanes"])
+        if disposition == "admit_scoped":
+            require(
+                {"contextual_retrieval", "corpus_ingest"} <= lanes,
+                f"{source_id}: scoped admission must include contextual retrieval and corpus ingest",
+            )
+            require(
+                decision["exactness_status"] == "verified_for_scoped_use", f"{source_id}: admission lacks exactness"
+            )
+            require(not decision["missing_evidence"], f"{source_id}: admitted source still names missing evidence")
+        elif disposition == "contextual_only":
+            require(
+                lanes == {"contextual_retrieval", "corpus_ingest"},
+                f"{source_id}: contextual-only lane set is not closed",
+            )
+            require(decision["exactness_status"] == "context_only", f"{source_id}: contextual exactness mismatch")
+        else:
+            require(not lanes, f"{source_id}: blocked source cannot enter a production lane")
+            expected_exactness = "failed" if disposition == "quarantine" else "insufficient"
+            require(decision["exactness_status"] == expected_exactness, f"{source_id}: blocked exactness mismatch")
+            require(decision["missing_evidence"], f"{source_id}: blocked source must name concrete missing evidence")
+
+        if "linguistic_rule_evidence" in lanes:
+            require(disposition == "admit_scoped", f"{source_id}: only scoped admission may support rules")
+            require(
+                "explicit_rule" in decision["primary_source_roles"], f"{source_id}: rule lane lacks explicit-rule role"
+            )
+        if decision["orthography_regime"] == "pre_2019" and disposition == "admit_scoped":
+            require(
+                _contains_marker(decision["prohibited_uses"], "post_2019"),
+                f"{source_id}: pre-2019 admission lacks a post-2019 authority restriction",
+            )
+        if decision["rights_capability"] == "cc_by_nc_4_0_noncommercial_only":
+            require(
+                _contains_marker(decision["prohibited_uses"], "commercial"),
+                f"{source_id}: non-commercial rights restriction is not preserved",
+            )
+
+    approve = review["review_disposition"] == "APPROVE_POLICY_GENERATION"
+    require(review["policy_generation_authorized"] is approve, "review disposition and policy authorization disagree")
+    return dict(review)
+
+
+def validate_input_artifacts(paths: Mapping[str, Path]) -> None:
+    """Verify exact bytes for every externally supplied audit input."""
+    require(set(paths) == set(EXPECTED_INPUT_HASHES), "input artifact path set is incomplete")
+    for key, expected_sha256 in EXPECTED_INPUT_HASHES.items():
+        path = Path(paths[key])
+        require(path.is_file(), f"missing bound input artifact: {key}")
+        require(sha256_file(path) == expected_sha256, f"bound input artifact drift: {key}")
+
+
+def validate_dispatch_transport(
+    state: Mapping[str, Any],
+    *,
+    expected_task_id: str,
+    result_path: Path,
+    raw_result_sha256: str,
+    semantic_result_sha256: str,
+    normalization: str,
+) -> dict[str, Any]:
+    """Normalize a clean review dispatch or the known ignored-metadata leak."""
+    require(state.get("task_id") == expected_task_id, "review dispatch task identity drift")
+    require(state.get("exit_code") == 0, f"{expected_task_id}: reviewer subprocess did not exit successfully")
+    recorded_result = state.get("result_file")
+    require(isinstance(recorded_result, str), f"{expected_task_id}: dispatch result path is absent")
+    require(
+        Path(recorded_result).resolve() == Path(result_path).resolve(),
+        f"{expected_task_id}: dispatch result path drift",
+    )
+    mutation_paths = sorted(state.get("read_only_mutation_paths") or [])
+    status = state.get("status")
+    if status == "done":
+        require(not mutation_paths, f"{expected_task_id}: done dispatch still reports checkout mutation")
+        normalized_status = "done"
+    else:
+        require(status == "failed", f"{expected_task_id}: dispatch is not terminal")
+        require(mutation_paths, f"{expected_task_id}: failed dispatch lacks an attributable mutation")
+        require(
+            all(path.startswith(METADATA_ONLY_MUTATION_PREFIXES) for path in mutation_paths),
+            f"{expected_task_id}: failed dispatch mutated a non-metadata path",
+        )
+        require(
+            str(state.get("last_error", "")).startswith("read-only checkout mutation detected:"),
+            f"{expected_task_id}: failure was not the known read-only metadata leak",
+        )
+        normalized_status = "failed_metadata_only"
+    return {
+        "task_id": expected_task_id,
+        "normalized_status": normalized_status,
+        "exit_code": 0,
+        "raw_result_sha256": raw_result_sha256,
+        "semantic_result_sha256": semantic_result_sha256,
+        "normalization": normalization,
+        "metadata_only_mutation_paths": mutation_paths,
+    }
+
+
+def validate_scope_review(review: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the independent complete-matrix scope review."""
+    scope_schema_path = DATA / "contracts/phase3_university_source_scope_review_v1.schema.json"
+    _validate_schema(review, scope_schema_path, "source scope review")
+    require(
+        review["verified_inputs"] == EXPECTED_SCOPE_INPUT_HASHES,
+        "scope-review input hashes do not match the frozen audit inputs",
+    )
+    topic_matrix = review["topic_matrix"]
+    require(
+        [row["area"] for row in topic_matrix] == list(TOPIC_AREAS),
+        "scope review does not cover the exact ordered 26-area matrix",
+    )
+    for row in topic_matrix:
+        support = set(row["supporting_source_ids"])
+        require(support <= FULL_SOURCE_IDS, f"{row['area']}: supporting source falls outside the 30-source universe")
+        require(not support & QUARANTINE_IDS, f"{row['area']}: quarantined source received coverage credit")
+        if row["status"] == "missing":
+            require(not support, f"{row['area']}: missing area cannot claim supporting sources")
+        else:
+            require(support, f"{row['area']}: non-missing area lacks supporting sources")
+    counts = Counter(row["status"] for row in topic_matrix)
+    require(
+        review["topic_counts"]
+        == {
+            "sufficient": counts.get("sufficient", 0),
+            "partial": counts.get("partial", 0),
+            "missing": counts.get("missing", 0),
+            "total": len(TOPIC_AREAS),
+        },
+        "scope-review topic counts do not match its 26 rows",
+    )
+    approved = review["matrix_disposition"] == "APPROVE_ADMISSION_MATRIX"
+    require(review["source_admission_matrix_ready"] is approved, "scope disposition and readiness disagree")
+    if approved:
+        require(not review["source_disposition_corrections"], "approved matrix still changes source dispositions")
+    return dict(review)
+
+
+def build_gate(
+    review: Mapping[str, Any],
+    scope_review: Mapping[str, Any],
+    *,
+    review_sha256: str,
+    scope_review_sha256: str,
+    transport: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the text-free policy-generation gate from a valid review."""
+    validated = validate_review(review)
+    require(validated["policy_generation_authorized"] is True, "review does not authorize policy generation")
+    require(
+        review_sha256 == EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
+        "review bytes differ from the review checked by the scope critic",
+    )
+    validated_scope = validate_scope_review(scope_review)
+    require(validated_scope["source_admission_matrix_ready"] is True, "scope review does not approve the matrix")
+    require(set(transport) == {"ukrainian_review", "scope_review"}, "review transport receipt set is incomplete")
+    require(
+        transport["ukrainian_review"]["semantic_result_sha256"] == review_sha256,
+        "Ukrainian-review transport receipt hash drift",
+    )
+    require(
+        transport["scope_review"]["semantic_result_sha256"] == scope_review_sha256,
+        "scope-review transport receipt hash drift",
+    )
+    decisions = []
+    for decision in validated["decisions"]:
+        decisions.append(
+            {
+                key: decision[key]
+                for key in (
+                    "source_id",
+                    "final_disposition",
+                    "source_state",
+                    "allowed_lanes",
+                    "orthography_regime",
+                    "rights_capability",
+                    "primary_source_roles",
+                    "claim_types",
+                    "supported_uses",
+                    "prohibited_uses",
+                    "exactness_status",
+                    "evidence_hashes",
+                    "missing_evidence",
+                )
+            }
+        )
+    counts = Counter(decision["final_disposition"] for decision in decisions)
+    finding_counts = Counter(finding["severity"] for finding in validated_scope["findings"])
+    body: dict[str, Any] = {
+        "schema_version": "phase3_university_source_admission_gate_v1",
+        "text_free": True,
+        "bindings": {
+            **EXPECTED_INPUT_HASHES,
+            "review_sha256": review_sha256,
+            "scope_review_sha256": scope_review_sha256,
+        },
+        "transport": dict(transport),
+        "denominator_count": len(SOURCE_IDS),
+        "denominator": list(SOURCE_IDS),
+        "disposition_counts": {disposition: counts.get(disposition, 0) for disposition in DISPOSITIONS},
+        "topic_counts": validated_scope["topic_counts"],
+        "scope_review_finding_counts": {
+            "material": finding_counts.get("material", 0),
+            "minor": finding_counts.get("minor", 0),
+        },
+        "rights_and_exactness_residual_count": len(validated_scope["rights_and_exactness_residuals"]),
+        "complete_residual_count": len(validated_scope["complete_residuals"]),
+        "decisions": decisions,
+        "scope_review_ready": True,
+        "policy_generation_ready": True,
+        "database_ingest_authorized": False,
+        "source_freeze_ready": False,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+    gate = {
+        **body,
+        "receipt_sha256": hashlib.sha256((canonical_json(body) + "\n").encode("utf-8")).hexdigest(),
+    }
+    _validate_schema(gate, GATE_SCHEMA_PATH, "source-admission gate")
+    return gate
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--review", type=Path, required=True)
+    parser.add_argument("--review-state", type=Path, required=True)
+    parser.add_argument("--scope-review", type=Path, required=True)
+    parser.add_argument("--scope-review-state", type=Path, required=True)
+    parser.add_argument("--phase3-reboot-prompt-v3", type=Path, required=True)
+    parser.add_argument("--phase3-recovery-prompt-v2", type=Path, required=True)
+    parser.add_argument("--university-source-matrix-v3", type=Path, required=True)
+    parser.add_argument("--tracked-university-policy-v3", type=Path, required=True)
+    parser.add_argument("--university-corpus-reconciliation-v3", type=Path, required=True)
+    parser.add_argument("--final-drive-backup-receipt", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    input_paths = {
+        "phase3_reboot_prompt_v3_sha256": args.phase3_reboot_prompt_v3,
+        "phase3_recovery_prompt_v2_sha256": args.phase3_recovery_prompt_v2,
+        "university_source_matrix_v3_sha256": args.university_source_matrix_v3,
+        "tracked_university_policy_v3_sha256": args.tracked_university_policy_v3,
+        "university_corpus_reconciliation_v3_sha256": args.university_corpus_reconciliation_v3,
+        "final_drive_backup_receipt_sha256": args.final_drive_backup_receipt,
+    }
+    validate_input_artifacts(input_paths)
+    review, review_raw_sha256, review_sha256, review_normalization = read_review_result(args.review)
+    scope_review, scope_raw_sha256, scope_review_sha256, scope_normalization = read_review_result(args.scope_review)
+    transport = {
+        "ukrainian_review": validate_dispatch_transport(
+            read_json(args.review_state),
+            expected_task_id="phase3-v3-final-source-admission-review-20-correction",
+            result_path=args.review,
+            raw_result_sha256=review_raw_sha256,
+            semantic_result_sha256=review_sha256,
+            normalization=review_normalization,
+        ),
+        "scope_review": validate_dispatch_transport(
+            read_json(args.scope_review_state),
+            expected_task_id="phase3-v3-university-source-scope-review-21",
+            result_path=args.scope_review,
+            raw_result_sha256=scope_raw_sha256,
+            semantic_result_sha256=scope_review_sha256,
+            normalization=scope_normalization,
+        ),
+    }
+    gate = build_gate(
+        review,
+        scope_review,
+        review_sha256=review_sha256,
+        scope_review_sha256=scope_review_sha256,
+        transport=transport,
+    )
+    encoded = json.dumps(gate, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(encoded, end="")
+    else:
+        write_text_atomic(args.output, encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_university_source_admission.py
+++ b/scripts/projects/open_model_data/phase3_university_source_admission.py
@@ -152,6 +152,14 @@ CLAIM_TYPES = frozenset(
         "unresolved",
     }
 )
+POST_2019_AUTHORITY_RESTRICTIONS = frozenset(
+    {
+        "post_2019_orthography_rules",
+        "post_2019_orthography_spelling_rules",
+        "post_2019_orthography_spelling_rules_without_current_corroboration",
+    }
+)
+NONCOMMERCIAL_RESTRICTION = "unrestricted_commercial_training"
 
 
 class SourceAdmissionError(ValueError):
@@ -223,7 +231,6 @@ def read_review_result(path: Path) -> tuple[dict[str, Any], str, str, str]:
     except json.JSONDecodeError:
         start = raw_text.find("{")
         require(start > 0, f"review result has no recoverable JSON object: {path}")
-        require("{" not in raw_text[:start], f"review result prefix contains an ambiguous JSON opener: {path}")
         try:
             value, consumed = json.JSONDecoder().raw_decode(raw_text[start:])
         except json.JSONDecodeError as exc:
@@ -247,11 +254,6 @@ def _validate_schema(value: Mapping[str, Any], schema_path: Path, label: str) ->
         key=lambda error: tuple(str(part) for part in error.absolute_path),
     )
     require(not errors, f"{label} schema violation: {errors[0].message if errors else ''}")
-
-
-def _contains_marker(values: list[str], *markers: str) -> bool:
-    lowered = [value.casefold() for value in values]
-    return any(all(marker in value for marker in markers) for value in lowered)
 
 
 def validate_review(review: Mapping[str, Any]) -> dict[str, Any]:
@@ -307,12 +309,12 @@ def validate_review(review: Mapping[str, Any]) -> dict[str, Any]:
             )
         if decision["orthography_regime"] == "pre_2019" and disposition == "admit_scoped":
             require(
-                _contains_marker(decision["prohibited_uses"], "post_2019"),
+                bool(set(decision["prohibited_uses"]) & POST_2019_AUTHORITY_RESTRICTIONS),
                 f"{source_id}: pre-2019 admission lacks a post-2019 authority restriction",
             )
         if decision["rights_capability"] == "cc_by_nc_4_0_noncommercial_only":
             require(
-                _contains_marker(decision["prohibited_uses"], "commercial"),
+                NONCOMMERCIAL_RESTRICTION in decision["prohibited_uses"],
                 f"{source_id}: non-commercial rights restriction is not preserved",
             )
 
@@ -376,13 +378,65 @@ def validate_dispatch_transport(
     }
 
 
-def validate_scope_review(review: Mapping[str, Any]) -> dict[str, Any]:
+def derive_source_set_check(source_matrix: Mapping[str, Any]) -> dict[str, Any]:
+    """Derive the scope critic's source-set facts from matrix rows."""
+    require(
+        source_matrix.get("schema_version") == "phase3-university-source-matrix-consolidated.v3",
+        "university source matrix schema-version drift",
+    )
+    require(source_matrix.get("text_free") is True, "university source matrix is not text-free")
+    rows = source_matrix.get("source_dispositions")
+    require(isinstance(rows, list), "university source matrix has no source-disposition rows")
+    source_ids: list[str] = []
+    by_disposition: dict[str, set[str]] = {
+        "admit_candidate": set(),
+        "contextual_only": set(),
+        "quarantine": set(),
+    }
+    for row in rows:
+        require(isinstance(row, Mapping), "university source matrix row is not an object")
+        source_id = row.get("source_id")
+        disposition = row.get("disposition")
+        require(isinstance(source_id, str) and source_id, "university source matrix row has no source ID")
+        require(disposition in by_disposition, f"{source_id}: unsupported matrix disposition")
+        source_ids.append(source_id)
+        by_disposition[disposition].add(source_id)
+
+    unique_source_ids = set(source_ids)
+    derived_counts = {
+        "admit_candidate": len(by_disposition["admit_candidate"]),
+        "contextual_only": len(by_disposition["contextual_only"]),
+        "quarantine": len(by_disposition["quarantine"]),
+        "total_unique_sources": len(unique_source_ids),
+    }
+    require(
+        source_matrix.get("source_disposition_counts") == derived_counts,
+        "university source matrix disposition counts do not match its rows",
+    )
+    return {
+        "total_unique_sources": len(unique_source_ids),
+        "admit_scoped_count": len(by_disposition["admit_candidate"]),
+        "contextual_only_count": len(by_disposition["contextual_only"]),
+        "quarantine_count": len(by_disposition["quarantine"]),
+        "no_extras": unique_source_ids <= FULL_SOURCE_IDS,
+        "no_omissions": unique_source_ids >= FULL_SOURCE_IDS,
+        "no_duplicate_credit": len(source_ids) == len(unique_source_ids),
+        "quarantines_preserved": by_disposition["quarantine"] == QUARANTINE_IDS,
+    }
+
+
+def validate_scope_review(review: Mapping[str, Any], source_matrix: Mapping[str, Any]) -> dict[str, Any]:
     """Validate the independent complete-matrix scope review."""
     scope_schema_path = DATA / "contracts/phase3_university_source_scope_review_v1.schema.json"
     _validate_schema(review, scope_schema_path, "source scope review")
     require(
         review["verified_inputs"] == EXPECTED_SCOPE_INPUT_HASHES,
         "scope-review input hashes do not match the frozen audit inputs",
+    )
+    derived_source_set_check = derive_source_set_check(source_matrix)
+    require(
+        review["source_set_check"] == derived_source_set_check,
+        "scope-review source-set facts do not match the matrix rows",
     )
     topic_matrix = review["topic_matrix"]
     require(
@@ -411,6 +465,25 @@ def validate_scope_review(review: Mapping[str, Any]) -> dict[str, Any]:
     approved = review["matrix_disposition"] == "APPROVE_ADMISSION_MATRIX"
     require(review["source_admission_matrix_ready"] is approved, "scope disposition and readiness disagree")
     if approved:
+        require(
+            all(
+                derived_source_set_check[key]
+                for key in ("no_extras", "no_omissions", "no_duplicate_credit", "quarantines_preserved")
+            ),
+            "approved scope review has an incomplete, duplicated, or misclassified source set",
+        )
+        rows_by_disposition = {
+            disposition: {
+                row["source_id"] for row in source_matrix["source_dispositions"] if row["disposition"] == disposition
+            }
+            for disposition in ("admit_candidate", "contextual_only", "quarantine")
+        }
+        require(
+            rows_by_disposition["admit_candidate"] == set(SOURCE_IDS)
+            and rows_by_disposition["contextual_only"] == CONTEXTUAL_ONLY_IDS
+            and rows_by_disposition["quarantine"] == QUARANTINE_IDS,
+            "approved scope review has a source in the wrong disposition group",
+        )
         require(not review["source_disposition_corrections"], "approved matrix still changes source dispositions")
     return dict(review)
 
@@ -418,6 +491,7 @@ def validate_scope_review(review: Mapping[str, Any]) -> dict[str, Any]:
 def build_gate(
     review: Mapping[str, Any],
     scope_review: Mapping[str, Any],
+    source_matrix: Mapping[str, Any],
     *,
     review_sha256: str,
     scope_review_sha256: str,
@@ -430,7 +504,7 @@ def build_gate(
         review_sha256 == EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
         "review bytes differ from the review checked by the scope critic",
     )
-    validated_scope = validate_scope_review(scope_review)
+    validated_scope = validate_scope_review(scope_review, source_matrix)
     require(validated_scope["source_admission_matrix_ready"] is True, "scope review does not approve the matrix")
     require(set(transport) == {"ukrainian_review", "scope_review"}, "review transport receipt set is incomplete")
     require(
@@ -550,6 +624,7 @@ def main() -> int:
     gate = build_gate(
         review,
         scope_review,
+        read_json(args.university_source_matrix_v3),
         review_sha256=review_sha256,
         scope_review_sha256=scope_review_sha256,
         transport=transport,

--- a/tests/test_open_model_phase3_university_source_admission.py
+++ b/tests/test_open_model_phase3_university_source_admission.py
@@ -1,0 +1,322 @@
+"""Hermetic tests for the Phase 3 university source-admission gate."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_university_source_admission as admission
+
+
+def _decision(source_id: str) -> dict[str, object]:
+    return {
+        "source_id": source_id,
+        "final_disposition": "needs_more_evidence",
+        "source_state": "db_resident" if source_id in admission.DB_RESIDENT_IDS else "staged_not_ingested",
+        "audience_class": "A_ukrainian_university_audience",
+        "allowed_lanes": [],
+        "orthography_regime": "post_2019",
+        "rights_capability": "cc_by_4_0",
+        "primary_source_roles": ["explicit_rule"],
+        "claim_types": ["unresolved"],
+        "supported_uses": [],
+        "prohibited_uses": ["all production use before exact evidence"],
+        "exactness_status": "insufficient",
+        "evidence_hashes": ["a" * 64],
+        "missing_evidence": ["exact source-level admission evidence"],
+        "reason": "The source remains default-deny until the named evidence exists.",
+    }
+
+
+def _review() -> dict[str, object]:
+    return {
+        "schema_version": "phase3_v3_final_source_admission_review_v1",
+        "reviewer_identity": "controller_phase3_ukrainian_reviewer_01",
+        "role": "ukrainian_source_reviewer",
+        "verified_inputs": {**admission.EXPECTED_INPUT_HASHES, "prior_reviews_verified": True},
+        "denominator": list(admission.SOURCE_IDS),
+        "decisions": [_decision(source_id) for source_id in admission.SOURCE_IDS],
+        "findings": [],
+        "complete_residuals": ["complete source freeze remains separate"],
+        "review_disposition": "APPROVE_POLICY_GENERATION",
+        "policy_generation_authorized": True,
+        "database_ingest_authorized": False,
+        "source_freeze_authorized": False,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+
+
+def _scope_review() -> dict[str, object]:
+    topic_matrix = []
+    for area in admission.TOPIC_AREAS:
+        topic_matrix.append(
+            {
+                "area": area,
+                "status": "partial",
+                "bounded_scope": "Only the exact reviewed source scope receives credit.",
+                "supporting_source_ids": [admission.SOURCE_IDS[0]],
+                "residual": "A complete source-family depth proof remains open.",
+            }
+        )
+    return {
+        "schema_version": "phase3_university_source_scope_review_v1",
+        "reviewer_identity": "controller_phase3_scope_critic_01",
+        "role": "scope_circularity_critic",
+        "verified_inputs": admission.EXPECTED_SCOPE_INPUT_HASHES,
+        "source_set_check": {
+            "total_unique_sources": 30,
+            "admit_scoped_count": 11,
+            "contextual_only_count": 15,
+            "quarantine_count": 4,
+            "no_extras": True,
+            "no_omissions": True,
+            "no_duplicate_credit": True,
+            "quarantines_preserved": True,
+        },
+        "source_disposition_corrections": [],
+        "topic_matrix": topic_matrix,
+        "topic_counts": {"sufficient": 0, "partial": 26, "missing": 0, "total": 26},
+        "rights_and_exactness_residuals": [],
+        "findings": [],
+        "complete_residuals": ["database ingest and the complete freeze remain separate"],
+        "matrix_disposition": "APPROVE_ADMISSION_MATRIX",
+        "source_admission_matrix_ready": True,
+        "database_ingest_authorized": False,
+        "source_freeze_authorized": False,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+
+
+def _transport() -> dict[str, object]:
+    return {
+        "ukrainian_review": {
+            "task_id": "phase3-v3-final-source-admission-review-20-correction",
+            "normalized_status": "failed_metadata_only",
+            "exit_code": 0,
+            "raw_result_sha256": admission.EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
+            "semantic_result_sha256": admission.EXPECTED_SCOPE_INPUT_HASHES[
+                "university_source_admission_review_sha256"
+            ],
+            "normalization": "direct_json",
+            "metadata_only_mutation_paths": [".agent/sessions/reviewer.json"],
+        },
+        "scope_review": {
+            "task_id": "phase3-v3-university-source-scope-review-21",
+            "normalized_status": "done",
+            "exit_code": 0,
+            "raw_result_sha256": "c" * 64,
+            "semantic_result_sha256": "c" * 64,
+            "normalization": "direct_json",
+            "metadata_only_mutation_paths": [],
+        },
+    }
+
+
+def test_valid_exact_denominator_builds_deterministic_text_free_gate() -> None:
+    review = _review()
+    scope_review = _scope_review()
+    first = admission.build_gate(
+        review,
+        scope_review,
+        review_sha256=admission.EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
+        scope_review_sha256="c" * 64,
+        transport=_transport(),
+    )
+    second = admission.build_gate(
+        copy.deepcopy(review),
+        copy.deepcopy(scope_review),
+        review_sha256=admission.EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
+        scope_review_sha256="c" * 64,
+        transport=copy.deepcopy(_transport()),
+    )
+    assert first == second
+    assert first["denominator_count"] == 11
+    assert first["disposition_counts"] == {
+        "admit_scoped": 0,
+        "contextual_only": 0,
+        "quarantine": 0,
+        "needs_more_evidence": 11,
+    }
+    assert first["policy_generation_ready"] is True
+    assert first["scope_review_ready"] is True
+    assert first["topic_counts"]["total"] == 26
+    assert first["scope_review_finding_counts"] == {"material": 0, "minor": 0}
+    assert first["complete_residual_count"] == 1
+    assert first["database_ingest_authorized"] is False
+    assert first["source_freeze_ready"] is False
+    assert first["phase4_blocked"] is True
+    assert "reason" not in first["decisions"][0]
+
+
+def test_missing_or_reordered_source_fails_closed() -> None:
+    review = _review()
+    review["denominator"][0], review["denominator"][1] = review["denominator"][1], review["denominator"][0]
+    with pytest.raises(admission.SourceAdmissionError, match="exact sorted 11-source"):
+        admission.validate_review(review)
+
+
+def test_source_state_drift_fails_closed() -> None:
+    review = _review()
+    review["decisions"][0]["source_state"] = "db_resident"
+    with pytest.raises(admission.SourceAdmissionError, match="source-state drift"):
+        admission.validate_review(review)
+
+
+def test_blocked_source_cannot_enter_production_lane() -> None:
+    review = _review()
+    review["decisions"][0]["allowed_lanes"] = ["contextual_retrieval"]
+    with pytest.raises(admission.SourceAdmissionError, match="blocked source cannot enter"):
+        admission.validate_review(review)
+
+
+def test_rule_evidence_requires_explicit_rule_role_and_verified_exactness() -> None:
+    review = _review()
+    decision = review["decisions"][0]
+    decision.update(
+        {
+            "final_disposition": "admit_scoped",
+            "allowed_lanes": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"],
+            "exactness_status": "verified_for_scoped_use",
+            "missing_evidence": [],
+            "primary_source_roles": ["ordinary_narration"],
+        }
+    )
+    with pytest.raises(admission.SourceAdmissionError, match="explicit-rule role"):
+        admission.validate_review(review)
+
+
+def test_pre_2019_admission_requires_current_orthography_restriction() -> None:
+    review = _review()
+    decision = review["decisions"][2]
+    decision.update(
+        {
+            "final_disposition": "admit_scoped",
+            "allowed_lanes": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"],
+            "orthography_regime": "pre_2019",
+            "exactness_status": "verified_for_scoped_use",
+            "missing_evidence": [],
+            "prohibited_uses": ["unrelated restriction"],
+        }
+    )
+    with pytest.raises(admission.SourceAdmissionError, match="post-2019 authority restriction"):
+        admission.validate_review(review)
+
+
+def test_noncommercial_rights_cannot_lose_commercial_restriction() -> None:
+    review = _review()
+    decision = review["decisions"][0]
+    decision["rights_capability"] = "cc_by_nc_4_0_noncommercial_only"
+    decision["prohibited_uses"] = ["automatic admission"]
+    with pytest.raises(admission.SourceAdmissionError, match="non-commercial rights restriction"):
+        admission.validate_review(review)
+
+
+def test_review_input_hash_drift_fails_closed() -> None:
+    review = _review()
+    review["verified_inputs"]["university_source_matrix_v3_sha256"] = "0" * 64
+    with pytest.raises(admission.SourceAdmissionError, match="input hashes"):
+        admission.validate_review(review)
+
+
+def test_policy_generation_boolean_must_match_disposition() -> None:
+    review = _review()
+    review["review_disposition"] = "CHANGES_REQUIRED"
+    with pytest.raises(admission.SourceAdmissionError, match="policy authorization disagree"):
+        admission.validate_review(review)
+
+
+def test_scope_review_rejects_quarantine_coverage_credit() -> None:
+    review = _scope_review()
+    review["topic_matrix"][0]["supporting_source_ids"] = [next(iter(admission.QUARANTINE_IDS))]
+    with pytest.raises(admission.SourceAdmissionError, match="quarantined source"):
+        admission.validate_scope_review(review)
+
+
+def test_scope_review_requires_exact_26_area_order() -> None:
+    review = _scope_review()
+    review["topic_matrix"][0], review["topic_matrix"][1] = review["topic_matrix"][1], review["topic_matrix"][0]
+    with pytest.raises(admission.SourceAdmissionError, match="exact ordered 26-area"):
+        admission.validate_scope_review(review)
+
+
+def test_approved_scope_review_can_report_findings_applied_to_final_matrix() -> None:
+    review = _scope_review()
+    review["findings"] = [
+        {
+            "severity": "material",
+            "finding": "A material circularity defect remains.",
+            "required_action": "Correct the matrix.",
+        }
+    ]
+    assert admission.validate_scope_review(review)["findings"] == review["findings"]
+
+
+def test_dispatch_transport_accepts_only_known_ignored_metadata_leak(tmp_path) -> None:
+    result = tmp_path / "review.result"
+    result.write_text("{}", encoding="utf-8")
+    state = {
+        "task_id": "review-task",
+        "status": "failed",
+        "exit_code": 0,
+        "result_file": str(result),
+        "last_error": "read-only checkout mutation detected: .agent/sessions/review.json",
+        "read_only_mutation_paths": [".agent/sessions/review.json", ".entire/metadata/review/prompt.txt"],
+    }
+    receipt = admission.validate_dispatch_transport(
+        state,
+        expected_task_id="review-task",
+        result_path=result,
+        raw_result_sha256=admission.sha256_file(result),
+        semantic_result_sha256=admission.sha256_file(result),
+        normalization="direct_json",
+    )
+    assert receipt["normalized_status"] == "failed_metadata_only"
+
+
+def test_dispatch_transport_rejects_non_metadata_mutation(tmp_path) -> None:
+    result = tmp_path / "review.result"
+    result.write_text("{}", encoding="utf-8")
+    state = {
+        "task_id": "review-task",
+        "status": "failed",
+        "exit_code": 0,
+        "result_file": str(result),
+        "last_error": "read-only checkout mutation detected: source.py",
+        "read_only_mutation_paths": ["source.py"],
+    }
+    with pytest.raises(admission.SourceAdmissionError, match="non-metadata path"):
+        admission.validate_dispatch_transport(
+            state,
+            expected_task_id="review-task",
+            result_path=result,
+            raw_result_sha256=admission.sha256_file(result),
+            semantic_result_sha256=admission.sha256_file(result),
+            normalization="direct_json",
+        )
+
+
+def test_review_result_strips_only_one_non_json_prefix(tmp_path) -> None:
+    result = tmp_path / "review.result"
+    result.write_text('progress note\n{"ok":true}', encoding="utf-8")
+    value, raw_sha256, semantic_sha256, normalization = admission.read_review_result(result)
+    assert value == {"ok": True}
+    assert raw_sha256 != semantic_sha256
+    assert normalization == "stripped_non_json_prefix"
+
+
+def test_review_result_rejects_trailing_commentary(tmp_path) -> None:
+    result = tmp_path / "review.result"
+    result.write_text('{"ok":true}\ntrailing note', encoding="utf-8")
+    with pytest.raises(admission.SourceAdmissionError, match="no recoverable JSON"):
+        admission.read_review_result(result)
+
+
+def test_atomic_receipt_write_replaces_complete_file(tmp_path) -> None:
+    output = tmp_path / "nested" / "gate.json"
+    admission.write_text_atomic(output, "first\n")
+    admission.write_text_atomic(output, "second\n")
+    assert output.read_text(encoding="utf-8") == "second\n"
+    assert not list(output.parent.glob(".gate.json.*.tmp"))

--- a/tests/test_open_model_phase3_university_source_admission.py
+++ b/tests/test_open_model_phase3_university_source_admission.py
@@ -21,10 +21,10 @@ def _decision(source_id: str) -> dict[str, object]:
         "primary_source_roles": ["explicit_rule"],
         "claim_types": ["unresolved"],
         "supported_uses": [],
-        "prohibited_uses": ["all production use before exact evidence"],
+        "prohibited_uses": ["all_production_use_before_exact_evidence"],
         "exactness_status": "insufficient",
         "evidence_hashes": ["a" * 64],
-        "missing_evidence": ["exact source-level admission evidence"],
+        "missing_evidence": ["exact_source_level_admission_evidence"],
         "reason": "The source remains default-deny until the named evidence exists.",
     }
 
@@ -90,6 +90,28 @@ def _scope_review() -> dict[str, object]:
     }
 
 
+def _source_matrix() -> dict[str, object]:
+    rows = [
+        *({"source_id": source_id, "disposition": "admit_candidate"} for source_id in admission.SOURCE_IDS),
+        *(
+            {"source_id": source_id, "disposition": "contextual_only"}
+            for source_id in sorted(admission.CONTEXTUAL_ONLY_IDS)
+        ),
+        *({"source_id": source_id, "disposition": "quarantine"} for source_id in sorted(admission.QUARANTINE_IDS)),
+    ]
+    return {
+        "schema_version": "phase3-university-source-matrix-consolidated.v3",
+        "text_free": True,
+        "source_disposition_counts": {
+            "admit_candidate": 11,
+            "contextual_only": 15,
+            "quarantine": 4,
+            "total_unique_sources": 30,
+        },
+        "source_dispositions": rows,
+    }
+
+
 def _transport() -> dict[str, object]:
     return {
         "ukrainian_review": {
@@ -121,6 +143,7 @@ def test_valid_exact_denominator_builds_deterministic_text_free_gate() -> None:
     first = admission.build_gate(
         review,
         scope_review,
+        _source_matrix(),
         review_sha256=admission.EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
         scope_review_sha256="c" * 64,
         transport=_transport(),
@@ -128,6 +151,7 @@ def test_valid_exact_denominator_builds_deterministic_text_free_gate() -> None:
     second = admission.build_gate(
         copy.deepcopy(review),
         copy.deepcopy(scope_review),
+        copy.deepcopy(_source_matrix()),
         review_sha256=admission.EXPECTED_SCOPE_INPUT_HASHES["university_source_admission_review_sha256"],
         scope_review_sha256="c" * 64,
         transport=copy.deepcopy(_transport()),
@@ -198,7 +222,24 @@ def test_pre_2019_admission_requires_current_orthography_restriction() -> None:
             "orthography_regime": "pre_2019",
             "exactness_status": "verified_for_scoped_use",
             "missing_evidence": [],
-            "prohibited_uses": ["unrelated restriction"],
+            "prohibited_uses": ["unrelated_restriction"],
+        }
+    )
+    with pytest.raises(admission.SourceAdmissionError, match="post-2019 authority restriction"):
+        admission.validate_review(review)
+
+
+def test_pre_2019_restriction_rejects_descriptive_marker_sentence() -> None:
+    review = _review()
+    decision = review["decisions"][2]
+    decision.update(
+        {
+            "final_disposition": "admit_scoped",
+            "allowed_lanes": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"],
+            "orthography_regime": "pre_2019",
+            "exactness_status": "verified_for_scoped_use",
+            "missing_evidence": [],
+            "prohibited_uses": ["discusses_commercial_trends_after_post_2019"],
         }
     )
     with pytest.raises(admission.SourceAdmissionError, match="post-2019 authority restriction"):
@@ -209,8 +250,24 @@ def test_noncommercial_rights_cannot_lose_commercial_restriction() -> None:
     review = _review()
     decision = review["decisions"][0]
     decision["rights_capability"] = "cc_by_nc_4_0_noncommercial_only"
-    decision["prohibited_uses"] = ["automatic admission"]
+    decision["prohibited_uses"] = ["automatic_admission"]
     with pytest.raises(admission.SourceAdmissionError, match="non-commercial rights restriction"):
+        admission.validate_review(review)
+
+
+def test_noncommercial_restriction_rejects_uncontrolled_commercial_marker() -> None:
+    review = _review()
+    decision = review["decisions"][0]
+    decision["rights_capability"] = "cc_by_nc_4_0_noncommercial_only"
+    decision["prohibited_uses"] = ["commercial_topic_context"]
+    with pytest.raises(admission.SourceAdmissionError, match="non-commercial rights restriction"):
+        admission.validate_review(review)
+
+
+def test_gate_metadata_fields_reject_free_form_source_text() -> None:
+    review = _review()
+    review["decisions"][0]["supported_uses"] = ["verbatim source passage"]
+    with pytest.raises(admission.SourceAdmissionError, match="schema violation"):
         admission.validate_review(review)
 
 
@@ -232,14 +289,41 @@ def test_scope_review_rejects_quarantine_coverage_credit() -> None:
     review = _scope_review()
     review["topic_matrix"][0]["supporting_source_ids"] = [next(iter(admission.QUARANTINE_IDS))]
     with pytest.raises(admission.SourceAdmissionError, match="quarantined source"):
-        admission.validate_scope_review(review)
+        admission.validate_scope_review(review, _source_matrix())
 
 
 def test_scope_review_requires_exact_26_area_order() -> None:
     review = _scope_review()
     review["topic_matrix"][0], review["topic_matrix"][1] = review["topic_matrix"][1], review["topic_matrix"][0]
     with pytest.raises(admission.SourceAdmissionError, match="exact ordered 26-area"):
-        admission.validate_scope_review(review)
+        admission.validate_scope_review(review, _source_matrix())
+
+
+def test_scope_review_source_set_facts_are_derived_from_matrix_rows() -> None:
+    review = _scope_review()
+    review["source_set_check"]["no_extras"] = False
+    with pytest.raises(admission.SourceAdmissionError, match="source-set facts"):
+        admission.validate_scope_review(review, _source_matrix())
+
+
+def test_negative_scope_review_can_encode_a_matrix_extra() -> None:
+    matrix = _source_matrix()
+    matrix["source_dispositions"].append({"source_id": "unexpected-source", "disposition": "contextual_only"})
+    matrix["source_disposition_counts"].update({"contextual_only": 16, "total_unique_sources": 31})
+    review = _scope_review()
+    review["source_set_check"].update({"total_unique_sources": 31, "contextual_only_count": 16, "no_extras": False})
+    review["matrix_disposition"] = "CHANGES_REQUIRED"
+    review["source_admission_matrix_ready"] = False
+    assert admission.validate_scope_review(review, matrix)["source_set_check"]["no_extras"] is False
+
+
+def test_approved_scope_review_rejects_swapped_disposition_groups() -> None:
+    matrix = _source_matrix()
+    candidate = next(row for row in matrix["source_dispositions"] if row["disposition"] == "admit_candidate")
+    contextual = next(row for row in matrix["source_dispositions"] if row["disposition"] == "contextual_only")
+    candidate["disposition"], contextual["disposition"] = contextual["disposition"], candidate["disposition"]
+    with pytest.raises(admission.SourceAdmissionError, match="wrong disposition group"):
+        admission.validate_scope_review(_scope_review(), matrix)
 
 
 def test_approved_scope_review_can_report_findings_applied_to_final_matrix() -> None:
@@ -251,7 +335,7 @@ def test_approved_scope_review_can_report_findings_applied_to_final_matrix() -> 
             "required_action": "Correct the matrix.",
         }
     ]
-    assert admission.validate_scope_review(review)["findings"] == review["findings"]
+    assert admission.validate_scope_review(review, _source_matrix())["findings"] == review["findings"]
 
 
 def test_dispatch_transport_accepts_only_known_ignored_metadata_leak(tmp_path) -> None:
@@ -311,6 +395,13 @@ def test_review_result_rejects_trailing_commentary(tmp_path) -> None:
     result = tmp_path / "review.result"
     result.write_text('{"ok":true}\ntrailing note', encoding="utf-8")
     with pytest.raises(admission.SourceAdmissionError, match="no recoverable JSON"):
+        admission.read_review_result(result)
+
+
+def test_review_result_rejects_prefix_with_earlier_json_opener(tmp_path) -> None:
+    result = tmp_path / "review.result"
+    result.write_text('progress {not json}\n{"ok":true}', encoding="utf-8")
+    with pytest.raises(admission.SourceAdmissionError, match="payload is malformed"):
         admission.read_review_result(result)
 
 


### PR DESCRIPTION
## Summary

- add strict review, scope-review, and gate schemas for the Phase 3 university source-admission boundary
- validate the exact 11-source Ukrainian-review denominator and the complete 30-source / 26-topic scope matrix
- fail closed on stale hashes, missing or reordered sources, unsupported roles or lanes, quarantined support, pre-2019 authority leakage, and non-commercial-rights leakage
- normalize only a single non-JSON reviewer prefix and explicitly record metadata-only dispatch failures instead of treating them as semantic success or failure
- publish receipts atomically while keeping DB ingest, the complete source/evaluation freeze, Phase 3 completion, and Phase 4 blocked

## Reviewed outcome

- Ukrainian source review: 11 scoped admissions (7 DB-resident, 4 staged)
- independent matrix review: 30 unique sources = 11 scoped admissions / 15 contextual-only / 4 quarantine
- final 26-topic matrix: 3 sufficient / 23 partial / 0 missing
- critic correction: syntax is partial, and unsupported cross-topic source credit must be removed during policy generation
- all corpus roots remain covered by the verified 982-file / 6.29 GB Google Drive backup receipt

The generated live gate receipt is private runtime evidence and is intentionally not committed. This PR supplies the deterministic, testable contract required to regenerate it from exact reviewed inputs.

## Verification

- `35 passed` across the new gate tests and the merged complete-context representation canary
- Ruff lint: pass
- Ruff format check: pass
- all three JSON Schemas pass Draft 2020-12 schema validation
- `git diff --check`: pass

Issue: #6375
