### PR TITLE
Phase 3: reconcile Saint Sophia corpus state

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_saint_sophia_db_reconciliation_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_saint_sophia_db_reconciliation_v1.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://learn-ukrainian.github.io/contracts/phase3_saint_sophia_db_reconciliation_v1.schema.json",
+  "title":"Phase 3 Saint Sophia database reconciliation receipt",
+  "type":"object","additionalProperties":false,
+  "required":["schema_version","text_free","provider_calls","mode","bindings","database","invariants","safeguards","phase_boundaries","receipt_sha256"],
+  "properties":{
+    "schema_version":{"const":"phase3_saint_sophia_db_reconciliation_v1"},"text_free":{"const":true},"provider_calls":{"const":false},
+    "mode":{"enum":["candidate_atomic_replace","in_place_sqlite_backup"]},"bindings":{"$ref":"#/$defs/bindings"},"database":{"$ref":"#/$defs/database"},"invariants":{"$ref":"#/$defs/invariants"},"safeguards":{"$ref":"#/$defs/safeguards"},"phase_boundaries":{"$ref":"#/$defs/phaseBoundaries"},"receipt_sha256":{"$ref":"#/$defs/sha256"}
+  },
+  "$defs":{
+    "sha256":{"type":"string","pattern":"^[0-9a-f]{64}$"},
+    "bindings":{"type":"object","additionalProperties":false,"required":["implementation_sha256","schema_sha256","denominator_sha256","expected_pre_database_sha256","saint_sophia_jsonl_sha256","saint_sophia_coverage_sha256","coverage_receipt_sha256"],"properties":{"implementation_sha256":{"$ref":"#/$defs/sha256"},"schema_sha256":{"$ref":"#/$defs/sha256"},"denominator_sha256":{"$ref":"#/$defs/sha256"},"expected_pre_database_sha256":{"$ref":"#/$defs/sha256"},"saint_sophia_jsonl_sha256":{"$ref":"#/$defs/sha256"},"saint_sophia_coverage_sha256":{"$ref":"#/$defs/sha256"},"coverage_receipt_sha256":{"$ref":"#/$defs/sha256"}}},
+    "database":{"type":"object","additionalProperties":false,"required":["pre_sha256","post_sha256","historical_rows_before","historical_rows_after","historical_fts_rows_after","foreign_key_failures_before","foreign_key_failures_after","foreign_key_failure_sha256_before","foreign_key_failure_sha256_after"],"properties":{"pre_sha256":{"$ref":"#/$defs/sha256"},"post_sha256":{"$ref":"#/$defs/sha256"},"historical_rows_before":{"type":"integer","minimum":0},"historical_rows_after":{"type":"integer","minimum":1},"historical_fts_rows_after":{"type":"integer","minimum":1},"foreign_key_failures_before":{"type":"integer","minimum":0},"foreign_key_failures_after":{"type":"integer","minimum":0},"foreign_key_failure_sha256_before":{"$ref":"#/$defs/sha256"},"foreign_key_failure_sha256_after":{"$ref":"#/$defs/sha256"}}},
+    "invariants":{"type":"object","additionalProperties":false,"required":["saint_sophia_id_set_sha256","non_historical_table_fingerprint_before","non_historical_table_fingerprint_after","integrity_check"],"properties":{"saint_sophia_id_set_sha256":{"$ref":"#/$defs/sha256"},"non_historical_table_fingerprint_before":{"$ref":"#/$defs/sha256"},"non_historical_table_fingerprint_after":{"$ref":"#/$defs/sha256"},"integrity_check":{"const":"ok"}}},
+    "safeguards":{"type":"object","additionalProperties":false,"required":["exact_expected_rows","exact_fts_parity","foreign_key_failures_unchanged","non_historical_invariants_unchanged","output_private_0600"],"properties":{"exact_expected_rows":{"const":true},"exact_fts_parity":{"const":true},"foreign_key_failures_unchanged":{"const":true},"non_historical_invariants_unchanged":{"const":true},"output_private_0600":{"const":true}}},
+    "phaseBoundaries":{"type":"object","additionalProperties":false,"required":["historical_modern_correction_eligible","phase4_blocked"],"properties":{"historical_modern_correction_eligible":{"const":false},"phase4_blocked":{"const":true}}}
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_v3_prefreeze_readiness_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_v3_prefreeze_readiness_v1.schema.json
@@ -67,6 +67,10 @@
         "historical_full_gate_receipt_sha256": {"$ref": "#/$defs/sha256"},
         "historical_full_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
         "historical_full_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_schema_sha256": {"$ref": "#/$defs/sha256"},
         "sources_database_sha256": {"$ref": "#/$defs/sha256"},
         "prefreeze_implementation_sha256": {"$ref": "#/$defs/sha256"},
         "prefreeze_schema_sha256": {"$ref": "#/$defs/sha256"}
@@ -208,6 +212,7 @@
         "university_content_audit_ready": {"const": true},
         "university_source_freeze_ready": {"const": true},
         "historical_full_materialization_ready": {"const": true},
+        "saint_sophia_db_reconciliation_ready": {"type": "boolean"},
         "linguistic_representation_ready": {"const": true},
         "semantic_canary_ready": {"const": true},
         "functional_role_contract_ready": {"const": true},

--- a/scripts/projects/open_model_data/phase3_saint_sophia_db_reconciliation.py
+++ b/scripts/projects/open_model_data/phase3_saint_sophia_db_reconciliation.py
@@ -344,10 +344,16 @@ def reconcile(*, database_path: Path, expected_pre_db_sha256: str, jsonl_path: P
     candidate_ingest_receipt: Path | None = None
     rollback: Path | None = None
     cutover_started = False
+    rollback_retained = False
     try:
         _reject_nonempty_wal(target)
+        require(
+            sha256_file(target) == before["sha256"],
+            "pre-database bytes drifted before reconciliation",
+        )
         rollback = _candidate_path(target)
         shutil.copy2(target, rollback)
+        os.chmod(rollback, PRIVATE_FILE_MODE)
         candidate = _candidate_path(target)
         _sqlite_backup(target, candidate)
         candidate_ingest_receipt = candidate.with_suffix(".ingest-receipt.json")
@@ -384,9 +390,16 @@ def reconcile(*, database_path: Path, expected_pre_db_sha256: str, jsonl_path: P
         receipt = validate_receipt(_receipt(mode=mode, collection=collection, denominator_hash=denominator_hash, jsonl_path=Path(jsonl_path), coverage_path=Path(coverage_receipt_path), before=before, after=after, post_sha256=post_sha256))
         _atomic_write_private(Path(output_receipt_path), receipt)
         return receipt
-    except BaseException:
+    except BaseException as reconciliation_error:
         if cutover_started and rollback is not None:
-            _restore_exact_prestate(rollback, target, before["sha256"])
+            try:
+                _restore_exact_prestate(rollback, target, before["sha256"])
+            except BaseException as restore_error:
+                rollback_retained = True
+                raise SaintSophiaReconciliationError(
+                    "reconciliation and automatic rollback both failed; "
+                    f"exact predecessor copy retained at {rollback}: {restore_error}"
+                ) from reconciliation_error
         raise
     finally:
         if candidate is not None:
@@ -394,7 +407,7 @@ def reconcile(*, database_path: Path, expected_pre_db_sha256: str, jsonl_path: P
             _cleanup_sidecars(candidate)
         if candidate_ingest_receipt is not None:
             candidate_ingest_receipt.unlink(missing_ok=True)
-        if rollback is not None:
+        if rollback is not None and not rollback_retained:
             rollback.unlink(missing_ok=True)
             _cleanup_sidecars(rollback)
 

--- a/scripts/projects/open_model_data/phase3_saint_sophia_db_reconciliation.py
+++ b/scripts/projects/open_model_data/phase3_saint_sophia_db_reconciliation.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Fail-closed Saint Sophia historical-corpus reconciliation for ``sources.db``.
+
+The default is a plan only. ``--apply`` validates a same-directory candidate
+and atomically replaces the target. ``--apply-in-place`` validates the same
+candidate then uses SQLite online backup into the existing target inode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import yaml
+from jsonschema import Draft202012Validator
+
+from scripts.ingest import incremental_historical_source_ingest as ingest
+from scripts.wiki import historical_sources
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_saint_sophia_db_reconciliation_v1.schema.json"
+DENOMINATOR_PATH = ROOT / "data/historical_language_corpus_denominator.yaml"
+COLLECTION_ID = "saint-sophia-inscriptions"
+EXPECTED_ROWS = 4_157
+EXPECTED_ID_SET_SHA256 = "44b6428c07a8f496e7b933b53fa7476b8ddd54c548c9c397f2a516f26d3e584b"
+EXPECTED_JSONL_SHA256 = "6199f2a92bd948dfe63d12e9da68637b02a4d16ff58b0ddba3d5e252bb3ec4fe"
+EXPECTED_COVERAGE_SHA256 = "2a12ad921efc1d88f7f039e1de133ceed7c4c39715d622c316e1af14ea29c5a7"
+PRIVATE_FILE_MODE = 0o600
+
+
+class SaintSophiaReconciliationError(ValueError):
+    """The input or database cannot support a safe reconciliation."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SaintSophiaReconciliationError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (canonical_json(value) + "\n").encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with Path(path).open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise SaintSophiaReconciliationError(f"cannot read file: {path}") from exc
+    return digest.hexdigest()
+
+
+def receipt_sha256(value: Mapping[str, Any]) -> str:
+    return sha256_bytes(canonical_bytes({key: item for key, item in value.items() if key != "receipt_sha256"}))
+
+
+def _regular_file(path: Path, label: str) -> None:
+    try:
+        result = Path(path).lstat()
+    except OSError as exc:
+        raise SaintSophiaReconciliationError(f"missing {label}: {path}") from exc
+    require(stat.S_ISREG(result.st_mode) and not Path(path).is_symlink(), f"{label} must be a regular file")
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    _regular_file(path, label)
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SaintSophiaReconciliationError(f"cannot read {label}") from exc
+    require(isinstance(value, dict), f"{label} must be a JSON object")
+    return value
+
+
+def _schema_validator() -> Draft202012Validator:
+    schema = _read_json(SCHEMA_PATH, "reconciliation schema")
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _validate_schema(value: Mapping[str, Any]) -> None:
+    errors = sorted(_schema_validator().iter_errors(value), key=lambda item: list(item.path))
+    if errors:
+        place = "/".join(str(part) for part in errors[0].absolute_path) or "receipt"
+        raise SaintSophiaReconciliationError(f"reconciliation schema violation at {place}: {errors[0].message}")
+
+
+def _denominator() -> tuple[dict[str, Any], str]:
+    _regular_file(DENOMINATOR_PATH, "historical denominator")
+    try:
+        value = yaml.safe_load(DENOMINATOR_PATH.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise SaintSophiaReconciliationError("cannot read historical denominator") from exc
+    require(isinstance(value, dict), "historical denominator must be an object")
+    collections = value.get("collections")
+    require(isinstance(collections, list), "historical denominator collections are missing")
+    collection = next((item for item in collections if item.get("collection_id") == COLLECTION_ID), None)
+    require(isinstance(collection, dict), "Saint Sophia denominator collection is missing")
+    return collection, sha256_file(DENOMINATOR_PATH)
+
+
+def _ids_sha256(values: Sequence[str]) -> str:
+    def sort_key(value: str) -> tuple[int, int | str]:
+        return (0, int(value)) if value.isdecimal() else (1, value)
+
+    return sha256_bytes("".join(f"{value}\n" for value in sorted(values, key=sort_key)).encode("utf-8"))
+
+
+def _foreign_key_evidence(connection: sqlite3.Connection) -> tuple[int, str]:
+    failures = sorted(tuple(row) for row in connection.execute("PRAGMA foreign_key_check").fetchall())
+    return len(failures), sha256_bytes(canonical_json(failures).encode("utf-8"))
+
+
+def _non_historical_fingerprint(connection: sqlite3.Connection) -> str:
+    rows = connection.execute(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master "
+        "WHERE name NOT LIKE 'historical_source_records%' AND name NOT LIKE 'idx_historical_%' "
+        "AND name NOT LIKE 'sqlite_%' ORDER BY type, name"
+    ).fetchall()
+    entries: list[dict[str, Any]] = []
+    for item_type, name, table, definition in rows:
+        entry: dict[str, Any] = {"type": item_type, "name": name, "table": table, "sql": definition}
+        if item_type == "table":
+            count = connection.execute(f'SELECT COUNT(*) FROM "{name.replace(chr(34), chr(34) * 2)}"').fetchone()[0]
+            entry["row_count"] = count
+        entries.append(entry)
+    return sha256_bytes(canonical_json(entries).encode("utf-8"))
+
+
+def _database_evidence(path: Path) -> dict[str, Any]:
+    _regular_file(path, "database")
+    uri = f"file:{Path(path).resolve()}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            has_historical = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='historical_source_records'"
+            ).fetchone()
+            historical_rows = (
+                connection.execute("SELECT COUNT(*) FROM historical_source_records WHERE collection_id=?", (COLLECTION_ID,)).fetchone()[0]
+                if has_historical else 0
+            )
+            historical_fts_rows = (
+                connection.execute(
+                    "SELECT COUNT(*) FROM historical_source_records_fts AS f "
+                    "JOIN historical_source_records AS r ON r.id=f.rowid WHERE r.collection_id=?", (COLLECTION_ID,)
+                ).fetchone()[0]
+                if has_historical else 0
+            )
+            foreign_count, foreign_hash = _foreign_key_evidence(connection)
+            return {
+                "sha256": sha256_file(path), "historical_rows": historical_rows,
+                "historical_fts_rows": historical_fts_rows, "foreign_key_failures": foreign_count,
+                "foreign_key_failure_sha256": foreign_hash,
+                "non_historical_table_fingerprint": _non_historical_fingerprint(connection),
+                "integrity_check": str(connection.execute("PRAGMA integrity_check").fetchone()[0]),
+            }
+    except sqlite3.Error as exc:
+        raise SaintSophiaReconciliationError(f"cannot inspect database: {exc}") from exc
+
+
+def _validate_inputs(*, database_path: Path, expected_pre_db_sha256: str, jsonl_path: Path, coverage_receipt_path: Path) -> tuple[list[tuple[Any, ...]], dict[str, Any], str]:
+    collection, denominator_hash = _denominator()
+    _regular_file(database_path, "database")
+    require(sha256_file(database_path) == expected_pre_db_sha256, "caller expected pre-database SHA-256 does not match")
+    artifact_hashes = collection.get("artifact_sha256")
+    canonical_db = collection.get("canonical_database")
+    require(isinstance(artifact_hashes, dict) and isinstance(canonical_db, dict), "Saint Sophia denominator hashes are missing")
+    _regular_file(jsonl_path, "Saint Sophia JSONL")
+    _regular_file(coverage_receipt_path, "Saint Sophia coverage receipt")
+    require(sha256_file(jsonl_path) == artifact_hashes.get("historical_source_records_jsonl"), "Saint Sophia JSONL hash drift")
+    require(sha256_file(coverage_receipt_path) == artifact_hashes.get("coverage_receipt_json"), "Saint Sophia coverage hash drift")
+    require(canonical_db.get("historical_source_rows") == EXPECTED_ROWS, "Saint Sophia row denominator drift")
+    require(canonical_db.get("historical_fts_rows") == EXPECTED_ROWS, "Saint Sophia FTS denominator drift")
+    require(canonical_db.get("sha256") != expected_pre_db_sha256, "pre-database SHA must be pre-reconciliation")
+    try:
+        rows = historical_sources.load_rows(jsonl_path)
+    except historical_sources.HistoricalSourceError as exc:
+        raise SaintSophiaReconciliationError(str(exc)) from exc
+    require(len(rows) == EXPECTED_ROWS and {row[0] for row in rows} == {COLLECTION_ID}, "Saint Sophia input rows drift")
+    require(_ids_sha256([str(row[1]) for row in rows]) == EXPECTED_ID_SET_SHA256, "Saint Sophia input ID set drift")
+    coverage = _read_json(coverage_receipt_path, "Saint Sophia coverage receipt")
+    require(coverage.get("public_inscription_count") == EXPECTED_ROWS, "coverage receipt row count drift")
+    require(coverage.get("id_set_sha256") == EXPECTED_ID_SET_SHA256, "coverage receipt ID set drift")
+    try:
+        ingest._read_coverage_receipt(coverage_receipt_path, jsonl_path=jsonl_path, rows=rows)
+    except historical_sources.HistoricalSourceError as exc:
+        raise SaintSophiaReconciliationError(str(exc)) from exc
+    return rows, collection, denominator_hash
+
+
+def _verify_post_evidence(path: Path, before: Mapping[str, Any]) -> dict[str, Any]:
+    after = _database_evidence(path)
+    require(after["historical_rows"] == EXPECTED_ROWS, "Saint Sophia row denominator drift")
+    require(after["historical_fts_rows"] == EXPECTED_ROWS, "Saint Sophia FTS parity drift")
+    require(after["integrity_check"] == "ok", "PRAGMA integrity_check is not ok")
+    require(
+        (after["foreign_key_failures"], after["foreign_key_failure_sha256"])
+        == (before["foreign_key_failures"], before["foreign_key_failure_sha256"]),
+        "foreign-key failures changed",
+    )
+    require(
+        after["non_historical_table_fingerprint"] == before["non_historical_table_fingerprint"],
+        "non-historical corpus/table invariants changed",
+    )
+    return after
+
+
+def _candidate_path(live_path: Path) -> Path:
+    fd, candidate = tempfile.mkstemp(dir=live_path.parent, prefix=f".{live_path.name}.saint-sophia-", suffix=".candidate")
+    os.close(fd)
+    return Path(candidate)
+
+
+def _sidecars(path: Path) -> tuple[Path, Path]:
+    return path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm")
+
+
+def _reject_nonempty_wal(path: Path) -> None:
+    wal, _ = _sidecars(path)
+    require(not wal.exists() or wal.stat().st_size == 0, "database has a non-empty WAL; reconciliation is unsafe")
+
+
+def _cleanup_sidecars(path: Path) -> None:
+    for sidecar in _sidecars(path):
+        sidecar.unlink(missing_ok=True)
+
+
+def _require_empty_or_absent_wal(path: Path) -> None:
+    wal, _ = _sidecars(path)
+    require(not wal.exists() or wal.stat().st_size == 0, "database WAL remains non-empty after backup")
+
+
+def _sqlite_backup(source: Path, target: Path) -> None:
+    """Copy a closed SQLite snapshot while preserving *target*'s inode."""
+    source_uri = f"file:{Path(source).resolve()}?mode=ro"
+    try:
+        with sqlite3.connect(source_uri, uri=True) as source_connection, sqlite3.connect(target) as target_connection:
+            source_connection.backup(target_connection)
+            target_connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.Error as exc:
+        raise SaintSophiaReconciliationError(f"SQLite online backup failed: {exc}") from exc
+
+
+def _restore_exact_prestate(rollback: Path, target: Path, expected_sha256: str) -> None:
+    """First use SQLite backup, then byte-rescue if SQLite layout differs."""
+    _sqlite_backup(rollback, target)
+    _require_empty_or_absent_wal(target)
+    if sha256_file(target) != expected_sha256:
+        with rollback.open("rb") as source, target.open("r+b") as destination:
+            destination.seek(0)
+            destination.truncate(0)
+            shutil.copyfileobj(source, destination)
+            destination.flush()
+            os.fsync(destination.fileno())
+    _require_empty_or_absent_wal(target)
+    require(sha256_file(target) == expected_sha256, "rollback did not restore the exact pre-database SHA-256")
+
+
+def _atomic_write_private(path: Path, value: Mapping[str, Any]) -> None:
+    parent = Path(path).parent
+    parent.mkdir(parents=True, exist_ok=True)
+    require(parent.is_dir() and not parent.is_symlink(), "receipt parent must be a real directory")
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=parent, prefix=f".{Path(path).name}.", delete=False) as handle:
+            temporary = Path(handle.name)
+            handle.write(canonical_bytes(value))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, PRIVATE_FILE_MODE)
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _receipt(*, mode: str, collection: Mapping[str, Any], denominator_hash: str, jsonl_path: Path, coverage_path: Path, before: Mapping[str, Any], after: Mapping[str, Any], post_sha256: str) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version":"phase3_saint_sophia_db_reconciliation_v1", "text_free":True, "provider_calls":False, "mode":mode,
+        "bindings":{"implementation_sha256":sha256_file(Path(__file__).resolve()), "schema_sha256":sha256_file(SCHEMA_PATH), "denominator_sha256":denominator_hash, "expected_pre_database_sha256":before["sha256"], "saint_sophia_jsonl_sha256":sha256_file(jsonl_path), "saint_sophia_coverage_sha256":sha256_file(coverage_path), "coverage_receipt_sha256":sha256_file(coverage_path)},
+        "database":{"pre_sha256":before["sha256"], "post_sha256":post_sha256, "historical_rows_before":before["historical_rows"], "historical_rows_after":after["historical_rows"], "historical_fts_rows_after":after["historical_fts_rows"], "foreign_key_failures_before":before["foreign_key_failures"], "foreign_key_failures_after":after["foreign_key_failures"], "foreign_key_failure_sha256_before":before["foreign_key_failure_sha256"], "foreign_key_failure_sha256_after":after["foreign_key_failure_sha256"]},
+        "invariants":{"saint_sophia_id_set_sha256":collection["public_record_id_set_sha256"], "non_historical_table_fingerprint_before":before["non_historical_table_fingerprint"], "non_historical_table_fingerprint_after":after["non_historical_table_fingerprint"], "integrity_check":after["integrity_check"]},
+        "safeguards":{"exact_expected_rows":True,"exact_fts_parity":True,"foreign_key_failures_unchanged":True,"non_historical_invariants_unchanged":True,"output_private_0600":True},
+        "phase_boundaries":{"historical_modern_correction_eligible":False,"phase4_blocked":True},
+    }
+    return {**body, "receipt_sha256":receipt_sha256(body)}
+
+
+def validate_receipt(value: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = dict(value)
+    _validate_schema(receipt)
+    require(receipt["receipt_sha256"] == receipt_sha256(receipt), "reconciliation receipt body hash drift")
+    require(receipt["provider_calls"] is False and receipt["phase_boundaries"]["phase4_blocked"] is True, "reconciliation boundary drift")
+    require(receipt["database"]["pre_sha256"] == receipt["bindings"]["expected_pre_database_sha256"], "pre-database binding drift")
+    require(receipt["database"]["historical_rows_after"] == EXPECTED_ROWS, "historical row denominator drift")
+    require(receipt["database"]["historical_fts_rows_after"] == EXPECTED_ROWS, "historical FTS denominator drift")
+    require(receipt["invariants"]["saint_sophia_id_set_sha256"] == EXPECTED_ID_SET_SHA256, "Saint Sophia ID set drift")
+    bindings = receipt["bindings"]
+    require(bindings["saint_sophia_jsonl_sha256"] == EXPECTED_JSONL_SHA256, "Saint Sophia JSONL binding drift")
+    require(bindings["saint_sophia_coverage_sha256"] == EXPECTED_COVERAGE_SHA256, "Saint Sophia coverage binding drift")
+    require(bindings["coverage_receipt_sha256"] == EXPECTED_COVERAGE_SHA256, "Saint Sophia duplicate coverage binding drift")
+    require(receipt["database"]["foreign_key_failures_before"] == receipt["database"]["foreign_key_failures_after"], "foreign-key failure count drift")
+    require(receipt["database"]["foreign_key_failure_sha256_before"] == receipt["database"]["foreign_key_failure_sha256_after"], "foreign-key failure fingerprint drift")
+    require(receipt["invariants"]["non_historical_table_fingerprint_before"] == receipt["invariants"]["non_historical_table_fingerprint_after"], "non-historical invariant drift")
+    return receipt
+
+
+def reconcile(*, database_path: Path, expected_pre_db_sha256: str, jsonl_path: Path, coverage_receipt_path: Path, output_receipt_path: Path | None = None, apply: bool = False, apply_in_place: bool = False) -> dict[str, Any]:
+    """Plan by default; apply exactly one explicit, fail-closed mutation mode."""
+    require(not (apply and apply_in_place), "choose only one apply mode")
+    rows, collection, denominator_hash = _validate_inputs(database_path=Path(database_path), expected_pre_db_sha256=expected_pre_db_sha256, jsonl_path=Path(jsonl_path), coverage_receipt_path=Path(coverage_receipt_path))
+    before = _database_evidence(Path(database_path))
+    plan = {"text_free":True,"provider_calls":False,"mode":"dry_run","pre_database_sha256":before["sha256"],"input_rows":len(rows),"saint_sophia_id_set_sha256":EXPECTED_ID_SET_SHA256,"phase4_blocked":True}
+    if not apply and not apply_in_place:
+        return plan
+    require(output_receipt_path is not None, "output receipt is required for apply")
+    mode = "in_place_sqlite_backup" if apply_in_place else "candidate_atomic_replace"
+    target = Path(database_path)
+    candidate: Path | None = None
+    candidate_ingest_receipt: Path | None = None
+    rollback: Path | None = None
+    cutover_started = False
+    try:
+        _reject_nonempty_wal(target)
+        rollback = _candidate_path(target)
+        shutil.copy2(target, rollback)
+        candidate = _candidate_path(target)
+        _sqlite_backup(target, candidate)
+        candidate_ingest_receipt = candidate.with_suffix(".ingest-receipt.json")
+        try:
+            ingest.ingest(
+                db_path=candidate,
+                jsonl_path=Path(jsonl_path),
+                coverage_receipt_path=Path(coverage_receipt_path),
+                output_receipt_path=candidate_ingest_receipt,
+            )
+        except (historical_sources.HistoricalSourceError, OSError, sqlite3.Error) as exc:
+            raise SaintSophiaReconciliationError(str(exc)) from exc
+        after_candidate = _verify_post_evidence(candidate, before)
+        candidate_ingest_receipt.unlink(missing_ok=True)
+        candidate_ingest_receipt = None
+        if apply:
+            cutover_started = True
+            os.replace(candidate, target)
+            candidate = None
+            _require_empty_or_absent_wal(target)
+            after = _verify_post_evidence(target, before)
+            post_sha256 = sha256_file(target)
+        else:
+            cutover_started = True
+            _sqlite_backup(candidate, target)
+            _require_empty_or_absent_wal(target)
+            after = _verify_post_evidence(target, before)
+            post_sha256 = sha256_file(target)
+        require(
+            {key: value for key, value in after.items() if key != "sha256"}
+            == {key: value for key, value in after_candidate.items() if key != "sha256"},
+            "live postconditions differ from validated candidate",
+        )
+        receipt = validate_receipt(_receipt(mode=mode, collection=collection, denominator_hash=denominator_hash, jsonl_path=Path(jsonl_path), coverage_path=Path(coverage_receipt_path), before=before, after=after, post_sha256=post_sha256))
+        _atomic_write_private(Path(output_receipt_path), receipt)
+        return receipt
+    except BaseException:
+        if cutover_started and rollback is not None:
+            _restore_exact_prestate(rollback, target, before["sha256"])
+        raise
+    finally:
+        if candidate is not None:
+            candidate.unlink(missing_ok=True)
+            _cleanup_sidecars(candidate)
+        if candidate_ingest_receipt is not None:
+            candidate_ingest_receipt.unlink(missing_ok=True)
+        if rollback is not None:
+            rollback.unlink(missing_ok=True)
+            _cleanup_sidecars(rollback)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database", type=Path, required=True)
+    parser.add_argument("--expected-pre-db-sha256", required=True)
+    parser.add_argument("--saint-sophia-jsonl", type=Path, required=True)
+    parser.add_argument("--coverage-receipt", type=Path, required=True)
+    parser.add_argument("--output-receipt", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--apply-in-place", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = reconcile(database_path=args.database, expected_pre_db_sha256=args.expected_pre_db_sha256, jsonl_path=args.saint_sophia_jsonl, coverage_receipt_path=args.coverage_receipt, output_receipt_path=args.output_receipt, apply=args.apply, apply_in_place=args.apply_in_place)
+        print(canonical_json({"ok":True,"mode":result["mode"],"receipt_sha256":result.get("receipt_sha256")}))
+    except SaintSophiaReconciliationError as exc:
+        print(canonical_json({"ok": False, "error": str(exc)}))
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
+++ b/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
@@ -28,6 +28,7 @@ from jsonschema import Draft202012Validator
 from scripts.projects.open_model_data import phase3_historical_full_materialization as historical
 from scripts.projects.open_model_data import phase3_linguistic_canary as canary
 from scripts.projects.open_model_data import phase3_linguistic_representation as representation
+from scripts.projects.open_model_data import phase3_saint_sophia_db_reconciliation as sophia_reconciliation
 from scripts.projects.open_model_data import phase3_ua_gec_complete_context as ua_context
 from scripts.projects.open_model_data import phase3_university_content_audit_freeze as university
 from scripts.projects.open_model_data import phase3_v2_compatibility as compatibility
@@ -155,6 +156,30 @@ def _validate_historical_receipt(path: Path, gate_file_sha256: str) -> tuple[dic
     return value, sha256_file(path)
 
 
+def _validate_saint_sophia_reconciliation_receipt(
+    path: Path, *, university_database_sha256: str, current_database_sha256: str
+) -> tuple[dict[str, Any], str]:
+    value = _read_json(path, "Saint Sophia database reconciliation receipt")
+    require(
+        stat.S_IMODE(Path(path).stat().st_mode) == PRIVATE_FILE_MODE,
+        "Saint Sophia reconciliation receipt must be mode 0600",
+    )
+    try:
+        receipt = sophia_reconciliation.validate_receipt(value)
+    except sophia_reconciliation.SaintSophiaReconciliationError as exc:
+        raise PrefreezeReadinessError(str(exc)) from exc
+    bindings = receipt["bindings"]
+    require(bindings["implementation_sha256"] == sha256_file(Path(sophia_reconciliation.__file__).resolve()), "Saint Sophia reconciliation implementation drift")
+    require(bindings["schema_sha256"] == sha256_file(sophia_reconciliation.SCHEMA_PATH), "Saint Sophia reconciliation schema drift")
+    require(
+        bindings["denominator_sha256"] == sha256_file(sophia_reconciliation.DENOMINATOR_PATH),
+        "Saint Sophia reconciliation denominator drift",
+    )
+    require(receipt["database"]["pre_sha256"] == university_database_sha256, "Saint Sophia pre-database hash does not equal university freeze")
+    require(receipt["database"]["post_sha256"] == current_database_sha256, "Saint Sophia post-database hash does not equal current sources database")
+    return receipt, sha256_file(path)
+
+
 def _validate_university_freeze() -> tuple[dict[str, Any], str]:
     value = _read_json(UNIVERSITY_FREEZE_PATH, "university content-audit freeze")
     try:
@@ -195,6 +220,7 @@ def build_readiness(
     ua_gec_root: Path,
     ua_gec_context_receipt_path: Path,
     historical_full_receipt_path: Path,
+    saint_sophia_reconciliation_receipt_path: Path | None = None,
 ) -> dict[str, Any]:
     """Build and validate the deterministic, explicitly incomplete receipt."""
     _validate_reboot_prompt(Path(phase3_reboot_prompt_path))
@@ -215,13 +241,22 @@ def build_readiness(
         Path(ua_gec_context_receipt_path), sources_database_sha256
     )
     university_freeze, university_file_sha256 = _validate_university_freeze()
-    require(
-        university_freeze["database"]["sha256"] == sources_database_sha256,
-        "university freeze and sources database hash disagree",
-    )
     historical_receipt, historical_receipt_file_sha256 = _validate_historical_receipt(
         Path(historical_full_receipt_path), historical_gate_file_sha256
     )
+    sophia_receipt: dict[str, Any] | None = None
+    sophia_receipt_file_sha256: str | None = None
+    if saint_sophia_reconciliation_receipt_path is not None:
+        sophia_receipt, sophia_receipt_file_sha256 = _validate_saint_sophia_reconciliation_receipt(
+            Path(saint_sophia_reconciliation_receipt_path),
+            university_database_sha256=university_freeze["database"]["sha256"],
+            current_database_sha256=sources_database_sha256,
+        )
+    else:
+        require(
+            university_freeze["database"]["sha256"] == sources_database_sha256,
+            "university freeze and sources database hash disagree",
+        )
     battery, canary_verification = _validate_canary(Path(ua_gec_root))
 
     ua_complete = ua_receipt["complete_context"]
@@ -258,6 +293,15 @@ def build_readiness(
             "historical_full_gate_receipt_sha256": historical_gate["receipt_sha256"],
             "historical_full_receipt_file_sha256": historical_receipt_file_sha256,
             "historical_full_receipt_sha256": historical_receipt["receipt_sha256"],
+            **(
+                {
+                    "saint_sophia_reconciliation_receipt_file_sha256": sophia_receipt_file_sha256,
+                    "saint_sophia_reconciliation_receipt_sha256": sophia_receipt["receipt_sha256"],
+                    "saint_sophia_reconciliation_implementation_sha256": sha256_file(Path(sophia_reconciliation.__file__).resolve()),
+                    "saint_sophia_reconciliation_schema_sha256": sha256_file(sophia_reconciliation.SCHEMA_PATH),
+                }
+                if sophia_receipt is not None else {}
+            ),
             "sources_database_sha256": sources_database_sha256,
             "prefreeze_implementation_sha256": sha256_file(SCRIPT_PATH),
             "prefreeze_schema_sha256": sha256_file(SCHEMA_PATH),
@@ -320,6 +364,7 @@ def build_readiness(
             "university_content_audit_ready": True,
             "university_source_freeze_ready": True,
             "historical_full_materialization_ready": True,
+            "saint_sophia_db_reconciliation_ready": sophia_receipt is not None,
             "linguistic_representation_ready": True,
             "semantic_canary_ready": True,
             "functional_role_contract_ready": True,
@@ -356,6 +401,20 @@ def validate_readiness(value: Mapping[str, Any]) -> dict[str, Any]:
     require(receipt["readiness"]["complete_evaluation_package_ready"] is False, "evaluation package overclaim")
     require(receipt["gates"]["source_authoring_authorized"] is False, "source authoring opened before freeze")
     require(receipt["gates"]["phase4_blocked"] is True, "Phase 4 opened before Phase 3 completion")
+    bindings = receipt["bindings"]
+    sophia_keys = {
+        "saint_sophia_reconciliation_receipt_file_sha256",
+        "saint_sophia_reconciliation_receipt_sha256",
+        "saint_sophia_reconciliation_implementation_sha256",
+        "saint_sophia_reconciliation_schema_sha256",
+    }
+    require(sophia_keys.issubset(bindings) or not sophia_keys.intersection(bindings), "partial Saint Sophia reconciliation binding")
+    readiness_value = receipt["readiness"].get("saint_sophia_db_reconciliation_ready")
+    if readiness_value is not None:
+        require(
+            readiness_value is sophia_keys.issubset(bindings),
+            "Saint Sophia readiness does not equal reconciliation binding presence",
+        )
     return receipt
 
 
@@ -380,6 +439,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--ua-gec-root", type=Path, required=True)
     parser.add_argument("--ua-gec-context-receipt", type=Path, required=True)
     parser.add_argument("--historical-full-receipt", type=Path, required=True)
+    parser.add_argument("--saint-sophia-reconciliation-receipt", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args(argv)
 
@@ -393,6 +453,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ua_gec_root=args.ua_gec_root,
             ua_gec_context_receipt_path=args.ua_gec_context_receipt,
             historical_full_receipt_path=args.historical_full_receipt,
+            saint_sophia_reconciliation_receipt_path=args.saint_sophia_reconciliation_receipt,
         )
         _atomic_write(args.output, canonical_bytes(receipt))
         print(canonical_json({"ok": True, "output": str(args.output), "receipt_sha256": receipt["receipt_sha256"]}))

--- a/tests/test_open_model_phase3_saint_sophia_db_reconciliation.py
+++ b/tests/test_open_model_phase3_saint_sophia_db_reconciliation.py
@@ -212,6 +212,74 @@ def test_live_backup_failure_after_copy_restores_exact_prestate(tmp_path: Path, 
     assert not list(tmp_path.glob(".sources.db.saint-sophia-*"))
 
 
+def test_restore_failure_retains_private_exact_predecessor_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    original_backup = reconciliation._sqlite_backup
+    interrupted = False
+
+    def copy_then_fail(source: Path, target: Path) -> None:
+        nonlocal interrupted
+        original_backup(source, target)
+        if target == database and not interrupted:
+            interrupted = True
+            raise reconciliation.SaintSophiaReconciliationError("cutover failure")
+
+    def fail_restore(*_args: object, **_kwargs: object) -> None:
+        raise reconciliation.SaintSophiaReconciliationError("restore failure")
+
+    monkeypatch.setattr(reconciliation, "_sqlite_backup", copy_then_fail)
+    monkeypatch.setattr(reconciliation, "_restore_exact_prestate", fail_restore)
+    with pytest.raises(
+        reconciliation.SaintSophiaReconciliationError,
+        match="exact predecessor copy retained",
+    ) as caught:
+        reconciliation.reconcile(
+            database_path=database,
+            expected_pre_db_sha256=expected,
+            jsonl_path=jsonl,
+            coverage_receipt_path=coverage,
+            output_receipt_path=tmp_path / "never.json",
+            apply_in_place=True,
+        )
+    retained = list(tmp_path.glob(".sources.db.saint-sophia-*.candidate"))
+    assert len(retained) == 1
+    assert str(retained[0]) in str(caught.value)
+    assert reconciliation.sha256_file(retained[0]) == expected
+    assert stat.S_IMODE(retained[0].stat().st_mode) == 0o600
+    assert not (tmp_path / "never.json").exists()
+
+
+def test_predecessor_drift_is_rechecked_immediately_before_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    original_evidence = reconciliation._database_evidence
+
+    def mutate_after_evidence(path: Path) -> dict[str, object]:
+        evidence = original_evidence(path)
+        with sqlite3.connect(path) as connection:
+            connection.execute("UPDATE stable_records SET value='drifted' WHERE id=1")
+        return evidence
+
+    monkeypatch.setattr(reconciliation, "_database_evidence", mutate_after_evidence)
+    with pytest.raises(
+        reconciliation.SaintSophiaReconciliationError,
+        match="pre-database bytes drifted",
+    ):
+        reconciliation.reconcile(
+            database_path=database,
+            expected_pre_db_sha256=expected,
+            jsonl_path=jsonl,
+            coverage_receipt_path=coverage,
+            output_receipt_path=tmp_path / "never.json",
+            apply_in_place=True,
+        )
+    assert not list(tmp_path.glob(".sources.db.saint-sophia-*.candidate"))
+    assert not (tmp_path / "never.json").exists()
+
+
 def test_receipt_rejects_authority_or_boundary_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
     receipt = reconciliation.reconcile(database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl, coverage_receipt_path=coverage, output_receipt_path=tmp_path / "receipt.json", apply=True)

--- a/tests/test_open_model_phase3_saint_sophia_db_reconciliation.py
+++ b/tests/test_open_model_phase3_saint_sophia_db_reconciliation.py
@@ -1,0 +1,227 @@
+"""Hermetic fixture tests for Saint Sophia database reconciliation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_saint_sophia_db_reconciliation as reconciliation
+
+
+def _row(source_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "historical-source-record.v1", "collection_id": reconciliation.COLLECTION_ID,
+        "source_record_id": source_id, "title": None, "source_url": None, "published": True,
+        "original_transcription": None, "epidoc_text": None, "epidoc_interpretation": None,
+        "interpretative_edition": None, "romanisation": None, "translation_ukr": None,
+        "translation_eng": None, "commentary_ukr": None, "commentary_eng": None,
+        "source_language_label": None, "source_writing_system_label": None, "min_year": None,
+        "max_year": None, "disposition": "non_textual_or_no_text", "stage_label": None,
+        "quality_flags": [], "metadata": {}, "raw_record_sha256": "a" * 64,
+    }
+
+
+def _fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path, str]:
+    jsonl = tmp_path / "saint-sophia.jsonl"
+    identifiers = ["1", "2"]
+    jsonl.write_text("".join(json.dumps(_row(identifier), separators=(",", ":")) + "\n" for identifier in identifiers), encoding="utf-8")
+    id_hash = reconciliation._ids_sha256(identifiers)
+    coverage = tmp_path / "coverage.json"
+    coverage_value = {
+        "public_inscription_count": 2, "id_set_sha256": id_hash,
+        "output_hashes": {"historical_source_records.jsonl": reconciliation.sha256_file(jsonl)},
+    }
+    coverage.write_text(json.dumps(coverage_value), encoding="utf-8")
+    database = tmp_path / "sources.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE stable_records (id INTEGER PRIMARY KEY, value TEXT)")
+        connection.execute("INSERT INTO stable_records VALUES (1, 'fixture')")
+    expected = reconciliation.sha256_file(database)
+    collection = {
+        "collection_id": reconciliation.COLLECTION_ID,
+        "public_record_id_set_sha256": id_hash,
+        "artifact_sha256": {
+            "historical_source_records_jsonl": reconciliation.sha256_file(jsonl),
+            "coverage_receipt_json": reconciliation.sha256_file(coverage),
+        },
+        "canonical_database": {"historical_source_rows": 2, "historical_fts_rows": 2, "sha256": "b" * 64},
+    }
+    monkeypatch.setattr(reconciliation, "EXPECTED_ROWS", 2)
+    monkeypatch.setattr(reconciliation, "EXPECTED_ID_SET_SHA256", id_hash)
+    monkeypatch.setattr(reconciliation, "EXPECTED_JSONL_SHA256", reconciliation.sha256_file(jsonl))
+    monkeypatch.setattr(reconciliation, "EXPECTED_COVERAGE_SHA256", reconciliation.sha256_file(coverage))
+    monkeypatch.setattr(reconciliation, "_denominator", lambda: (collection, "c" * 64))
+    return database, jsonl, coverage, expected
+
+
+def test_dry_run_is_text_free_and_does_not_mutate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    result = reconciliation.reconcile(
+        database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+        coverage_receipt_path=coverage,
+    )
+    assert result["mode"] == "dry_run"
+    assert result["text_free"] is True and result["provider_calls"] is False
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='historical_source_records'"
+        ).fetchone() is None
+        assert connection.execute("SELECT value FROM stable_records").fetchone()[0] == "fixture"
+
+
+def test_numeric_ids_match_established_numeric_first_hash() -> None:
+    assert reconciliation._ids_sha256(["2", "10"]) == reconciliation.ingest._sha256_lines(["2", "10"])
+
+
+def test_candidate_apply_writes_private_receipt_and_preserves_non_historical_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    receipt_path = tmp_path / "private-receipt.json"
+    receipt = reconciliation.reconcile(
+        database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+        coverage_receipt_path=coverage, output_receipt_path=receipt_path, apply=True,
+    )
+    assert reconciliation.validate_receipt(receipt) == receipt
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o600
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 2
+        assert connection.execute("SELECT COUNT(*) FROM historical_source_records_fts").fetchone()[0] == 2
+        assert connection.execute("SELECT value FROM stable_records").fetchone()[0] == "fixture"
+
+
+def test_candidate_failure_keeps_live_database_and_output_receipt_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text("previous", encoding="utf-8")
+    before_database = database.read_bytes()
+    monkeypatch.setattr(
+        reconciliation.ingest,
+        "ingest",
+        lambda **_kwargs: (_ for _ in ()).throw(reconciliation.historical_sources.HistoricalSourceError("fixture failure")),
+    )
+    with pytest.raises(reconciliation.SaintSophiaReconciliationError, match="fixture failure"):
+        reconciliation.reconcile(database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl, coverage_receipt_path=coverage, output_receipt_path=receipt_path, apply=True)
+    assert database.read_bytes() == before_database
+    assert receipt_path.read_text(encoding="utf-8") == "previous"
+
+
+def test_in_place_backup_bootstraps_missing_schema_and_preserves_inode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    inode = database.stat().st_ino
+    receipt = reconciliation.reconcile(
+        database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+        coverage_receipt_path=coverage, output_receipt_path=tmp_path / "receipt.json", apply_in_place=True,
+    )
+    assert receipt["mode"] == "in_place_sqlite_backup"
+    assert database.stat().st_ino == inode
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 2
+    assert not list(tmp_path.glob(".sources.db.saint-sophia-*"))
+    assert not list(tmp_path.glob("*.candidate-wal"))
+    assert not list(tmp_path.glob("*.candidate-shm"))
+
+
+def test_in_place_backup_leaves_preexisting_zero_byte_live_sidecars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    wal, shm = reconciliation._sidecars(database)
+    wal.touch()
+    shm.touch()
+    wal_inode, shm_inode = wal.stat().st_ino, shm.stat().st_ino
+    reconciliation.reconcile(
+        database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+        coverage_receipt_path=coverage, output_receipt_path=tmp_path / "receipt.json", apply_in_place=True,
+    )
+    assert wal.exists() and shm.exists()
+    assert wal.stat().st_ino == wal_inode and shm.stat().st_ino == shm_inode
+    assert wal.stat().st_size == 0
+    assert not list(tmp_path.glob(".sources.db.saint-sophia-*"))
+
+
+def test_in_place_transaction_rolls_back_on_postcondition_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    with sqlite3.connect(database) as connection:
+        reconciliation.historical_sources.ensure_historical_source_schema(connection)
+    expected = reconciliation.sha256_file(database)
+    original = reconciliation._non_historical_fingerprint
+    calls = 0
+
+    def changed_fingerprint(connection: sqlite3.Connection) -> str:
+        nonlocal calls
+        calls += 1
+        return original(connection) if calls == 1 else "0" * 64
+
+    monkeypatch.setattr(reconciliation, "_non_historical_fingerprint", changed_fingerprint)
+    with pytest.raises(reconciliation.SaintSophiaReconciliationError, match="non-historical"):
+        reconciliation.reconcile(database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl, coverage_receipt_path=coverage, output_receipt_path=tmp_path / "never.json", apply_in_place=True)
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM historical_source_records").fetchone()[0] == 0
+        assert connection.execute("SELECT value FROM stable_records").fetchone()[0] == "fixture"
+
+
+def test_receipt_write_failure_restores_prestate_and_removes_output_and_temps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "missing-receipt.json"
+    monkeypatch.setattr(
+        reconciliation,
+        "_atomic_write_private",
+        lambda *_args: (_ for _ in ()).throw(OSError("fixture receipt failure")),
+    )
+    with pytest.raises(OSError, match="fixture receipt failure"):
+        reconciliation.reconcile(
+            database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+            coverage_receipt_path=coverage, output_receipt_path=output, apply=True,
+        )
+    assert reconciliation.sha256_file(database) == expected
+    assert not output.exists()
+    assert not list(tmp_path.glob(".sources.db.saint-sophia-*"))
+    assert not list(tmp_path.glob("*.candidate-wal"))
+    assert not list(tmp_path.glob("*.candidate-shm"))
+
+
+def test_live_backup_failure_after_copy_restores_exact_prestate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "missing-receipt.json"
+    original_backup = reconciliation._sqlite_backup
+    interrupted = False
+
+    def copy_then_fail(source: Path, target: Path) -> None:
+        nonlocal interrupted
+        original_backup(source, target)
+        if target == database and not interrupted:
+            interrupted = True
+            raise reconciliation.SaintSophiaReconciliationError("backup interrupted after copy")
+
+    monkeypatch.setattr(reconciliation, "_sqlite_backup", copy_then_fail)
+    with pytest.raises(reconciliation.SaintSophiaReconciliationError, match="backup interrupted"):
+        reconciliation.reconcile(
+            database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl,
+            coverage_receipt_path=coverage, output_receipt_path=output, apply_in_place=True,
+        )
+    assert reconciliation.sha256_file(database) == expected
+    assert not output.exists()
+    assert not list(tmp_path.glob(".sources.db.saint-sophia-*"))
+
+
+def test_receipt_rejects_authority_or_boundary_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, jsonl, coverage, expected = _fixture(tmp_path, monkeypatch)
+    receipt = reconciliation.reconcile(database_path=database, expected_pre_db_sha256=expected, jsonl_path=jsonl, coverage_receipt_path=coverage, output_receipt_path=tmp_path / "receipt.json", apply=True)
+    broken = copy.deepcopy(receipt)
+    broken["provider_calls"] = True
+    broken["receipt_sha256"] = reconciliation.receipt_sha256(broken)
+    with pytest.raises(reconciliation.SaintSophiaReconciliationError):
+        reconciliation.validate_receipt(broken)
+    forged = copy.deepcopy(receipt)
+    forged["bindings"]["saint_sophia_jsonl_sha256"] = "0" * 64
+    forged["receipt_sha256"] = reconciliation.receipt_sha256(forged)
+    with pytest.raises(reconciliation.SaintSophiaReconciliationError, match="JSONL binding drift"):
+        reconciliation.validate_receipt(forged)

--- a/tests/test_open_model_phase3_v3_prefreeze_readiness.py
+++ b/tests/test_open_model_phase3_v3_prefreeze_readiness.py
@@ -157,6 +157,154 @@ def test_validator_preserves_historical_v1_receipts_without_adapter_binding(
     assert readiness.validate_readiness(receipt) == receipt
 
 
+def test_optional_saint_sophia_receipt_binds_without_opening_other_gates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_external_receipts(monkeypatch)
+    saint_receipt = {"receipt_sha256": SHA_A}
+    captured: dict[str, str] = {}
+
+    def validate_saint(path: Path, *, university_database_sha256: str, current_database_sha256: str) -> tuple[dict, str]:
+        captured.update({"path": str(path), "pre": university_database_sha256, "post": current_database_sha256})
+        return saint_receipt, SHA_B
+
+    monkeypatch.setattr(readiness, "_validate_saint_sophia_reconciliation_receipt", validate_saint)
+    receipt = readiness.build_readiness(
+        phase3_reboot_prompt_path=Path("unused"), sources_database_path=Path("unused"),
+        ua_gec_root=Path("unused"), ua_gec_context_receipt_path=Path("unused"),
+        historical_full_receipt_path=Path("unused"),
+        saint_sophia_reconciliation_receipt_path=Path("saint-sophia.json"),
+    )
+    assert captured == {
+        "path": "saint-sophia.json", "pre": readiness.university.EXPECTED_DATABASE["sha256"],
+        "post": readiness.university.EXPECTED_DATABASE["sha256"],
+    }
+    assert receipt["readiness"]["saint_sophia_db_reconciliation_ready"] is True
+    assert receipt["gates"]["phase4_blocked"] is True
+    assert receipt["gates"]["source_authoring_authorized"] is False
+    assert receipt["bindings"]["saint_sophia_reconciliation_receipt_sha256"] == SHA_A
+
+
+def test_optional_saint_sophia_receipt_allows_distinct_pre_and_post_database_hashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_external_receipts(monkeypatch)
+    pre_sha, post_sha = "c" * 64, "d" * 64
+    monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: post_sha)
+    university_freeze, university_file_sha256 = readiness._validate_university_freeze()
+    university_freeze = copy.deepcopy(university_freeze)
+    university_freeze["database"]["sha256"] = pre_sha
+    monkeypatch.setattr(readiness, "_validate_university_freeze", lambda: (university_freeze, university_file_sha256))
+    captured: dict[str, str] = {}
+
+    def validate_saint(_path: Path, *, university_database_sha256: str, current_database_sha256: str) -> tuple[dict, str]:
+        captured.update({"pre": university_database_sha256, "post": current_database_sha256})
+        return {"receipt_sha256": SHA_A}, SHA_B
+
+    monkeypatch.setattr(readiness, "_validate_saint_sophia_reconciliation_receipt", validate_saint)
+    receipt = readiness.build_readiness(
+        phase3_reboot_prompt_path=Path("unused"), sources_database_path=Path("unused"),
+        ua_gec_root=Path("unused"), ua_gec_context_receipt_path=Path("unused"),
+        historical_full_receipt_path=Path("unused"), saint_sophia_reconciliation_receipt_path=Path("sophia.json"),
+    )
+    assert captured == {"pre": pre_sha, "post": post_sha}
+    assert receipt["bindings"]["sources_database_sha256"] == post_sha
+
+
+def test_validator_rejects_saint_sophia_readiness_without_matching_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _build(monkeypatch)
+    receipt["readiness"]["saint_sophia_db_reconciliation_ready"] = True
+    receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
+    with pytest.raises(readiness.PrefreezeReadinessError, match="Saint Sophia readiness"):
+        readiness.validate_readiness(receipt)
+
+
+def test_saint_sophia_receipt_requires_current_implementation_and_database_bindings(
+    tmp_path: Path,
+) -> None:
+    sophia = readiness.sophia_reconciliation
+    database_sha = readiness.university.EXPECTED_DATABASE["sha256"]
+    body = {
+        "schema_version": "phase3_saint_sophia_db_reconciliation_v1", "text_free": True,
+        "provider_calls": False, "mode": "candidate_atomic_replace",
+        "bindings": {
+            "implementation_sha256": readiness.sha256_file(Path(sophia.__file__).resolve()),
+            "schema_sha256": readiness.sha256_file(sophia.SCHEMA_PATH),
+            "denominator_sha256": readiness.sha256_file(sophia.DENOMINATOR_PATH),
+            "expected_pre_database_sha256": database_sha,
+            "saint_sophia_jsonl_sha256": sophia.EXPECTED_JSONL_SHA256,
+            "saint_sophia_coverage_sha256": sophia.EXPECTED_COVERAGE_SHA256,
+            "coverage_receipt_sha256": sophia.EXPECTED_COVERAGE_SHA256,
+        },
+        "database": {
+            "pre_sha256": database_sha, "post_sha256": database_sha, "historical_rows_before": 0,
+            "historical_rows_after": 4157, "historical_fts_rows_after": 4157,
+            "foreign_key_failures_before": 0, "foreign_key_failures_after": 0,
+            "foreign_key_failure_sha256_before": SHA_B, "foreign_key_failure_sha256_after": SHA_B,
+        },
+        "invariants": {
+            "saint_sophia_id_set_sha256": sophia.EXPECTED_ID_SET_SHA256,
+            "non_historical_table_fingerprint_before": SHA_A,
+            "non_historical_table_fingerprint_after": SHA_A, "integrity_check": "ok",
+        },
+        "safeguards": {"exact_expected_rows": True, "exact_fts_parity": True,
+                       "foreign_key_failures_unchanged": True, "non_historical_invariants_unchanged": True,
+                       "output_private_0600": True},
+        "phase_boundaries": {"historical_modern_correction_eligible": False, "phase4_blocked": True},
+    }
+    receipt = {**body, "receipt_sha256": sophia.receipt_sha256(body)}
+    path = tmp_path / "saint-sophia-receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    path.chmod(0o600)
+    assert readiness._validate_saint_sophia_reconciliation_receipt(
+        path, university_database_sha256=database_sha, current_database_sha256=database_sha
+    )[0] == receipt
+    receipt["bindings"]["implementation_sha256"] = SHA_A
+    receipt["receipt_sha256"] = sophia.receipt_sha256(receipt)
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    with pytest.raises(readiness.PrefreezeReadinessError, match="implementation drift"):
+        readiness._validate_saint_sophia_reconciliation_receipt(
+            path, university_database_sha256=database_sha, current_database_sha256=database_sha
+        )
+
+
+def test_saint_sophia_receipt_rejects_nonprivate_mode(tmp_path: Path) -> None:
+    sophia = readiness.sophia_reconciliation
+    database_sha = readiness.university.EXPECTED_DATABASE["sha256"]
+    body = {
+        "schema_version": "phase3_saint_sophia_db_reconciliation_v1", "text_free": True,
+        "provider_calls": False, "mode": "candidate_atomic_replace",
+        "bindings": {"implementation_sha256": readiness.sha256_file(Path(sophia.__file__).resolve()),
+                     "schema_sha256": readiness.sha256_file(sophia.SCHEMA_PATH),
+                     "denominator_sha256": readiness.sha256_file(sophia.DENOMINATOR_PATH),
+                     "expected_pre_database_sha256": database_sha,
+                     "saint_sophia_jsonl_sha256": sophia.EXPECTED_JSONL_SHA256,
+                     "saint_sophia_coverage_sha256": sophia.EXPECTED_COVERAGE_SHA256,
+                     "coverage_receipt_sha256": sophia.EXPECTED_COVERAGE_SHA256},
+        "database": {"pre_sha256": database_sha, "post_sha256": database_sha, "historical_rows_before": 0,
+                     "historical_rows_after": 4157, "historical_fts_rows_after": 4157,
+                     "foreign_key_failures_before": 0, "foreign_key_failures_after": 0,
+                     "foreign_key_failure_sha256_before": SHA_B, "foreign_key_failure_sha256_after": SHA_B},
+        "invariants": {"saint_sophia_id_set_sha256": sophia.EXPECTED_ID_SET_SHA256,
+                       "non_historical_table_fingerprint_before": SHA_A,
+                       "non_historical_table_fingerprint_after": SHA_A, "integrity_check": "ok"},
+        "safeguards": {"exact_expected_rows": True, "exact_fts_parity": True,
+                       "foreign_key_failures_unchanged": True, "non_historical_invariants_unchanged": True,
+                       "output_private_0600": True},
+        "phase_boundaries": {"historical_modern_correction_eligible": False, "phase4_blocked": True},
+    }
+    receipt = {**body, "receipt_sha256": sophia.receipt_sha256(body)}
+    path = tmp_path / "public-mode.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    path.chmod(0o644)
+    with pytest.raises(readiness.PrefreezeReadinessError, match="mode 0600"):
+        readiness._validate_saint_sophia_reconciliation_receipt(
+            path, university_database_sha256=database_sha, current_database_sha256=database_sha
+        )
+
+
 def test_build_rejects_incomplete_canary(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_external_receipts(monkeypatch)
     monkeypatch.setattr(


### PR DESCRIPTION
## Outcome

Adds a fail-closed recovery path for the 4,157-row Saint Sophia historical corpus that was present before the later university database cutover but is absent from the current live `sources.db`.

- Pins and verifies the existing canonical Drive JSONL, coverage receipt, 4,157-row denominator, and exact ID-set hash.
- Defaults to a text-free, non-mutating dry run.
- Builds and validates a same-directory candidate before either cutover mode.
- Provides explicit SQLite-online-backup cutover for an open live database while preserving its inode.
- Rejects a non-empty live WAL; preserves live reader sidecars; restores the exact predecessor DB hash if cutover, post-validation, or receipt writing fails.
- Proves row/FTS parity, integrity, unchanged foreign-key failures, and unchanged non-historical schema/table-count fingerprint.
- Emits a private `0600` receipt with `provider_calls=false`, historical forms excluded from modern-correction authority, and Phase 4 blocked.
- Optionally binds the successor DB and reconciliation receipt into v3 pre-freeze readiness while keeping older receipts valid and every completion/authoring gate closed.

No private corpus text, database bytes, or generated receipts are committed. This PR does not itself mutate the live database.

## Verification

- Real dry run against current 1.9 GB database + canonical Drive corpus: PASS, 4,157 inputs, no mutation
- Integrated Phase 3 regression suite: 137 passed
- Targeted reconciliation/prefreeze suite: 26 passed
- Ruff: clean
- `git diff --check`: clean

Tracking: #6375

X-Agent: codex/6375-sophia-db-reconcile
