### PR TITLE
feat(data): add historical evidence-first spine

### DIFF
--- a/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
+++ b/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
@@ -1,0 +1,354 @@
+{
+  "authority_policy": {
+    "direct_attestation_definition": "A dated or date-bounded inscription, manuscript, document, or historical print witness with immutable provenance; a modern scholarly reconstruction is not a direct witness.",
+    "historical_forms_protected": true,
+    "learner_exposition": {
+      "historical_authority_eligible": false,
+      "preserve_for_instructional_evaluation": true,
+      "training_text_eligibility": "pending_separate_rights_and_quality_review"
+    },
+    "old_east_slavic_is_modern_russian": false,
+    "proto_reconstruction_is_direct_attestation": false,
+    "ranked_layers": [
+      "direct_attested_source",
+      "qualified_edition_or_translation",
+      "qualified_ukrainian_linguistic_analysis",
+      "comparative_reconstruction",
+      "learner_exposition"
+    ],
+    "scalar_language_age_claim_allowed": false
+  },
+  "bindings": {
+    "historical_denominator_sha256": "4d89bfdb7e935008ad1332426ff9c40dca97efdf72053f35cdb1dad05117e6aa",
+    "historical_full_materialization_gate_sha256": "3a4f409be28560dbc6a9c2c5defa043414dc659870be11a03f8e7297e8249e21",
+    "historical_full_materialization_receipt_file_sha256": "05322d450a8e90b103fff7521605395250e1da957fbf63e8ecf1df8d3d5f6307",
+    "historical_full_materialization_receipt_sha256": "8e3d33b4c5d5a5a4bd3c5da7788460d016e16b9058515b64a6683a725a14c2de",
+    "historical_periodization_freeze_sha256": "94d07a2e4e2fe453334a494007bc823cf4be7ce07f0a21779c73163ac821a198",
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "phase3_recovery_prompt_v2_sha256": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+  },
+  "collections": [
+    {
+      "collection_id": "saint-sophia-inscriptions",
+      "corpus_role": "auxiliary_historical_evidence",
+      "custody_state": "materialized",
+      "evidence_layer": "direct_attested_source",
+      "facts": {
+        "century_or_wider_intervals": 3550,
+        "exact_year_intervals": 168,
+        "invalid_date_intervals": 2,
+        "known_identified_total_lower_bound": 7000,
+        "known_unexposed_residual": true,
+        "language_labels": {
+          "Ancient Greek": 150,
+          "Armenian": 32,
+          "Church Slavonic": 1306,
+          "Greek": 10,
+          "Latin": 34,
+          "Low German": 1,
+          "Mixed": 10,
+          "N/A": 12,
+          "Polish": 286,
+          "Russian": 10,
+          "Ukrainian": 588,
+          "unlabelled": 1718
+        },
+        "middle_date_band": {
+          "interval_overlaps": 2920,
+          "interval_wholly_inside": 1155,
+          "semantic_stage_assignment": "pending_qualified_review",
+          "text_bearing_ukrainian_label_wholly_inside": 549,
+          "year_end": 1799,
+          "year_start": 1400
+        },
+        "missing_date_intervals": 10,
+        "non_textual_or_no_text": 11,
+        "old_date_band": {
+          "interval_overlaps": 2989,
+          "interval_wholly_inside": 1225,
+          "semantic_stage_assignment": "pending_qualified_review",
+          "text_bearing_ukrainian_label_wholly_inside": 7,
+          "year_end": 1399,
+          "year_start": 1000
+        },
+        "quarantined_metadata": 2,
+        "retrieval_scope": "complete_current_public_api",
+        "stage_labels_assigned": 0,
+        "text_bearing": 4144,
+        "valid_date_intervals": 4145,
+        "writing_system_labels": {
+          "Armenian": 31,
+          "Cyrillic": 1982,
+          "Glagolitic": 1,
+          "Greek": 157,
+          "Latin": 367,
+          "Mixed script": 7,
+          "N/A": 2,
+          "unlabelled": 1610
+        }
+      },
+      "locators": [
+        {
+          "label": "Saint Sophia's Inscriptions portal",
+          "local_bytes_acquired": false,
+          "locator_role": "source_portal",
+          "url": "https://saintsophia.dh.gu.se/"
+        },
+        {
+          "label": "Saint Sophia's Inscriptions API",
+          "local_bytes_acquired": false,
+          "locator_role": "api_root",
+          "url": "https://saintsophia.dh.gu.se/api/"
+        }
+      ],
+      "modern_correction_eligible": false,
+      "record_count": 4157,
+      "rights": {
+        "reuse_scope": "private_research_only_until_explicit_clearance",
+        "source_text_committed": false,
+        "status": "restricted_pending_explicit_clearance"
+      },
+      "source_kind": "epigraphy",
+      "source_sha256": "6199f2a92bd948dfe63d12e9da68637b02a4d16ff58b0ddba3d5e252bb3ec4fe"
+    },
+    {
+      "collection_id": "kyiv-pechersk-lavra-graffiti",
+      "corpus_role": "acquisition_candidate_direct_historical_evidence",
+      "custody_state": "not_materialized",
+      "evidence_layer": "direct_attested_source",
+      "facts": {
+        "corpus_count_known": false,
+        "rights_verified": false,
+        "separate_from_saint_sophia": true,
+        "source_bytes_acquired": false
+      },
+      "locators": [
+        {
+          "label": "Kyiv-Pechersk Lavra official evidence of cave graffiti",
+          "local_bytes_acquired": false,
+          "locator_role": "official_monument_evidence",
+          "url": "https://kplavra.kyiv.ua/ua/21-kvitnya-hrafiti-ukr"
+        },
+        {
+          "label": "NBUV catalogue: S. O. Vysotskyi, Kyiv graffiti XI-XVII centuries",
+          "local_bytes_acquired": false,
+          "locator_role": "bibliographic_catalog",
+          "url": "https://irbis-nbuv.gov.ua/ulib/item/UKR0004515"
+        }
+      ],
+      "modern_correction_eligible": false,
+      "record_count": null,
+      "rights": {
+        "reuse_scope": "no_corpus_use_until_source_and_rights_are_verified",
+        "source_text_committed": false,
+        "status": "unknown_pending_review"
+      },
+      "source_kind": "epigraphy",
+      "source_sha256": null
+    },
+    {
+      "collection_id": "ud-old-east-slavic-ruthenian-05a029e00ccf",
+      "corpus_role": "historical_recognition_and_analysis_candidate",
+      "custody_state": "materialized",
+      "evidence_layer": "qualified_edition_or_translation",
+      "facts": {
+        "exact_dated_documents": 4,
+        "exact_years": [1413, 1436, 1456, 1473],
+        "file_sha256": {
+          "orv_ruthenian-ud-dev.conllu": "a2047c4c734dab0a5b68f888979a3ca14670d217d7dcc11bb12b775f2dbbfd1d",
+          "orv_ruthenian-ud-test.conllu": "f34964cee7d6a38b3dd39ceb4dbde38a4fd9aacd8512272c19318027e044ea0d",
+          "orv_ruthenian-ud-train.conllu": "fc13f73dc71e5fac95938eba424b3d5236bfa8edd8ce7bd0e28db2d28a2f9680"
+        },
+        "periodization_assignment_state": "unresolved",
+        "sentences": 1311,
+        "token_rows": 35081,
+        "undated_documents": 78
+      },
+      "locators": [
+        {
+          "label": "Universal Dependencies Old East Slavic-Ruthenian repository",
+          "local_bytes_acquired": true,
+          "locator_role": "dataset_repository",
+          "url": "https://github.com/UniversalDependencies/UD_Old_East_Slavic-Ruthenian"
+        }
+      ],
+      "modern_correction_eligible": false,
+      "record_count": 82,
+      "rights": {
+        "reuse_scope": "public_training_with_share_alike_and_attribution",
+        "source_text_committed": false,
+        "status": "admitted"
+      },
+      "source_kind": "documentary_treebank",
+      "source_sha256": null
+    },
+    {
+      "collection_id": "plug2-zenodo-19482961",
+      "corpus_role": "new_ukrainian_historical_text_evidence",
+      "custody_state": "materialized",
+      "evidence_layer": "direct_attested_source",
+      "facts": {
+        "all_documents": 56245,
+        "archive_sha256": "ff1ff139049539fc7c9ab69b006c12444567989758738baa948cfa0837aabe23",
+        "date_max": 1954,
+        "date_min": 1816,
+        "exact_dated_documents": 56080,
+        "materialized_record_count": 1910748,
+        "pre_1800_documents": 0,
+        "uk_token_sum": 71802066
+      },
+      "locators": [
+        {
+          "label": "PluG2 Zenodo record",
+          "local_bytes_acquired": true,
+          "locator_role": "dataset_doi",
+          "url": "https://doi.org/10.5281/zenodo.19482961"
+        }
+      ],
+      "modern_correction_eligible": false,
+      "record_count": 56080,
+      "rights": {
+        "reuse_scope": "public_training_with_attribution",
+        "source_text_committed": false,
+        "status": "admitted"
+      },
+      "source_kind": "historical_text_corpus",
+      "source_sha256": "a9f79149606b570ebd6895020292eb06016d883e5c75dcb38a6e2cfd15378494"
+    }
+  ],
+  "framework_policy": {
+    "bound_framework_ids": [
+      "university_five_stage_synthesis",
+      "shevelov_detailed_six_period",
+      "nimchuk_five_stage_with_middle_subperiods"
+    ],
+    "canonical_framework_id": null,
+    "frameworks_preserved_without_collapse": true,
+    "instructional_navigation_framework_id": "university_five_stage_synthesis",
+    "instructional_navigation_scope": "coarse_navigation_only_not_semantic_gold",
+    "record_assignment_requires_attributed_evidence": true
+  },
+  "gaps": [
+    {
+      "blocking_for": ["medieval_kyiv_epigraphy_coverage", "historical_source_coverage_ready"],
+      "do_not_claim": "Do not infer Lavra coverage from the Saint Sophia portal or fabricate a Lavra inscription count.",
+      "evidence": "Official Lavra evidence and the national-library catalogue establish relevant graffiti, but no reusable corpus bytes, denominator, or rights receipt is held.",
+      "gap_id": "lavra_epigraphy_not_materialized",
+      "kind": "direct_epigraphic_collection_not_acquired",
+      "next_action": "Identify the exact scholarly edition or crawlable collection, verify rights and provenance, back up one copy to Drive, then run a bounded text-first canary.",
+      "nonblocking_for": ["saint_sophia_use_as_separate_auxiliary_evidence"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["complete_saint_sophia_collection_claim"],
+      "do_not_claim": "Do not call records absent from the public API crawled or materialized.",
+      "evidence": "The current public API yielded 4,157 records while the portal states that more than 7,000 inscriptions are known.",
+      "gap_id": "saint_sophia_public_residual",
+      "kind": "known_collection_residual_not_publicly_exposed",
+      "next_action": "Monitor the public API or request an authorized export; retain the current complete-public-API denominator until the source changes.",
+      "nonblocking_for": ["complete_current_public_api_claim"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["old_ukrainian_direct_text_depth", "historical_source_coverage_ready"],
+      "do_not_claim": "Do not relabel Church Slavonic, unlabelled, Greek, or mixed inscriptions as Ukrainian solely from their date or location.",
+      "evidence": "Saint Sophia has 1,225 valid intervals wholly inside 1000-1399, but only seven are both text-bearing and source-labelled Ukrainian; no additional Old-Ukrainian documentary corpus is currently materialized.",
+      "gap_id": "old_ukrainian_direct_text_depth",
+      "kind": "insufficient_language_qualified_old_period_primary_text",
+      "next_action": "Acquire rights-cleared diplomatic editions of Ukrainian-territory documents and manuscripts with qualified feature-level language attribution.",
+      "nonblocking_for": ["multilingual_medieval_epigraphy_recognition"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["document_level_historical_periodization", "historical_source_freeze_ready"],
+      "do_not_claim": "Do not derive dates from filenames, titles, publication dates, or model inference without qualified document evidence.",
+      "evidence": "Only four of 82 Ukrainian-labelled UD documents expose exact created years; 78 have no machine-readable created date.",
+      "gap_id": "ud_document_date_and_provenance_review",
+      "kind": "document_metadata_and_periodization_unresolved",
+      "next_action": "Bind each document to its edition and qualified date/provenance evidence, preserving unresolved and falsification labels.",
+      "nonblocking_for": ["historical_recognition", "dependency_analysis_with_original_ud_label"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["middle_ukrainian_genre_region_coverage", "historical_source_coverage_ready"],
+      "do_not_claim": "Do not treat one municipal-book cluster and four exact-dated charters as representative of every Middle-Ukrainian region, genre, or register.",
+      "evidence": "The materialized UD Ukrainian set is small and 78/82 documents are not machine-dated; Saint Sophia adds mixed-language epigraphy, not a balanced documentary and print corpus.",
+      "gap_id": "middle_ukrainian_genre_and_region_depth",
+      "kind": "unbalanced_middle_period_primary_text",
+      "next_action": "Add rights-cleared charters, municipal and chancery books, polemical and religious print, private writing, and regional witnesses through qualified editions.",
+      "nonblocking_for": ["bounded_attested_example_use"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["primary_source_grade_for_nimchuk_framework", "historical_source_freeze_ready"],
+      "do_not_claim": "Do not upgrade a secondary reproduction into the missing primary article.",
+      "evidence": "The existing periodization freeze binds qualified Ukrainian reproductions and a peer-reviewed discussion, while the 1997/1998 primary article remains bibliographic-only.",
+      "gap_id": "nimchuk_primary_periodization_text",
+      "kind": "primary_scholarly_text_not_locally_acquired",
+      "next_action": "Obtain the exact two-part article lawfully, hash it, and verify the reproduced boundaries without replacing the other attributed frameworks.",
+      "nonblocking_for": ["qualified_attributed_framework_comparison"],
+      "state": "open"
+    }
+  ],
+  "gates": {
+    "evidence_first_spine_defined": true,
+    "historical_source_coverage_ready": false,
+    "historical_source_freeze_ready": false,
+    "phase3_complete": false,
+    "phase4_authorized": false,
+    "phase4_blocked": true,
+    "private_corpus_audit_reproducible": true
+  },
+  "instructional_sequence": [
+    {
+      "collection_ids": ["saint-sophia-inscriptions", "kyiv-pechersk-lavra-graffiti"],
+      "coverage_state": "materialized_with_open_gaps",
+      "evidence_mode": "direct_attestation",
+      "label_uk": "Середньовічна київська епіграфіка",
+      "position": 1,
+      "purpose": "Begin with locally attested writing on Kyiv monuments; keep Saint Sophia and Lavra as separate provenances.",
+      "sequence_id": "kyiv_medieval_epigraphy"
+    },
+    {
+      "collection_ids": ["saint-sophia-inscriptions"],
+      "coverage_state": "insufficient",
+      "evidence_mode": "direct_text",
+      "label_uk": "Староукраїнські документальні й книжні пам’ятки",
+      "position": 2,
+      "purpose": "Expand from epigraphy to diplomatically edited primary witnesses with explicit language-layer attribution.",
+      "sequence_id": "old_ukrainian_documentary_and_literary"
+    },
+    {
+      "collection_ids": ["saint-sophia-inscriptions", "ud-old-east-slavic-ruthenian-05a029e00ccf"],
+      "coverage_state": "insufficient",
+      "evidence_mode": "direct_text",
+      "label_uk": "Середньоукраїнські документи й друки",
+      "position": 3,
+      "purpose": "Cover dated documents, chancery and municipal writing, print genres, regions, and language contact without flattening mixed layers.",
+      "sequence_id": "middle_ukrainian_documentary_and_print"
+    },
+    {
+      "collection_ids": ["plug2-zenodo-19482961"],
+      "coverage_state": "large_but_not_complete",
+      "evidence_mode": "direct_text",
+      "label_uk": "Нова й сучасна українська мова",
+      "position": 4,
+      "purpose": "Use the large 1816-1954 attested corpus alongside separately admitted modern Ukrainian sources.",
+      "sequence_id": "new_and_modern_ukrainian"
+    },
+    {
+      "collection_ids": [],
+      "coverage_state": "comparative_only",
+      "evidence_mode": "comparative_reconstruction",
+      "label_uk": "Порівняльна реконструкція передписемних розвитку й діалектів",
+      "position": 5,
+      "purpose": "Explain backward from attested changes; never generate reconstructed Proto-Slavic or Proto-Ukrainian forms as direct corpus witnesses.",
+      "sequence_id": "comparative_reconstruction_backlink"
+    }
+  ],
+  "provider_calls": false,
+  "receipt_sha256": "eb075580b05fa494300ffe8fb815a969208de3be2176c817482b634070678c86",
+  "schema_version": "phase3_historical_evidence_spine_v1",
+  "status": "EVIDENCE_FIRST_SPINE_DEFINED_SOURCE_GAPS_OPEN",
+  "text_free": true
+}

--- a/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
+++ b/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
@@ -97,8 +97,22 @@
           },
           "license_evidence": {
             "explicit_data_license_at_pinned_sources": null,
+            "korniienko_media_assets": {
+              "asset_count_at_snapshot": 6477,
+              "included_in_text_training": false,
+              "license_label": "CC BY-NC",
+              "license_version_declared": false
+            },
             "official_docs_describe_api_as_open_and_reusable": true,
-            "official_docs_describe_dataset_as_open": true
+            "official_docs_describe_dataset_as_open": true,
+            "operator_use_decision": {
+              "binary_media_in_scope": false,
+              "decision": "proceed_without_pre_use_permission_wait",
+              "decision_date": "2026-08-12",
+              "full_publications_in_scope": false,
+              "response_policy": "adapt_remove_or_reclassify_affected_material_on_substantiated_rights_notice",
+              "scope": "public_structured_text_and_metadata_for_phase3_training_with_attribution_and_field_level_provenance"
+            }
           },
           "official_bulk_download": {
             "api_url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
@@ -181,7 +195,7 @@
       "modern_correction_eligible": false,
       "record_count": 4157,
       "rights": {
-        "reuse_scope": "private_research_and_internal_analysis_only_until_an_explicit_data_license_is_verified",
+        "reuse_scope": "phase3_textual_dataset_training_and_derived_data_release_with_attribution_field_provenance_and_takedown_readiness",
         "source_text_committed": false,
         "status": "publicly_downloadable_license_not_declared"
       },
@@ -327,14 +341,14 @@
       "state": "open"
     },
     {
-      "blocking_for": ["public_training_release", "redistributable_historical_corpus"],
-      "do_not_claim": "Do not treat public downloadability, an open API, or public source-code repositories as an explicit license for corpus redistribution or training-data release.",
-      "evidence": "The pinned official documentation calls the Korniienko-derived dataset open and the REST API open and reusable, but no explicit data-license expression was found in the pinned project documentation or repositories.",
+      "blocking_for": ["claim_of_explicit_standardized_data_license", "license_warranty_or_indemnity"],
+      "do_not_claim": "Do not claim that the textual dataset has a standardized license expression or warranty, and do not extend the per-asset CC BY-NC label to unlabelled fields or full publications.",
+      "evidence": "The pinned official documentation calls the Korniienko-derived dataset open and the REST API open and reusable. No standardized data-license expression was found, while the stored 4,157-record snapshot contains 6,477 attached Korniienko photographs and drawings, all labelled CC BY-NC without a declared version.",
       "gap_id": "saint_sophia_license_expression_missing",
       "kind": "public_access_without_explicit_data_license",
-      "next_action": "Obtain or locate an explicit data-license statement from the Saint Sophia project or rights holders and bind its exact version before public training-data release.",
-      "nonblocking_for": ["private_research", "internal_text_free_audit", "complete_current_public_api_claim"],
-      "state": "open"
+      "next_action": "Do not wait for pre-use permission: preserve attribution and field-level provenance, monitor upstream rights statements, and adapt, remove, or reclassify affected material on a substantiated rights notice; bind an exact license version if one is later published.",
+      "nonblocking_for": ["private_research", "internal_text_free_audit", "complete_current_public_api_claim", "phase3_textual_dataset_use", "model_training", "derived_training_data_release"],
+      "state": "accepted_operational_risk"
     },
     {
       "blocking_for": ["graffito_108_semantic_gold", "graffito_108_dating_gold"],
@@ -444,7 +458,7 @@
     }
   ],
   "provider_calls": false,
-  "receipt_sha256": "08d3e6546a6c8e320743fa1a3d2e40fed1aed4e6c629bc9e352952bcdc7adb8b",
+  "receipt_sha256": "cc19bc1189b6c31714434027ce46c340c9f00a8ef6574e22005a2a5c44a2ae71",
   "schema_version": "phase3_historical_evidence_spine_v1",
   "status": "EVIDENCE_FIRST_SPINE_DEFINED_SOURCE_GAPS_OPEN",
   "text_free": true

--- a/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
+++ b/data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json
@@ -73,6 +73,47 @@
         },
         "quarantined_metadata": 2,
         "retrieval_scope": "complete_current_public_api",
+        "source_provenance": {
+          "ai_assistance": {
+            "affected_field_classes": [
+              "english_translation_and_commentary",
+              "romanisation"
+            ],
+            "affected_record_membership_known": false,
+            "disclosed_by_official_documentation": true,
+            "human_gold_eligible_without_review": false
+          },
+          "foundational_dataset": {
+            "edition_title": "Корпус Графіті Софії Київської",
+            "publication_year_end": 2020,
+            "publication_year_start": 2009,
+            "volume_count": 12
+          },
+          "gippius_2023": {
+            "doi": "10.4324/9781003256236-14",
+            "portal_bibliography_present": false,
+            "role": "qualified_secondary_reanalysis_candidate",
+            "target": "Kyiv graffito No. 108"
+          },
+          "license_evidence": {
+            "explicit_data_license_at_pinned_sources": null,
+            "official_docs_describe_api_as_open_and_reusable": true,
+            "official_docs_describe_dataset_as_open": true
+          },
+          "official_bulk_download": {
+            "api_url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
+            "download_label": "Download all inscription data",
+            "record_count_at_snapshot": 4157,
+            "same_public_api_stream": true
+          },
+          "part_ix": {
+            "bibliography_id": 11,
+            "linked_public_records": 306,
+            "publication_year": 2019,
+            "scope": "північні внутрішня та зовнішня галереї"
+          },
+          "portal_version": "v1.6"
+        },
         "stage_labels_assigned": 0,
         "text_bearing": 4144,
         "valid_date_intervals": 4145,
@@ -99,14 +140,50 @@
           "local_bytes_acquired": false,
           "locator_role": "api_root",
           "url": "https://saintsophia.dh.gu.se/api/"
+        },
+        {
+          "label": "Official bulk inscription download API",
+          "local_bytes_acquired": true,
+          "locator_role": "official_bulk_download_api",
+          "url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2"
+        },
+        {
+          "label": "Pinned official Saint Sophia dataset and API documentation",
+          "local_bytes_acquired": false,
+          "locator_role": "dataset_documentation",
+          "url": "https://github.com/gu-gridh/documentation/blob/eee39a2f5b009efed451e083a9654a48785b896c/gridh-projects/saintsophia.md"
+        },
+        {
+          "label": "Pinned official Saint Sophia backend repository",
+          "local_bytes_acquired": false,
+          "locator_role": "dataset_repository",
+          "url": "https://github.com/gu-gridh/Saint_Sophia/tree/4eca1b8ad9293759ce3f39a139ff9daf027882ef"
+        },
+        {
+          "label": "Pinned official bulk-download implementation",
+          "local_bytes_acquired": false,
+          "locator_role": "official_bulk_download_implementation",
+          "url": "https://github.com/gu-gridh/multimodal-map/blob/574914b6a740b639eb8e90f143664aae9a86cac7/projects/sophia/Footer.vue"
+        },
+        {
+          "label": "Official bibliography record for Korniienko Part IX",
+          "local_bytes_acquired": true,
+          "locator_role": "foundational_bibliography_record",
+          "url": "https://saintsophia.dh.gu.se/api/inscriptions/bibliography-item/11/"
+        },
+        {
+          "label": "Gippius 2023 reanalysis of Kyiv graffito No. 108",
+          "local_bytes_acquired": false,
+          "locator_role": "scholarly_reanalysis_doi",
+          "url": "https://doi.org/10.4324/9781003256236-14"
         }
       ],
       "modern_correction_eligible": false,
       "record_count": 4157,
       "rights": {
-        "reuse_scope": "private_research_only_until_explicit_clearance",
+        "reuse_scope": "private_research_and_internal_analysis_only_until_an_explicit_data_license_is_verified",
         "source_text_committed": false,
-        "status": "restricted_pending_explicit_clearance"
+        "status": "publicly_downloadable_license_not_declared"
       },
       "source_kind": "epigraphy",
       "source_sha256": "6199f2a92bd948dfe63d12e9da68637b02a4d16ff58b0ddba3d5e252bb3ec4fe"
