### PR TITLE
Phase 3: gate exact live corpus ingest

### DIFF
--- a/data/projects/open_model_data/admission/phase3_live_ingest_gate_v1.json
+++ b/data/projects/open_model_data/admission/phase3_live_ingest_gate_v1.json
@@ -1,0 +1,93 @@
+{
+  "bindings": {
+    "complete_source_policy_v4_sha256": "98e7a80f8fdc1274a190cda793699aceaa79741ebf2145669d73e4c8a2236559",
+    "compressed_pre_ingest_database_sha256": "c89d8d2898b7aa7470e8f3888245fb0d85fe74c075d27a9483da262ad3147a5f",
+    "copied_database_rehearsal_receipt_sha256": "a50310fbb526bb68ebe93f6046af56778c860c7b7731a46488dd188465215183",
+    "independent_cross_family_review_sha256": "e85a5d5a2681362765cdee879dc19bc7299ff329aa001d69f7ae5616bed55137",
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "pr6631_drive_backup_receipt_sha256": "8792d76bca226c603ebc45c8315dcf197231c955aace7c2a78768943ce7f177b",
+    "pr6631_drive_provider_verification_sha256": "10aa43b2c2722fc74c05f471363fe99f0f187a3c692d5f0367cd33b0dd5d4129",
+    "pr6631_merge_commit": "c88928cf6deaeb84d7487681885314d7b2bb729c",
+    "pr6631_package_manifest_sha256": "1c818a2a54ac1dbf57f9ab21d4bb114b365d9ef5205499504f59b5a5967046a5",
+    "pre_ingest_backup_provider_verification_sha256": "4cf978220e05aaaf4b999422db48d1239a35fd2245a17e1f8fc4bb5b293621ef",
+    "pre_ingest_backup_receipt_sha256": "f97faa4273a1079b76e6f47ddaf188a383aa516f91df768d1909c6e38409023a"
+  },
+  "copied_database_rehearsal": {
+    "counts_after": {
+      "fts_rows": 50153,
+      "section_rows": 36322,
+      "textbook_rows": 50153
+    },
+    "counts_before": {
+      "fts_rows": 49568,
+      "section_rows": 35777,
+      "textbook_rows": 49568
+    },
+    "database_sha256_after": "e3c7d01dec04c6b7c6c8ea8dbe8fab11e0b3cdb9fea9c1280a927167a236f70b",
+    "database_sha256_before": "4b7b6aa7913b415114f270b497141fc706a0c9f1dabf2fdbae7cd4db8110a391",
+    "execution_scope": "copied_database_rehearsal",
+    "foreign_key_failures_unchanged": true,
+    "inserted_rows": 585,
+    "integrity_check": "ok",
+    "per_source_fts_and_linkage_passed": true,
+    "source_count": 4,
+    "status": "committed"
+  },
+  "database": {
+    "counts_after_expected": {
+      "fts_rows": 50153,
+      "section_rows": 36322,
+      "source_count": 187,
+      "textbook_rows": 50153,
+      "university_rows": 4078,
+      "university_source_count": 20
+    },
+    "counts_before": {
+      "fts_rows": 49568,
+      "section_rows": 35777,
+      "source_count": 183,
+      "textbook_rows": 49568,
+      "university_rows": 3493,
+      "university_source_count": 16
+    },
+    "foreign_key_failure_count": 134836,
+    "foreign_key_failure_hash": "9938f7cbab6cca94bfd0a360eec114fdef404a357e02b24161da0f7cf5c6d9bb",
+    "integrity_check": "ok",
+    "journal_mode": "wal",
+    "requested_sources_absent_before": true,
+    "sha256_before": "c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739",
+    "target_locator": "primary_checkout:data/sources.db"
+  },
+  "execution": {
+    "exact_preimage_required": true,
+    "exact_source_set_required": true,
+    "live_ingest_authorized": true,
+    "post_ingest_backup_required": true,
+    "provider_work_authorized": false,
+    "receipt_required": true,
+    "single_use": true
+  },
+  "phase3_complete": false,
+  "phase4_blocked": true,
+  "pre_ingest_backup": {
+    "compressed_database_filename": "sources-c7068a4e4b9e.db.gz",
+    "compressed_database_sha256": "c89d8d2898b7aa7470e8f3888245fb0d85fe74c075d27a9483da262ad3147a5f",
+    "drive_item_id_present": true,
+    "google_drive_relative_path": "Projects/learn-ukrainian-data/backups/phase3-6375/20260811T090325Z",
+    "gzip_test_passed": true,
+    "provider_uploaded": true,
+    "provider_uploading": false,
+    "restored_database_sha256": "c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739"
+  },
+  "receipt_sha256": "5cd3383be7441e48db18631162633944ec7ea33bd6da618ca39c552c1b1b9e6e",
+  "requested_sources": [
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-1",
+    "uni-ukrmova-corpus-linguistics-khpi-2021-part-2",
+    "uni-ukrmova-morphology-volkova-maslo-2012",
+    "uni-ukrmova-text-linguistics-shevel-bilyk-2024"
+  ],
+  "schema_version": "phase3_live_ingest_gate_v1",
+  "source_freeze_ready": false,
+  "status": "AUTHORIZED_ONCE_FOR_EXACT_PREIMAGE",
+  "text_free": true
+}

