### PR TITLE
ci: exclude Lob detector from TruffleHog (#6575)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,9 +674,10 @@ jobs:
 
       # Folded from standalone jobs (#4811): each extra always-on job competed for
       # the account concurrent-runner pool and delayed CI Gate (last to start).
-      - uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+      - name: TruffleHog secret scan
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
+          extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Reject negated closing references
         env:

--- a/.trufflehogignore
+++ b/.trufflehogignore
@@ -1,3 +1,6 @@
+# TruffleHog configuration: Lob detector false-positives are excluded via
+# --exclude-detectors=Lob in .github/workflows/ci.yml (#6575).
+#
 # Public Algolia search credentials are intentionally embedded in site config.
 ^starlight/astro\.config\.mjs$
 

--- a/docs/best-practices/ci-health.md
+++ b/docs/best-practices/ci-health.md
@@ -7,7 +7,7 @@ Issue: #1405
 Scope of the 2026-04-22 repair pass:
 
 - `Validate YAML Files / Curriculum Plans`: install `jsonschema` in the workflow so `validate_plan_config.py` imports cleanly.
-- `CI / Secret Scanning (gitleaks)`: migrate the GitHub Actions job to TruffleHog while preserving the existing allowlist intent for public Algolia keys and lockfiles.
+- `CI / Secret scanning (TruffleHog)`: migrate the GitHub Actions job to TruffleHog while preserving the existing allowlist intent for public Algolia keys and lockfiles, and exclude the Lob detector via `--exclude-detectors=Lob` to prevent false-positives on test names (#6575).
 - `CI / Quality Gates (radon)`: evaluate only changed `scripts/**/*.py` files so historic complexity debt on untouched files does not block unrelated PRs.
 - `CI / No new root scripts`: diff only true `scripts/*.py` root files, not nested `scripts/**`.
 - `CI / Test (pytest)`: create a repo-local `.venv` in CI, install from `requirements-lock.txt`, force CPU `torch` wheels on GitHub-hosted Linux, and exclude non-hermetic integration files that require local corpora, generated review/orchestration artifacts, or sidecar tooling (`vesum.db`, `pdfinfo`, `codex`, `embed-venv`) that the runner does not provide.
@@ -17,5 +17,5 @@ Verification notes:
 
 - Use a smoke PR after workflow edits to confirm the GitHub-required `CI` checks are green on a normal branch.
 - The required PR checks now scope `Validate YAML Files`, `radon`, and `pytest` toward hermetic validation so unrelated repo debt does not force admin merges on otherwise clean PRs.
-- If `CI / Secret Scanning (gitleaks)` goes red again, verify the pinned TruffleHog action SHA and `.trufflehogignore` patterns before changing policy.
+- If `CI / Secret scanning (TruffleHog)` goes red again, verify the pinned TruffleHog action SHA, `--exclude-detectors=Lob`, and `.trufflehogignore` patterns before changing policy.
 - Docs-only validation commits should leave non-required CI jobs skipped while the required pytest check succeeds quickly.

--- a/docs/runbooks/ci-gate.md
+++ b/docs/runbooks/ci-gate.md
@@ -95,3 +95,24 @@ exit_condition: measurable condition, expiry date, or tracking issue
 Every entry needs all three fields. The `exit_condition` must provide a
 concrete removal path, not an open-ended intention. For incident context, see
 the CI-gate autopsy at `docs/bug-autopsies/2026-07-25-invisible-ci-gate.md`.
+
+## Secret Scanning & TruffleHog Lob detector (#6575)
+
+Secret scanning in CI runs via `trufflesecurity/trufflehog` in the `contracts` job with `--exclude-detectors=Lob`.
+
+### Lob detector false-positive repro recipe
+
+TruffleHog's built-in `Lob` detector attempts online verification on patterns matching well-shaped `test_<string>` identifiers (e.g., long pytest function names like `test_check_budget_hard_sub_on_hot_status`). When the external API verification endpoint returns a false positive, TruffleHog flags them as verified secret leaks.
+
+Local reproduction:
+```bash
+trufflehog git file://$PWD --results=verified,unknown --exclude-paths=.trufflehogignore
+```
+
+To exclude `Lob` detector false-positives locally or in CI:
+```bash
+trufflehog git file://$PWD --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
+```
+
+Because the repository does not use Lob credentials, excluding the `Lob` detector in `.github/workflows/ci.yml` via `--exclude-detectors=Lob` permanently eliminates these false-positives.
+


### PR DESCRIPTION
Closes #6575

## Summary
Exclude TruffleHog **Lob** detector (false positives on long `test_*` pytest names; Lob sandbox verifies any well-shaped string). Aligns with issue option 1.

Also re-confirmed on #6655 capacity PR (`test_check_budget_hard_sub_on_hot_status`).

## Test plan
- [ ] CI Gate green
- [x] Prior local repro documented in issue / runbook if present in commit