@@ -250,6 +327,26 @@
       "state": "open"
     },
     {
+      "blocking_for": ["public_training_release", "redistributable_historical_corpus"],
+      "do_not_claim": "Do not treat public downloadability, an open API, or public source-code repositories as an explicit license for corpus redistribution or training-data release.",
+      "evidence": "The pinned official documentation calls the Korniienko-derived dataset open and the REST API open and reusable, but no explicit data-license expression was found in the pinned project documentation or repositories.",
+      "gap_id": "saint_sophia_license_expression_missing",
+      "kind": "public_access_without_explicit_data_license",
+      "next_action": "Obtain or locate an explicit data-license statement from the Saint Sophia project or rights holders and bind its exact version before public training-data release.",
+      "nonblocking_for": ["private_research", "internal_text_free_audit", "complete_current_public_api_claim"],
+      "state": "open"
+    },
+    {
+      "blocking_for": ["graffito_108_semantic_gold", "graffito_108_dating_gold"],
+      "do_not_claim": "Do not merge the portal transcription, Korniienko edition, Vysotsky number, and Gippius reanalysis into one unquestioned gold record without an exact identifier crosswalk and qualified adjudication.",
+      "evidence": "The official portal bibliography contains the twelve Korniienko volumes and links Part IX to 306 public records, but it does not contain Gippius 2023 and the current public record titles do not expose an exact 108 or 108a identifier.",
+      "gap_id": "kyiv_graffito_108_scholarly_crosswalk",
+      "kind": "edition_identifier_and_reanalysis_crosswalk_unresolved",
+      "next_action": "Map Vysotsky No. 108, Korniienko's identifier, the current portal record, and DOI 10.4324/9781003256236-14; retain each reading and date as attributed evidence until qualified Ukrainian historical-linguistic adjudication.",
+      "nonblocking_for": ["part_ix_collection_level_coverage", "other_saint_sophia_records"],
+      "state": "open"
+    },
+    {
       "blocking_for": ["old_ukrainian_direct_text_depth", "historical_source_coverage_ready"],
       "do_not_claim": "Do not relabel Church Slavonic, unlabelled, Greek, or mixed inscriptions as Ukrainian solely from their date or location.",
       "evidence": "Saint Sophia has 1,225 valid intervals wholly inside 1000-1399, but only seven are both text-bearing and source-labelled Ukrainian; no additional Old-Ukrainian documentary corpus is currently materialized.",
@@ -347,7 +444,7 @@
     }
   ],
   "provider_calls": false,
-  "receipt_sha256": "eb075580b05fa494300ffe8fb815a969208de3be2176c817482b634070678c86",
+  "receipt_sha256": "08d3e6546a6c8e320743fa1a3d2e40fed1aed4e6c629bc9e352952bcdc7adb8b",
   "schema_version": "phase3_historical_evidence_spine_v1",
   "status": "EVIDENCE_FIRST_SPINE_DEFINED_SOURCE_GAPS_OPEN",
   "text_free": true

--- a/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
@@ -147,7 +147,7 @@
     "gaps": {
       "type": "array",
       "minItems": 5,
-      "maxItems": 6,
+      "maxItems": 8,
       "uniqueItems": true,
       "items": {"$ref": "#/$defs/gap"}
     },
@@ -218,7 +218,7 @@
       "additionalProperties": false,
       "required": ["status", "reuse_scope", "source_text_committed"],
       "properties": {
-        "status": {"enum": ["admitted", "restricted_pending_explicit_clearance", "unknown_pending_review"]},
+        "status": {"enum": ["admitted", "publicly_downloadable_license_not_declared", "restricted_pending_explicit_clearance", "unknown_pending_review"]},
         "reuse_scope": {"type": "string", "minLength": 1},
         "source_text_committed": {"const": false}
       }
@@ -230,8 +230,88 @@
       "properties": {
         "label": {"type": "string", "minLength": 1},
         "url": {"type": "string", "format": "uri", "pattern": "^https?://"},
-        "locator_role": {"enum": ["source_portal", "api_root", "official_monument_evidence", "bibliographic_catalog", "dataset_repository", "dataset_doi"]},
+        "locator_role": {"enum": ["source_portal", "api_root", "official_bulk_download_api", "official_bulk_download_implementation", "dataset_documentation", "official_monument_evidence", "bibliographic_catalog", "foundational_bibliography_record", "scholarly_reanalysis_doi", "dataset_repository", "dataset_doi"]},
         "local_bytes_acquired": {"type": "boolean"}
+      }
+    },
+    "sophiaProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["portal_version", "official_bulk_download", "foundational_dataset", "part_ix", "gippius_2023", "ai_assistance", "license_evidence"],
+      "properties": {
+        "portal_version": {"const": "v1.6"},
+        "official_bulk_download": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["download_label", "api_url", "same_public_api_stream", "record_count_at_snapshot"],
+          "properties": {
+            "download_label": {"const": "Download all inscription data"},
+            "api_url": {"const": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2"},
+            "same_public_api_stream": {"const": true},
+            "record_count_at_snapshot": {"const": 4157}
+          }
+        },
+        "foundational_dataset": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["edition_title", "volume_count", "publication_year_start", "publication_year_end"],
+          "properties": {
+            "edition_title": {"const": "Корпус Графіті Софії Київської"},
+            "volume_count": {"const": 12},
+            "publication_year_start": {"const": 2009},
+            "publication_year_end": {"const": 2020}
+          }
+        },
+        "part_ix": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bibliography_id", "publication_year", "scope", "linked_public_records"],
+          "properties": {
+            "bibliography_id": {"const": 11},
+            "publication_year": {"const": 2019},
+            "scope": {"const": "північні внутрішня та зовнішня галереї"},
+            "linked_public_records": {"const": 306}
+          }
+        },
+        "gippius_2023": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["doi", "target", "role", "portal_bibliography_present"],
+          "properties": {
+            "doi": {"const": "10.4324/9781003256236-14"},
+            "target": {"const": "Kyiv graffito No. 108"},
+            "role": {"const": "qualified_secondary_reanalysis_candidate"},
+            "portal_bibliography_present": {"const": false}
+          }
+        },
+        "ai_assistance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["disclosed_by_official_documentation", "affected_field_classes", "affected_record_membership_known", "human_gold_eligible_without_review"],
+          "properties": {
+            "disclosed_by_official_documentation": {"const": true},
+            "affected_field_classes": {
+              "type": "array",
+              "prefixItems": [
+                {"const": "english_translation_and_commentary"},
+                {"const": "romanisation"}
+              ],
+              "items": false
+            },
+            "affected_record_membership_known": {"const": false},
+            "human_gold_eligible_without_review": {"const": false}
+          }
+        },
+        "license_evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["official_docs_describe_dataset_as_open", "official_docs_describe_api_as_open_and_reusable", "explicit_data_license_at_pinned_sources"],
+          "properties": {
+            "official_docs_describe_dataset_as_open": {"const": true},
+            "official_docs_describe_api_as_open_and_reusable": {"const": true},
+            "explicit_data_license_at_pinned_sources": {"type": "null"}
+          }
+        }
       }
     },
     "saintSophia": {
@@ -250,7 +330,7 @@
         "facts": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["retrieval_scope", "text_bearing", "non_textual_or_no_text", "quarantined_metadata", "known_identified_total_lower_bound", "known_unexposed_residual", "stage_labels_assigned", "valid_date_intervals", "exact_year_intervals", "century_or_wider_intervals", "missing_date_intervals", "invalid_date_intervals", "old_date_band", "middle_date_band", "language_labels", "writing_system_labels"],
+          "required": ["retrieval_scope", "text_bearing", "non_textual_or_no_text", "quarantined_metadata", "known_identified_total_lower_bound", "known_unexposed_residual", "stage_labels_assigned", "valid_date_intervals", "exact_year_intervals", "century_or_wider_intervals", "missing_date_intervals", "invalid_date_intervals", "old_date_band", "middle_date_band", "language_labels", "writing_system_labels", "source_provenance"],
           "properties": {
             "retrieval_scope": {"const": "complete_current_public_api"},
             "text_bearing": {"const": 4144},
@@ -267,7 +347,8 @@
             "old_date_band": {"$ref": "#/$defs/dateBand"},
             "middle_date_band": {"$ref": "#/$defs/dateBand"},
             "language_labels": {"$ref": "#/$defs/stringCountMap"},
-            "writing_system_labels": {"$ref": "#/$defs/stringCountMap"}
+            "writing_system_labels": {"$ref": "#/$defs/stringCountMap"},
+            "source_provenance": {"$ref": "#/$defs/sophiaProvenance"}
           }
         },
         "rights": {"$ref": "#/$defs/rights"},

