### PR TITLE
fix(scripts): remove hardcoded operator paths from live scripts (#6571)

### DIFF
--- a/scripts/dataset/export_ukrainian_pedagogy_dataset.py
+++ b/scripts/dataset/export_ukrainian_pedagogy_dataset.py
@@ -6,10 +6,14 @@ open-weights LLM alignment (Gemma, Llama, Mistral).
 """
 
 import json
+import os
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PRIVATE_ROOT = Path("/Users/krisztiankoos/projects/learn-ukrainian-infra-private")
+# Private infra repo is external; resolve via env var, not a hardcoded path
+# (#6571). When unset, the .exists() guards below degrade gracefully (empty
+# export) rather than crashing at import.
+PRIVATE_ROOT = Path(os.environ.get("LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT", ""))
 DATASET_DIR = REPO_ROOT / "data" / "datasets" / "hramatka_uk_pedagogy_v1"
 DATASET_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -108,14 +108,44 @@ from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
 
 MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
-_PRIMARY_ROOT = Path("/Users/krisztiankoos/projects/learn-ukrainian")
+
+
+@lru_cache(maxsize=1)
+def _resolve_primary_checkout() -> Path | None:
+    """Primary checkout root via the shared ``.git`` common dir (#6571).
+
+    Dispatch worktrees sparse-exclude the large ``data/`` artifacts, so they
+    live only in the primary checkout. Resolve that root from git (works on any
+    operator's machine) instead of a hardcoded absolute path. Returns None
+    outside a git repo so callers fall back honestly.
+    """
+    try:
+        from scripts.guardrails.worktree_containment import (
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    except ImportError:  # scripts/ stripped from sys.path
+        from guardrails.worktree_containment import (  # type: ignore[no-redef]
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    try:
+        return resolve_main_root(ROOT)
+    except NotAGitRepositoryError:
+        return None
+
+
 _SOURCES_DB_CANDIDATE = ROOT / "data" / "sources.db"
-if (not _SOURCES_DB_CANDIDATE.is_file() or _SOURCES_DB_CANDIDATE.stat().st_size < 1_000_000) and (_PRIMARY_ROOT / "data" / "sources.db").is_file():
-    _SOURCES_DB_CANDIDATE = _PRIMARY_ROOT / "data" / "sources.db"
+if not _SOURCES_DB_CANDIDATE.is_file() or _SOURCES_DB_CANDIDATE.stat().st_size < 1_000_000:
+    _primary = _resolve_primary_checkout()
+    if _primary is not None and (_primary / "data" / "sources.db").is_file():
+        _SOURCES_DB_CANDIDATE = _primary / "data" / "sources.db"
 SOURCES_DB = Path(os.environ.get("SOURCES_DB_PATH", str(_SOURCES_DB_CANDIDATE)))
 KAIKKI_LOOKUP = ROOT / "data" / "lexicon" / "kaikki_uk_lookup.json"
-if not KAIKKI_LOOKUP.is_file() and (_PRIMARY_ROOT / "data" / "lexicon" / "kaikki_uk_lookup.json").is_file():
-    KAIKKI_LOOKUP = _PRIMARY_ROOT / "data" / "lexicon" / "kaikki_uk_lookup.json"
+if not KAIKKI_LOOKUP.is_file():
+    _primary = _resolve_primary_checkout()
+    if _primary is not None and (_primary / "data" / "lexicon" / "kaikki_uk_lookup.json").is_file():
+        KAIKKI_LOOKUP = _primary / "data" / "lexicon" / "kaikki_uk_lookup.json"
 WIKI_REFERENCE_CACHE = ROOT / "data" / "lexicon" / "cache" / "wiki_reference.json"
 GRAC_FREQUENCY_CACHE = ROOT / "data" / "lexicon" / "cache" / "grac_frequency.json"
 

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -415,13 +415,42 @@ if hasattr(os, "register_at_fork"):
         os.register_at_fork(after_in_child=_clear_thread_local_cache_in_child)
 
 
+@lru_cache(maxsize=1)
+def _resolve_primary_checkout() -> Path | None:
+    """Primary checkout root via the shared ``.git`` common dir (#6571).
+
+    Returns None outside a git repo so callers fall back honestly.
+    """
+    try:
+        from guardrails.worktree_containment import (
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    except ImportError:  # repo root on sys.path instead of scripts/
+        from scripts.guardrails.worktree_containment import (  # type: ignore[no-redef]
+            NotAGitRepositoryError,
+            resolve_main_root,
+        )
+    try:
+        return resolve_main_root(ROOT)
+    except NotAGitRepositoryError:
+        return None
+
+
 def _source_db_path(db_path: str | Path | None = None) -> Path:
     target = Path(db_path) if db_path is not None else SOURCES_DB
+    if target.is_file() and target.stat().st_size >= 1_000_000:
+        return target
+    # Sparse worktree fallback: the multi-GB sources.db lives only in the
+    # primary checkout. Try the worktree-local path first (often a symlink into
+    # it), then the primary checkout resolved from the shared .git common dir
+    # instead of a hardcoded absolute path (#6571).
     primary = ROOT / "data" / "sources.db"
-    abs_primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db")
-    if not target.is_file() or target.stat().st_size < 1_000_000:
-        if primary.is_file() and primary.stat().st_size >= 1_000_000:
-            return primary
+    if primary.is_file() and primary.stat().st_size >= 1_000_000:
+        return primary
+    primary_checkout = _resolve_primary_checkout()
+    if primary_checkout is not None:
+        abs_primary = primary_checkout / "data" / "sources.db"
         if abs_primary.is_file() and abs_primary.stat().st_size >= 1_000_000:
             return abs_primary
     return target

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -21,6 +21,7 @@
 #
 # Env overrides:
 #   ATLAS_RUNNER_HOST (default vps), ATLAS_RUN_ROOT, ATLAS_REPO,
+#   ATLAS_PRIMARY_ROOT (default: primary checkout from shared .git common dir),
 #   ATLAS_RE_ENRICH_WORK_DIR, ATLAS_RE_ENRICH_RESIDUAL (local slugs dump),
 #   ATLAS_LOCAL_VESUM_DB, ATLAS_LOCAL_SLOVNYK_CACHE
 #   (local enrichment data for the work-dir overlay),
@@ -31,7 +32,23 @@
 set -euo pipefail
 
 WORKTREE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python}"
+
+# Primary checkout root (shared .git common dir), portable across operators
+# instead of a hardcoded /Users/... path (#6571). In a worktree,
+# `git rev-parse --git-common-dir` returns <primary>/.git; its parent is the
+# primary checkout root. Explicit override wins (fixtures / other hosts).
+_primary_common_dir="$(git -C "$WORKTREE" rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -z "$_primary_common_dir" ]]; then
+  echo "cannot resolve primary checkout root (git rev-parse --git-common-dir failed)" >&2
+  exit 1
+fi
+# git rev-parse may emit a path relative to $WORKTREE; make it absolute.
+case "$_primary_common_dir" in
+  /*) : ;;
+  *)  _primary_common_dir="$WORKTREE/$_primary_common_dir" ;;
+esac
+PRIMARY_ROOT="${ATLAS_PRIMARY_ROOT:-$(cd "$_primary_common_dir/.." && pwd)}"
+PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-$PRIMARY_ROOT/.venv/bin/python}"
 
 HOST="${ATLAS_RUNNER_HOST:-vps}"
 RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
@@ -47,7 +64,7 @@ LOCAL_LAUNCHER="$WORKTREE/scripts/lexicon/runner/launch_reenrich_class_b.sh"
 # it contains the large catalog; sparse worktrees normally fall back to the
 # operator's primary checkout.
 LOCAL_LIVE_MANIFEST_CANDIDATE="$WORKTREE/site/src/data/lexicon-manifest.json"
-PRIMARY_LIVE_MANIFEST="/Users/krisztiankoos/projects/learn-ukrainian/site/src/data/lexicon-manifest.json"
+PRIMARY_LIVE_MANIFEST="$PRIMARY_ROOT/site/src/data/lexicon-manifest.json"
 MIN_LIVE_MANIFEST_BYTES=1048576
 # The driver imports ``scripts.lexicon.enrich_manifest`` and its supporting
 # modules. The VPS checkout is deliberately allowed to stay stale, so deploy
@@ -114,8 +131,8 @@ LOCAL_SOURCES_DB_CANDIDATE="${ATLAS_LOCAL_SOURCES_DB:-$WORKTREE/data/sources.db}
 REMOTE_SOURCES_DB="${ATLAS_SOURCES_DB:-$REMOTE_REPO/data/sources.db}"
 if [[ ! -e "$LOCAL_SOURCES_DB_CANDIDATE" ]]; then
   # Fall back to primary checkout data path (worktrees often sparse/omit data/)
-  if [[ -e "/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db" ]]; then
-    LOCAL_SOURCES_DB_CANDIDATE="/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db"
+  if [[ -e "$PRIMARY_ROOT/data/sources.db" ]]; then
+    LOCAL_SOURCES_DB_CANDIDATE="$PRIMARY_ROOT/data/sources.db"
   else
     echo "local sources.db not found (tried worktree + primary checkout)" >&2
     exit 1
@@ -133,8 +150,8 @@ fi
 # disposable work-dir overlay rather than changing that checkout.
 LOCAL_VESUM_DB_CANDIDATE="${ATLAS_LOCAL_VESUM_DB:-$WORKTREE/data/vesum.db}"
 if [[ ! -e "$LOCAL_VESUM_DB_CANDIDATE" ]]; then
-  if [[ -e "/Users/krisztiankoos/projects/learn-ukrainian/data/vesum.db" ]]; then
-    LOCAL_VESUM_DB_CANDIDATE="/Users/krisztiankoos/projects/learn-ukrainian/data/vesum.db"
+  if [[ -e "$PRIMARY_ROOT/data/vesum.db" ]]; then
+    LOCAL_VESUM_DB_CANDIDATE="$PRIMARY_ROOT/data/vesum.db"
   else
     echo "local vesum.db not found (tried worktree + primary checkout)" >&2
     exit 1
@@ -147,7 +164,7 @@ if [[ ! -f "$LOCAL_VESUM_DB" ]]; then
 fi
 LOCAL_SLOVNYK_CACHE="${ATLAS_LOCAL_SLOVNYK_CACHE:-$WORKTREE/data/lexicon/slovnyk_cache}"
 if [[ ! -d "$LOCAL_SLOVNYK_CACHE" ]]; then
-  LOCAL_SLOVNYK_CACHE="/Users/krisztiankoos/projects/learn-ukrainian/data/lexicon/slovnyk_cache"
+  LOCAL_SLOVNYK_CACHE="$PRIMARY_ROOT/data/lexicon/slovnyk_cache"
 fi
 if [[ ! -d "$LOCAL_SLOVNYK_CACHE" ]]; then
   echo "local slovnyk cache not found (tried worktree + primary checkout)" >&2

--- a/scripts/rag/verify_module_1_v6_extra.py
+++ b/scripts/rag/verify_module_1_v6_extra.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 # Add scripts/ directory to sys.path
-PROJECT_ROOT = Path("/Users/krisztiankoos/projects/learn-ukrainian")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 try:

--- a/scripts/run_otaman_serial_12_15.sh
+++ b/scripts/run_otaman_serial_12_15.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OTAMAN_SKILL_MD="$REPO_ROOT/.gemini/skills/otaman/SKILL.md"
+
 echo "Starting serial otaman execution for A1 modules 12-15"
 
 for i in {12..15}; do
   echo "--- Processing Module $i ---"
-  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini "Activate skill otaman. Read and execute the instructions at /Users/krisztiankoos/projects/learn-ukrainian/.gemini/skills/otaman/SKILL.md to process a1 $i" --task-id otaman-a1-$i --allow-write --model gemini-3-pro-preview > /tmp/otaman-a1-$i-serial.log 2>&1
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini "Activate skill otaman. Read and execute the instructions at $OTAMAN_SKILL_MD to process a1 $i" --task-id otaman-a1-$i --allow-write --model gemini-3-pro-preview > /tmp/otaman-a1-$i-serial.log 2>&1
   
   if [ $? -eq 0 ]; then
     echo "Module $i completed successfully."

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,6 +1,4 @@
 {
-  "schema_version": 1,
-  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "inputs": {
     "lexicon_code": [
       {
@@ -93,7 +91,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "e8c463749405156394c5dbb31d8092cfc713fb8e0c52ba0e015fe36b2839cc1e"
+        "sha256": "1816257eccf5026f15f6aea24fbcbd52337c4b8b743dd9f4ebee5a910448682e"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -145,7 +143,7 @@
       },
       {
         "path": "scripts/lexicon/heritage_classifier.py",
-        "sha256": "e0aeebad823fb9938d91f09c047bc0952929a26f5b1930b788591a5ec30a53c3"
+        "sha256": "beb47e26a2bdffb1e65dac1e50f3dd7975a042425c12448eced60581f658d43c"
       },
       {
         "path": "scripts/lexicon/lemma_normalization.py",
@@ -252,5 +250,7 @@
         "sha256": "395d77478ebddaed38b6a94cc15227deec39e7aafa8735a7d8d434ccbdf6c79a"
       }
     ]
-  }
+  },
+  "schema_version": 1,
+  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state"
 }

--- a/tests/test_export_ukrainian_pedagogy_dataset.py
+++ b/tests/test_export_ukrainian_pedagogy_dataset.py
@@ -1,0 +1,44 @@
+"""Portable path-resolution tests for the UNLP pedagogy dataset exporter (#6571).
+
+The exporter reads from an external private infra repo. That root must be
+supplied via ``LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT`` (env var), never a
+hardcoded ``/Users/...`` operator path. When the env var is unset the export
+must degrade gracefully (empty dataset) rather than crashing at import.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scripts.dataset import export_ukrainian_pedagogy_dataset as exporter
+
+
+def test_source_has_no_hardcoded_operator_path() -> None:
+    src = Path(exporter.__file__).read_text(encoding="utf-8")
+    assert "/Users/krisztiankoos/projects/learn-ukrainian-infra-private" not in src
+    assert "/Users/krisztiankoos" not in src
+
+
+def test_project_root_resolves_from_file_location() -> None:
+    # scripts/dataset/export_ukrainian_pedagogy_dataset.py -> parents[2] is repo root
+    assert Path(__file__).resolve().parents[1] == exporter.REPO_ROOT
+
+
+def test_export_degrades_gracefully_without_private_root(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT", raising=False)
+    monkeypatch.setattr(exporter, "DATASET_DIR", tmp_path)
+    # Reload PRIVATE_ROOT semantics: the module reads the env var at import, so
+    # point it at a clearly empty dir to force the .exists() guards off.
+    monkeypatch.setattr(exporter, "PRIVATE_ROOT", tmp_path / "does-not-exist")
+
+    result = exporter.export_pedagogy_dataset()
+
+    assert result["status"] == "ok"
+    assert result["records_exported"] == 0
+    assert (tmp_path / "hramatka_uk_pedagogy_v1.jsonl").read_text(encoding="utf-8") == ""
+    assert (tmp_path / "README.md").exists()
+
+
+def test_export_uses_env_var_private_root(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT", str(tmp_path / "custom-private"))
+    assert os.environ["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] == str(tmp_path / "custom-private")

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -393,3 +393,33 @@ def test_connection_pooling_query_only_mode() -> None:
         except sqlite3.OperationalError:
             pass
     close_cached_connections()
+
+
+def test_resolve_primary_checkout_matches_git_common_dir() -> None:
+    """_source_db_path's primary-checkout fallback is portable, not hardcoded (#6571).
+
+    _resolve_primary_checkout must agree with resolve_main_root and, when set,
+    point at a directory owning the shared ``.git`` store (a primary checkout,
+    not a worktree gitdir)."""
+    from scripts.guardrails.worktree_containment import (
+        NotAGitRepositoryError,
+        resolve_main_root,
+    )
+    from scripts.lexicon import heritage_classifier
+
+    resolved = heritage_classifier._resolve_primary_checkout()
+    try:
+        expected = resolve_main_root(heritage_classifier.ROOT)
+    except NotAGitRepositoryError:
+        assert resolved is None
+        return
+    assert resolved == expected
+    assert (resolved / ".git").is_dir()
+
+
+def test_source_db_path_has_no_hardcoded_absolute_path() -> None:
+    """The heritage classifier must not carry a hardcoded operator path (#6571)."""
+    from scripts.lexicon import heritage_classifier as hc
+
+    src = Path(hc.__file__).read_text(encoding="utf-8")
+    assert "/Users/krisztiankoos/projects/learn-ukrainian" not in src

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -164,3 +164,57 @@ def test_local_launcher_prefers_synced_package_on_systemd_import_path() -> None:
     assert 'WORK_MANIFEST="$WORK_DIR/manifest.json"' in source
     assert '"$CODE_ROOT/scripts/lexicon/enrich_manifest.py"' in source
     assert 'PYTHONPATH=$(printf \'%q\' "$CODE_ROOT"):\\$PYTHONPATH:$(printf \'%q\' "$REPO")' in source
+
+
+def _primary_root_block(source: str) -> str:
+    """Extract the portable PRIMARY_ROOT resolution block verbatim."""
+    start = source.index('_primary_common_dir=')
+    end = source.index("\n\n", start)
+    return source[start:end]
+
+
+def test_remote_wrapper_resolves_primary_root_portably() -> None:
+    """The remote wrapper must not hardcode /Users/... primary paths (#6571).
+
+    PRIMARY_ROOT is resolved from the shared .git common dir so the script
+    works on any operator's machine. Run the resolution block against this
+    worktree and confirm the result points at a real primary checkout.
+    """
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+
+    # Ban the hardcoded absolute path in live source.
+    assert "/Users/krisztiankoos/projects/learn-ukrainian" not in source
+    assert "ATLAS_PRIMARY_ROOT" in source
+    assert 'git -C "$WORKTREE" rev-parse --git-common-dir' in source
+
+    worktree = str(ROOT)
+    block = _primary_root_block(source)
+    proc = subprocess.run(
+        ["bash", "-c", f'WORKTREE={worktree!r}\n{block}\nprintf "%s" "$PRIMARY_ROOT"'],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stderr
+    resolved = Path(proc.stdout)
+    # The resolved primary root owns the shared .git store (a real checkout,
+    # not a worktree gitdir).
+    assert resolved.is_dir()
+    assert (resolved / ".git").is_dir()
+
+
+def test_remote_wrapper_primary_root_override_wins() -> None:
+    """ATLAS_PRIMARY_ROOT explicit override is honored (#6571)."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    block = _primary_root_block(source)
+    proc = subprocess.run(
+        ["bash", "-c", f'WORKTREE={str(ROOT)!r}\n{block}\nprintf "%s" "$PRIMARY_ROOT"'],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": "/usr/bin:/bin", "ATLAS_PRIMARY_ROOT": "/tmp/custom-primary"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "/tmp/custom-primary"

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 import typing
+from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
@@ -4818,3 +4819,29 @@ def test_etymology_rejects_mid_cut_esum_stubs() -> None:
 
     assert not _etymology_text_is_displayable("свіжий, свіжаік «новачок; свіжа во-")
     assert _etymology_text_is_displayable("From Proto-Slavic *svěžь.")
+
+
+def test_resolve_primary_checkout_matches_git_common_dir() -> None:
+    """enrich_manifest's primary-checkout fallback is portable, not hardcoded (#6571).
+
+    _resolve_primary_checkout must agree with resolve_main_root and, when set,
+    point at a directory owning the shared ``.git`` store. The source must not
+    embed a /Users/... operator path (the runtime value legitimately reflects
+    wherever this checkout lives)."""
+    from scripts.guardrails.worktree_containment import (
+        NotAGitRepositoryError,
+        resolve_main_root,
+    )
+
+    resolved = enrich_manifest_module._resolve_primary_checkout()
+    try:
+        expected = resolve_main_root(enrich_manifest_module.ROOT)
+    except NotAGitRepositoryError:
+        assert resolved is None
+        return
+    assert resolved == expected
+    assert (resolved / ".git").is_dir()
+    # Portability is a source-code property: the module must resolve the
+    # primary checkout dynamically rather than embed an operator's absolute path.
+    src = Path(enrich_manifest_module.__file__).read_text(encoding="utf-8")
+    assert "/Users/krisztiankoos/projects/learn-ukrainian" not in src


### PR DESCRIPTION
Closes #6571

Portable root resolution instead of hardcoded /Users/krisztiankoos paths in live scripts (not archive).

Author: glm (local-only). Orchestrator: grok-infra.