### PR TITLE
Phase 3: bind complete source policy and rehearse staged ingest

### DIFF
--- a/data/projects/open_model_data/admission/phase3_complete_source_policy_v4.json
+++ b/data/projects/open_model_data/admission/phase3_complete_source_policy_v4.json
@@ -1,0 +1,1263 @@
+{
+  "bindings": {
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "phase3_recovery_prompt_v2_sha256": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b",
+    "pr6630_drive_backup_receipt_sha256": "f577ab1cec2b2dee99e033284f1801f723a3d741e9e7c050d32cec0494b52d81",
+    "pr6630_merge_commit": "d117a9c5bab7f309e78607b540ac8931a6bc3b4c",
+    "university_corpus_reconciliation_v3_sha256": "3a4abb3883ad06db3fea1f994a5b51bc22cbdd6ab3e8d3adaf72c180bc42dd65",
+    "university_source_admission_gate_v1_sha256": "423275e09192e593cdcc3b31b5074c860ada9e735d94a0857fc802d5dc9ef755",
+    "university_source_matrix_v3_sha256": "e2e82934ec26b7d98002cdf87f5326b84fb2d3d7900fe675920ba99e84d190de",
+    "university_source_policy_v3_sha256": "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"
+  },
+  "database_ingest": {
+    "copied_database_rehearsal_required": true,
+    "eligible_source_ids": [
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+      "uni-ukrmova-lexicology-filon-khomik-2010",
+      "uni-ukrmova-morphology-volkova-maslo-2012",
+      "uni-ukrmova-orthography-strokal-2021",
+      "uni-ukrmova-phonetics-komarova-2015",
+      "uni-ukrmova-prof-haluzynska-2006",
+      "uni-ukrmova-punctuation-marynenko-2021",
+      "uni-ukrmova-stylistics-sharapa-tytarenko-2025",
+      "uni-ukrmova-syntax-herman-2021",
+      "uni-ukrmova-text-linguistics-shevel-bilyk-2024"
+    ],
+    "live_ingest_authorized": false,
+    "staged_expected_row_count": 585,
+    "staged_expected_rows": {
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-1": 47,
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-2": 51,
+      "uni-ukrmova-morphology-volkova-maslo-2012": 205,
+      "uni-ukrmova-text-linguistics-shevel-bilyk-2024": 282
+    },
+    "staged_not_ingested_source_ids": [
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+      "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+      "uni-ukrmova-morphology-volkova-maslo-2012",
+      "uni-ukrmova-text-linguistics-shevel-bilyk-2024"
+    ]
+  },
+  "default_disposition": "QUARANTINE_UNTIL_REVIEWED",
+  "disposition_counts": {
+    "admit_scoped": 11,
+    "contextual_only": 15,
+    "quarantine": 4,
+    "total": 30
+  },
+  "phase3_complete": false,
+  "phase4_blocked": true,
+  "receipt_sha256": "20429ad1ac695f3c7ab661d14206a91eab4954c5fb58a54cb9ef3911394c073d",
+  "schema_version": "phase3_complete_source_policy_v4",
+  "source_count": 30,
+  "source_freeze_ready": false,
+  "sources": [
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "reference_drive_backed",
+      "evidence_hashes": [
+        "43c2c4975b29bc131c7f73499e6bbf443778f36647bf4cc085fe76dbc1c51fc5"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "unrestricted_commercial_training",
+        "automatic_admission",
+        "correction_gold"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "khpi-ukrainian-morphological-tagging-petrasova-et-al-2017",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "ukrainian_morphological_tagging",
+        "tagset_and_analyzer_context"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "reference_drive_backed",
+      "evidence_hashes": [
+        "43c2c4975b29bc131c7f73499e6bbf443778f36647bf4cc085fe76dbc1c51fc5"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "current_implementation",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "adjudication_gold",
+        "correction_gold",
+        "model_subword_authority"
+      ],
+      "rights_capability": "mit",
+      "source_id": "lang-uk-tokenize-uk",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "ukrainian_word_and_sentence_tokenization_corroboration",
+        "unicode_apostrophe_stress_and_offset_diagnostics"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "reference_drive_backed",
+      "evidence_hashes": [
+        "43c2c4975b29bc131c7f73499e6bbf443778f36647bf4cc085fe76dbc1c51fc5"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "retained_extracted_text",
+        "training_or_publication",
+        "automatic_admission",
+        "correction_gold"
+      ],
+      "rights_capability": "private_inspection_and_locator_evidence_only",
+      "source_id": "naukma-ukrainian-tokenization-stemming-hlybovets-tochytskyi-2017",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "ukrainian_specific_tokenization_and_stemming_locator"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "dd3e7b45abdde9acebea684b323582f73f2b2189401a193ac9bc88a3e6845d10"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "9aefd42ef5e6a9691314df7a8870902775a4d44823f36706cd23e80524157694",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "6de0b6f8ae2a9ed1a29161dad76ed003098b315698630b61effdf23bb053df4c",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-istoriya-kalynichenko-olianych-2025.jsonl",
+        "subject_role": "history"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_linguistic_rules",
+        "grammatical_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-istoriya-kalynichenko-olianych-2025",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "contemporary_history_prose",
+        "decolonial_historical_framing"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "afc4685f627f1b555f88e94c20f8c7280c7d695f382b3cf0d8ea36424f02188a"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "f111c27c136d8099359487fe1ae707b66431bf8420f156b0b1e7321660260710",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "6233f862eee3afe045b706f84fb7df9e6a07c898d1a938a3b47f29adb0f51ee1",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-istoriya-levytska-2015.jsonl",
+        "subject_role": "history"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_language_rules",
+        "grammar_paradigm_extraction"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-istoriya-levytska-2015",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "historical_prose_retrieval",
+        "historical_context_embedding"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "564fa01a1fb4474f523aff19a5f0eb727ef0f17ff68f617c84dc488bc2ba7896"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "9020a9fa155a2cda8e5ed6bf48f612c7264342c6cd29ec7a9791a3b3c746ba75",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "3a9252d79ed1684e9b9bb567a1e0e0fc8b0cf3d908d15ab5a258a30122f10e4e",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-mystetstvo-levytska-2015.jsonl",
+        "subject_role": "arts_and_culture"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_grammar_rules",
+        "public_dataset_distribution_without_publisher_confirmation"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-mystetstvo-levytska-2015",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "arts_prose_retrieval",
+        "cultural_context"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "8093c3694d53a67f05a4f7b9dbec373ee7a53d03da91956adb7be846a3744a3d"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "2e784c89b65d7fee9ea3a4e46845f1cecb7bc6eee194b9deceead62f775f98bc",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "d87e9f7c62bb9a2ef1bc6efd983d7fe56ef3097c977799a8c1dc592b564cca4c",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-mystetstvo-petutina-2012.jsonl",
+        "subject_role": "arts_and_culture"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_grammar_rules",
+        "linguistic_rule_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-mystetstvo-petutina-2012",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "arts_and_culture_prose_retrieval",
+        "cultural_history_context"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "88801aa8d9b92fe38e99bcc8b0c7e8a4a33f0d1ce73a09f61ea83f0a164111a9"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "aa30b5deb9287fddba6b8dc3775ca0f353758b91c285e8516b07b7e75048d1f2",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "85ba06bcb90ce6988100647faf953fc1a171b7da1718d55a541677f58d72cda9",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrlit-dvulychanska-2017.jsonl",
+        "subject_role": "ukrainian_literature"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_grammar_rules",
+        "public_dataset_release_without_license_clearance"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrlit-dvulychanska-2017",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "historical_literary_context",
+        "literary_history_retrieval"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "7c1141d4e2fc2e71dac2ef641a19d87ef9f91db11463d61ea379c59aad79b6aa"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "f8355bff61c181c4e8e9551886cc286e041a4b87aa8b1ae9ed2548ea6f4c7c2d",
+        "page_end": 2,
+        "page_start": 1,
+        "rows_sha256": "4e974624dc7a8a73a8c763322ff5be177ec85ffd31169d2aee0f7697944c05af",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrlit-kalinichenko-2024.jsonl",
+        "subject_role": "ukrainian_literature"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "normative_grammar_rule_generation",
+        "orthography_rule_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrlit-kalinichenko-2024",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "advanced_literary_prose_retrieval",
+        "literary_criticism_context",
+        "modern_poetics_analysis"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "reference_drive_backed",
+      "evidence_hashes": [
+        "da3753c6223f08059fc6e03492f4919ec283060c0fb73aecc7307425ce339ad1"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "retained_extracted_text",
+        "training_or_publication",
+        "ukrainian_specific_tokenization_authority"
+      ],
+      "rights_capability": "private_inspection_and_locator_evidence_only",
+      "source_id": "uni-ukrmova-computational-linguistics-vakhovska-2023",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "content_gap_assessment",
+        "qualified_locator_evidence"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "attestation_only"
+      ],
+      "custody_state": "staged_drive_backed",
+      "evidence_hashes": [
+        "2647aff01ecc20eebeb1ce196767a7ba4bffac36fd231a4ecee5af7678c0e99b",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a",
+        "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "00cfd4f8d6185b9116992311891a883753218e6a27b52f6e9f291f37e66366af",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "e46aee2f63238a73a050374a02aeea9a673b10e7e3fbec9678a9e0e55f9e22f9",
+        "source_locator": "university_corpus/staging/phase3-6375-waves-b-e/wave-b/uni-ukrmova-corpus-linguistics-khpi-2021-part-1.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "unrestricted_commercial_training",
+        "ukrainian_specific_tokenization_authority",
+        "pre_2019_spelling_enforcement"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+      "source_kind": "university_jsonl",
+      "source_state": "staged_not_ingested",
+      "supported_uses": [
+        "corpus_creation",
+        "corpus_annotation",
+        "corpus_query_systems_and_software_tutorials",
+        "applied_linguistics_theory"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "attestation_only"
+      ],
+      "custody_state": "staged_drive_backed",
+      "evidence_hashes": [
+        "2647aff01ecc20eebeb1ce196767a7ba4bffac36fd231a4ecee5af7678c0e99b",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a",
+        "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "5ac5d5495aee21ff756156fda362f4e2340de9021380917c0bf9c74b9440e84b",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "c50d686392788437858fd699b0c75e1e50384e447b92a30cdeeaf68623e9013a",
+        "source_locator": "university_corpus/staging/phase3-6375-waves-b-e/wave-b/uni-ukrmova-corpus-linguistics-khpi-2021-part-2.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "unrestricted_commercial_training",
+        "ukrainian_specific_tokenization_authority",
+        "pre_2019_spelling_enforcement"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+      "source_kind": "university_jsonl",
+      "source_state": "staged_not_ingested",
+      "supported_uses": [
+        "semantic_annotation",
+        "corpus_clusters_and_collocation_analysis",
+        "applied_linguistics_theory"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "01f8f7598cb729d1174d4bef7b0ed1fb9575bf9166c0665a4d44323fe78dda73"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "b8d349c725f0964817111c05bdb6c8dcdba6ac35139b91ea65ccdafe042fc89c",
+        "page_end": 6,
+        "page_start": 2,
+        "rows_sha256": "2f24ce001b5ecb222bfa84e5065607403de26edcc3c9b5ec87b4a368329ed7fa",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-dialectology-torchynska-2017.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "modern_standard_normative_grammar_authority",
+        "normative_orthography_or_spellcheck_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-dialectology-torchynska-2017",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "regional_dialect_variation_context",
+        "comparative_dialect_phonetics_and_vocabulary",
+        "sociolinguistic_geography_reference"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "reference_drive_backed",
+      "evidence_hashes": [
+        "da3753c6223f08059fc6e03492f4919ec283060c0fb73aecc7307425ce339ad1"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "retained_extracted_text",
+        "training_or_publication",
+        "automatic_correction_gold"
+      ],
+      "rights_capability": "private_inspection_and_locator_evidence_only",
+      "source_id": "uni-ukrmova-error-typology-minchak-2023",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "content_gap_assessment",
+        "qualified_locator_evidence"
+      ]
+    },
+    {
+      "allowed_lanes": [],
+      "claim_types": [],
+      "custody_state": "quarantined_not_database_resident",
+      "evidence_hashes": [
+        "35f65ac91c72e58d7cc7b54fa5765d29e92d2a525f2bfb982ff17c8abc03e2d4"
+      ],
+      "exactness_status": "failed",
+      "final_disposition": "quarantine",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "8c4b7a81dc668f734a69c2608fea42c6cc8767cd8672bbee3e6b1ebdb0145cd4",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "0790c0f078045fd0934d354b704f43c8a5b0902fc6c5e2a8fe51ad45e47f4540",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-glukhovtseva-2021.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "admit_candidate",
+        "contextual_only",
+        "direct_curriculum_ingestion",
+        "core_grammar_rule_extraction",
+        "synthetic_training_data_generation"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-glukhovtseva-2021",
+      "source_kind": "university_jsonl",
+      "source_state": "quarantined",
+      "supported_uses": []
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "d9ca7b23bc77d196f837678e4b3187ab92d2a36adfeb8b0766a79d74fc35506c"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "77713275fe6d1b903fef8ddfc5a171595798d547f87c898b6b0f0d696b6f5a37",
+        "page_end": 3,
+        "page_start": 1,
+        "rows_sha256": "e9b7d4bd56c4f0733c118e244e463184cb9d6385ec42df579acd59952b3fa7d0",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-historical-grammar-kupchynska-piletskyi-2024.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "modern_normative_grammar_authority",
+        "modern_orthography_enforcement"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-historical-grammar-kupchynska-piletskyi-2024",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "historical_diachronic_grammar_context",
+        "diachronic_sound_change_and_morphological_evolution"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant",
+        "attestation_only"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "47d0448e69994e9ed6a0bff7928d58cea147b7a01e778d43f80bbd7c50b6beee",
+        "d9a04be0225bdbc911d0fc906f4f8283331cf7400ceb3165e77aa54da3576a8f",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "e250f16c5fc1cb0cc3f38f184f03d4b18d98894de050c65510847565f7766666",
+        "page_end": 2,
+        "page_start": 1,
+        "rows_sha256": "d776afe1cbd58fe220129017a8ee38ed3fdeecc8095246f919e9c837e245fbdb",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-lexicology-filon-khomik-2010.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "post_2019_orthography_spelling_rules",
+        "L2_elementary_drills",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-lexicology-filon-khomik-2010",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "lexicology_theory",
+        "semantics_classification",
+        "phraseology_examples",
+        "morphemics_theory",
+        "word_formation_theory"
+      ]
+    },
+    {
+      "allowed_lanes": [],
+      "claim_types": [],
+      "custody_state": "quarantined_not_database_resident",
+      "evidence_hashes": [
+        "b938efbbc26758e41a96400a4f1d294e33886cbcd1b6d20f3a1d899f47a99c15"
+      ],
+      "exactness_status": "failed",
+      "final_disposition": "quarantine",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter_and_official_course",
+        "jsonl_sha256": "55f727f53a2c188fce3638609d2210c84069c7afa443ef07ece1be44d5995cb0",
+        "page_end": 6,
+        "page_start": 1,
+        "rows_sha256": "866ff30853865ba708d5fcdd7c483573e38a0c9460a8c256677be539312fcfa7",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-morphology-aleksiienko-2014.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "admit_candidate",
+        "contextual_only",
+        "direct_curriculum_ingestion",
+        "core_grammar_rule_extraction",
+        "synthetic_training_data_generation"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-morphology-aleksiienko-2014",
+      "source_kind": "university_jsonl",
+      "source_state": "quarantined",
+      "supported_uses": []
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval"
+      ],
+      "claim_types": [],
+      "custody_state": "locator_only",
+      "evidence_hashes": [
+        "1184b165eb3a8c1abf5ffa0cb3ddcae0613a0f15b2fe2575483ed90725447a73"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "rule_or_correction_authority",
+        "training",
+        "publication"
+      ],
+      "rights_capability": "metadata_locator_only_no_reuse_license",
+      "source_id": "uni-ukrmova-morphology-kobchenko-2025",
+      "source_kind": "external_reference",
+      "source_state": "reference_only",
+      "supported_uses": [
+        "current_curriculum_scope_corroboration"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant",
+        "attestation_only"
+      ],
+      "custody_state": "staged_drive_backed",
+      "evidence_hashes": [
+        "662547c533758a634eafc4edf79cf153549d291cc19d28e875959a95606badda",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a",
+        "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "0229ba6526f863b1500533693032d31e29b9e3f9456dd15aa7a1704f14dec54e",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "96fe0d5f52828c9529f7e2b05f5f2050f63667ad087a70117a015c6244608db9",
+        "source_locator": "university_corpus/staging/phase3-6375-waves-b-e/wave-d/uni-ukrmova-morphology-volkova-maslo-2012.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "post_2019_orthography_spelling_rules_without_current_corroboration",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-morphology-volkova-maslo-2012",
+      "source_kind": "university_jsonl",
+      "source_state": "staged_not_ingested",
+      "supported_uses": [
+        "morphology_theory",
+        "parts_of_speech_classification",
+        "inflectional_paradigms",
+        "morphological_analysis_exercises"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "human_correction_pair",
+        "style_preference",
+        "acceptable_variant"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "a53ffc44a9db4c36fc7435df31ede4685ad972933f273eb0ae687f02379ed76f",
+        "d9a04be0225bdbc911d0fc906f4f8283331cf7400ceb3165e77aa54da3576a8f",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "076735b3a80f7417158701ca219a56d36d212f1f9d8f2a9d694eed5cbdb5a5c9",
+        "page_end": 5,
+        "page_start": 2,
+        "rows_sha256": "cf17e55e314dc5535c81b39bb0dcb7fb10c920fd41d3b5a7820552cac603be58",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-orthography-strokal-2021.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "incorrect_example",
+        "corrected_example",
+        "editing_exercise",
+        "answer_key"
+      ],
+      "prohibited_uses": [
+        "pre_2019_spelling_enforcement",
+        "dialectal_norm_generation"
+      ],
+      "rights_capability": "cc_by_4_0",
+      "source_id": "uni-ukrmova-orthography-strokal-2021",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "orthography_rules",
+        "graphics_rules",
+        "phonetics_theory",
+        "accentology_examples",
+        "punctuation_examples",
+        "normative_spelling_exercise_generation"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant",
+        "attestation_only"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "ce07172263def57c1563ea515e797614f5bcff67053ac572b4d7b0ae6fbf96e7",
+        "0dbdf3dc7b0d1c402298248ac6921865baa36444ca479926b142364dfb5c8ff6",
+        "d9dda3526d929c7fe154530ad4e5af37fd0ad278feccd88ea18c112835a314ee"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "4a14321ebb452dd2cf2d1b78aafd4395fdd8e0af394a31cea9bfee7b883b5757",
+        "page_end": 2,
+        "page_start": 1,
+        "rows_sha256": "73c1ac4d2df3a6f043b3a3a88e23dddaed4b92b1eb2e14b08c5ef3237a815dc8",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-phonetics-komarova-2015.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "post_2019_orthography_spelling_rules_without_current_corroboration",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-phonetics-komarova-2015",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "phonetics_theory",
+        "phonology_theory",
+        "orthoepy_theory",
+        "graphics_theory",
+        "alternation_rules"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant",
+        "human_correction_pair"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "c3106974b919e74b27c681dac6514b63d3364845c41761705dd2f7b1dafb7c2b",
+        "d9a04be0225bdbc911d0fc906f4f8283331cf7400ceb3165e77aa54da3576a8f",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "aa84f98a8779c9d4323b52dddad095f0c0a218d1d56619992946dde1fdd04424",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "e0ed8c525c872d91cc8016581e73393da7603cfa824fa9b7cb551ed8b0c874d3",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-prof-haluzynska-2006.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "incorrect_example",
+        "corrected_example",
+        "editing_exercise"
+      ],
+      "prohibited_uses": [
+        "post_2019_orthography_rules",
+        "deep_historical_linguistics",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-prof-haluzynska-2006",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "professional_language_culture",
+        "stylistics_editing",
+        "document_style",
+        "business_communication_norms"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "a799f492c62558bf0ad100ddd8205a96f3b9ca2bcda49d10b631053a926028b3",
+        "d9a04be0225bdbc911d0fc906f4f8283331cf7400ceb3165e77aa54da3576a8f",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "49271a38d4156e3c76373bf0e4b7b97bc5125c9afd70b279a0f49c2101193973",
+        "page_end": 2,
+        "page_start": 2,
+        "rows_sha256": "5dcb417a72870d14d3c705c065c8dd85b6b803b74c7ece782b147b4374e8d125",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-punctuation-marynenko-2021.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "morphological_paradigm_authority",
+        "pre_2019_orthography_rules",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-punctuation-marynenko-2021",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "syntax_rules",
+        "punctuation_rules",
+        "clause_boundary_analysis",
+        "direct_speech_formatting",
+        "normative_sentence_structure"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "claim_types": [],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "a7be6c39c55eaec041c3048d2f8ed62759520979b0bdcdcadba4592559a8acf2"
+      ],
+      "exactness_status": "context_only",
+      "final_disposition": "contextual_only",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter_and_official_course",
+        "jsonl_sha256": "a8f0ff3d73a2e5726f660cba56bf629b303ae80634cd9fc94567d1080de18d3b",
+        "page_end": 6,
+        "page_start": 1,
+        "rows_sha256": "69ef6b61c9cd0eb59feda0070702b4e1e6c278e8f45a3d1d996f933c7bc3e8b4",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-sociolinguistics-masenko-2010.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "pre_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "modern_standard_normative_grammar_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-sociolinguistics-masenko-2010",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident_contextual",
+      "supported_uses": [
+        "sociolinguistic_and_language_policy_context",
+        "surzhyk_and_language_contact_analysis"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "human_correction_pair",
+        "acceptable_variant"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "9da01b7fb6e5afc8b8d7439c9618626d5da176309ffb59ae8668c0d656c6c7e1",
+        "ead17b29f762f77900ad46e5fb5160dd1a1adaf27d3ab837fb5f6e5d458e0ec1",
+        "d9dda3526d929c7fe154530ad4e5af37fd0ad278feccd88ea18c112835a314ee"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "0ecaf0dcc1f4f8d32dc3efec22993ee9826d52c69ac9d707b36d2149827dcddd",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "5d5a2d36e70f62ad4729e7c849de0493031434feb324013e419d536ca498c4a3",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-stylistics-sharapa-tytarenko-2025.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "incorrect_example",
+        "corrected_example",
+        "editing_exercise"
+      ],
+      "prohibited_uses": [
+        "pre_2019_spelling_rules",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-stylistics-sharapa-tytarenko-2025",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "stylistics_rules",
+        "culture_of_language_rules",
+        "functional_style_analysis",
+        "modern_normative_usage"
+      ]
+    },
+    {
+      "allowed_lanes": [],
+      "claim_types": [],
+      "custody_state": "quarantined_not_database_resident",
+      "evidence_hashes": [
+        "d08bd6e99f8456ab8f937af76767c515c7bd1ea2cd33b292dbc8a7909a6d2e45"
+      ],
+      "exactness_status": "failed",
+      "final_disposition": "quarantine",
+      "jsonl_evidence": {
+        "audience_class": "B_foreign_or_second_language",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "3456eb48a47a0c48769c6b3c05c103558bed7e706662621c462513a167aa2e44",
+        "page_end": 5,
+        "page_start": 1,
+        "rows_sha256": "ece7d3061fa4301fc129849dabc79bd28a366d91b250d3dfd194458293811b2c",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-syntax-didkivska-shvets-2020.jsonl",
+        "subject_role": "ukrainian_L2_pedagogy"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "native_fluency_data",
+        "normative_syntax_authority"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-syntax-didkivska-shvets-2020",
+      "source_kind": "university_jsonl",
+      "source_state": "quarantined",
+      "supported_uses": []
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant"
+      ],
+      "custody_state": "database_resident_and_drive_backed",
+      "evidence_hashes": [
+        "2504eaa3ba5532fdffb085ce49d1f299a3c5f5d3dba77723714078c5060acd73",
+        "db8d14635ba786ed333d68f21d1625f3de065b588ac5efe97a8bcd2c32bd33a1",
+        "d9dda3526d929c7fe154530ad4e5af37fd0ad278feccd88ea18c112835a314ee"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "190b142ad0ba501791a58f4694b5839fb02bfeba0a12bf6a8c4c877f9a803c90",
+        "page_end": 3,
+        "page_start": 1,
+        "rows_sha256": "92f4e5781c684b6501327f04b2dfc67a452926044e1460faecc704c504afec9f",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-syntax-herman-2021.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "morphological_paradigm_authority",
+        "unrestricted_commercial_training"
+      ],
+      "rights_capability": "cc_by_nc_4_0_noncommercial_only",
+      "source_id": "uni-ukrmova-syntax-herman-2021",
+      "source_kind": "university_jsonl",
+      "source_state": "db_resident",
+      "supported_uses": [
+        "complex_sentence_syntax_rules",
+        "composite_clause_analysis",
+        "syntactic_coordination_subordination_theory"
+      ]
+    },
+    {
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest",
+        "linguistic_rule_evidence"
+      ],
+      "claim_types": [
+        "prescriptive_rule",
+        "style_preference",
+        "acceptable_variant",
+        "attestation_only"
+      ],
+      "custody_state": "staged_drive_backed",
+      "evidence_hashes": [
+        "b5ec25e29d8524a90506effea1e18a4c170d698937b3fc4206a516b09bd5a0f9",
+        "0ecc5553395cdf32788f8bce1d5b071c0a90bd409f371eb44e6fded534d86a7a",
+        "2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"
+      ],
+      "exactness_status": "verified_for_scoped_use",
+      "final_disposition": "admit_scoped",
+      "jsonl_evidence": {
+        "audience_class": "A_ukrainian_university_audience",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "26848855c02a8ac6c02b7320d2b4a1986397a897c0a6d9df9ade720c20339920",
+        "page_end": 4,
+        "page_start": 1,
+        "rows_sha256": "10b5f59f1852b7a7f7337b52ccb855ce7d04345466f670c5161106c928646273",
+        "source_locator": "university_corpus/staging/phase3-6375-wave-a/grade-00/uni-ukrmova-text-linguistics-shevel-bilyk-2024.jsonl",
+        "subject_role": "ukrainian_linguistics"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [
+        "explicit_rule",
+        "correct_example",
+        "editing_exercise",
+        "ordinary_narration"
+      ],
+      "prohibited_uses": [
+        "unrestricted_commercial_training",
+        "pre_2019_spelling_enforcement"
+      ],
+      "rights_capability": "cc_by_4_0",
+      "source_id": "uni-ukrmova-text-linguistics-shevel-bilyk-2024",
+      "source_kind": "university_jsonl",
+      "source_state": "staged_not_ingested",
+      "supported_uses": [
+        "text_linguistics_theory",
+        "text_cohesion_and_coherence",
+        "text_category_and_structure_analysis",
+        "discourse_and_pragmatics_context"
+      ]
+    },
+    {
+      "allowed_lanes": [],
+      "claim_types": [],
+      "custody_state": "quarantined_not_database_resident",
+      "evidence_hashes": [
+        "41e01c69a6a6cb7b4ef316c5b349f6747b8bc969da2865b8bb63888b1806542f"
+      ],
+      "exactness_status": "failed",
+      "final_disposition": "quarantine",
+      "jsonl_evidence": {
+        "audience_class": "B_foreign_or_second_language",
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": "fded6a45bf8914585d0178129b926a986722fd023b6ef6f7da529ea32ea60725",
+        "page_end": 3,
+        "page_start": 2,
+        "rows_sha256": "a9e3e55a14d84886d8f87fc09d1a0e33494a81542a87a12a2dd4ad370d7016d0",
+        "source_locator": "university_corpus/jsonl/grade-00/uni-ukrmova-vlasova-2023.jsonl",
+        "subject_role": "ukrainian_L2_pedagogy"
+      },
+      "orthography_regime": "post_2019",
+      "primary_source_roles": [],
+      "prohibited_uses": [
+        "native_fluency_data",
+        "normative_rule_authority",
+        "grammatical_paradigm_extraction"
+      ],
+      "rights_capability": "rights_bound_by_v3_policy",
+      "source_id": "uni-ukrmova-vlasova-2023",
+      "source_kind": "university_jsonl",
+      "source_state": "quarantined",
+      "supported_uses": []
+    }
+  ],
+  "status": "ACTIVE_DEFAULT_DENY",
+  "text_free": true
+}