--- a/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_historical_evidence_spine_v1.schema.json",
+  "title": "Phase 3 evidence-first historical Ukrainian coverage spine v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status",
+    "text_free",
+    "provider_calls",
+    "bindings",
+    "framework_policy",
+    "authority_policy",
+    "instructional_sequence",
+    "collections",
+    "gaps",
+    "gates",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_historical_evidence_spine_v1"},
+    "status": {"const": "EVIDENCE_FIRST_SPINE_DEFINED_SOURCE_GAPS_OPEN"},
+    "text_free": {"const": true},
+    "provider_calls": {"const": false},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "historical_denominator_sha256",
+        "historical_full_materialization_gate_sha256",
+        "historical_full_materialization_receipt_file_sha256",
+        "historical_full_materialization_receipt_sha256",
+        "historical_periodization_freeze_sha256",
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256"
+      ],
+      "properties": {
+        "historical_denominator_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_materialization_gate_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_materialization_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_materialization_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_periodization_freeze_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_reboot_prompt_v3_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_recovery_prompt_v2_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "framework_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_framework_id",
+        "instructional_navigation_framework_id",
+        "instructional_navigation_scope",
+        "bound_framework_ids",
+        "frameworks_preserved_without_collapse",
+        "record_assignment_requires_attributed_evidence"
+      ],
+      "properties": {
+        "canonical_framework_id": {"type": "null"},
+        "instructional_navigation_framework_id": {"const": "university_five_stage_synthesis"},
+        "instructional_navigation_scope": {"const": "coarse_navigation_only_not_semantic_gold"},
+        "bound_framework_ids": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "university_five_stage_synthesis",
+              "shevelov_detailed_six_period",
+              "nimchuk_five_stage_with_middle_subperiods"
+            ]
+          }
+        },
+        "frameworks_preserved_without_collapse": {"const": true},
+        "record_assignment_requires_attributed_evidence": {"const": true}
+      }
+    },
+    "authority_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ranked_layers",
+        "direct_attestation_definition",
+        "proto_reconstruction_is_direct_attestation",
+        "learner_exposition",
+        "historical_forms_protected",
+        "old_east_slavic_is_modern_russian",
+        "scalar_language_age_claim_allowed"
+      ],
+      "properties": {
+        "ranked_layers": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "prefixItems": [
+            {"const": "direct_attested_source"},
+            {"const": "qualified_edition_or_translation"},
+            {"const": "qualified_ukrainian_linguistic_analysis"},
+            {"const": "comparative_reconstruction"},
+            {"const": "learner_exposition"}
+          ],
+          "items": false
+        },
+        "direct_attestation_definition": {"type": "string", "minLength": 1},
+        "proto_reconstruction_is_direct_attestation": {"const": false},
+        "learner_exposition": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "historical_authority_eligible",
+            "preserve_for_instructional_evaluation",
+            "training_text_eligibility"
+          ],
+          "properties": {
+            "historical_authority_eligible": {"const": false},
+            "preserve_for_instructional_evaluation": {"const": true},
+            "training_text_eligibility": {"const": "pending_separate_rights_and_quality_review"}
+          }
+        },
+        "historical_forms_protected": {"const": true},
+        "old_east_slavic_is_modern_russian": {"const": false},
+        "scalar_language_age_claim_allowed": {"const": false}
+      }
+    },
+    "instructional_sequence": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {"$ref": "#/$defs/sequence"}
+    },
+    "collections": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/saintSophia"},
+          {"$ref": "#/$defs/lavra"},
+          {"$ref": "#/$defs/ud"},
+          {"$ref": "#/$defs/plug2"}
+        ]
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/gap"}
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_first_spine_defined",
+        "private_corpus_audit_reproducible",
+        "historical_source_coverage_ready",
+        "historical_source_freeze_ready",
+        "phase3_complete",
+        "phase4_authorized",
+        "phase4_blocked"
+      ],
+      "properties": {
+        "evidence_first_spine_defined": {"const": true},
+        "private_corpus_audit_reproducible": {"const": true},
+        "historical_source_coverage_ready": {"const": false},
+        "historical_source_freeze_ready": {"const": false},
+        "phase3_complete": {"const": false},
+        "phase4_authorized": {"const": false},
+        "phase4_blocked": {"const": true}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "nonnegative": {"type": "integer", "minimum": 0},
+    "stringCountMap": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"$ref": "#/$defs/nonnegative"}
+    },
+    "sequence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequence_id",
+        "position",
+        "label_uk",
+        "evidence_mode",
+        "collection_ids",
+        "coverage_state",
+        "purpose"
+      ],
+      "properties": {
+        "sequence_id": {
+          "enum": [
+            "kyiv_medieval_epigraphy",
+            "old_ukrainian_documentary_and_literary",
+            "middle_ukrainian_documentary_and_print",
+            "new_and_modern_ukrainian",
+            "comparative_reconstruction_backlink"
+          ]
+        },
+        "position": {"type": "integer", "minimum": 1, "maximum": 5},
+        "label_uk": {"type": "string", "minLength": 1},
+        "evidence_mode": {"enum": ["direct_attestation", "direct_text", "comparative_reconstruction"]},
+        "collection_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "coverage_state": {"enum": ["materialized_with_open_gaps", "insufficient", "large_but_not_complete", "comparative_only"]},
+        "purpose": {"type": "string", "minLength": 1}
+      }
+    },
+    "rights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reuse_scope", "source_text_committed"],
+      "properties": {
+        "status": {"enum": ["admitted", "restricted_pending_explicit_clearance", "unknown_pending_review"]},
+        "reuse_scope": {"type": "string", "minLength": 1},
+        "source_text_committed": {"const": false}
+      }
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "url", "locator_role", "local_bytes_acquired"],
+      "properties": {
+        "label": {"type": "string", "minLength": 1},
+        "url": {"type": "string", "format": "uri", "pattern": "^https?://"},
+        "locator_role": {"enum": ["source_portal", "api_root", "official_monument_evidence", "bibliographic_catalog", "dataset_repository", "dataset_doi"]},
+        "local_bytes_acquired": {"type": "boolean"}
+      }
+    },
+    "saintSophia": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collection_id", "evidence_layer", "source_kind", "custody_state", "record_count", "source_sha256", "corpus_role", "modern_correction_eligible", "facts", "rights", "locators"],
+      "properties": {
+        "collection_id": {"const": "saint-sophia-inscriptions"},
+        "evidence_layer": {"const": "direct_attested_source"},
+        "source_kind": {"const": "epigraphy"},
+        "custody_state": {"const": "materialized"},
+        "record_count": {"const": 4157},
+        "source_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_role": {"const": "auxiliary_historical_evidence"},
+        "modern_correction_eligible": {"const": false},
+        "facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["retrieval_scope", "text_bearing", "non_textual_or_no_text", "quarantined_metadata", "known_identified_total_lower_bound", "known_unexposed_residual", "stage_labels_assigned", "valid_date_intervals", "exact_year_intervals", "century_or_wider_intervals", "missing_date_intervals", "invalid_date_intervals", "old_date_band", "middle_date_band", "language_labels", "writing_system_labels"],
+          "properties": {
+            "retrieval_scope": {"const": "complete_current_public_api"},
+            "text_bearing": {"const": 4144},
+            "non_textual_or_no_text": {"const": 11},
+            "quarantined_metadata": {"const": 2},
+            "known_identified_total_lower_bound": {"type": "integer", "minimum": 7000},
+            "known_unexposed_residual": {"const": true},
+            "stage_labels_assigned": {"const": 0},
+            "valid_date_intervals": {"$ref": "#/$defs/nonnegative"},
+            "exact_year_intervals": {"$ref": "#/$defs/nonnegative"},
+            "century_or_wider_intervals": {"$ref": "#/$defs/nonnegative"},
+            "missing_date_intervals": {"$ref": "#/$defs/nonnegative"},
+            "invalid_date_intervals": {"$ref": "#/$defs/nonnegative"},
+            "old_date_band": {"$ref": "#/$defs/dateBand"},
+            "middle_date_band": {"$ref": "#/$defs/dateBand"},
+            "language_labels": {"$ref": "#/$defs/stringCountMap"},
+            "writing_system_labels": {"$ref": "#/$defs/stringCountMap"}
+          }
+        },
+        "rights": {"$ref": "#/$defs/rights"},
+        "locators": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/locator"}}
+      }
+    },
+    "dateBand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["year_start", "year_end", "interval_wholly_inside", "interval_overlaps", "text_bearing_ukrainian_label_wholly_inside", "semantic_stage_assignment"],
+      "properties": {
+        "year_start": {"type": "integer"},
+        "year_end": {"type": "integer"},
+        "interval_wholly_inside": {"$ref": "#/$defs/nonnegative"},
+        "interval_overlaps": {"$ref": "#/$defs/nonnegative"},
+        "text_bearing_ukrainian_label_wholly_inside": {"$ref": "#/$defs/nonnegative"},
+        "semantic_stage_assignment": {"const": "pending_qualified_review"}
+      }
+    },
+    "lavra": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collection_id", "evidence_layer", "source_kind", "custody_state", "record_count", "source_sha256", "corpus_role", "modern_correction_eligible", "facts", "rights", "locators"],
+      "properties": {
+        "collection_id": {"const": "kyiv-pechersk-lavra-graffiti"},
+        "evidence_layer": {"const": "direct_attested_source"},
+        "source_kind": {"const": "epigraphy"},
+        "custody_state": {"const": "not_materialized"},
+        "record_count": {"type": "null"},
+        "source_sha256": {"type": "null"},
+        "corpus_role": {"const": "acquisition_candidate_direct_historical_evidence"},
+        "modern_correction_eligible": {"const": false},
+        "facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["corpus_count_known", "source_bytes_acquired", "rights_verified", "separate_from_saint_sophia"],
+          "properties": {
+            "corpus_count_known": {"const": false},
+            "source_bytes_acquired": {"const": false},
+            "rights_verified": {"const": false},
+            "separate_from_saint_sophia": {"const": true}
+          }
+        },
+        "rights": {"$ref": "#/$defs/rights"},
+        "locators": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/locator"}}
+      }
+    },
+    "ud": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collection_id", "evidence_layer", "source_kind", "custody_state", "record_count", "source_sha256", "corpus_role", "modern_correction_eligible", "facts", "rights", "locators"],
+      "properties": {
+        "collection_id": {"const": "ud-old-east-slavic-ruthenian-05a029e00ccf"},
+        "evidence_layer": {"const": "qualified_edition_or_translation"},
+        "source_kind": {"const": "documentary_treebank"},
+        "custody_state": {"const": "materialized"},
+        "record_count": {"const": 82},
+        "source_sha256": {"type": "null"},
+        "corpus_role": {"const": "historical_recognition_and_analysis_candidate"},
+        "modern_correction_eligible": {"const": false},
+        "facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sentences", "token_rows", "exact_dated_documents", "exact_years", "undated_documents", "periodization_assignment_state", "file_sha256"],
+          "properties": {
+            "sentences": {"const": 1311},
+            "token_rows": {"const": 35081},
+            "exact_dated_documents": {"const": 4},
+            "exact_years": {"type": "array", "prefixItems": [{"const": 1413}, {"const": 1436}, {"const": 1456}, {"const": 1473}], "items": false},
+            "undated_documents": {"const": 78},
+            "periodization_assignment_state": {"const": "unresolved"},
+            "file_sha256": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["orv_ruthenian-ud-dev.conllu", "orv_ruthenian-ud-test.conllu", "orv_ruthenian-ud-train.conllu"],
+              "properties": {
+                "orv_ruthenian-ud-dev.conllu": {"$ref": "#/$defs/sha256"},
+                "orv_ruthenian-ud-test.conllu": {"$ref": "#/$defs/sha256"},
+                "orv_ruthenian-ud-train.conllu": {"$ref": "#/$defs/sha256"}
+              }
+            }
+          }
+        },
+        "rights": {"$ref": "#/$defs/rights"},
+        "locators": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/locator"}}
+      }
+    },
+    "plug2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collection_id", "evidence_layer", "source_kind", "custody_state", "record_count", "source_sha256", "corpus_role", "modern_correction_eligible", "facts", "rights", "locators"],
+      "properties": {
+        "collection_id": {"const": "plug2-zenodo-19482961"},
+        "evidence_layer": {"const": "direct_attested_source"},
+        "source_kind": {"const": "historical_text_corpus"},
+        "custody_state": {"const": "materialized"},
+        "record_count": {"const": 56080},
+        "source_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_role": {"const": "new_ukrainian_historical_text_evidence"},
+        "modern_correction_eligible": {"const": false},
+        "facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["all_documents", "uk_token_sum", "date_min", "date_max", "exact_dated_documents", "pre_1800_documents", "archive_sha256", "materialized_record_count"],
+          "properties": {
+            "all_documents": {"const": 56245},
+            "uk_token_sum": {"const": 71802066},
+            "date_min": {"const": 1816},
+            "date_max": {"const": 1954},
+            "exact_dated_documents": {"const": 56080},
+            "pre_1800_documents": {"const": 0},
+            "archive_sha256": {"$ref": "#/$defs/sha256"},
+            "materialized_record_count": {"const": 1910748}
+          }
+        },
+        "rights": {"$ref": "#/$defs/rights"},
+        "locators": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/locator"}}
+      }
+    },
+    "gap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gap_id", "kind", "state", "blocking_for", "nonblocking_for", "evidence", "next_action", "do_not_claim"],
+      "properties": {
+        "gap_id": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1},
+        "state": {"const": "open"},
+        "blocking_for": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "nonblocking_for": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "evidence": {"type": "string", "minLength": 1},
+        "next_action": {"type": "string", "minLength": 1},
+        "do_not_claim": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json
@@ -305,11 +305,35 @@
         "license_evidence": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["official_docs_describe_dataset_as_open", "official_docs_describe_api_as_open_and_reusable", "explicit_data_license_at_pinned_sources"],
