### PR TITLE
feat(practice): add heritage activity variants

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 8db90640a46fc825d4db766f8d2ea4968a46230212720eba956466a8e622a4ef
+  components_sha256: 1b15a1d534434a9b2806bf5686b8381cf9a0872bbbb5379d70f691908eae8e81
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: feeba6a2ee8f8ea78b2be325de6afbdb6026516a6744acb2f1266bc0b7b1ede4
+  components_sha256: 8db90640a46fc825d4db766f8d2ea4968a46230212720eba956466a8e622a4ef
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/ErrorCorrection.tsx
+++ b/site/src/components/ErrorCorrection.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 import { shuffle } from './utils';
 
-interface ErrorCorrectionItemProps {
+export interface ErrorCorrectionItemProps {
   /**
    * @schemaDescription Sentence shown to the learner.
    * @ukrainianText true
@@ -34,6 +34,10 @@ interface ErrorCorrectionItemProps {
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /** Called once after a complete answer; false includes reveal-only completion. */
+  onComplete?: (correct: boolean) => void;
+  /** Lets a host lock this item after it has recorded the result. */
+  disabled?: boolean;
 }
 
 type Step = 'identify' | 'fix' | 'complete';
@@ -44,7 +48,9 @@ export function ErrorCorrectionItem({
   correctForm,
   options,
   explanation,
-  isUkrainian
+  isUkrainian,
+  onComplete,
+  disabled = false,
 }: ErrorCorrectionItemProps) {
   // Shuffle options on mount
   const shuffledOptions = useMemo(() => shuffle([...options]), [options]);
@@ -54,6 +60,15 @@ export function ErrorCorrectionItem({
   const [selectedFix, setSelectedFix] = useState<string | null>(null);
   const [wrongAttempts, setWrongAttempts] = useState<string[]>([]);
   const [revealedCorrection, setRevealedCorrection] = useState(false);
+  const completionReportedRef = useRef(false);
+
+  const complete = (correct: boolean) => {
+    setStep('complete');
+    if (!completionReportedRef.current) {
+      completionReportedRef.current = true;
+      onComplete?.(correct);
+    }
+  };
 
   // Split sentence into words while preserving punctuation
   const words = sentence.match(/[\wа-яіїєґА-ЯІЇЄҐ']+|[^\s\wа-яіїєґА-ЯІЇЄҐ']+|\s+/gi) || [];
@@ -69,7 +84,7 @@ export function ErrorCorrectionItem({
   };
 
   const handleWordClick = (word: string) => {
-    if (step !== 'identify') return;
+    if (disabled || step !== 'identify') return;
 
     // Clean word for comparison (remove punctuation)
     const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
@@ -91,11 +106,11 @@ export function ErrorCorrectionItem({
   };
 
   const handleNoError = () => {
-    if (step !== 'identify') return;
+    if (disabled || step !== 'identify') return;
 
     if (errorWord === null) {
       // Correct - there was no error
-      setStep('complete');
+      complete(true);
     } else {
       // Wrong - there was an error
       setWrongAttempts(prev => [...prev, '__no_error__']);
@@ -103,27 +118,29 @@ export function ErrorCorrectionItem({
   };
 
   const handleFixSelect = (fix: string) => {
-    if (step !== 'fix') return;
+    if (disabled || step !== 'fix') return;
 
     setRevealedCorrection(false);
     setSelectedFix(fix);
-    setStep('complete');
+    complete(fix === correctForm);
   };
 
   const handleRevealCorrection = () => {
-    if (step !== 'fix' || shuffledOptions.length > 0) return;
+    if (disabled || step !== 'fix' || shuffledOptions.length > 0) return;
 
     setRevealedCorrection(true);
     setSelectedFix(correctForm);
-    setStep('complete');
+    complete(false);
   };
 
   const handleReset = () => {
+    if (disabled) return;
     setStep('identify');
     setSelectedWord(null);
     setSelectedFix(null);
     setWrongAttempts([]);
     setRevealedCorrection(false);
+    completionReportedRef.current = false;
   };
 
   const isFixCorrect = selectedFix === correctForm;
@@ -207,6 +224,7 @@ export function ErrorCorrectionItem({
           className={`${styles.noErrorButton} ${wrongAttempts.includes('__no_error__') ? styles.noErrorWrong : ''}`}
           data-activity="error-correction-no-error"
           onClick={handleNoError}
+          disabled={disabled}
         >
           {noErrorLabel}
         </button>
@@ -223,6 +241,7 @@ export function ErrorCorrectionItem({
                 className={styles.chip}
                 data-activity="error-correction-fix-chip"
                 onClick={() => handleFixSelect(option)}
+                disabled={disabled}
               >
                 {option}
               </button>
@@ -240,6 +259,7 @@ export function ErrorCorrectionItem({
               className={styles.chip}
               data-activity="error-correction-reveal"
               onClick={handleRevealCorrection}
+              disabled={disabled}
             >
               {revealCorrectionLabel}
             </button>
@@ -269,7 +289,7 @@ export function ErrorCorrectionItem({
             )}
           </div>
           <div className={styles.buttonRow}>
-            <button className={styles.resetButton} onClick={handleReset}>
+            <button className={styles.resetButton} onClick={handleReset} disabled={disabled}>
               {retryBtnLabel}
             </button>
           </div>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -6,6 +6,8 @@ import PracticeFlashcard from './PracticeFlashcard';
 import PracticeFormRail, { type FormRailVerdict } from './PracticeFormRail';
 import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSessionSummary';
 import PracticeStress from './PracticeStress';
+import { ErrorCorrectionItem } from './ErrorCorrection';
+import { UnjumbleQuestion } from './Unjumble';
 import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
 import { CHROME_STRINGS, type ChromeKey } from '../lib/i18n/chrome';
 import {
@@ -97,6 +99,7 @@ import {
 } from '../lib/lexicon/custom-decks';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
 import { usablePracticeSentenceEnglish } from '../lib/lexicon/practice-sentence-en';
+import { selectHeritagePracticePresentation } from '../lib/lexicon/practice-activity-adapters';
 import { searchShardForQuery, type SearchRow, type SearchShardManifest } from '../lib/lexicon/search';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
 import ZnoPractice, { ZNO_PRACTICE_DECKS, type ZnoPracticeDeck } from './ZnoPractice';
@@ -3249,6 +3252,19 @@ function LexiconPracticeIsland({
     setPendingOutcome(outcome);
   }
 
+  function handleHeritageActivityComplete(correct: boolean) {
+    if (!selection || answerLocked) return;
+    const rating: PracticeRating = correct ? 'good' : 'again';
+    const outcome = recordReview(selection, rating);
+    setAnswerLocked(true);
+    setFeedback({
+      uk: `${selection.lemma.lemma}: ${correct ? 'Правильно' : 'Ще раз'}`,
+      en: `${selection.lemma.lemma}: ${correct ? 'Correct' : 'Again'}`,
+    });
+    pendingOutcomeRef.current = outcome;
+    setPendingOutcome(outcome);
+  }
+
   function submitCloze(value: string, source: 'typed' | 'chip') {
     if (!selection?.cloze) return;
     const answer = value.trim();
@@ -4121,6 +4137,8 @@ function LexiconPracticeIsland({
                     onMatchingComplete={handleMatchingComplete}
                     onMatchingMatch={handleMatchingMatch}
                     onClozeSubmit={submitCloze}
+                    onHeritageActivityComplete={handleHeritageActivityComplete}
+                    presentationVariants={mode === 'mixed'}
                     onBackToModes={finishPractice}
                     showEnglishSubtitles={showEnglishSubtitles}
                     chromeLocale={chromeLocale}
@@ -4179,6 +4197,8 @@ function PracticeItem({
   onMatchingComplete,
   onMatchingMatch,
   onClozeSubmit,
+  onHeritageActivityComplete,
+  presentationVariants,
   onBackToModes,
   showEnglishSubtitles,
   chromeLocale,
@@ -4205,6 +4225,8 @@ function PracticeItem({
   onMatchingComplete(): void;
   onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
+  onHeritageActivityComplete(correct: boolean): void;
+  presentationVariants: boolean;
   /** P0-2: option-build failures (empty matching/choice pools) get a real exit, not just prose. */
   onBackToModes(): void;
   showEnglishSubtitles: boolean;
@@ -4313,6 +4335,33 @@ function PracticeItem({
   }
 
   if (selection.mode === 'heritage' && selection.heritage) {
+    const presentation = presentationVariants
+      ? selectHeritagePracticePresentation(selection.heritage, sessionSeed)
+      : { kind: 'mc' as const };
+    if (presentation.kind === 'error-correction') {
+      return (
+        <div data-testid="practice-heritage-error-correction">
+          <ErrorCorrectionItem
+            {...presentation.item}
+            isUkrainian={chromeLocale === 'uk'}
+            disabled={answerLocked}
+            onComplete={onHeritageActivityComplete}
+          />
+        </div>
+      );
+    }
+    if (presentation.kind === 'unjumble') {
+      return (
+        <div data-testid="practice-heritage-unjumble">
+          <UnjumbleQuestion
+            {...presentation.item}
+            isUkrainian={chromeLocale === 'uk'}
+            disabled={answerLocked}
+            onComplete={onHeritageActivityComplete}
+          />
+        </div>
+      );
+    }
     return (
       <PracticeHeritage
         item={selection.heritage}

--- a/site/src/components/Unjumble.tsx
+++ b/site/src/components/Unjumble.tsx
@@ -53,9 +53,12 @@ export function UnjumbleQuestion({
   onComplete,
   disabled = false,
 }: UnjumbleQuestionProps) {
-  // Parse words (can be separated by /, |, or ,) and shuffle so they're never in correct order
+  // Preserve punctuation inside already-jumbled slash-delimited tokens while
+  // retaining the legacy separators used by lesson MDX inputs.
   const wordList = useMemo(() => {
-    const rawWords = words.split(/[\/|,]\s*/).map(w => w.trim());
+    const rawWords = (
+      wordsAreJumbled ? words.split(' / ') : words.split(/[\/|,]\s*/)
+    ).map(w => w.trim());
     const correctOrder = answer.split(/\s+/);
 
     // Shuffle ensuring words are NOT in the correct answer order

--- a/site/src/components/Unjumble.tsx
+++ b/site/src/components/Unjumble.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 import { shuffleNotCorrect } from './utils';
@@ -15,7 +15,7 @@ function getWordColor(word: string, index: number): string {
   return WORD_COLORS[(charSum + index) % WORD_COLORS.length];
 }
 
-interface UnjumbleQuestionProps {
+export interface UnjumbleQuestionProps {
   /**
    * @schemaDescription Words shown to the learner.
    * @ukrainianText true
@@ -36,31 +36,46 @@ interface UnjumbleQuestionProps {
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /** Skip the legacy shuffle when a host provides deterministic jumbled tokens. */
+  wordsAreJumbled?: boolean;
+  /** Called once when the learner checks a complete sentence. */
+  onComplete?: (correct: boolean) => void;
+  /** Lets a host lock retry after it has recorded the result. */
+  disabled?: boolean;
 }
 
-export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQuestionProps) {
+export function UnjumbleQuestion({
+  words,
+  answer,
+  hint,
+  isUkrainian,
+  wordsAreJumbled = false,
+  onComplete,
+  disabled = false,
+}: UnjumbleQuestionProps) {
   // Parse words (can be separated by /, |, or ,) and shuffle so they're never in correct order
   const wordList = useMemo(() => {
     const rawWords = words.split(/[\/|,]\s*/).map(w => w.trim());
     const correctOrder = answer.split(/\s+/);
 
     // Shuffle ensuring words are NOT in the correct answer order
-    const shuffled = shuffleNotCorrect(rawWords, correctOrder);
+    const shuffled = wordsAreJumbled ? rawWords : shuffleNotCorrect(rawWords, correctOrder);
 
     return shuffled.map((word, idx) => ({
       id: `word-${idx}`,
       text: word,
       color: getWordColor(word, idx)
     }));
-  }, [words, answer]);
+  }, [words, answer, wordsAreJumbled]);
 
   const [availableWords, setAvailableWords] = useState(wordList);
   const [selectedWords, setSelectedWords] = useState<typeof wordList>([]);
   const [showResult, setShowResult] = useState(false);
   const [draggedWord, setDraggedWord] = useState<string | null>(null);
+  const completionReportedRef = useRef(false);
 
   const handleWordClick = (word: typeof wordList[0], fromSelected: boolean) => {
-    if (showResult) return;
+    if (disabled || showResult) return;
 
     if (fromSelected) {
       // Move back to available
@@ -85,7 +100,7 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
 
   const handleDropOnSentence = (e: React.DragEvent) => {
     e.preventDefault();
-    if (!draggedWord || showResult) return;
+    if (!draggedWord || disabled || showResult) return;
 
     const word = availableWords.find(w => w.id === draggedWord);
     if (word) {
@@ -97,7 +112,7 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
 
   const handleDropOnBank = (e: React.DragEvent) => {
     e.preventDefault();
-    if (!draggedWord || showResult) return;
+    if (!draggedWord || disabled || showResult) return;
 
     const word = selectedWords.find(w => w.id === draggedWord);
     if (word) {
@@ -111,7 +126,7 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
   const handleDropOnWord = (e: React.DragEvent, targetIndex: number) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!draggedWord || showResult) return;
+    if (!draggedWord || disabled || showResult) return;
 
     const draggedFromSelected = selectedWords.find(w => w.id === draggedWord);
     const draggedFromAvailable = availableWords.find(w => w.id === draggedWord);
@@ -136,13 +151,20 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
   };
 
   const handleCheck = () => {
+    if (disabled || showResult) return;
     setShowResult(true);
+    if (!completionReportedRef.current) {
+      completionReportedRef.current = true;
+      onComplete?.(isCorrect);
+    }
   };
 
   const handleReset = () => {
+    if (disabled) return;
     setAvailableWords(wordList);
     setSelectedWords([]);
     setShowResult(false);
+    completionReportedRef.current = false;
   };
 
   const userAnswer = selectedWords.map(w => w.text).join(' ');
@@ -174,12 +196,12 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
                 color: 'white',
                 cursor: showResult ? 'default' : 'grab'
               }}
-              draggable={!showResult}
+              draggable={!showResult && !disabled}
               onDragStart={(e) => handleDragStart(e, word.id)}
               onDragOver={handleDragOver}
               onDrop={(e) => handleDropOnWord(e, index)}
               onClick={() => handleWordClick(word, true)}
-              disabled={showResult}
+              disabled={showResult || disabled}
             >
               {word.text}
             </button>
@@ -205,10 +227,10 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
               color: 'white',
               cursor: showResult ? 'default' : 'grab'
             }}
-            draggable={!showResult}
+            draggable={!showResult && !disabled}
             onDragStart={(e) => handleDragStart(e, word.id)}
             onClick={() => handleWordClick(word, false)}
-            disabled={showResult}
+            disabled={showResult || disabled}
           >
             {word.text}
           </button>
@@ -220,12 +242,12 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
           <button
             className={styles.submitButton}
             onClick={handleCheck}
-            disabled={availableWords.length > 0}
+            disabled={availableWords.length > 0 || disabled}
           >
             {checkBtnLabel}
           </button>
         ) : (
-          <button className={styles.resetButton} onClick={handleReset}>
+          <button className={styles.resetButton} onClick={handleReset} disabled={disabled}>
             {retryBtnLabel}
           </button>
         )}

--- a/site/src/lib/lexicon/practice-activity-adapters.ts
+++ b/site/src/lib/lexicon/practice-activity-adapters.ts
@@ -1,0 +1,126 @@
+import type { ErrorCorrectionItemProps } from '../../components/ErrorCorrection';
+import type { UnjumbleQuestionProps } from '../../components/Unjumble';
+import { seededPracticeHash, type PracticeHeritageItem } from './srs';
+
+export type HeritagePracticePresentation =
+  | { kind: 'mc' }
+  | { kind: 'error-correction'; item: HeritageErrorCorrectionItem }
+  | { kind: 'unjumble'; item: HeritageUnjumbleQuestion };
+
+export type HeritageErrorCorrectionItem = Pick<
+  ErrorCorrectionItemProps,
+  'sentence' | 'errorWord' | 'correctForm' | 'options' | 'explanation'
+>;
+
+export type HeritageUnjumbleQuestion = Pick<
+  UnjumbleQuestionProps,
+  'words' | 'answer' | 'hint' | 'wordsAreJumbled'
+>;
+
+const BLANK = '___';
+const CONTENT_TOKEN = /[\p{L}\p{N}]/u;
+
+function fillSingleBlank(prompt: string, replacement: string): string | null {
+  if (!prompt || !replacement) return null;
+  const firstBlank = prompt.indexOf(BLANK);
+  if (firstBlank < 0 || prompt.indexOf(BLANK, firstBlank + BLANK.length) >= 0) return null;
+  return `${prompt.slice(0, firstBlank)}${replacement}${prompt.slice(firstBlank + BLANK.length)}`.trim();
+}
+
+function contentWords(text: string): string[] {
+  return text.match(/[\p{L}\p{M}\p{N}’'-]+/gu) ?? [];
+}
+
+function appearsExactlyOnce(sentence: string, phrase: string): boolean {
+  const sentenceWords = contentWords(sentence).map((word) => word.toLocaleLowerCase());
+  const phraseWords = contentWords(phrase).map((word) => word.toLocaleLowerCase());
+  if (phraseWords.length === 0 || phraseWords.length > sentenceWords.length) return false;
+
+  let matches = 0;
+  for (let start = 0; start <= sentenceWords.length - phraseWords.length; start += 1) {
+    if (phraseWords.every((word, index) => sentenceWords[start + index] === word)) matches += 1;
+  }
+  return matches === 1;
+}
+
+function sourceOptions(item: PracticeHeritageItem): string[] | null {
+  const options = Array.from(
+    new Set(item.options.map((option) => option.label.trim()).filter(Boolean)),
+  );
+  return options.includes(item.answer) ? options : null;
+}
+
+function correctSentenceTokens(item: PracticeHeritageItem): string[] | null {
+  const sentence = fillSingleBlank(item.prompt, item.answer);
+  if (!sentence) return null;
+  const tokens = sentence.split(/\s+/).filter((token) => CONTENT_TOKEN.test(token));
+  return tokens.length >= 4 ? tokens : null;
+}
+
+function jumbledTokens(tokens: readonly string[], seed: number, item: PracticeHeritageItem): string[] {
+  const result = [...tokens];
+  let state = seededPracticeHash(seed, `heritage-unjumble:${item.srsKey}`) || 1;
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    const target = state % (index + 1);
+    [result[index], result[target]] = [result[target], result[index]];
+  }
+  if (result.every((token, index) => token === tokens[index]) && result.length > 1) {
+    result.push(result.shift()!);
+  }
+  return result;
+}
+
+/**
+ * Adapts only unambiguous, source-backed heritage frames. Frames with multiple
+ * blanks, missing source choices, or repeated calque spans stay in heritage MC.
+ */
+export function heritageToErrorCorrection(
+  item: PracticeHeritageItem,
+): HeritageErrorCorrectionItem | null {
+  const sentence = fillSingleBlank(item.prompt, item.calque);
+  const options = sourceOptions(item);
+  if (!sentence || !options || !item.calque.trim() || !item.answer.trim()) return null;
+  if (!appearsExactlyOnce(sentence, item.calque)) return null;
+  return {
+    sentence,
+    errorWord: item.calque,
+    correctForm: item.answer,
+    options,
+    explanation: item.rationaleUk || item.rationale,
+  };
+}
+
+/**
+ * Retains source token spelling and punctuation while excluding standalone
+ * punctuation noise. Four content tokens keeps this a sentence-building task.
+ */
+export function heritageToUnjumble(
+  item: PracticeHeritageItem,
+  sessionSeed: number,
+): HeritageUnjumbleQuestion | null {
+  const tokens = correctSentenceTokens(item);
+  if (!tokens) return null;
+  return {
+    words: jumbledTokens(tokens, sessionSeed, item).join(' / '),
+    answer: tokens.join(' '),
+    hint: item.rationaleUk || item.rationale,
+    wordsAreJumbled: true,
+  };
+}
+
+/**
+ * A presentation is derived from the persisted session seed, so a resumed card
+ * keeps its interaction while sharing the untouched heritage card key and SRS state.
+ */
+export function selectHeritagePracticePresentation(
+  item: PracticeHeritageItem,
+  sessionSeed: number,
+): HeritagePracticePresentation {
+  const presentations: HeritagePracticePresentation[] = [{ kind: 'mc' }];
+  const errorCorrection = heritageToErrorCorrection(item);
+  if (errorCorrection) presentations.push({ kind: 'error-correction', item: errorCorrection });
+  const unjumble = heritageToUnjumble(item, sessionSeed);
+  if (unjumble) presentations.push({ kind: 'unjumble', item: unjumble });
+  return presentations[seededPracticeHash(sessionSeed, `heritage-presentation:${item.srsKey}`) % presentations.length];
+}

--- a/site/src/lib/lexicon/practice-activity-adapters.ts
+++ b/site/src/lib/lexicon/practice-activity-adapters.ts
@@ -81,6 +81,7 @@ export function heritageToErrorCorrection(
   const sentence = fillSingleBlank(item.prompt, item.calque);
   const options = sourceOptions(item);
   if (!sentence || !options || !item.calque.trim() || !item.answer.trim()) return null;
+  if (contentWords(item.calque).length !== 1) return null;
   if (!appearsExactlyOnce(sentence, item.calque)) return null;
   return {
     sentence,

--- a/site/tests/unit/ErrorCorrection.test.tsx
+++ b/site/tests/unit/ErrorCorrection.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
@@ -172,6 +172,18 @@ describe('ErrorCorrectionItem (correct → identify → fix → complete path)',
     expect(itemContainer(container).getAttribute('data-step')).toBe('identify');
     expect(feedback(container)).toBeNull();
     expect(noErrorBtn(container)).toBeInTheDocument();
+  });
+
+  test('reports one correct completion to a practice host', async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<ErrorCorrectionItem {...baseProps} onComplete={onComplete} />);
+
+    await user.click(wordByText(container, 'goed'));
+    await user.click(fixChipByText(container, 'went'));
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(onComplete).toHaveBeenCalledWith(true);
   });
 });
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -42,6 +42,7 @@ import {
   type CustomSet,
 } from '@site/src/lib/lexicon/custom-decks';
 import { dateSeed, pickDaily, type DailyWord } from '@site/src/lib/lexicon/daily';
+import { selectHeritagePracticePresentation } from '@site/src/lib/lexicon/practice-activity-adapters';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
 
@@ -477,6 +478,19 @@ function heritageDeck({ includeItems = true } = {}): PracticeDeckData {
     synonym: [],
     heritage: includeItems ? [heritagePracticeItem()] : [],
   };
+}
+
+function seedForHeritagePresentation(kind: 'error-correction' | 'unjumble'): number {
+  for (let seed = 0; seed < 512; seed += 1) {
+    if (selectHeritagePracticePresentation(heritagePracticeItem(), seed).kind === kind) return seed;
+  }
+  throw new Error(`no deterministic ${kind} presentation seed found`);
+}
+
+function useHeritagePresentationSeed(kind: 'error-correction' | 'unjumble') {
+  const seed = seedForHeritagePresentation(kind);
+  vi.spyOn(Date, 'now').mockReturnValue(0);
+  vi.spyOn(Math, 'random').mockReturnValue(seed / 4294967296);
 }
 
 function sampleDeckWithOnlyMode(lemmaId: string, mode: PracticeMode): PracticeDeckData {
@@ -1944,7 +1958,7 @@ describe('LexiconPractice', () => {
     expect(labels.some((label) => label === 'бачити' || label === 'to see')).toBe(true);
   });
 
-  test('heritage renders in mixed sessions and heritage focus mode', async () => {
+  test('heritage renders as a sourced presentation in mixed sessions and as MC in heritage focus mode', async () => {
     const user = userEvent.setup();
     const mixedRender = render(
       <LexiconPractice
@@ -1955,10 +1969,11 @@ describe('LexiconPractice', () => {
       />,
     );
 
-    expect(screen.getByTestId('practice-heritage')).toBeInTheDocument();
-    expect(screen.getByText('Оберіть питоме українське слово.')).toBeInTheDocument();
-    expect(screen.getByTestId('practice-heritage-severity')).toHaveTextContent('Російська калька');
-    expect(screen.getByText(/Я бачу/)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('practice-heritage') ??
+        screen.queryByTestId('practice-heritage-error-correction') ??
+        screen.queryByTestId('practice-heritage-unjumble'),
+    ).toBeInTheDocument();
 
     mixedRender.unmount();
     const { container } = render(<LexiconPractice initialDeck={heritageDeck()} />);
@@ -2064,6 +2079,49 @@ describe('LexiconPractice', () => {
         mode: 'heritage',
         rating: 'good',
         cardKey: cardKey('dim', 'heritage'),
+      });
+    });
+  });
+
+  test('mixed heritage renders error correction, keeps red feedback visible, and records again on failure', async () => {
+    useHeritagePresentationSeed('error-correction');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="mixed" />);
+
+    const activity = await screen.findByTestId('practice-heritage-error-correction');
+    await user.click(activity.querySelector<HTMLElement>('[data-word="дом"]')!);
+    await user.click(within(activity).getByRole('button', { name: 'хата' }));
+
+    expect(activity.querySelector('[data-activity="error-correction-feedback"]')).toHaveAttribute('data-correct', 'false');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        cardKey: cardKey('dim', 'heritage'),
+        mode: 'heritage',
+        rating: 'again',
+      });
+    });
+  });
+
+  test('mixed heritage renders unjumble, keeps green feedback visible, and records good on success', async () => {
+    useHeritagePresentationSeed('unjumble');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="mixed" />);
+
+    const activity = await screen.findByTestId('practice-heritage-unjumble');
+    const wordBank = within(activity.querySelector<HTMLElement>('[data-activity="word-bank"]')!);
+    for (const word of ['Я', 'бачу', 'дім', 'щодня.']) {
+      await user.click(wordBank.getByRole('button', { name: word }));
+    }
+    await user.click(within(activity).getByRole('button', { name: 'Перевірити' }));
+
+    expect(activity.querySelector('[data-activity="feedback"]')).toHaveAttribute('data-correct', 'true');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        cardKey: cardKey('dim', 'heritage'),
+        mode: 'heritage',
+        rating: 'good',
       });
     });
   });
@@ -2315,7 +2373,11 @@ describe('LexiconPractice', () => {
       render(<LexiconPractice initialDeck={multiLemmaDeck} autoStart={false} />);
 
       await waitFor(() => {
-        expect(screen.getByTestId('practice-heritage')).toBeInTheDocument();
+        expect(
+          screen.queryByTestId('practice-heritage') ??
+            screen.queryByTestId('practice-heritage-error-correction') ??
+            screen.queryByTestId('practice-heritage-unjumble'),
+        ).toBeInTheDocument();
       });
       expect(screen.queryByTestId('practice-flashcards')).not.toBeInTheDocument();
 

--- a/site/tests/unit/Unjumble.test.tsx
+++ b/site/tests/unit/Unjumble.test.tsx
@@ -155,6 +155,25 @@ describe('UnjumbleQuestion', () => {
     );
     expect(tilesIn(container, 'word-bank').length).toBe(3);
   });
+
+  test('preserves punctuation inside already-jumbled tokens during round-trip', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <UnjumbleQuestion
+        words="дім, / який / ..."
+        answer="дім, який ..."
+        wordsAreJumbled
+      />
+    );
+
+    for (const word of ['дім,', 'який', '...']) {
+      const wordBank = within(container.querySelector('[data-activity="word-bank"]')!);
+      await user.click(wordBank.getByRole('button', { name: word }));
+    }
+    await user.click(submitBtn(container));
+
+    expect(container.querySelector('[data-activity="feedback"]')).toHaveAttribute('data-correct', 'true');
+  });
 });
 
 // ── Unjumble wrapper ──────────────────────────────────────────────────────────

--- a/site/tests/unit/Unjumble.test.tsx
+++ b/site/tests/unit/Unjumble.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UnjumbleQuestion } from '@site/src/components/Unjumble';
@@ -99,6 +99,22 @@ describe('UnjumbleQuestion', () => {
     await user.click(submitBtn(container));
 
     expect(container.querySelector('[data-activity="feedback"]')).toBeInTheDocument();
+  });
+
+  test('reports completion to a practice host after checking', async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <UnjumbleQuestion words="the / dog / runs" answer="the dog runs" onComplete={onComplete} />,
+    );
+
+    for (const word of ['the', 'dog', 'runs']) {
+      await user.click(within(container.querySelector('[data-activity="word-bank"]')!).getByRole('button', { name: word }));
+    }
+    await user.click(submitBtn(container));
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(onComplete).toHaveBeenCalledWith(true);
   });
 
   test('reset restores initial state', async () => {

--- a/site/tests/unit/practice-activity-adapters.test.ts
+++ b/site/tests/unit/practice-activity-adapters.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import {
+  heritageToErrorCorrection,
+  heritageToUnjumble,
+  selectHeritagePracticePresentation,
+} from '@site/src/lib/lexicon/practice-activity-adapters';
+import { cardKey, type PracticeHeritageItem } from '@site/src/lib/lexicon/srs';
+
+function heritage(overrides: Partial<PracticeHeritageItem> = {}): PracticeHeritageItem {
+  return {
+    heritageId: 'heritage-adapter-fixture',
+    lemmaId: 'dim',
+    srsKey: cardKey('dim', 'heritage'),
+    lemma: 'дім',
+    nativeLemma: 'дім',
+    kind: 'lexical',
+    severity: 'russianism',
+    prompt: 'Я бачу ___ щодня.',
+    answer: 'дім',
+    calque: 'дом',
+    cefr: 'A2',
+    options: [{ label: 'дім' }, { label: 'дом' }, { label: 'хата' }, { label: 'місто' }],
+    rationale: 'Потрібне питоме українське слово.',
+    rationaleUk: 'Потрібне питоме українське слово.',
+    citations: ['fixture'],
+    corrections: ['дім'],
+    ...overrides,
+  };
+}
+
+describe('heritage practice activity adapters', () => {
+  test('adapts a full heritage frame into exact ErrorCorrection props', () => {
+    expect(heritageToErrorCorrection(heritage())).toEqual({
+      sentence: 'Я бачу дом щодня.',
+      errorWord: 'дом',
+      correctForm: 'дім',
+      options: ['дім', 'дом', 'хата', 'місто'],
+      explanation: 'Потрібне питоме українське слово.',
+    });
+  });
+
+  test.each([
+    ['multiple blanks', { prompt: 'Я бачу ___ і ___ щодня.' }],
+    ['repeated calque span', { prompt: 'Дом стоїть біля ___.', calque: 'дом' }],
+    ['missing correct source option', { options: [{ label: 'дом' }, { label: 'хата' }] }],
+  ])('keeps %s in heritage MC', (_reason, overrides) => {
+    expect(heritageToErrorCorrection(heritage(overrides))).toBeNull();
+  });
+
+  test('adapts a full source sentence into a deterministic non-trivial unjumble question', () => {
+    const question = heritageToUnjumble(heritage(), 42);
+    expect(question).toMatchObject({
+      answer: 'Я бачу дім щодня.',
+      hint: 'Потрібне питоме українське слово.',
+      wordsAreJumbled: true,
+    });
+    expect(question?.words.split(' / ')).toHaveLength(4);
+    expect(new Set(question?.words.split(' / '))).toEqual(new Set(['Я', 'бачу', 'дім', 'щодня.']));
+    expect(heritageToUnjumble(heritage(), 42)).toEqual(question);
+  });
+
+  test('skips short and punctuation-only unjumble sources', () => {
+    expect(heritageToUnjumble(heritage({ prompt: 'Це ___.' }), 42)).toBeNull();
+    expect(heritageToUnjumble(heritage({ prompt: '___ — ! ? …' }), 42)).toBeNull();
+  });
+
+  test('selects only reproducible presentation variants and preserves MC fallback', () => {
+    const kinds = new Set(
+      Array.from({ length: 64 }, (_unused, seed) =>
+        selectHeritagePracticePresentation(heritage(), seed).kind,
+      ),
+    );
+    expect(kinds).toEqual(new Set(['mc', 'error-correction', 'unjumble']));
+    expect(selectHeritagePracticePresentation(heritage({ prompt: '___ і ___' }), 42)).toEqual({ kind: 'mc' });
+  });
+});

--- a/site/tests/unit/practice-activity-adapters.test.ts
+++ b/site/tests/unit/practice-activity-adapters.test.ts
@@ -47,6 +47,10 @@ describe('heritage practice activity adapters', () => {
     expect(heritageToErrorCorrection(heritage(overrides))).toBeNull();
   });
 
+  test('rejects a multi-word calque from ErrorCorrection', () => {
+    expect(heritageToErrorCorrection(heritage({ calque: 'так як' }))).toBeNull();
+  });
+
   test('adapts a full source sentence into a deterministic non-trivial unjumble question', () => {
     const question = heritageToUnjumble(heritage(), 42);
     expect(question).toMatchObject({


### PR DESCRIPTION
## Summary

Implements Sprint A through Option A: sourced heritage frames can become Error Correction or Unjumble presentations in mixed practice; all other frames retain the current heritage MC presentation.

## Changes

- Adds strict, source-backed heritage adapters: exactly one blank, source option set contains the answer, one visible calque span for Error Correction, and at least four content tokens for Unjumble.
- Uses the persisted session seed to choose MC, Error Correction, or Unjumble deterministically without changing the heritage card key or SRS mode.
- Reuses the existing components with a once-only completion callback. Correct answers record `good`; incorrect/revealed answers record `again`; the existing feedback and Next dwell remain in place.
- Covers adapter fallbacks, deterministic variants, component callbacks, and mixed-practice green/red + SRS smoke paths.

## Testing

- [x] `cd site && node_modules/.bin/vitest run tests/unit/ErrorCorrection.test.tsx tests/unit/Unjumble.test.tsx tests/unit/practice-activity-adapters.test.ts tests/unit/LexiconPractice.test.tsx --silent` (203 passed)
- [x] `git diff --check`
- [ ] Modules pass audit (not applicable to this UI-only change)
- [ ] Website builds without errors — `astro check` still reports 30 pre-existing diagnostics outside these paths. The normal `npm test -- --run` wrapper also invokes a worktree-local `.venv/bin/python`, which this dispatch contract correctly forbids; the focused Vitest command above ran directly.
- [x] Ukrainian text reviewed for naturalness — no learner-facing Ukrainian content was added; adapters expose only loaded source fields.

## Manual smoke

Open Practice → Mixed. A source-eligible heritage card can render Error Correction or Unjumble: a wrong selection is red, a correct selection is green, then the existing Next control advances after SRS recording. Thin or ambiguous frames remain heritage MC.

## Related Issues

Refs #4700
Refs #4387

## Residual

This sparse worktree intentionally omits `site/public/lexicon/practice-heritage.*.json`, so per-level eligible-carrier counts were not measured locally. At runtime, unavailable or ineligible fields fail closed to the existing MC presentation.