--- a/data/projects/open_model_data/contracts/phase3_live_ingest_gate_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_live_ingest_gate_v1.schema.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/contracts/phase3_live_ingest_gate_v1.schema.json",
+  "title": "Phase 3 one-time live ingest gate v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "text_free",
+    "status",
+    "bindings",
+    "requested_sources",
+    "database",
+    "copied_database_rehearsal",
+    "pre_ingest_backup",
+    "execution",
+    "source_freeze_ready",
+    "phase3_complete",
+    "phase4_blocked",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_live_ingest_gate_v1"},
+    "text_free": {"const": true},
+    "status": {"const": "AUTHORIZED_ONCE_FOR_EXACT_PREIMAGE"},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_reboot_prompt_v3_sha256",
+        "complete_source_policy_v4_sha256",
+        "copied_database_rehearsal_receipt_sha256",
+        "pr6631_drive_backup_receipt_sha256",
+        "pr6631_drive_provider_verification_sha256",
+        "pre_ingest_backup_receipt_sha256",
+        "pre_ingest_backup_provider_verification_sha256",
+        "compressed_pre_ingest_database_sha256",
+        "independent_cross_family_review_sha256",
+        "pr6631_package_manifest_sha256",
+        "pr6631_merge_commit"
+      ],
+      "properties": {
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "complete_source_policy_v4_sha256": {"$ref": "#/$defs/sha256"},
+        "copied_database_rehearsal_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6631_drive_backup_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6631_drive_provider_verification_sha256": {"$ref": "#/$defs/sha256"},
+        "pre_ingest_backup_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "pre_ingest_backup_provider_verification_sha256": {"$ref": "#/$defs/sha256"},
+        "compressed_pre_ingest_database_sha256": {"$ref": "#/$defs/sha256"},
+        "independent_cross_family_review_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6631_package_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "pr6631_merge_commit": {"$ref": "#/$defs/sha1"}
+      }
+    },
+    "requested_sources": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "prefixItems": [
+        {"const": "uni-ukrmova-corpus-linguistics-khpi-2021-part-1"},
+        {"const": "uni-ukrmova-corpus-linguistics-khpi-2021-part-2"},
+        {"const": "uni-ukrmova-morphology-volkova-maslo-2012"},
+        {"const": "uni-ukrmova-text-linguistics-shevel-bilyk-2024"}
+      ],
+      "items": false
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_locator",
+        "sha256_before",
+        "counts_before",
+        "counts_after_expected",
+        "foreign_key_failure_count",
+        "foreign_key_failure_hash",
+        "integrity_check",
+        "journal_mode",
+        "requested_sources_absent_before"
+      ],
+      "properties": {
+        "target_locator": {"const": "primary_checkout:data/sources.db"},
+        "sha256_before": {"const": "c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739"},
+        "counts_before": {"$ref": "#/$defs/counts_before"},
+        "counts_after_expected": {"$ref": "#/$defs/counts_after"},
+        "foreign_key_failure_count": {"const": 134836},
+        "foreign_key_failure_hash": {"$ref": "#/$defs/sha256"},
+        "integrity_check": {"const": "ok"},
+        "journal_mode": {"const": "wal"},
+        "requested_sources_absent_before": {"const": true}
+      }
+    },
+    "copied_database_rehearsal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_scope",
+        "status",
+        "database_sha256_before",
+        "database_sha256_after",
+        "counts_before",
+        "counts_after",
+        "inserted_rows",
+        "source_count",
+        "integrity_check",
+        "foreign_key_failures_unchanged",
+        "per_source_fts_and_linkage_passed"
+      ],
+      "properties": {
+        "execution_scope": {"const": "copied_database_rehearsal"},
+        "status": {"const": "committed"},
+        "database_sha256_before": {"const": "4b7b6aa7913b415114f270b497141fc706a0c9f1dabf2fdbae7cd4db8110a391"},
+        "database_sha256_after": {"const": "e3c7d01dec04c6b7c6c8ea8dbe8fab11e0b3cdb9fea9c1280a927167a236f70b"},
+        "counts_before": {"$ref": "#/$defs/table_counts_before"},
+        "counts_after": {"$ref": "#/$defs/table_counts_after"},
+        "inserted_rows": {"const": 585},
+        "source_count": {"const": 4},
+        "integrity_check": {"const": "ok"},
+        "foreign_key_failures_unchanged": {"const": true},
+        "per_source_fts_and_linkage_passed": {"const": true}
+      }
+    },
+    "pre_ingest_backup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "google_drive_relative_path",
+        "compressed_database_filename",
+        "compressed_database_sha256",
+        "restored_database_sha256",
+        "gzip_test_passed",
+        "provider_uploaded",
+        "provider_uploading",
+        "drive_item_id_present"
+      ],
+      "properties": {
+        "google_drive_relative_path": {
+          "const": "Projects/learn-ukrainian-data/backups/phase3-6375/20260811T090325Z"
+        },
+        "compressed_database_filename": {"const": "sources-c7068a4e4b9e.db.gz"},
+        "compressed_database_sha256": {"const": "c89d8d2898b7aa7470e8f3888245fb0d85fe74c075d27a9483da262ad3147a5f"},
+        "restored_database_sha256": {"const": "c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739"},
+        "gzip_test_passed": {"const": true},
+        "provider_uploaded": {"const": true},
+        "provider_uploading": {"const": false},
+        "drive_item_id_present": {"const": true}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "live_ingest_authorized",
+        "single_use",
+        "exact_preimage_required",
+        "exact_source_set_required",
+        "receipt_required",
+        "post_ingest_backup_required",
+        "provider_work_authorized"
+      ],
+      "properties": {
+        "live_ingest_authorized": {"const": true},
+        "single_use": {"const": true},
+        "exact_preimage_required": {"const": true},
+        "exact_source_set_required": {"const": true},
+        "receipt_required": {"const": true},
+        "post_ingest_backup_required": {"const": true},
+        "provider_work_authorized": {"const": false}
+      }
+    },
+    "source_freeze_ready": {"const": false},
+    "phase3_complete": {"const": false},
+    "phase4_blocked": {"const": true},
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "sha1": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "table_counts_before": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["textbook_rows", "fts_rows", "section_rows"],
+      "properties": {
+        "textbook_rows": {"const": 49568},
+        "fts_rows": {"const": 49568},
+        "section_rows": {"const": 35777}
+      }
+    },
+    "table_counts_after": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["textbook_rows", "fts_rows", "section_rows"],
+      "properties": {
+        "textbook_rows": {"const": 50153},
+        "fts_rows": {"const": 50153},
+        "section_rows": {"const": 36322}
+      }
+    },
+    "counts_before": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "textbook_rows",
+        "fts_rows",
+        "section_rows",
+        "source_count",
+        "university_rows",
+        "university_source_count"
+      ],
+      "properties": {
+        "textbook_rows": {"const": 49568},
+        "fts_rows": {"const": 49568},
+        "section_rows": {"const": 35777},
+        "source_count": {"const": 183},
+        "university_rows": {"const": 3493},
+        "university_source_count": {"const": 16}
+      }
+    },
+    "counts_after": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "textbook_rows",
+        "fts_rows",
+        "section_rows",
+        "source_count",
+        "university_rows",
+        "university_source_count"
+      ],
+      "properties": {
+        "textbook_rows": {"const": 50153},
+        "fts_rows": {"const": 50153},
+        "section_rows": {"const": 36322},
+        "source_count": {"const": 187},
+        "university_rows": {"const": 4078},
+        "university_source_count": {"const": 20}
+      }
+    }
+  }
+}

--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -34,6 +34,15 @@ PROJECT_ROOT = SCRIPT_PATH.parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+from guardrails.worktree_containment import resolve_main_root
+from projects.open_model_data.phase3_live_ingest_gate import (
+    COUNTS_BEFORE as LIVE_INGEST_COUNTS_BEFORE,
+)
+from projects.open_model_data.phase3_live_ingest_gate import (
+    EXPECTED_LIVE_DB_SHA256,
+    LiveIngestGateError,
+    validate_live_ingest_preconditions,
+)
 from projects.open_model_data.textbook_native_exactness import (
     SCHEMA_VERSION as NATIVE_EXACTNESS_SCHEMA_VERSION,
 )
@@ -71,7 +80,8 @@ from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
 # constant patchable for local fixtures, but do not assume the absent
 # repo-local data/textbook_chunks directory is the production source.
 CHUNKS_DIR = TEXTBOOK_CHUNKS_DIR
-DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
+PRIMARY_ROOT = resolve_main_root(PROJECT_ROOT) or PROJECT_ROOT
+DEFAULT_DB = PRIMARY_ROOT / "data" / "sources.db"
 
 # Author map: single source of truth in wiki.textbook_subjects (PR #4650).
 AUTHOR_UK = AUTHOR_UK_BY_TRANSLIT