+          "required": ["official_docs_describe_dataset_as_open", "official_docs_describe_api_as_open_and_reusable", "explicit_data_license_at_pinned_sources", "korniienko_media_assets", "operator_use_decision"],
           "properties": {
             "official_docs_describe_dataset_as_open": {"const": true},
             "official_docs_describe_api_as_open_and_reusable": {"const": true},
-            "explicit_data_license_at_pinned_sources": {"type": "null"}
+            "explicit_data_license_at_pinned_sources": {"type": "null"},
+            "korniienko_media_assets": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["asset_count_at_snapshot", "license_label", "license_version_declared", "included_in_text_training"],
+              "properties": {
+                "asset_count_at_snapshot": {"const": 6477},
+                "license_label": {"const": "CC BY-NC"},
+                "license_version_declared": {"const": false},
+                "included_in_text_training": {"const": false}
+              }
+            },
+            "operator_use_decision": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["decision_date", "decision", "scope", "full_publications_in_scope", "binary_media_in_scope", "response_policy"],
+              "properties": {
+                "decision_date": {"const": "2026-08-12"},
+                "decision": {"const": "proceed_without_pre_use_permission_wait"},
+                "scope": {"const": "public_structured_text_and_metadata_for_phase3_training_with_attribution_and_field_level_provenance"},
+                "full_publications_in_scope": {"const": false},
+                "binary_media_in_scope": {"const": false},
+                "response_policy": {"const": "adapt_remove_or_reclassify_affected_material_on_substantiated_rights_notice"}
+              }
+            }
           }
         }
       }
