### PR TITLE
feat(fleet): permanent capacity-first dispatch routing

### DIFF
--- a/agents_extensions/shared/rules/fleet-driver-routing.md
+++ b/agents_extensions/shared/rules/fleet-driver-routing.md
@@ -45,10 +45,26 @@ Do **not** burn Fable/Sol on lockfiles, pointer publishes, rsync gates, or smoke
 
 ---
 
-### 1b. Free-lane utilization (operator 2026-08-08 / #6468)
+### 1b. Free-lane utilization (operator 2026-08-08 / #6468; capacity-first 2026-08-12 / #4707)
 
 **Utilize, do not trim.** Keep **Kimi** and **Z.AI/GLM** as first-class seats. Live check:
-`codexbar usage --json --provider <lane>` + `/api/delegate/active` + disk.
+`python -m scripts.fleet.capacity_pick` (preferred) + `codexbar usage --json --provider <lane>`
++ `/api/delegate/active` + disk.
+
+**Mandatory pre-dispatch (binding):** Before every implement `delegate.py dispatch`, run:
+
+```bash
+.venv/bin/python -m scripts.fleet.capacity_pick
+# then dispatch with budget guard (flag or LU_DISPATCH_CHECK_BUDGET=1):
+.venv/bin/python scripts/delegate.py dispatch --check-budget ...
+```
+
+**Refuse deficit when cooler seats exist.** Do **not** habit-route to Codex (or any
+subscription lane) while CodexBar/`routing-budget` shows hot / near_cap /
+`will_last_to_reset=False` **and** `capacity_pick` lists cool/idle free seats
+(Cursor, AGY, GLM, Kimi, …). `--check-budget` hard-subs when
+`dispatch_fallbacks` has a row (e.g. `codex → cursor`); otherwise it **refuses**
+unless `--force-agent` with a written NOTE.
 
 **Concurrent drivers (typical):** ~**2 Grok** + **1 Claude** + **1–4 Codex**. Shared free
 worker pools — coordinate via active-delegate + disjoint owned paths so drivers do not
@@ -67,11 +83,11 @@ stampede one hot lane.
 
 **OpenRouter:** mainly **Pool + Gemma**. Not a general multi-model bus.
 
-**Codex near_cap / timed pause:** shed mechanical CI to Cursor Auto / Flash / AGY /
-k3-256k / GLM. **Return-at example:** Codex weekly window **2026-08-10T19:47Z** → auto-return
+**Codex near_cap / timed pause / deficit:** shed mechanical CI to Cursor Auto / Flash / AGY /
+k3-256k / GLM (`capacity_pick` + `dispatch_fallbacks: codex → cursor`). **Return-at example:** Codex weekly window **2026-08-10T19:47Z** → auto-return
 to rotation. Novel/hard may stay on Terra/Luna among the 1–4 Codex drivers.
 
