### PR TITLE
fix(fleet-comms): surface bounce/resolver warnings in post() return (#5889)

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -308,7 +308,19 @@ def _resolve_delivery_agent(
     warnings: list[str],
     warn_if_unheld: bool,
 ) -> str:
-    """Resolve a slot to its live holder, retaining unheld slots unchanged."""
+    """Resolve a slot to its live holder, retaining unheld slots unchanged.
+
+    Two distinct failure categories, both surfaced (#5889):
+
+    - **Resolver/import failure** (``resolve_slot_holder`` raises, or the
+      module cannot be imported): an infrastructure problem, NOT a "no live
+      holder" state. Always appended to ``warnings`` — never silent-dropped
+      — and the slot identity is returned so the post still queues.
+    - **No live holder** (resolver returned ``has_holder=False``): the
+      normal bounce. Appended to ``warnings`` only when ``warn_if_unheld``
+      is set (recipient side); the ``from_agent`` side stays quiet because
+      an unheld sender is not a delivery concern.
+    """
     if "-" not in agent or agent in STATIC_VALID_AGENTS:
         return agent
 
@@ -316,7 +328,19 @@ def _resolve_delivery_agent(
         from scripts.orchestration.slot_routing import resolve_slot_holder
 
         res = resolve_slot_holder(agent)
-    except Exception:
+    except Exception as exc:
+        # Never silent-drop a resolver/import failure (#5889 item 2). It is
+        # a distinct category from "no live holder": the resolver itself
+        # broke or could not be imported. Surface it as a warning and keep
+        # the slot identity so the post can still queue at identity.
+        msg = (
+            f"⚠️ channel-bridge: slot resolver failed for '{agent}' "
+            f"({type(exc).__name__}: {exc}) — queued at identity"
+        )
+        warnings.append(msg)
+        import sys as _sys
+
+        print(msg, file=_sys.stderr)
         return agent
 
     if res.has_holder:
@@ -977,7 +1001,18 @@ def post(
 ) -> dict[str, Any]:
     """Create a new channel_messages row + N deliveries rows atomically.
 
-    Returns ``{"message_id": ..., "thread_id": ..., "delivery_ids": [...]}``.
+    Returns a dict::
+
+        {
+            "message_id": ...,
+            "thread_id": ...,
+            "delivery_ids": [...],
+            "warnings": [...],   # bounce/resolver warnings (#5889); may be empty
+        }
+
+    ``warnings`` (always present, possibly empty) collects no-live-holder
+    bounces and resolver/import failures surfaced during recipient
+    resolution, so callers can react without scraping stderr (#5889).
 
     Atomicity is enforced by ``BEGIN IMMEDIATE`` — under concurrent posts,
     the second caller queues on the 5-second ``busy_timeout`` rather than
@@ -1225,6 +1260,12 @@ def post(
             "round_index": round_index,
             "delivery_ids": delivery_ids,
             "created_at": created_at,
+            # Bounce/resolver warnings collected during recipient resolution
+            # (#5889 item 1): no-live-holder bounces AND resolver/import
+            # failures. Surfaced in the return dict so CLI/callers can react
+            # instead of scraping stderr. Extra key — callers that ignore it
+            # are unaffected.
+            "warnings": warnings,
         }
     except Exception:
         # Catches both sqlite3.Error (insert failure) AND ValueError

--- a/scripts/config/area_assignments.yaml
+++ b/scripts/config/area_assignments.yaml
@@ -45,6 +45,13 @@ assignments:
     slots: []
   seminars:
     driver_agent_type: curriculum-orchestrator
+    # NAME vs RESOLUTION (r2 ruling, #5889): these lane-named slots resolve
+    # through the AREA's full epic union (see fleet_taxonomy.yaml → seminars:
+    # epics 2836 folk + 4431/4215 bio + 3120/3079 cross), NOT a single lane.
+    # So claude-folk and claude-bio both match ANY active seminars lease — a
+    # delivery to claude-folk is pickable by a bio-track driver. The lane
+    # suffix is an addressing hint only; do not narrow it without an
+    # operator/advisor GO.
     slots:
       - claude-folk
       - codex-folk

--- a/scripts/orchestration/slot_routing.py
+++ b/scripts/orchestration/slot_routing.py
@@ -4,6 +4,30 @@ Resolves a slot (e.g. claude-atlas, grok-infra, claude-folk) -> area -> live lea
 in .agent/session-streams/v1/session-streams.sqlite3.
 
 READ-ONLY: Never writes or mutates the session-streams database.
+
+## Lane NAME vs AREA resolution — the load-bearing mismatch (r2 ruling, #5889)
+
+A slot's NAME carries a lane/track hint, but resolution is **area-centric**,
+not lane-centric. The slot name is an addressing convenience only; it does
+NOT scope which lease the delivery binds to.
+
+    slot name        area_assignments.yaml      fleet_taxonomy.yaml        lease matched
+    -----------      ----------------------      ------------------        -------------
+    claude-folk   -> seminars area            -> epics {2836,4431,4215, -> ANY active lease
+                    (slots: folk AND bio)         3120,3079}              on ANY of those
+                                                                         epics — folk OR bio
+
+So ``claude-folk`` and ``claude-bio`` both resolve through the SAME
+``seminars`` area epic union. A delivery addressed to ``claude-folk`` is
+pickable by whichever driver holds an active ``seminars`` lease — including
+a bio-track driver, because the area unions folk + bio + cross epics. The
+``folk``/``bio`` suffix in the slot name is a naming hint, not a resolution
+filter.
+
+This is intentional per the r2 ruling and is NOT to be changed without an
+operator/advisor GO. Per-lane epic scoping (resolving ``claude-folk`` ONLY
+to the folk epic 2836) is a documented design decision, out of scope here;
+see ``resolve_slot_holder`` below for the current algorithm.
 """
 
 from __future__ import annotations
@@ -102,10 +126,20 @@ def resolve_slot_holder(
     Steps:
     1. Look up slot in area_assignments.yaml, or parse slot into provider prefix & area part.
     2. Resolve area via resolve_area() (canonical ID or alias).
-    3. Query session-streams DB for active leases matching the area's epics.
+    3. Query session-streams DB for active leases matching **the area's full
+       epic union** — not a single lane epic.
     4. Return holder facts if an active, non-expired lease exists; else no-holder.
 
     For multi-epic areas with several live leases, the farthest-expiry lease wins.
+
+    **Area-union resolution (r2 ruling, #5889):** the query matches the whole
+    area's epic set, so a lane-named slot resolves to ANY active lease in its
+    area. Concretely, ``claude-folk`` and ``claude-bio`` both resolve through
+    the ``seminars`` area (epics 2836 folk + 4431/4215 bio + 3120/3079 cross):
+    a delivery to ``claude-folk`` is pickable by a bio-track lease holder. The
+    lane suffix in the name is an addressing hint, not a per-lane filter.
+    Per-lane epic scoping is a future design decision — do not narrow this
+    here without an operator/advisor GO.
 
     READ-ONLY — never writes that DB from this path.
     """

--- a/tests/test_fleet_taxonomy_slot_addressing.py
+++ b/tests/test_fleet_taxonomy_slot_addressing.py
@@ -335,7 +335,12 @@ def test_resolve_slot_holder_alias_slot(session_db_fixture: Path) -> None:
 
 
 def test_post_to_slot_with_no_live_holder_warns_and_queues(capsys: pytest.CaptureFixture[str]) -> None:
-    """Verify post to a valid slot with no live holder prints a stderr warning while still queuing delivery."""
+    """Verify post to a valid slot with no live holder prints a stderr warning while still queuing delivery.
+
+    Also asserts the bounce warning is surfaced in the post() return dict
+    (#5889 item 1) — not only on stderr — so callers can react without
+    scraping stderr.
+    """
     with contextlib.suppress(Exception):
         _channels.init_db()
 
@@ -347,4 +352,154 @@ def test_post_to_slot_with_no_live_holder_warns_and_queues(capsys: pytest.Captur
 
     assert "⚠️ channel-bridge: recipient slot 'grok-infra' has no live holder" in captured.err
     assert "channels DB delivery queue for 'grok-infra'" in captured.err
+    assert len(result["delivery_ids"]) == 1
+    # #5889 item 1: bounce warning also reachable via the return dict.
+    assert "warnings" in result
+    assert isinstance(result["warnings"], list)
+    assert any("recipient slot 'grok-infra' has no live holder" in w for w in result["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# 4b. Bounce/resolver warnings in post() return dict (#5889)
+# ---------------------------------------------------------------------------
+
+
+def test_post_bounce_warning_in_return_dict_hermetic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-live-holder bounce warning appears in post() return dict (#5889 item 1).
+
+    Hermetic (step-3 r2 pattern): ``resolve_slot_holder`` is stubbed to a
+    deterministic no-holder result, so this does not depend on real
+    session-streams state.
+
+    MUTATION-CHECK (revert→fail): if the ``warnings`` key is removed from
+    post()'s return dict, the ``in result`` and content assertions fail —
+    the warning would only reach stderr and be unreachable to callers.
+    """
+    from scripts.orchestration import slot_routing
+    from scripts.orchestration.slot_routing import SlotHolderResult
+
+    def _no_holder(slot: str, **kwargs: object) -> SlotHolderResult:
+        return SlotHolderResult(
+            has_holder=False,
+            slot=slot,
+            area_id="infra",
+            queue_location=f"channels DB delivery queue for '{slot}'",
+            reason="no-live-holder",
+        )
+
+    monkeypatch.setattr(slot_routing, "resolve_slot_holder", _no_holder)
+
+    with contextlib.suppress(Exception):
+        _channels.init_db()
+    with contextlib.suppress(ValueError):
+        _channels.create_channel("test-bounce-ret", description="test channel")
+
+    result = _channels.post(
+        "test-bounce-ret",
+        "user",
+        "Hello bounce",
+        to_agents=["grok-infra"],
+        auto_snapshot=False,
+    )
+
+    # Item 1: warnings present in the return dict as list[str] (not just stderr).
+    assert "warnings" in result
+    assert isinstance(result["warnings"], list)
+    assert len(result["warnings"]) == 1
+    assert "recipient slot 'grok-infra' has no live holder" in result["warnings"][0]
+    assert "channels DB delivery queue for 'grok-infra'" in result["warnings"][0]
+    # Delivery still queued at the slot identity.
+    assert len(result["delivery_ids"]) == 1
+
+
+def test_post_resolver_failure_surfaces_warning_not_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Resolver/import failure surfaces a warning instead of silent-dropping (#5889 item 2).
+
+    Hermetic: ``resolve_slot_holder`` is stubbed to raise, exercising the
+    exception path directly without depending on real infrastructure.
+
+    MUTATION-CHECK (revert→fail): if the bare ``except Exception: return
+    agent`` swallow is restored, ``result['warnings']`` stays empty (the
+    failure is silent-dropped) and every warning assertion below fails.
+    """
+    from scripts.orchestration import slot_routing
+
+    def _boom(slot: str, **kwargs: object) -> None:
+        raise RuntimeError("simulated resolver/import failure")
+
+    monkeypatch.setattr(slot_routing, "resolve_slot_holder", _boom)
+
+    with contextlib.suppress(Exception):
+        _channels.init_db()
+    with contextlib.suppress(ValueError):
+        _channels.create_channel("test-resolver-fail", description="test channel")
+
+    result = _channels.post(
+        "test-resolver-fail",
+        "user",
+        "Hello resolver-fail",
+        to_agents=["grok-infra"],
+        auto_snapshot=False,
+    )
+
+    # Item 2: resolver failure surfaced as a warning in the return dict...
+    assert "warnings" in result
+    assert any("slot resolver failed for 'grok-infra'" in w for w in result["warnings"])
+    assert any("RuntimeError" in w for w in result["warnings"])
+    assert any("simulated resolver/import failure" in w for w in result["warnings"])
+    # ...and on stderr (visible handling, not silent).
+    captured = capsys.readouterr()
+    assert "slot resolver failed for 'grok-infra'" in captured.err
+    # Delivery still queued at the slot identity (fail-open on delivery).
+    assert len(result["delivery_ids"]) == 1
+
+
+def test_post_no_warnings_key_is_empty_list_when_all_held(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """post() return dict always carries a warnings key (empty when nothing bounces).
+
+    MUTATION-CHECK (revert→fail): if the ``warnings`` key is dropped from the
+    return dict, ``result['warnings']`` raises KeyError / ``in`` is False.
+    """
+    from scripts.orchestration import slot_routing
+    from scripts.orchestration.slot_routing import SlotHolderResult
+
+    def _held(slot: str, **kwargs: object) -> SlotHolderResult:
+        return SlotHolderResult(
+            has_holder=True,
+            slot=slot,
+            area_id="infra",
+            stream_id="epic:4707",
+            session_id="sess-1",
+            holder_agent="grok-infra",
+            holder_harness="grok",
+            generation=1,
+            expires_at=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            queue_location=f"channels DB delivery queue for '{slot}'",
+        )
+
+    monkeypatch.setattr(slot_routing, "resolve_slot_holder", _held)
+
+    with contextlib.suppress(Exception):
+        _channels.init_db()
+    with contextlib.suppress(ValueError):
+        _channels.create_channel("test-held", description="test channel")
+
+    # Recipient resolves to a live holder; from_agent 'user' never resolves.
+    result = _channels.post(
+        "test-held",
+        "user",
+        "Hello held",
+        to_agents=["grok-infra"],
+        auto_snapshot=False,
+    )
+
+    assert "warnings" in result
+    assert result["warnings"] == []
     assert len(result["delivery_ids"]) == 1


### PR DESCRIPTION
## Summary

Closes #5889. Post-#5878 follow-ups for slot addressing v1 (stream #4707, infra-harness). Independent review found real gaps in bounce/resolver visibility; none were release-blocking for the v1 advisory bounce.

## Changes

### 1. Bounce warnings in structured `post()` return
`scripts/ai_agent_bridge/_channels.py` — `post()` collected bounce `warnings` but only printed them to stderr. The return dict now carries a `warnings` (list[str]) key so CLI/callers can surface no-live-holder bounces without scraping stderr. Extra key — callers that ignore it are unaffected.

### 2. Stop swallowing resolver failures
`_resolve_delivery_agent` replaced its bare `except Exception: return agent` (silent-drop) with visible handling: resolver/import failures are appended to `warnings` and printed to stderr. The failure category (resolver broke / module unimportable) is distinct from "no live holder" and must not silent-drop. The slot identity is still returned so the post queues (fail-open on delivery).

### 3. Lane-vs-area binding (documented, not changed)
Per r2 ruling: document, do not change resolution. Lane-named slots resolve through the AREA epic union — e.g. `claude-folk` → seminars area → folk (2836) **AND** bio (4431/4215) leases. Documented in:
- `scripts/orchestration/slot_routing.py` module + `resolve_slot_holder` docstrings
- `scripts/config/area_assignments.yaml` seminars comment

### 4. Test polish
`tests/test_fleet_taxonomy_slot_addressing.py`:
- Existing bounce test now also asserts the warning in the return dict.
- Hermetic tests (monkeypatched resolver, step-3 r2 pattern) for: bounce warning in return dict, resolver failure surfaces a warning (not silent), and `warnings` always present (empty when all held).
- Mutation-checks verified **revert→fail** direction for both items 1 and 2 (removing the `warnings` key / restoring the bare `except` makes the new tests fail).

## Validation
- `pytest tests/test_fleet_taxonomy_slot_addressing.py` — 19 passed
- `pytest tests/test_bridge_channels.py tests/test_fleet_taxonomy_slot_addressing.py` — 119 passed (no caller breaks from the extra key)
- `pytest tests/test_validate_fleet_taxonomy.py` — 6 passed
- `ruff check` on touched Python — all checks passed
- YAML validity confirmed via `yaml.safe_load`

## Out of scope
- Per-lane epic scoping redesign (design decision only — documented)
- Fleet plane mode flips
- Unrelated taxonomy step 5/6

X-Agent: glm/5889-slot-addressing-v2