### PR TITLE
fix(practice): remove false clock-jump warning

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 74a4032b694756efe172269b9e68c759ffb7c4df75ea78780e3ee2c516fcd28b
+  components_sha256: feeba6a2ee8f8ea78b2be325de6afbdb6026516a6744acb2f1266bc0b7b1ede4
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -494,12 +494,6 @@ function translateStorageWarning(warning: string | null): { uk: string; en: stri
       en: 'Progress suspended until browser storage becomes available.',
     };
   }
-  if (warning.includes('годинник пристрою')) {
-    return {
-      uk: 'Час повторення може бути неточним: змінився годинник пристрою.',
-      en: 'Review schedule may be inaccurate: device clock changed.',
-    };
-  }
   return { uk: warning, en: warning };
 }
 
@@ -1814,8 +1808,6 @@ function LexiconPracticeIsland({
       setStorageWarning(SRS_STORAGE_FULL_WARNING);
     } else if (state.flags.storageWriteFailed || state.flags.corrupt || state.flags.migrationFailed) {
       setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
-    } else if (state.flags.clockJump) {
-      setStorageWarning('Час повторення може бути неточним: змінився годинник пристрою.');
     }
 
     if (typeof window !== 'undefined') {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -443,12 +443,6 @@ export interface SrsFlags {
   storageWriteFailed: boolean;
   storageFull: boolean;
   settingsCorrupt: boolean;
-  clockJump: ClockJump | null;
-}
-
-export interface ClockJump {
-  direction: 'forward' | 'backward';
-  deltaDays: number;
 }
 
 export interface LoadedSrsState {
@@ -750,7 +744,7 @@ function currentStorage(): StorageLike {
   return activeStorage ?? resolveStorage();
 }
 
-function emptyFlags(clockJump: ClockJump | null = null): SrsFlags {
+function emptyFlags(): SrsFlags {
   return {
     corrupt: false,
     migrationFailed: false,
@@ -759,7 +753,6 @@ function emptyFlags(clockJump: ClockJump | null = null): SrsFlags {
     storageWriteFailed: false,
     storageFull: false,
     settingsCorrupt: false,
-    clockJump,
   };
 }
 
@@ -1048,21 +1041,6 @@ function serializeSettings(settings: SrsSettings): string {
   });
 }
 
-export function detectClockJump(
-  previous: Date | number | string | undefined,
-  now: Date | number = Date.now(),
-): ClockJump | null {
-  const previousTime = toTime(previous);
-  const nowTime = toTime(now);
-  if (previousTime === null || nowTime === null) return null;
-  const delta = nowTime - previousTime;
-  if (Math.abs(delta) <= 7 * DAY_MS) return null;
-  return {
-    direction: delta > 0 ? 'forward' : 'backward',
-    deltaDays: Math.round(Math.abs(delta) / DAY_MS),
-  };
-}
-
 export function loadState(
   storage: StorageLike = resolveStorage(),
   now: Date | number = Date.now(),
@@ -1111,7 +1089,6 @@ export function loadState(
     const state = hydrateStore(parsed as unknown as PersistedSrsSchemaV4, settings, raw, {
       ...emptyFlags(),
       settingsCorrupt,
-      clockJump: detectClockJump((parsed as unknown as PersistedSrsSchemaV4).lastSavedAt, now),
     });
     if (state) {
       if (compactReviewHistory(state.reviews, state.reviewAggregates, MAX_RAW_REVIEW_LOG_ENTRIES)) {
@@ -1139,7 +1116,6 @@ export function loadState(
       ...emptyFlags(),
       migrated: true,
       settingsCorrupt,
-      clockJump: detectClockJump(migrated.lastSavedAt, now),
     });
     if (!state) throw new Error('migrated SRS schema is invalid');
     activeState = state;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -877,6 +877,31 @@ describe('LexiconPractice', () => {
     expect(getTeacherLessonVirtualDeck()).toBe(getTeacherLessonVirtualDeck());
   });
 
+  test('does not warn about the review schedule after a long inactivity gap', async () => {
+    localStorage.setItem(
+      SRS_STORAGE_KEY,
+      JSON.stringify({
+        version: 4,
+        cards: {},
+        reviews: [],
+        reviewAggregates: {},
+        lastSavedAt: NOW.getTime() - 9 * 24 * 60 * 60 * 1000,
+      }),
+    );
+    const { fn } = mockShardFetch({ A1: 4 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+    render(<LexiconPractice initialDeck={sampleDeck()} />);
+
+    await screen.findByTestId('practice-daily-deck');
+    expect(
+      screen.queryByText('Час повторення може бути неточним: змінився годинник пристрою.'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Review schedule may be inaccurate: device clock changed.'),
+    ).not.toBeInTheDocument();
+  });
+
   test('filters excluded and private-name teacher cloze cards before they reach the practice deck', () => {
     expect(
       filterTeacherClozeItems([

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -14,7 +14,6 @@ import {
   cardKey,
   countDailyPracticeDone,
   deriveDailyPracticeRows,
-  detectClockJump,
   getDueQueue,
   isPracticeMode,
   loadState,
@@ -803,14 +802,6 @@ describe('lexicon SRS facade', () => {
     expect(state.flags.corrupt).toBe(true);
     expect(result.ok).toBe(false);
     expect(localStorage.getItem(SRS_STORAGE_KEY)).toBe('{not json');
-  });
-
-  test('detects clock jumps beyond seven days', () => {
-    expect(detectClockJump(NOW, new Date('2026-07-02T12:00:00.000Z'))).toEqual({
-      direction: 'forward',
-      deltaDays: 9,
-    });
-    expect(detectClockJump(NOW, new Date('2026-06-25T12:00:00.000Z'))).toBeNull();
   });
 
   test('due queue includes new cards and excludes future reviews per mode', () => {


### PR DESCRIPTION
## Summary

- Remove the Practice clock-jump flag, detector, and learner-visible review-schedule/device-clock warning.
- Preserve `lastSavedAt` persistence, FSRS scheduling, due queues, and legitimate full/corrupt/write-failed storage warnings.
- Add a regression test proving a return after a 9-day inactivity gap shows no clock warning.

## Root cause

A forward gap of more than seven days was classified as a clock jump even though it is normal learner inactivity. Practice rendered that false-positive flag as a red alert.

## Validation

- `./node_modules/.bin/vitest run tests/unit/lexicon-srs.test.ts` — 60 passed.
- `./node_modules/.bin/vitest run tests/unit/LexiconPractice.test.tsx` — 140 passed.
- `git diff --check` — passed.
- Repository-wide source search confirms no remaining `clockJump` or `detectClockJump` references.
- The requested `npm test -- --run tests/unit/lexicon-srs.test.ts` wrapper cannot hydrate in this dispatch worktree because its script invokes a relative `.venv/bin/python`; equivalent hydration completed with the mandated absolute primary interpreter before the focused runs.
- `tsc --noEmit` remains at the repository's existing baseline errors outside this change.

Refs #4700
Refs #4387