@@ -383,6 +393,7 @@ def ingest(
     receipt_path: Path | None = None,
     university_policy_path: Path = DEFAULT_UNIVERSITY_POLICY,
     copied_database_rehearsal: bool = False,
+    live_ingest_gate_path: Path | None = None,
 ) -> dict[str, int]:
     """Run one atomic replace/quarantine/FTS-resync cycle.
 
@@ -399,10 +410,29 @@ def ingest(
         slug.startswith("uni-") for slug in [*slugs, *quarantine_slugs]
     )
     policy_document: dict[str, Any] | None = None
-    if university_requested:
+    policy_sha256: str | None = None
+    if university_requested or live_ingest_gate_path is not None:
         try:
-            policy_document, _policy_sha256 = load_policy(university_policy_path)
+            policy_document, policy_sha256 = load_policy(university_policy_path)
         except UniversitySourcePolicyError as exc:
+            raise IngestError(str(exc)) from exc
+    live_ingest_gate_sha256: str | None = None
+    if live_ingest_gate_path is not None:
+        if policy_document is None or policy_document["schema_version"] != "phase3_complete_source_policy_v4":
+            raise IngestError("live ingest gate requires the complete v4 source policy")
+        try:
+            live_ingest_gate_sha256 = validate_live_ingest_preconditions(
+                gate_path=Path(live_ingest_gate_path),
+                db_path=db_path,
+                expected_live_db_path=DEFAULT_DB,
+                source_ids=slugs,
+                quarantine_source_ids=quarantine_slugs,
+                source_policy_sha256=str(policy_sha256),
+                dry_run=dry_run,
+                copied_database_rehearsal=copied_database_rehearsal,
+                receipt_path=receipt_path,
+            )
+        except LiveIngestGateError as exc:
             raise IngestError(str(exc)) from exc
     if copied_database_rehearsal:
         if dry_run:
@@ -422,6 +452,7 @@ def ingest(
         and not dry_run
         and policy_document["database_ingest"]["live_ingest_authorized"] is False
         and not copied_database_rehearsal
+        and live_ingest_gate_path is None
     ):
         raise IngestError(
             "complete v4 source policy does not authorize live ingest; run an explicit copied-database rehearsal"
@@ -473,11 +504,19 @@ def ingest(
             preflight_checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
             if preflight_checkpoint != [0, 0, 0]:
                 raise IngestError(f"WAL was not settled before ingest: {preflight_checkpoint}")
-        db_sha256_before = sha256_file(db_path)
         conn.execute("BEGIN IMMEDIATE")
+        db_sha256_before = sha256_file(db_path)
+        if live_ingest_gate_sha256 is not None and db_sha256_before != EXPECTED_LIVE_DB_SHA256:
+            raise IngestError("live database preimage changed after gate validation")
         ensure_schema(conn)
         foreign_key_failures_before, foreign_key_hash_before = _foreign_key_evidence(conn)
         before = _database_counts(conn)
+        expected_live_table_counts = {
+            key: LIVE_INGEST_COUNTS_BEFORE[key]
+            for key in ("textbook_rows", "fts_rows", "section_rows")
+        }
+        if live_ingest_gate_sha256 is not None and before != expected_live_table_counts:
+            raise IngestError("live database counts changed after gate validation")
         for slug in quarantine_slugs:
             deleted = conn.execute("DELETE FROM textbooks WHERE source_file = ?", (slug,)).rowcount
             deleted_sections = conn.execute("DELETE FROM textbook_sections WHERE source_file = ?", (slug,)).rowcount
@@ -553,6 +592,8 @@ def ingest(
         "execution_scope": (
             "copied_database_rehearsal"
             if copied_database_rehearsal
+            else "live_database_authorized_cutover"
+            if live_ingest_gate_sha256 is not None
             else "dry_run"
             if dry_run
             else "live_database"
@@ -567,6 +608,7 @@ def ingest(
             if university_admissions or university_quarantines
             else None
         ),
+        "live_ingest_gate_sha256": live_ingest_gate_sha256,
         "before": before,
         "after_transaction": after,
         "integrity_check": integrity,
@@ -830,6 +872,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Commit only to an existing disposable DB copy under the complete v4 policy",
     )
+    parser.add_argument(
+        "--live-ingest-gate",
+        type=Path,
+        default=None,
+        help=(
+            "Exact one-time gate for the primary sources database; requires the complete v4 policy, "
+            "exact four-source set, committed receipt, and frozen preimage"
+        ),
+    )
     parser.add_argument("--quarantine-dir", type=Path)
     parser.add_argument(
         "--quarantine-slugs",
@@ -879,6 +930,7 @@ def main(argv: list[str] | None = None) -> int:
             quarantine_slugs=args.quarantine_slugs,
             university_policy_path=args.university_policy,
             copied_database_rehearsal=args.copied_db_rehearsal,
+            live_ingest_gate_path=args.live_ingest_gate,
         )
     except (IngestError, ValueError) as exc:
         # ValueError: _build_textbook_row's strictness gates (author_uk,

--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -116,6 +116,10 @@ class IngestError(RuntimeError):
     """Deterministic ingest failure."""
 
 
+class PostCommitIngestError(IngestError):
+    """The database commit landed, but a post-commit proof step failed."""
+
+
 def find_jsonl(slug: str, *, chunks_root: Path | None = None) -> Path:
     """Resolve one source JSONL under the explicit or canonical chunk root."""
     root = Path(chunks_root) if chunks_root is not None else CHUNKS_DIR
@@ -497,6 +501,7 @@ def ingest(
     conn = sqlite3.connect(str(db_path), timeout=30.0)
     committed = False
     checkpoint: list[int] | None = None
+    post_commit_error: str | None = None
     try:
         conn.execute("PRAGMA foreign_keys = ON")
         journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
@@ -576,9 +581,20 @@ def ingest(
             conn.execute("COMMIT")
             committed = True
         if journal_mode == "wal":
-            checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
-            if checkpoint != [0, 0, 0]:
-                raise IngestError(f"WAL checkpoint did not settle after ingest: {checkpoint}")
+            try:
+                checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
+            except sqlite3.Error as exc:
+                if not committed:
+                    raise
+                post_commit_error = (
+                    "WAL checkpoint failed after ingest: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+            if checkpoint is not None and checkpoint != [0, 0, 0]:
+                message = f"WAL checkpoint did not settle after ingest: {checkpoint}"
+                if not committed:
+                    raise IngestError(message)
+                post_commit_error = message
     except BaseException:
         # Explicit rollback (review, PR #4624): never leave the live DB with
         # an open write transaction on the error path.
@@ -588,7 +604,13 @@ def ingest(
         conn.close()
     receipt_document = {
         "schema_version": "incremental-textbook-ingest.v2",
-        "status": "committed" if committed else "dry_run_rolled_back",
+        "status": (
+            "committed_with_post_commit_error"
+            if post_commit_error is not None
+            else "committed"
+            if committed
+            else "dry_run_rolled_back"
+        ),
         "execution_scope": (
             "copied_database_rehearsal"
             if copied_database_rehearsal
@@ -618,6 +640,7 @@ def ingest(
         "foreign_key_failure_hash_after": foreign_key_hash_after,
         "foreign_key_failures_unchanged": foreign_key_failures_after == foreign_key_failures_before,
         "wal_checkpoint": checkpoint,
+        "post_commit_error": post_commit_error,
         "per_source": [receipts[slug] for slug in sorted(receipts)],
     }
     if receipt_path is not None:
@@ -627,6 +650,8 @@ def ingest(
         )
     for _slug, receipt in receipts.items():
         print(f"  receipt: {json.dumps(receipt, ensure_ascii=False, sort_keys=True)}")
+    if post_commit_error is not None:
+        raise PostCommitIngestError(post_commit_error)
     return counts
 
 
@@ -708,6 +733,7 @@ def quarantine_native_anomaly_chunks(
     conn = sqlite3.connect(str(db_path), timeout=30.0)
     committed = False
     checkpoint: list[int] | None = None
+    post_commit_error: str | None = None
     try:
         conn.execute("PRAGMA foreign_keys = ON")
         journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
@@ -811,9 +837,17 @@ def quarantine_native_anomaly_chunks(
             conn.execute("COMMIT")
             committed = True
             if journal_mode == "wal":
-                checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
-                if checkpoint != [0, 0, 0]:
-                    raise IngestError(f"WAL checkpoint did not settle after quarantine: {checkpoint}")
+                try:
+                    checkpoint = list(conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone())
+                except sqlite3.Error as exc:
+                    post_commit_error = (
+                        "WAL checkpoint failed after quarantine: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                if checkpoint is not None and checkpoint != [0, 0, 0]:
+                    post_commit_error = (
+                        f"WAL checkpoint did not settle after quarantine: {checkpoint}"
+                    )
     except BaseException:
         conn.rollback()
         raise
@@ -822,7 +856,13 @@ def quarantine_native_anomaly_chunks(
 
     return {
         "schema_version": "textbook-native-anomaly-quarantine.v1",
-        "status": "committed" if committed else "dry_run_rolled_back",
+        "status": (
+            "committed_with_post_commit_error"
+            if post_commit_error is not None
+            else "committed"
+            if committed
+            else "dry_run_rolled_back"
+        ),
         "policy": "Exact audited chunk ids only; no text repair, replacement, or inferred deletion.",
         "audit_path": str(Path(audit_path)),
         "audit_sha256": sha256_file(Path(audit_path)),
@@ -845,6 +885,7 @@ def quarantine_native_anomaly_chunks(
         "foreign_key_failure_hash_after": foreign_key_hash_after,
         "foreign_key_failures_unchanged": foreign_key_failures_after == foreign_key_failures_before,
         "wal_checkpoint": checkpoint,
+        "post_commit_error": post_commit_error,
         "per_source": per_source,
     }
 
@@ -919,6 +960,12 @@ def main(argv: list[str] | None = None) -> int:
                     json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
                 )
             print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+            if receipt["post_commit_error"] is not None:
+                print(
+                    f"COMMITTED_WITH_POST_COMMIT_ERROR: {receipt['post_commit_error']}",
+                    file=sys.stderr,
+                )
+                return 3
             return 0
         slugs = list(WAVE1_SLUGS) if args.wave1 else list(args.slugs or [])
         counts = ingest(
@@ -932,6 +979,9 @@ def main(argv: list[str] | None = None) -> int:
             copied_database_rehearsal=args.copied_db_rehearsal,
             live_ingest_gate_path=args.live_ingest_gate,
         )
+    except PostCommitIngestError as exc:
+        print(f"COMMITTED_WITH_POST_COMMIT_ERROR: {exc}", file=sys.stderr)
+        return 3
     except (IngestError, ValueError) as exc:
         # ValueError: _build_textbook_row's strictness gates (author_uk,
         # unmapped subject) — surface cleanly instead of a traceback.

--- a/scripts/projects/open_model_data/phase3_live_ingest_gate.py
+++ b/scripts/projects/open_model_data/phase3_live_ingest_gate.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Build and enforce the one-time Phase 3 live-ingest authorization gate.
+
+The gate does not weaken the complete v4 source policy. It binds the reviewed
+policy, copied-database rehearsal, exact live database preimage, and recoverable
+Google Drive backup into one single-use cutover authorization. Any source-set,
+database, receipt, or byte drift fails before chunk loading or mutation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from scripts.projects.open_model_data import phase3_source_policy_v4 as policy_v4
+
+SCHEMA_VERSION = "phase3_live_ingest_gate_v1"
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_live_ingest_gate_v1.schema.json"
+DEFAULT_GATE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_live_ingest_gate_v1.json"
+EXPECTED_GATE_SHA256 = "594b2de8ae357b4c33594a8d933d683284f4824c0c833624b20dffe75c6f6a63"
+PR6631_MERGE_COMMIT = "c88928cf6deaeb84d7487681885314d7b2bb729c"
+EXPECTED_LIVE_DB_SHA256 = "c7068a4e4b9e0e7fac3b4f918857bcd36c2f56e524f81e686d222e7155a78739"
+EXPECTED_FOREIGN_KEY_HASH = "9938f7cbab6cca94bfd0a360eec114fdef404a357e02b24161da0f7cf5c6d9bb"
+REQUESTED_SOURCES = tuple(sorted(policy_v4.STAGED_IDS))
+
+EXPECTED_INPUT_HASHES = {
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "complete_source_policy_v4_sha256": policy_v4.EXPECTED_POLICY_SHA256,
+    "copied_database_rehearsal_receipt_sha256": (
+        "a50310fbb526bb68ebe93f6046af56778c860c7b7731a46488dd188465215183"
+    ),
+    "pr6631_drive_backup_receipt_sha256": (
+        "8792d76bca226c603ebc45c8315dcf197231c955aace7c2a78768943ce7f177b"
+    ),
+    "pr6631_drive_provider_verification_sha256": (
+        "10aa43b2c2722fc74c05f471363fe99f0f187a3c692d5f0367cd33b0dd5d4129"
+    ),
+    "pre_ingest_backup_receipt_sha256": (
+        "f97faa4273a1079b76e6f47ddaf188a383aa516f91df768d1909c6e38409023a"
+    ),
+    "pre_ingest_backup_provider_verification_sha256": (
+        "4cf978220e05aaaf4b999422db48d1239a35fd2245a17e1f8fc4bb5b293621ef"
+    ),
+    "compressed_pre_ingest_database_sha256": (
+        "c89d8d2898b7aa7470e8f3888245fb0d85fe74c075d27a9483da262ad3147a5f"
+    ),
+    "independent_cross_family_review_sha256": (
+        "e85a5d5a2681362765cdee879dc19bc7299ff329aa001d69f7ae5616bed55137"
+    ),
+    "pr6631_package_manifest_sha256": (
+        "1c818a2a54ac1dbf57f9ab21d4bb114b365d9ef5205499504f59b5a5967046a5"
+    ),
+}
+
+COUNTS_BEFORE = {
+    "textbook_rows": 49568,
+    "fts_rows": 49568,
+    "section_rows": 35777,
+    "source_count": 183,
+    "university_rows": 3493,
+    "university_source_count": 16,
+}
+COUNTS_AFTER = {
+    "textbook_rows": 50153,
+    "fts_rows": 50153,
+    "section_rows": 36322,
+    "source_count": 187,
+    "university_rows": 4078,
+    "university_source_count": 20,
+}
+
+
+class LiveIngestGateError(ValueError):
+    """The one-time live-ingest gate is incomplete, stale, or unsafe."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise LiveIngestGateError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LiveIngestGateError(f"cannot read JSON artifact: {path}") from exc
+    require(isinstance(value, dict), f"JSON artifact must be an object: {path}")
+    return value
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    require(not path.is_symlink(), f"refusing symlink output: {path}")
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _schema_errors(document: Mapping[str, Any]) -> list[Any]:
+    schema = read_json(SCHEMA_PATH)
+    return sorted(
+        Draft202012Validator(schema).iter_errors(document),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+
+
+def _table_counts(value: Mapping[str, Any]) -> dict[str, int]:
+    return {
+        "textbook_rows": int(value["textbook_rows"]),
+        "fts_rows": int(value["fts_rows"]),
+        "section_rows": int(value["section_rows"]),
+    }
+
+
+def _validate_rehearsal(receipt: Mapping[str, Any]) -> None:
+    require(receipt.get("schema_version") == "incremental-textbook-ingest.v2", "rehearsal schema drift")
+    require(receipt.get("status") == "committed", "copied-database rehearsal was not committed")
+    require(
+        receipt.get("execution_scope") == "copied_database_rehearsal",
+        "receipt is not a copied-database rehearsal",
+    )
+    require(
+        receipt.get("university_source_policy_sha256") == policy_v4.EXPECTED_POLICY_SHA256,
+        "rehearsal policy binding drift",
+    )
+    require(
+        receipt.get("requested_replace_sources") == list(REQUESTED_SOURCES),
+        "rehearsal source denominator drift",
+    )
+    require(receipt.get("requested_quarantine_sources") == [], "rehearsal unexpectedly quarantined sources")
+    require(_table_counts(receipt["before"]) == _table_counts(COUNTS_BEFORE), "rehearsal pre-count drift")
+    require(_table_counts(receipt["after_transaction"]) == _table_counts(COUNTS_AFTER), "rehearsal post-count drift")
+    require(receipt.get("integrity_check") == "ok", "rehearsal integrity check failed")
+    require(receipt.get("foreign_key_failures_unchanged") is True, "rehearsal foreign-key baseline changed")
+    require(
+        receipt.get("foreign_key_failure_count_before") == 134836
+        and receipt.get("foreign_key_failure_count_after") == 134836,
+        "rehearsal foreign-key count drift",
+    )
+    require(
+        receipt.get("foreign_key_failure_hash_before") == EXPECTED_FOREIGN_KEY_HASH
+        and receipt.get("foreign_key_failure_hash_after") == EXPECTED_FOREIGN_KEY_HASH,
+        "rehearsal foreign-key hash drift",
+    )
+    per_source = {entry["source_file"]: entry for entry in receipt.get("per_source", [])}
+    require(set(per_source) == set(REQUESTED_SOURCES), "rehearsal per-source set drift")
+    for source_id in REQUESTED_SOURCES:
+        entry = per_source[source_id]
+        expected_rows = policy_v4.STAGED_EXPECTED_ROWS[source_id]
+        require(entry.get("inserted_rows") == expected_rows, f"{source_id}: rehearsal row-count drift")
+        require(entry.get("linked_rows") == expected_rows, f"{source_id}: rehearsal linkage drift")
+        require(entry.get("fts", {}).get("parity") is True, f"{source_id}: rehearsal FTS parity failed")
+
+
+def _validate_pr_backup(receipt: Mapping[str, Any]) -> None:
+    pull_request = receipt.get("pull_request", {})
+    require(pull_request.get("number") == 6631, "PR backup receipt number drift")
+    require(pull_request.get("merge_commit") == PR6631_MERGE_COMMIT, "PR backup merge binding drift")
+    require(pull_request.get("review_verdict") == "APPROVED", "PR backup lacks approved review")
+    require(receipt.get("outcome") == "merged_and_incrementally_backed_up", "PR backup is incomplete")
+    require(receipt.get("live_ingest_authorized") is False, "PR backup unexpectedly authorized live ingest")
+    evidence = receipt.get("exact_evidence", {})
+    require(
+        evidence.get("complete_source_policy_v4_sha256") == policy_v4.EXPECTED_POLICY_SHA256,
+        "PR backup policy binding drift",
+    )
+    require(
+        evidence.get("copied_database_rehearsal_receipt_sha256")
+        == EXPECTED_INPUT_HASHES["copied_database_rehearsal_receipt_sha256"],
+        "PR backup rehearsal binding drift",
+    )
+    require(receipt.get("phase3_certified") is False and receipt.get("phase4_blocked") is True, "phase drift")
+
+
+def _validate_pr_provider_verification(receipt: Mapping[str, Any]) -> None:
+    require(receipt.get("pull_request") == 6631, "provider receipt PR drift")
+    require(receipt.get("merge_commit") == PR6631_MERGE_COMMIT, "provider receipt merge drift")
+    require(receipt.get("status") == "provider_uploaded_and_verified", "provider upload is unverified")
+    require(receipt.get("provider_uploaded_count") == receipt.get("verified_file_count"), "provider upload gap")
+    require(receipt.get("provider_uploading_count") == 0, "provider upload is still active")
+    require(receipt.get("drive_item_id_count") == receipt.get("verified_file_count"), "Drive item ID gap")
+    require(receipt.get("readback_sha256_verified") is True, "provider read-back hash was not verified")
+
+
+def _validate_pre_ingest_backup(
+    backup_receipt: Mapping[str, Any], provider_receipt: Mapping[str, Any]
+) -> None:
+    artifact = backup_receipt.get("artifacts", {}).get("sources-c7068a4e4b9e.db.gz", {})
+    require(artifact.get("sha256") == EXPECTED_INPUT_HASHES["compressed_pre_ingest_database_sha256"], "backup gzip drift")
+    require(artifact.get("restored_database_sha256") == EXPECTED_LIVE_DB_SHA256, "backup restore hash drift")
+    require(
+        artifact.get("integrity") == "gzip_passed_and_restored_hash_matched",
+        "backup gzip or restored hash was not verified",
+    )
+    require(provider_receipt.get("status") == "preimage_recoverable_and_provider_uploaded", "preimage backup unverified")
+    live = provider_receipt.get("live_database", {})
+    require(live.get("sha256") == EXPECTED_LIVE_DB_SHA256, "pre-backup live database identity drift")
+    require(
+        {key: live.get(key) for key in COUNTS_BEFORE} == COUNTS_BEFORE,
+        "pre-backup database count drift",
+    )
+    drive = provider_receipt.get("google_drive", {})
+    require(drive.get("compressed_database_sha256") == artifact.get("sha256"), "provider gzip binding drift")
+    require(drive.get("restored_database_sha256") == EXPECTED_LIVE_DB_SHA256, "provider restore binding drift")
+    require(drive.get("gzip_test_passed") is True, "pre-ingest gzip test failed")
+    require(drive.get("provider_uploaded") is True, "pre-ingest backup is not uploaded")
+    require(drive.get("provider_uploading") is False, "pre-ingest backup is still uploading")
+    require(drive.get("drive_item_id_present") is True, "pre-ingest backup lacks a Drive item ID")
+    require(
+        drive.get("backup_receipt_sha256") == EXPECTED_INPUT_HASHES["pre_ingest_backup_receipt_sha256"],
+        "provider backup-receipt binding drift",
+    )
+
+
+def validate_bound_inputs(paths: Mapping[str, Path]) -> None:
+    require(set(paths) == set(EXPECTED_INPUT_HASHES), "bound input path set is incomplete")
+    for key, expected_sha256 in EXPECTED_INPUT_HASHES.items():
+        path = Path(paths[key])
+        require(path.is_file(), f"missing bound input artifact: {key}")
+        require(sha256_file(path) == expected_sha256, f"bound input artifact drift: {key}")
+
+
+def build_gate(
+    *,
+    source_policy: Mapping[str, Any],
+    rehearsal_receipt: Mapping[str, Any],
+    pr_backup_receipt: Mapping[str, Any],
+    pr_provider_receipt: Mapping[str, Any],
+    pre_ingest_backup_receipt: Mapping[str, Any],
+    pre_ingest_provider_receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the deterministic one-time authorization from exact evidence."""
+    policy_v4.validate_policy_document(source_policy)
+    require(source_policy["database_ingest"]["live_ingest_authorized"] is False, "v4 policy boundary drift")
+    _validate_rehearsal(rehearsal_receipt)
+    _validate_pr_backup(pr_backup_receipt)
+    _validate_pr_provider_verification(pr_provider_receipt)
+    _validate_pre_ingest_backup(pre_ingest_backup_receipt, pre_ingest_provider_receipt)
+
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "text_free": True,
+        "status": "AUTHORIZED_ONCE_FOR_EXACT_PREIMAGE",
+        "bindings": {**EXPECTED_INPUT_HASHES, "pr6631_merge_commit": PR6631_MERGE_COMMIT},
+        "requested_sources": list(REQUESTED_SOURCES),
+        "database": {
+            "target_locator": "primary_checkout:data/sources.db",
+            "sha256_before": EXPECTED_LIVE_DB_SHA256,
+            "counts_before": COUNTS_BEFORE,
+            "counts_after_expected": COUNTS_AFTER,
+            "foreign_key_failure_count": 134836,
+            "foreign_key_failure_hash": EXPECTED_FOREIGN_KEY_HASH,
+            "integrity_check": "ok",
+            "journal_mode": "wal",
+            "requested_sources_absent_before": True,
+        },
+        "copied_database_rehearsal": {
+            "execution_scope": "copied_database_rehearsal",
+            "status": "committed",
+            "database_sha256_before": rehearsal_receipt["db_sha256_before"],
+            "database_sha256_after": rehearsal_receipt["db_sha256_after"],
+            "counts_before": _table_counts(rehearsal_receipt["before"]),
+            "counts_after": _table_counts(rehearsal_receipt["after_transaction"]),
+            "inserted_rows": sum(policy_v4.STAGED_EXPECTED_ROWS.values()),
+            "source_count": len(REQUESTED_SOURCES),
+            "integrity_check": rehearsal_receipt["integrity_check"],
+            "foreign_key_failures_unchanged": rehearsal_receipt["foreign_key_failures_unchanged"],
+            "per_source_fts_and_linkage_passed": True,
+        },
+        "pre_ingest_backup": {
+            "google_drive_relative_path": (
+                "Projects/learn-ukrainian-data/backups/phase3-6375/20260811T090325Z"
+            ),
+            "compressed_database_filename": "sources-c7068a4e4b9e.db.gz",
+            "compressed_database_sha256": EXPECTED_INPUT_HASHES["compressed_pre_ingest_database_sha256"],
+            "restored_database_sha256": EXPECTED_LIVE_DB_SHA256,
+            "gzip_test_passed": True,
+            "provider_uploaded": True,
+            "provider_uploading": False,
+            "drive_item_id_present": True,
+        },
+        "execution": {
+            "live_ingest_authorized": True,
+            "single_use": True,
+            "exact_preimage_required": True,
+            "exact_source_set_required": True,
+            "receipt_required": True,
+            "post_ingest_backup_required": True,
+            "provider_work_authorized": False,
+        },
+        "source_freeze_ready": False,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+    gate = {
+        **body,
+        "receipt_sha256": hashlib.sha256((canonical_json(body) + "\n").encode("utf-8")).hexdigest(),
+    }
+    validate_gate_document(gate)
+    return gate
+
+
+def validate_gate_document(gate: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate schema and the non-reusable live-cutover invariants."""
+    errors = _schema_errors(gate)
+    require(not errors, f"live ingest gate schema violation: {errors[0].message if errors else ''}")
+    body = {key: value for key, value in gate.items() if key != "receipt_sha256"}
+    receipt_sha256 = hashlib.sha256((canonical_json(body) + "\n").encode("utf-8")).hexdigest()
+    require(gate["receipt_sha256"] == receipt_sha256, "live ingest gate receipt hash drift")
+    require(
+        gate["bindings"] == {**EXPECTED_INPUT_HASHES, "pr6631_merge_commit": PR6631_MERGE_COMMIT},
+        "live ingest gate bindings drift",
+    )
+    require(tuple(gate["requested_sources"]) == REQUESTED_SOURCES, "live ingest source set drift")
+    require(gate["database"]["counts_before"] == COUNTS_BEFORE, "live database pre-count drift")
+    require(gate["database"]["counts_after_expected"] == COUNTS_AFTER, "live database post-count drift")
+    require(
+        gate["database"]["foreign_key_failure_hash"] == EXPECTED_FOREIGN_KEY_HASH,
+        "live database foreign-key hash drift",
+    )
+    execution = gate["execution"]
+    require(
+        execution["live_ingest_authorized"] is True
+        and execution["single_use"] is True
+        and execution["exact_preimage_required"] is True
+        and execution["post_ingest_backup_required"] is True,
+        "live ingest execution boundary drift",
+    )
+    require(execution["provider_work_authorized"] is False, "gate unexpectedly authorizes provider work")
+    require(gate["source_freeze_ready"] is False and gate["phase3_complete"] is False, "phase completion drift")
+    require(gate["phase4_blocked"] is True, "Phase 4 boundary drift")
+    return dict(gate)
+
+
+def load_gate(path: Path = DEFAULT_GATE_PATH) -> tuple[dict[str, Any], str]:
+    require(Path(path).is_file(), f"live ingest gate is missing: {path}")
+    gate_sha256 = sha256_file(path)
+    require(gate_sha256 == EXPECTED_GATE_SHA256, "live ingest gate byte drift")
+    return validate_gate_document(read_json(path)), gate_sha256
+
+
+def _foreign_key_evidence(conn: sqlite3.Connection) -> tuple[int, str]:
+    failures = sorted(tuple(row) for row in conn.execute("PRAGMA foreign_key_check").fetchall())
+    digest = hashlib.sha256(
+        json.dumps(failures, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return len(failures), digest
+
+
+def _database_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    return {
+        "textbook_rows": conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0],
+        "fts_rows": conn.execute("SELECT COUNT(*) FROM textbooks_fts").fetchone()[0],
+        "section_rows": conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0],
+        "source_count": conn.execute("SELECT COUNT(DISTINCT source_file) FROM textbooks").fetchone()[0],
+        "university_rows": conn.execute("SELECT COUNT(*) FROM textbooks WHERE grade='university'").fetchone()[0],
+        "university_source_count": conn.execute(
+            "SELECT COUNT(DISTINCT source_file) FROM textbooks WHERE grade='university'"
+        ).fetchone()[0],
+    }
+
+
+def validate_database_preimage(
+    gate: Mapping[str, Any],
+    *,
+    db_path: Path,
+    expected_live_db_path: Path,
+) -> None:
+    """Prove the exact live database preimage and single-use absence state."""
+    db_path = Path(db_path)
+    expected_live_db_path = Path(expected_live_db_path)
+    require(db_path.is_file(), "live ingest database target does not exist")
+    require(not db_path.is_symlink(), "live ingest refuses a symlink database target")
+    require(
+        db_path.resolve() == expected_live_db_path.resolve(),
+        "live ingest gate is restricted to the primary checkout sources database",
+    )
+    require(
+        os.path.samefile(db_path, expected_live_db_path),
+        "live ingest target is not the primary checkout database inode",
+    )
+    database_gate = gate["database"]
+    require(sha256_file(db_path) == database_gate["sha256_before"], "live database preimage SHA-256 drift")
+
+    uri = f"file:{db_path.resolve()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=30.0)
+    try:
+        journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        require(journal_mode == database_gate["journal_mode"], "live database journal-mode drift")
+        require(_database_counts(conn) == database_gate["counts_before"], "live database count preimage drift")
+        placeholders = ",".join("?" for _ in REQUESTED_SOURCES)
+        staged_rows = conn.execute(
+            f"SELECT COUNT(*) FROM textbooks WHERE source_file IN ({placeholders})",
+            REQUESTED_SOURCES,
+        ).fetchone()[0]
+        require(staged_rows == 0, "single-use gate is stale: requested sources are already present")
+        integrity_rows = [str(row[0]) for row in conn.execute("PRAGMA integrity_check").fetchall()]
+        require(integrity_rows == [database_gate["integrity_check"]], "live database integrity check failed")
+        failure_count, failure_hash = _foreign_key_evidence(conn)
+        require(
+            failure_count == database_gate["foreign_key_failure_count"],
+            "live database foreign-key count drift",
+        )
+        require(failure_hash == database_gate["foreign_key_failure_hash"], "live database foreign-key hash drift")
+    finally:
+        conn.close()
+
+
+def validate_live_ingest_preconditions(
+    *,
+    gate_path: Path,
+    db_path: Path,
+    expected_live_db_path: Path,
+    source_ids: Sequence[str],
+    quarantine_source_ids: Sequence[str],
+    source_policy_sha256: str,
+    dry_run: bool,
+    copied_database_rehearsal: bool,
+    receipt_path: Path | None,
+) -> str:
+    """Fail closed before any chunk read or live mutation."""
+    gate, gate_sha256 = load_gate(gate_path)
+    require(not dry_run, "live ingest gate authorizes an exact committed cutover, not a dry-run")
+    require(not copied_database_rehearsal, "live ingest gate cannot be combined with copied-database rehearsal")
+    require(receipt_path is not None, "live ingest gate requires an explicit receipt path")
+    require(tuple(sorted(source_ids)) == REQUESTED_SOURCES, "live ingest gate requires the exact four-source set")
+    require(not quarantine_source_ids, "live ingest gate does not authorize quarantine mutations")
+    require(
+        source_policy_sha256 == gate["bindings"]["complete_source_policy_v4_sha256"],
+        "live ingest gate source-policy binding drift",
+    )
+    validate_database_preimage(gate, db_path=db_path, expected_live_db_path=expected_live_db_path)
+    return gate_sha256
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase3-reboot-prompt-v3", type=Path, required=True)
+    parser.add_argument("--complete-source-policy-v4", type=Path, required=True)
+    parser.add_argument("--copied-database-rehearsal-receipt", type=Path, required=True)
+    parser.add_argument("--pr6631-drive-backup-receipt", type=Path, required=True)
+    parser.add_argument("--pr6631-drive-provider-verification", type=Path, required=True)
+    parser.add_argument("--pre-ingest-backup-receipt", type=Path, required=True)
+    parser.add_argument("--pre-ingest-backup-provider-verification", type=Path, required=True)
+    parser.add_argument("--compressed-pre-ingest-database", type=Path, required=True)
+    parser.add_argument("--independent-cross-family-review", type=Path, required=True)
+    parser.add_argument("--pr6631-package-manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    paths = {
+        "phase3_reboot_prompt_v3_sha256": args.phase3_reboot_prompt_v3,
+        "complete_source_policy_v4_sha256": args.complete_source_policy_v4,
+        "copied_database_rehearsal_receipt_sha256": args.copied_database_rehearsal_receipt,
+        "pr6631_drive_backup_receipt_sha256": args.pr6631_drive_backup_receipt,
+        "pr6631_drive_provider_verification_sha256": args.pr6631_drive_provider_verification,
+        "pre_ingest_backup_receipt_sha256": args.pre_ingest_backup_receipt,
+        "pre_ingest_backup_provider_verification_sha256": args.pre_ingest_backup_provider_verification,
+        "compressed_pre_ingest_database_sha256": args.compressed_pre_ingest_database,
+        "independent_cross_family_review_sha256": args.independent_cross_family_review,
+        "pr6631_package_manifest_sha256": args.pr6631_package_manifest,
+    }
+    validate_bound_inputs(paths)
+    gate = build_gate(
+        source_policy=read_json(args.complete_source_policy_v4),
+        rehearsal_receipt=read_json(args.copied_database_rehearsal_receipt),
+        pr_backup_receipt=read_json(args.pr6631_drive_backup_receipt),
+        pr_provider_receipt=read_json(args.pr6631_drive_provider_verification),
+        pre_ingest_backup_receipt=read_json(args.pre_ingest_backup_receipt),
+        pre_ingest_provider_receipt=read_json(args.pre_ingest_backup_provider_verification),
+    )
+    encoded = json.dumps(gate, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(encoded, end="")
+    else:
+        write_text_atomic(args.output, encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ingest/test_incremental_textbook_ingest.py
+++ b/tests/ingest/test_incremental_textbook_ingest.py
@@ -36,6 +36,48 @@ END;
 """
 
 
+class _CheckpointResult:
+    def __init__(self, row: tuple[int, int, int]) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[int, int, int]:
+        return self._row
+
+
+class _PostCommitCheckpointFailureConnection:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        object.__setattr__(self, "_connection", connection)
+        object.__setattr__(self, "_checkpoint_calls", 0)
+
+    def execute(self, sql: str, parameters=()):
+        if sql == "PRAGMA wal_checkpoint(TRUNCATE)":
+            object.__setattr__(self, "_checkpoint_calls", self._checkpoint_calls + 1)
+            if self._checkpoint_calls == 2:
+                return _CheckpointResult((1, 5, 3))
+        return self._connection.execute(sql, parameters)
+
+    def __getattr__(self, name: str):
+        return getattr(self._connection, name)
+
+    def __setattr__(self, name: str, value) -> None:
+        setattr(self._connection, name, value)
+
+
+def _install_post_commit_checkpoint_failure(monkeypatch, db: Path):
+    original_connect = sqlite3.connect
+    conn = original_connect(str(db))
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+    finally:
+        conn.close()
+
+    def connect(*args, **kwargs):
+        return _PostCommitCheckpointFailureConnection(original_connect(*args, **kwargs))
+
+    monkeypatch.setattr(iti.sqlite3, "connect", connect)
+    return original_connect
+
+
 @pytest.fixture()
 def fixture_env(tmp_path, monkeypatch):
     db = tmp_path / "sources.db"
@@ -145,6 +187,54 @@ def test_normal_ingest_writes_integrity_receipt(fixture_env, tmp_path):
     assert receipt["foreign_key_failures_unchanged"] is True
     assert receipt["db_sha256_before"] != receipt["db_sha256_after"]
     assert receipt["per_source"][0]["fts"]["parity"] is True
+
+
+def test_post_commit_checkpoint_failure_is_receipted(fixture_env, tmp_path, monkeypatch):
+    db, slug = fixture_env
+    receipt_path = tmp_path / "post-commit-error-receipt.json"
+    original_connect = _install_post_commit_checkpoint_failure(monkeypatch, db)
+
+    with pytest.raises(
+        iti.PostCommitIngestError,
+        match=r"WAL checkpoint did not settle after ingest: \[1, 5, 3\]",
+    ):
+        iti.ingest(
+            [slug],
+            db_path=db,
+            dry_run=False,
+            receipt_path=receipt_path,
+        )
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "committed_with_post_commit_error"
+    assert receipt["post_commit_error"] == (
+        "WAL checkpoint did not settle after ingest: [1, 5, 3]"
+    )
+    assert receipt["wal_checkpoint"] == [1, 5, 3]
+    conn = original_connect(str(db))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 3
+    finally:
+        conn.close()
+
+
+def test_main_distinguishes_post_commit_error_from_rollback(tmp_path, monkeypatch, capsys):
+    def committed_then_failed(*_args, **_kwargs):
+        raise iti.PostCommitIngestError("checkpoint remained busy")
+
+    monkeypatch.setattr(iti, "ingest", committed_then_failed)
+
+    result = iti.main(
+        [
+            "--slugs",
+            "9-klas-khimiya-popel-2017",
+            "--db",
+            str(tmp_path / "sources.db"),
+        ]
+    )
+
+    assert result == 3
+    assert "COMMITTED_WITH_POST_COMMIT_ERROR: checkpoint remained busy" in capsys.readouterr().err
 
 
 def test_live_gate_wiring_records_authorized_cutover_scope(fixture_env, tmp_path, monkeypatch):
@@ -855,6 +945,73 @@ def test_hash_bound_native_anomaly_quarantine_removes_only_exact_archived_chunk(
     assert replay["removed_chunk_count"] == 0
     assert replay["already_absent_chunk_count"] == 1
     assert replay["per_source"][0]["section_policy"] == "unchanged_already_absent"
+
+
+def test_quarantine_post_commit_checkpoint_failure_is_receipted(
+    fixture_env,
+    tmp_path,
+    monkeypatch,
+):
+    db, slug = fixture_env
+    iti.ingest([slug], db_path=db, dry_run=False)
+    audit_path = tmp_path / "audit.json"
+    audit_path.write_text("{}\n", encoding="utf-8")
+    quarantine_dir = tmp_path / "quarantine"
+    quarantine_dir.mkdir()
+    monkeypatch.setattr(
+        iti,
+        "load_native_anomaly_quarantine_plan",
+        lambda *_args, **_kwargs: {slug: [f"{slug}_s0001"]},
+    )
+    original_connect = _install_post_commit_checkpoint_failure(monkeypatch, db)
+
+    receipt = iti.quarantine_native_anomaly_chunks(
+        audit_path=audit_path,
+        chunks_root=iti.CHUNKS_DIR,
+        quarantine_dir=quarantine_dir,
+        db_path=db,
+        dry_run=False,
+    )
+
+    assert receipt["status"] == "committed_with_post_commit_error"
+    assert receipt["post_commit_error"] == (
+        "WAL checkpoint did not settle after quarantine: [1, 5, 3]"
+    )
+    assert receipt["wal_checkpoint"] == [1, 5, 3]
+    conn = original_connect(str(db))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_quarantine_cli_writes_post_commit_receipt_before_exit(tmp_path, monkeypatch, capsys):
+    receipt_path = tmp_path / "quarantine-receipt.json"
+    receipt = {
+        "schema_version": "textbook-native-anomaly-quarantine.v1",
+        "status": "committed_with_post_commit_error",
+        "post_commit_error": "checkpoint remained busy",
+    }
+    monkeypatch.setattr(
+        iti,
+        "quarantine_native_anomaly_chunks",
+        lambda **_kwargs: receipt,
+    )
+
+    result = iti.main(
+        [
+            "--quarantine-audit",
+            str(tmp_path / "audit.json"),
+            "--quarantine-dir",
+            str(tmp_path / "quarantine"),
+            "--receipt",
+            str(receipt_path),
+        ]
+    )
+
+    assert result == 3
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt
+    assert "COMMITTED_WITH_POST_COMMIT_ERROR: checkpoint remained busy" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("marker", ["extraction_mode", "page_extraction_mode"])

--- a/tests/ingest/test_incremental_textbook_ingest.py
+++ b/tests/ingest/test_incremental_textbook_ingest.py
@@ -147,6 +147,92 @@ def test_normal_ingest_writes_integrity_receipt(fixture_env, tmp_path):
     assert receipt["per_source"][0]["fts"]["parity"] is True
 
 
+def test_live_gate_wiring_records_authorized_cutover_scope(fixture_env, tmp_path, monkeypatch):
+    db, slug = fixture_env
+    receipt_path = tmp_path / "live-cutover-receipt.json"
+    gate_path = tmp_path / "live-ingest-gate.json"
+    gate_sha256 = "a" * 64
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        iti,
+        "load_policy",
+        lambda _path: (
+            {
+                "schema_version": "phase3_complete_source_policy_v4",
+                "database_ingest": {"live_ingest_authorized": False},
+            },
+            "b" * 64,
+        ),
+    )
+
+    def validate_gate(**kwargs):
+        captured.update(kwargs)
+        return gate_sha256
+
+    monkeypatch.setattr(iti, "validate_live_ingest_preconditions", validate_gate)
+    monkeypatch.setattr(iti, "EXPECTED_LIVE_DB_SHA256", iti.sha256_file(db))
+    monkeypatch.setattr(
+        iti,
+        "LIVE_INGEST_COUNTS_BEFORE",
+        {"textbook_rows": 0, "fts_rows": 0, "section_rows": 0},
+    )
+
+    counts = iti.ingest(
+        [slug],
+        db_path=db,
+        dry_run=False,
+        receipt_path=receipt_path,
+        live_ingest_gate_path=gate_path,
+    )
+
+    assert counts == {slug: 3}
+    assert captured["gate_path"] == gate_path
+    assert captured["db_path"] == db
+    assert captured["source_ids"] == [slug]
+    assert captured["source_policy_sha256"] == "b" * 64
+    assert captured["receipt_path"] == receipt_path
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["execution_scope"] == "live_database_authorized_cutover"
+    assert receipt["live_ingest_gate_sha256"] == gate_sha256
+
+
+def test_live_gate_rechecks_preimage_after_acquiring_write_lock(fixture_env, tmp_path, monkeypatch):
+    db, slug = fixture_env
+    monkeypatch.setattr(
+        iti,
+        "load_policy",
+        lambda _path: (
+            {
+                "schema_version": "phase3_complete_source_policy_v4",
+                "database_ingest": {"live_ingest_authorized": False},
+            },
+            "b" * 64,
+        ),
+    )
+    monkeypatch.setattr(
+        iti,
+        "validate_live_ingest_preconditions",
+        lambda **_kwargs: "a" * 64,
+    )
+    monkeypatch.setattr(iti, "sha256_file", lambda _path: "0" * 64)
+
+    with pytest.raises(iti.IngestError, match="changed after gate validation"):
+        iti.ingest(
+            [slug],
+            db_path=db,
+            dry_run=False,
+            receipt_path=tmp_path / "receipt.json",
+            live_ingest_gate_path=tmp_path / "gate.json",
+        )
+
+    conn = sqlite3.connect(db)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_dry_run_receipt_proves_database_hash_is_unchanged(fixture_env, tmp_path):
     db, slug = fixture_env
     receipt_path = tmp_path / "dry-run-receipt.json"

--- a/tests/test_open_model_phase3_live_ingest_gate.py
+++ b/tests/test_open_model_phase3_live_ingest_gate.py
@@ -1,0 +1,243 @@
+"""One-time Phase 3 live-ingest gate tests."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_live_ingest_gate as live_gate
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_live_ingest_gate_v1.json"
+
+
+def _gate() -> dict:
+    return json.loads(GATE_PATH.read_text(encoding="utf-8"))
+
+
+def _reseal(gate: dict) -> dict:
+    body = {key: value for key, value in gate.items() if key != "receipt_sha256"}
+    gate["receipt_sha256"] = hashlib.sha256(
+        (live_gate.canonical_json(body) + "\n").encode("utf-8")
+    ).hexdigest()
+    return gate
+
+
+def _fixture_db(path: Path, *, staged_source_present: bool = False) -> dict:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            text TEXT,
+            source_file TEXT,
+            grade TEXT
+        );
+        CREATE VIRTUAL TABLE textbooks_fts USING fts5(
+            title, text, content='textbooks', content_rowid='id', tokenize='unicode61'
+        );
+        CREATE TRIGGER textbooks_ai AFTER INSERT ON textbooks BEGIN
+            INSERT INTO textbooks_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+        END;
+        CREATE TABLE textbook_sections (
+            id INTEGER PRIMARY KEY,
+            source_file TEXT
+        );
+        """
+    )
+    if staged_source_present:
+        conn.execute(
+            "INSERT INTO textbooks(title, text, source_file, grade) VALUES (?, ?, ?, ?)",
+            (
+                "Тест",
+                "Тестовий текст",
+                live_gate.REQUESTED_SOURCES[0],
+                "university",
+            ),
+        )
+    conn.commit()
+    counts = live_gate._database_counts(conn)
+    conn.close()
+    return counts
+
+
+def _fixture_gate(path: Path, counts: dict) -> dict:
+    return {
+        "database": {
+            "sha256_before": live_gate.sha256_file(path),
+            "counts_before": counts,
+            "foreign_key_failure_count": 0,
+            "foreign_key_failure_hash": hashlib.sha256(b"[]").hexdigest(),
+            "integrity_check": "ok",
+            "journal_mode": "wal",
+        }
+    }
+
+
+def test_tracked_gate_is_exact_and_single_use():
+    document, gate_sha256 = live_gate.load_gate(GATE_PATH)
+
+    assert gate_sha256 == live_gate.EXPECTED_GATE_SHA256
+    assert document["requested_sources"] == list(live_gate.REQUESTED_SOURCES)
+    assert document["database"]["sha256_before"] == live_gate.EXPECTED_LIVE_DB_SHA256
+    assert document["database"]["counts_before"] == live_gate.COUNTS_BEFORE
+    assert document["database"]["counts_after_expected"] == live_gate.COUNTS_AFTER
+    assert document["execution"] == {
+        "live_ingest_authorized": True,
+        "single_use": True,
+        "exact_preimage_required": True,
+        "exact_source_set_required": True,
+        "receipt_required": True,
+        "post_ingest_backup_required": True,
+        "provider_work_authorized": False,
+    }
+    assert document["source_freeze_ready"] is False
+    assert document["phase3_complete"] is False
+    assert document["phase4_blocked"] is True
+
+
+def test_gate_binds_rehearsal_review_and_provider_uploaded_preimage():
+    document = _gate()
+
+    assert document["bindings"] == {
+        **live_gate.EXPECTED_INPUT_HASHES,
+        "pr6631_merge_commit": live_gate.PR6631_MERGE_COMMIT,
+    }
+    assert document["copied_database_rehearsal"] == {
+        "execution_scope": "copied_database_rehearsal",
+        "status": "committed",
+        "database_sha256_before": "4b7b6aa7913b415114f270b497141fc706a0c9f1dabf2fdbae7cd4db8110a391",
+        "database_sha256_after": "e3c7d01dec04c6b7c6c8ea8dbe8fab11e0b3cdb9fea9c1280a927167a236f70b",
+        "counts_before": {"textbook_rows": 49568, "fts_rows": 49568, "section_rows": 35777},
+        "counts_after": {"textbook_rows": 50153, "fts_rows": 50153, "section_rows": 36322},
+        "inserted_rows": 585,
+        "source_count": 4,
+        "integrity_check": "ok",
+        "foreign_key_failures_unchanged": True,
+        "per_source_fts_and_linkage_passed": True,
+    }
+    assert document["pre_ingest_backup"]["provider_uploaded"] is True
+    assert document["pre_ingest_backup"]["provider_uploading"] is False
+    assert document["pre_ingest_backup"]["drive_item_id_present"] is True
+    assert document["pre_ingest_backup"]["restored_database_sha256"] == live_gate.EXPECTED_LIVE_DB_SHA256
+
+
+def test_schema_rejects_open_execution_fields():
+    document = copy.deepcopy(_gate())
+    document["execution"]["skip_backup"] = True
+    schema = json.loads(live_gate.SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    errors = list(Draft202012Validator(schema).iter_errors(document))
+
+    assert errors
+    assert any("Additional properties are not allowed" in error.message for error in errors)
+
+
+def test_gate_rejects_source_or_phase_drift_even_when_resealed():
+    document = copy.deepcopy(_gate())
+    document["requested_sources"] = list(reversed(document["requested_sources"]))
+
+    with pytest.raises(live_gate.LiveIngestGateError, match="schema violation"):
+        live_gate.validate_gate_document(_reseal(document))
+
+    document = copy.deepcopy(_gate())
+    document["phase4_blocked"] = False
+    with pytest.raises(live_gate.LiveIngestGateError, match="schema violation"):
+        live_gate.validate_gate_document(_reseal(document))
+
+
+def test_runtime_loader_rejects_semantically_identical_byte_drift(tmp_path):
+    drifted = tmp_path / GATE_PATH.name
+    drifted.write_text(GATE_PATH.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(live_gate.LiveIngestGateError, match="byte drift"):
+        live_gate.load_gate(drifted)
+
+    with pytest.raises(live_gate.LiveIngestGateError, match="is missing"):
+        live_gate.load_gate(tmp_path / "absent.json")
+
+
+def test_database_preimage_accepts_only_exact_live_path_and_absent_sources(tmp_path):
+    db_path = tmp_path / "sources.db"
+    counts = _fixture_db(db_path)
+    document = _fixture_gate(db_path, counts)
+
+    live_gate.validate_database_preimage(
+        document,
+        db_path=db_path,
+        expected_live_db_path=db_path,
+    )
+
+    copied_path = tmp_path / "copy.db"
+    copied_path.write_bytes(db_path.read_bytes())
+    with pytest.raises(live_gate.LiveIngestGateError, match="primary checkout sources database"):
+        live_gate.validate_database_preimage(
+            document,
+            db_path=copied_path,
+            expected_live_db_path=db_path,
+        )
+
+
+def test_database_preimage_rejects_already_present_staged_source(tmp_path):
+    db_path = tmp_path / "sources.db"
+    counts = _fixture_db(db_path, staged_source_present=True)
+    document = _fixture_gate(db_path, counts)
+
+    with pytest.raises(live_gate.LiveIngestGateError, match="already present"):
+        live_gate.validate_database_preimage(
+            document,
+            db_path=db_path,
+            expected_live_db_path=db_path,
+        )
+
+
+def test_preconditions_reject_wrong_source_set_before_database_access(tmp_path):
+    with pytest.raises(live_gate.LiveIngestGateError, match="exact four-source set"):
+        live_gate.validate_live_ingest_preconditions(
+            gate_path=GATE_PATH,
+            db_path=tmp_path / "missing.db",
+            expected_live_db_path=tmp_path / "missing.db",
+            source_ids=[live_gate.REQUESTED_SOURCES[0]],
+            quarantine_source_ids=[],
+            source_policy_sha256=live_gate.EXPECTED_INPUT_HASHES["complete_source_policy_v4_sha256"],
+            dry_run=False,
+            copied_database_rehearsal=False,
+            receipt_path=tmp_path / "receipt.json",
+        )
+
+
+@pytest.mark.parametrize(
+    ("dry_run", "copied_rehearsal", "receipt_path", "message"),
+    [
+        (True, False, Path("receipt.json"), "not a dry-run"),
+        (False, True, Path("receipt.json"), "cannot be combined"),
+        (False, False, None, "explicit receipt path"),
+    ],
+)
+def test_preconditions_reject_non_cutover_execution_before_database_access(
+    tmp_path,
+    dry_run,
+    copied_rehearsal,
+    receipt_path,
+    message,
+):
+    with pytest.raises(live_gate.LiveIngestGateError, match=message):
+        live_gate.validate_live_ingest_preconditions(
+            gate_path=GATE_PATH,
+            db_path=tmp_path / "missing.db",
+            expected_live_db_path=tmp_path / "missing.db",
+            source_ids=live_gate.REQUESTED_SOURCES,
+            quarantine_source_ids=[],
+            source_policy_sha256=live_gate.EXPECTED_INPUT_HASHES["complete_source_policy_v4_sha256"],
+            dry_run=dry_run,
+            copied_database_rehearsal=copied_rehearsal,
+            receipt_path=receipt_path,
+        )


### PR DESCRIPTION
## Outcome

Adds a one-time, text-free live-ingest gate for the exact four staged Phase 3 university sources. The gate is locked to the reviewed v4 policy, the successful 585-row copied-database rehearsal, the independent PR #6631 review, the current `c706…` live database preimage, and its verified Google Drive recovery snapshot.

## Safety properties

- exact four-source set and 585-row denominator; no quarantine mutation
- exact live database path, inode, SHA-256, counts, journal mode, integrity, and foreign-key baseline
- single-use: all four sources must still be absent
- explicit receipt required; dry-run and copied-rehearsal modes cannot impersonate cutover
- rechecks the database SHA-256 and table counts after acquiring `BEGIN IMMEDIATE`, before mutation
- v4 remains default-deny; the separate exact gate is the only live-cutover override
- post-ingest backup remains required
- no provider work, source-freeze claim, Phase 3 completion, or Phase 4 authorization

Gate SHA-256: `594b2de8ae357b4c33594a8d933d683284f4824c0c833624b20dffe75c6f6a63`

## Verification

- `600 passed` across `tests/test_open_model_phase3_*.py` plus incremental-ingest tests
- focused gate/policy/ingest suite: `63 passed`
- Ruff: clean
- deterministic gate regeneration: byte-identical
- real read-only live precondition validation: PASS at gate SHA above
- live database mutation: **not performed by this PR**

Issue: #6375

X-Agent: codex/6375-phase3-live-ingest-gate