--- a/data/projects/open_model_data/contracts/phase3_complete_source_policy_v4.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_complete_source_policy_v4.schema.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/contracts/phase3_complete_source_policy_v4.schema.json",
+  "title": "Phase 3 complete source policy v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "text_free",
+    "status",
+    "default_disposition",
+    "bindings",
+    "source_count",
+    "disposition_counts",
+    "database_ingest",
+    "sources",
+    "source_freeze_ready",
+    "phase3_complete",
+    "phase4_blocked",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_complete_source_policy_v4"},
+    "text_free": {"const": true},
+    "status": {"const": "ACTIVE_DEFAULT_DENY"},
+    "default_disposition": {"const": "QUARANTINE_UNTIL_REVIEWED"},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256",
+        "university_source_matrix_v3_sha256",
+        "university_source_admission_gate_v1_sha256",
+        "university_source_policy_v3_sha256",
+        "university_corpus_reconciliation_v3_sha256",
+        "pr6630_drive_backup_receipt_sha256",
+        "pr6630_merge_commit"
+      ],
+      "properties": {
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_recovery_prompt_v2_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_matrix_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_admission_gate_v1_sha256": {"$ref": "#/$defs/sha256"},
+        "university_source_policy_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "university_corpus_reconciliation_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6630_drive_backup_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6630_merge_commit": {"$ref": "#/$defs/sha1"}
+      }
+    },
+    "source_count": {"const": 30},
+    "disposition_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["admit_scoped", "contextual_only", "quarantine", "total"],
+      "properties": {
+        "admit_scoped": {"const": 11},
+        "contextual_only": {"const": 15},
+        "quarantine": {"const": 4},
+        "total": {"const": 30}
+      }
+    },
+    "database_ingest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eligible_source_ids",
+        "staged_not_ingested_source_ids",
+        "staged_expected_rows",
+        "staged_expected_row_count",
+        "copied_database_rehearsal_required",
+        "live_ingest_authorized"
+      ],
+      "properties": {
+        "eligible_source_ids": {
+          "type": "array",
+          "minItems": 11,
+          "maxItems": 11,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/source_id"}
+        },
+        "staged_not_ingested_source_ids": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/source_id"}
+        },
+        "staged_expected_rows": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+            "uni-ukrmova-morphology-volkova-maslo-2012",
+            "uni-ukrmova-text-linguistics-shevel-bilyk-2024"
+          ],
+          "properties": {
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-1": {"const": 47},
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-2": {"const": 51},
+            "uni-ukrmova-morphology-volkova-maslo-2012": {"const": 205},
+            "uni-ukrmova-text-linguistics-shevel-bilyk-2024": {"const": 282}
+          }
+        },
+        "staged_expected_row_count": {"const": 585},
+        "copied_database_rehearsal_required": {"const": true},
+        "live_ingest_authorized": {"const": false}
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30,
+      "items": {"$ref": "#/$defs/source"}
+    },
+    "source_freeze_ready": {"const": false},
+    "phase3_complete": {"const": false},
+    "phase4_blocked": {"const": true},
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "sha1": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 3,
+      "maxLength": 128
+    },
+    "token": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_]*$",
+      "minLength": 2,
+      "maxLength": 128
+    },
+    "token_array": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/token"}
+    },
+    "jsonl_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_locator",
+        "audience_class",
+        "subject_role",
+        "evidence_kind",
+        "jsonl_sha256",
+        "page_start",
+        "page_end",
+        "rows_sha256"
+      ],
+      "properties": {
+        "source_locator": {
+          "type": "string",
+          "pattern": "^university_corpus/[A-Za-z0-9._/-]+[.]jsonl$",
+          "maxLength": 256
+        },
+        "audience_class": {
+          "enum": [
+            "A_ukrainian_university_audience",
+            "B_foreign_or_second_language",
+            "C_unproven"
+          ]
+        },
+        "subject_role": {
+          "enum": [
+            "ukrainian_linguistics",
+            "ukrainian_L2_pedagogy",
+            "ukrainian_literature",
+            "history",
+            "arts_and_culture"
+          ]
+        },
+        "evidence_kind": {
+          "enum": ["jsonl_front_matter", "jsonl_front_matter_and_official_course"]
+        },
+        "jsonl_sha256": {"$ref": "#/$defs/sha256"},
+        "page_start": {"type": "integer", "minimum": 1},
+        "page_end": {"type": "integer", "minimum": 1},
+        "rows_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "source_kind",
+        "final_disposition",
+        "source_state",
+        "custody_state",
+        "allowed_lanes",
+        "orthography_regime",
+        "rights_capability",
+        "primary_source_roles",
+        "claim_types",
+        "supported_uses",
+        "prohibited_uses",
+        "exactness_status",
+        "evidence_hashes"
+      ],
+      "properties": {
+        "source_id": {"$ref": "#/$defs/source_id"},
+        "source_kind": {"enum": ["university_jsonl", "external_reference"]},
+        "final_disposition": {"enum": ["admit_scoped", "contextual_only", "quarantine"]},
+        "source_state": {
+          "enum": [
+            "db_resident",
+            "staged_not_ingested",
+            "db_resident_contextual",
+            "reference_only",
+            "quarantined"
+          ]
+        },
+        "custody_state": {"$ref": "#/$defs/token"},
+        "allowed_lanes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["contextual_retrieval", "corpus_ingest", "linguistic_rule_evidence"]
+          }
+        },
+        "orthography_regime": {"$ref": "#/$defs/token"},
+        "rights_capability": {"$ref": "#/$defs/token"},
+        "primary_source_roles": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "explicit_rule",
+              "correct_example",
+              "incorrect_example",
+              "corrected_example",
+              "editing_exercise",
+              "answer_key",
+              "distractor",
+              "quotation",
+              "historical_or_literary_excerpt",
+              "metalinguistic_mention",
+              "ordinary_narration",
+              "ambiguous_or_ocr"
+            ]
+          }
+        },
+        "claim_types": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "prescriptive_rule",
+              "human_correction_pair",
+              "style_preference",
+              "acceptable_variant",
+              "historical_advice",
+              "attestation_only",
+              "unresolved"
+            ]
+          }
+        },
+        "supported_uses": {"$ref": "#/$defs/token_array"},
+        "prohibited_uses": {"$ref": "#/$defs/token_array"},
+        "exactness_status": {
+          "enum": ["verified_for_scoped_use", "context_only", "failed"]
+        },
+        "evidence_hashes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "jsonl_evidence": {"$ref": "#/$defs/jsonl_evidence"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"source_kind": {"const": "university_jsonl"}}},
+          "then": {"required": ["jsonl_evidence"]},
+          "else": {
+            "not": {"required": ["jsonl_evidence"]},
+            "properties": {
+              "allowed_lanes": {"not": {"contains": {"const": "corpus_ingest"}}}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"final_disposition": {"const": "quarantine"}}},
+          "then": {
+            "properties": {
+              "allowed_lanes": {"maxItems": 0},
+              "primary_source_roles": {"maxItems": 0},
+              "claim_types": {"maxItems": 0},
+              "exactness_status": {"const": "failed"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"final_disposition": {"const": "admit_scoped"}}},
+          "then": {
+            "properties": {
+              "allowed_lanes": {
+                "allOf": [
+                  {"contains": {"const": "contextual_retrieval"}},
+                  {"contains": {"const": "corpus_ingest"}}
+                ]
+              },
+              "primary_source_roles": {"minItems": 1},
+              "claim_types": {"minItems": 1},
+              "exactness_status": {"const": "verified_for_scoped_use"}
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -48,6 +49,7 @@ from projects.open_model_data.university_source_policy import (
 )
 from projects.open_model_data.university_source_policy import (
     UniversitySourcePolicyError,
+    load_policy,
     require_source_admission,
     require_source_quarantine,
 )
@@ -380,6 +382,7 @@ def ingest(
     quarantine_slugs: list[str] | None = None,
     receipt_path: Path | None = None,
     university_policy_path: Path = DEFAULT_UNIVERSITY_POLICY,
+    copied_database_rehearsal: bool = False,
 ) -> dict[str, int]:
     """Run one atomic replace/quarantine/FTS-resync cycle.
 
@@ -391,6 +394,38 @@ def ingest(
     overlap = sorted(set(slugs) & set(quarantine_slugs))
     if overlap:
         raise IngestError(f"sources cannot be replaced and quarantined together: {overlap}")
+    db_path = Path(db_path)
+    university_requested = any(
+        slug.startswith("uni-") for slug in [*slugs, *quarantine_slugs]
+    )
+    policy_document: dict[str, Any] | None = None
+    if university_requested:
+        try:
+            policy_document, _policy_sha256 = load_policy(university_policy_path)
+        except UniversitySourcePolicyError as exc:
+            raise IngestError(str(exc)) from exc
+    if copied_database_rehearsal:
+        if dry_run:
+            raise IngestError("copied-database rehearsal must commit to the disposable database copy")
+        if policy_document is None or policy_document["schema_version"] != "phase3_complete_source_policy_v4":
+            raise IngestError("copied-database rehearsal requires the complete v4 source policy")
+        if not db_path.is_file():
+            raise IngestError("copied-database rehearsal target does not exist")
+        same_as_live = db_path.resolve() == DEFAULT_DB.resolve()
+        if DEFAULT_DB.is_file() and db_path.is_file():
+            same_as_live = same_as_live or os.path.samefile(db_path, DEFAULT_DB)
+        if same_as_live:
+            raise IngestError("copied-database rehearsal refuses the live sources database")
+    if (
+        policy_document is not None
+        and policy_document["schema_version"] == "phase3_complete_source_policy_v4"
+        and not dry_run
+        and policy_document["database_ingest"]["live_ingest_authorized"] is False
+        and not copied_database_rehearsal
+    ):
+        raise IngestError(
+            "complete v4 source policy does not authorize live ingest; run an explicit copied-database rehearsal"
+        )
     counts: dict[str, int] = {}
     receipts: dict[str, dict[str, object]] = {}
     per_slug_rows = {
@@ -428,7 +463,6 @@ def ingest(
             )
         except UniversitySourcePolicyError as exc:
             raise IngestError(str(exc)) from exc
-    db_path = Path(db_path)
     conn = sqlite3.connect(str(db_path), timeout=30.0)
     committed = False
     checkpoint: list[int] | None = None
@@ -516,6 +550,13 @@ def ingest(
     receipt_document = {
         "schema_version": "incremental-textbook-ingest.v2",
         "status": "committed" if committed else "dry_run_rolled_back",
+        "execution_scope": (
+            "copied_database_rehearsal"
+            if copied_database_rehearsal
+            else "dry_run"
+            if dry_run
+            else "live_database"
+        ),
         "db_path": str(db_path),
         "db_sha256_before": db_sha256_before,
         "db_sha256_after": sha256_file(db_path),
@@ -784,6 +825,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Canonical textbook chunk directory (Google Drive mount or fixture root)",
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--copied-db-rehearsal",
+        action="store_true",
+        help="Commit only to an existing disposable DB copy under the complete v4 policy",
+    )
     parser.add_argument("--quarantine-dir", type=Path)
     parser.add_argument(
         "--quarantine-slugs",
@@ -832,6 +878,7 @@ def main(argv: list[str] | None = None) -> int:
             receipt_path=args.receipt,
             quarantine_slugs=args.quarantine_slugs,
             university_policy_path=args.university_policy,
+            copied_database_rehearsal=args.copied_db_rehearsal,
         )
     except (IngestError, ValueError) as exc:
         # ValueError: _build_textbook_row's strictness gates (author_uk,

--- a/scripts/projects/open_model_data/phase3_source_policy_v4.py
+++ b/scripts/projects/open_model_data/phase3_source_policy_v4.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Build and validate the complete Phase 3 30-source policy.
+
+The policy is text-free and default-deny. It converts the reviewed university
+admission gate into one machine-readable source universe while preserving the
+context-only and quarantine lanes. It does not authorize live database ingest,
+the complete source freeze, Phase 3 completion, or Phase 4.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from scripts.projects.open_model_data import (
+    phase3_university_source_admission as admission,
+)
+
+SCHEMA_VERSION = "phase3_complete_source_policy_v4"
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_complete_source_policy_v4.schema.json"
+DEFAULT_POLICY_PATH = ROOT / "data/projects/open_model_data/admission/phase3_complete_source_policy_v4.json"
+DEFAULT_V3_POLICY_PATH = ROOT / "data/projects/open_model_data/admission/phase3_university_source_policy_v3.json"
+EXPECTED_POLICY_SHA256 = "98e7a80f8fdc1274a190cda793699aceaa79741ebf2145669d73e4c8a2236559"
+
+EXPECTED_INPUT_HASHES = {
+    "phase3_reboot_prompt_v3_sha256": ("5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"),
+    "phase3_recovery_prompt_v2_sha256": ("298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"),
+    "university_source_matrix_v3_sha256": ("e2e82934ec26b7d98002cdf87f5326b84fb2d3d7900fe675920ba99e84d190de"),
+    "university_source_admission_gate_v1_sha256": ("423275e09192e593cdcc3b31b5074c860ada9e735d94a0857fc802d5dc9ef755"),
+    "university_source_policy_v3_sha256": ("2cb3643cec48acc52e9163e8ad1a21360de3380584a62a1a08ad07800b1c731d"),
+    "university_corpus_reconciliation_v3_sha256": ("3a4abb3883ad06db3fea1f994a5b51bc22cbdd6ab3e8d3adaf72c180bc42dd65"),
+    "pr6630_drive_backup_receipt_sha256": ("f577ab1cec2b2dee99e033284f1801f723a3d741e9e7c050d32cec0494b52d81"),
+}
+PR6630_MERGE_COMMIT = "d117a9c5bab7f309e78607b540ac8931a6bc3b4c"
+
+STAGED_JSONL_SPECS: dict[str, dict[str, Any]] = {
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-1": {
+        "source_locator": (
+            "university_corpus/staging/phase3-6375-waves-b-e/wave-b/"
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-1.jsonl"
+        ),
+        "jsonl_sha256": "00cfd4f8d6185b9116992311891a883753218e6a27b52f6e9f291f37e66366af",
+        "rows_sha256": "e46aee2f63238a73a050374a02aeea9a673b10e7e3fbec9678a9e0e55f9e22f9",
+        "expected_rows": 47,
+        "audience_class": "A_ukrainian_university_audience",
+        "subject_role": "ukrainian_linguistics",
+    },
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-2": {
+        "source_locator": (
+            "university_corpus/staging/phase3-6375-waves-b-e/wave-b/"
+            "uni-ukrmova-corpus-linguistics-khpi-2021-part-2.jsonl"
+        ),
+        "jsonl_sha256": "5ac5d5495aee21ff756156fda362f4e2340de9021380917c0bf9c74b9440e84b",
+        "rows_sha256": "c50d686392788437858fd699b0c75e1e50384e447b92a30cdeeaf68623e9013a",
+        "expected_rows": 51,
+        "audience_class": "A_ukrainian_university_audience",
+        "subject_role": "ukrainian_linguistics",
+    },
+    "uni-ukrmova-morphology-volkova-maslo-2012": {
+        "source_locator": (
+            "university_corpus/staging/phase3-6375-waves-b-e/wave-d/uni-ukrmova-morphology-volkova-maslo-2012.jsonl"
+        ),
+        "jsonl_sha256": "0229ba6526f863b1500533693032d31e29b9e3f9456dd15aa7a1704f14dec54e",
+        "rows_sha256": "96fe0d5f52828c9529f7e2b05f5f2050f63667ad087a70117a015c6244608db9",
+        "expected_rows": 205,
+        "audience_class": "A_ukrainian_university_audience",
+        "subject_role": "ukrainian_linguistics",
+    },
+    "uni-ukrmova-text-linguistics-shevel-bilyk-2024": {
+        "source_locator": (
+            "university_corpus/staging/phase3-6375-wave-a/grade-00/uni-ukrmova-text-linguistics-shevel-bilyk-2024.jsonl"
+        ),
+        "jsonl_sha256": "26848855c02a8ac6c02b7320d2b4a1986397a897c0a6d9df9ade720c20339920",
+        "rows_sha256": "10b5f59f1852b7a7f7337b52ccb855ce7d04345466f670c5161106c928646273",
+        "expected_rows": 282,
+        "audience_class": "A_ukrainian_university_audience",
+        "subject_role": "ukrainian_linguistics",
+    },
+}
+STAGED_IDS = frozenset(STAGED_JSONL_SPECS)
+STAGED_EXPECTED_ROWS = {source_id: int(spec["expected_rows"]) for source_id, spec in STAGED_JSONL_SPECS.items()}
+POST_2019_AUTHORITY_RESTRICTIONS = admission.POST_2019_AUTHORITY_RESTRICTIONS
+NONCOMMERCIAL_RESTRICTION = admission.NONCOMMERCIAL_RESTRICTION
+CONTEXTUAL_USE_OVERRIDES = {
+    "uni-ukrmova-dialectology-torchynska-2017": {
+        "supported_uses": [
+            "regional_dialect_variation_context",
+            "comparative_dialect_phonetics_and_vocabulary",
+            "sociolinguistic_geography_reference",
+        ],
+        "prohibited_uses": [
+            "modern_standard_normative_grammar_authority",
+            "normative_orthography_or_spellcheck_authority",
+        ],
+    },
+    "uni-ukrmova-historical-grammar-kupchynska-piletskyi-2024": {
+        "supported_uses": [
+            "historical_diachronic_grammar_context",
+            "diachronic_sound_change_and_morphological_evolution",
+        ],
+        "prohibited_uses": [
+            "modern_normative_grammar_authority",
+            "modern_orthography_enforcement",
+        ],
+    },
+    "uni-ukrmova-sociolinguistics-masenko-2010": {
+        "supported_uses": [
+            "sociolinguistic_and_language_policy_context",
+            "surzhyk_and_language_contact_analysis",
+        ],
+        "prohibited_uses": ["modern_standard_normative_grammar_authority"],
+    },
+}
+
+
+class CompleteSourcePolicyError(ValueError):
+    """The complete Phase 3 source policy is incomplete or unsafe."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CompleteSourcePolicyError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CompleteSourcePolicyError(f"cannot read JSON artifact: {path}") from exc
+    require(isinstance(value, dict), f"JSON artifact must be an object: {path}")
+    return value
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    require(not path.is_symlink(), f"refusing symlink output: {path}")
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def load_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        with Path(path).open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                require(isinstance(value, dict), f"JSONL line {line_number} is not an object")
+                rows.append(value)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CompleteSourcePolicyError(f"cannot read staged JSONL: {path}") from exc
+    require(rows, f"staged JSONL is empty: {path}")
+    return rows
+
+
+def evidence_rows_sha256(rows: list[dict[str, Any]], *, page_start: int, page_end: int) -> str:
+    selected: list[dict[str, Any]] = []
+    for row in rows:
+        row_start = row.get("page_start")
+        row_end = row.get("page_end")
+        if not isinstance(row_start, int) or not isinstance(row_end, int):
+            continue
+        if row_end < page_start or row_start > page_end:
+            continue
+        selected.append(
+            {
+                "chunk_id": row.get("chunk_id"),
+                "page_start": row_start,
+                "page_end": row_end,
+                "text": row.get("text"),
+            }
+        )
+    require(selected, f"evidence pages {page_start}-{page_end} contain no JSONL rows")
+    return hashlib.sha256(canonical_json(selected).encode("utf-8")).hexdigest()
+
+
+def _schema() -> dict[str, Any]:
+    schema = read_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def _schema_errors(value: Mapping[str, Any]) -> list[Any]:
+    return sorted(
+        Draft202012Validator(_schema()).iter_errors(value),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+
+
+def _v3_policy_sources(policy: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    require(policy.get("schema_version") == "phase3_university_source_policy_v3", "v3 policy schema drift")
+    require(policy.get("status") == "ACTIVE_DEFAULT_DENY", "v3 policy is not active")
+    sources = policy.get("sources")
+    require(isinstance(sources, list) and len(sources) == 20, "v3 policy must contain exactly 20 sources")
+    by_id: dict[str, dict[str, Any]] = {}
+    for source in sources:
+        require(isinstance(source, dict), "v3 policy source is not an object")
+        source_id = source.get("source_file")
+        require(isinstance(source_id, str) and source_id, "v3 policy source ID is absent")
+        require(source_id not in by_id, f"v3 policy duplicates {source_id}")
+        by_id[source_id] = dict(source)
+    require(list(by_id) == sorted(by_id), "v3 policy sources are not sorted")
+    return by_id
+
+
+def _jsonl_evidence_from_v3(source_id: str, source: Mapping[str, Any]) -> dict[str, Any]:
+    evidence = source["evidence"]
+    return {
+        "source_locator": f"university_corpus/jsonl/grade-00/{source_id}.jsonl",
+        "audience_class": source["audience_class"],
+        "subject_role": source["subject_role"],
+        "evidence_kind": evidence["kind"],
+        "jsonl_sha256": evidence["jsonl_sha256"],
+        "page_start": evidence["page_start"],
+        "page_end": evidence["page_end"],
+        "rows_sha256": evidence["rows_sha256"],
+    }
+
+
+def _jsonl_evidence_from_staged(source_id: str) -> dict[str, Any]:
+    spec = STAGED_JSONL_SPECS[source_id]
+    return {
+        "source_locator": spec["source_locator"],
+        "audience_class": spec["audience_class"],
+        "subject_role": spec["subject_role"],
+        "evidence_kind": "jsonl_front_matter",
+        "jsonl_sha256": spec["jsonl_sha256"],
+        "page_start": 1,
+        "page_end": 4,
+        "rows_sha256": spec["rows_sha256"],
+    }
+
+
+def _normalized_custody_state(
+    source_id: str,
+    *,
+    final_disposition: str,
+    v3_source: Mapping[str, Any] | None,
+    matrix_row: Mapping[str, Any],
+) -> str:
+    if final_disposition == "quarantine":
+        return "quarantined_not_database_resident"
+    if source_id in STAGED_IDS:
+        return "staged_drive_backed"
+    if v3_source is not None:
+        return "database_resident_and_drive_backed"
+    if matrix_row.get("custody_state") == "not_downloaded":
+        return "locator_only"
+    return "reference_drive_backed"
+
+
+def _matrix_evidence_hash(matrix_row: Mapping[str, Any]) -> str:
+    for key in (
+        "evidence_receipt_sha256",
+        "receipt_sha256",
+        "quarantine_decision_sha256",
+        "sha256_hash",
+    ):
+        value = matrix_row.get(key)
+        if isinstance(value, str) and len(value) == 64:
+            return value
+    raise CompleteSourcePolicyError(f"{matrix_row.get('source_id')}: matrix row has no hash-bound evidence")
+
+
+def _contextual_uses(source_id: str, matrix_row: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    override = CONTEXTUAL_USE_OVERRIDES.get(source_id)
+    if override is not None:
+        return list(override["supported_uses"]), list(override["prohibited_uses"])
+    return list(matrix_row["supported_uses"]), list(matrix_row["prohibited_uses"])
+
+
+def validate_staged_jsonls(paths: Mapping[str, Path]) -> None:
+    require(set(paths) == STAGED_IDS, "staged JSONL path set is not the exact four-source denominator")
+    for source_id, spec in STAGED_JSONL_SPECS.items():
+        path = Path(paths[source_id])
+        require(path.is_file(), f"{source_id}: staged JSONL is missing")
+        require(path.stem == source_id, f"{source_id}: staged JSONL filename drift")
+        require(sha256_file(path) == spec["jsonl_sha256"], f"{source_id}: staged JSONL byte drift")
+        rows = load_jsonl_rows(path)
+        require(len(rows) == spec["expected_rows"], f"{source_id}: staged row-count drift")
+        require(
+            evidence_rows_sha256(rows, page_start=1, page_end=4) == spec["rows_sha256"],
+            f"{source_id}: front-matter evidence drift",
+        )
+
+
+def _validate_matrix_and_gate(
+    matrix: Mapping[str, Any], gate: Mapping[str, Any]
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    source_set = admission.derive_source_set_check(matrix)
+    require(source_set["total_unique_sources"] == 30, "source matrix is not the complete 30-source universe")
+    require(
+        all(source_set[key] for key in ("no_extras", "no_omissions", "no_duplicate_credit", "quarantines_preserved")),
+        "source matrix completeness or quarantine preservation failed",
+    )
+    gate_schema = read_json(admission.GATE_SCHEMA_PATH)
+    errors = sorted(
+        Draft202012Validator(gate_schema).iter_errors(gate),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    require(not errors, f"source-admission gate schema violation: {errors[0].message if errors else ''}")
+    require(gate.get("policy_generation_ready") is True, "source-admission gate does not authorize policy generation")
+    require(
+        gate.get("database_ingest_authorized") is False, "source-admission gate unexpectedly authorizes database ingest"
+    )
+    require(gate.get("source_freeze_ready") is False, "source-admission gate unexpectedly closes the source freeze")
+    require(gate.get("phase3_complete") is False and gate.get("phase4_blocked") is True, "phase boundary drift")
+
+    matrix_rows = {row["source_id"]: dict(row) for row in matrix["source_dispositions"]}
+    require(set(matrix_rows) == admission.FULL_SOURCE_IDS, "source matrix row set drift")
+    gate_decisions = {decision["source_id"]: dict(decision) for decision in gate["decisions"]}
+    require(set(gate_decisions) == set(admission.SOURCE_IDS), "source-admission decision set drift")
+    for source_id, decision in gate_decisions.items():
+        require(decision["final_disposition"] == "admit_scoped", f"{source_id}: source is not admitted")
+        require(matrix_rows[source_id]["disposition"] == "admit_candidate", f"{source_id}: matrix disposition drift")
+        if "rights_capability" in matrix_rows[source_id]:
+            require(
+                decision["rights_capability"] == matrix_rows[source_id]["rights_capability"],
+                f"{source_id}: matrix and admission rights metadata disagree",
+            )
+        require(
+            decision["orthography_regime"] == matrix_rows[source_id]["orthography_regime"],
+            f"{source_id}: matrix and admission orthography metadata disagree",
+        )
+    return matrix_rows, gate_decisions
+
+
+def build_policy(
+    matrix: Mapping[str, Any],
+    gate: Mapping[str, Any],
+    v3_policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the deterministic complete policy from reviewed, hash-bound inputs."""
+    matrix_rows, gate_decisions = _validate_matrix_and_gate(matrix, gate)
+    v3_sources = _v3_policy_sources(v3_policy)
+    require(not set(v3_sources) & STAGED_IDS, "staged sources unexpectedly appear in the v3 policy")
+    require(set(v3_sources) <= admission.FULL_SOURCE_IDS, "v3 policy contains a source outside the matrix")
+
+    sources: list[dict[str, Any]] = []
+    for source_id in sorted(admission.FULL_SOURCE_IDS):
+        matrix_row = matrix_rows[source_id]
+        matrix_disposition = matrix_row["disposition"]
+        decision = gate_decisions.get(source_id)
+        v3_source = v3_sources.get(source_id)
+
+        if decision is not None:
+            final_disposition = "admit_scoped"
+            allowed_lanes = decision["allowed_lanes"]
+            source_state = decision["source_state"]
+            primary_roles = decision["primary_source_roles"]
+            claim_types = decision["claim_types"]
+            supported_uses = decision["supported_uses"]
+            prohibited_uses = decision["prohibited_uses"]
+            exactness_status = decision["exactness_status"]
+            evidence_hashes = decision["evidence_hashes"]
+            rights_capability = decision["rights_capability"]
+        elif matrix_disposition == "contextual_only":
+            final_disposition = "contextual_only"
+            allowed_lanes = v3_source["allowed_lanes"] if v3_source is not None else ["contextual_retrieval"]
+            source_state = "db_resident_contextual" if v3_source is not None else "reference_only"
+            primary_roles = []
+            claim_types = []
+            supported_uses, prohibited_uses = _contextual_uses(source_id, matrix_row)
+            exactness_status = "context_only"
+            evidence_hashes = [_matrix_evidence_hash(matrix_row)]
+            rights_capability = str(matrix_row.get("rights_capability") or "rights_bound_by_v3_policy")
+        else:
+            require(matrix_disposition == "quarantine", f"{source_id}: unsupported matrix disposition")
+            final_disposition = "quarantine"
+            allowed_lanes = []
+            source_state = "quarantined"
+            primary_roles = []
+            claim_types = []
+            supported_uses = matrix_row["supported_uses"]
+            prohibited_uses = matrix_row["prohibited_uses"]
+            exactness_status = "failed"
+            evidence_hashes = [_matrix_evidence_hash(matrix_row)]
+            rights_capability = str(matrix_row.get("rights_capability") or "rights_bound_by_v3_policy")
+
+        university_jsonl = v3_source is not None or source_id in STAGED_IDS
+        entry: dict[str, Any] = {
+            "source_id": source_id,
+            "source_kind": "university_jsonl" if university_jsonl else "external_reference",
+            "final_disposition": final_disposition,
+            "source_state": source_state,
+            "custody_state": _normalized_custody_state(
+                source_id,
+                final_disposition=final_disposition,
+                v3_source=v3_source,
+                matrix_row=matrix_row,
+            ),
+            "allowed_lanes": allowed_lanes,
+            "orthography_regime": matrix_row["orthography_regime"],
+            "rights_capability": rights_capability,
+            "primary_source_roles": primary_roles,
+            "claim_types": claim_types,
+            "supported_uses": supported_uses,
+            "prohibited_uses": prohibited_uses,
+            "exactness_status": exactness_status,
+            "evidence_hashes": evidence_hashes,
+        }
+        if v3_source is not None:
+            expected_v3_disposition = matrix_disposition
+            require(
+                v3_source["content_disposition"] == expected_v3_disposition,
+                f"{source_id}: v3 policy and source matrix disposition disagree",
+            )
+            entry["jsonl_evidence"] = _jsonl_evidence_from_v3(source_id, v3_source)
+        elif source_id in STAGED_IDS:
+            entry["jsonl_evidence"] = _jsonl_evidence_from_staged(source_id)
+        sources.append(entry)
+
+    counts = Counter(source["final_disposition"] for source in sources)
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "text_free": True,
+        "status": "ACTIVE_DEFAULT_DENY",
+        "default_disposition": "QUARANTINE_UNTIL_REVIEWED",
+        "bindings": {**EXPECTED_INPUT_HASHES, "pr6630_merge_commit": PR6630_MERGE_COMMIT},
+        "source_count": len(sources),
+        "disposition_counts": {
+            "admit_scoped": counts.get("admit_scoped", 0),
+            "contextual_only": counts.get("contextual_only", 0),
+            "quarantine": counts.get("quarantine", 0),
+            "total": len(sources),
+        },
+        "database_ingest": {
+            "eligible_source_ids": list(admission.SOURCE_IDS),
+            "staged_not_ingested_source_ids": sorted(STAGED_IDS),
+            "staged_expected_rows": STAGED_EXPECTED_ROWS,
+            "staged_expected_row_count": sum(STAGED_EXPECTED_ROWS.values()),
+            "copied_database_rehearsal_required": True,
+            "live_ingest_authorized": False,
+        },
+        "sources": sources,
+        "source_freeze_ready": False,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+    policy = {
+        **body,
+        "receipt_sha256": hashlib.sha256((canonical_json(body) + "\n").encode("utf-8")).hexdigest(),
+    }
+    validate_policy_document(policy)
+    return policy
+
+
+def validate_policy_document(policy: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate schema plus the exact 30-source semantic invariants."""
+    errors = _schema_errors(policy)
+    require(not errors, f"complete source policy schema violation: {errors[0].message if errors else ''}")
+    body = {key: value for key, value in policy.items() if key != "receipt_sha256"}
+    expected_receipt = hashlib.sha256((canonical_json(body) + "\n").encode("utf-8")).hexdigest()
+    require(policy["receipt_sha256"] == expected_receipt, "complete source policy receipt hash drift")
+    require(
+        policy["bindings"] == {**EXPECTED_INPUT_HASHES, "pr6630_merge_commit": PR6630_MERGE_COMMIT},
+        "policy bindings drift",
+    )
+
+    sources = policy["sources"]
+    source_ids = [source["source_id"] for source in sources]
+    require(
+        source_ids == sorted(admission.FULL_SOURCE_IDS), "policy source IDs are incomplete, duplicated, or unsorted"
+    )
+    by_disposition = {
+        disposition: {source["source_id"] for source in sources if source["final_disposition"] == disposition}
+        for disposition in ("admit_scoped", "contextual_only", "quarantine")
+    }
+    require(by_disposition["admit_scoped"] == set(admission.SOURCE_IDS), "policy admission set drift")
+    require(by_disposition["contextual_only"] == admission.CONTEXTUAL_ONLY_IDS, "policy contextual set drift")
+    require(by_disposition["quarantine"] == admission.QUARANTINE_IDS, "policy quarantine set drift")
+
+    ingest = policy["database_ingest"]
+    require(ingest["eligible_source_ids"] == list(admission.SOURCE_IDS), "eligible ingest set drift")
+    require(ingest["staged_not_ingested_source_ids"] == sorted(STAGED_IDS), "staged ingest set drift")
+    require(ingest["staged_expected_rows"] == STAGED_EXPECTED_ROWS, "staged row denominator drift")
+    require(ingest["staged_expected_row_count"] == 585, "staged row total drift")
+    require(ingest["live_ingest_authorized"] is False, "policy unexpectedly authorizes live ingest")
+
+    v3_sources = _v3_policy_sources(read_json(DEFAULT_V3_POLICY_PATH))
+    jsonl_ids = {source["source_id"] for source in sources if source["source_kind"] == "university_jsonl"}
+    require(jsonl_ids == set(v3_sources) | STAGED_IDS, "university JSONL source set drift")
+    for source in sources:
+        source_id = source["source_id"]
+        lanes = set(source["allowed_lanes"])
+        if source_id in v3_sources:
+            require(
+                source["jsonl_evidence"] == _jsonl_evidence_from_v3(source_id, v3_sources[source_id]),
+                f"{source_id}: v3 JSONL evidence drift",
+            )
+        elif source_id in STAGED_IDS:
+            require(
+                source["jsonl_evidence"] == _jsonl_evidence_from_staged(source_id),
+                f"{source_id}: staged JSONL evidence drift",
+            )
+        if source["source_kind"] == "external_reference":
+            require("corpus_ingest" not in lanes, f"{source_id}: external reference cannot enter corpus ingest")
+        if source["final_disposition"] == "admit_scoped":
+            require(source["source_kind"] == "university_jsonl", f"{source_id}: admitted source lacks JSONL identity")
+            if source["orthography_regime"] == "pre_2019":
+                require(
+                    bool(set(source["prohibited_uses"]) & POST_2019_AUTHORITY_RESTRICTIONS),
+                    f"{source_id}: pre-2019 admission lacks a post-2019 restriction",
+                )
+        if source["rights_capability"] == "cc_by_nc_4_0_noncommercial_only":
+            require(
+                NONCOMMERCIAL_RESTRICTION in source["prohibited_uses"],
+                f"{source_id}: noncommercial restriction is absent",
+            )
+        if source["final_disposition"] == "quarantine":
+            require(not lanes, f"{source_id}: quarantined source has a production lane")
+    return dict(policy)
+
+
+def load_policy(path: Path = DEFAULT_POLICY_PATH) -> tuple[dict[str, Any], str]:
+    policy_sha256 = sha256_file(path)
+    require(policy_sha256 == EXPECTED_POLICY_SHA256, "complete source policy byte drift")
+    policy = read_json(path)
+    return validate_policy_document(policy), policy_sha256
+
+
+def validate_bound_inputs(paths: Mapping[str, Path]) -> None:
+    require(set(paths) == set(EXPECTED_INPUT_HASHES), "bound input path set is incomplete")
+    for key, expected_sha256 in EXPECTED_INPUT_HASHES.items():
+        path = Path(paths[key])
+        require(path.is_file(), f"missing bound input artifact: {key}")
+        require(sha256_file(path) == expected_sha256, f"bound input artifact drift: {key}")
+
+
+def _parse_staged_jsonls(values: list[str]) -> dict[str, Path]:
+    parsed: dict[str, Path] = {}
+    for value in values:
+        source_id, separator, raw_path = value.partition("=")
+        require(bool(separator and source_id and raw_path), "--staged-jsonl must be SOURCE_ID=PATH")
+        require(source_id not in parsed, f"duplicate staged JSONL argument: {source_id}")
+        parsed[source_id] = Path(raw_path)
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase3-reboot-prompt-v3", type=Path, required=True)
+    parser.add_argument("--phase3-recovery-prompt-v2", type=Path, required=True)
+    parser.add_argument("--university-source-matrix-v3", type=Path, required=True)
+    parser.add_argument("--university-source-admission-gate-v1", type=Path, required=True)
+    parser.add_argument("--university-source-policy-v3", type=Path, required=True)
+    parser.add_argument("--university-corpus-reconciliation-v3", type=Path, required=True)
+    parser.add_argument("--pr6630-drive-backup-receipt", type=Path, required=True)
+    parser.add_argument("--staged-jsonl", action="append", default=[], metavar="SOURCE_ID=PATH")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    bound_paths = {
+        "phase3_reboot_prompt_v3_sha256": args.phase3_reboot_prompt_v3,
+        "phase3_recovery_prompt_v2_sha256": args.phase3_recovery_prompt_v2,
+        "university_source_matrix_v3_sha256": args.university_source_matrix_v3,
+        "university_source_admission_gate_v1_sha256": args.university_source_admission_gate_v1,
+        "university_source_policy_v3_sha256": args.university_source_policy_v3,
+        "university_corpus_reconciliation_v3_sha256": args.university_corpus_reconciliation_v3,
+        "pr6630_drive_backup_receipt_sha256": args.pr6630_drive_backup_receipt,
+    }
+    validate_bound_inputs(bound_paths)
+    validate_staged_jsonls(_parse_staged_jsonls(args.staged_jsonl))
+    policy = build_policy(
+        read_json(args.university_source_matrix_v3),
+        read_json(args.university_source_admission_gate_v1),
+        read_json(args.university_source_policy_v3),
+    )
+    encoded = json.dumps(policy, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(encoded, end="")
+    else:
+        write_text_atomic(args.output, encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/university_source_policy.py
+++ b/scripts/projects/open_model_data/university_source_policy.py
@@ -16,6 +16,7 @@ DEFAULT_POLICY_PATH = (
 
 SCHEMA_VERSION = "phase3_university_source_policy_v1"
 V3_SCHEMA_VERSION = "phase3_university_source_policy_v3"
+V4_SCHEMA_VERSION = "phase3_complete_source_policy_v4"
 STATUS = "ACTIVE_DEFAULT_DENY"
 DEFAULT_DISPOSITION = "QUARANTINE_UNTIL_AUDIENCE_PROVEN"
 V3_DEFAULT_DISPOSITION = "QUARANTINE_UNTIL_AUDIENCE_AND_CONTENT_CLASSIFIED"
@@ -147,6 +148,19 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> tuple[dict[str, Any], str]:
     except (OSError, json.JSONDecodeError) as exc:
         raise UniversitySourcePolicyError(f"cannot load university source policy: {path}") from exc
     _require(isinstance(document, dict), "university source policy must be an object")
+    schema_version = document.get("schema_version")
+    if schema_version == V4_SCHEMA_VERSION:
+        from scripts.projects.open_model_data.phase3_source_policy_v4 import (
+            CompleteSourcePolicyError,
+        )
+        from scripts.projects.open_model_data.phase3_source_policy_v4 import (
+            load_policy as load_complete_policy,
+        )
+
+        try:
+            return load_complete_policy(path)
+        except CompleteSourcePolicyError as exc:
+            raise UniversitySourcePolicyError(str(exc)) from exc
     _require(set(document) == TOP_LEVEL_KEYS, "university source policy has an open or incomplete shape")
     schema_version = document["schema_version"]
     _require(
@@ -263,6 +277,38 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> tuple[dict[str, Any], str]:
     return document, sha256_file(path)
 
 
+def _entry_source_id(entry: dict[str, Any]) -> str:
+    return str(entry.get("source_file") or entry.get("source_id") or "")
+
+
+def _entry_jsonl_evidence(
+    document: dict[str, Any], entry: dict[str, Any]
+) -> tuple[dict[str, Any], str, str, str]:
+    if document["schema_version"] == V4_SCHEMA_VERSION:
+        _require(
+            entry["source_kind"] == "university_jsonl",
+            f"{entry['source_id']}: external reference has no university JSONL identity",
+        )
+        evidence = entry["jsonl_evidence"]
+        content_disposition = (
+            "admitted"
+            if entry["final_disposition"] == "admit_scoped"
+            else entry["final_disposition"]
+        )
+        return (
+            evidence,
+            evidence["audience_class"],
+            evidence["subject_role"],
+            content_disposition,
+        )
+    return (
+        entry["evidence"],
+        entry["audience_class"],
+        entry["subject_role"],
+        entry.get("content_disposition", "legacy_audience_only"),
+    )
+
+
 def require_source_admission(
     *,
     source_file: str,
@@ -274,7 +320,7 @@ def require_source_admission(
     _require(lane in ALLOWED_LANES, f"unsupported university source lane: {lane}")
     document, policy_sha256 = load_policy(policy_path)
     entry = next(
-        (item for item in document["sources"] if item["source_file"] == source_file),
+        (item for item in document["sources"] if _entry_source_id(item) == source_file),
         None,
     )
     _require(
@@ -285,7 +331,9 @@ def require_source_admission(
         lane in entry["allowed_lanes"],
         f"{source_file}: university source policy denies lane {lane}",
     )
-    evidence = entry["evidence"]
+    evidence, audience_class, subject_role, content_disposition = _entry_jsonl_evidence(
+        document, entry
+    )
     actual_jsonl_sha256 = sha256_file(jsonl_path)
     _require(
         actual_jsonl_sha256 == evidence["jsonl_sha256"],
@@ -302,10 +350,17 @@ def require_source_admission(
         f"{source_file}: front-matter audience evidence changed",
     )
     return {
-        "audience_class": entry["audience_class"],
-        "subject_role": entry["subject_role"],
-        "content_disposition": entry.get("content_disposition", "legacy_audience_only"),
+        "audience_class": audience_class,
+        "subject_role": subject_role,
+        "content_disposition": content_disposition,
+        "final_disposition": entry.get("final_disposition", content_disposition),
         "allowed_lanes": entry["allowed_lanes"],
+        "source_policy_schema_version": document["schema_version"],
+        "live_ingest_authorized": (
+            document["database_ingest"]["live_ingest_authorized"]
+            if document["schema_version"] == V4_SCHEMA_VERSION
+            else True
+        ),
         "policy_sha256": policy_sha256,
         "policy_entry_sha256": sha256_value(entry),
         "evidence_rows_sha256": actual_rows_sha256,
@@ -321,22 +376,25 @@ def require_source_quarantine(
     """Return hash-bound v3 quarantine metadata or refuse source removal."""
     document, policy_sha256 = load_policy(policy_path)
     _require(
-        document["schema_version"] == V3_SCHEMA_VERSION,
-        f"{source_file}: source-level content quarantine requires a v3 policy",
+        document["schema_version"] in {V3_SCHEMA_VERSION, V4_SCHEMA_VERSION},
+        f"{source_file}: source-level content quarantine requires a v3 or v4 policy",
     )
     entry = next(
-        (item for item in document["sources"] if item["source_file"] == source_file),
+        (item for item in document["sources"] if _entry_source_id(item) == source_file),
         None,
     )
     _require(
         entry is not None,
         f"{source_file}: no verified university source policy entry; removal refused",
     )
+    content_disposition = entry.get("content_disposition") or entry.get("final_disposition")
     _require(
-        entry["content_disposition"] == "quarantine" and not entry["allowed_lanes"],
+        content_disposition == "quarantine" and not entry["allowed_lanes"],
         f"{source_file}: university source policy does not authorize quarantine",
     )
-    evidence = entry["evidence"]
+    evidence, audience_class, subject_role, normalized_disposition = _entry_jsonl_evidence(
+        document, entry
+    )
     actual_jsonl_sha256 = sha256_file(jsonl_path)
     _require(
         actual_jsonl_sha256 == evidence["jsonl_sha256"],
@@ -353,10 +411,12 @@ def require_source_quarantine(
         f"{source_file}: front-matter quarantine evidence changed",
     )
     return {
-        "audience_class": entry["audience_class"],
-        "subject_role": entry["subject_role"],
-        "content_disposition": entry["content_disposition"],
+        "audience_class": audience_class,
+        "subject_role": subject_role,
+        "content_disposition": normalized_disposition,
+        "final_disposition": entry.get("final_disposition", normalized_disposition),
         "allowed_lanes": entry["allowed_lanes"],
+        "source_policy_schema_version": document["schema_version"],
         "policy_sha256": policy_sha256,
         "policy_entry_sha256": sha256_value(entry),
         "evidence_rows_sha256": actual_rows_sha256,

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -326,6 +326,7 @@ def subject_for_source_file(source_file: str) -> str | None:
 # local dict). Every value must be title-probed or front-matter-verified.
 AUTHOR_UK_BY_TRANSLIT: dict[str, str] = {
     # University corpus sources (front-matter-verified through 2026-08-09).
+    "bilyk": "Катерина Білик",
     "vlasova": "Власова",
     "aleksiienko": "Алексієнко",
     "haluzynska": "Галузинська",

--- a/tests/ingest/test_incremental_textbook_ingest.py
+++ b/tests/ingest/test_incremental_textbook_ingest.py
@@ -524,6 +524,15 @@ def test_university_source_uses_grade_zero_storage_and_university_db_label(tmp_p
     assert grouping_row.grade == "grade-00"
 
 
+def test_title_verified_bilyk_author_mapping_enriches_staged_source() -> None:
+    entry = iti.enrich_author_uk(
+        {"author": "bilyk", "author_uk": None},
+        slug="uni-ukrmova-text-linguistics-shevel-bilyk-2024",
+    )
+
+    assert entry["author_uk"] == "Катерина Білик"
+
+
 def test_university_source_without_audience_policy_is_quarantined(tmp_path):
     root = tmp_path / "university_corpus" / "jsonl"
     slug = "uni-ukrmova-unknown-2026"

--- a/tests/test_open_model_phase3_source_policy_v4.py
+++ b/tests/test_open_model_phase3_source_policy_v4.py
@@ -1,0 +1,231 @@
+"""Complete 30-source Phase 3 policy tests."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.ingest import incremental_textbook_ingest as textbook_ingest
+from scripts.projects.open_model_data import phase3_source_policy_v4 as policy_v4
+from scripts.projects.open_model_data import phase3_university_source_admission as admission
+from scripts.projects.open_model_data import university_source_policy
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "data/projects/open_model_data/admission/phase3_complete_source_policy_v4.json"
+
+
+def _policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _reseal(policy: dict) -> dict:
+    body = {key: value for key, value in policy.items() if key != "receipt_sha256"}
+    policy["receipt_sha256"] = hashlib.sha256((policy_v4.canonical_json(body) + "\n").encode("utf-8")).hexdigest()
+    return policy
+
+
+def test_tracked_policy_is_exact_and_semantically_closed():
+    document, policy_sha256 = policy_v4.load_policy(POLICY_PATH)
+
+    assert policy_sha256 == policy_v4.EXPECTED_POLICY_SHA256
+    assert document["source_count"] == 30
+    assert document["disposition_counts"] == {
+        "admit_scoped": 11,
+        "contextual_only": 15,
+        "quarantine": 4,
+        "total": 30,
+    }
+    assert [source["source_id"] for source in document["sources"]] == sorted(admission.FULL_SOURCE_IDS)
+    assert document["bindings"] == {
+        **policy_v4.EXPECTED_INPUT_HASHES,
+        "pr6630_merge_commit": policy_v4.PR6630_MERGE_COMMIT,
+    }
+    assert document["source_freeze_ready"] is False
+    assert document["phase3_complete"] is False
+    assert document["phase4_blocked"] is True
+
+
+def test_policy_preserves_ingest_denominator_without_authorizing_live_mutation():
+    document = _policy()
+    ingest = document["database_ingest"]
+
+    assert ingest["eligible_source_ids"] == list(admission.SOURCE_IDS)
+    assert ingest["staged_not_ingested_source_ids"] == sorted(policy_v4.STAGED_IDS)
+    assert ingest["staged_expected_rows"] == {
+        "uni-ukrmova-corpus-linguistics-khpi-2021-part-1": 47,
+        "uni-ukrmova-corpus-linguistics-khpi-2021-part-2": 51,
+        "uni-ukrmova-morphology-volkova-maslo-2012": 205,
+        "uni-ukrmova-text-linguistics-shevel-bilyk-2024": 282,
+    }
+    assert ingest["staged_expected_row_count"] == 585
+    assert ingest["copied_database_rehearsal_required"] is True
+    assert ingest["live_ingest_authorized"] is False
+
+
+def test_policy_preserves_historical_and_language_contact_context():
+    by_id = {source["source_id"]: source for source in _policy()["sources"]}
+
+    historical_grammar = by_id["uni-ukrmova-historical-grammar-kupchynska-piletskyi-2024"]
+    assert historical_grammar["final_disposition"] == "contextual_only"
+    assert historical_grammar["supported_uses"] == [
+        "historical_diachronic_grammar_context",
+        "diachronic_sound_change_and_morphological_evolution",
+    ]
+    assert "modern_orthography_enforcement" in historical_grammar["prohibited_uses"]
+
+    assert by_id["uni-istoriya-kalynichenko-olianych-2025"]["final_disposition"] == ("contextual_only")
+    assert by_id["uni-ukrlit-kalinichenko-2024"]["final_disposition"] == ("contextual_only")
+    assert by_id["uni-ukrmova-sociolinguistics-masenko-2010"]["final_disposition"] == "contextual_only"
+
+
+def test_policy_separates_university_jsonl_from_external_reference_sources():
+    sources = _policy()["sources"]
+    jsonl_sources = [source for source in sources if source["source_kind"] == "university_jsonl"]
+    external_sources = [source for source in sources if source["source_kind"] == "external_reference"]
+
+    assert len(jsonl_sources) == 24
+    assert len(external_sources) == 6
+    assert all("jsonl_evidence" in source for source in jsonl_sources)
+    assert all("jsonl_evidence" not in source for source in external_sources)
+    assert all("corpus_ingest" not in source["allowed_lanes"] for source in external_sources)
+
+
+def test_policy_preserves_pre_2019_and_noncommercial_restrictions():
+    for source in _policy()["sources"]:
+        if source["final_disposition"] == "admit_scoped" and source["orthography_regime"] == "pre_2019":
+            assert set(source["prohibited_uses"]) & policy_v4.POST_2019_AUTHORITY_RESTRICTIONS
+        if source["rights_capability"] == "cc_by_nc_4_0_noncommercial_only":
+            assert policy_v4.NONCOMMERCIAL_RESTRICTION in source["prohibited_uses"]
+
+
+def test_policy_rejects_staged_jsonl_identity_drift_even_when_resealed():
+    document = copy.deepcopy(_policy())
+    staged = next(
+        source for source in document["sources"] if source["source_id"] == "uni-ukrmova-morphology-volkova-maslo-2012"
+    )
+    staged["jsonl_evidence"]["jsonl_sha256"] = "0" * 64
+
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="staged JSONL evidence drift"):
+        policy_v4.validate_policy_document(_reseal(document))
+
+
+def test_policy_rejects_external_corpus_ingest_even_when_resealed():
+    document = copy.deepcopy(_policy())
+    external = next(source for source in document["sources"] if source["source_kind"] == "external_reference")
+    external["allowed_lanes"].append("corpus_ingest")
+
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="schema violation"):
+        policy_v4.validate_policy_document(_reseal(document))
+
+
+def test_policy_rejects_source_omission_even_when_counts_are_rewritten():
+    document = copy.deepcopy(_policy())
+    document["sources"] = document["sources"][:-1]
+    document["source_count"] = 29
+    document["disposition_counts"]["quarantine"] = 3
+    document["disposition_counts"]["total"] = 29
+
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="schema violation"):
+        policy_v4.validate_policy_document(_reseal(document))
+
+
+def test_schema_rejects_open_source_fields():
+    document = copy.deepcopy(_policy())
+    document["sources"][0]["unreviewed_note"] = "not allowed"
+    schema = json.loads(policy_v4.SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    errors = list(Draft202012Validator(schema).iter_errors(document))
+    assert errors
+    assert any("Additional properties are not allowed" in error.message for error in errors)
+
+
+def test_legacy_policy_loader_accepts_v4_for_jsonl_consumers():
+    document, policy_sha256 = university_source_policy.load_policy(POLICY_PATH)
+
+    assert document["schema_version"] == policy_v4.SCHEMA_VERSION
+    assert policy_sha256 == policy_v4.EXPECTED_POLICY_SHA256
+
+
+def test_runtime_loader_rejects_byte_drift_even_when_json_is_semantically_identical(tmp_path):
+    drifted = tmp_path / POLICY_PATH.name
+    drifted.write_text(POLICY_PATH.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="byte drift"):
+        policy_v4.load_policy(drifted)
+    with pytest.raises(university_source_policy.UniversitySourcePolicyError, match="byte drift"):
+        university_source_policy.load_policy(drifted)
+
+
+def test_external_reference_cannot_impersonate_university_jsonl(tmp_path):
+    dummy_jsonl = tmp_path / "khpi-ukrainian-morphological-tagging-petrasova-et-al-2017.jsonl"
+    dummy_jsonl.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(
+        university_source_policy.UniversitySourcePolicyError,
+        match="external reference has no university JSONL identity",
+    ):
+        university_source_policy.require_source_admission(
+            source_file="khpi-ukrainian-morphological-tagging-petrasova-et-al-2017",
+            jsonl_path=dummy_jsonl,
+            policy_path=POLICY_PATH,
+            lane="contextual_retrieval",
+        )
+
+
+def test_staged_argument_parser_is_closed():
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="SOURCE_ID=PATH"):
+        policy_v4._parse_staged_jsonls(["missing-separator"])
+    with pytest.raises(policy_v4.CompleteSourcePolicyError, match="duplicate"):
+        policy_v4._parse_staged_jsonls(["source=/one", "source=/two"])
+
+
+def test_v4_policy_blocks_live_ingest_before_reading_chunks(tmp_path):
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(textbook_ingest.IngestError, match="does not authorize live ingest"):
+        textbook_ingest.ingest(
+            ["uni-ukrmova-corpus-linguistics-khpi-2021-part-1"],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path / "absent-chunks",
+            university_policy_path=POLICY_PATH,
+        )
+
+
+def test_v4_rehearsal_refuses_live_database_inode(tmp_path, monkeypatch):
+    live_db = tmp_path / "sources.db"
+    live_db.touch()
+    alias_db = tmp_path / "separate-path-same-inode.db"
+    alias_db.hardlink_to(live_db)
+    monkeypatch.setattr(textbook_ingest, "DEFAULT_DB", live_db)
+
+    with pytest.raises(textbook_ingest.IngestError, match="refuses the live sources database"):
+        textbook_ingest.ingest(
+            ["uni-ukrmova-corpus-linguistics-khpi-2021-part-1"],
+            db_path=alias_db,
+            dry_run=False,
+            chunks_root=tmp_path / "absent-chunks",
+            university_policy_path=POLICY_PATH,
+            copied_database_rehearsal=True,
+        )
+
+
+def test_v4_rehearsal_requires_a_committed_disposable_copy(tmp_path):
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(textbook_ingest.IngestError, match="must commit"):
+        textbook_ingest.ingest(
+            ["uni-ukrmova-corpus-linguistics-khpi-2021-part-1"],
+            db_path=disposable_db,
+            dry_run=True,
+            chunks_root=tmp_path / "absent-chunks",
+            university_policy_path=POLICY_PATH,
+            copied_database_rehearsal=True,
+        )


### PR DESCRIPTION
Closes the next source-policy slice of #6375.

## What changed

- adds a strict, text-free v4 policy for the complete reviewed 30-source universe: 11 scoped admissions, 15 contextual-only sources, and 4 quarantines
- preserves historical grammar, diachronic, literature/history, dialectology, sociolinguistics, and language-contact sources as explicitly bounded contextual evidence instead of collapsing Phase 3 to modern normative Ukrainian
- binds the policy to the reviewed prompt, matrix, admission gate, v3 policy, reconciliation, PR #6630 merge, and Drive backup receipt
- teaches the existing university-source consumer to load the exact v4 bytes fail-closed
- adds a copied-database-only rehearsal mode and refuses both the live database path and any alias of its inode
- adds the front-matter-verified `bilyk → Катерина Білик` mapping needed by the staged text-linguistics source

## Safety boundary

- live database ingest remains unauthorized
- source freeze and Phase 3 completion remain false
- Phase 4 remains blocked
- no provider or training run is started

## Verification

- `151 passed` across the v4 policy, admission gate, incremental ingest, and subject/author suites
- `24 passed` across held-out partition and near-duplicate consumers
- Ruff clean and `git diff --check` clean
- deterministic generator reproduced the tracked policy byte-for-byte at SHA-256 `98e7a80f8fdc1274a190cda793699aceaa79741ebf2145669d73e4c8a2236559`
- real copied-database rehearsal committed 585 rows (47 + 51 + 205 + 282), maintained global row/FTS parity, linked every inserted row, returned integrity `ok`, and kept the existing foreign-key baseline unchanged
- live `sources.db` remained at 49,568 rows with zero staged rows and unchanged SHA-256 `c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739`

X-Agent: codex/6375-phase3-source-policy