@@ -475,7 +499,7 @@
       "properties": {
         "gap_id": {"type": "string", "minLength": 1},
         "kind": {"type": "string", "minLength": 1},
-        "state": {"const": "open"},
+        "state": {"enum": ["open", "accepted_operational_risk"]},
         "blocking_for": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "nonblocking_for": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "evidence": {"type": "string", "minLength": 1},

--- a/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
+++ b/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
@@ -30,7 +30,7 @@ DENOMINATOR_PATH = ROOT / "data/historical_language_corpus_denominator.yaml"
 FULL_GATE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_historical_full_materialization_gate_v1.json"
 
 SCHEMA_VERSION = "phase3_historical_evidence_spine_v1"
-EXPECTED_SPINE_SHA256 = "2c8907fc5c04dd2e73de425ac7627002028dc6056513802a19f199191b6ea55b"
+EXPECTED_SPINE_SHA256 = "61a937f150a4cbecf6b12774ef812d67289705d9523c4e766c95e721b7451076"
 EXPECTED_BINDINGS = {
     "historical_denominator_sha256": "4d89bfdb7e935008ad1332426ff9c40dca97efdf72053f35cdb1dad05117e6aa",
     "historical_full_materialization_gate_sha256": "3a4f409be28560dbc6a9c2c5defa043414dc659870be11a03f8e7297e8249e21",
@@ -83,6 +83,20 @@ EXPECTED_SOPHIA_PROVENANCE = {
         "official_docs_describe_dataset_as_open": True,
         "official_docs_describe_api_as_open_and_reusable": True,
         "explicit_data_license_at_pinned_sources": None,
+        "korniienko_media_assets": {
+            "asset_count_at_snapshot": 6477,
+            "included_in_text_training": False,
+            "license_label": "CC BY-NC",
+            "license_version_declared": False,
+        },
+        "operator_use_decision": {
+            "binary_media_in_scope": False,
+            "decision": "proceed_without_pre_use_permission_wait",
+            "decision_date": "2026-08-12",
+            "full_publications_in_scope": False,
+            "response_policy": "adapt_remove_or_reclassify_affected_material_on_substantiated_rights_notice",
+            "scope": "public_structured_text_and_metadata_for_phase3_training_with_attribution_and_field_level_provenance",
+        },
     },
     "official_bulk_download": {
         "api_url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
@@ -163,6 +177,10 @@ EXPECTED_GAPS = {
     "middle_ukrainian_genre_and_region_depth",
     "nimchuk_primary_periodization_text",
 }
+EXPECTED_GAP_STATES = {
+    gap_id: ("accepted_operational_risk" if gap_id == "saint_sophia_license_expression_missing" else "open")
+    for gap_id in EXPECTED_GAPS
+}
 EXPECTED_SEQUENCE_CONTRACT = [
     {
         "sequence_id": "kyiv_medieval_epigraphy",
@@ -202,7 +220,7 @@ EXPECTED_SEQUENCE_CONTRACT = [
 ]
 EXPECTED_RIGHTS = {
     "saint-sophia-inscriptions": {
-        "reuse_scope": "private_research_and_internal_analysis_only_until_an_explicit_data_license_is_verified",
+        "reuse_scope": "phase3_textual_dataset_training_and_derived_data_release_with_attribution_field_provenance_and_takedown_readiness",
         "source_text_committed": False,
         "status": "publicly_downloadable_license_not_declared",
     },
@@ -243,6 +261,11 @@ EXPECTED_SOPHIA_PRIVATE_AUDIT = {
         "gippius_2023_portal_bibliography_matches": 0,
         "part_ix_bibliography_id": 11,
         "part_ix_linked_records": 306,
+    },
+    "media_assets": {
+        "asset_count": 6477,
+        "license_counts": {"CC BY-NC": 6477},
+        "type_counts": {"Drawing": 3248, "Photograph": 3229},
     },
     "coarse_date_observations": {
         "old_1000_1399": {
@@ -426,7 +449,10 @@ def validate_spine(value: Mapping[str, Any]) -> dict[str, Any]:
 
     gaps = _by_id(spine["gaps"], "gap_id", "gap")
     require(gaps.keys() == EXPECTED_GAPS, "historical coverage gap denominator drift")
-    require(all(item["state"] == "open" for item in gaps.values()), "open source gaps cannot be silently closed")
+    require(
+        {gap_id: item["state"] for gap_id, item in gaps.items()} == EXPECTED_GAP_STATES,
+        "historical coverage gap disposition drift",
+    )
 
     gates = spine["gates"]
     require(gates["evidence_first_spine_defined"] is True, "evidence spine definition is incomplete")
@@ -472,6 +498,8 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
     old_definite = old_possible = old_ukrainian_definite = 0
     middle_definite = middle_possible = middle_ukrainian_definite = 0
     bibliography_ids: set[int] = set()
+    media_licenses: Counter[str] = Counter()
+    media_types: Counter[str] = Counter()
     part_ix_linked_records = 0
     gippius_2023_matches = 0
     for line_number, raw_line in enumerate(path.open(encoding="utf-8"), start=1):
@@ -484,8 +512,11 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
         dispositions[str(row.get("disposition"))] += 1
         languages[str(row.get("source_language_label") or "unlabelled")] += 1
         writing_systems[str(row.get("source_writing_system_label") or "unlabelled")] += 1
-        source_record = row.get("metadata", {}).get("source_record", {})
-        bibliography = source_record.get("bibliography", []) if isinstance(source_record, dict) else []
+        metadata = row.get("metadata")
+        require(isinstance(metadata, dict), f"Saint Sophia line {line_number} metadata is not an object")
+        source_record = metadata.get("source_record", {})
+        require(isinstance(source_record, dict), f"Saint Sophia line {line_number} source record is not an object")
+        bibliography = source_record.get("bibliography", [])
         require(isinstance(bibliography, list), f"Saint Sophia line {line_number} bibliography is not a list")
         has_part_ix = False
         has_gippius = False
@@ -501,6 +532,12 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
             has_gippius = has_gippius or any(name in bibliography_text for name in ("gippius", "гиппиус", "гіппіус"))
         part_ix_linked_records += has_part_ix
         gippius_2023_matches += has_gippius
+        media_assets = source_record.get("korniienko_image", [])
+        require(isinstance(media_assets, list), f"Saint Sophia line {line_number} media assets are not a list")
+        for asset in media_assets:
+            require(isinstance(asset, dict), f"Saint Sophia line {line_number} media asset is not an object")
+            media_licenses[str(asset.get("type_of_license") or "unlabelled")] += 1
+            media_types[str(asset.get("type_of_image") or "unlabelled")] += 1
         minimum, maximum = row.get("min_year"), row.get("max_year")
         if minimum is None or maximum is None:
             missing_dates += 1
@@ -539,6 +576,11 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
             "gippius_2023_portal_bibliography_matches": gippius_2023_matches,
             "part_ix_bibliography_id": 11,
             "part_ix_linked_records": part_ix_linked_records,
+        },
+        "media_assets": {
+            "asset_count": sum(media_licenses.values()),
+            "license_counts": dict(sorted(media_licenses.items())),
+            "type_counts": dict(sorted(media_types.items())),
         },
         "coarse_date_observations": {
             "old_1000_1399": {
@@ -766,7 +808,10 @@ def main() -> int:
         "schema_version": spine["schema_version"],
         "status": spine["status"],
         "receipt_sha256": spine["receipt_sha256"],
-        "open_gap_count": len(spine["gaps"]),
+        "open_gap_count": sum(item["state"] == "open" for item in spine["gaps"]),
+        "accepted_operational_risk_count": sum(
+            item["state"] == "accepted_operational_risk" for item in spine["gaps"]
+        ),
         "phase3_complete": spine["gates"]["phase3_complete"],
         "phase4_blocked": spine["gates"]["phase4_blocked"],
         "provider_calls": False,

--- a/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
+++ b/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Validate the evidence-first historical Ukrainian coverage spine.
+
+The spine is deliberately not a fourth periodization.  It binds the existing
+attributed Ukrainian scholarly frameworks and records what the locally held
+corpora can actually prove.  Direct attestations lead the instructional order;
+reconstruction and learner exposition remain separately labelled evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_historical_materialization as materialization
+from scripts.projects.open_model_data import phase3_historical_periodization as periodization
+
+ROOT = Path(__file__).resolve().parents[3]
+SPINE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_historical_evidence_spine_v1.json"
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_historical_evidence_spine_v1.schema.json"
+DENOMINATOR_PATH = ROOT / "data/historical_language_corpus_denominator.yaml"
+FULL_GATE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_historical_full_materialization_gate_v1.json"
+
+SCHEMA_VERSION = "phase3_historical_evidence_spine_v1"
+EXPECTED_SPINE_SHA256 = "4c775a9c2170e7aa521d6188cac2dba29b7f1e808cc8963d210363f78faef5c9"
+EXPECTED_BINDINGS = {
+    "historical_denominator_sha256": "4d89bfdb7e935008ad1332426ff9c40dca97efdf72053f35cdb1dad05117e6aa",
+    "historical_full_materialization_gate_sha256": "3a4f409be28560dbc6a9c2c5defa043414dc659870be11a03f8e7297e8249e21",
+    "historical_full_materialization_receipt_file_sha256": "05322d450a8e90b103fff7521605395250e1da957fbf63e8ecf1df8d3d5f6307",
+    "historical_full_materialization_receipt_sha256": "8e3d33b4c5d5a5a4bd3c5da7788460d016e16b9058515b64a6683a725a14c2de",
+    "historical_periodization_freeze_sha256": periodization.EXPECTED_FREEZE_SHA256,
+    "phase3_reboot_prompt_v3_sha256": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d",
+    "phase3_recovery_prompt_v2_sha256": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b",
+}
+EXPECTED_COLLECTIONS = {
+    "saint-sophia-inscriptions",
+    "kyiv-pechersk-lavra-graffiti",
+    materialization.UD_COLLECTION_ID,
+    materialization.PLUG2_COLLECTION_ID,
+}
+EXPECTED_AUTHORITY_ORDER = [
+    "direct_attested_source",
+    "qualified_edition_or_translation",
+    "qualified_ukrainian_linguistic_analysis",
+    "comparative_reconstruction",
+    "learner_exposition",
+]
+EXPECTED_INSTRUCTIONAL_ORDER = [
+    "kyiv_medieval_epigraphy",
+    "old_ukrainian_documentary_and_literary",
+    "middle_ukrainian_documentary_and_print",
+    "new_and_modern_ukrainian",
+    "comparative_reconstruction_backlink",
+]
+EXPECTED_SOPHIA_FACTS = {
+    "century_or_wider_intervals": 3550,
+    "exact_year_intervals": 168,
+    "invalid_date_intervals": 2,
+    "known_identified_total_lower_bound": 7000,
+    "known_unexposed_residual": True,
+    "language_labels": {
+        "Ancient Greek": 150,
+        "Armenian": 32,
+        "Church Slavonic": 1306,
+        "Greek": 10,
+        "Latin": 34,
+        "Low German": 1,
+        "Mixed": 10,
+        "N/A": 12,
+        "Polish": 286,
+        "Russian": 10,
+        "Ukrainian": 588,
+        "unlabelled": 1718,
+    },
+    "middle_date_band": {
+        "interval_overlaps": 2920,
+        "interval_wholly_inside": 1155,
+        "semantic_stage_assignment": "pending_qualified_review",
+        "text_bearing_ukrainian_label_wholly_inside": 549,
+        "year_end": 1799,
+        "year_start": 1400,
+    },
+    "missing_date_intervals": 10,
+    "non_textual_or_no_text": 11,
+    "old_date_band": {
+        "interval_overlaps": 2989,
+        "interval_wholly_inside": 1225,
+        "semantic_stage_assignment": "pending_qualified_review",
+        "text_bearing_ukrainian_label_wholly_inside": 7,
+        "year_end": 1399,
+        "year_start": 1000,
+    },
+    "quarantined_metadata": 2,
+    "retrieval_scope": "complete_current_public_api",
+    "stage_labels_assigned": 0,
+    "text_bearing": 4144,
+    "valid_date_intervals": 4145,
+    "writing_system_labels": {
+        "Armenian": 31,
+        "Cyrillic": 1982,
+        "Glagolitic": 1,
+        "Greek": 157,
+        "Latin": 367,
+        "Mixed script": 7,
+        "N/A": 2,
+        "unlabelled": 1610,
+    },
+}
+EXPECTED_GAPS = {
+    "lavra_epigraphy_not_materialized",
+    "saint_sophia_public_residual",
+    "old_ukrainian_direct_text_depth",
+    "ud_document_date_and_provenance_review",
+    "middle_ukrainian_genre_and_region_depth",
+    "nimchuk_primary_periodization_text",
+}
+EXPECTED_SEQUENCE_CONTRACT = [
+    {
+        "sequence_id": "kyiv_medieval_epigraphy",
+        "position": 1,
+        "evidence_mode": "direct_attestation",
+        "collection_ids": ["saint-sophia-inscriptions", "kyiv-pechersk-lavra-graffiti"],
+        "coverage_state": "materialized_with_open_gaps",
+    },
+    {
+        "sequence_id": "old_ukrainian_documentary_and_literary",
+        "position": 2,
+        "evidence_mode": "direct_text",
+        "collection_ids": ["saint-sophia-inscriptions"],
+        "coverage_state": "insufficient",
+    },
+    {
+        "sequence_id": "middle_ukrainian_documentary_and_print",
+        "position": 3,
+        "evidence_mode": "direct_text",
+        "collection_ids": ["saint-sophia-inscriptions", materialization.UD_COLLECTION_ID],
+        "coverage_state": "insufficient",
+    },
+    {
+        "sequence_id": "new_and_modern_ukrainian",
+        "position": 4,
+        "evidence_mode": "direct_text",
+        "collection_ids": [materialization.PLUG2_COLLECTION_ID],
+        "coverage_state": "large_but_not_complete",
+    },
+    {
+        "sequence_id": "comparative_reconstruction_backlink",
+        "position": 5,
+        "evidence_mode": "comparative_reconstruction",
+        "collection_ids": [],
+        "coverage_state": "comparative_only",
+    },
+]
+EXPECTED_RIGHTS = {
+    "saint-sophia-inscriptions": {
+        "reuse_scope": "private_research_only_until_explicit_clearance",
+        "source_text_committed": False,
+        "status": "restricted_pending_explicit_clearance",
+    },
+    "kyiv-pechersk-lavra-graffiti": {
+        "reuse_scope": "no_corpus_use_until_source_and_rights_are_verified",
+        "source_text_committed": False,
+        "status": "unknown_pending_review",
+    },
+    materialization.UD_COLLECTION_ID: {
+        "reuse_scope": "public_training_with_share_alike_and_attribution",
+        "source_text_committed": False,
+        "status": "admitted",
+    },
+    materialization.PLUG2_COLLECTION_ID: {
+        "reuse_scope": "public_training_with_attribution",
+        "source_text_committed": False,
+        "status": "admitted",
+    },
+}
+EXPECTED_SOPHIA_PRIVATE_AUDIT = {
+    "records": 4157,
+    "dispositions": {
+        "non_textual_or_no_text": 11,
+        "quarantined_metadata": 2,
+        "text_bearing": 4144,
+    },
+    "languages": EXPECTED_SOPHIA_FACTS["language_labels"],
+    "writing_systems": EXPECTED_SOPHIA_FACTS["writing_system_labels"],
+    "dates": {
+        "valid_intervals": EXPECTED_SOPHIA_FACTS["valid_date_intervals"],
+        "exact_year_intervals": EXPECTED_SOPHIA_FACTS["exact_year_intervals"],
+        "century_or_wider_intervals": EXPECTED_SOPHIA_FACTS["century_or_wider_intervals"],
+        "missing_intervals": EXPECTED_SOPHIA_FACTS["missing_date_intervals"],
+        "invalid_intervals": EXPECTED_SOPHIA_FACTS["invalid_date_intervals"],
+    },
+    "coarse_date_observations": {
+        "old_1000_1399": {
+            "interval_wholly_inside": EXPECTED_SOPHIA_FACTS["old_date_band"]["interval_wholly_inside"],
+            "interval_overlaps": EXPECTED_SOPHIA_FACTS["old_date_band"]["interval_overlaps"],
+            "text_bearing_ukrainian_label_wholly_inside": EXPECTED_SOPHIA_FACTS["old_date_band"][
+                "text_bearing_ukrainian_label_wholly_inside"
+            ],
+        },
+        "middle_1400_1799": {
+            "interval_wholly_inside": EXPECTED_SOPHIA_FACTS["middle_date_band"]["interval_wholly_inside"],
+            "interval_overlaps": EXPECTED_SOPHIA_FACTS["middle_date_band"]["interval_overlaps"],
+            "text_bearing_ukrainian_label_wholly_inside": EXPECTED_SOPHIA_FACTS["middle_date_band"][
+                "text_bearing_ukrainian_label_wholly_inside"
+            ],
+        },
+    },
+}
+
+
+class HistoricalEvidenceSpineError(ValueError):
+    """The historical evidence spine is stale, overclaiming, or unsafe."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise HistoricalEvidenceSpineError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HistoricalEvidenceSpineError(f"cannot read {label}: {path}") from exc
+    require(isinstance(value, dict), f"{label} must be a JSON object")
+    return value
+
+
+def _schema_validator() -> Draft202012Validator:
+    schema = _read_json(SCHEMA_PATH, "historical evidence spine schema")
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _validate_schema(value: Mapping[str, Any]) -> None:
+    errors = sorted(_schema_validator().iter_errors(value), key=lambda error: list(error.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "spine"
+        raise HistoricalEvidenceSpineError(
+            f"historical evidence spine schema violation at {location}: {errors[0].message}"
+        )
+
+
+def _by_id(items: list[dict[str, Any]], key: str, label: str) -> dict[str, dict[str, Any]]:
+    result = {item[key]: item for item in items}
+    require(len(result) == len(items), f"duplicate {label} ID")
+    return result
+
+
+def validate_spine(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the tracked text-free coverage and evidence-authority contract."""
+    spine = json.loads(json.dumps(value, ensure_ascii=False))
+    _validate_schema(spine)
+    require(spine["schema_version"] == SCHEMA_VERSION, "historical evidence spine version drift")
+    require(spine["bindings"] == EXPECTED_BINDINGS, "historical evidence spine bindings drift")
+
+    body = {key: item for key, item in spine.items() if key != "receipt_sha256"}
+    expected_receipt = hashlib.sha256((canonical_json(body) + "\n").encode()).hexdigest()
+    require(spine["receipt_sha256"] == expected_receipt, "historical evidence spine seal mismatch")
+
+    framework_policy = spine["framework_policy"]
+    require(framework_policy["canonical_framework_id"] is None, "one chronology cannot be canonicalized")
+    require(framework_policy["frameworks_preserved_without_collapse"], "attributed frameworks must be preserved")
+    require(
+        set(framework_policy["bound_framework_ids"]) == set(periodization.REQUIRED_FRAMEWORKS),
+        "historical framework set drift",
+    )
+
+    authority = spine["authority_policy"]
+    require(authority["ranked_layers"] == EXPECTED_AUTHORITY_ORDER, "evidence authority order drift")
+    require(authority["scalar_language_age_claim_allowed"] is False, "scalar language-age claims are forbidden")
+    require(authority["proto_reconstruction_is_direct_attestation"] is False, "reconstruction cannot become corpus fact")
+    learner = authority["learner_exposition"]
+    require(learner["historical_authority_eligible"] is False, "learner material cannot become historical authority")
+    require(learner["preserve_for_instructional_evaluation"] is True, "learner material must remain available for evaluation")
+
+    sequence = spine["instructional_sequence"]
+    require([item["sequence_id"] for item in sequence] == EXPECTED_INSTRUCTIONAL_ORDER, "instructional sequence drift")
+    sequence_contract = [
+        {key: item[key] for key in ("sequence_id", "position", "evidence_mode", "collection_ids", "coverage_state")}
+        for item in sequence
+    ]
+    require(sequence_contract == EXPECTED_SEQUENCE_CONTRACT, "instructional sequence evidence binding drift")
+    require(sequence[0]["evidence_mode"] == "direct_attestation", "direct medieval evidence must lead the sequence")
+    require(sequence[-1]["evidence_mode"] == "comparative_reconstruction", "reconstruction must remain a backlink")
+
+    collections = _by_id(spine["collections"], "collection_id", "collection")
+    require(set(collections) == EXPECTED_COLLECTIONS, "historical collection denominator drift")
+    require(
+        {collection_id: item["rights"] for collection_id, item in collections.items()} == EXPECTED_RIGHTS,
+        "collection-specific rights posture drift",
+    )
+
+    sophia = collections["saint-sophia-inscriptions"]
+    require(sophia["custody_state"] == "materialized", "Saint Sophia must remain materialized")
+    require(sophia["record_count"] == 4157, "Saint Sophia record denominator drift")
+    require(sophia["source_sha256"] == "6199f2a92bd948dfe63d12e9da68637b02a4d16ff58b0ddba3d5e252bb3ec4fe", "Saint Sophia source hash drift")
+    require(sophia["facts"] == EXPECTED_SOPHIA_FACTS, "Saint Sophia audited facts drift")
+    require(sophia["modern_correction_eligible"] is False, "Saint Sophia cannot become modern correction gold")
+    require(
+        {(item["locator_role"], item["url"]) for item in sophia["locators"]}
+        == {
+            ("source_portal", "https://saintsophia.dh.gu.se/"),
+            ("api_root", "https://saintsophia.dh.gu.se/api/"),
+        },
+        "Saint Sophia locator set drift",
+    )
+
+    lavra = collections["kyiv-pechersk-lavra-graffiti"]
+    require(lavra["custody_state"] == "not_materialized", "Lavra coverage cannot be claimed before acquisition")
+    require(lavra["record_count"] is None, "unknown Lavra denominator cannot be fabricated")
+    require(lavra["facts"]["corpus_count_known"] is False, "Lavra corpus denominator must remain unknown")
+    require(lavra["facts"]["source_bytes_acquired"] is False, "Lavra source bytes are not acquired")
+    require(
+        {(item["locator_role"], item["url"]) for item in lavra["locators"]}
+        == {
+            ("official_monument_evidence", "https://kplavra.kyiv.ua/ua/21-kvitnya-hrafiti-ukr"),
+            ("bibliographic_catalog", "https://irbis-nbuv.gov.ua/ulib/item/UKR0004515"),
+        },
+        "Lavra acquisition locator set drift",
+    )
+
+    ud = collections[materialization.UD_COLLECTION_ID]
+    require(ud["record_count"] == 82, "UD Ukrainian document denominator drift")
+    require(ud["facts"]["sentences"] == 1311 and ud["facts"]["token_rows"] == 35081, "UD denominator drift")
+    require(ud["facts"]["exact_dated_documents"] == 4, "UD exact-date denominator drift")
+    require(ud["facts"]["undated_documents"] == 78, "UD unresolved-date denominator drift")
+    require(ud["facts"]["periodization_assignment_state"] == "unresolved", "UD cannot be auto-periodized")
+    require(ud["facts"]["file_sha256"] == materialization.UD_EXPECTED_SHA256, "UD file hash set drift")
+
+    plug2 = collections[materialization.PLUG2_COLLECTION_ID]
+    require(plug2["record_count"] == 56080, "PluG2 Ukrainian document denominator drift")
+    require(plug2["facts"]["date_min"] == 1816 and plug2["facts"]["date_max"] == 1954, "PluG2 date span drift")
+    require(plug2["facts"]["pre_1800_documents"] == 0, "PluG2 cannot claim medieval coverage")
+    require(plug2["facts"]["uk_token_sum"] == 71802066, "PluG2 token denominator drift")
+    require(plug2["source_sha256"] == materialization.PLUG2_METADATA_SHA256, "PluG2 metadata hash drift")
+    require(plug2["facts"]["archive_sha256"] == materialization.PLUG2_ARCHIVE_SHA256, "PluG2 archive hash drift")
+
+    gaps = _by_id(spine["gaps"], "gap_id", "gap")
+    require(gaps.keys() == EXPECTED_GAPS, "historical coverage gap denominator drift")
+    require(all(item["state"] == "open" for item in gaps.values()), "open source gaps cannot be silently closed")
+
+    gates = spine["gates"]
+    require(gates["evidence_first_spine_defined"] is True, "evidence spine definition is incomplete")
+    for key in (
+        "historical_source_coverage_ready",
+        "historical_source_freeze_ready",
+        "phase3_complete",
+        "phase4_authorized",
+    ):
+        require(gates[key] is False, f"{key} cannot be asserted")
+    require(gates["phase4_blocked"] is True, "Phase 4 must remain blocked")
+    require(spine["provider_calls"] is False and spine["text_free"] is True, "spine must be deterministic and text-free")
+    return spine
+
+
+def load_spine(path: Path = SPINE_PATH) -> dict[str, Any]:
+    """Load the exact tracked spine and reject byte drift at canonical paths."""
+    path = Path(path)
+    spine = validate_spine(_read_json(path, "historical evidence spine"))
+    require(sha256_file(periodization.FREEZE_PATH) == EXPECTED_BINDINGS["historical_periodization_freeze_sha256"], "periodization freeze byte drift")
+    require(sha256_file(DENOMINATOR_PATH) == EXPECTED_BINDINGS["historical_denominator_sha256"], "historical denominator byte drift")
+    require(sha256_file(FULL_GATE_PATH) == EXPECTED_BINDINGS["historical_full_materialization_gate_sha256"], "historical full gate byte drift")
+    if path.resolve() == SPINE_PATH.resolve():
+        require(sha256_file(path) == EXPECTED_SPINE_SHA256, "tracked historical evidence spine byte drift")
+    return spine
+
+
+def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dict[str, Any]:
+    """Derive text-free Saint Sophia coverage facts from canonical private rows."""
+    path = Path(path)
+    require(path.is_file(), f"missing Saint Sophia JSONL: {path}")
+    if expected_sha256 is not None:
+        require(sha256_file(path) == expected_sha256, "Saint Sophia JSONL byte drift")
+    dispositions: Counter[str] = Counter()
+    languages: Counter[str] = Counter()
+    writing_systems: Counter[str] = Counter()
+    rows = 0
+    valid_dates = 0
+    exact_dates = 0
+    broad_dates = 0
+    missing_dates = 0
+    invalid_dates = 0
+    old_definite = old_possible = old_ukrainian_definite = 0
+    middle_definite = middle_possible = middle_ukrainian_definite = 0
+    for line_number, raw_line in enumerate(path.open(encoding="utf-8"), start=1):
+        try:
+            row = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise HistoricalEvidenceSpineError(f"invalid Saint Sophia JSONL line {line_number}") from exc
+        require(isinstance(row, dict), f"Saint Sophia line {line_number} is not an object")
+        rows += 1
+        dispositions[str(row.get("disposition"))] += 1
+        languages[str(row.get("source_language_label") or "unlabelled")] += 1
+        writing_systems[str(row.get("source_writing_system_label") or "unlabelled")] += 1
+        minimum, maximum = row.get("min_year"), row.get("max_year")
+        if minimum is None or maximum is None:
+            missing_dates += 1
+            continue
+        if not isinstance(minimum, int) or not isinstance(maximum, int) or not (0 <= minimum <= maximum <= 2026):
+            invalid_dates += 1
+            continue
+        valid_dates += 1
+        exact_dates += minimum == maximum
+        broad_dates += maximum - minimum >= 99
+        text_ukrainian = row.get("disposition") == "text_bearing" and row.get("source_language_label") == "Ukrainian"
+        if minimum >= 1000 and maximum <= 1399:
+            old_definite += 1
+            old_ukrainian_definite += text_ukrainian
+        if maximum >= 1000 and minimum <= 1399:
+            old_possible += 1
+        if minimum >= 1400 and maximum <= 1799:
+            middle_definite += 1
+            middle_ukrainian_definite += text_ukrainian
+        if maximum >= 1400 and minimum <= 1799:
+            middle_possible += 1
+    return {
+        "records": rows,
+        "dispositions": dict(sorted(dispositions.items())),
+        "languages": dict(sorted(languages.items())),
+        "writing_systems": dict(sorted(writing_systems.items())),
+        "dates": {
+            "valid_intervals": valid_dates,
+            "exact_year_intervals": exact_dates,
+            "century_or_wider_intervals": broad_dates,
+            "missing_intervals": missing_dates,
+            "invalid_intervals": invalid_dates,
+        },
+        "coarse_date_observations": {
+            "old_1000_1399": {
+                "interval_wholly_inside": old_definite,
+                "interval_overlaps": old_possible,
+                "text_bearing_ukrainian_label_wholly_inside": old_ukrainian_definite,
+            },
+            "middle_1400_1799": {
+                "interval_wholly_inside": middle_definite,
+                "interval_overlaps": middle_possible,
+                "text_bearing_ukrainian_label_wholly_inside": middle_ukrainian_definite,
+            },
+        },
+    }
+
+
+def audit_plug2_metadata(path: Path, *, expected_sha256: str | None = None) -> dict[str, Any]:
+    """Derive the exact Ukrainian-original PluG2 date denominator."""
+    path = Path(path)
+    require(path.is_file(), f"missing PluG2 metadata: {path}")
+    if expected_sha256 is not None:
+        require(sha256_file(path) == expected_sha256, "PluG2 metadata byte drift")
+    with path.open(encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="|", quotechar='"'))
+    selected = [row for row in rows if row.get("doc.original") == "UK"]
+    years: list[int] = []
+    tokens = 0
+    for row in selected:
+        raw_year = row.get("doc.date", "")
+        require(raw_year.isdigit() and len(raw_year) == 4, f"non-exact PluG2 Ukrainian date: {raw_year!r}")
+        years.append(int(raw_year))
+        try:
+            tokens += int(row.get("doc.tokenCount", ""))
+        except ValueError as exc:
+            raise HistoricalEvidenceSpineError("invalid PluG2 token count") from exc
+    require(years, "PluG2 Ukrainian denominator is empty")
+    return {
+        "all_documents": len(rows),
+        "uk_documents": len(selected),
+        "uk_token_sum": tokens,
+        "date_min": min(years),
+        "date_max": max(years),
+        "pre_1800_documents": sum(year < 1800 for year in years),
+        "exact_dated_documents": len(years),
+    }
+
+
+def audit_ud(root: Path, *, expected_hashes: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """Derive document/date facts for explicitly Ukrainian-labelled UD rows."""
+    root = Path(root)
+    expected = dict(materialization.UD_EXPECTED_SHA256 if expected_hashes is None else expected_hashes)
+    sentences = []
+    for name, digest in sorted(expected.items()):
+        path = root / name
+        require(path.is_file(), f"missing UD file: {path}")
+        require(sha256_file(path) == digest, f"UD file byte drift: {name}")
+        sentences.extend(materialization.parse_conllu(path, source_file_sha256=digest))
+    selected = [sentence for sentence in sentences if sentence.language == "orv-uk"]
+    documents: dict[str, dict[str, Any]] = {}
+    for sentence in selected:
+        entry = documents.setdefault(
+            sentence.document_id,
+            {"created": sentence.created, "sentences": 0, "tokens": 0},
+        )
+        require(entry["created"] == sentence.created, f"UD document date drift: {sentence.document_id}")
+        entry["sentences"] += 1
+        entry["tokens"] += len(sentence.tokens)
+    exact_years = sorted(
+        int(entry["created"])
+        for entry in documents.values()
+        if isinstance(entry["created"], str) and entry["created"].isdigit() and len(entry["created"]) == 4
+    )
+    undated = sum(entry["created"] is None for entry in documents.values())
+    nonexact = len(documents) - len(exact_years) - undated
+    return {
+        "documents": len(documents),
+        "sentences": len(selected),
+        "token_rows": sum(len(sentence.tokens) for sentence in selected),
+        "exact_dated_documents": len(exact_years),
+        "exact_years": exact_years,
+        "undated_documents": undated,
+        "nonexact_dated_documents": nonexact,
+    }
+
+
+def audit_full_materialization_receipt(
+    path: Path,
+    *,
+    expected_file_sha256: str,
+    expected_receipt_sha256: str,
+) -> dict[str, Any]:
+    """Verify the text-free receipt that proves the full historical conversion ran."""
+    path = Path(path)
+    require(path.is_file(), f"missing historical full materialization receipt: {path}")
+    require(sha256_file(path) == expected_file_sha256, "historical full materialization receipt byte drift")
+    receipt = _read_json(path, "historical full materialization receipt")
+    body = {key: item for key, item in receipt.items() if key != "receipt_sha256"}
+    actual_receipt_sha256 = hashlib.sha256(canonical_json(body).encode()).hexdigest()
+    require(receipt.get("receipt_sha256") == expected_receipt_sha256, "historical full materialization receipt identity drift")
+    require(actual_receipt_sha256 == expected_receipt_sha256, "historical full materialization receipt seal mismatch")
+    require(receipt.get("schema_version") == "phase3_historical_full_materialization_receipt_v1", "historical full materialization receipt version drift")
+    require(receipt.get("text_free") is True, "historical full materialization receipt must be text-free")
+    require(receipt.get("coverage") == {
+        "full_materialization_complete": True,
+        "non_eligible_inputs_excluded": True,
+        "periodization_assignment_state": "unresolved_pending_qualified_historical_review",
+        "plug2_eligible_set_equal": True,
+        "ud_eligible_set_equal": True,
+    }, "historical full materialization coverage drift")
+    require(receipt.get("denominators") == {
+        "plug2": {
+            "documents": 56245,
+            "non_uk_or_unknown_documents": 165,
+            "token_sum": 74497787,
+            "uk_documents": 56080,
+        },
+        "plug2_candidate_uk_token_sum": 71802066,
+        "ud_explicit_orv_uk": {"documents": 82, "sentences": 1311, "token_rows": 35081},
+        "ud_other_or_unresolved_sentences": 4054,
+    }, "historical full materialization denominator drift")
+    require(receipt.get("outputs", {}).get("plug2") == {
+        "bytes": 2075643781,
+        "filename": "plug2-uk-full.jsonl.gz",
+        "records": 1910748,
+        "sha256": "7cf7efd0ff48827f84c503ecb84c578cb540b0d08e6fc5c857bf72ad20f96b94",
+    }, "PluG2 full materialization output drift")
+    require(receipt.get("outputs", {}).get("ud") == {
+        "bytes": 2150133,
+        "filename": "ud-orv-uk-full.jsonl.gz",
+        "records": 1311,
+        "sha256": "e883abd511121a2d01b3b1bc7559c4672c9dae3d0e0af3a8df1f7a6a05865cb0",
+    }, "UD full materialization output drift")
+    require(receipt.get("safeguards") == {
+        "historical_forms_protected": True,
+        "modern_correction_eligible": False,
+        "phase4_authorized": False,
+        "provider_calls": False,
+        "source_bytes_preserved": True,
+    }, "historical full materialization safeguards drift")
+    return {
+        "file_sha256": expected_file_sha256,
+        "receipt_sha256": expected_receipt_sha256,
+        "full_materialization_complete": True,
+        "plug2_output_sha256": receipt["outputs"]["plug2"]["sha256"],
+        "ud_output_sha256": receipt["outputs"]["ud"]["sha256"],
+    }
+
+
+def audit_private_inputs(
+    *,
+    sophia_jsonl: Path,
+    plug2_metadata: Path,
+    ud_root: Path,
+    full_materialization_receipt: Path,
+    spine_value: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Reproduce the current text-free corpus facts without exporting source text."""
+    checked_spine = load_spine() if spine_value is None else validate_spine(spine_value)
+    collections = _by_id(checked_spine["collections"], "collection_id", "collection")
+    sophia = audit_saint_sophia(
+        sophia_jsonl,
+        expected_sha256=collections["saint-sophia-inscriptions"]["source_sha256"],
+    )
+    plug2 = audit_plug2_metadata(
+        plug2_metadata,
+        expected_sha256=collections[materialization.PLUG2_COLLECTION_ID]["source_sha256"],
+    )
+    ud = audit_ud(ud_root)
+    require(sophia == EXPECTED_SOPHIA_PRIVATE_AUDIT, "Saint Sophia private audit denominator drift")
+    require(plug2 == {
+        "all_documents": 56245,
+        "uk_documents": 56080,
+        "uk_token_sum": 71802066,
+        "date_min": 1816,
+        "date_max": 1954,
+        "pre_1800_documents": 0,
+        "exact_dated_documents": 56080,
+    }, "PluG2 private audit denominator drift")
+    require(ud == {
+        "documents": 82,
+        "sentences": 1311,
+        "token_rows": 35081,
+        "exact_dated_documents": 4,
+        "exact_years": [1413, 1436, 1456, 1473],
+        "undated_documents": 78,
+        "nonexact_dated_documents": 0,
+    }, "UD private audit denominator drift")
+    full_receipt = audit_full_materialization_receipt(
+        full_materialization_receipt,
+        expected_file_sha256=checked_spine["bindings"]["historical_full_materialization_receipt_file_sha256"],
+        expected_receipt_sha256=checked_spine["bindings"]["historical_full_materialization_receipt_sha256"],
+    )
+    return {
+        "schema_version": "phase3_historical_evidence_private_audit_v1",
+        "text_free": True,
+        "provider_calls": False,
+        "saint_sophia": sophia,
+        "plug2": plug2,
+        "ud": ud,
+        "full_materialization_receipt": full_receipt,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spine", type=Path, default=SPINE_PATH)
+    parser.add_argument("--saint-sophia-jsonl", type=Path)
+    parser.add_argument("--plug2-metadata", type=Path)
+    parser.add_argument("--ud-root", type=Path)
+    parser.add_argument("--full-materialization-receipt", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    spine = load_spine(args.spine)
+    supplied = [
+        args.saint_sophia_jsonl,
+        args.plug2_metadata,
+        args.ud_root,
+        args.full_materialization_receipt,
+    ]
+    require(all(item is None for item in supplied) or all(item is not None for item in supplied), "private audit paths must be supplied together")
+    result: dict[str, Any] = {
+        "schema_version": spine["schema_version"],
+        "status": spine["status"],
+        "receipt_sha256": spine["receipt_sha256"],
+        "open_gap_count": len(spine["gaps"]),
+        "phase3_complete": spine["gates"]["phase3_complete"],
+        "phase4_blocked": spine["gates"]["phase4_blocked"],
+        "provider_calls": False,
+    }
+    if all(item is not None for item in supplied):
+        result["private_audit"] = audit_private_inputs(
+            sophia_jsonl=args.saint_sophia_jsonl,
+            plug2_metadata=args.plug2_metadata,
+            ud_root=args.ud_root,
+            full_materialization_receipt=args.full_materialization_receipt,
+            spine_value=spine,
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
+++ b/scripts/projects/open_model_data/phase3_historical_evidence_spine.py
@@ -30,7 +30,7 @@ DENOMINATOR_PATH = ROOT / "data/historical_language_corpus_denominator.yaml"
 FULL_GATE_PATH = ROOT / "data/projects/open_model_data/admission/phase3_historical_full_materialization_gate_v1.json"
 
 SCHEMA_VERSION = "phase3_historical_evidence_spine_v1"
-EXPECTED_SPINE_SHA256 = "4c775a9c2170e7aa521d6188cac2dba29b7f1e808cc8963d210363f78faef5c9"
+EXPECTED_SPINE_SHA256 = "2c8907fc5c04dd2e73de425ac7627002028dc6056513802a19f199191b6ea55b"
 EXPECTED_BINDINGS = {
     "historical_denominator_sha256": "4d89bfdb7e935008ad1332426ff9c40dca97efdf72053f35cdb1dad05117e6aa",
     "historical_full_materialization_gate_sha256": "3a4f409be28560dbc6a9c2c5defa043414dc659870be11a03f8e7297e8249e21",
@@ -60,6 +60,44 @@ EXPECTED_INSTRUCTIONAL_ORDER = [
     "new_and_modern_ukrainian",
     "comparative_reconstruction_backlink",
 ]
+EXPECTED_SOPHIA_PROVENANCE = {
+    "ai_assistance": {
+        "affected_field_classes": ["english_translation_and_commentary", "romanisation"],
+        "affected_record_membership_known": False,
+        "disclosed_by_official_documentation": True,
+        "human_gold_eligible_without_review": False,
+    },
+    "foundational_dataset": {
+        "edition_title": "Корпус Графіті Софії Київської",
+        "publication_year_end": 2020,
+        "publication_year_start": 2009,
+        "volume_count": 12,
+    },
+    "gippius_2023": {
+        "doi": "10.4324/9781003256236-14",
+        "portal_bibliography_present": False,
+        "role": "qualified_secondary_reanalysis_candidate",
+        "target": "Kyiv graffito No. 108",
+    },
+    "license_evidence": {
+        "official_docs_describe_dataset_as_open": True,
+        "official_docs_describe_api_as_open_and_reusable": True,
+        "explicit_data_license_at_pinned_sources": None,
+    },
+    "official_bulk_download": {
+        "api_url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
+        "download_label": "Download all inscription data",
+        "record_count_at_snapshot": 4157,
+        "same_public_api_stream": True,
+    },
+    "part_ix": {
+        "bibliography_id": 11,
+        "linked_public_records": 306,
+        "publication_year": 2019,
+        "scope": "північні внутрішня та зовнішня галереї",
+    },
+    "portal_version": "v1.6",
+}
 EXPECTED_SOPHIA_FACTS = {
     "century_or_wider_intervals": 3550,
     "exact_year_intervals": 168,
@@ -99,6 +137,7 @@ EXPECTED_SOPHIA_FACTS = {
         "year_start": 1000,
     },
     "quarantined_metadata": 2,
+    "source_provenance": EXPECTED_SOPHIA_PROVENANCE,
     "retrieval_scope": "complete_current_public_api",
     "stage_labels_assigned": 0,
     "text_bearing": 4144,
@@ -115,8 +154,10 @@ EXPECTED_SOPHIA_FACTS = {
     },
 }
 EXPECTED_GAPS = {
+    "kyiv_graffito_108_scholarly_crosswalk",
     "lavra_epigraphy_not_materialized",
     "saint_sophia_public_residual",
+    "saint_sophia_license_expression_missing",
     "old_ukrainian_direct_text_depth",
     "ud_document_date_and_provenance_review",
     "middle_ukrainian_genre_and_region_depth",
@@ -161,9 +202,9 @@ EXPECTED_SEQUENCE_CONTRACT = [
 ]
 EXPECTED_RIGHTS = {
     "saint-sophia-inscriptions": {
-        "reuse_scope": "private_research_only_until_explicit_clearance",
+        "reuse_scope": "private_research_and_internal_analysis_only_until_an_explicit_data_license_is_verified",
         "source_text_committed": False,
-        "status": "restricted_pending_explicit_clearance",
+        "status": "publicly_downloadable_license_not_declared",
     },
     "kyiv-pechersk-lavra-graffiti": {
         "reuse_scope": "no_corpus_use_until_source_and_rights_are_verified",
@@ -196,6 +237,12 @@ EXPECTED_SOPHIA_PRIVATE_AUDIT = {
         "century_or_wider_intervals": EXPECTED_SOPHIA_FACTS["century_or_wider_intervals"],
         "missing_intervals": EXPECTED_SOPHIA_FACTS["missing_date_intervals"],
         "invalid_intervals": EXPECTED_SOPHIA_FACTS["invalid_date_intervals"],
+    },
+    "bibliography": {
+        "distinct_items": 12,
+        "gippius_2023_portal_bibliography_matches": 0,
+        "part_ix_bibliography_id": 11,
+        "part_ix_linked_records": 306,
     },
     "coarse_date_observations": {
         "old_1000_1399": {
@@ -322,6 +369,27 @@ def validate_spine(value: Mapping[str, Any]) -> dict[str, Any]:
         == {
             ("source_portal", "https://saintsophia.dh.gu.se/"),
             ("api_root", "https://saintsophia.dh.gu.se/api/"),
+            (
+                "official_bulk_download_api",
+                "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
+            ),
+            (
+                "dataset_documentation",
+                "https://github.com/gu-gridh/documentation/blob/eee39a2f5b009efed451e083a9654a48785b896c/gridh-projects/saintsophia.md",
+            ),
+            (
+                "dataset_repository",
+                "https://github.com/gu-gridh/Saint_Sophia/tree/4eca1b8ad9293759ce3f39a139ff9daf027882ef",
+            ),
+            (
+                "official_bulk_download_implementation",
+                "https://github.com/gu-gridh/multimodal-map/blob/574914b6a740b639eb8e90f143664aae9a86cac7/projects/sophia/Footer.vue",
+            ),
+            (
+                "foundational_bibliography_record",
+                "https://saintsophia.dh.gu.se/api/inscriptions/bibliography-item/11/",
+            ),
+            ("scholarly_reanalysis_doi", "https://doi.org/10.4324/9781003256236-14"),
         },
         "Saint Sophia locator set drift",
     )
@@ -403,6 +471,9 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
     invalid_dates = 0
     old_definite = old_possible = old_ukrainian_definite = 0
     middle_definite = middle_possible = middle_ukrainian_definite = 0
+    bibliography_ids: set[int] = set()
+    part_ix_linked_records = 0
+    gippius_2023_matches = 0
     for line_number, raw_line in enumerate(path.open(encoding="utf-8"), start=1):
         try:
             row = json.loads(raw_line)
@@ -413,6 +484,23 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
         dispositions[str(row.get("disposition"))] += 1
         languages[str(row.get("source_language_label") or "unlabelled")] += 1
         writing_systems[str(row.get("source_writing_system_label") or "unlabelled")] += 1
+        source_record = row.get("metadata", {}).get("source_record", {})
+        bibliography = source_record.get("bibliography", []) if isinstance(source_record, dict) else []
+        require(isinstance(bibliography, list), f"Saint Sophia line {line_number} bibliography is not a list")
+        has_part_ix = False
+        has_gippius = False
+        for item in bibliography:
+            require(isinstance(item, dict), f"Saint Sophia line {line_number} bibliography item is not an object")
+            bibliography_id = item.get("id")
+            if isinstance(bibliography_id, int):
+                bibliography_ids.add(bibliography_id)
+                has_part_ix = has_part_ix or bibliography_id == 11
+            bibliography_text = " ".join(
+                str(item.get(key) or "") for key in ("title", "authors", "body_of_publication")
+            ).casefold()
+            has_gippius = has_gippius or any(name in bibliography_text for name in ("gippius", "гиппиус", "гіппіус"))
+        part_ix_linked_records += has_part_ix
+        gippius_2023_matches += has_gippius
         minimum, maximum = row.get("min_year"), row.get("max_year")
         if minimum is None or maximum is None:
             missing_dates += 1
@@ -445,6 +533,12 @@ def audit_saint_sophia(path: Path, *, expected_sha256: str | None = None) -> dic
             "century_or_wider_intervals": broad_dates,
             "missing_intervals": missing_dates,
             "invalid_intervals": invalid_dates,
+        },
+        "bibliography": {
+            "distinct_items": len(bibliography_ids),
+            "gippius_2023_portal_bibliography_matches": gippius_2023_matches,
+            "part_ix_bibliography_id": 11,
+            "part_ix_linked_records": part_ix_linked_records,
         },
         "coarse_date_observations": {
             "old_1000_1399": {

--- a/tests/test_open_model_phase3_historical_evidence_spine.py
+++ b/tests/test_open_model_phase3_historical_evidence_spine.py
@@ -123,7 +123,25 @@ def test_saint_sophia_provenance_binds_official_download_part_ix_and_ai_disclosu
     assert provenance["gippius_2023"]["portal_bibliography_present"] is False
     assert provenance["ai_assistance"]["human_gold_eligible_without_review"] is False
     assert provenance["license_evidence"]["explicit_data_license_at_pinned_sources"] is None
+    assert provenance["license_evidence"]["korniienko_media_assets"] == {
+        "asset_count_at_snapshot": 6477,
+        "included_in_text_training": False,
+        "license_label": "CC BY-NC",
+        "license_version_declared": False,
+    }
+    assert provenance["license_evidence"]["operator_use_decision"] == {
+        "binary_media_in_scope": False,
+        "decision": "proceed_without_pre_use_permission_wait",
+        "decision_date": "2026-08-12",
+        "full_publications_in_scope": False,
+        "response_policy": "adapt_remove_or_reclassify_affected_material_on_substantiated_rights_notice",
+        "scope": "public_structured_text_and_metadata_for_phase3_training_with_attribution_and_field_level_provenance",
+    }
     assert sophia["rights"]["status"] == "publicly_downloadable_license_not_declared"
+    assert sophia["rights"]["reuse_scope"] == (
+        "phase3_textual_dataset_training_and_derived_data_release_with_attribution_"
+        "field_provenance_and_takedown_readiness"
+    )
 
     locators = {(item["locator_role"], item["url"]) for item in sophia["locators"]}
     assert (
@@ -170,7 +188,12 @@ def test_phase_boundaries_remain_fail_closed():
         "phase4_blocked": True,
         "private_corpus_audit_reproducible": True,
     }
-    assert {item["state"] for item in value["gaps"]} == {"open"}
+    gap_states = {item["gap_id"]: item["state"] for item in value["gaps"]}
+    assert gap_states["saint_sophia_license_expression_missing"] == "accepted_operational_risk"
+    assert {
+        state for gap_id, state in gap_states.items()
+        if gap_id != "saint_sophia_license_expression_missing"
+    } == {"open"}
 
 
 def test_validator_rejects_framework_collapse_even_when_resealed():
@@ -208,6 +231,29 @@ def test_validator_rejects_rights_overclaim_even_when_resealed():
     sophia["rights"]["reuse_scope"] = "public_training_with_attribution"
 
     with pytest.raises(spine.HistoricalEvidenceSpineError, match="rights posture drift"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_erased_operator_use_decision_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    sophia = next(item for item in value["collections"] if item["collection_id"] == "saint-sophia-inscriptions")
+    sophia["facts"]["source_provenance"]["license_evidence"]["operator_use_decision"]["decision"] = (
+        "wait_for_pre_use_permission"
+    )
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="schema violation"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_reblocking_accepted_rights_risk_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    license_gap = next(
+        item for item in value["gaps"]
+        if item["gap_id"] == "saint_sophia_license_expression_missing"
+    )
+    license_gap["state"] = "open"
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="gap disposition drift"):
         spine.validate_spine(_reseal(value))
 
 
@@ -251,11 +297,63 @@ def test_validator_rejects_receipt_drift():
 def test_saint_sophia_private_audit_excludes_missing_reversed_and_out_of_bounds_dates(tmp_path):
     source = tmp_path / "sophia.jsonl"
     rows = [
-        {"disposition": "text_bearing", "source_language_label": "Ukrainian", "source_writing_system_label": "Cyrillic", "min_year": 1100, "max_year": 1100, "metadata": {"source_record": {"bibliography": [{"id": 11, "title": "Part IX", "authors": "Korniienko"}]}}},
-        {"disposition": "text_bearing", "source_language_label": "Church Slavonic", "source_writing_system_label": "Cyrillic", "min_year": 1450, "max_year": 1600, "metadata": {"source_record": {"bibliography": [{"id": 11, "title": "Part IX", "authors": "Korniienko"}, {"id": 99, "title": "Reanalysis", "authors": "Gippius"}]}}},
-        {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1600, "max_year": 1597},
-        {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1025, "max_year": 13015},
-        {"disposition": "non_textual_or_no_text", "source_language_label": None, "source_writing_system_label": None, "min_year": None, "max_year": None},
+        {
+            "disposition": "text_bearing",
+            "source_language_label": "Ukrainian",
+            "source_writing_system_label": "Cyrillic",
+            "min_year": 1100,
+            "max_year": 1100,
+            "metadata": {
+                "source_record": {
+                    "bibliography": [{"id": 11, "title": "Part IX", "authors": "Korniienko"}],
+                    "korniienko_image": [
+                        {"type_of_license": "CC BY-NC", "type_of_image": "Photograph"}
+                    ],
+                }
+            },
+        },
+        {
+            "disposition": "text_bearing",
+            "source_language_label": "Church Slavonic",
+            "source_writing_system_label": "Cyrillic",
+            "min_year": 1450,
+            "max_year": 1600,
+            "metadata": {
+                "source_record": {
+                    "bibliography": [
+                        {"id": 11, "title": "Part IX", "authors": "Korniienko"},
+                        {"id": 99, "title": "Reanalysis", "authors": "Gippius"},
+                    ],
+                    "korniienko_image": [
+                        {"type_of_license": "CC BY-NC", "type_of_image": "Drawing"}
+                    ],
+                }
+            },
+        },
+        {
+            "disposition": "quarantined_metadata",
+            "source_language_label": None,
+            "source_writing_system_label": None,
+            "min_year": 1600,
+            "max_year": 1597,
+            "metadata": {"source_record": {"bibliography": [], "korniienko_image": []}},
+        },
+        {
+            "disposition": "quarantined_metadata",
+            "source_language_label": None,
+            "source_writing_system_label": None,
+            "min_year": 1025,
+            "max_year": 13015,
+            "metadata": {"source_record": {"bibliography": [], "korniienko_image": []}},
+        },
+        {
+            "disposition": "non_textual_or_no_text",
+            "source_language_label": None,
+            "source_writing_system_label": None,
+            "min_year": None,
+            "max_year": None,
+            "metadata": {"source_record": {"bibliography": [], "korniienko_image": []}},
+        },
     ]
     _write_jsonl(source, rows)
 
@@ -276,6 +374,11 @@ def test_saint_sophia_private_audit_excludes_missing_reversed_and_out_of_bounds_
         "gippius_2023_portal_bibliography_matches": 1,
         "part_ix_bibliography_id": 11,
         "part_ix_linked_records": 2,
+    }
+    assert result["media_assets"] == {
+        "asset_count": 2,
+        "license_counts": {"CC BY-NC": 2},
+        "type_counts": {"Drawing": 1, "Photograph": 1},
     }
 
 

--- a/tests/test_open_model_phase3_historical_evidence_spine.py
+++ b/tests/test_open_model_phase3_historical_evidence_spine.py
@@ -1,0 +1,369 @@
+"""Hermetic tests for the evidence-first historical Ukrainian coverage spine."""
+
+from __future__ import annotations
+
+import copy
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_historical_evidence_spine as spine
+
+
+def _tracked() -> dict:
+    return json.loads(spine.SPINE_PATH.read_text(encoding="utf-8"))
+
+
+def _reseal(value: dict) -> dict:
+    body = {key: item for key, item in value.items() if key != "receipt_sha256"}
+    value["receipt_sha256"] = hashlib.sha256((spine.canonical_json(body) + "\n").encode()).hexdigest()
+    return value
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows), encoding="utf-8")
+
+
+def _full_receipt_fixture() -> dict:
+    body = {
+        "schema_version": "phase3_historical_full_materialization_receipt_v1",
+        "text_free": True,
+        "coverage": {
+            "full_materialization_complete": True,
+            "non_eligible_inputs_excluded": True,
+            "periodization_assignment_state": "unresolved_pending_qualified_historical_review",
+            "plug2_eligible_set_equal": True,
+            "ud_eligible_set_equal": True,
+        },
+        "denominators": {
+            "plug2": {
+                "documents": 56245,
+                "non_uk_or_unknown_documents": 165,
+                "token_sum": 74497787,
+                "uk_documents": 56080,
+            },
+            "plug2_candidate_uk_token_sum": 71802066,
+            "ud_explicit_orv_uk": {"documents": 82, "sentences": 1311, "token_rows": 35081},
+            "ud_other_or_unresolved_sentences": 4054,
+        },
+        "outputs": {
+            "plug2": {
+                "bytes": 2075643781,
+                "filename": "plug2-uk-full.jsonl.gz",
+                "records": 1910748,
+                "sha256": "7cf7efd0ff48827f84c503ecb84c578cb540b0d08e6fc5c857bf72ad20f96b94",
+            },
+            "ud": {
+                "bytes": 2150133,
+                "filename": "ud-orv-uk-full.jsonl.gz",
+                "records": 1311,
+                "sha256": "e883abd511121a2d01b3b1bc7559c4672c9dae3d0e0af3a8df1f7a6a05865cb0",
+            },
+        },
+        "safeguards": {
+            "historical_forms_protected": True,
+            "modern_correction_eligible": False,
+            "phase4_authorized": False,
+            "provider_calls": False,
+            "source_bytes_preserved": True,
+        },
+    }
+    body["receipt_sha256"] = hashlib.sha256(spine.canonical_json(body).encode()).hexdigest()
+    return body
+
+
+def test_tracked_spine_starts_with_direct_kyiv_epigraphy_and_keeps_frameworks_attributed():
+    value = spine.load_spine()
+
+    assert spine.sha256_file(spine.SPINE_PATH) == spine.EXPECTED_SPINE_SHA256
+    assert value["instructional_sequence"][0]["sequence_id"] == "kyiv_medieval_epigraphy"
+    assert value["instructional_sequence"][0]["evidence_mode"] == "direct_attestation"
+    assert value["instructional_sequence"][-1]["sequence_id"] == "comparative_reconstruction_backlink"
+    assert value["framework_policy"]["canonical_framework_id"] is None
+    assert value["framework_policy"]["instructional_navigation_scope"] == "coarse_navigation_only_not_semantic_gold"
+    assert set(value["framework_policy"]["bound_framework_ids"]) == {
+        "university_five_stage_synthesis",
+        "shevelov_detailed_six_period",
+        "nimchuk_five_stage_with_middle_subperiods",
+    }
+
+
+def test_saint_sophia_and_lavra_are_separate_and_only_one_is_materialized():
+    collections = {item["collection_id"]: item for item in spine.load_spine()["collections"]}
+    sophia = collections["saint-sophia-inscriptions"]
+    lavra = collections["kyiv-pechersk-lavra-graffiti"]
+
+    assert sophia["record_count"] == 4157
+    assert sophia["facts"]["retrieval_scope"] == "complete_current_public_api"
+    assert sophia["facts"]["stage_labels_assigned"] == 0
+    assert lavra["custody_state"] == "not_materialized"
+    assert lavra["record_count"] is None
+    assert lavra["facts"]["corpus_count_known"] is False
+    assert lavra["facts"]["separate_from_saint_sophia"] is True
+
+
+def test_current_materialized_coverage_does_not_fake_old_or_middle_depth():
+    collections = {item["collection_id"]: item for item in spine.load_spine()["collections"]}
+    sophia = collections["saint-sophia-inscriptions"]["facts"]
+    ud = collections["ud-old-east-slavic-ruthenian-05a029e00ccf"]["facts"]
+    plug2 = collections["plug2-zenodo-19482961"]["facts"]
+
+    assert sophia["old_date_band"]["interval_wholly_inside"] == 1225
+    assert sophia["old_date_band"]["text_bearing_ukrainian_label_wholly_inside"] == 7
+    assert sophia["old_date_band"]["semantic_stage_assignment"] == "pending_qualified_review"
+    assert ud["exact_years"] == [1413, 1436, 1456, 1473]
+    assert ud["undated_documents"] == 78
+    assert ud["periodization_assignment_state"] == "unresolved"
+    assert plug2["date_min"] == 1816
+    assert plug2["date_max"] == 1954
+    assert plug2["pre_1800_documents"] == 0
+
+
+def test_learner_material_is_preserved_but_not_historical_authority():
+    learner = spine.load_spine()["authority_policy"]["learner_exposition"]
+
+    assert learner["preserve_for_instructional_evaluation"] is True
+    assert learner["historical_authority_eligible"] is False
+    assert learner["training_text_eligibility"] == "pending_separate_rights_and_quality_review"
+
+
+def test_phase_boundaries_remain_fail_closed():
+    value = spine.load_spine()
+
+    assert value["gates"] == {
+        "evidence_first_spine_defined": True,
+        "historical_source_coverage_ready": False,
+        "historical_source_freeze_ready": False,
+        "phase3_complete": False,
+        "phase4_authorized": False,
+        "phase4_blocked": True,
+        "private_corpus_audit_reproducible": True,
+    }
+    assert {item["state"] for item in value["gaps"]} == {"open"}
+
+
+def test_validator_rejects_framework_collapse_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    value["framework_policy"]["canonical_framework_id"] = "university_five_stage_synthesis"
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="schema violation"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_fabricated_lavra_denominator_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    lavra = next(item for item in value["collections"] if item["collection_id"] == "kyiv-pechersk-lavra-graffiti")
+    lavra["record_count"] = 100
+    lavra["facts"]["corpus_count_known"] = True
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="schema violation"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_audited_fact_tampering_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    sophia = next(item for item in value["collections"] if item["collection_id"] == "saint-sophia-inscriptions")
+    sophia["facts"]["language_labels"]["Ukrainian"] += 1
+    sophia["facts"]["language_labels"]["unlabelled"] -= 1
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="audited facts drift"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_rights_overclaim_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    sophia = next(item for item in value["collections"] if item["collection_id"] == "saint-sophia-inscriptions")
+    sophia["rights"]["status"] = "admitted"
+    sophia["rights"]["reuse_scope"] = "public_training_with_attribution"
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="rights posture drift"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_instructional_collection_reshuffle_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    old = next(
+        item for item in value["instructional_sequence"]
+        if item["sequence_id"] == "old_ukrainian_documentary_and_literary"
+    )
+    old["collection_ids"] = ["plug2-zenodo-19482961"]
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="sequence evidence binding drift"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_erased_gap_even_when_resealed():
+    value = copy.deepcopy(_tracked())
+    value["gaps"] = [item for item in value["gaps"] if item["gap_id"] != "lavra_epigraphy_not_materialized"]
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="gap denominator drift"):
+        spine.validate_spine(_reseal(value))
+
+
+def test_validator_rejects_receipt_drift():
+    value = copy.deepcopy(_tracked())
+    value["gaps"][0]["next_action"] += " drift"
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="seal mismatch"):
+        spine.validate_spine(value)
+
+
+def test_saint_sophia_private_audit_excludes_missing_reversed_and_out_of_bounds_dates(tmp_path):
+    source = tmp_path / "sophia.jsonl"
+    rows = [
+        {"disposition": "text_bearing", "source_language_label": "Ukrainian", "source_writing_system_label": "Cyrillic", "min_year": 1100, "max_year": 1100},
+        {"disposition": "text_bearing", "source_language_label": "Church Slavonic", "source_writing_system_label": "Cyrillic", "min_year": 1450, "max_year": 1600},
+        {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1600, "max_year": 1597},
+        {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1025, "max_year": 13015},
+        {"disposition": "non_textual_or_no_text", "source_language_label": None, "source_writing_system_label": None, "min_year": None, "max_year": None},
+    ]
+    _write_jsonl(source, rows)
+
+    result = spine.audit_saint_sophia(source, expected_sha256=spine.sha256_file(source))
+
+    assert result["records"] == 5
+    assert result["dates"] == {
+        "valid_intervals": 2,
+        "exact_year_intervals": 1,
+        "century_or_wider_intervals": 1,
+        "missing_intervals": 1,
+        "invalid_intervals": 2,
+    }
+    assert result["coarse_date_observations"]["old_1000_1399"]["interval_wholly_inside"] == 1
+    assert result["coarse_date_observations"]["middle_1400_1799"]["interval_wholly_inside"] == 1
+
+
+def test_plug2_private_audit_uses_original_language_and_exact_dates(tmp_path):
+    source = tmp_path / "metadata.psv"
+    fieldnames = ["path", "doc.original", "doc.date", "doc.tokenCount"]
+    with source.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="|", quotechar='"', quoting=csv.QUOTE_ALL)
+        writer.writeheader()
+        writer.writerow({"path": "uk-old.txt", "doc.original": "UK", "doc.date": "1816", "doc.tokenCount": "10"})
+        writer.writerow({"path": "uk-new.txt", "doc.original": "UK", "doc.date": "1954", "doc.tokenCount": "20"})
+        writer.writerow({"path": "translation.txt", "doc.original": "PL", "doc.date": "1900", "doc.tokenCount": "30"})
+
+    result = spine.audit_plug2_metadata(source, expected_sha256=spine.sha256_file(source))
+
+    assert result == {
+        "all_documents": 3,
+        "uk_documents": 2,
+        "uk_token_sum": 30,
+        "date_min": 1816,
+        "date_max": 1954,
+        "pre_1800_documents": 0,
+        "exact_dated_documents": 2,
+    }
+
+
+def test_ud_private_audit_preserves_missing_dates_as_unresolved(tmp_path):
+    source = tmp_path / "fixture.conllu"
+    source.write_text(
+        "# newdoc id = dated\n"
+        "# lang = orv-uk\n"
+        "# created = 1413\n"
+        "# sent_id = dated-1\n"
+        "# text = Слово.\n"
+        "1\tСлово\tслово\tNOUN\t_\t_\t0\troot\t_\tSpaceAfter=No\n"
+        "2\t.\t.\tPUNCT\t_\t_\t1\tpunct\t_\t_\n\n"
+        "# newdoc id = undated\n"
+        "# lang = orv-uk\n"
+        "# sent_id = undated-1\n"
+        "# text = Текст.\n"
+        "1\tТекст\tтекст\tNOUN\t_\t_\t0\troot\t_\tSpaceAfter=No\n"
+        "2\t.\t.\tPUNCT\t_\t_\t1\tpunct\t_\t_\n\n"
+        "# newdoc id = other\n"
+        "# lang = orv-be\n"
+        "# sent_id = other-1\n"
+        "# text = Інше.\n"
+        "1\tІнше\tінший\tDET\t_\t_\t0\troot\t_\tSpaceAfter=No\n"
+        "2\t.\t.\tPUNCT\t_\t_\t1\tpunct\t_\t_\n\n",
+        encoding="utf-8",
+    )
+
+    result = spine.audit_ud(tmp_path, expected_hashes={source.name: spine.sha256_file(source)})
+
+    assert result == {
+        "documents": 2,
+        "sentences": 2,
+        "token_rows": 4,
+        "exact_dated_documents": 1,
+        "exact_years": [1413],
+        "undated_documents": 1,
+        "nonexact_dated_documents": 0,
+    }
+
+
+def test_full_materialization_receipt_is_hash_and_seal_bound(tmp_path):
+    path = tmp_path / "full-receipt.json"
+    receipt = _full_receipt_fixture()
+    path.write_text(json.dumps(receipt, ensure_ascii=False), encoding="utf-8")
+    file_sha256 = spine.sha256_file(path)
+
+    result = spine.audit_full_materialization_receipt(
+        path,
+        expected_file_sha256=file_sha256,
+        expected_receipt_sha256=receipt["receipt_sha256"],
+    )
+
+    assert result["full_materialization_complete"] is True
+    assert result["file_sha256"] == file_sha256
+
+    receipt["outputs"]["plug2"]["records"] -= 1
+    path.write_text(json.dumps(receipt, ensure_ascii=False), encoding="utf-8")
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="byte drift"):
+        spine.audit_full_materialization_receipt(
+            path,
+            expected_file_sha256=file_sha256,
+            expected_receipt_sha256=receipt["receipt_sha256"],
+        )
+
+
+def test_private_audit_uses_supplied_spine_without_reloading_default(monkeypatch, tmp_path):
+    checked = spine.validate_spine(_tracked())
+    monkeypatch.setattr(spine, "load_spine", lambda *_args, **_kwargs: pytest.fail("default spine reloaded"))
+    monkeypatch.setattr(spine, "audit_saint_sophia", lambda *_args, **_kwargs: copy.deepcopy(spine.EXPECTED_SOPHIA_PRIVATE_AUDIT))
+    monkeypatch.setattr(
+        spine,
+        "audit_plug2_metadata",
+        lambda *_args, **_kwargs: {
+            "all_documents": 56245,
+            "uk_documents": 56080,
+            "uk_token_sum": 71802066,
+            "date_min": 1816,
+            "date_max": 1954,
+            "pre_1800_documents": 0,
+            "exact_dated_documents": 56080,
+        },
+    )
+    monkeypatch.setattr(
+        spine,
+        "audit_ud",
+        lambda *_args, **_kwargs: {
+            "documents": 82,
+            "sentences": 1311,
+            "token_rows": 35081,
+            "exact_dated_documents": 4,
+            "exact_years": [1413, 1436, 1456, 1473],
+            "undated_documents": 78,
+            "nonexact_dated_documents": 0,
+        },
+    )
+    monkeypatch.setattr(
+        spine,
+        "audit_full_materialization_receipt",
+        lambda *_args, **_kwargs: {"full_materialization_complete": True},
+    )
+
+    result = spine.audit_private_inputs(
+        sophia_jsonl=tmp_path / "sophia.jsonl",
+        plug2_metadata=tmp_path / "metadata.psv",
+        ud_root=tmp_path / "ud",
+        full_materialization_receipt=tmp_path / "receipt.json",
+        spine_value=checked,
+    )
+
+    assert result["full_materialization_receipt"]["full_materialization_complete"] is True

--- a/tests/test_open_model_phase3_historical_evidence_spine.py
+++ b/tests/test_open_model_phase3_historical_evidence_spine.py
@@ -105,6 +105,34 @@ def test_saint_sophia_and_lavra_are_separate_and_only_one_is_materialized():
     assert lavra["facts"]["separate_from_saint_sophia"] is True
 
 
+def test_saint_sophia_provenance_binds_official_download_part_ix_and_ai_disclosure():
+    sophia = next(
+        item for item in spine.load_spine()["collections"]
+        if item["collection_id"] == "saint-sophia-inscriptions"
+    )
+    provenance = sophia["facts"]["source_provenance"]
+
+    assert provenance["official_bulk_download"] == {
+        "api_url": "https://saintsophia.dh.gu.se/api/inscriptions/inscription/?depth=2",
+        "download_label": "Download all inscription data",
+        "record_count_at_snapshot": 4157,
+        "same_public_api_stream": True,
+    }
+    assert provenance["part_ix"]["bibliography_id"] == 11
+    assert provenance["part_ix"]["linked_public_records"] == 306
+    assert provenance["gippius_2023"]["portal_bibliography_present"] is False
+    assert provenance["ai_assistance"]["human_gold_eligible_without_review"] is False
+    assert provenance["license_evidence"]["explicit_data_license_at_pinned_sources"] is None
+    assert sophia["rights"]["status"] == "publicly_downloadable_license_not_declared"
+
+    locators = {(item["locator_role"], item["url"]) for item in sophia["locators"]}
+    assert (
+        "official_bulk_download_implementation",
+        "https://github.com/gu-gridh/multimodal-map/blob/574914b6a740b639eb8e90f143664aae9a86cac7/projects/sophia/Footer.vue",
+    ) in locators
+    assert ("scholarly_reanalysis_doi", "https://doi.org/10.4324/9781003256236-14") in locators
+
+
 def test_current_materialized_coverage_does_not_fake_old_or_middle_depth():
     collections = {item["collection_id"]: item for item in spine.load_spine()["collections"]}
     sophia = collections["saint-sophia-inscriptions"]["facts"]
@@ -183,6 +211,15 @@ def test_validator_rejects_rights_overclaim_even_when_resealed():
         spine.validate_spine(_reseal(value))
 
 
+def test_validator_rejects_ai_assisted_portal_fields_as_unreviewed_human_gold():
+    value = copy.deepcopy(_tracked())
+    sophia = next(item for item in value["collections"] if item["collection_id"] == "saint-sophia-inscriptions")
+    sophia["facts"]["source_provenance"]["ai_assistance"]["human_gold_eligible_without_review"] = True
+
+    with pytest.raises(spine.HistoricalEvidenceSpineError, match="schema violation"):
+        spine.validate_spine(_reseal(value))
+
+
 def test_validator_rejects_instructional_collection_reshuffle_even_when_resealed():
     value = copy.deepcopy(_tracked())
     old = next(
@@ -214,8 +251,8 @@ def test_validator_rejects_receipt_drift():
 def test_saint_sophia_private_audit_excludes_missing_reversed_and_out_of_bounds_dates(tmp_path):
     source = tmp_path / "sophia.jsonl"
     rows = [
-        {"disposition": "text_bearing", "source_language_label": "Ukrainian", "source_writing_system_label": "Cyrillic", "min_year": 1100, "max_year": 1100},
-        {"disposition": "text_bearing", "source_language_label": "Church Slavonic", "source_writing_system_label": "Cyrillic", "min_year": 1450, "max_year": 1600},
+        {"disposition": "text_bearing", "source_language_label": "Ukrainian", "source_writing_system_label": "Cyrillic", "min_year": 1100, "max_year": 1100, "metadata": {"source_record": {"bibliography": [{"id": 11, "title": "Part IX", "authors": "Korniienko"}]}}},
+        {"disposition": "text_bearing", "source_language_label": "Church Slavonic", "source_writing_system_label": "Cyrillic", "min_year": 1450, "max_year": 1600, "metadata": {"source_record": {"bibliography": [{"id": 11, "title": "Part IX", "authors": "Korniienko"}, {"id": 99, "title": "Reanalysis", "authors": "Gippius"}]}}},
         {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1600, "max_year": 1597},
         {"disposition": "quarantined_metadata", "source_language_label": None, "source_writing_system_label": None, "min_year": 1025, "max_year": 13015},
         {"disposition": "non_textual_or_no_text", "source_language_label": None, "source_writing_system_label": None, "min_year": None, "max_year": None},
@@ -234,6 +271,12 @@ def test_saint_sophia_private_audit_excludes_missing_reversed_and_out_of_bounds_
     }
     assert result["coarse_date_observations"]["old_1000_1399"]["interval_wholly_inside"] == 1
     assert result["coarse_date_observations"]["middle_1400_1799"]["interval_wholly_inside"] == 1
+    assert result["bibliography"] == {
+        "distinct_items": 2,
+        "gippius_2023_portal_bibliography_matches": 1,
+        "part_ix_bibliography_id": 11,
+        "part_ix_linked_records": 2,
+    }
 
 
 def test_plug2_private_audit_uses_original_language_and_exact_dates(tmp_path):


### PR DESCRIPTION
## What changed

- adds a text-free, evidence-first historical Ukrainian coverage spine;
- starts the instructional evidence order with separate Saint Sophia and Kyiv-Pechersk Lavra epigraphy;
- binds three attributed Ukrainian periodization frameworks without selecting one scholar's chronology as universal canon;
- binds the Saint Sophia collection to the official bulk-download/API, pinned dataset documentation, backend repository, and frontend implementation;
- records Viacheslav Korniienko's twelve-volume 2009–2020 corpus as the portal dataset's foundation and Part IX (2019; bibliography id 11; 306 links in the stored 4,157-record snapshot) as portal-native evidence;
- keeps A. Gippius's 2023 graffito No. 108 chapter as separate secondary reanalysis pending an exact scholarly crosswalk;
- excludes officially disclosed AI-assisted English translation/commentary and romanisation fields from unreviewed human gold;
- records the operator-approved decision to proceed with public structured Saint Sophia text and metadata for Phase 3 without a pre-use permission wait;
- excludes binary media and full publications, preserves attribution and field-level provenance, and retains substantiated-notice removal/reclassification readiness;
- records all 6,477 attached Korniienko photographs/drawings as labelled `CC BY-NC` without a declared version and excludes them from text training;
- keeps the missing standardized data-license expression as one accepted operational risk that blocks only licence/warranty claims, not textual training or derived-data release;
- reproduces exact Saint Sophia, UD Old East Slavic/Ruthenian, and PluG2 coverage facts from hash-bound Drive inputs and the completed materialization receipt;
- records seven remaining source/evidence gaps and keeps historical source coverage, Phase 3 completion, and Phase 4 authorization fail-closed.

## Source lineage

- Portal: https://saintsophia.dh.gu.se/
- Pinned dataset documentation: https://github.com/gu-gridh/documentation/blob/eee39a2f5b009efed451e083a9654a48785b896c/gridh-projects/saintsophia.md
- Pinned backend: https://github.com/gu-gridh/Saint_Sophia/tree/4eca1b8ad9293759ce3f39a139ff9daf027882ef
- Pinned bulk-download implementation: https://github.com/gu-gridh/multimodal-map/blob/574914b6a740b639eb8e90f143664aae9a86cac7/projects/sophia/Footer.vue
- Korniienko Part IX bibliography record: https://saintsophia.dh.gu.se/api/inscriptions/bibliography-item/11/
- Gippius 2023 DOI: https://doi.org/10.4324/9781003256236-14

## Why

Phase 3 needs direct attestation to lead historical competence. The Saint Sophia portal is an unusually valuable official publication surface, but it is not a substitute for Lavra graffiti, balanced Old- and Middle-Ukrainian documentary/literary coverage, qualified stage-label review, or source-specific provenance. This contract makes those boundaries mechanical without turning an absent standardized licence string into a pre-use waiting gate.

## Validation

- `77 passed` across the evidence spine and adjacent historical full-materialization, periodization, university-freeze, and linguistic-representation suites;
- Ruff clean and `git diff --check` clean;
- private Drive audit reproduced 4,157 Saint Sophia rows, 12 bibliography items, 306 Part IX links, zero Gippius bibliography matches, and 6,477 media assets: 3,248 drawings plus 3,229 photographs, all labelled `CC BY-NC` and all excluded from text training;
- the broader historical snapshot still reproduces 82 UD Ukrainian documents / 1,311 sentences / 35,081 token rows and 56,080 PluG2 Ukrainian documents / 71,802,066 tokens;
- independent Claude Sonnet 5 exact-head review: PASS for `9d2c86bf17dc91628a05acc62c29892a25909012`;
- no source text or media committed, no provider calls, historical source freeze remains false, and Phase 4 remains blocked.

Refs #6375
Epic #6321