-Full table: `model-assignment.md` § *No-idle utilization + transport map*. Issue: **#6468**.
+Full table: `model-assignment.md` § *No-idle utilization + transport map*. Issue: **#6468** / stream **#4707**.
 
 ## 2. Default execution shape (binding)
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -102,8 +102,10 @@ as specified in that runbook; only `ALLOW` permits the new action.
 .venv/bin/python -m scripts.fleet_comms dead-letters   # stuck deliveries
 ```
 Fleet-comms externalizes topology + usage so you decide against fresh state, not a
-stale in-context snapshot. For per-lane budget health:
-`scripts/delegate.py --check-budget` (+ `/api/state/routing-budget` for subscription lanes).
+stale in-context snapshot. For per-lane budget health before dispatch:
+`.venv/bin/python -m scripts.fleet.capacity_pick` then
+`scripts/delegate.py dispatch --check-budget` (or `LU_DISPATCH_CHECK_BUDGET=1`)
+(+ `/api/state/routing-budget` for subscription lanes).
 
 ### 2. Pick the next unblocked action
 
@@ -181,7 +183,20 @@ source's pedagogical or evidential role before consuming an occurrence.
 
 ### 4. Dispatch
 
-`scripts/delegate.py dispatch --agent <lane> --worktree ...` with a numbered brief
+**Capacity-first (binding — operator 2026-08-12 / #4707):** Before every implement
+dispatch, run `capacity_pick` and pass `--check-budget` (or export
+`LU_DISPATCH_CHECK_BUDGET=1` in the launcher):
+
+```bash
+.venv/bin/python -m scripts.fleet.capacity_pick
+.venv/bin/python scripts/delegate.py dispatch --check-budget --agent <lane> --worktree ...
+```
+
+Refuse habit-routing to hot / near_cap / CodexBar-deficit lanes when cooler seats
+are listed. `--check-budget` hard-subs via `dispatch_fallbacks` when mapped
+(e.g. `codex → cursor`); otherwise exits non-zero unless `--force-agent` + NOTE.
+
+Then dispatch with a numbered brief
 (worktree → work → tests → ruff → conventional commit → push → PR → **no auto-merge by
 the worker**) and the `#M-4` evidence preamble (each claim + its deterministic tool +
 quoted raw evidence). Classify the task and pass the research flags

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -679,6 +679,13 @@ work uses AGY; the legacy Gemini CLI route is unsupported.
 
 Fire-and-forget **execution** with status polling and completion artifacts. This is the right tool when you need another agent to write code, run commands, and commit — not to hold a conversation. For discussion, reviews, or Q&A see [Inter-Agent Communication](#inter-agent-communication) below (`ai_agent_bridge` channel bridge, `ask-*`).
 
+**Capacity-first routing (operator 2026-08-12 / #4707):** before implement dispatch, run
+`.venv/bin/python -m scripts.fleet.capacity_pick` and pass `--check-budget` (or set
+`LU_DISPATCH_CHECK_BUDGET=1` in seat launchers). The guard hard-subs hot/near_cap/deficit
+lanes when `scripts/config/agent_fallback_substitutions.yaml` `dispatch_fallbacks` has a
+row (e.g. `codex → cursor`); otherwise it refuses unless `--force-agent`. Flag stays
+opt-in for hermetic tests; launchers should enable the env.
+
 For write-capable delegation, prefer `--worktree`. `delegate.py` creates the worktree if missing and records its path in the task state. `--mode danger` now requires `--worktree` so background agents cannot switch branches in the main checkout by accident.
 
 #### Project Research Registry — orchestrator dispatch duty

--- a/scripts/config/agent_fallback_substitutions.yaml
+++ b/scripts/config/agent_fallback_substitutions.yaml
@@ -2,18 +2,24 @@
 # Consumed by /api/state/routing-budget and delegate.py --check-budget hard auto-sub.
 # referenced by orchestrator routing decisions (MEMORY.md, this file).
 
-# Machine-readable for hard auto-sub (when lane >90% burn on fresh snapshot):
+# Machine-readable for hard auto-sub (when lane is near_cap, hot, or CodexBar
+# deficit / will_last_to_reset=False on a fresh snapshot):
 dispatch_fallbacks:
   claude: codex
-  # codex/gemini/grok/cursor: unaffected (separate quotas) or per context in prose below
+  # Mechanical shed when Codex is hot or in weekly deficit while free seats
+  # (Cursor) sit idle — operator 2026-08-12 / stream #4707.
+  codex: cursor
+  # gemini/grok/cursor/kimi/agy/glm: no automatic mapping without an explicit
+  # operator comment (refuse dispatch when hot/deficit and no row here).
 #
-# Trigger condition: when a budget bucket is at status `near_cap` or higher
-# (burn_pct > 90), the orchestrator MUST use the substitution path below
-# instead of the surface that would drain the depleted bucket.
+# Trigger condition: when a budget bucket is at status `near_cap` or `hot`,
+# or CodexBar reports will_last_to_reset=False (deficit), the orchestrator
+# MUST use the substitution path below instead of draining the depleted
+# bucket. Missing mapping → refuse unless --force-agent.
 #
 # Provenance: user direction 2026-05-13 — "you need to store this and add to
 # router" (paste of the substitution table built during the budget-economics
-# discussion that day).
+# discussion that day). Capacity-first codex→cursor shed: operator 2026-08-12.
 
 substitutions:
   - currently_uses: "delegate.py --agent claude (adversarial review)"
@@ -41,8 +47,11 @@ substitutions:
     budget_bucket: "Codex + interactive"
 
   - currently_uses: "delegate.py --agent codex"
-    fallback: "(unaffected — separate weekly quota)"
-    budget_bucket: "Codex weekly"
+    fallback: |
+      When Codex is hot / near_cap / weekly deficit: hard auto-sub to
+      `delegate.py --agent cursor` via dispatch_fallbacks (operator 2026-08-12).
+      Otherwise Codex weekly quota is independent of Claude interactive.
+    budget_bucket: "Codex weekly → Cursor when shed"
 
   - currently_uses: "delegate.py --agent gemini"
     fallback: "(unaffected — separate quota)"

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4197,8 +4197,12 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"❌ {exc}", file=sys.stderr)
         return 2
 
-    if getattr(args, "check_budget", False) and not getattr(args, "force_agent", False):
-        dispatch_agent = _resolve_agent_with_budget_guard(args.agent)
+    if _dispatch_check_budget_enabled(args) and not getattr(args, "force_agent", False):
+        try:
+            dispatch_agent = _resolve_agent_with_budget_guard(args.agent)
+        except BudgetGuardRefuseError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return 2
     else:
         dispatch_agent = args.agent
 
@@ -4816,9 +4820,19 @@ class MonitorApiUnavailable(RuntimeError):
     """Raised when the local Monitor API cannot answer a task status query."""
 
 
+class BudgetGuardRefuseError(RuntimeError):
+    """Raised when --check-budget must refuse dispatch (hot/deficit/near_cap, no fallback)."""
+
+
 def _monitor_api_base_url() -> str:
     return os.environ.get("DELEGATE_MONITOR_API", _MONITOR_API_BASE_URL).rstrip("/")
 
+
+def _dispatch_check_budget_enabled(args: argparse.Namespace) -> bool:
+    """True when --check-budget is set or LU_DISPATCH_CHECK_BUDGET=1."""
+    if getattr(args, "check_budget", False):
+        return True
+    return os.environ.get("LU_DISPATCH_CHECK_BUDGET", "").strip() in {"1", "true", "yes", "on"}
 
 def _age_seconds_from_started_at(started_at: Any) -> int:
     try:
@@ -4866,10 +4880,67 @@ def _load_dispatch_fallbacks() -> dict[str, str]:
     return {}
 
 
+def _budget_lane_status(agent: str, agent_info: dict[str, Any]) -> str | None:
+    if agent == "claude":
+        return (agent_info.get("interactive") or {}).get("status") or agent_info.get("status")
+    return agent_info.get("status")
+
+
+def _budget_will_last_to_reset(agent_info: dict[str, Any]) -> bool | None:
+    cb = agent_info.get("codexbar")
+    if not isinstance(cb, dict) or "will_last_to_reset" not in cb:
+        return None
+    val = cb.get("will_last_to_reset")
+    if val is None:
+        return None
+    return bool(val)
+
+
+def _budget_cooler_lanes(agents: dict[str, Any], *, exclude: str) -> list[str]:
+    cool: list[str] = []
+    for lane, info in agents.items():
+        if not isinstance(info, dict):
+            continue
+        lane_l = str(lane).strip().lower()
+        if lane_l == exclude:
+            continue
+        status = _budget_lane_status(lane_l, info)
+        will_last = _budget_will_last_to_reset(info)
+        if status in {"hot", "near_cap"} or will_last is False:
+            continue
+        if status in {"cool", "warm"}:
+            cool.append(lane_l)
+    return sorted(cool)
+
+
+def _budget_needs_hard_capacity_action(
+    *,
+    status: str | None,
+    will_last: bool | None,
+    is_stale: bool,
+    records_loaded: int,
+) -> tuple[bool, str]:
+    """Return (needs_action, reason) for near_cap / hot / CodexBar deficit."""
+    if is_stale:
+        return False, ""
+    # Keep existing near_cap gate (fresh ledger) and extend to hot/deficit.
+    if status == "near_cap" and records_loaded > 0:
+        return True, "near_cap (>90% on FRESH snapshot)"
+    if status == "hot":
+        return True, "status=hot"
+    if will_last is False:
+        return True, "codexbar will_last_to_reset=False (deficit)"
+    return False, ""
+
+
 def _resolve_agent_with_budget_guard(agent: str) -> str:
-    """Return possibly-substituted agent. Hard sub only on fresh snapshot when chosen lane near_cap (>90%).
-    Stale/empty: advisory only, no sub (never-trip guard). --force wins before call.
-    Substitution is NOTED (operator contract).
+    """Return possibly-substituted agent.
+
+    Hard auto-sub on fresh snapshot when chosen lane is near_cap, hot, or in
+    CodexBar deficit (will_last_to_reset is False), if yaml dispatch_fallbacks
+    has a known target. Without a usable fallback: refuse (raise
+    BudgetGuardRefuseError) unless caller used --force-agent before this call.
+    Stale/empty: advisory only, no sub (never-trip guard).
     """
     requested = (agent or "").strip().lower()
     try:
@@ -4907,7 +4978,7 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
     if records_loaded == 0:
         for warning in rec.get("warnings") or []:
             if "is in deficit" in str(warning):
-                print(f"⚠ ROUTING CHECK: {warning}; no hard sub (ledger empty).", file=sys.stderr)
+                print(f"⚠ ROUTING CHECK: {warning}", file=sys.stderr)
 
     if is_stale:
         print(
@@ -4927,45 +4998,56 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
             if rec.get("rationale"):
                 print(f"Rationale: {rec['rationale']}", file=sys.stderr)
 
-    # HARD auto-sub only for subscription near_cap on FRESH non-empty
     agent_info = agents.get(requested, {}) or {}
-    # claude may be nested
-    if requested == "claude":
-        status = (agent_info.get("interactive") or {}).get("status") or agent_info.get("status")
-    else:
-        status = agent_info.get("status")
+    status = _budget_lane_status(requested, agent_info if isinstance(agent_info, dict) else {})
+    will_last = _budget_will_last_to_reset(agent_info if isinstance(agent_info, dict) else {})
     burn = (
         agent_info.get("burn_pct_7d")
         if requested != "claude"
         else (agent_info.get("interactive") or {}).get("burn_pct_7d") or agent_info.get("burn_pct_7d")
     )
 
-    if status == "near_cap" and not is_stale and records_loaded > 0:
-        fallbacks = _load_dispatch_fallbacks()
-        sub = fallbacks.get(requested)
-        # The yaml `dispatch_fallbacks` map is the ONLY source for hard subs —
-        # no inferred/hardcoded mappings (a deleted config entry must mean
-        # "no hard sub", not silently resurrect an old route).
-        if sub and sub not in _DISPATCH_AGENT_CHOICES:
-            print(
-                f"⚠ ROUTING: dispatch_fallbacks maps {requested} → {sub}, "
-                "not a known dispatch agent — ignoring hard sub.",
-                file=sys.stderr,
-            )
-            sub = None
-        if sub and sub != requested:
-            note = (
-                f"🔄 HARD AUTO-SUBSTITUTE: --agent {requested} → {sub} "
-                f"(lane window >90% used / status=near_cap on FRESH snapshot; "
-                f"sub per agent_fallback_substitutions.yaml dispatch_fallbacks + documented cases). "
-                "Substitution noted for operator contract / review independence."
-            )
-            print(note, file=sys.stderr)
-            if burn is not None:
-                print(f"  (burn_pct_7d was ~{burn}%; resets_at={agent_info.get('resets_at')})", file=sys.stderr)
-            return sub
+    needs_action, reason = _budget_needs_hard_capacity_action(
+        status=status,
+        will_last=will_last,
+        is_stale=is_stale,
+        records_loaded=records_loaded,
+    )
+    if not needs_action:
+        return requested
 
-    return requested
+    fallbacks = _load_dispatch_fallbacks()
+    sub = fallbacks.get(requested)
+    # The yaml `dispatch_fallbacks` map is the ONLY source for hard subs —
+    # no inferred/hardcoded mappings (a deleted config entry must mean
+    # refuse or advisory, not silently resurrect an old route).
+    if sub and sub not in _DISPATCH_AGENT_CHOICES:
+        print(
+            f"⚠ ROUTING: dispatch_fallbacks maps {requested} → {sub}, "
+            "not a known dispatch agent — ignoring hard sub.",
+            file=sys.stderr,
+        )
+        sub = None
+    if sub and sub != requested:
+        note = (
+            f"🔄 HARD AUTO-SUBSTITUTE: --agent {requested} → {sub} "
+            f"({reason}; "
+            f"sub per agent_fallback_substitutions.yaml dispatch_fallbacks). "
+            "Substitution noted for operator contract / review independence."
+        )
+        print(note, file=sys.stderr)
+        if burn is not None:
+            print(f"  (burn_pct_7d was ~{burn}%; resets_at={agent_info.get('resets_at')})", file=sys.stderr)
+        return sub
+
+    cooler = _budget_cooler_lanes(agents if isinstance(agents, dict) else {}, exclude=requested)
+    cooler_txt = ", ".join(cooler) if cooler else "(none marked cool/warm in snapshot)"
+    raise BudgetGuardRefuseError(
+        f"ROUTING REFUSED: --agent {requested} is {reason} and "
+        f"dispatch_fallbacks has no usable substitute. "
+        f"Cooler seats from budget snapshot: {cooler_txt}. "
+        "Re-route (see `python -m scripts.fleet.capacity_pick`) or pass --force-agent."
+    )
 
 
 def _check_capacity_hint(dispatch_agent: str, args: argparse.Namespace | None = None) -> None:
@@ -5475,14 +5557,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--check-budget",
         action="store_true",
         help=(
-            "Query /api/state/routing-budget before spawning and warn when "
-            "budget telemetry recommends a different agent."
+            "Query /api/state/routing-budget before spawning; hard-sub or refuse "
+            "when the requested lane is near_cap/hot/deficit. Also enabled when "
+            "LU_DISPATCH_CHECK_BUDGET=1 (launchers can force without flag churn)."
         ),
     )
     d.add_argument(
         "--force-agent",
         action="store_true",
-        help="Suppress --check-budget routing warnings and dispatch with the requested agent.",
+        help=(
+            "Suppress --check-budget / LU_DISPATCH_CHECK_BUDGET routing guard "
+            "and dispatch with the requested agent."
+        ),
     )
     d.add_argument(
         "--dry-run",

--- a/scripts/fleet/capacity_pick.py
+++ b/scripts/fleet/capacity_pick.py
@@ -39,7 +39,7 @@ def _monitor_base() -> str:
 
 
 def lane_status(agent_info: dict[str, Any] | None) -> str:
-    """Resolve display status for a routing-budget agent blob."""
+    """Resolve display status for a routing-budget agent record."""
     info = agent_info or {}
     status = info.get("status")
     if not status and isinstance(info.get("interactive"), dict):

--- a/scripts/fleet/capacity_pick.py
+++ b/scripts/fleet/capacity_pick.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Capacity-first lane picker for pre-dispatch routing (operator 2026-08-12).
+
+Drivers run this before every implement dispatch. Prefer cool/idle seats;
+mark hot / near_cap / deficit lanes AVOID. Uses ``compute_routing_budget``
+(already embeds CodexBar) — no multi-provider refresh loops unless ``--fresh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+# Subscription + free seats drivers may pick for code implement.
+CODE_LANES: tuple[str, ...] = (
+    "claude",
+    "codex",
+    "gemini",
+    "grok",
+    "cursor",
+    "kimi",
+    "agy",
+    "deepseek",
+    "glm",
+)
+
+_AVOID_STATUSES = frozenset({"hot", "near_cap"})
+_COOL_STATUSES = frozenset({"cool", "warm", "idle"})
+_MONITOR_DEFAULT = "http://127.0.0.1:8765"
+
+
+def _monitor_base() -> str:
+    return os.environ.get("DELEGATE_MONITOR_API", _MONITOR_DEFAULT).rstrip("/")
+
+
+def lane_status(agent_info: dict[str, Any] | None) -> str:
+    """Resolve display status for a routing-budget agent blob."""
+    info = agent_info or {}
+    status = info.get("status")
+    if not status and isinstance(info.get("interactive"), dict):
+        status = info["interactive"].get("status")
+    return str(status or "unknown")
+
+
+def will_last_to_reset(agent_info: dict[str, Any] | None) -> bool | None:
+    info = agent_info or {}
+    cb = info.get("codexbar")
+    if isinstance(cb, dict) and "will_last_to_reset" in cb:
+        val = cb.get("will_last_to_reset")
+        if val is None:
+            return None
+        return bool(val)
+    return None
+
+
+def is_avoid_lane(agent_info: dict[str, Any] | None) -> bool:
+    """True when status is hot/near_cap or CodexBar deficit (will_last_to_reset is False)."""
+    status = lane_status(agent_info)
+    if status in _AVOID_STATUSES:
+        return True
+    return will_last_to_reset(agent_info) is False
+
+
+def remaining_pct(agent_info: dict[str, Any] | None) -> float | None:
+    info = agent_info or {}
+    rem = info.get("remaining_pct")
+    if isinstance(rem, (int, float)):
+        return float(rem)
+    burn = info.get("burn_pct_7d")
+    if isinstance(burn, (int, float)):
+        return 100.0 - float(burn)
+    cb = info.get("codexbar") if isinstance(info.get("codexbar"), dict) else {}
+    weekly = cb.get("weekly_remaining_pct") if isinstance(cb, dict) else None
+    if isinstance(weekly, (int, float)):
+        return float(weekly)
+    return None
+
+
+def pace_summary(agent_info: dict[str, Any] | None) -> str:
+    info = agent_info or {}
+    cb = info.get("codexbar") if isinstance(info.get("codexbar"), dict) else {}
+    if isinstance(cb, dict):
+        summary = cb.get("pace_summary")
+        if summary:
+            return str(summary)
+        delta = cb.get("weekly_pace_delta_pct")
+        if isinstance(delta, (int, float)):
+            return f"pace_delta={delta:+.1f}%"
+    return "—"
+
+
+def fetch_active_in_flight(*, timeout: float = 2.0) -> dict[str, int]:
+    """Fail-open read of /api/delegate/active → agent → count."""
+    url = f"{_monitor_base()}/api/delegate/active"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    counts: dict[str, int] = {}
+    for task in payload.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        agent = str(task.get("agent") or "").strip().lower()
+        if not agent:
+            continue
+        counts[agent] = counts.get(agent, 0) + 1
+    return counts
+
+
+def build_lane_rows(
+    budget: dict[str, Any],
+    *,
+    active_in_flight: dict[str, int] | None = None,
+    lanes: tuple[str, ...] = CODE_LANES,
+) -> list[dict[str, Any]]:
+    """Pure formatter input: one row per lane from a routing-budget payload."""
+    agents = budget.get("agents") if isinstance(budget.get("agents"), dict) else {}
+    budget_flight = budget.get("in_flight") if isinstance(budget.get("in_flight"), dict) else {}
+    active = active_in_flight or {}
+    rows: list[dict[str, Any]] = []
+    for lane in lanes:
+        info = agents.get(lane) if isinstance(agents.get(lane), dict) else {}
+        status = lane_status(info)
+        will_last = will_last_to_reset(info)
+        avoid = is_avoid_lane(info)
+        in_flight = int(active.get(lane, budget_flight.get(lane, 0) or 0) or 0)
+        notes: list[str] = []
+        if avoid:
+            notes.append("AVOID")
+            if will_last is False:
+                notes.append("deficit")
+            if status in _AVOID_STATUSES:
+                notes.append(status)
+        elif in_flight == 0 and status in _COOL_STATUSES:
+            notes.append("idle")
+        elif in_flight > 0:
+            notes.append(f"{in_flight} in flight")
+        rem = remaining_pct(info)
+        rows.append(
+            {
+                "lane": lane,
+                "status": status,
+                "remaining_pct": rem,
+                "will_last": will_last,
+                "pace": pace_summary(info),
+                "in_flight": in_flight,
+                "avoid": avoid,
+                "notes": "; ".join(notes) if notes else "",
+            }
+        )
+    return rows
+
+
+def build_pick_order(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Cool/idle first; AVOID lanes last with pick=AVOID."""
+
+    def _sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+        avoid = bool(row.get("avoid"))
+        status = str(row.get("status") or "unknown")
+        rem = row.get("remaining_pct")
+        rem_key = -float(rem) if isinstance(rem, (int, float)) else 0.0
+        in_flight = int(row.get("in_flight") or 0)
+        status_rank = {
+            "cool": 0,
+            "warm": 1,
+            "unknown": 2,
+            "pre_launch": 3,
+            "hot": 8,
+            "near_cap": 9,
+        }.get(status, 5)
+        return (avoid, status_rank, in_flight, rem_key, str(row.get("lane")))
+
+    ordered = sorted(rows, key=_sort_key)
+    out: list[dict[str, Any]] = []
+    rank = 1
+    for row in ordered:
+        entry = dict(row)
+        if row.get("avoid"):
+            entry["pick"] = "AVOID"
+        else:
+            entry["pick"] = rank
+            rank += 1
+        out.append(entry)
+    return out
+
+
+def format_table(rows: list[dict[str, Any]]) -> str:
+    headers = ("lane", "status", "remaining%", "will_last", "pace", "in_flight", "notes")
+    cells: list[tuple[str, ...]] = []
+    for row in rows:
+        rem = row.get("remaining_pct")
+        rem_s = f"{rem:.1f}" if isinstance(rem, (int, float)) else "—"
+        will = row.get("will_last")
+        will_s = "—" if will is None else ("yes" if will else "no")
+        cells.append(
+            (
+                str(row.get("lane") or ""),
+                str(row.get("status") or ""),
+                rem_s,
+                will_s,
+                str(row.get("pace") or "—"),
+                str(int(row.get("in_flight") or 0)),
+                str(row.get("notes") or ""),
+            )
+        )
+    widths = [len(h) for h in headers]
+    for cell in cells:
+        for i, val in enumerate(cell):
+            widths[i] = max(widths[i], len(val))
+    lines = [
+        " | ".join(h.ljust(widths[i]) for i, h in enumerate(headers)),
+        "-+-".join("-" * widths[i] for i in range(len(headers))),
+    ]
+    for cell in cells:
+        lines.append(" | ".join(cell[i].ljust(widths[i]) for i in range(len(headers))))
+    return "\n".join(lines)
+
+
+def format_pick_order(pick_order: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for entry in pick_order:
+        pick = entry.get("pick")
+        lane = entry.get("lane")
+        if pick == "AVOID":
+            parts.append(f"AVOID:{lane}")
+        else:
+            parts.append(f"{pick}.{lane}")
+    return "pick order (code implement): " + " → ".join(parts)
+
+
+def cooler_lanes(rows: list[dict[str, Any]]) -> list[str]:
+    return [str(r["lane"]) for r in rows if not r.get("avoid") and r.get("status") in _COOL_STATUSES]
+
+
+def build_report(
+    budget: dict[str, Any],
+    *,
+    active_in_flight: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    rows = build_lane_rows(budget, active_in_flight=active_in_flight)
+    pick_order = build_pick_order(rows)
+    rec = budget.get("recommendation") if isinstance(budget.get("recommendation"), dict) else {}
+    return {
+        "generated_at": budget.get("generated_at"),
+        "rows": rows,
+        "pick_order": pick_order,
+        "cooler_lanes": cooler_lanes(rows),
+        "recommendation": {
+            "primary_agent_for_code": rec.get("primary_agent_for_code"),
+            "rationale": rec.get("rationale"),
+            "warnings": list(rec.get("warnings") or []),
+        },
+        "diagnostics": budget.get("diagnostics") or {},
+        "active_in_flight": dict(active_in_flight or {}),
+    }
+
+
+def format_human(report: dict[str, Any]) -> str:
+    lines = [
+        "capacity_pick — capacity-first dispatch routing",
+        format_table(list(report.get("rows") or [])),
+        "",
+    ]
+    rec = report.get("recommendation") or {}
+    primary = rec.get("primary_agent_for_code")
+    lines.append(f"recommendation.primary_agent_for_code: {primary}")
+    if rec.get("rationale"):
+        lines.append(f"rationale: {rec['rationale']}")
+    for warning in rec.get("warnings") or []:
+        lines.append(f"warning: {warning}")
+    lines.append("")
+    lines.append(format_pick_order(list(report.get("pick_order") or [])))
+    cool = report.get("cooler_lanes") or []
+    if cool:
+        lines.append(f"cooler seats: {', '.join(cool)}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.fleet.capacity_pick",
+        description="Print capacity-first lane pick order before implement dispatch.",
+    )
+    parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="Pass fresh_codexbar=True to compute_routing_budget (may be slow).",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON only.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 2 when no cool/warm lane is available.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from scripts.api.state_router import compute_routing_budget
+    except ImportError:  # pragma: no cover - script path fallback
+        from api.state_router import compute_routing_budget  # type: ignore
+
+    budget = compute_routing_budget(fresh_codexbar=bool(args.fresh))
+    active = fetch_active_in_flight()
+    report = build_report(budget, active_in_flight=active)
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(format_human(report))
+
+    if args.strict and not report.get("cooler_lanes"):
+        if not args.json:
+            print("❌ --strict: no cool/warm lane available", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fleet/capacity_pick.py
+++ b/scripts/fleet/capacity_pick.py
@@ -5,6 +5,7 @@ Drivers run this before every implement dispatch. Prefer cool/idle seats;
 mark hot / near_cap / deficit lanes AVOID. Uses ``compute_routing_budget``
 (already embeds CodexBar) — no multi-provider refresh loops unless ``--fresh``.
 """
+# Note: prefer routing-budget API over ad-hoc capacity probes.
 
 from __future__ import annotations
 

--- a/tests/test_capacity_pick.py
+++ b/tests/test_capacity_pick.py
@@ -1,0 +1,121 @@
+"""Unit tests for scripts.fleet.capacity_pick pure formatting (no live CodexBar)."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.fleet import capacity_pick
+
+
+def _fixture_budget() -> dict:
+    return {
+        "generated_at": "2026-08-12T12:00:00Z",
+        "agents": {
+            "codex": {
+                "status": "hot",
+                "burn_pct_7d": 72.0,
+                "remaining_pct": 28.0,
+                "codexbar": {
+                    "will_last_to_reset": False,
+                    "pace_summary": "won't last to reset",
+                    "weekly_pace_delta_pct": 12.0,
+                },
+            },
+            "cursor": {
+                "status": "cool",
+                "burn_pct_7d": 8.0,
+                "remaining_pct": 92.0,
+                "codexbar": {"will_last_to_reset": True, "pace_summary": "on pace"},
+            },
+            "claude": {
+                "status": "near_cap",
+                "interactive": {"status": "near_cap", "burn_pct_7d": 95.0},
+                "burn_pct_7d": 95.0,
+                "remaining_pct": 5.0,
+                "codexbar": {"will_last_to_reset": False},
+            },
+            "agy": {"status": "cool", "burn_pct_7d": 15.0, "remaining_pct": 85.0},
+            "kimi": {"status": "warm", "burn_pct_7d": 55.0, "remaining_pct": 45.0},
+            "gemini": {"status": "unknown", "burn_pct_7d": None},
+            "grok": {"status": "cool", "burn_pct_7d": 20.0, "remaining_pct": 80.0},
+            "deepseek": {"status": "cool", "burn_pct_7d": 10.0, "remaining_pct": 90.0},
+            "glm": {"status": "cool", "burn_pct_7d": 12.0, "remaining_pct": 88.0},
+        },
+        "in_flight": {"cursor": 0, "codex": 1},
+        "recommendation": {
+            "primary_agent_for_code": "cursor",
+            "rationale": "Cursor is cool; Codex is in deficit.",
+            "warnings": ["lane codex is in deficit"],
+        },
+        "diagnostics": {"records_loaded": 4, "stale": False},
+    }
+
+
+def test_build_lane_rows_marks_avoid_for_hot_near_cap_deficit():
+    rows = {r["lane"]: r for r in capacity_pick.build_lane_rows(_fixture_budget())}
+    assert rows["codex"]["avoid"] is True
+    assert "AVOID" in rows["codex"]["notes"]
+    assert "deficit" in rows["codex"]["notes"]
+    assert rows["claude"]["avoid"] is True
+    assert rows["cursor"]["avoid"] is False
+    assert rows["cursor"]["status"] == "cool"
+    assert rows["cursor"]["will_last"] is True
+
+
+def test_build_pick_order_puts_cool_before_avoid():
+    report = capacity_pick.build_report(_fixture_budget(), active_in_flight={"codex": 2})
+    picks = report["pick_order"]
+    avoid_lanes = [p["lane"] for p in picks if p["pick"] == "AVOID"]
+    ranked = [p for p in picks if p["pick"] != "AVOID"]
+    assert "codex" in avoid_lanes
+    assert "claude" in avoid_lanes
+    assert ranked[0]["lane"] in {"cursor", "deepseek", "glm", "agy", "grok"}
+    assert all(p["lane"] not in avoid_lanes for p in ranked)
+    assert report["recommendation"]["primary_agent_for_code"] == "cursor"
+    assert "cursor" in report["cooler_lanes"]
+
+
+def test_format_table_and_human_include_recommendation():
+    report = capacity_pick.build_report(_fixture_budget())
+    table = capacity_pick.format_table(report["rows"])
+    assert "lane" in table and "codex" in table and "cursor" in table
+    human = capacity_pick.format_human(report)
+    assert "recommendation.primary_agent_for_code: cursor" in human
+    assert "pick order (code implement):" in human
+    assert "AVOID:codex" in human or "AVOID:claude" in human
+
+
+def test_main_json_uses_fixture_compute(monkeypatch, capsys):
+    monkeypatch.setattr(
+        capacity_pick,
+        "fetch_active_in_flight",
+        lambda **_kwargs: {"cursor": 0},
+    )
+
+    fake_budget = _fixture_budget()
+
+    import scripts.api.state_router as state_router
+
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: fake_budget)
+
+    rc = capacity_pick.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendation"]["primary_agent_for_code"] == "cursor"
+    assert any(row["lane"] == "codex" and row["avoid"] for row in payload["rows"])
+
+
+def test_main_strict_exits_when_no_cool(monkeypatch, capsys):
+    monkeypatch.setattr(capacity_pick, "fetch_active_in_flight", lambda **_kwargs: {})
+    hot_only = {
+        "generated_at": "2026-08-12T12:00:00Z",
+        "agents": {lane: {"status": "hot", "burn_pct_7d": 90.0} for lane in capacity_pick.CODE_LANES},
+        "in_flight": {},
+        "recommendation": {"primary_agent_for_code": None, "rationale": "", "warnings": []},
+        "diagnostics": {},
+    }
+    import scripts.api.state_router as state_router
+
+    monkeypatch.setattr(state_router, "compute_routing_budget", lambda **_kwargs: hot_only)
+    assert capacity_pick.main(["--strict"]) == 2
+    assert "no cool/warm lane" in capsys.readouterr().err

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -283,7 +283,7 @@ def test_check_budget_no_hard_sub_on_stale(monkeypatch, tmp_path, capsys):
 
 
 def test_check_budget_reports_deficit_from_empty_ledger_codexbar(monkeypatch, tmp_path, capsys):
-    """Empty ledger plus authoritative CodexBar must show the live deficit."""
+    """Empty ledger plus authoritative CodexBar deficit → hard-sub when fallback exists."""
     _patch_spawn(monkeypatch, tmp_path)
     monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
     monkeypatch.setattr(
@@ -295,7 +295,11 @@ def test_check_budget_reports_deficit_from_empty_ledger_codexbar(monkeypatch, tm
                 "rationale": "Codex has live headroom.",
                 "warnings": ["lane claude is in deficit (27% in deficit)"],
             },
-            "agents": {"claude": {"status": "hot", "burn_pct_7d": 74.0}},
+            "agents": {
+                "claude": {"status": "hot", "burn_pct_7d": 74.0},
+                "codex": {"status": "cool", "burn_pct_7d": 20.0},
+                "cursor": {"status": "cool", "burn_pct_7d": 5.0},
+            },
             "diagnostics": {
                 "records_loaded": 0,
                 "stale": False,
@@ -310,7 +314,8 @@ def test_check_budget_reports_deficit_from_empty_ledger_codexbar(monkeypatch, tm
     err = capsys.readouterr().err
     assert "lane claude is in deficit (27% in deficit)" in err
     assert "budget UNKNOWN" not in err
-    assert "HARD AUTO-SUBSTITUTE" not in err
+    assert "HARD AUTO-SUBSTITUTE" in err
+    assert "claude" in err and "codex" in err
 
 
 def test_check_budget_reports_unknown_when_empty_ledger_codexbar_unavailable(monkeypatch, tmp_path, capsys):
@@ -340,8 +345,8 @@ def test_check_budget_reports_unknown_when_empty_ledger_codexbar_unavailable(mon
     assert "HARD AUTO-SUBSTITUTE" not in err
 
 
-def test_check_budget_no_hard_sub_without_yaml_mapping(monkeypatch, tmp_path, capsys):
-    """Removed hardcode regression: yaml mapping absent → NO hard sub, even near_cap fresh."""
+def test_check_budget_refuse_without_yaml_mapping(monkeypatch, tmp_path, capsys):
+    """near_cap/hot without yaml mapping → refuse dispatch (exit non-zero)."""
     _patch_spawn(monkeypatch, tmp_path)
     monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
     monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {})
@@ -357,12 +362,14 @@ def test_check_budget_no_hard_sub_without_yaml_mapping(monkeypatch, tmp_path, ca
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
 
-    assert rc == 0
-    assert "HARD AUTO-SUBSTITUTE" not in capsys.readouterr().err
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "ROUTING REFUSED" in err
+    assert "HARD AUTO-SUBSTITUTE" not in err
 
 
 def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_path, capsys):
-    """A yaml typo must never dispatch a nonexistent adapter: unknown target → warn + no sub."""
+    """A yaml typo must never dispatch a nonexistent adapter: unknown target → refuse."""
     _patch_spawn(monkeypatch, tmp_path)
     monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
     monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {"claude": "gemeni"})
@@ -378,10 +385,167 @@ def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
 
-    assert rc == 0
+    assert rc == 2
     err = capsys.readouterr().err
     assert "not a known dispatch agent" in err
+    assert "ROUTING REFUSED" in err
     assert "HARD AUTO-SUBSTITUTE" not in err
+
+
+def test_check_budget_hard_sub_on_hot_status(monkeypatch, tmp_path, capsys):
+    """hot status with yaml fallback → hard auto-sub (same path as near_cap)."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        delegate,
+        "_fetch_routing_budget",
+        lambda: {
+            "recommendation": {
+                "primary_agent_for_code": "cursor",
+                "rationale": "Codex hot; Cursor cool.",
+                "warnings": [],
+            },
+            "agents": {
+                "codex": {"status": "hot", "burn_pct_7d": 70.0, "resets_at": "2026-08-14T00:00:00Z"},
+                "cursor": {"status": "cool", "burn_pct_7d": 10.0},
+                "claude": {"status": "cool", "burn_pct_7d": 20.0},
+            },
+            "diagnostics": {"records_loaded": 5, "stale": False, "codexbar_data_available": True},
+        },
+    )
+    monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {"codex": "cursor"})
+
+    rc = delegate.cmd_dispatch(
+        delegate.build_parser().parse_args(
+            [
+                "dispatch",
+                "--agent",
+                "codex",
+                "--task-id",
+                "budget-check-hot",
+                "--prompt",
+                "no-op",
+                "--mode",
+                "read-only",
+                "--check-budget",
+            ]
+        )
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "HARD AUTO-SUBSTITUTE" in err
+    assert "codex" in err and "cursor" in err
+    assert "status=hot" in err
+
+
+def test_check_budget_hard_sub_on_deficit_will_last(monkeypatch, tmp_path, capsys):
+    """will_last_to_reset=False (deficit) → hard auto-sub even if status is warm."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        delegate,
+        "_fetch_routing_budget",
+        lambda: {
+            "recommendation": {
+                "primary_agent_for_code": "cursor",
+                "rationale": "Codex deficit.",
+                "warnings": [],
+            },
+            "agents": {
+                "codex": {
+                    "status": "warm",
+                    "burn_pct_7d": 55.0,
+                    "codexbar": {"will_last_to_reset": False, "pace_summary": "won't last"},
+                },
+                "cursor": {"status": "cool", "burn_pct_7d": 5.0},
+            },
+            "diagnostics": {"records_loaded": 3, "stale": False, "codexbar_data_available": True},
+        },
+    )
+    monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {"codex": "cursor"})
+
+    rc = delegate.cmd_dispatch(
+        delegate.build_parser().parse_args(
+            [
+                "dispatch",
+                "--agent",
+                "codex",
+                "--task-id",
+                "budget-check-deficit",
+                "--prompt",
+                "no-op",
+                "--mode",
+                "read-only",
+                "--check-budget",
+            ]
+        )
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "HARD AUTO-SUBSTITUTE" in err
+    assert "will_last_to_reset=False" in err
+
+
+def test_check_budget_refuse_hot_without_fallback_lists_cooler(monkeypatch, tmp_path, capsys):
+    """hot lane with no yaml fallback → refuse and list cooler seats."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {})
+    monkeypatch.setattr(
+        delegate,
+        "_fetch_routing_budget",
+        lambda: {
+            "recommendation": {"primary_agent_for_code": "cursor", "rationale": "x", "warnings": []},
+            "agents": {
+                "codex": {"status": "hot", "burn_pct_7d": 80.0},
+                "cursor": {"status": "cool", "burn_pct_7d": 5.0},
+                "agy": {"status": "cool", "burn_pct_7d": 10.0},
+            },
+            "diagnostics": {"records_loaded": 4, "stale": False, "codexbar_data_available": True},
+        },
+    )
+
+    rc = delegate.cmd_dispatch(
+        delegate.build_parser().parse_args(
+            [
+                "dispatch",
+                "--agent",
+                "codex",
+                "--task-id",
+                "budget-refuse-hot",
+                "--prompt",
+                "no-op",
+                "--mode",
+                "read-only",
+                "--check-budget",
+            ]
+        )
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "ROUTING REFUSED" in err
+    assert "cursor" in err
+    assert "agy" in err
+
+
+def test_check_budget_env_lu_dispatch_forces_guard(monkeypatch, tmp_path, capsys):
+    """LU_DISPATCH_CHECK_BUDGET=1 enables the guard without --check-budget."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setenv("LU_DISPATCH_CHECK_BUDGET", "1")
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        _urlopen_routing(_FakeBudgetResponse("codex")),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args())
+
+    assert rc == 0
+    assert "ROUTING WARNING" in capsys.readouterr().err
 
 
 def test_dispatch_capacity_hint_printed_when_target_lane_busy(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Add `python -m scripts.fleet.capacity_pick` for pre-dispatch cool/idle pick order (marks hot/near_cap/deficit as AVOID).
- Harden `delegate.py --check-budget`: hard-sub on hot or CodexBar deficit when `dispatch_fallbacks` maps the lane; otherwise refuse (unless `--force-agent`). Add `LU_DISPATCH_CHECK_BUDGET=1` and `codex → cursor` shed.
- Bind drivers via `fleet-driver-routing.md`, `drive-epic` §4, and `docs/SCRIPTS.md`.

Closes nothing alone — stream #4707.

## Test plan
- [x] `pytest tests/test_delegate_check_budget.py tests/test_capacity_pick.py`
- [x] `ruff check` on touched Python
- [ ] Cross-family review before merge (worker will not arm auto-merge)


Made with [Cursor](https://cursor.com)