### PR TITLE
fix(lexicon): restore complete lexicon-manifest.fingerprint.json

### DIFF
--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,4 +1,5 @@
 {
+  "fingerprint": "f2fecc06e31cad1aa06abfaf981a7ec662a730fd3251a808f93d9b18f4c14203",
   "inputs": {
     "lexicon_code": [
       {
@@ -244,5 +245,8 @@
     ]
   },
   "schema_version": 1,
-  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state"
+  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
+  "stats": {
+    "lexicon_code_files": 60
+  }
 }


### PR DESCRIPTION
## Problem
`site/src/data/lexicon-manifest.fingerprint.json` on `main` was missing the top-level `fingerprint` string (only `inputs` / `schema_version` / `scope`). That breaks `merge_translation_delta --write` when embedding the sidecar.

## Fix
Regenerate the complete sidecar via `build_fingerprint` / full JSON write.

## Verify
- File contains `fingerprint` + `schema_version` + `stats`
- `check_manifest_freshness` / merge write can read sidecar

X-Agent: claude/6632-fingerprint-complete