### PR TITLE
feat(practice): port FillIn, MatchUp, MarkTheWords into mixed heritage

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6851ff3cd0464e4a3e770744326a2162fff8dc21c2595770f12008f3890753fa
+  components_sha256: 38f175aef9b33a50abdcbef1c23c213b3750957410fc7c34f5400a5ede5c49a4
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1213,12 +1213,16 @@ components:
         description: Optional practice-only pair-coding mode.
         ukrainian_text: 'false'
       - name: onComplete
-        type: () => void
+        type: '(correct: boolean) => void'
         description: onComplete prop.
         ukrainian_text: 'false'
       - name: onMatch
         type: '(pairIndex: number, rating: ''again'' | ''hard'' | ''good'') => void'
         description: onMatch prop.
+        ukrainian_text: 'false'
+      - name: disabled
+        type: boolean
+        description: disabled prop.
         ukrainian_text: 'false'
     nested_types:
       MatchPair:

--- a/packages/activity-kit/src/components/MatchUp.tsx
+++ b/packages/activity-kit/src/components/MatchUp.tsx
@@ -38,14 +38,15 @@ export interface MatchUpProps {
    * @ukrainianText false
    */
   matchedPairCoding?: 'semantic-four';
-  onComplete?: () => void;
+  /** Called once after every pair is connected correctly. */
+  onComplete?: (correct: boolean) => void;
   onMatch?: (pairIndex: number, rating: 'again' | 'hard' | 'good') => void;
+  /** Lets a host lock the board after it has recorded the result. */
+  disabled?: boolean;
 }
 
-
 const MATCH_PAIR_HUES = [
-  199, 32, 262, 174, 239, 92, 286, 151, 215, 49,
-  271, 188, 230, 108, 300, 164, 206, 67, 253, 181,
+  199, 32, 262, 174, 239, 92, 286, 151, 215, 49, 271, 188, 230, 108, 300, 164, 206, 67, 253, 181,
   222, 132, 288, 192, 243, 78, 278, 142, 218, 58,
 ] as const;
 const MATCH_PAIR_COLOR_COUNT = MATCH_PAIR_HUES.length;
