### PR TITLE
fix(practice): WP1 paradigm densification — VESUM case-key normalization

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -2595,6 +2595,24 @@ def _single_surface(value: Any) -> str | None:
     return text
 
 
+def _paradigm_slot_case_key(case_name: str) -> str | None:
+    """Normalize enrichment/VESUM case keys to Ukrainian slot labels.
+
+    Atlas enrichment may store Ukrainian short names (``називний``) while
+    ``_paradigm_from_vesum_lemma_search`` emits English internal keys
+    (``nominative``).  ``_build_paradigm_items`` labels slots from
+    ``CASE_SLOT_LABELS``, so accept either spelling.
+    """
+    key = case_name.strip()
+    if key in CASE_SLOT_LABELS:
+        return key
+    english = key.casefold()
+    for internal, ukrainian in CASE_LABELS_UA.items():
+        if internal.casefold() == english:
+            return ukrainian
+    return None
+
+
 def _build_paradigm_items(lexeme: dict[str, Any]) -> list[dict[str, Any]]:
     if not _normalize_cefr(lexeme.get("cefr")):
         return []
@@ -2607,8 +2625,8 @@ def _build_paradigm_items(lexeme: dict[str, Any]) -> list[dict[str, Any]]:
     for case_name, forms in cases.items():
         if not isinstance(case_name, str) or not isinstance(forms, dict):
             continue
-        case_key = case_name.strip()
-        if case_key not in CASE_SLOT_LABELS:
+        case_key = _paradigm_slot_case_key(case_name)
+        if case_key is None:
             continue
         for number in NUMBER_KEYS:
             form = _single_surface(forms.get(number))

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -1254,6 +1254,33 @@ def test_paradigm_answer_position_is_deterministically_shuffled() -> None:
     assert any(item["options"][0]["kind"] != "answer" for item in items)
 
 
+def test_paradigm_items_accept_vesum_english_case_keys() -> None:
+    """VESUM lemma search stores internal English case names, not Ukrainian labels."""
+    items = _build_paradigm_items(
+        {
+            "lemmaId": "borshch",
+            "lemma": "борщ",
+            "cefr": "A1",
+            "paradigm": {
+                "cases": {
+                    "nominative": {"singular": "борщ"},
+                    "genitive": {"singular": "борщу"},
+                    "dative": {"singular": "борщеві"},
+                    "accusative": {"singular": "борщ"},
+                    "instrumental": {"singular": "борщем"},
+                    "locative": {"singular": "борщі"},
+                }
+            },
+        }
+    )
+
+    assert items
+    slot_cases = {item["slot"]["case"] for item in items}
+    assert "родовий" in slot_cases
+    assert "давальний" in slot_cases
+    assert len(slot_cases) >= 3
+
+
 def test_meaning_mc_eligibility_marks_clean_and_messy_glosses() -> None:
     shards = _build()
     a1 = shards["A1"]


### PR DESCRIPTION
## Summary

- **Root cause:** `_paradigm_from_vesum_lemma_search` stores English internal case keys (`nominative`, `genitive`, …) but `_build_paradigm_items` only accepted Ukrainian slot labels (`називний`, `родовий`, …), silently dropping ~2350 inflected lemmas that already had verified VESUM paradigms.
- **Fix:** Add `_paradigm_slot_case_key()` to normalize either spelling before building paradigm MC items; regression test covers English-key paradigms (e.g. борщ).
- **Pair-mode inventory:** YAML vs emit funnel analyzed; thin modes below the ≥1000 lemma bar documented locally in `batch_state/practice/thin-mode-residual.json` (gitignored).

## Coverage before → after (full manifest regen, `--vesum-db`)

| Mode | Before | After | Bar |
|------|--------|-------|-----|
| paradigm | 798 | **1973** | ≥1000 ✓ |
| synonym | 251 | 251 | ≥1000 ✗ |
| antonym | 209 | 209 | ≥1000 ✗ |
| paronym | 32 | 32 | ≥1000 ✗ |
| homonym | 22 | 22 | ≥1000 ✗ |

**Paradigm by level (after):** A1 517 · A2 463 · B1 528 · B2 295 · C1 172

Pair modes remain thin because curated YAML inventory is far below 1000 resolvable pairs and most slug legs are outside the 6000-lexeme practice pool (synonym: 551 approved / 1398 awaiting verification; paronym: 102 YAML pairs / ~70 missing pool legs).

## Test plan

- [x] `.venv/bin/python -m scripts.practice.coverage_report` (before/after measured on primary manifest + VESUM)
- [x] `.venv/bin/ruff check scripts/audit/generate_practice_deck.py`
- [x] `.venv/bin/pytest tests/test_practice_coverage_report.py tests/test_generate_practice_deck.py::test_paradigm_items_accept_vesum_english_case_keys -q`


Made with [Cursor](https://cursor.com)