### PR TITLE
fix(lexicon): derive embed fingerprint from merge-friendly sidecar

### DIFF
--- a/scripts/lexicon/merge_translation_delta.py
+++ b/scripts/lexicon/merge_translation_delta.py
@@ -38,25 +38,42 @@ def sync_embedded_fingerprint_from_sidecar(
     manifest: dict[str, Any],
     *,
     fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    root: Path = ROOT,
 ) -> dict[str, Any]:
-    """Embed the committed fingerprint sidecar without regenerating it.
+    """Embed derived fingerprint for publish; committed sidecar stays merge-friendly.
 
-    Sparse worktrees may omit fingerprint inputs (for example ``curriculum/``),
-    so ``write_fingerprint`` / ``build_fingerprint`` can drift. Publishing only
-    requires the embedded value to match the committed sidecar.
+    Committed ``lexicon-manifest.fingerprint.json`` stores only
+    ``{schema_version, scope, inputs}`` (see ``sidecar_payload``). The aggregate
+    digest is derived via ``build_fingerprint`` at write time so sparse
+    worktrees and merge-union sidecars both work. When the sidecar exists,
+    its merge-friendly body must match ``sidecar_payload(build_fingerprint)``
+    so we fail closed on stale code/sidecar pairs.
     """
-    payload = json.loads(fingerprint_path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"{fingerprint_path} must contain a JSON object")
-    schema_version = payload.get("schema_version")
-    fingerprint = payload.get("fingerprint")
-    if schema_version is None or not isinstance(fingerprint, str) or not fingerprint:
-        raise ValueError(f"{fingerprint_path} missing schema_version/fingerprint")
+    from scripts.lexicon.manifest_fingerprint import build_fingerprint, sidecar_payload
+
+    full = build_fingerprint(root)
+    if fingerprint_path.exists():
+        committed = json.loads(fingerprint_path.read_text(encoding="utf-8"))
+        if not isinstance(committed, dict):
+            raise ValueError(f"{fingerprint_path} must contain a JSON object")
+        expected = sidecar_payload(full)
+        # Compare canonical body (ignore derived fingerprint/stats if present)
+        committed_body = {
+            "schema_version": committed.get("schema_version"),
+            "scope": committed.get("scope"),
+            "inputs": committed.get("inputs"),
+        }
+        if committed_body != expected:
+            raise ValueError(
+                f"{fingerprint_path} does not match current lexicon code; "
+                "run write_fingerprint / make atlas fingerprint step and re-commit."
+            )
     manifest["manifest_fingerprint"] = {
-        "schema_version": schema_version,
-        "fingerprint": fingerprint,
+        "schema_version": full["schema_version"],
+        "fingerprint": full["fingerprint"],
     }
-    return payload
+    return full
+
 
 
 def entry_has_translation(entry: dict[str, Any]) -> bool:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -159,7 +159,7 @@
       },
       {
         "path": "scripts/lexicon/merge_translation_delta.py",
-        "sha256": "ea68d272a2fb0df30ebda5d434a540ee9ee9fda45a680c617ba7566f0533236f"
+        "sha256": "f8ede84be0231383c1d47701856e805b92518aa6e2ae9d6f1132cbcc97bec9f4"
       },
       {
         "path": "scripts/lexicon/migrate_slovnyk_cache_v3.py",

--- a/tests/test_merge_translation_delta.py
+++ b/tests/test_merge_translation_delta.py
@@ -136,17 +136,25 @@ def test_overwrite_proof_returns_nonzero_when_nonempty_en_changes() -> None:
 
 
 def test_sync_embedded_fingerprint_from_sidecar(tmp_path: Path) -> None:
+    from scripts.lexicon.manifest_fingerprint import build_fingerprint, sidecar_payload
+    from scripts.lexicon.merge_translation_delta import sync_embedded_fingerprint_from_sidecar
+
+    root = Path(__file__).resolve().parents[1]
+    full = build_fingerprint(root)
     sidecar = tmp_path / "lexicon-manifest.fingerprint.json"
     sidecar.write_text(
-        json.dumps({"schema_version": 1, "fingerprint": "abc123"}, ensure_ascii=False) + "\n",
+        json.dumps(sidecar_payload(full), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     live = {"entries": [_entry("x", "ікс")]}
-    from scripts.lexicon.merge_translation_delta import sync_embedded_fingerprint_from_sidecar
-
-    payload = sync_embedded_fingerprint_from_sidecar(live, fingerprint_path=sidecar)
-    assert payload["fingerprint"] == "abc123"
-    assert live["manifest_fingerprint"] == {"schema_version": 1, "fingerprint": "abc123"}
+    payload = sync_embedded_fingerprint_from_sidecar(
+        live, fingerprint_path=sidecar, root=root
+    )
+    assert payload["fingerprint"] == full["fingerprint"]
+    assert live["manifest_fingerprint"] == {
+        "schema_version": full["schema_version"],
+        "fingerprint": full["fingerprint"],
+    }
 
 
 def test_write_roundtrip_preserves_fill(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem
`merge_translation_delta --write` required a top-level `fingerprint` string in the committed sidecar. That field is **intentionally not committed** (`sidecar_payload` keeps only `{schema_version, scope, inputs}` for merge-union). Result: honest merge writes failed with `missing schema_version/fingerprint`.

## Fix
Derive the digest with `build_fingerprint`, verify the committed merge-friendly body matches, embed `{schema_version, fingerprint}` on the manifest.

## Related
Closes the real issue behind closed #6632 (wrong approach: putting digest back into the committed sidecar).

X-Agent: claude/6633-merge-fingerprint-derive