@@ -93,6 +94,7 @@ export default function MatchUp({
   matchedPairCoding,
   onComplete,
   onMatch,
+  disabled = false,
 }: MatchUpProps) {
   const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
   const [matched, setMatched] = useState<Set<number>>(new Set());
@@ -102,6 +104,7 @@ export default function MatchUp({
   const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
   const [misses, setMisses] = useState<Record<number, number>>({});
   const completedRef = useRef(false);
+  const hadIncorrectAttemptRef = useRef(false);
 
   // Reset state when pairs change (attempt counting resets between boards)
   useEffect(() => {
@@ -113,6 +116,7 @@ export default function MatchUp({
     setWrongPair(null);
     setMisses({});
     completedRef.current = false;
+    hadIncorrectAttemptRef.current = false;
   }, [pairs]);
 
   // Shuffle right side (deterministic — seeded by content)
@@ -122,13 +126,14 @@ export default function MatchUp({
   }, [pairs]);
 
   const handleLeftClick = (index: number) => {
-    if (matchedRef.current.has(index) || wrongPair) return;
+    if (disabled || matchedRef.current.has(index) || wrongPair) return;
     setSelectedLeft(index);
     setWrongPair(null);
   };
 
   const handleRightClick = (originalIndex: number) => {
-    if (selectedLeft === null || matchedRef.current.has(originalIndex) || wrongPair) return;
+    if (disabled || selectedLeft === null || matchedRef.current.has(originalIndex) || wrongPair)
+      return;
 
     if (selectedLeft === originalIndex) {
       // Correct match
@@ -145,6 +150,7 @@ export default function MatchUp({
       setSelectedLeft(null);
     } else {
       // Wrong match
+      hadIncorrectAttemptRef.current = true;
       setMisses((prev) => ({
         ...prev,
         [selectedLeft]: (prev[selectedLeft] || 0) + 1,
@@ -157,13 +163,12 @@ export default function MatchUp({
     }
   };
 
-
   const allMatched = matched.size === pairs.length;
 
   useEffect(() => {
     if (allMatched && !completedRef.current) {
       completedRef.current = true;
-      onComplete?.();
+      onComplete?.(!hadIncorrectAttemptRef.current);
     }
     if (!allMatched) completedRef.current = false;
   }, [allMatched, onComplete]);
@@ -175,7 +180,10 @@ export default function MatchUp({
     return circledNumber(order);
   };
 
-  const pairAccessibleName = (originalIndex: number, side: 'left' | 'right'): string | undefined => {
+  const pairAccessibleName = (
+    originalIndex: number,
+    side: 'left' | 'right',
+  ): string | undefined => {
     if (matchedPairCoding !== 'semantic-four' || !matched.has(originalIndex)) return undefined;
     const pair = pairs[originalIndex];
     if (!pair) return undefined;
@@ -197,7 +205,9 @@ export default function MatchUp({
     <>
       <span lang="uk">Знайдіть пару</span>
       {' / '}
-      <span style={{ fontSize: '0.8rem', opacity: 0.8 }} lang="en">Match Up</span>
+      <span style={{ fontSize: '0.8rem', opacity: 0.8 }} lang="en">
+        Match Up
+      </span>
     </>
   );
   const successLabel = isUkrainian ? (
@@ -206,7 +216,9 @@ export default function MatchUp({
     <>
       <span lang="uk">✓ Все з’єднано правильно!</span>
       {' / '}
-      <span style={{ fontSize: '0.9rem', opacity: 0.8 }} lang="en">All matched correctly!</span>
+      <span style={{ fontSize: '0.9rem', opacity: 0.8 }} lang="en">
+        All matched correctly!
+      </span>
     </>
   );
 
@@ -261,7 +273,11 @@ export default function MatchUp({
               data-matched={matched.has(index) ? 'true' : 'false'}
               data-pair-color={matched.has(index) ? index % MATCH_PAIR_COLOR_COUNT : undefined}
               data-pair-coding={matchedPairCoding}
-              data-pair-token={matchedPairCoding === 'semantic-four' ? index % SEMANTIC_FOUR_TOKENS.length : undefined}
+              data-pair-token={
+                matchedPairCoding === 'semantic-four'
+                  ? index % SEMANTIC_FOUR_TOKENS.length
+                  : undefined
+              }
               data-selected={selectedLeft === index ? 'true' : 'false'}
               data-original-index={index}
               aria-pressed={selectedLeft === index}
@@ -272,11 +288,13 @@ export default function MatchUp({
                   : getMatchedPairStyle(index, matched.has(index))
               }
               onClick={() => handleLeftClick(index)}
-              disabled={matched.has(index)}
+              disabled={disabled || matched.has(index)}
             >
               {parseMarkdown(pair.left)}
               {matchedPairCoding === 'semantic-four' && pairTag(index) ? (
-                <span className="matchPairTag" aria-hidden="true">{pairTag(index)}</span>
+                <span className="matchPairTag" aria-hidden="true">
+                  {pairTag(index)}
+                </span>
               ) : null}
             </button>
           ))}
@@ -288,14 +306,22 @@ export default function MatchUp({
               className={`matchItem ${matched.has(originalIndex) ? 'matched' : ''} ${
                 wrongPair?.right === originalIndex ? 'wrong' : ''
               } ${
-                matchedPairCoding === 'semantic-four' && matched.has(originalIndex) ? PAIR_CODING_CLASS : ''
+                matchedPairCoding === 'semantic-four' && matched.has(originalIndex)
+                  ? PAIR_CODING_CLASS
+                  : ''
               }`}
               data-activity="match-right-tile"
               data-matched={matched.has(originalIndex) ? 'true' : 'false'}
               data-original-index={originalIndex}
-              data-pair-color={matched.has(originalIndex) ? originalIndex % MATCH_PAIR_COLOR_COUNT : undefined}
+              data-pair-color={
+                matched.has(originalIndex) ? originalIndex % MATCH_PAIR_COLOR_COUNT : undefined
+              }
               data-pair-coding={matchedPairCoding}
-              data-pair-token={matchedPairCoding === 'semantic-four' ? originalIndex % SEMANTIC_FOUR_TOKENS.length : undefined}
+              data-pair-token={
+                matchedPairCoding === 'semantic-four'
+                  ? originalIndex % SEMANTIC_FOUR_TOKENS.length
+                  : undefined
+              }
               style={
                 matchedPairCoding === 'semantic-four'
                   ? getSemanticTokenStyle(originalIndex)
@@ -303,11 +329,13 @@ export default function MatchUp({
               }
               aria-label={pairAccessibleName(originalIndex, 'right')}
               onClick={() => handleRightClick(originalIndex)}
-              disabled={matched.has(originalIndex)}
+              disabled={disabled || matched.has(originalIndex)}
             >
               {parseMarkdown(pairs[originalIndex].right)}
               {matchedPairCoding === 'semantic-four' && pairTag(originalIndex) ? (
-                <span className="matchPairTag" aria-hidden="true">{pairTag(originalIndex)}</span>
+                <span className="matchPairTag" aria-hidden="true">
+                  {pairTag(originalIndex)}
+                </span>
               ) : null}
             </button>
           ))}

--- a/site/src/components/FillIn.tsx
+++ b/site/src/components/FillIn.tsx
@@ -1,13 +1,24 @@
-import React, { useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import styles from './Activities.module.css';
 import { parseMarkdown, shuffle } from './utils';
 import ActivityHelp from './ActivityHelp';
 
 // Generate consistent colors for option chips
 const CHIP_COLORS = [
-  '#E53935', '#D81B60', '#8E24AA', '#5E35B1', '#3949AB',
-  '#1E88E5', '#039BE5', '#00ACC1', '#00897B', '#43A047',
-  '#7CB342', '#FB8C00', '#F4511E', '#6D4C41'
+  '#E53935',
+  '#D81B60',
+  '#8E24AA',
+  '#5E35B1',
+  '#3949AB',
+  '#1E88E5',
+  '#039BE5',
+  '#00ACC1',
+  '#00897B',
+  '#43A047',
+  '#7CB342',
+  '#FB8C00',
+  '#F4511E',
+  '#6D4C41',
 ];
 
 function getChipColor(text: string, index: number): string {
@@ -15,7 +26,7 @@ function getChipColor(text: string, index: number): string {
   return CHIP_COLORS[(charSum + index) % CHIP_COLORS.length];
 }
 
-interface FillInQuestionProps {
+export interface FillInQuestionProps {
   /**
    * @schemaDescription Sentence shown to the learner.
    * @ukrainianText true
@@ -31,26 +42,54 @@ interface FillInQuestionProps {
    * @ukrainianText true
    */
   options?: string[];
+  /**
+   * UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+  /** Called once when the learner locks an answer. */
+  onComplete?: (correct: boolean) => void;
+  /** Lets a host lock this item after it has recorded the result. */
+  disabled?: boolean;
 }
 
-export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestionProps) {
+export function FillInQuestion({
+  sentence,
+  answer,
+  options = [],
+  isUkrainian,
+  onComplete,
+  disabled = false,
+}: FillInQuestionProps) {
   const [selected, setSelected] = useState<string | null>(null);
   const [showResult, setShowResult] = useState(false);
   const [draggedOption, setDraggedOption] = useState<string | null>(null);
+  const [typedAnswer, setTypedAnswer] = useState('');
+  const completionReportedRef = useRef(false);
 
   // Shuffle and create colored option chips
   const coloredOptions = useMemo(() => {
     const shuffled = shuffle([...options]);
     return shuffled.map((opt, idx) => ({
       text: opt,
-      color: getChipColor(opt, idx)
+      color: getChipColor(opt, idx),
     }));
   }, [options]);
 
-  const handleSelect = (option: string) => {
-    if (showResult) return;
-    setSelected(option);
+  const complete = (value: string) => {
+    if (disabled || showResult) return;
+    const correct = value === answer;
+    setSelected(value);
     setShowResult(true);
+    if (!completionReportedRef.current) {
+      completionReportedRef.current = true;
+      onComplete?.(correct);
+    }
+  };
+
+  const handleSelect = (option: string) => {
+    if (disabled || showResult) return;
+    complete(option);
   };
 
   const handleDragStart = (e: React.DragEvent, option: string) => {
@@ -65,23 +104,30 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    if (draggedOption && !showResult) {
-      setSelected(draggedOption);
-      setShowResult(true);
+    if (draggedOption && !showResult && !disabled) {
+      complete(draggedOption);
     }
     setDraggedOption(null);
   };
 
   const handleReset = () => {
+    if (disabled) return;
     setSelected(null);
     setShowResult(false);
+    setTypedAnswer('');
+    completionReportedRef.current = false;
   };
 
   const isCorrect = selected === answer;
 
   // Parse sentence - look for ___ or [blank]
   const parts = sentence.split(/___|\\[blank\\]/);
-  const selectedColor = coloredOptions.find(o => o.text === selected)?.color;
+  const selectedColor = coloredOptions.find((o) => o.text === selected)?.color;
+  const dragHereLabel = isUkrainian ? 'перетягніть сюди' : 'drag here';
+  const retryLabel = isUkrainian ? 'Спробувати знову' : 'Try Again';
+  const correctLabel = isUkrainian ? '✓ Правильно!' : '✓ Correct!';
+  const answerLabel = isUkrainian ? '✗ Правильна відповідь:' : '✗ The answer is:';
+  const checkLabel = isUkrainian ? 'Перевірити' : 'Check Answer';
 
   return (
     <div className={styles.fillInQuestion} data-activity="fillin-question">
@@ -92,13 +138,30 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
           data-activity="fillin-blank"
           onDragOver={handleDragOver}
           onDrop={handleDrop}
-          style={selected && selectedColor ? {
-            backgroundColor: selectedColor,
-            color: 'white',
-            borderStyle: 'solid'
-          } : undefined}
+          style={
+            selected && selectedColor
+              ? {
+                  backgroundColor: selectedColor,
+                  color: 'white',
+                  borderStyle: 'solid',
+                }
+              : undefined
+          }
         >
-          {selected || 'drag here'}
+          {options.length === 0 && !showResult ? (
+            <input
+              aria-label={isUkrainian ? 'Ваша відповідь' : 'Your answer'}
+              className={styles.fillInSelect}
+              value={typedAnswer}
+              onChange={(event) => setTypedAnswer(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && typedAnswer.trim()) complete(typedAnswer.trim());
+              }}
+              disabled={disabled}
+            />
+          ) : (
+            selected || dragHereLabel
+          )}
         </span>
         {parseMarkdown(parts[1] || '')}
       </p>
@@ -111,11 +174,12 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
               className={styles.chipDraggable}
               style={{
                 backgroundColor: option.color,
-                color: 'white'
+                color: 'white',
               }}
               draggable
               onDragStart={(e) => handleDragStart(e, option.text)}
               onClick={() => handleSelect(option.text)}
+              disabled={disabled}
             >
               {option.text}
             </button>
@@ -123,10 +187,22 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
         </div>
       )}
 
+      {options.length === 0 && !showResult && (
+        <div className={styles.buttonRow}>
+          <button
+            className={styles.submitButton}
+            onClick={() => complete(typedAnswer.trim())}
+            disabled={disabled || !typedAnswer.trim()}
+          >
+            {checkLabel}
+          </button>
+        </div>
+      )}
+
       {showResult && (
         <div className={styles.buttonRow}>
-          <button className={styles.resetButton} onClick={handleReset}>
-            Try Again
+          <button className={styles.resetButton} onClick={handleReset} disabled={disabled}>
+            {retryLabel}
           </button>
         </div>
       )}
@@ -137,7 +213,7 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
           data-activity="fillin-feedback"
           data-correct={isCorrect ? 'true' : 'false'}
         >
-          {isCorrect ? '✓ Correct!' : `✗ The answer is: ${answer}`}
+          {isCorrect ? correctLabel : `${answerLabel} ${answer}`}
         </div>
       )}
     </div>
@@ -201,11 +277,13 @@ export default function FillIn({ items, instruction, isUkrainian }: FillInProps)
         <ActivityHelp activityType="fill-in" isUkrainian={isUkrainian} />
       </div>
       {instruction && (
-        <p className={styles.instruction}><strong>{instruction}</strong></p>
+        <p className={styles.instruction}>
+          <strong>{instruction}</strong>
+        </p>
       )}
       <div className={styles.activityContent}>
         {items.map((item, index) => {
-          const parts = item.sentence.split(/_{3,}/);  // Match 3+ underscores
+          const parts = item.sentence.split(/_{3,}/); // Match 3+ underscores
           const isCorrect = answers[index] === item.answer;
 
           return (
@@ -213,8 +291,9 @@ export default function FillIn({ items, instruction, isUkrainian }: FillInProps)
               <span className={styles.fillInText}>
                 {parseMarkdown(parts[0])}
                 <select
-                  className={`${styles.fillInSelect} ${showResults ? (isCorrect ? styles.correct : styles.incorrect) : ''
-                    }`}
+                  className={`${styles.fillInSelect} ${
+                    showResults ? (isCorrect ? styles.correct : styles.incorrect) : ''
+                  }`}
                   value={answers[index] || ''}
                   onChange={(e) => handleSelect(index, e.target.value)}
                   disabled={showResults}

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -7,6 +7,8 @@ import PracticeFormRail, { type FormRailVerdict } from './PracticeFormRail';
 import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSessionSummary';
 import PracticeStress from './PracticeStress';
 import { ErrorCorrectionItem } from './ErrorCorrection';
+import { FillInQuestion } from './FillIn';
+import { MarkTheWordsActivity } from './MarkTheWords';
 import { UnjumbleQuestion } from './Unjumble';
 import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
 import { CHROME_STRINGS, type ChromeKey } from '../lib/i18n/chrome';
@@ -4274,6 +4276,18 @@ function PracticeItem({
 }) {
   const [matchingPromptIndex, setMatchingPromptIndex] = useState<number | null>(0);
   const matchedPairIndexesRef = useRef<Set<number>>(new Set());
+  // MatchUp intentionally resets when its pair-array prop changes. Keep an
+  // adapted heritage board referentially stable while the host locks and shows
+  // feedback, otherwise its successful board would clear before the learner
+  // could see the green state.
+  const heritagePresentation = useMemo(
+    () => (
+      selection.mode === 'heritage' && selection.heritage && presentationVariants
+        ? selectHeritagePracticePresentation(selection.heritage, sessionSeed, deck.heritage ?? [])
+        : { kind: 'mc' as const }
+    ),
+    [deck.heritage, presentationVariants, selection.heritage, selection.mode, sessionSeed],
+  );
 
   if (selection.mode === 'flashcards') {
     const intervalPreviews = previewRatingIntervals(
@@ -4374,9 +4388,7 @@ function PracticeItem({
   }
 
   if (selection.mode === 'heritage' && selection.heritage) {
-    const presentation = presentationVariants
-      ? selectHeritagePracticePresentation(selection.heritage, sessionSeed)
-      : { kind: 'mc' as const };
+    const presentation = heritagePresentation;
     if (presentation.kind === 'error-correction') {
       return (
         <div data-testid="practice-heritage-error-correction">
@@ -4393,6 +4405,43 @@ function PracticeItem({
       return (
         <div data-testid="practice-heritage-unjumble">
           <UnjumbleQuestion
+            {...presentation.item}
+            isUkrainian={chromeLocale === 'uk'}
+            disabled={answerLocked}
+            onComplete={onHeritageActivityComplete}
+          />
+        </div>
+      );
+    }
+    if (presentation.kind === 'fill-in') {
+      return (
+        <div data-testid="practice-heritage-fill-in">
+          <FillInQuestion
+            {...presentation.item}
+            isUkrainian={chromeLocale === 'uk'}
+            disabled={answerLocked}
+            onComplete={onHeritageActivityComplete}
+          />
+        </div>
+      );
+    }
+    if (presentation.kind === 'match-up') {
+      return (
+        <div data-testid="practice-heritage-match-up">
+          <MatchUp
+            {...presentation.item}
+            instruction="З’єднайте кальку з питомим українським відповідником."
+            isUkrainian={chromeLocale === 'uk'}
+            disabled={answerLocked}
+            onComplete={onHeritageActivityComplete}
+          />
+        </div>
+      );
+    }
+    if (presentation.kind === 'mark-the-words') {
+      return (
+        <div data-testid="practice-heritage-mark-the-words">
+          <MarkTheWordsActivity
             {...presentation.item}
             isUkrainian={chromeLocale === 'uk'}
             disabled={answerLocked}

--- a/site/src/components/MarkTheWords.tsx
+++ b/site/src/components/MarkTheWords.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 
-interface MarkTheWordsActivityProps {
+export interface MarkTheWordsActivityProps {
   /**
    * @schemaDescription Text passage shown to the learner.
    * @ukrainianText true
@@ -23,23 +23,35 @@ interface MarkTheWordsActivityProps {
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /** Called once when the learner checks the marked words. */
+  onComplete?: (correct: boolean) => void;
+  /** Lets a host lock the activity after it has recorded the result. */
+  disabled?: boolean;
 }
 
-export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrainian }: MarkTheWordsActivityProps) {
+export function MarkTheWordsActivity({
+  text,
+  correctWords,
+  instruction,
+  isUkrainian,
+  onComplete,
+  disabled = false,
+}: MarkTheWordsActivityProps) {
   const [markedIndices, setMarkedIndices] = useState<Set<number>>(new Set());
   const [submitted, setSubmitted] = useState(false);
+  const completionReportedRef = useRef(false);
 
   // Split text into words while preserving punctuation and spaces
-  const tokens = text.match(/[\wа-яіїєґА-ЯІЇЄҐ']+|[^\s\wа-яіїєґА-ЯІЇЄҐ']+|\s+/gi) || [];
+  const tokens = text.match(/[\wа-яіїєґА-ЯІЇЄҐ'-]+|[^\s\wа-яіїєґА-ЯІЇЄҐ'-]+|\s+/gi) || [];
 
   // Normalize for comparison
-  const normalizedCorrect = correctWords.map(w => w.toLowerCase().trim());
+  const normalizedCorrect = correctWords.map((w) => w.toLowerCase().trim());
 
   const handleWordClick = (idx: number) => {
-    if (submitted) return;
+    if (disabled || submitted) return;
 
     const token = tokens[idx];
-    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ'-]/gi, '');
     if (!cleanWord) return;
 
     const newMarked = new Set(markedIndices);
@@ -52,21 +64,28 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
   };
 
   const handleSubmit = () => {
+    if (disabled || submitted) return;
     setSubmitted(true);
+    if (!completionReportedRef.current) {
+      completionReportedRef.current = true;
+      onComplete?.(isFullyCorrect);
+    }
   };
 
   const handleReset = () => {
+    if (disabled) return;
     setMarkedIndices(new Set());
     setSubmitted(false);
+    completionReportedRef.current = false;
   };
 
   const isWordCorrect = (word: string) => {
-    const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '').toLowerCase();
+    const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ'-]/gi, '').toLowerCase();
     return normalizedCorrect.includes(cleanWord);
   };
 
   const getWordClass = (token: string, idx: number) => {
-    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ'-]/gi, '');
     if (!cleanWord) return '';
 
     const isMarked = markedIndices.has(idx);
@@ -85,12 +104,12 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
 
   // Calculate score
   const markedArray = Array.from(markedIndices);
-  const correctMarks = markedArray.filter(idx => isWordCorrect(tokens[idx])).length;
-  const wrongMarks = markedArray.filter(idx => !isWordCorrect(tokens[idx])).length;
+  const correctMarks = markedArray.filter((idx) => isWordCorrect(tokens[idx])).length;
+  const wrongMarks = markedArray.filter((idx) => !isWordCorrect(tokens[idx])).length;
 
   // Total instances of correct words available in the text
-  const totalCorrectInstances = tokens.filter(t => {
-    const clean = t.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+  const totalCorrectInstances = tokens.filter((t) => {
+    const clean = t.replace(/[^\wа-яіїєґА-ЯІЇЄҐ'-]/gi, '');
     return clean && isWordCorrect(t);
   }).length;
 
@@ -100,7 +119,9 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
 
   const checkBtnLabel = isUkrainian ? 'Перевірити' : 'Check Answer';
   const retryBtnLabel = isUkrainian ? 'Спробувати знову' : 'Try Again';
-  const successLabel = isUkrainian ? '✓ Чудово! Ви знайшли всі правильні слова.' : '✓ Perfect! You found all the correct words.';
+  const successLabel = isUkrainian
+    ? '✓ Чудово! Ви знайшли всі правильні слова.'
+    : '✓ Perfect! You found all the correct words.';
   const correctPlural = isUkrainian ? 'правильно' : 'correct';
   const incorrectPlural = isUkrainian ? 'неправильно' : 'incorrect';
   const missedLabel = isUkrainian ? 'Пропущено' : 'Missed';
@@ -109,11 +130,13 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
   return (
     <div>
       {instruction && (
-        <p className={styles.instruction}><strong>{instruction}</strong></p>
+        <p className={styles.instruction}>
+          <strong>{instruction}</strong>
+        </p>
       )}
       <p className={styles.markWordsText}>
         {tokens.map((token, idx) => {
-          const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+          const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ'-]/gi, '');
 
           // Non-word tokens (punctuation, spaces)
           if (!cleanWord) {
@@ -125,6 +148,16 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
               key={idx}
               className={`${styles.markableWord} ${getWordClass(token, idx)}`}
               onClick={() => handleWordClick(idx)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  handleWordClick(idx);
+                }
+              }}
+              role="button"
+              tabIndex={disabled || submitted ? -1 : 0}
+              aria-pressed={markedIndices.has(idx)}
+              aria-disabled={disabled || submitted}
             >
               {token}
             </span>
@@ -134,10 +167,7 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
 
       {!submitted && (
         <div className={styles.buttonRow}>
-          <button
-            className={styles.submitButton}
-            onClick={handleSubmit}
-          >
+          <button className={styles.submitButton} onClick={handleSubmit} disabled={disabled}>
             {checkBtnLabel}
           </button>
         </div>
@@ -145,21 +175,37 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
 
       {submitted && (
         <>
-          <div className={`${styles.feedback} ${isFullyCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect}`}>
+          <div
+            className={`${styles.feedback} ${isFullyCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect}`}
+          >
             {isFullyCorrect ? (
               successLabel
             ) : (
               <>
-                {correctMarks > 0 && <span>✓ {correctMarks} {correctPlural}. </span>}
-                {wrongMarks > 0 && <span>✗ {wrongMarks} {incorrectPlural}. </span>}
-                {missedMarks > 0 && <span>{missedLabel}: {missedMarks}. </span>}
+                {correctMarks > 0 && (
+                  <span>
+                    ✓ {correctMarks} {correctPlural}.{' '}
+                  </span>
+                )}
+                {wrongMarks > 0 && (
+                  <span>
+                    ✗ {wrongMarks} {incorrectPlural}.{' '}
+                  </span>
+                )}
+                {missedMarks > 0 && (
+                  <span>
+                    {missedLabel}: {missedMarks}.{' '}
+                  </span>
+                )}
                 <br />
-                <span>{correctWordsLabel} <strong>{correctWords.join(', ')}</strong></span>
+                <span>
+                  {correctWordsLabel} <strong>{correctWords.join(', ')}</strong>
+                </span>
               </>
             )}
           </div>
           <div className={styles.buttonRow}>
-            <button className={styles.resetButton} onClick={handleReset}>
+            <button className={styles.resetButton} onClick={handleReset} disabled={disabled}>
               {retryBtnLabel}
             </button>
           </div>

--- a/site/src/components/MatchUp.tsx
+++ b/site/src/components/MatchUp.tsx
@@ -37,8 +37,11 @@ export interface MatchUpProps {
    * @ukrainianText false
    */
   matchedPairCoding?: 'semantic-four';
-  onComplete?: () => void;
+  /** Called once after every pair is connected correctly. */
+  onComplete?: (correct: boolean) => void;
   onMatch?: (pairIndex: number, rating: 'again' | 'hard' | 'good') => void;
+  /** Lets a host lock the board after it has recorded the result. */
+  disabled?: boolean;
 }
 
 export { default } from '../../../packages/activity-kit/src/components/MatchUp';

--- a/site/src/lib/lexicon/practice-activity-adapters.ts
+++ b/site/src/lib/lexicon/practice-activity-adapters.ts
@@ -1,11 +1,17 @@
 import type { ErrorCorrectionItemProps } from '../../components/ErrorCorrection';
+import type { FillInQuestionProps } from '../../components/FillIn';
+import type { MatchPair } from '../../components/MatchUp';
+import type { MarkTheWordsActivityProps } from '../../components/MarkTheWords';
 import type { UnjumbleQuestionProps } from '../../components/Unjumble';
 import { seededPracticeHash, type PracticeHeritageItem } from './srs';
 
 export type HeritagePracticePresentation =
   | { kind: 'mc' }
   | { kind: 'error-correction'; item: HeritageErrorCorrectionItem }
-  | { kind: 'unjumble'; item: HeritageUnjumbleQuestion };
+  | { kind: 'unjumble'; item: HeritageUnjumbleQuestion }
+  | { kind: 'fill-in'; item: HeritageFillInQuestion }
+  | { kind: 'match-up'; item: HeritageMatchUpQuestion }
+  | { kind: 'mark-the-words'; item: HeritageMarkTheWordsQuestion };
 
 export type HeritageErrorCorrectionItem = Pick<
   ErrorCorrectionItemProps,
@@ -15,6 +21,17 @@ export type HeritageErrorCorrectionItem = Pick<
 export type HeritageUnjumbleQuestion = Pick<
   UnjumbleQuestionProps,
   'words' | 'answer' | 'hint' | 'wordsAreJumbled'
+>;
+
+export type HeritageFillInQuestion = Pick<FillInQuestionProps, 'sentence' | 'answer' | 'options'>;
+
+export type HeritageMatchUpQuestion = {
+  pairs: MatchPair[];
+};
+
+export type HeritageMarkTheWordsQuestion = Pick<
+  MarkTheWordsActivityProps,
+  'text' | 'correctWords' | 'instruction'
 >;
 
 const BLANK = '___';
@@ -43,11 +60,29 @@ function appearsExactlyOnce(sentence: string, phrase: string): boolean {
   return matches === 1;
 }
 
+function targetWordsAppearExactlyOnce(sentence: string, targetWords: readonly string[]): boolean {
+  const sentenceWords = contentWords(sentence).map((word) => word.toLocaleLowerCase());
+  const targets = targetWords.map((word) => word.toLocaleLowerCase());
+  return (
+    new Set(targets).size === targets.length &&
+    targets.every((target) => sentenceWords.filter((word) => word === target).length === 1)
+  );
+}
+
 function sourceOptions(item: PracticeHeritageItem): string[] | null {
   const options = Array.from(
     new Set(item.options.map((option) => option.label.trim()).filter(Boolean)),
   );
   return options.includes(item.answer) ? options : null;
+}
+
+function heritageMatchPair(item: PracticeHeritageItem): MatchPair | null {
+  const options = sourceOptions(item);
+  const left = item.calque.trim();
+  const right = item.answer.trim();
+  if (!options || !left || !right || left.toLocaleLowerCase() === right.toLocaleLowerCase())
+    return null;
+  return { left, right, lemmaId: item.lemmaId };
 }
 
 function correctSentenceTokens(item: PracticeHeritageItem): string[] | null {
@@ -57,7 +92,11 @@ function correctSentenceTokens(item: PracticeHeritageItem): string[] | null {
   return tokens.length >= 4 ? tokens : null;
 }
 
-function jumbledTokens(tokens: readonly string[], seed: number, item: PracticeHeritageItem): string[] {
+function jumbledTokens(
+  tokens: readonly string[],
+  seed: number,
+  item: PracticeHeritageItem,
+): string[] {
   const result = [...tokens];
   let state = seededPracticeHash(seed, `heritage-unjumble:${item.srsKey}`) || 1;
   for (let index = result.length - 1; index > 0; index -= 1) {
@@ -111,17 +150,103 @@ export function heritageToUnjumble(
 }
 
 /**
+ * Keeps the reviewed blank and its original answer bank intact. The component
+ * supports typing, but Practice only offers chips when the reviewed source
+ * supplied them, rather than manufacturing distractors.
+ */
+export function heritageToFillIn(item: PracticeHeritageItem): HeritageFillInQuestion | null {
+  const options = sourceOptions(item);
+  if (!fillSingleBlank(item.prompt, item.answer) || !options) return null;
+  return {
+    sentence: item.prompt,
+    answer: item.answer,
+    options,
+  };
+}
+
+/**
+ * A marked target must be the one reviewed correction span in its corrected
+ * frame. Repeated targets are rejected so the learner never has to infer which
+ * occurrence a source record meant.
+ */
+export function heritageToMarkTheWords(
+  item: PracticeHeritageItem,
+): HeritageMarkTheWordsQuestion | null {
+  const options = sourceOptions(item);
+  const text = fillSingleBlank(item.prompt, item.answer);
+  const correctWords = contentWords(item.answer);
+  if (
+    !options ||
+    !text ||
+    correctWords.length === 0 ||
+    !appearsExactlyOnce(text, item.answer) ||
+    !targetWordsAppearExactlyOnce(text, correctWords)
+  )
+    return null;
+  return {
+    text,
+    correctWords,
+    instruction: 'Позначте питоме українське слово або сполуку.',
+  };
+}
+
+/**
+ * A board is made from reviewed calque-to-correction relations only. It always
+ * includes the scheduled card, caps density at four pairs, and fails closed
+ * unless at least two unique source pairs can be shown.
+ */
+export function heritageToMatchUp(
+  item: PracticeHeritageItem,
+  availableItems: readonly PracticeHeritageItem[],
+  sessionSeed: number,
+): HeritageMatchUpQuestion | null {
+  const primary = heritageMatchPair(item);
+  if (!primary) return null;
+
+  const pairs = [primary];
+  const seenLeft = new Set([primary.left.toLocaleLowerCase()]);
+  const seenRight = new Set([primary.right.toLocaleLowerCase()]);
+  const start =
+    seededPracticeHash(sessionSeed, `heritage-match-up:${item.srsKey}`) %
+    Math.max(availableItems.length, 1);
+
+  for (let offset = 0; offset < availableItems.length && pairs.length < 4; offset += 1) {
+    const candidate = availableItems[(start + offset) % availableItems.length];
+    if (!candidate || candidate.heritageId === item.heritageId) continue;
+    const pair = heritageMatchPair(candidate);
+    if (!pair) continue;
+    const left = pair.left.toLocaleLowerCase();
+    const right = pair.right.toLocaleLowerCase();
+    if (seenLeft.has(left) || seenRight.has(right)) continue;
+    pairs.push(pair);
+    seenLeft.add(left);
+    seenRight.add(right);
+  }
+
+  return pairs.length >= 2 ? { pairs } : null;
+}
+
+/**
  * A presentation is derived from the persisted session seed, so a resumed card
  * keeps its interaction while sharing the untouched heritage card key and SRS state.
  */
 export function selectHeritagePracticePresentation(
   item: PracticeHeritageItem,
   sessionSeed: number,
+  availableItems: readonly PracticeHeritageItem[] = [],
 ): HeritagePracticePresentation {
   const presentations: HeritagePracticePresentation[] = [{ kind: 'mc' }];
   const errorCorrection = heritageToErrorCorrection(item);
   if (errorCorrection) presentations.push({ kind: 'error-correction', item: errorCorrection });
   const unjumble = heritageToUnjumble(item, sessionSeed);
   if (unjumble) presentations.push({ kind: 'unjumble', item: unjumble });
-  return presentations[seededPracticeHash(sessionSeed, `heritage-presentation:${item.srsKey}`) % presentations.length];
+  const fillIn = heritageToFillIn(item);
+  if (fillIn) presentations.push({ kind: 'fill-in', item: fillIn });
+  const matchUp = heritageToMatchUp(item, availableItems, sessionSeed);
+  if (matchUp) presentations.push({ kind: 'match-up', item: matchUp });
+  const markTheWords = heritageToMarkTheWords(item);
+  if (markTheWords) presentations.push({ kind: 'mark-the-words', item: markTheWords });
+  return presentations[
+    seededPracticeHash(sessionSeed, `heritage-presentation:${item.srsKey}`) % presentations.length
+  ];
 }

--- a/site/tests/unit/FillIn.test.tsx
+++ b/site/tests/unit/FillIn.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FillIn, { FillInQuestion } from '@site/src/components/FillIn';
@@ -18,7 +18,7 @@ function chipsIn(container: HTMLElement) {
 }
 
 function chipByText(container: HTMLElement, text: string) {
-  const btn = chipsIn(container).find(b => b.textContent?.trim() === text);
+  const btn = chipsIn(container).find((b) => b.textContent?.trim() === text);
   if (!btn) throw new Error(`chip "${text}" not found`);
   return btn;
 }
@@ -33,13 +33,13 @@ function feedback(container: HTMLElement) {
 
 function tryAgainBtn(container: HTMLElement) {
   return [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-    b => b.textContent?.trim() === 'Try Again' || b.textContent?.trim() === 'Спробувати знову'
+    (b) => b.textContent?.trim() === 'Try Again' || b.textContent?.trim() === 'Спробувати знову',
   );
 }
 
 function checkButton(container: HTMLElement) {
   return [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-    b => b.textContent?.trim() === 'Check Answers' || b.textContent?.trim() === 'Перевірити'
+    (b) => b.textContent?.trim() === 'Check Answers' || b.textContent?.trim() === 'Перевірити',
   );
 }
 
@@ -64,7 +64,7 @@ describe('FillInQuestion', () => {
 
   test('renders all option texts regardless of shuffle order', () => {
     const { container } = render(<FillInQuestion {...baseProps} />);
-    const texts = chipsIn(container).map(b => b.textContent?.trim());
+    const texts = chipsIn(container).map((b) => b.textContent?.trim());
     expect(new Set(texts)).toEqual(new Set(['Kyiv', 'Moscow', 'Warsaw']));
   });
 
@@ -138,19 +138,45 @@ describe('FillInQuestion', () => {
 
   test('handles sentences with an underscore-style blank marker', () => {
     const { container } = render(
-      <FillInQuestion sentence="I ___ pizza." answer="love" options={['love']} />
+      <FillInQuestion sentence="I ___ pizza." answer="love" options={['love']} />,
     );
     expect(container.textContent).toContain('I');
     expect(container.textContent).toContain('pizza');
   });
 
   test('renders without options (no chip bank)', () => {
-    const { container } = render(
-      <FillInQuestion sentence="The answer is ___." answer="42" />
-    );
+    const { container } = render(<FillInQuestion sentence="The answer is ___." answer="42" />);
     expect(chipsIn(container)).toHaveLength(0);
     // Sentence + blank zone still present
     expect(blankZone(container)).toBeInTheDocument();
+  });
+
+  test('accepts a typed answer when no reviewed choice bank is supplied', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<FillInQuestion sentence="The answer is ___." answer="42" onComplete={onComplete} />);
+
+    await user.type(screen.getByRole('textbox', { name: 'Your answer' }), '42{Enter}');
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(true);
+    expect(feedback(document.body)).toHaveAttribute('data-correct', 'true');
+  });
+
+  test('reports chip correctness once and obeys a host answer lock', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { container, rerender } = render(
+      <FillInQuestion {...baseProps} onComplete={onComplete} />,
+    );
+
+    await user.click(chipByText(container, 'Moscow'));
+    expect(onComplete).toHaveBeenCalledWith(false);
+
+    rerender(<FillInQuestion {...baseProps} onComplete={onComplete} disabled />);
+    expect(tryAgainBtn(container)).toBeDisabled();
+    await user.click(tryAgainBtn(container)!);
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -480,15 +480,21 @@ function heritageDeck({ includeItems = true } = {}): PracticeDeckData {
   };
 }
 
-function seedForHeritagePresentation(kind: 'error-correction' | 'unjumble'): number {
+function seedForHeritagePresentation(
+  kind: 'error-correction' | 'unjumble' | 'fill-in' | 'match-up' | 'mark-the-words',
+  availableItems: readonly PracticeHeritageItem[] = [],
+): number {
   for (let seed = 0; seed < 512; seed += 1) {
-    if (selectHeritagePracticePresentation(heritagePracticeItem(), seed).kind === kind) return seed;
+    if (selectHeritagePracticePresentation(heritagePracticeItem(), seed, availableItems).kind === kind) return seed;
   }
   throw new Error(`no deterministic ${kind} presentation seed found`);
 }
 
-function useHeritagePresentationSeed(kind: 'error-correction' | 'unjumble') {
-  const seed = seedForHeritagePresentation(kind);
+function useHeritagePresentationSeed(
+  kind: 'error-correction' | 'unjumble' | 'fill-in' | 'match-up' | 'mark-the-words',
+  availableItems: readonly PracticeHeritageItem[] = [],
+) {
+  const seed = seedForHeritagePresentation(kind, availableItems);
   vi.spyOn(Date, 'now').mockReturnValue(0);
   vi.spyOn(Math, 'random').mockReturnValue(seed / 4294967296);
 }
@@ -505,6 +511,38 @@ function sampleDeckWithOnlyMode(lemmaId: string, mode: PracticeMode): PracticeDe
     })),
     cloze: [],
   };
+}
+
+function heritageMatchDeck(): PracticeDeckData {
+  const deck = heritageDeck();
+  deck.heritage = [
+    heritagePracticeItem(),
+    {
+      ...heritagePracticeItem(),
+      heritageId: 'heritage-knyha',
+      lemmaId: 'knyha',
+      srsKey: cardKey('knyha', 'heritage'),
+      lemma: 'книга',
+      nativeLemma: 'книга',
+      prompt: 'Я читаю ___ щодня.',
+      answer: 'книгу',
+      calque: 'кнігу',
+      options: [{ label: 'книгу' }, { label: 'кнігу' }, { label: 'газету' }],
+    },
+    {
+      ...heritagePracticeItem(),
+      heritageId: 'heritage-oselia',
+      lemmaId: 'oselia',
+      srsKey: cardKey('oselia', 'heritage'),
+      lemma: 'оселя',
+      nativeLemma: 'оселя',
+      prompt: 'Вона повернулася до ___ ввечері.',
+      answer: 'оселі',
+      calque: 'дому',
+      options: [{ label: 'оселі' }, { label: 'дому' }, { label: 'школи' }],
+    },
+  ];
+  return deck;
 }
 
 /**
@@ -1972,7 +2010,10 @@ describe('LexiconPractice', () => {
     expect(
       screen.queryByTestId('practice-heritage') ??
         screen.queryByTestId('practice-heritage-error-correction') ??
-        screen.queryByTestId('practice-heritage-unjumble'),
+        screen.queryByTestId('practice-heritage-unjumble') ??
+        screen.queryByTestId('practice-heritage-fill-in') ??
+        screen.queryByTestId('practice-heritage-match-up') ??
+        screen.queryByTestId('practice-heritage-mark-the-words'),
     ).toBeInTheDocument();
 
     mixedRender.unmount();
@@ -2116,6 +2157,72 @@ describe('LexiconPractice', () => {
     await user.click(within(activity).getByRole('button', { name: 'Перевірити' }));
 
     expect(activity.querySelector('[data-activity="feedback"]')).toHaveAttribute('data-correct', 'true');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        cardKey: cardKey('dim', 'heritage'),
+        mode: 'heritage',
+        rating: 'good',
+      });
+    });
+  });
+
+  test('mixed heritage renders FillIn, locks after a wrong chip, and records again', async () => {
+    useHeritagePresentationSeed('fill-in');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="mixed" />);
+
+    const activity = await screen.findByTestId('practice-heritage-fill-in');
+    await user.click(within(activity).getByRole('button', { name: 'хата' }));
+
+    expect(activity.querySelector('[data-activity="fillin-feedback"]')).toHaveAttribute('data-correct', 'false');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        cardKey: cardKey('dim', 'heritage'),
+        mode: 'heritage',
+        rating: 'again',
+      });
+    });
+  });
+
+  test('mixed heritage renders MarkTheWords, keeps green feedback visible, and records good', async () => {
+    useHeritagePresentationSeed('mark-the-words');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="mixed" />);
+
+    const activity = await screen.findByTestId('practice-heritage-mark-the-words');
+    await user.click(within(activity).getByRole('button', { name: 'дім' }));
+    await user.click(within(activity).getByRole('button', { name: 'Перевірити' }));
+
+    expect(activity).toHaveTextContent('Чудово! Ви знайшли всі правильні слова.');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        cardKey: cardKey('dim', 'heritage'),
+        mode: 'heritage',
+        rating: 'good',
+      });
+    });
+  });
+
+  test('mixed heritage renders a source-backed MatchUp board and records good after every pair', async () => {
+    const deck = heritageMatchDeck();
+    useHeritagePresentationSeed('match-up', deck.heritage);
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="mixed" />);
+
+    const activity = await screen.findByTestId('practice-heritage-match-up');
+    const left = within(activity.querySelector<HTMLElement>('[data-activity="match-left-column"]')!);
+    const right = within(activity.querySelector<HTMLElement>('[data-activity="match-right-column"]')!);
+    for (const [calque, correction] of [['дом', 'дім'], ['кнігу', 'книгу'], ['дому', 'оселі']]) {
+      await user.click(left.getByRole('button', { name: calque }));
+      await user.click(right.getByRole('button', { name: correction }));
+    }
+
+    await waitFor(() => {
+      expect(activity.querySelector('[data-activity="match-feedback"]')).toHaveAttribute('data-correct', 'true');
+    });
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     await waitFor(() => {
       expect(storedState().reviews[0]).toMatchObject({
@@ -2376,7 +2483,10 @@ describe('LexiconPractice', () => {
         expect(
           screen.queryByTestId('practice-heritage') ??
             screen.queryByTestId('practice-heritage-error-correction') ??
-            screen.queryByTestId('practice-heritage-unjumble'),
+            screen.queryByTestId('practice-heritage-unjumble') ??
+            screen.queryByTestId('practice-heritage-fill-in') ??
+            screen.queryByTestId('practice-heritage-match-up') ??
+            screen.queryByTestId('practice-heritage-mark-the-words'),
         ).toBeInTheDocument();
       });
       expect(screen.queryByTestId('practice-flashcards')).not.toBeInTheDocument();

--- a/site/tests/unit/MarkTheWords.test.tsx
+++ b/site/tests/unit/MarkTheWords.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+
+describe('MarkTheWordsActivity Practice host contract', () => {
+  test('reports a correct checked selection once', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(
+      <MarkTheWordsActivity
+        text="Я бачу дім щодня."
+        correctWords={['дім']}
+        isUkrainian
+        onComplete={onComplete}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'дім' }));
+    await user.click(screen.getByRole('button', { name: 'Перевірити' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(true);
+    expect(screen.getByText(/Чудово! Ви знайшли всі правильні слова/)).toBeInTheDocument();
+  });
+
+  test('reports an incorrect checked selection and respects a host lock', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { rerender } = render(
+      <MarkTheWordsActivity
+        text="Я бачу дім щодня."
+        correctWords={['дім']}
+        onComplete={onComplete}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Я' }));
+    await user.click(screen.getByRole('button', { name: 'Check Answer' }));
+    expect(onComplete).toHaveBeenCalledWith(false);
+
+    rerender(
+      <MarkTheWordsActivity
+        text="Я бачу дім щодня."
+        correctWords={['дім']}
+        onComplete={onComplete}
+        disabled
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('treats a hyphenated Ukrainian form as one tappable word', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<MarkTheWordsActivity text="Це будь-що." correctWords={['будь-що']} onComplete={onComplete} />);
+
+    await user.click(screen.getByRole('button', { name: 'будь-що' }));
+    await user.click(screen.getByRole('button', { name: 'Check Answer' }));
+
+    expect(onComplete).toHaveBeenCalledWith(true);
+  });
+});

--- a/site/tests/unit/MatchUp.test.tsx
+++ b/site/tests/unit/MatchUp.test.tsx
@@ -60,13 +60,13 @@ describe('MatchUp', () => {
 
   test('left column preserves the original order', () => {
     const { container } = render(<MatchUp pairs={pairs} />);
-    const texts = leftTiles(container).map(b => b.textContent?.trim());
+    const texts = leftTiles(container).map((b) => b.textContent?.trim());
     expect(texts).toEqual(['Cat', 'Dog', 'Cow']);
   });
 
   test('right column contains all right texts regardless of shuffle order', () => {
     const { container } = render(<MatchUp pairs={pairs} />);
-    const texts = rightTiles(container).map(b => b.textContent?.trim());
+    const texts = rightTiles(container).map((b) => b.textContent?.trim());
     expect(new Set(texts)).toEqual(new Set(['Meow', 'Bark', 'Moo']));
   });
 
@@ -88,6 +88,49 @@ describe('MatchUp', () => {
   test('renders instruction text when provided', () => {
     render(<MatchUp pairs={pairs} instruction="Match sounds to animals" />);
     expect(screen.getByText('Match sounds to animals')).toBeInTheDocument();
+  });
+
+  test('does not permit a host-locked board to start a match', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<MatchUp pairs={pairs} disabled />);
+
+    await user.click(leftTiles(container)[0]);
+
+    expect(leftTiles(container)[0]).toBeDisabled();
+    expect(leftTiles(container)[0]).toHaveAttribute('data-selected', 'false');
+  });
+
+  test('reports a correct completion to the Practice host', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { container } = render(<MatchUp pairs={pairs} onComplete={onComplete} />);
+
+    for (const pair of pairs) {
+      await user.click(
+        leftTiles(container).find((button) => button.textContent?.trim() === pair.left)!,
+      );
+      await user.click(findRightByText(container, pair.right));
+    }
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(true);
+  });
+
+  test('reports an incorrect completion after a wrong pairing attempt', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { container } = render(<MatchUp pairs={pairs} onComplete={onComplete} />);
+
+    await user.click(leftTiles(container)[0]);
+    await user.click(findRightByText(container, 'Bark'));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    for (const pair of pairs) {
+      await user.click(leftTiles(container).find((button) => button.textContent?.trim() === pair.left)!);
+      await user.click(findRightByText(container, pair.right));
+    }
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(false);
   });
 
   test('clicking a correct pair marks both tiles as matched', async () => {
@@ -240,7 +283,7 @@ describe('MatchUp', () => {
         pairs={lessonPairs}
         instruction="Match each Ukrainian noun with its English cue."
         isUkrainian={false}
-      />
+      />,
     );
 
     expect(screen.getByText('Match each Ukrainian noun with its English cue.')).toBeInTheDocument();
@@ -393,10 +436,13 @@ describe('MatchUp', () => {
       expect(barkTile).toHaveClass('wrong');
       expect(onMatch).not.toHaveBeenCalled();
 
-      await waitFor(() => {
-        expect(catTile).not.toHaveClass('wrong');
-        expect(barkTile).not.toHaveClass('wrong');
-      }, { timeout: 500 });
+      await waitFor(
+        () => {
+          expect(catTile).not.toHaveClass('wrong');
+          expect(barkTile).not.toHaveClass('wrong');
+        },
+        { timeout: 500 },
+      );
 
       expect(onMatch).not.toHaveBeenCalled();
     });

--- a/site/tests/unit/practice-activity-adapters.test.ts
+++ b/site/tests/unit/practice-activity-adapters.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import {
   heritageToErrorCorrection,
+  heritageToFillIn,
+  heritageToMarkTheWords,
+  heritageToMatchUp,
   heritageToUnjumble,
   selectHeritagePracticePresentation,
 } from '@site/src/lib/lexicon/practice-activity-adapters';
@@ -68,13 +71,101 @@ describe('heritage practice activity adapters', () => {
     expect(heritageToUnjumble(heritage({ prompt: '___ — ! ? …' }), 42)).toBeNull();
   });
 
+  test('adapts a reviewed single blank and its source choices into FillIn props', () => {
+    expect(heritageToFillIn(heritage())).toEqual({
+      sentence: 'Я бачу ___ щодня.',
+      answer: 'дім',
+      options: ['дім', 'дом', 'хата', 'місто'],
+    });
+    expect(heritageToFillIn(heritage({ prompt: 'Я бачу ___ і ___ щодня.' }))).toBeNull();
+  });
+
+  test('marks only the exact reviewed replacement span in a corrected frame', () => {
+    expect(heritageToMarkTheWords(heritage())).toEqual({
+      text: 'Я бачу дім щодня.',
+      correctWords: ['дім'],
+      instruction: 'Позначте питоме українське слово або сполуку.',
+    });
+    expect(heritageToMarkTheWords(heritage({ prompt: 'Я бачу ___ і ___ щодня.' }))).toBeNull();
+    expect(
+      heritageToMarkTheWords(
+        heritage({
+          prompt: 'Я бачу ___, бо мій сад поруч.',
+          answer: 'мій дім',
+          calque: 'мой дом',
+          options: [{ label: 'мій дім' }, { label: 'мой дом' }],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test('builds a distinct, source-backed match-up board that includes the scheduled card', () => {
+    const companions = [
+      heritage(),
+      heritage({
+        heritageId: 'heritage-adapter-fixture-2',
+        lemmaId: 'knyha',
+        srsKey: cardKey('knyha', 'heritage'),
+        prompt: 'Я читаю ___ щодня.',
+        answer: 'книгу',
+        calque: 'кнігу',
+        options: [{ label: 'книгу' }, { label: 'кнігу' }, { label: 'газету' }],
+      }),
+      heritage({
+        heritageId: 'heritage-adapter-fixture-3',
+        lemmaId: 'oselia',
+        srsKey: cardKey('oselia', 'heritage'),
+        prompt: 'Вона повернулася до ___ ввечері.',
+        answer: 'оселі',
+        calque: 'дому',
+        options: [{ label: 'оселі' }, { label: 'дому' }, { label: 'школи' }],
+      }),
+    ];
+    expect(heritageToMatchUp(companions[0]!, companions, 42)).toEqual({
+      pairs: [
+        { left: 'дом', right: 'дім', lemmaId: 'dim' },
+        { left: 'дому', right: 'оселі', lemmaId: 'oselia' },
+        { left: 'кнігу', right: 'книгу', lemmaId: 'knyha' },
+      ],
+    });
+    expect(heritageToMatchUp(heritage(), [heritage()], 42)).toBeNull();
+  });
+
   test('selects only reproducible presentation variants and preserves MC fallback', () => {
     const kinds = new Set(
-      Array.from({ length: 64 }, (_unused, seed) =>
-        selectHeritagePracticePresentation(heritage(), seed).kind,
+      Array.from(
+        { length: 64 },
+        (_unused, seed) => selectHeritagePracticePresentation(heritage(), seed).kind,
       ),
     );
-    expect(kinds).toEqual(new Set(['mc', 'error-correction', 'unjumble']));
-    expect(selectHeritagePracticePresentation(heritage({ prompt: '___ і ___' }), 42)).toEqual({ kind: 'mc' });
+    expect(kinds).toEqual(
+      new Set(['mc', 'error-correction', 'unjumble', 'fill-in', 'mark-the-words']),
+    );
+    expect(selectHeritagePracticePresentation(heritage({ prompt: '___ і ___' }), 42)).toEqual({
+      kind: 'mc',
+    });
+  });
+
+  test('selects match-up only when the source set can form a real board', () => {
+    const companions = [
+      heritage(),
+      heritage({
+        heritageId: 'heritage-adapter-fixture-2',
+        lemmaId: 'knyha',
+        srsKey: cardKey('knyha', 'heritage'),
+        prompt: 'Я читаю ___ щодня.',
+        answer: 'книгу',
+        calque: 'кнігу',
+        options: [{ label: 'книгу' }, { label: 'кнігу' }, { label: 'газету' }],
+      }),
+    ];
+    const kinds = new Set(
+      Array.from(
+        { length: 128 },
+        (_unused, seed) =>
+          selectHeritagePracticePresentation(companions[0]!, seed, companions).kind,
+      ),
+    );
+    expect(kinds).toContain('match-up');
   });
 });


### PR DESCRIPTION
## Summary
- Reuse LU **FillIn**, **MatchUp**, and **MarkTheWords** in Practice mixed heritage sessions
- Source-backed adapters only; SRS good/again + answer lock (parity with #6638 / #6619)
- Extends practice-activity-adapters + LexiconPractice host

## Verification
- Focused Vitest **215** tests passed
- `git show --check` clean

Refs #4700 #4387

X-Agent: codex/practice-lu-activities-sprint-b