### PR TITLE
feat(phase3): route Spas layout candidates

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_spas_catalog_materialization_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_spas_catalog_materialization_receipt_v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_spas_catalog_materialization_receipt_v1.schema.json",
+  "title": "Phase 3 Spas na Berestovi raw catalogue materialization text-free receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "implementation_version",
+    "mode",
+    "text_free",
+    "inputs",
+    "denominator",
+    "private_use_audit",
+    "output",
+    "rights_and_scope",
+    "safeguards",
+    "residuals",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_spas_catalog_materialization_receipt_v1"},
+    "implementation_version": {"const": "phase3_spas_catalog_materialization_v1"},
+    "mode": {"const": "full_catalogue_boundary_materialization"},
+    "text_free": {"const": true},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collection_id",
+        "source_author",
+        "source_title",
+        "source_year",
+        "source_record_url",
+        "source_pdf_sha256",
+        "pdf_pages",
+        "catalog_pdf_page_start",
+        "catalog_pdf_page_end",
+        "extraction_backend",
+        "extraction_backend_version"
+      ],
+      "properties": {
+        "collection_id": {"const": "korniienko-spas-na-berestovi-2013"},
+        "source_author": {"const": "В. В. Корнієнко"},
+        "source_title": {
+          "const": "Корпус графіті церкви Спаса на Берестові (остання третина XI – перша третина XVIII ст.)"
+        },
+        "source_year": {"const": 2013},
+        "source_record_url": {"const": "https://resource.history.org.ua/item/0015198"},
+        "source_pdf_sha256": {"$ref": "#/$defs/sha256"},
+        "pdf_pages": {"type": "integer", "minimum": 1},
+        "catalog_pdf_page_start": {"type": "integer", "minimum": 1},
+        "catalog_pdf_page_end": {"type": "integer", "minimum": 1},
+        "extraction_backend": {"const": "pypdf.page.extract_text"},
+        "extraction_backend_version": {"type": "string", "minLength": 1}
+      }
+    },
+    "denominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "catalog_pages",
+        "nonempty_native_text_pages",
+        "native_text_characters",
+        "expected_records",
+        "materialized_records",
+        "unique_record_numbers",
+        "sequential_record_numbers"
+      ],
+      "properties": {
+        "catalog_pages": {"type": "integer", "minimum": 1},
+        "nonempty_native_text_pages": {"type": "integer", "minimum": 1},
+        "native_text_characters": {"type": "integer", "minimum": 1},
+        "expected_records": {"type": "integer", "minimum": 1},
+        "materialized_records": {"type": "integer", "minimum": 1},
+        "unique_record_numbers": {"type": "integer", "minimum": 1},
+        "sequential_record_numbers": {"const": true}
+      }
+    },
+    "private_use_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_occurrences",
+        "pages_with_private_use_glyphs",
+        "codepoint_counts",
+        "glyph_font_observed_during_visual_canary",
+        "mapping_status"
+      ],
+      "properties": {
+        "total_occurrences": {"type": "integer", "minimum": 0},
+        "pages_with_private_use_glyphs": {"type": "integer", "minimum": 0},
+        "codepoint_counts": {
+          "type": "object",
+          "propertyNames": {"pattern": "^U\\+[0-9A-F]{4,6}$"},
+          "additionalProperties": {"type": "integer", "minimum": 1}
+        },
+        "glyph_font_observed_during_visual_canary": {"const": "Bukyvede"},
+        "mapping_status": {"const": "pending_visual_source_verified_adapter"}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "records", "bytes", "sha256", "record_identity_manifest_sha256"],
+      "properties": {
+        "filename": {"const": "spas-na-berestovi-raw-catalog.jsonl.gz"},
+        "records": {"type": "integer", "minimum": 1},
+        "bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "record_identity_manifest_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rights_and_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "public_institutional_full_text",
+        "standardized_dataset_license_expression_found",
+        "bounded_text_first_use_decision",
+        "attribution_and_field_level_removal_preserved",
+        "binary_media_reuse_authorized",
+        "full_publication_training_export_authorized",
+        "adapt_on_substantiated_rights_notice"
+      ],
+      "properties": {
+        "public_institutional_full_text": {"const": true},
+        "standardized_dataset_license_expression_found": {"const": false},
+        "bounded_text_first_use_decision": {"const": "accepted_operational_risk"},
+        "attribution_and_field_level_removal_preserved": {"const": true},
+        "binary_media_reuse_authorized": {"const": false},
+        "full_publication_training_export_authorized": {"const": false},
+        "adapt_on_substantiated_rights_notice": {"const": true}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_source_preserved",
+        "historical_forms_protected",
+        "normalized_historical_text_emitted",
+        "commentary_and_inscription_layers_separated",
+        "page_header_footer_cleanup_applied",
+        "modern_correction_eligible",
+        "training_eligible",
+        "ocr_used",
+        "inferred_character_repairs",
+        "images_included",
+        "provider_calls",
+        "phase4_authorized"
+      ],
+      "properties": {
+        "raw_source_preserved": {"const": true},
+        "historical_forms_protected": {"const": true},
+        "normalized_historical_text_emitted": {"const": false},
+        "commentary_and_inscription_layers_separated": {"const": false},
+        "page_header_footer_cleanup_applied": {"const": false},
+        "modern_correction_eligible": {"const": false},
+        "training_eligible": {"const": false},
+        "ocr_used": {"const": false},
+        "inferred_character_repairs": {"const": false},
+        "images_included": {"const": false},
+        "provider_calls": {"const": false},
+        "phase4_authorized": {"const": false}
+      }
+    },
+    "residuals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spas_na_berestovi_is_lavra_associated",
+        "spas_na_berestovi_is_not_lavra_cave_corpus",
+        "lavra_cave_corpus_gap_closed",
+        "glyph_mapping_pending",
+        "commentary_transcription_separation_pending"
+      ],
+      "properties": {
+        "spas_na_berestovi_is_lavra_associated": {"const": true},
+        "spas_na_berestovi_is_not_lavra_cave_corpus": {"const": true},
+        "lavra_cave_corpus_gap_closed": {"const": false},
+        "glyph_mapping_pending": {"const": true},
+        "commentary_transcription_separation_pending": {"const": true}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_spas_glyph_adapter_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_spas_glyph_adapter_receipt_v1.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_spas_glyph_adapter_receipt_v1.schema.json",
+  "title": "Phase 3 Spas na Berestovi Bukyvede glyph adapter text-free receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "implementation_version",
+    "mode",
+    "text_free",
+    "inputs",
+    "mapping_contract",
+    "denominator",
+    "output",
+    "rights_and_scope",
+    "safeguards",
+    "residuals",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_spas_glyph_adapter_receipt_v1"},
+    "implementation_version": {"const": "phase3_spas_glyph_adapter_v1"},
+    "mode": {"const": "source_verified_bukyvede_to_unicode_adapter"},
+    "text_free": {"const": true},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collection_id",
+        "source_pdf_sha256",
+        "raw_catalog_filename",
+        "raw_catalog_sha256",
+        "raw_materialization_receipt_filename",
+        "raw_materialization_receipt_file_sha256",
+        "raw_materialization_receipt_sha256",
+        "mapping_evidence_filename",
+        "mapping_evidence_sha256",
+        "embedded_font_sha256",
+        "to_unicode_cmap_sha256",
+        "implementation_sha256",
+        "receipt_schema_sha256"
+      ],
+      "properties": {
+        "collection_id": {"const": "korniienko-spas-na-berestovi-2013"},
+        "source_pdf_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_catalog_filename": {"const": "spas-na-berestovi-raw-catalog.jsonl.gz"},
+        "raw_catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_materialization_receipt_filename": {"const": "materialization-receipt-v1.json"},
+        "raw_materialization_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_materialization_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "mapping_evidence_filename": {"const": "bukyvede-glyph-mapping-evidence-v1.json"},
+        "mapping_evidence_sha256": {"$ref": "#/$defs/sha256"},
+        "embedded_font_sha256": {"$ref": "#/$defs/sha256"},
+        "to_unicode_cmap_sha256": {"$ref": "#/$defs/sha256"},
+        "implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "receipt_schema_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "mapping_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rules",
+        "observed_counts",
+        "longest_match_first",
+        "offset_basis",
+        "source_adapter_not_semantic_gold"
+      ],
+      "properties": {
+        "rules": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": {"$ref": "#/$defs/mapping_rule"}
+        },
+        "observed_counts": {
+          "type": "object",
+          "minProperties": 5,
+          "maxProperties": 5,
+          "propertyNames": {"type": "string", "minLength": 1},
+          "additionalProperties": {"type": "integer", "minimum": 1}
+        },
+        "longest_match_first": {"const": true},
+        "offset_basis": {"const": "unicode_code_points"},
+        "source_adapter_not_semantic_gold": {"const": true}
+      }
+    },
+    "denominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_records",
+        "output_records",
+        "input_characters",
+        "output_characters",
+        "records_with_mappings",
+        "mapping_events",
+        "input_private_use_occurrences",
+        "output_private_use_occurrences",
+        "raw_reconstruction_failures"
+      ],
+      "properties": {
+        "input_records": {"type": "integer", "minimum": 1},
+        "output_records": {"type": "integer", "minimum": 1},
+        "input_characters": {"type": "integer", "minimum": 1},
+        "output_characters": {"type": "integer", "minimum": 1},
+        "records_with_mappings": {"type": "integer", "minimum": 1},
+        "mapping_events": {"type": "integer", "minimum": 1},
+        "input_private_use_occurrences": {"type": "integer", "minimum": 1},
+        "output_private_use_occurrences": {"const": 0},
+        "raw_reconstruction_failures": {"const": 0}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "records", "bytes", "sha256", "record_identity_manifest_sha256"],
+      "properties": {
+        "filename": {"const": "spas-na-berestovi-unicode-adapter-v1.jsonl.gz"},
+        "records": {"type": "integer", "minimum": 1},
+        "bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "record_identity_manifest_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rights_and_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inherits_upstream_accepted_operational_risk",
+        "attribution_and_field_level_removal_preserved",
+        "binary_media_reuse_authorized",
+        "full_publication_training_export_authorized",
+        "adapt_on_substantiated_rights_notice"
+      ],
+      "properties": {
+        "inherits_upstream_accepted_operational_risk": {"const": true},
+        "attribution_and_field_level_removal_preserved": {"const": true},
+        "binary_media_reuse_authorized": {"const": false},
+        "full_publication_training_export_authorized": {"const": false},
+        "adapt_on_substantiated_rights_notice": {"const": true}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_source_preserved_in_every_record",
+        "historical_forms_protected",
+        "deterministic_mapping_only",
+        "commentary_and_inscription_layers_separated",
+        "training_eligible",
+        "modern_correction_eligible",
+        "semantic_gold",
+        "provider_calls",
+        "phase4_authorized"
+      ],
+      "properties": {
+        "raw_source_preserved_in_every_record": {"const": true},
+        "historical_forms_protected": {"const": true},
+        "deterministic_mapping_only": {"const": true},
+        "commentary_and_inscription_layers_separated": {"const": false},
+        "training_eligible": {"const": false},
+        "modern_correction_eligible": {"const": false},
+        "semantic_gold": {"const": false},
+        "provider_calls": {"const": false},
+        "phase4_authorized": {"const": false}
+      }
+    },
+    "residuals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "glyph_mapping_pending",
+        "commentary_transcription_separation_pending",
+        "qualified_historical_review_pending",
+        "lavra_cave_corpus_gap_closed"
+      ],
+      "properties": {
+        "glyph_mapping_pending": {"const": false},
+        "commentary_transcription_separation_pending": {"const": true},
+        "qualified_historical_review_pending": {"const": true},
+        "lavra_cave_corpus_gap_closed": {"const": false}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "codepoint": {"type": "string", "pattern": "^U\\+[0-9A-F]{4,6}$"},
+    "mapping_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mapping_id", "raw_pattern", "normalized_pattern", "unicode_name", "expected_occurrences"],
+      "properties": {
+        "mapping_id": {"type": "string", "minLength": 1},
+        "raw_pattern": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/codepoint"}},
+        "normalized_pattern": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/codepoint"}},
+        "unicode_name": {"type": "string", "minLength": 1},
+        "expected_occurrences": {"type": "integer", "minimum": 1}
+      }
+    }
+  }
+}

--- a/data/projects/open_model_data/contracts/phase3_spas_layout_candidate_receipt_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_spas_layout_candidate_receipt_v1.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/open-model-data/phase3_spas_layout_candidate_receipt_v1.schema.json",
+  "title": "Phase 3 Spas font-layout candidate routing text-free receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "implementation_version",
+    "mode",
+    "text_free",
+    "inputs",
+    "routing_contract",
+    "denominator",
+    "output",
+    "rights_and_scope",
+    "safeguards",
+    "residuals",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_spas_layout_candidate_receipt_v1"},
+    "implementation_version": {"const": "phase3_spas_layout_candidates_v1"},
+    "mode": {"const": "source_font_layout_candidate_routing"},
+    "text_free": {"const": true},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collection_id",
+        "source_pdf_sha256",
+        "raw_catalog_sha256",
+        "raw_materialization_receipt_file_sha256",
+        "raw_materialization_receipt_sha256",
+        "mapping_evidence_sha256",
+        "adapter_output_sha256",
+        "adapter_receipt_file_sha256",
+        "adapter_receipt_sha256",
+        "pypdf_version",
+        "implementation_sha256",
+        "receipt_schema_sha256",
+        "page_layout_manifest_sha256"
+      ],
+      "properties": {
+        "collection_id": {"const": "korniienko-spas-na-berestovi-2013"},
+        "source_pdf_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_materialization_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_materialization_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "mapping_evidence_sha256": {"$ref": "#/$defs/sha256"},
+        "adapter_output_sha256": {"$ref": "#/$defs/sha256"},
+        "adapter_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "adapter_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "pypdf_version": {"type": "string", "minLength": 1},
+        "implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "receipt_schema_sha256": {"$ref": "#/$defs/sha256"},
+        "page_layout_manifest_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "routing_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "font_base_name",
+        "dominance_rule",
+        "context_window_codepoints",
+        "required_text_cue",
+        "shape_cues",
+        "trigger_classification",
+        "fallback_classification",
+        "classifications_are_semantic_gold"
+      ],
+      "properties": {
+        "font_base_name": {"const": "/GATIPV+Bukyvede"},
+        "dominance_rule": {"const": "2 * bukyvede_nonspace_characters >= line_nonspace_characters"},
+        "context_window_codepoints": {"const": 220},
+        "required_text_cue": {"const": "whole_word:текст"},
+        "shape_cues": {
+          "const": ["таким чином", "вигляд", "реконструк", "віднов"]
+        },
+        "trigger_classification": {"const": "author_reconstruction_trigger_candidate"},
+        "fallback_classification": {"const": "dominant_historic_script_unresolved"},
+        "classifications_are_semantic_gold": {"const": false}
+      }
+    },
+    "denominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_records",
+        "output_records",
+        "records_with_bukyvede",
+        "records_without_bukyvede",
+        "bukyvede_font_spans",
+        "bukyvede_characters",
+        "bukyvede_nonspace_characters",
+        "lines_with_bukyvede",
+        "dominant_line_candidates",
+        "records_with_dominant_candidates",
+        "trigger_line_candidates",
+        "records_with_trigger_candidates",
+        "unresolved_dominant_line_candidates",
+        "records_with_unresolved_candidates",
+        "trigger_unresolved_record_overlap"
+      ],
+      "properties": {
+        "input_records": {"type": "integer", "minimum": 1},
+        "output_records": {"type": "integer", "minimum": 1},
+        "records_with_bukyvede": {"type": "integer", "minimum": 0},
+        "records_without_bukyvede": {"type": "integer", "minimum": 0},
+        "bukyvede_font_spans": {"type": "integer", "minimum": 0},
+        "bukyvede_characters": {"type": "integer", "minimum": 0},
+        "bukyvede_nonspace_characters": {"type": "integer", "minimum": 0},
+        "lines_with_bukyvede": {"type": "integer", "minimum": 0},
+        "dominant_line_candidates": {"type": "integer", "minimum": 0},
+        "records_with_dominant_candidates": {"type": "integer", "minimum": 0},
+        "trigger_line_candidates": {"type": "integer", "minimum": 0},
+        "records_with_trigger_candidates": {"type": "integer", "minimum": 0},
+        "unresolved_dominant_line_candidates": {"type": "integer", "minimum": 0},
+        "records_with_unresolved_candidates": {"type": "integer", "minimum": 0},
+        "trigger_unresolved_record_overlap": {"type": "integer", "minimum": 0}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "records", "bytes", "sha256", "record_identity_manifest_sha256"],
+      "properties": {
+        "filename": {"const": "spas-na-berestovi-layout-candidates-v1.jsonl.gz"},
+        "records": {"type": "integer", "minimum": 1},
+        "bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "record_identity_manifest_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rights_and_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inherits_upstream_accepted_operational_risk",
+        "private_review_queue_only",
+        "attribution_and_field_level_removal_preserved",
+        "binary_media_reuse_authorized",
+        "full_publication_training_export_authorized",
+        "adapt_on_substantiated_rights_notice"
+      ],
+      "properties": {
+        "inherits_upstream_accepted_operational_risk": {"const": true},
+        "private_review_queue_only": {"const": true},
+        "attribution_and_field_level_removal_preserved": {"const": true},
+        "binary_media_reuse_authorized": {"const": false},
+        "full_publication_training_export_authorized": {"const": false},
+        "adapt_on_substantiated_rights_notice": {"const": true}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "complete_record_context_preserved",
+        "raw_and_normalized_offsets_preserved",
+        "font_spans_source_derived",
+        "candidate_routing_only",
+        "commentary_and_inscription_layers_separated",
+        "qualified_historical_review_complete",
+        "semantic_gold",
+        "training_eligible",
+        "modern_correction_eligible",
+        "images_included",
+        "provider_calls",
+        "phase4_authorized"
+      ],
+      "properties": {
+        "complete_record_context_preserved": {"const": true},
+        "raw_and_normalized_offsets_preserved": {"const": true},
+        "font_spans_source_derived": {"const": true},
+        "candidate_routing_only": {"const": true},
+        "commentary_and_inscription_layers_separated": {"const": false},
+        "qualified_historical_review_complete": {"const": false},
+        "semantic_gold": {"const": false},
+        "training_eligible": {"const": false},
+        "modern_correction_eligible": {"const": false},
+        "images_included": {"const": false},
+        "provider_calls": {"const": false},
+        "phase4_authorized": {"const": false}
+      }
+    },
+    "residuals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "all_dominant_line_candidates_require_review",
+        "candidate_review_denominator",
+        "inline_or_nondominant_font_spans_remain_context_only",
+        "commentary_transcription_separation_pending",
+        "lavra_cave_corpus_gap_closed"
+      ],
+      "properties": {
+        "all_dominant_line_candidates_require_review": {"const": true},
+        "candidate_review_denominator": {"type": "integer", "minimum": 1},
+        "inline_or_nondominant_font_spans_remain_context_only": {"const": true},
+        "commentary_transcription_separation_pending": {"const": true},
+        "lavra_cave_corpus_gap_closed": {"const": false}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+  }
+}

--- a/scripts/projects/open_model_data/phase3_spas_catalog_materialization.py
+++ b/scripts/projects/open_model_data/phase3_spas_catalog_materialization.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Materialize the Spas na Berestovi graffiti catalogue as protected raw records.
+
+The source is a Lavra-associated church corpus, not the Kyiv-Pechersk Lavra
+cave-graffiti corpus.  Native PDF text is split only at the 477 printed
+``Графіті №`` headings.  The private output preserves raw extraction and exact
+page offsets; it deliberately does not normalize historical glyphs, separate
+the author's commentary from inscription readings, or authorize training use.
+The public receipt is text-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import shutil
+import tempfile
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from pypdf import PdfReader
+
+from scripts.projects.open_model_data.phase3_linguistic_representation import canonical_json, sha256_value
+
+ROOT = Path(__file__).resolve().parents[3]
+RECEIPT_SCHEMA_PATH = (
+    ROOT / "data/projects/open_model_data/contracts/phase3_spas_catalog_materialization_receipt_v1.schema.json"
+)
+
+SCHEMA_VERSION = "phase3_spas_catalog_materialization_receipt_v1"
+IMPLEMENTATION_VERSION = "phase3_spas_catalog_materialization_v1"
+COLLECTION_ID = "korniienko-spas-na-berestovi-2013"
+SOURCE_TITLE = "Корпус графіті церкви Спаса на Берестові (остання третина XI – перша третина XVIII ст.)"
+SOURCE_AUTHOR = "В. В. Корнієнко"
+SOURCE_YEAR = 2013
+SOURCE_RECORD_URL = "https://resource.history.org.ua/item/0015198"
+SOURCE_PDF_SHA256 = "b464439c73dee0a3092bb0cc37f56a0cd7d32709392c7b8745869d5df9b9281a"
+EXPECTED_PDF_PAGES = 303
+CATALOG_PDF_PAGE_START = 15
+CATALOG_PDF_PAGE_END = 116
+EXPECTED_CATALOG_RECORDS = 477
+EXPECTED_NATIVE_TEXT_CHARACTERS = 229190
+EXPECTED_PRIVATE_USE_COUNTS = {
+    "U+E002": 13,
+    "U+E026": 4,
+    "U+E027": 10,
+    "U+E02E": 3,
+    "U+E02F": 27,
+}
+OUTPUT_FILENAME = "spas-na-berestovi-raw-catalog.jsonl.gz"
+RECEIPT_FILENAME = "materialization-receipt-v1.json"
+HEADING_PATTERN = r"Графіті\s*№\s*(\d+)(?=\s|\[|\()"
+HEADING_RE = re.compile(HEADING_PATTERN)
+RAW_RECORD_FIELDS = frozenset(
+    {
+        "schema_version",
+        "record_id",
+        "collection_id",
+        "source_record_identity",
+        "graffito_number",
+        "heading_text",
+        "source_pdf_sha256",
+        "source_page_fragments",
+        "source_text",
+        "source_text_sha256",
+        "offset_basis",
+        "private_use_codepoint_counts",
+        "contains_private_use_glyphs",
+        "materialization_status",
+        "normalization_status",
+        "commentary_and_inscription_layers_separated",
+        "page_header_footer_cleanup_applied",
+        "training_eligible",
+        "modern_correction_eligible",
+        "ocr_used",
+        "inferred_character_repairs",
+        "images_included",
+        "provider_calls",
+    }
+)
+
+
+class SpasCatalogMaterializationError(ValueError):
+    """An immutable identity or raw-materialization invariant failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SpasCatalogMaterializationError(message)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _private_use_counts(text: str) -> dict[str, int]:
+    counts = Counter(f"U+{ord(char):04X}" for char in text if 0xE000 <= ord(char) <= 0xF8FF)
+    return dict(sorted(counts.items()))
+
+
+def _inside_git_checkout(path: Path) -> bool:
+    return any((candidate / ".git").exists() for candidate in (path, *path.parents))
+
+
+def load_catalog_pages(
+    pdf_path: Path,
+    *,
+    expected_pdf_sha256: str = SOURCE_PDF_SHA256,
+    expected_pdf_pages: int = EXPECTED_PDF_PAGES,
+    catalog_pdf_page_start: int = CATALOG_PDF_PAGE_START,
+    catalog_pdf_page_end: int = CATALOG_PDF_PAGE_END,
+) -> dict[int, str]:
+    """Load the exact native-text catalogue page range from an immutable PDF."""
+    require(pdf_path.is_file(), f"source PDF is missing: {pdf_path}")
+    require(not pdf_path.is_symlink(), "source PDF cannot be a symbolic link")
+    actual_sha256 = file_sha256(pdf_path)
+    require(
+        actual_sha256 == expected_pdf_sha256,
+        f"source PDF SHA-256 mismatch: expected {expected_pdf_sha256}, got {actual_sha256}",
+    )
+    try:
+        reader = PdfReader(pdf_path)
+    except Exception as exc:  # pypdf exposes several backend-specific errors
+        raise SpasCatalogMaterializationError(f"cannot open source PDF: {exc}") from exc
+    require(not reader.is_encrypted, "encrypted source PDF is not supported")
+    require(len(reader.pages) == expected_pdf_pages, "source PDF page denominator drift")
+    require(
+        1 <= catalog_pdf_page_start <= catalog_pdf_page_end <= len(reader.pages),
+        "catalogue PDF page range is invalid",
+    )
+
+    pages: dict[int, str] = {}
+    for pdf_page_number in range(catalog_pdf_page_start, catalog_pdf_page_end + 1):
+        try:
+            text = reader.pages[pdf_page_number - 1].extract_text() or ""
+        except Exception as exc:
+            raise SpasCatalogMaterializationError(
+                f"native extraction failed on PDF page {pdf_page_number}: {exc}"
+            ) from exc
+        require(text.strip() != "", f"catalogue PDF page {pdf_page_number} has no native text")
+        require("\ufffd" not in text, f"catalogue PDF page {pdf_page_number} contains replacement characters")
+        pages[pdf_page_number] = text
+    return pages
+
+
+def split_catalog_records(
+    page_texts: Mapping[int, str],
+    *,
+    expected_record_count: int = EXPECTED_CATALOG_RECORDS,
+    source_pdf_sha256: str = SOURCE_PDF_SHA256,
+) -> list[dict[str, Any]]:
+    """Split native page text at exact printed graffito headings."""
+    require(bool(page_texts), "catalogue page set is empty")
+    page_numbers = sorted(page_texts)
+    require(
+        page_numbers == list(range(page_numbers[0], page_numbers[-1] + 1)),
+        "catalogue page set must be contiguous",
+    )
+    for page_number in page_numbers:
+        text = page_texts[page_number]
+        require(isinstance(text, str) and text.strip() != "", f"catalogue page {page_number} is empty")
+        require("\ufffd" not in text, f"catalogue page {page_number} contains replacement characters")
+
+    headings: list[tuple[int, int, int, str]] = []
+    for page_number in page_numbers:
+        for match in HEADING_RE.finditer(page_texts[page_number]):
+            headings.append((int(match.group(1)), page_number, match.start(), match.group(0)))
+
+    numbers = [number for number, _, _, _ in headings]
+    require(
+        numbers == list(range(1, expected_record_count + 1)),
+        "graffito heading denominator is not the exact sequential range",
+    )
+
+    records: list[dict[str, Any]] = []
+    for index, (number, start_page, start_offset, heading_text) in enumerate(headings):
+        if index + 1 < len(headings):
+            _, end_page, end_offset, _ = headings[index + 1]
+        else:
+            end_page = page_numbers[-1]
+            end_offset = len(page_texts[end_page])
+
+        fragments: list[dict[str, Any]] = []
+        fragment_texts: list[str] = []
+        for page_number in range(start_page, end_page + 1):
+            page_text = page_texts[page_number]
+            fragment_start = start_offset if page_number == start_page else 0
+            fragment_end = end_offset if page_number == end_page else len(page_text)
+            require(
+                0 <= fragment_start <= fragment_end <= len(page_text),
+                f"record {number} has an invalid page fragment",
+            )
+            if fragment_start == fragment_end:
+                continue
+            fragment_text = page_text[fragment_start:fragment_end]
+            fragment_texts.append(fragment_text)
+            fragments.append(
+                {
+                    "pdf_page_number": page_number,
+                    "start_char": fragment_start,
+                    "end_char": fragment_end,
+                    "text_sha256": hashlib.sha256(fragment_text.encode("utf-8")).hexdigest(),
+                }
+            )
+
+        require(bool(fragment_texts), f"record {number} has no source text")
+        source_text = "\n".join(fragment_texts)
+        require(HEADING_RE.match(source_text) is not None, f"record {number} does not begin at its heading")
+        pua_counts = _private_use_counts(source_text)
+        records.append(
+            {
+                "schema_version": "phase3_spas_raw_catalog_record_v1",
+                "record_id": f"spas-na-berestovi:graffito:{number:04d}",
+                "collection_id": COLLECTION_ID,
+                "source_record_identity": f"Графіті № {number}",
+                "graffito_number": number,
+                "heading_text": heading_text,
+                "source_pdf_sha256": source_pdf_sha256,
+                "source_page_fragments": fragments,
+                "source_text": source_text,
+                "source_text_sha256": hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+                "offset_basis": "unicode_code_points_in_pypdf_native_page_text",
+                "private_use_codepoint_counts": pua_counts,
+                "contains_private_use_glyphs": bool(pua_counts),
+                "materialization_status": "raw_record_boundary_verified",
+                "normalization_status": "not_applied",
+                "commentary_and_inscription_layers_separated": False,
+                "page_header_footer_cleanup_applied": False,
+                "training_eligible": False,
+                "modern_correction_eligible": False,
+                "ocr_used": False,
+                "inferred_character_repairs": False,
+                "images_included": False,
+                "provider_calls": False,
+            }
+        )
+    return records
+
+
+def _write_jsonl_gzip(path: Path, records: Iterable[Mapping[str, Any]]) -> tuple[int, int, str]:
+    temporary = path.with_name(f".{path.name}.tmp")
+    count = 0
+    try:
+        with (
+            temporary.open("wb") as raw_handle,
+            gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as gzip_handle,
+        ):
+            for record in records:
+                gzip_handle.write(canonical_json(record).encode("utf-8") + b"\n")
+                count += 1
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return count, path.stat().st_size, file_sha256(path)
+
+
+def _receipt_with_hash(body: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = dict(body)
+    receipt["receipt_sha256"] = sha256_value(body)
+    return receipt
+
+
+def _validate_receipt(receipt: Mapping[str, Any]) -> None:
+    try:
+        schema = json.loads(RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasCatalogMaterializationError(f"cannot read receipt schema: {RECEIPT_SCHEMA_PATH}") from exc
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(receipt), key=lambda item: list(item.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "receipt"
+        raise SpasCatalogMaterializationError(f"receipt schema violation at {location}: {errors[0].message}")
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    require(receipt["receipt_sha256"] == sha256_value(body), "receipt self-hash drift")
+    inputs = receipt["inputs"]
+    denominator = receipt["denominator"]
+    output = receipt["output"]
+    pua_audit = receipt["private_use_audit"]
+    require(
+        denominator["catalog_pages"] == inputs["catalog_pdf_page_end"] - inputs["catalog_pdf_page_start"] + 1,
+        "receipt catalogue page denominator drift",
+    )
+    require(
+        denominator["nonempty_native_text_pages"] == denominator["catalog_pages"],
+        "receipt nonempty page denominator drift",
+    )
+    require(
+        denominator["expected_records"]
+        == denominator["materialized_records"]
+        == denominator["unique_record_numbers"]
+        == output["records"],
+        "receipt record denominator drift",
+    )
+    require(
+        pua_audit["total_occurrences"] == sum(pua_audit["codepoint_counts"].values()),
+        "receipt private-use denominator drift",
+    )
+
+
+def _write_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    _validate_receipt(receipt)
+    path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _validate_raw_record(
+    record: Mapping[str, Any],
+    *,
+    expected_number: int,
+    expected_pdf_sha256: str,
+    page_texts: Mapping[int, str],
+) -> None:
+    require(set(record) == RAW_RECORD_FIELDS, f"raw record {expected_number} fields drift")
+    require(record["schema_version"] == "phase3_spas_raw_catalog_record_v1", "raw record schema drift")
+    require(record["record_id"] == f"spas-na-berestovi:graffito:{expected_number:04d}", "record id drift")
+    require(record["collection_id"] == COLLECTION_ID, "raw record collection drift")
+    require(record["source_record_identity"] == f"Графіті № {expected_number}", "source record identity drift")
+    require(record["graffito_number"] == expected_number, "graffito number drift")
+    require(record["source_pdf_sha256"] == expected_pdf_sha256, "raw record PDF identity drift")
+    require(
+        record["offset_basis"] == "unicode_code_points_in_pypdf_native_page_text",
+        "raw record offset basis drift",
+    )
+
+    fragments = record["source_page_fragments"]
+    require(isinstance(fragments, list) and fragments, f"raw record {expected_number} lacks page fragments")
+    fragment_texts: list[str] = []
+    previous_page = 0
+    for fragment in fragments:
+        require(
+            set(fragment) == {"pdf_page_number", "start_char", "end_char", "text_sha256"},
+            f"raw record {expected_number} fragment fields drift",
+        )
+        page_number = fragment["pdf_page_number"]
+        require(page_number in page_texts, f"raw record {expected_number} refers to an unknown page")
+        require(page_number > previous_page, f"raw record {expected_number} page fragments are not ordered")
+        previous_page = page_number
+        page_text = page_texts[page_number]
+        start, end = fragment["start_char"], fragment["end_char"]
+        require(
+            isinstance(start, int) and isinstance(end, int) and 0 <= start < end <= len(page_text),
+            f"raw record {expected_number} fragment offsets drift",
+        )
+        fragment_text = page_text[start:end]
+        require(
+            fragment["text_sha256"] == hashlib.sha256(fragment_text.encode("utf-8")).hexdigest(),
+            f"raw record {expected_number} fragment hash drift",
+        )
+        fragment_texts.append(fragment_text)
+
+    source_text = "\n".join(fragment_texts)
+    require(record["source_text"] == source_text, f"raw record {expected_number} source text does not round-trip")
+    require(
+        record["source_text_sha256"] == hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+        f"raw record {expected_number} source text hash drift",
+    )
+    heading = HEADING_RE.match(source_text)
+    require(heading is not None and int(heading.group(1)) == expected_number, "raw record heading drift")
+    require(record["heading_text"] == heading.group(0), "raw record heading text drift")
+    pua_counts = _private_use_counts(source_text)
+    require(record["private_use_codepoint_counts"] == pua_counts, "raw record private-use audit drift")
+    require(record["contains_private_use_glyphs"] is bool(pua_counts), "raw record private-use flag drift")
+    require(record["materialization_status"] == "raw_record_boundary_verified", "materialization status drift")
+    require(record["normalization_status"] == "not_applied", "normalization status drift")
+    for field in (
+        "commentary_and_inscription_layers_separated",
+        "page_header_footer_cleanup_applied",
+        "training_eligible",
+        "modern_correction_eligible",
+        "ocr_used",
+        "inferred_character_repairs",
+        "images_included",
+        "provider_calls",
+    ):
+        require(record[field] is False, f"unsafe raw record flag: {field}")
+
+
+def validate_existing_materialization(*, pdf_path: Path, private_output_dir: Path) -> dict[str, Any]:
+    """Rebind an existing private output to the immutable PDF and every source slice."""
+    receipt_path = private_output_dir / RECEIPT_FILENAME
+    output_path = private_output_dir / OUTPUT_FILENAME
+    require(receipt_path.is_file() and not receipt_path.is_symlink(), "materialization receipt is missing or unsafe")
+    require(output_path.is_file() and not output_path.is_symlink(), "private JSONL is missing or unsafe")
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasCatalogMaterializationError(f"cannot read materialization receipt: {exc}") from exc
+    require(isinstance(receipt, Mapping), "materialization receipt must be an object")
+    _validate_receipt(receipt)
+    inputs = receipt["inputs"]
+    denominator = receipt["denominator"]
+    pua_audit = receipt["private_use_audit"]
+    require(inputs["source_pdf_sha256"] == SOURCE_PDF_SHA256, "receipt source PDF identity drift")
+    require(inputs["pdf_pages"] == EXPECTED_PDF_PAGES, "receipt PDF page-count identity drift")
+    require(
+        inputs["catalog_pdf_page_start"] == CATALOG_PDF_PAGE_START,
+        "receipt catalogue start-page identity drift",
+    )
+    require(
+        inputs["catalog_pdf_page_end"] == CATALOG_PDF_PAGE_END,
+        "receipt catalogue end-page identity drift",
+    )
+    require(
+        denominator["native_text_characters"] == EXPECTED_NATIVE_TEXT_CHARACTERS,
+        "receipt native-text character identity drift",
+    )
+    require(
+        denominator["expected_records"] == EXPECTED_CATALOG_RECORDS,
+        "receipt record-count identity drift",
+    )
+    require(
+        pua_audit["codepoint_counts"] == EXPECTED_PRIVATE_USE_COUNTS,
+        "receipt private-use identity drift",
+    )
+    require(
+        inputs["extraction_backend_version"] == importlib.metadata.version("pypdf"),
+        "pypdf extraction version drift",
+    )
+    require(output_path.stat().st_size == receipt["output"]["bytes"], "private JSONL byte count drift")
+    require(file_sha256(output_path) == receipt["output"]["sha256"], "private JSONL SHA-256 drift")
+
+    pages = load_catalog_pages(
+        pdf_path,
+        expected_pdf_sha256=inputs["source_pdf_sha256"],
+        expected_pdf_pages=inputs["pdf_pages"],
+        catalog_pdf_page_start=inputs["catalog_pdf_page_start"],
+        catalog_pdf_page_end=inputs["catalog_pdf_page_end"],
+    )
+    require(sum(len(text) for text in pages.values()) == receipt["denominator"]["native_text_characters"], "native text denominator drift")
+    pua_counts: Counter[str] = Counter()
+    private_use_pages = 0
+    for text in pages.values():
+        page_counts = _private_use_counts(text)
+        pua_counts.update(page_counts)
+        private_use_pages += bool(page_counts)
+    require(
+        dict(sorted(pua_counts.items())) == receipt["private_use_audit"]["codepoint_counts"],
+        "source PDF private-use audit drift",
+    )
+    require(
+        private_use_pages == receipt["private_use_audit"]["pages_with_private_use_glyphs"],
+        "source PDF private-use page denominator drift",
+    )
+
+    try:
+        with gzip.open(output_path, "rt", encoding="utf-8") as handle:
+            records = [json.loads(line) for line in handle]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SpasCatalogMaterializationError(f"cannot read private JSONL: {exc}") from exc
+    require(len(records) == receipt["output"]["records"], "private JSONL record count drift")
+    expected_records = split_catalog_records(
+        pages,
+        expected_record_count=receipt["denominator"]["expected_records"],
+        source_pdf_sha256=inputs["source_pdf_sha256"],
+    )
+    require(records == expected_records, "private JSONL does not equal deterministic source-page materialization")
+    for expected_number, record in enumerate(records, start=1):
+        require(isinstance(record, Mapping), f"raw record {expected_number} must be an object")
+        _validate_raw_record(
+            record,
+            expected_number=expected_number,
+            expected_pdf_sha256=inputs["source_pdf_sha256"],
+            page_texts=pages,
+        )
+    manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "source_text_sha256": record["source_text_sha256"],
+            "source_page_fragments": record["source_page_fragments"],
+        }
+        for record in records
+    ]
+    require(
+        sha256_value(manifest) == receipt["output"]["record_identity_manifest_sha256"],
+        "record identity manifest drift",
+    )
+    return {
+        "ok": True,
+        "records": len(records),
+        "source_pdf_sha256": inputs["source_pdf_sha256"],
+        "private_jsonl_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+    }
+
+
+def materialize_spas_catalog(
+    *,
+    pdf_path: Path,
+    private_output_dir: Path,
+    receipt_output: Path,
+    expected_pdf_sha256: str = SOURCE_PDF_SHA256,
+    expected_pdf_pages: int = EXPECTED_PDF_PAGES,
+    catalog_pdf_page_start: int = CATALOG_PDF_PAGE_START,
+    catalog_pdf_page_end: int = CATALOG_PDF_PAGE_END,
+    expected_record_count: int = EXPECTED_CATALOG_RECORDS,
+    expected_native_text_characters: int = EXPECTED_NATIVE_TEXT_CHARACTERS,
+    expected_private_use_counts: Mapping[str, int] = EXPECTED_PRIVATE_USE_COUNTS,
+) -> dict[str, Any]:
+    """Write an immutable private JSONL plus a text-free public receipt."""
+    resolved_output = private_output_dir.resolve()
+    require(not _inside_git_checkout(resolved_output), "private text output cannot be inside a Git checkout")
+    require(receipt_output.parent.resolve() == resolved_output, "receipt must be inside private output directory")
+    require(receipt_output.name == RECEIPT_FILENAME, "receipt filename is not the frozen value")
+    require(not private_output_dir.exists(), "immutable private output directory already exists")
+    require(private_output_dir.parent.is_dir(), "private output parent directory does not exist")
+
+    pages = load_catalog_pages(
+        pdf_path,
+        expected_pdf_sha256=expected_pdf_sha256,
+        expected_pdf_pages=expected_pdf_pages,
+        catalog_pdf_page_start=catalog_pdf_page_start,
+        catalog_pdf_page_end=catalog_pdf_page_end,
+    )
+    native_text_characters = sum(len(text) for text in pages.values())
+    require(native_text_characters == expected_native_text_characters, "native catalogue character denominator drift")
+    page_private_use_counts: Counter[str] = Counter()
+    private_use_pages = 0
+    for text in pages.values():
+        counts = _private_use_counts(text)
+        page_private_use_counts.update(counts)
+        private_use_pages += bool(counts)
+    require(
+        dict(sorted(page_private_use_counts.items())) == dict(expected_private_use_counts),
+        "private-use glyph denominator drift",
+    )
+
+    records = split_catalog_records(
+        pages,
+        expected_record_count=expected_record_count,
+        source_pdf_sha256=expected_pdf_sha256,
+    )
+    record_identity_manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "source_text_sha256": record["source_text_sha256"],
+            "source_page_fragments": record["source_page_fragments"],
+        }
+        for record in records
+    ]
+
+    staging_dir = Path(
+        tempfile.mkdtemp(prefix=f".{private_output_dir.name}.staging-", dir=private_output_dir.parent)
+    )
+    try:
+        output_path = staging_dir / OUTPUT_FILENAME
+        record_count, output_bytes, output_sha256 = _write_jsonl_gzip(output_path, records)
+        require(record_count == expected_record_count, "private output record count drift")
+        body: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "implementation_version": IMPLEMENTATION_VERSION,
+            "mode": "full_catalogue_boundary_materialization",
+            "text_free": True,
+            "inputs": {
+                "collection_id": COLLECTION_ID,
+                "source_author": SOURCE_AUTHOR,
+                "source_title": SOURCE_TITLE,
+                "source_year": SOURCE_YEAR,
+                "source_record_url": SOURCE_RECORD_URL,
+                "source_pdf_sha256": expected_pdf_sha256,
+                "pdf_pages": expected_pdf_pages,
+                "catalog_pdf_page_start": catalog_pdf_page_start,
+                "catalog_pdf_page_end": catalog_pdf_page_end,
+                "extraction_backend": "pypdf.page.extract_text",
+                "extraction_backend_version": importlib.metadata.version("pypdf"),
+            },
+            "denominator": {
+                "catalog_pages": len(pages),
+                "nonempty_native_text_pages": len(pages),
+                "native_text_characters": native_text_characters,
+                "expected_records": expected_record_count,
+                "materialized_records": record_count,
+                "unique_record_numbers": len({record["graffito_number"] for record in records}),
+                "sequential_record_numbers": True,
+            },
+            "private_use_audit": {
+                "total_occurrences": sum(page_private_use_counts.values()),
+                "pages_with_private_use_glyphs": private_use_pages,
+                "codepoint_counts": dict(sorted(page_private_use_counts.items())),
+                "glyph_font_observed_during_visual_canary": "Bukyvede",
+                "mapping_status": "pending_visual_source_verified_adapter",
+            },
+            "output": {
+                "filename": OUTPUT_FILENAME,
+                "records": record_count,
+                "bytes": output_bytes,
+                "sha256": output_sha256,
+                "record_identity_manifest_sha256": sha256_value(record_identity_manifest),
+            },
+            "rights_and_scope": {
+                "public_institutional_full_text": True,
+                "standardized_dataset_license_expression_found": False,
+                "bounded_text_first_use_decision": "accepted_operational_risk",
+                "attribution_and_field_level_removal_preserved": True,
+                "binary_media_reuse_authorized": False,
+                "full_publication_training_export_authorized": False,
+                "adapt_on_substantiated_rights_notice": True,
+            },
+            "safeguards": {
+                "raw_source_preserved": True,
+                "historical_forms_protected": True,
+                "normalized_historical_text_emitted": False,
+                "commentary_and_inscription_layers_separated": False,
+                "page_header_footer_cleanup_applied": False,
+                "modern_correction_eligible": False,
+                "training_eligible": False,
+                "ocr_used": False,
+                "inferred_character_repairs": False,
+                "images_included": False,
+                "provider_calls": False,
+                "phase4_authorized": False,
+            },
+            "residuals": {
+                "spas_na_berestovi_is_lavra_associated": True,
+                "spas_na_berestovi_is_not_lavra_cave_corpus": True,
+                "lavra_cave_corpus_gap_closed": False,
+                "glyph_mapping_pending": True,
+                "commentary_transcription_separation_pending": True,
+            },
+        }
+        receipt = _receipt_with_hash(body)
+        _write_receipt(staging_dir / RECEIPT_FILENAME, receipt)
+        require(not private_output_dir.exists(), "immutable private output directory appeared during publication")
+        os.replace(staging_dir, private_output_dir)
+        return receipt
+    finally:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf", type=Path, required=True)
+    parser.add_argument("--private-output-dir", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    receipt_output = args.private_output_dir / RECEIPT_FILENAME
+    try:
+        receipt = materialize_spas_catalog(
+            pdf_path=args.pdf,
+            private_output_dir=args.private_output_dir,
+            receipt_output=receipt_output,
+        )
+    except SpasCatalogMaterializationError as exc:
+        print(canonical_json({"status": "blocked", "error": str(exc)}))
+        return 2
+    print(
+        canonical_json(
+            {
+                "status": "raw_catalogue_materialized",
+                "records": receipt["output"]["records"],
+                "training_eligible": receipt["safeguards"]["training_eligible"],
+                "receipt_sha256": receipt["receipt_sha256"],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_spas_glyph_adapter.py
+++ b/scripts/projects/open_model_data/phase3_spas_glyph_adapter.py
@@ -1,0 +1,765 @@
+#!/usr/bin/env python3
+"""Map source-verified Bukyvede glyphs to Unicode without admitting training data.
+
+The adapter consumes the immutable Spas na Berestovi raw catalogue, revalidates
+it against the canonical PDF, and writes a second private layer.  Raw text is
+retained byte-for-byte in every output record.  Only five source-verified
+Bukyvede patterns are mapped; any other private-use character fails closed.
+
+This step is a technical encoding adapter, not semantic gold.  The output
+remains ineligible for training until inscription readings are separated from
+the editor's prose and independently reviewed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data.phase3_linguistic_representation import canonical_json, sha256_value
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    COLLECTION_ID,
+    EXPECTED_CATALOG_RECORDS,
+    EXPECTED_PRIVATE_USE_COUNTS,
+    SOURCE_PDF_SHA256,
+    SpasCatalogMaterializationError,
+    _inside_git_checkout,
+    file_sha256,
+    validate_existing_materialization,
+)
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    OUTPUT_FILENAME as RAW_OUTPUT_FILENAME,
+)
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    RECEIPT_FILENAME as RAW_RECEIPT_FILENAME,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+RECEIPT_SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_spas_glyph_adapter_receipt_v1.schema.json"
+
+SCHEMA_VERSION = "phase3_spas_glyph_adapter_receipt_v1"
+IMPLEMENTATION_VERSION = "phase3_spas_glyph_adapter_v1"
+OUTPUT_FILENAME = "spas-na-berestovi-unicode-adapter-v1.jsonl.gz"
+RECEIPT_FILENAME = "glyph-adapter-receipt-v1.json"
+MAPPING_EVIDENCE_FILENAME = "bukyvede-glyph-mapping-evidence-v1.json"
+
+EXPECTED_RAW_OUTPUT_SHA256 = "974f05399d69faadc2fd7ffe96a06e0e2d1d409464a1eb1de9962bf772fabd05"
+EXPECTED_RAW_RECEIPT_FILE_SHA256 = "fe14a7c0dfb7fcb1304cf5ad360cba11135bcc42bb4cd78ef314773e948a492b"
+EXPECTED_RAW_RECEIPT_SHA256 = "a2521b1026878520e9180a04a11f68a683845cf214b44d3794c8c761c309b7d3"
+EXPECTED_MAPPING_EVIDENCE_SHA256 = "e91c0476c5a712ad4d050524c2fff5ea68b9601ed8702c0ca3a961ce6fef5552"
+EXPECTED_FONT_SHA256 = "7a8621566ed351efdd44c97ba7730c3e5566148c79a972be215b887991e6d7c9"
+EXPECTED_TO_UNICODE_SHA256 = "47d569411ebc3ab0f2ebba34f8c7f291afdd089d3a658ff2f1ab609e4f16ff21"
+EXPECTED_RAW_RECORD_CHARACTERS = 228066
+EXPECTED_NORMALIZED_CHARACTERS = 228036
+EXPECTED_RECORDS_WITH_MAPPINGS = 39
+EXPECTED_MAPPING_EVENTS = 57
+
+
+class SpasGlyphAdapterError(ValueError):
+    """A provenance, mapping, or immutable-output invariant failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SpasGlyphAdapterError(message)
+
+
+def _codepoints(text: str) -> list[str]:
+    return [f"U+{ord(char):04X}" for char in text]
+
+
+def _private_use_counts(text: str) -> dict[str, int]:
+    counts = Counter(f"U+{ord(char):04X}" for char in text if 0xE000 <= ord(char) <= 0xF8FF)
+    return dict(sorted(counts.items()))
+
+
+@dataclass(frozen=True)
+class MappingRule:
+    mapping_id: str
+    raw: str
+    normalized: str
+    unicode_name: str
+    expected_occurrences: int
+
+    def receipt_entry(self) -> dict[str, Any]:
+        return {
+            "mapping_id": self.mapping_id,
+            "raw_pattern": _codepoints(self.raw),
+            "normalized_pattern": _codepoints(self.normalized),
+            "unicode_name": self.unicode_name,
+            "expected_occurrences": self.expected_occurrences,
+        }
+
+
+MAPPING_RULES = (
+    MappingRule(
+        "capital_iotation_plus_a_to_iotified_a",
+        "\ue02e\u0410",
+        "\ua656",
+        "CYRILLIC CAPITAL LETTER IOTIFIED A",
+        3,
+    ),
+    MappingRule(
+        "small_iotation_plus_a_to_iotified_a",
+        "\ue02f\u0430",
+        "\ua657",
+        "CYRILLIC SMALL LETTER IOTIFIED A",
+        27,
+    ),
+    MappingRule(
+        "titolongcap_to_combining_cyrillic_titlo",
+        "\ue002",
+        "\u0483",
+        "COMBINING CYRILLIC TITLO",
+        13,
+    ),
+    MappingRule(
+        "cyfitamidbar_to_cyrillic_capital_fita",
+        "\ue026",
+        "\u0472",
+        "CYRILLIC CAPITAL LETTER FITA",
+        4,
+    ),
+    MappingRule(
+        "lowercase_fita_to_cyrillic_small_fita",
+        "\ue027",
+        "\u0473",
+        "CYRILLIC SMALL LETTER FITA",
+        10,
+    ),
+)
+RULE_BY_ID = {rule.mapping_id: rule for rule in MAPPING_RULES}
+EXPECTED_MAPPING_COUNTS = {rule.mapping_id: rule.expected_occurrences for rule in MAPPING_RULES}
+
+
+def apply_bukyvede_mapping(raw_text: str) -> tuple[str, list[dict[str, Any]]]:
+    """Apply only the frozen longest-first mapping contract."""
+    require(isinstance(raw_text, str) and raw_text != "", "raw text must be nonempty")
+    normalized_parts: list[str] = []
+    events: list[dict[str, Any]] = []
+    raw_offset = 0
+    normalized_offset = 0
+    while raw_offset < len(raw_text):
+        rule = next((candidate for candidate in MAPPING_RULES if raw_text.startswith(candidate.raw, raw_offset)), None)
+        if rule is None:
+            char = raw_text[raw_offset]
+            require(
+                not 0xE000 <= ord(char) <= 0xF8FF,
+                f"unmapped private-use character at raw offset {raw_offset}: U+{ord(char):04X}",
+            )
+            normalized_parts.append(char)
+            raw_offset += 1
+            normalized_offset += 1
+            continue
+
+        raw_end = raw_offset + len(rule.raw)
+        normalized_end = normalized_offset + len(rule.normalized)
+        events.append(
+            {
+                "mapping_id": rule.mapping_id,
+                "raw_start_char": raw_offset,
+                "raw_end_char": raw_end,
+                "raw_pattern": _codepoints(rule.raw),
+                "raw_pattern_sha256": hashlib.sha256(rule.raw.encode("utf-8")).hexdigest(),
+                "normalized_start_char": normalized_offset,
+                "normalized_end_char": normalized_end,
+                "normalized_pattern": _codepoints(rule.normalized),
+                "normalized_pattern_sha256": hashlib.sha256(rule.normalized.encode("utf-8")).hexdigest(),
+            }
+        )
+        normalized_parts.append(rule.normalized)
+        raw_offset = raw_end
+        normalized_offset = normalized_end
+
+    normalized_text = "".join(normalized_parts)
+    require(_private_use_counts(normalized_text) == {}, "normalized text still contains private-use characters")
+    return normalized_text, events
+
+
+def reconstruct_raw_text(normalized_text: str, events: Sequence[Mapping[str, Any]]) -> str:
+    """Reverse the adapter using normalized offsets and frozen event patterns."""
+    parts: list[str] = []
+    cursor = 0
+    previous_raw_end = 0
+    for event in events:
+        require(
+            set(event)
+            == {
+                "mapping_id",
+                "raw_start_char",
+                "raw_end_char",
+                "raw_pattern",
+                "raw_pattern_sha256",
+                "normalized_start_char",
+                "normalized_end_char",
+                "normalized_pattern",
+                "normalized_pattern_sha256",
+            },
+            "mapping event fields drift",
+        )
+        mapping_id = event["mapping_id"]
+        require(mapping_id in RULE_BY_ID, "mapping event id drift")
+        rule = RULE_BY_ID[mapping_id]
+        start = event["normalized_start_char"]
+        end = event["normalized_end_char"]
+        require(isinstance(start, int) and isinstance(end, int), "mapping event offsets must be integers")
+        require(cursor <= start < end <= len(normalized_text), "normalized mapping event offsets drift")
+        expected_raw_start = previous_raw_end + (start - cursor)
+        require(event["raw_start_char"] == expected_raw_start, "raw mapping event start offset drift")
+        require(event["raw_end_char"] - event["raw_start_char"] == len(rule.raw), "raw mapping width drift")
+        require(event["raw_pattern"] == _codepoints(rule.raw), "raw mapping pattern drift")
+        require(event["normalized_pattern"] == _codepoints(rule.normalized), "normalized mapping pattern drift")
+        require(normalized_text[start:end] == rule.normalized, "normalized mapping text drift")
+        require(
+            event["raw_pattern_sha256"] == hashlib.sha256(rule.raw.encode("utf-8")).hexdigest(),
+            "raw mapping pattern hash drift",
+        )
+        require(
+            event["normalized_pattern_sha256"] == hashlib.sha256(rule.normalized.encode("utf-8")).hexdigest(),
+            "normalized mapping pattern hash drift",
+        )
+        parts.append(normalized_text[cursor:start])
+        parts.append(rule.raw)
+        cursor = end
+        previous_raw_end = event["raw_end_char"]
+    parts.append(normalized_text[cursor:])
+    return "".join(parts)
+
+
+def build_normalized_record(raw_record: Mapping[str, Any], *, upstream_raw_sha256: str) -> dict[str, Any]:
+    """Build one reversible private record from one validated raw record."""
+    required = {
+        "record_id",
+        "collection_id",
+        "graffito_number",
+        "source_pdf_sha256",
+        "source_text",
+        "source_text_sha256",
+        "private_use_codepoint_counts",
+    }
+    require(required <= set(raw_record), "raw record lacks required adapter fields")
+    raw_text = raw_record["source_text"]
+    require(isinstance(raw_text, str) and raw_text != "", "raw record source text must be nonempty")
+    require(raw_record["collection_id"] == COLLECTION_ID, "raw record collection drift")
+    require(raw_record["source_pdf_sha256"] == SOURCE_PDF_SHA256, "raw record PDF identity drift")
+    require(
+        raw_record["source_text_sha256"] == hashlib.sha256(raw_text.encode("utf-8")).hexdigest(),
+        "raw record source text hash drift",
+    )
+    require(
+        raw_record["private_use_codepoint_counts"] == _private_use_counts(raw_text),
+        "raw record private-use counts drift",
+    )
+
+    normalized_text, events = apply_bukyvede_mapping(raw_text)
+    reconstructed = reconstruct_raw_text(normalized_text, events)
+    require(reconstructed == raw_text, "normalized record does not reverse to exact raw text")
+    counts = Counter(event["mapping_id"] for event in events)
+    return {
+        "schema_version": "phase3_spas_glyph_normalized_record_v1",
+        "record_id": f"{raw_record['record_id']}:unicode-v1",
+        "source_record_id": raw_record["record_id"],
+        "collection_id": COLLECTION_ID,
+        "graffito_number": raw_record["graffito_number"],
+        "source_pdf_sha256": SOURCE_PDF_SHA256,
+        "upstream_raw_catalog_sha256": upstream_raw_sha256,
+        "raw_source_text": raw_text,
+        "raw_source_text_sha256": raw_record["source_text_sha256"],
+        "normalized_text": normalized_text,
+        "normalized_text_sha256": hashlib.sha256(normalized_text.encode("utf-8")).hexdigest(),
+        "raw_offset_basis": "unicode_code_points_in_pypdf_native_page_text",
+        "normalized_offset_basis": "unicode_code_points_after_bukyvede_adapter_v1",
+        "mapping_events": events,
+        "mapping_event_counts": dict(sorted(counts.items())),
+        "input_private_use_codepoint_counts": raw_record["private_use_codepoint_counts"],
+        "output_private_use_codepoint_counts": {},
+        "mapping_status": "source_verified_bukyvede_glyph_adapter",
+        "raw_source_preserved": True,
+        "commentary_and_inscription_layers_separated": False,
+        "training_eligible": False,
+        "modern_correction_eligible": False,
+        "inferred_character_repairs": False,
+        "provider_calls": False,
+    }
+
+
+def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    require(path.is_file() and not path.is_symlink(), f"{description} is missing or unsafe")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasGlyphAdapterError(f"cannot read {description}: {exc}") from exc
+    require(isinstance(value, dict), f"{description} must be an object")
+    return value
+
+
+def validate_mapping_evidence(path: Path, *, expected_sha256: str | None = None) -> None:
+    """Validate the exact text-free evidence note and its frozen mapping contract."""
+    if expected_sha256 is None:
+        expected_sha256 = EXPECTED_MAPPING_EVIDENCE_SHA256
+    require(path.name == MAPPING_EVIDENCE_FILENAME, "mapping evidence filename drift")
+    require(file_sha256(path) == expected_sha256, "mapping evidence SHA-256 drift")
+    evidence = _load_json_object(path, description="mapping evidence")
+    require(file_sha256(path) == expected_sha256, "mapping evidence changed while validating")
+    require(
+        evidence.get("schema_version") == "private_phase3_spas_bukyvede_glyph_mapping_evidence_v1",
+        "mapping evidence schema drift",
+    )
+    require(evidence.get("text_free") is True, "mapping evidence must be text-free")
+    source = evidence.get("source", {})
+    require(source.get("collection_id") == COLLECTION_ID, "mapping evidence collection drift")
+    require(source.get("source_pdf_sha256") == SOURCE_PDF_SHA256, "mapping evidence PDF identity drift")
+    require(source.get("catalog_records") == EXPECTED_CATALOG_RECORDS, "mapping evidence record denominator drift")
+    require(source.get("raw_catalog_jsonl_sha256") == EXPECTED_RAW_OUTPUT_SHA256, "mapping evidence raw output drift")
+    require(
+        source.get("raw_materialization_receipt_sha256") == EXPECTED_RAW_RECEIPT_SHA256,
+        "mapping evidence raw receipt drift",
+    )
+    font = evidence.get("embedded_font", {})
+    require(font.get("font_sha256") == EXPECTED_FONT_SHA256, "mapping evidence font identity drift")
+    require(font.get("to_unicode_sha256") == EXPECTED_TO_UNICODE_SHA256, "mapping evidence ToUnicode identity drift")
+    candidates = evidence.get("source_verified_mapping_candidates")
+    require(
+        isinstance(candidates, list) and len(candidates) == len(MAPPING_RULES), "mapping candidate denominator drift"
+    )
+    observed = {
+        (tuple(candidate.get("raw_pattern", [])), tuple(candidate.get("normalized_pattern", []))): candidate.get(
+            "occurrences"
+        )
+        for candidate in candidates
+        if isinstance(candidate, dict)
+    }
+    expected = {
+        (tuple(_codepoints(rule.raw)), tuple(_codepoints(rule.normalized))): rule.expected_occurrences
+        for rule in MAPPING_RULES
+    }
+    require(observed == expected, "mapping evidence rule contract drift")
+    denominator = evidence.get("denominator_checks", {})
+    require(
+        denominator.get("private_use_occurrences") == EXPECTED_MAPPING_EVENTS, "mapping evidence PUA denominator drift"
+    )
+    require(
+        denominator.get("raw_pattern_occurrence_sum") == EXPECTED_MAPPING_EVENTS,
+        "mapping evidence pattern denominator drift",
+    )
+    require(denominator.get("unexpected_private_use_codepoints") == 0, "mapping evidence contains unexpected PUA")
+    safeguards = evidence.get("safeguards", {})
+    require(
+        safeguards.get("mapping_is_deterministic_source_adapter_not_semantic_gold") is True,
+        "mapping evidence authority drift",
+    )
+    require(safeguards.get("training_eligible") is False, "mapping evidence cannot authorize training")
+    require(safeguards.get("phase4_authorized") is False, "mapping evidence cannot authorize Phase 4")
+
+
+def _write_jsonl_gzip(path: Path, records: Sequence[Mapping[str, Any]]) -> tuple[int, int, str]:
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        with (
+            temporary.open("wb") as raw_handle,
+            gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as gzip_handle,
+        ):
+            for record in records:
+                gzip_handle.write(canonical_json(record).encode("utf-8") + b"\n")
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return len(records), path.stat().st_size, file_sha256(path)
+
+
+def _receipt_with_hash(body: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = dict(body)
+    receipt["receipt_sha256"] = sha256_value(body)
+    return receipt
+
+
+def _validate_receipt(receipt: Mapping[str, Any]) -> None:
+    try:
+        schema = json.loads(RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasGlyphAdapterError(f"cannot read receipt schema: {RECEIPT_SCHEMA_PATH}") from exc
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(receipt), key=lambda item: list(item.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "receipt"
+        raise SpasGlyphAdapterError(f"receipt schema violation at {location}: {errors[0].message}")
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    require(receipt["receipt_sha256"] == sha256_value(body), "receipt self-hash drift")
+    denominator = receipt["denominator"]
+    require(
+        denominator["input_records"] == denominator["output_records"] == receipt["output"]["records"],
+        "receipt record denominator drift",
+    )
+    require(
+        denominator["input_private_use_occurrences"]
+        == denominator["mapping_events"]
+        == sum(receipt["mapping_contract"]["observed_counts"].values()),
+        "receipt mapping denominator drift",
+    )
+    require(denominator["output_private_use_occurrences"] == 0, "receipt output PUA denominator drift")
+    require(
+        denominator["input_characters"] - denominator["output_characters"] == 30,
+        "receipt character-width delta drift",
+    )
+    require(
+        receipt["mapping_contract"]["rules"] == [rule.receipt_entry() for rule in MAPPING_RULES],
+        "receipt mapping-rule contract drift",
+    )
+
+
+def _write_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    _validate_receipt(receipt)
+    path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_raw_records(path: Path) -> list[dict[str, Any]]:
+    require(path.is_file() and not path.is_symlink(), "raw catalogue JSONL is missing or unsafe")
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as handle:
+            records = [json.loads(line) for line in handle]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SpasGlyphAdapterError(f"cannot read raw catalogue JSONL: {exc}") from exc
+    require(all(isinstance(record, dict) for record in records), "raw catalogue rows must be objects")
+    return records
+
+
+def _load_output_records(path: Path) -> list[dict[str, Any]]:
+    require(path.is_file() and not path.is_symlink(), "glyph adapter JSONL is missing or unsafe")
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as handle:
+            records = [json.loads(line) for line in handle]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SpasGlyphAdapterError(f"cannot read glyph adapter JSONL: {exc}") from exc
+    require(all(isinstance(record, dict) for record in records), "glyph adapter rows must be objects")
+    return records
+
+
+def _validate_normalized_record(record: Mapping[str, Any], raw_record: Mapping[str, Any]) -> None:
+    expected = build_normalized_record(raw_record, upstream_raw_sha256=EXPECTED_RAW_OUTPUT_SHA256)
+    require(record == expected, f"normalized record {raw_record['graffito_number']} deterministic replay drift")
+    require(
+        reconstruct_raw_text(record["normalized_text"], record["mapping_events"]) == record["raw_source_text"],
+        "raw reconstruction drift",
+    )
+
+
+def _remove_staging_dir(staging_dir: Path) -> None:
+    for filename in (OUTPUT_FILENAME, RECEIPT_FILENAME):
+        candidate = staging_dir / filename
+        if candidate.is_file() or candidate.is_symlink():
+            candidate.unlink()
+    if staging_dir.exists():
+        staging_dir.rmdir()
+
+
+def adapt_spas_glyphs(
+    *,
+    pdf_path: Path,
+    raw_catalog_dir: Path,
+    mapping_evidence_path: Path,
+    private_output_dir: Path,
+    expected_raw_output_sha256: str = EXPECTED_RAW_OUTPUT_SHA256,
+    expected_raw_receipt_file_sha256: str = EXPECTED_RAW_RECEIPT_FILE_SHA256,
+    expected_raw_receipt_sha256: str = EXPECTED_RAW_RECEIPT_SHA256,
+    expected_mapping_evidence_sha256: str = EXPECTED_MAPPING_EVIDENCE_SHA256,
+    expected_records: int = EXPECTED_CATALOG_RECORDS,
+    expected_raw_characters: int = EXPECTED_RAW_RECORD_CHARACTERS,
+    expected_normalized_characters: int = EXPECTED_NORMALIZED_CHARACTERS,
+    expected_records_with_mappings: int = EXPECTED_RECORDS_WITH_MAPPINGS,
+    expected_mapping_events: int = EXPECTED_MAPPING_EVENTS,
+) -> dict[str, Any]:
+    """Write an immutable private Unicode-adapter layer and text-free receipt."""
+    resolved_output = private_output_dir.resolve()
+    require(not _inside_git_checkout(resolved_output), "private text output cannot be inside a Git checkout")
+    require(not private_output_dir.exists(), "immutable private output directory already exists")
+    require(private_output_dir.parent.is_dir(), "private output parent directory does not exist")
+    require(
+        mapping_evidence_path.parent.resolve() == raw_catalog_dir.resolve(),
+        "mapping evidence must accompany raw catalogue",
+    )
+
+    upstream = validate_existing_materialization(pdf_path=pdf_path, private_output_dir=raw_catalog_dir)
+    require(upstream["source_pdf_sha256"] == SOURCE_PDF_SHA256, "upstream PDF identity drift")
+    require(upstream["records"] == expected_records, "upstream record denominator drift")
+    require(upstream["private_jsonl_sha256"] == expected_raw_output_sha256, "upstream raw output identity drift")
+    require(upstream["receipt_sha256"] == expected_raw_receipt_sha256, "upstream raw receipt identity drift")
+    require(upstream["training_eligible"] is False, "upstream raw layer cannot authorize training")
+
+    raw_path = raw_catalog_dir / RAW_OUTPUT_FILENAME
+    raw_receipt_path = raw_catalog_dir / RAW_RECEIPT_FILENAME
+    require(file_sha256(raw_path) == expected_raw_output_sha256, "raw catalogue SHA-256 drift")
+    require(file_sha256(raw_receipt_path) == expected_raw_receipt_file_sha256, "raw receipt file SHA-256 drift")
+    validate_mapping_evidence(mapping_evidence_path, expected_sha256=expected_mapping_evidence_sha256)
+    raw_records = _load_raw_records(raw_path)
+    require(file_sha256(raw_path) == expected_raw_output_sha256, "raw catalogue changed while adapting")
+    require(len(raw_records) == expected_records, "raw catalogue record denominator drift")
+    require(
+        [record.get("graffito_number") for record in raw_records] == list(range(1, expected_records + 1)),
+        "raw catalogue sequence drift",
+    )
+
+    normalized_records = [
+        build_normalized_record(record, upstream_raw_sha256=expected_raw_output_sha256) for record in raw_records
+    ]
+    raw_characters = sum(len(record["raw_source_text"]) for record in normalized_records)
+    normalized_characters = sum(len(record["normalized_text"]) for record in normalized_records)
+    records_with_mappings = sum(bool(record["mapping_events"]) for record in normalized_records)
+    mapping_events = sum(len(record["mapping_events"]) for record in normalized_records)
+    mapping_counts: Counter[str] = Counter()
+    input_pua: Counter[str] = Counter()
+    output_pua: Counter[str] = Counter()
+    for record in normalized_records:
+        mapping_counts.update(record["mapping_event_counts"])
+        input_pua.update(record["input_private_use_codepoint_counts"])
+        output_pua.update(record["output_private_use_codepoint_counts"])
+    require(raw_characters == expected_raw_characters, "raw record character denominator drift")
+    require(normalized_characters == expected_normalized_characters, "normalized character denominator drift")
+    require(records_with_mappings == expected_records_with_mappings, "mapped-record denominator drift")
+    require(mapping_events == expected_mapping_events, "mapping-event denominator drift")
+    require(dict(sorted(mapping_counts.items())) == EXPECTED_MAPPING_COUNTS, "mapping-rule counts drift")
+    require(dict(sorted(input_pua.items())) == EXPECTED_PRIVATE_USE_COUNTS, "input private-use counts drift")
+    require(not output_pua, "output contains private-use characters")
+
+    identity_manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "raw_source_text_sha256": record["raw_source_text_sha256"],
+            "normalized_text_sha256": record["normalized_text_sha256"],
+            "mapping_event_counts": record["mapping_event_counts"],
+        }
+        for record in normalized_records
+    ]
+    staging_dir = Path(tempfile.mkdtemp(prefix=f".{private_output_dir.name}.staging-", dir=private_output_dir.parent))
+    try:
+        output_path = staging_dir / OUTPUT_FILENAME
+        output_records, output_bytes, output_sha256 = _write_jsonl_gzip(output_path, normalized_records)
+        body: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "implementation_version": IMPLEMENTATION_VERSION,
+            "mode": "source_verified_bukyvede_to_unicode_adapter",
+            "text_free": True,
+            "inputs": {
+                "collection_id": COLLECTION_ID,
+                "source_pdf_sha256": SOURCE_PDF_SHA256,
+                "raw_catalog_filename": RAW_OUTPUT_FILENAME,
+                "raw_catalog_sha256": expected_raw_output_sha256,
+                "raw_materialization_receipt_filename": RAW_RECEIPT_FILENAME,
+                "raw_materialization_receipt_file_sha256": expected_raw_receipt_file_sha256,
+                "raw_materialization_receipt_sha256": expected_raw_receipt_sha256,
+                "mapping_evidence_filename": MAPPING_EVIDENCE_FILENAME,
+                "mapping_evidence_sha256": expected_mapping_evidence_sha256,
+                "embedded_font_sha256": EXPECTED_FONT_SHA256,
+                "to_unicode_cmap_sha256": EXPECTED_TO_UNICODE_SHA256,
+                "implementation_sha256": file_sha256(Path(__file__)),
+                "receipt_schema_sha256": file_sha256(RECEIPT_SCHEMA_PATH),
+            },
+            "mapping_contract": {
+                "rules": [rule.receipt_entry() for rule in MAPPING_RULES],
+                "observed_counts": dict(sorted(mapping_counts.items())),
+                "longest_match_first": True,
+                "offset_basis": "unicode_code_points",
+                "source_adapter_not_semantic_gold": True,
+            },
+            "denominator": {
+                "input_records": len(raw_records),
+                "output_records": output_records,
+                "input_characters": raw_characters,
+                "output_characters": normalized_characters,
+                "records_with_mappings": records_with_mappings,
+                "mapping_events": mapping_events,
+                "input_private_use_occurrences": sum(input_pua.values()),
+                "output_private_use_occurrences": sum(output_pua.values()),
+                "raw_reconstruction_failures": 0,
+            },
+            "output": {
+                "filename": OUTPUT_FILENAME,
+                "records": output_records,
+                "bytes": output_bytes,
+                "sha256": output_sha256,
+                "record_identity_manifest_sha256": sha256_value(identity_manifest),
+            },
+            "rights_and_scope": {
+                "inherits_upstream_accepted_operational_risk": True,
+                "attribution_and_field_level_removal_preserved": True,
+                "binary_media_reuse_authorized": False,
+                "full_publication_training_export_authorized": False,
+                "adapt_on_substantiated_rights_notice": True,
+            },
+            "safeguards": {
+                "raw_source_preserved_in_every_record": True,
+                "historical_forms_protected": True,
+                "deterministic_mapping_only": True,
+                "commentary_and_inscription_layers_separated": False,
+                "training_eligible": False,
+                "modern_correction_eligible": False,
+                "semantic_gold": False,
+                "provider_calls": False,
+                "phase4_authorized": False,
+            },
+            "residuals": {
+                "glyph_mapping_pending": False,
+                "commentary_transcription_separation_pending": True,
+                "qualified_historical_review_pending": True,
+                "lavra_cave_corpus_gap_closed": False,
+            },
+        }
+        receipt = _receipt_with_hash(body)
+        _write_receipt(staging_dir / RECEIPT_FILENAME, receipt)
+        require(not private_output_dir.exists(), "immutable private output directory appeared during publication")
+        os.replace(staging_dir, private_output_dir)
+        return receipt
+    finally:
+        _remove_staging_dir(staging_dir)
+
+
+def validate_existing_glyph_adapter(
+    *,
+    pdf_path: Path,
+    raw_catalog_dir: Path,
+    mapping_evidence_path: Path,
+    private_output_dir: Path,
+) -> dict[str, Any]:
+    """Rebind an existing adapter output to the PDF, raw layer, and mapping note."""
+    receipt_path = private_output_dir / RECEIPT_FILENAME
+    output_path = private_output_dir / OUTPUT_FILENAME
+    receipt = _load_json_object(receipt_path, description="glyph adapter receipt")
+    _validate_receipt(receipt)
+    inputs = receipt["inputs"]
+    denominator = receipt["denominator"]
+    require(inputs["collection_id"] == COLLECTION_ID, "receipt collection identity drift")
+    require(inputs["source_pdf_sha256"] == SOURCE_PDF_SHA256, "receipt PDF identity drift")
+    require(inputs["raw_catalog_sha256"] == EXPECTED_RAW_OUTPUT_SHA256, "receipt raw catalogue identity drift")
+    require(
+        inputs["raw_materialization_receipt_file_sha256"] == EXPECTED_RAW_RECEIPT_FILE_SHA256,
+        "receipt raw receipt file identity drift",
+    )
+    require(
+        inputs["raw_materialization_receipt_sha256"] == EXPECTED_RAW_RECEIPT_SHA256, "receipt upstream identity drift"
+    )
+    require(
+        inputs["mapping_evidence_sha256"] == EXPECTED_MAPPING_EVIDENCE_SHA256, "receipt mapping evidence identity drift"
+    )
+    require(inputs["embedded_font_sha256"] == EXPECTED_FONT_SHA256, "receipt font identity drift")
+    require(inputs["to_unicode_cmap_sha256"] == EXPECTED_TO_UNICODE_SHA256, "receipt ToUnicode identity drift")
+    require(inputs["implementation_sha256"] == file_sha256(Path(__file__)), "receipt implementation identity drift")
+    require(inputs["receipt_schema_sha256"] == file_sha256(RECEIPT_SCHEMA_PATH), "receipt schema identity drift")
+    require(denominator["input_records"] == EXPECTED_CATALOG_RECORDS, "receipt input record denominator drift")
+    require(
+        denominator["input_characters"] == EXPECTED_RAW_RECORD_CHARACTERS, "receipt raw character denominator drift"
+    )
+    require(
+        denominator["output_characters"] == EXPECTED_NORMALIZED_CHARACTERS,
+        "receipt normalized character denominator drift",
+    )
+    require(
+        denominator["records_with_mappings"] == EXPECTED_RECORDS_WITH_MAPPINGS,
+        "receipt mapped-record denominator drift",
+    )
+    require(denominator["mapping_events"] == EXPECTED_MAPPING_EVENTS, "receipt mapping-event denominator drift")
+    require(receipt["mapping_contract"]["observed_counts"] == EXPECTED_MAPPING_COUNTS, "receipt mapping counts drift")
+
+    upstream = validate_existing_materialization(pdf_path=pdf_path, private_output_dir=raw_catalog_dir)
+    require(upstream["private_jsonl_sha256"] == EXPECTED_RAW_OUTPUT_SHA256, "upstream raw output identity drift")
+    require(upstream["receipt_sha256"] == EXPECTED_RAW_RECEIPT_SHA256, "upstream raw receipt identity drift")
+    require(
+        file_sha256(raw_catalog_dir / RAW_RECEIPT_FILENAME) == EXPECTED_RAW_RECEIPT_FILE_SHA256,
+        "upstream receipt file drift",
+    )
+    validate_mapping_evidence(mapping_evidence_path)
+    require(output_path.is_file() and not output_path.is_symlink(), "glyph adapter JSONL is missing or unsafe")
+    require(output_path.stat().st_size == receipt["output"]["bytes"], "glyph adapter byte count drift")
+    require(file_sha256(output_path) == receipt["output"]["sha256"], "glyph adapter SHA-256 drift")
+
+    raw_path = raw_catalog_dir / RAW_OUTPUT_FILENAME
+    require(file_sha256(raw_path) == EXPECTED_RAW_OUTPUT_SHA256, "raw catalogue SHA-256 drift")
+    raw_records = _load_raw_records(raw_path)
+    output_records = _load_output_records(output_path)
+    require(len(raw_records) == len(output_records) == EXPECTED_CATALOG_RECORDS, "adapter record count drift")
+    expected_records = [
+        build_normalized_record(record, upstream_raw_sha256=EXPECTED_RAW_OUTPUT_SHA256) for record in raw_records
+    ]
+    require(output_records == expected_records, "glyph adapter output does not equal deterministic replay")
+    for record, raw_record in zip(output_records, raw_records, strict=True):
+        _validate_normalized_record(record, raw_record)
+    manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "raw_source_text_sha256": record["raw_source_text_sha256"],
+            "normalized_text_sha256": record["normalized_text_sha256"],
+            "mapping_event_counts": record["mapping_event_counts"],
+        }
+        for record in output_records
+    ]
+    require(
+        sha256_value(manifest) == receipt["output"]["record_identity_manifest_sha256"],
+        "adapter record identity manifest drift",
+    )
+    return {
+        "ok": True,
+        "records": len(output_records),
+        "mapping_events": denominator["mapping_events"],
+        "output_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+        "phase4_authorized": False,
+    }
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf", type=Path, required=True)
+    parser.add_argument("--raw-catalog-dir", type=Path, required=True)
+    parser.add_argument("--mapping-evidence", type=Path, required=True)
+    parser.add_argument("--private-output-dir", type=Path, required=True)
+    parser.add_argument("--validate-existing", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.validate_existing:
+            result = validate_existing_glyph_adapter(
+                pdf_path=args.pdf,
+                raw_catalog_dir=args.raw_catalog_dir,
+                mapping_evidence_path=args.mapping_evidence,
+                private_output_dir=args.private_output_dir,
+            )
+            status = "glyph_adapter_validated"
+        else:
+            receipt = adapt_spas_glyphs(
+                pdf_path=args.pdf,
+                raw_catalog_dir=args.raw_catalog_dir,
+                mapping_evidence_path=args.mapping_evidence,
+                private_output_dir=args.private_output_dir,
+            )
+            result = {
+                "records": receipt["output"]["records"],
+                "mapping_events": receipt["denominator"]["mapping_events"],
+                "output_sha256": receipt["output"]["sha256"],
+                "receipt_sha256": receipt["receipt_sha256"],
+                "training_eligible": False,
+                "phase4_authorized": False,
+            }
+            status = "glyph_adapter_materialized"
+    except (SpasGlyphAdapterError, SpasCatalogMaterializationError) as exc:
+        print(canonical_json({"status": "blocked", "error": str(exc)}))
+        return 2
+    print(canonical_json({"status": status, **result}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/phase3_spas_layout_candidates.py
+++ b/scripts/projects/open_model_data/phase3_spas_layout_candidates.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""Build a protected review queue for Spas transcription-layer separation.
+
+The canonical PDF's native text stream retains an embedded Bukyvede font. This
+module replays that stream with pypdf's font visitor, binds every font-tagged
+character to the existing raw and Unicode-adapter records, and emits exact
+font spans plus historic-script-dominant line candidates.
+
+The lexical cue is intentionally only a routing signal: a dominant line is
+classified as an ``author_reconstruction_trigger_candidate`` when the prior
+220 code points in the same complete record contain ``текст`` and a frozen
+shape/reconstruction cue.  No candidate becomes semantic gold or training
+data without qualified historical review of the complete record context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from pypdf import PdfReader
+
+from scripts.projects.open_model_data.phase3_linguistic_representation import canonical_json, sha256_value
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    CATALOG_PDF_PAGE_END,
+    CATALOG_PDF_PAGE_START,
+    COLLECTION_ID,
+    EXPECTED_CATALOG_RECORDS,
+    SOURCE_PDF_SHA256,
+    SpasCatalogMaterializationError,
+    _inside_git_checkout,
+    file_sha256,
+)
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    OUTPUT_FILENAME as RAW_OUTPUT_FILENAME,
+)
+from scripts.projects.open_model_data.phase3_spas_glyph_adapter import (
+    EXPECTED_MAPPING_EVIDENCE_SHA256,
+    EXPECTED_RAW_OUTPUT_SHA256,
+    EXPECTED_RAW_RECEIPT_FILE_SHA256,
+    EXPECTED_RAW_RECEIPT_SHA256,
+    SpasGlyphAdapterError,
+    validate_existing_glyph_adapter,
+)
+from scripts.projects.open_model_data.phase3_spas_glyph_adapter import (
+    OUTPUT_FILENAME as ADAPTER_OUTPUT_FILENAME,
+)
+from scripts.projects.open_model_data.phase3_spas_glyph_adapter import (
+    RECEIPT_FILENAME as ADAPTER_RECEIPT_FILENAME,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+RECEIPT_SCHEMA_PATH = (
+    ROOT / "data/projects/open_model_data/contracts/phase3_spas_layout_candidate_receipt_v1.schema.json"
+)
+
+SCHEMA_VERSION = "phase3_spas_layout_candidate_receipt_v1"
+IMPLEMENTATION_VERSION = "phase3_spas_layout_candidates_v1"
+OUTPUT_FILENAME = "spas-na-berestovi-layout-candidates-v1.jsonl.gz"
+RECEIPT_FILENAME = "layout-candidate-receipt-v1.json"
+BUKYVEDE_FONT_BASE_NAME = "/GATIPV+Bukyvede"
+CONTEXT_WINDOW_CODEPOINTS = 220
+SHAPE_CUES = ("таким чином", "вигляд", "реконструк", "віднов")
+TEXT_CUE_RE = re.compile(r"(?<!\w)текст(?!\w)")
+
+EXPECTED_ADAPTER_OUTPUT_SHA256 = "3a828f0a4ca57e5f44a4bf72536ed6de8597f6633e2987bab663cacc55dbf6d4"
+EXPECTED_ADAPTER_RECEIPT_FILE_SHA256 = "8278b133026ded0b197e8518167730189963a9a781d91e1ac7751eb73b3ca372"
+EXPECTED_ADAPTER_RECEIPT_SHA256 = "e494cd3030b74d40574a03498ca6089d23a6827e9e8283b5df0d34965c02adf8"
+
+EXPECTED_RECORDS_WITH_BUKYVEDE = 302
+EXPECTED_RECORDS_WITHOUT_BUKYVEDE = 175
+EXPECTED_BUKYVEDE_RUNS = 883
+EXPECTED_BUKYVEDE_CHARACTERS = 5393
+EXPECTED_BUKYVEDE_NONSPACE_CHARACTERS = 4896
+EXPECTED_LINES_WITH_BUKYVEDE = 637
+EXPECTED_DOMINANT_LINES = 101
+EXPECTED_DOMINANT_RECORDS = 90
+EXPECTED_TRIGGER_LINES = 82
+EXPECTED_TRIGGER_RECORDS = 81
+EXPECTED_UNRESOLVED_LINES = 19
+EXPECTED_UNRESOLVED_RECORDS = 12
+EXPECTED_TRIGGER_UNRESOLVED_RECORD_OVERLAP = 3
+
+
+class SpasLayoutCandidateError(ValueError):
+    """A source-layout, offset, denominator, or custody invariant failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SpasLayoutCandidateError(message)
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    require(path.is_file() and not path.is_symlink(), f"{description} is missing or unsafe")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasLayoutCandidateError(f"cannot read {description}: {exc}") from exc
+    require(isinstance(value, dict), f"{description} must be an object")
+    return value
+
+
+def _load_jsonl_gzip(path: Path, *, description: str) -> list[dict[str, Any]]:
+    require(path.is_file() and not path.is_symlink(), f"{description} is missing or unsafe")
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as handle:
+            rows = [json.loads(line) for line in handle]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SpasLayoutCandidateError(f"cannot read {description}: {exc}") from exc
+    require(all(isinstance(row, dict) for row in rows), f"{description} rows must be objects")
+    return rows
+
+
+def extract_font_layout_pages(
+    pdf_path: Path,
+    *,
+    page_start: int = CATALOG_PDF_PAGE_START,
+    page_end: int = CATALOG_PDF_PAGE_END,
+) -> dict[int, dict[str, Any]]:
+    """Return exact pypdf native page text plus one font label per code point."""
+    require(pdf_path.is_file() and not pdf_path.is_symlink(), "source PDF is missing or unsafe")
+    require(file_sha256(pdf_path) == SOURCE_PDF_SHA256, "source PDF SHA-256 drift")
+    try:
+        reader = PdfReader(pdf_path)
+    except Exception as exc:
+        raise SpasLayoutCandidateError(f"cannot open source PDF: {exc}") from exc
+    require(not reader.is_encrypted, "encrypted source PDF is not supported")
+    require(1 <= page_start <= page_end <= len(reader.pages), "catalogue page range is invalid")
+
+    layouts: dict[int, dict[str, Any]] = {}
+    for page_number in range(page_start, page_end + 1):
+        font_tags: list[str] = []
+
+        def visitor(
+            text: str,
+            _cm: Sequence[float],
+            _tm: Sequence[float],
+            font_dictionary: Mapping[str, Any] | None,
+            _font_size: float,
+            _font_tags: list[str] = font_tags,
+        ) -> None:
+            base_font = str(font_dictionary.get("/BaseFont")) if font_dictionary else "NONE"
+            _font_tags.extend([base_font] * len(text))
+
+        try:
+            text = reader.pages[page_number - 1].extract_text(visitor_text=visitor) or ""
+        except Exception as exc:
+            raise SpasLayoutCandidateError(f"font-layout extraction failed on PDF page {page_number}: {exc}") from exc
+        require(text != "", f"catalogue PDF page {page_number} has no native text")
+        require("\ufffd" not in text, f"catalogue PDF page {page_number} contains replacement characters")
+        require(len(text) == len(font_tags), f"font tag length drift on PDF page {page_number}")
+        layouts[page_number] = {
+            "text": text,
+            "text_sha256": _sha256_text(text),
+            "font_tags": font_tags,
+        }
+    require(file_sha256(pdf_path) == SOURCE_PDF_SHA256, "source PDF changed while extracting layout")
+    return layouts
+
+
+def _raw_boundary_to_normalized(record: Mapping[str, Any], raw_offset: int) -> int:
+    raw_text = record["raw_source_text"]
+    normalized_text = record["normalized_text"]
+    require(isinstance(raw_offset, int) and 0 <= raw_offset <= len(raw_text), "raw boundary is out of range")
+    delta = 0
+    for event in record["mapping_events"]:
+        raw_start = event["raw_start_char"]
+        raw_end = event["raw_end_char"]
+        normalized_start = event["normalized_start_char"]
+        normalized_end = event["normalized_end_char"]
+        require(normalized_start == raw_start - delta, "adapter event start relationship drift")
+        if raw_offset < raw_start:
+            return raw_offset - delta
+        if raw_offset == raw_start:
+            return normalized_start
+        require(not raw_start < raw_offset < raw_end, "candidate boundary splits a glyph mapping event")
+        if raw_offset == raw_end:
+            return normalized_end
+        delta += (raw_end - raw_start) - (normalized_end - normalized_start)
+    normalized_offset = raw_offset - delta
+    require(0 <= normalized_offset <= len(normalized_text), "normalized boundary is out of range")
+    return normalized_offset
+
+
+def _record_layout(
+    raw_record: Mapping[str, Any],
+    normalized_record: Mapping[str, Any],
+    page_layouts: Mapping[int, Mapping[str, Any]],
+) -> tuple[str, list[str], list[tuple[int, int] | None]]:
+    raw_text = raw_record["source_text"]
+    require(normalized_record["raw_source_text"] == raw_text, "adapter/raw record text drift")
+    require(normalized_record["source_record_id"] == raw_record["record_id"], "adapter/raw record id drift")
+    parts: list[str] = []
+    tags: list[str] = []
+    page_refs: list[tuple[int, int] | None] = []
+    for index, fragment in enumerate(raw_record["source_page_fragments"]):
+        if index:
+            parts.append("\n")
+            tags.append("NONE")
+            page_refs.append(None)
+        page_number = fragment["pdf_page_number"]
+        require(page_number in page_layouts, "record refers to an unknown layout page")
+        page_text = page_layouts[page_number]["text"]
+        page_tags = page_layouts[page_number]["font_tags"]
+        start, end = fragment["start_char"], fragment["end_char"]
+        require(0 <= start < end <= len(page_text), "record page fragment offsets drift")
+        fragment_text = page_text[start:end]
+        require(fragment["text_sha256"] == _sha256_text(fragment_text), "record page fragment hash drift")
+        parts.append(fragment_text)
+        tags.extend(page_tags[start:end])
+        page_refs.extend((page_number, page_offset) for page_offset in range(start, end))
+    reconstructed = "".join(parts)
+    require(reconstructed == raw_text, "record layout does not reproduce raw source text")
+    require(len(reconstructed) == len(tags) == len(page_refs), "record layout alignment drift")
+    return reconstructed, tags, page_refs
+
+
+def _font_spans(
+    raw_text: str,
+    normalized_record: Mapping[str, Any],
+    tags: Sequence[str],
+    page_refs: Sequence[tuple[int, int] | None],
+) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    cursor = 0
+    while cursor < len(tags):
+        if tags[cursor] != BUKYVEDE_FONT_BASE_NAME:
+            cursor += 1
+            continue
+        end = cursor + 1
+        while end < len(tags) and tags[end] == BUKYVEDE_FONT_BASE_NAME:
+            end += 1
+        refs = page_refs[cursor:end]
+        require(all(ref is not None for ref in refs), "Bukyvede font span crosses an inserted page separator")
+        typed_refs = [ref for ref in refs if ref is not None]
+        page_numbers = {ref[0] for ref in typed_refs}
+        require(len(page_numbers) == 1, "Bukyvede font span crosses PDF pages")
+        require(
+            [ref[1] for ref in typed_refs] == list(range(typed_refs[0][1], typed_refs[-1][1] + 1)),
+            "Bukyvede page offsets are not contiguous",
+        )
+        normalized_start = _raw_boundary_to_normalized(normalized_record, cursor)
+        normalized_end = _raw_boundary_to_normalized(normalized_record, end)
+        raw_span = raw_text[cursor:end]
+        normalized_span = normalized_record["normalized_text"][normalized_start:normalized_end]
+        spans.append(
+            {
+                "span_id": f"font-span:{len(spans) + 1:04d}",
+                "font_base_name": BUKYVEDE_FONT_BASE_NAME,
+                "pdf_page_number": typed_refs[0][0],
+                "page_start_char": typed_refs[0][1],
+                "page_end_char": typed_refs[-1][1] + 1,
+                "raw_start_char": cursor,
+                "raw_end_char": end,
+                "raw_text": raw_span,
+                "raw_text_sha256": _sha256_text(raw_span),
+                "normalized_start_char": normalized_start,
+                "normalized_end_char": normalized_end,
+                "normalized_text": normalized_span,
+                "normalized_text_sha256": _sha256_text(normalized_span),
+            }
+        )
+        cursor = end
+    return spans
+
+
+def _candidate_lines(
+    raw_text: str,
+    normalized_record: Mapping[str, Any],
+    tags: Sequence[str],
+    page_refs: Sequence[tuple[int, int] | None],
+) -> tuple[list[dict[str, Any]], int]:
+    candidates: list[dict[str, Any]] = []
+    lines_with_bukyvede = 0
+    raw_start = 0
+    for line in raw_text.splitlines(keepends=True):
+        raw_end = raw_start + len(line)
+        nonspace_positions = [offset for offset, char in enumerate(line) if not char.isspace()]
+        bukyvede_nonspace = sum(tags[raw_start + offset] == BUKYVEDE_FONT_BASE_NAME for offset in nonspace_positions)
+        if bukyvede_nonspace:
+            lines_with_bukyvede += 1
+        if nonspace_positions and 2 * bukyvede_nonspace >= len(nonspace_positions):
+            line_page_refs = [ref for ref in page_refs[raw_start:raw_end] if ref is not None]
+            require(bool(line_page_refs), "candidate line lacks a PDF page locator")
+            require(len({ref[0] for ref in line_page_refs}) == 1, "candidate line crosses PDF pages")
+            require(
+                [ref[1] for ref in line_page_refs] == list(range(line_page_refs[0][1], line_page_refs[-1][1] + 1)),
+                "candidate line page offsets are not contiguous",
+            )
+            context_start = max(0, raw_start - CONTEXT_WINDOW_CODEPOINTS)
+            context = raw_text[context_start:raw_start]
+            folded_context = context.casefold()
+            has_text_cue = TEXT_CUE_RE.search(folded_context) is not None
+            matched_shape_cues = [cue for cue in SHAPE_CUES if cue in folded_context]
+            classification = (
+                "author_reconstruction_trigger_candidate"
+                if has_text_cue and matched_shape_cues
+                else "dominant_historic_script_unresolved"
+            )
+            normalized_start = _raw_boundary_to_normalized(normalized_record, raw_start)
+            normalized_end = _raw_boundary_to_normalized(normalized_record, raw_end)
+            normalized_line = normalized_record["normalized_text"][normalized_start:normalized_end]
+            candidates.append(
+                {
+                    "candidate_id": f"dominant-line:{len(candidates) + 1:03d}",
+                    "classification": classification,
+                    "classification_is_semantic_gold": False,
+                    "pdf_page_number": line_page_refs[0][0],
+                    "page_start_char": line_page_refs[0][1],
+                    "page_end_char": line_page_refs[-1][1] + 1,
+                    "raw_start_char": raw_start,
+                    "raw_end_char": raw_end,
+                    "raw_text": line,
+                    "raw_text_sha256": _sha256_text(line),
+                    "normalized_start_char": normalized_start,
+                    "normalized_end_char": normalized_end,
+                    "normalized_text": normalized_line,
+                    "normalized_text_sha256": _sha256_text(normalized_line),
+                    "line_nonspace_characters": len(nonspace_positions),
+                    "bukyvede_nonspace_characters": bukyvede_nonspace,
+                    "dominance_numerator": bukyvede_nonspace,
+                    "dominance_denominator": len(nonspace_positions),
+                    "dominance_threshold": "at_least_one_half",
+                    "trigger_context_start_char": context_start,
+                    "trigger_context_end_char": raw_start,
+                    "trigger_context_sha256": _sha256_text(context),
+                    "text_cue_present": has_text_cue,
+                    "matched_shape_cues": matched_shape_cues,
+                    "qualified_historical_review_status": "pending",
+                    "training_eligible": False,
+                }
+            )
+        raw_start = raw_end
+    require(raw_start == len(raw_text), "line scan did not consume complete raw context")
+    return candidates, lines_with_bukyvede
+
+
+def build_layout_candidate_record(
+    raw_record: Mapping[str, Any],
+    normalized_record: Mapping[str, Any],
+    page_layouts: Mapping[int, Mapping[str, Any]],
+    *,
+    adapter_output_sha256: str,
+) -> dict[str, Any]:
+    """Build one complete-context, fail-closed layout-review record."""
+    raw_text, tags, page_refs = _record_layout(raw_record, normalized_record, page_layouts)
+    spans = _font_spans(raw_text, normalized_record, tags, page_refs)
+    candidates, lines_with_bukyvede = _candidate_lines(raw_text, normalized_record, tags, page_refs)
+    bukyvede_characters = sum(len(span["raw_text"]) for span in spans)
+    bukyvede_nonspace = sum(sum(not char.isspace() for char in span["raw_text"]) for span in spans)
+    return {
+        "schema_version": "phase3_spas_layout_candidate_record_v1",
+        "record_id": f"{raw_record['record_id']}:layout-candidates-v1",
+        "source_record_id": raw_record["record_id"],
+        "collection_id": COLLECTION_ID,
+        "graffito_number": raw_record["graffito_number"],
+        "source_pdf_sha256": SOURCE_PDF_SHA256,
+        "upstream_raw_catalog_sha256": EXPECTED_RAW_OUTPUT_SHA256,
+        "upstream_adapter_output_sha256": adapter_output_sha256,
+        "raw_context": raw_text,
+        "raw_context_sha256": _sha256_text(raw_text),
+        "normalized_context": normalized_record["normalized_text"],
+        "normalized_context_sha256": normalized_record["normalized_text_sha256"],
+        "font_spans": spans,
+        "historic_script_dominant_line_candidates": candidates,
+        "denominator": {
+            "bukyvede_font_spans": len(spans),
+            "bukyvede_characters": bukyvede_characters,
+            "bukyvede_nonspace_characters": bukyvede_nonspace,
+            "lines_with_bukyvede": lines_with_bukyvede,
+            "dominant_line_candidates": len(candidates),
+        },
+        "separation_status": "candidate_routing_only_pending_qualified_historical_review",
+        "commentary_and_inscription_layers_separated": False,
+        "semantic_gold": False,
+        "training_eligible": False,
+        "modern_correction_eligible": False,
+        "provider_calls": False,
+        "phase4_authorized": False,
+    }
+
+
+def _write_jsonl_gzip(path: Path, records: Sequence[Mapping[str, Any]]) -> tuple[int, int, str]:
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        with (
+            temporary.open("wb") as raw_handle,
+            gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as gzip_handle,
+        ):
+            for record in records:
+                gzip_handle.write(canonical_json(record).encode("utf-8") + b"\n")
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return len(records), path.stat().st_size, file_sha256(path)
+
+
+def _receipt_with_hash(body: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = dict(body)
+    receipt["receipt_sha256"] = sha256_value(body)
+    return receipt
+
+
+def _validate_receipt(receipt: Mapping[str, Any]) -> None:
+    try:
+        schema = json.loads(RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpasLayoutCandidateError(f"cannot read receipt schema: {RECEIPT_SCHEMA_PATH}") from exc
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(receipt), key=lambda item: list(item.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].path) or "receipt"
+        raise SpasLayoutCandidateError(f"receipt schema violation at {location}: {errors[0].message}")
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    require(receipt["receipt_sha256"] == sha256_value(body), "receipt self-hash drift")
+    denominator = receipt["denominator"]
+    require(
+        denominator["input_records"]
+        == denominator["output_records"]
+        == receipt["output"]["records"]
+        == EXPECTED_CATALOG_RECORDS,
+        "receipt record denominator drift",
+    )
+    require(
+        denominator["records_with_bukyvede"] + denominator["records_without_bukyvede"] == denominator["input_records"],
+        "receipt font-presence partition drift",
+    )
+    require(
+        denominator["trigger_line_candidates"] + denominator["unresolved_dominant_line_candidates"]
+        == denominator["dominant_line_candidates"],
+        "receipt candidate classification partition drift",
+    )
+    require(
+        receipt["residuals"]["candidate_review_denominator"] == denominator["dominant_line_candidates"],
+        "receipt review denominator drift",
+    )
+
+
+def _write_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    _validate_receipt(receipt)
+    path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _remove_staging_dir(path: Path) -> None:
+    for filename in (OUTPUT_FILENAME, RECEIPT_FILENAME):
+        candidate = path / filename
+        if candidate.is_file() or candidate.is_symlink():
+            candidate.unlink()
+    if path.exists():
+        path.rmdir()
+
+
+def materialize_layout_candidates(
+    *,
+    pdf_path: Path,
+    raw_catalog_dir: Path,
+    adapter_output_dir: Path,
+    mapping_evidence_path: Path,
+    private_output_dir: Path,
+    expected_records: int = EXPECTED_CATALOG_RECORDS,
+    expected_records_with_bukyvede: int = EXPECTED_RECORDS_WITH_BUKYVEDE,
+    expected_records_without_bukyvede: int = EXPECTED_RECORDS_WITHOUT_BUKYVEDE,
+    expected_bukyvede_runs: int = EXPECTED_BUKYVEDE_RUNS,
+    expected_bukyvede_characters: int = EXPECTED_BUKYVEDE_CHARACTERS,
+    expected_bukyvede_nonspace_characters: int = EXPECTED_BUKYVEDE_NONSPACE_CHARACTERS,
+    expected_lines_with_bukyvede: int = EXPECTED_LINES_WITH_BUKYVEDE,
+    expected_dominant_lines: int = EXPECTED_DOMINANT_LINES,
+    expected_dominant_records: int = EXPECTED_DOMINANT_RECORDS,
+    expected_trigger_lines: int = EXPECTED_TRIGGER_LINES,
+    expected_trigger_records: int = EXPECTED_TRIGGER_RECORDS,
+    expected_unresolved_lines: int = EXPECTED_UNRESOLVED_LINES,
+    expected_unresolved_records: int = EXPECTED_UNRESOLVED_RECORDS,
+    expected_overlap_records: int = EXPECTED_TRIGGER_UNRESOLVED_RECORD_OVERLAP,
+) -> dict[str, Any]:
+    """Write an immutable private review queue plus a text-free receipt."""
+    resolved_output = private_output_dir.resolve()
+    require(not _inside_git_checkout(resolved_output), "private text output cannot be inside a Git checkout")
+    require(not private_output_dir.exists(), "immutable private output directory already exists")
+    require(private_output_dir.parent.is_dir(), "private output parent directory does not exist")
+    require(mapping_evidence_path.parent.resolve() == raw_catalog_dir.resolve(), "mapping evidence path drift")
+
+    upstream = validate_existing_glyph_adapter(
+        pdf_path=pdf_path,
+        raw_catalog_dir=raw_catalog_dir,
+        mapping_evidence_path=mapping_evidence_path,
+        private_output_dir=adapter_output_dir,
+    )
+    require(upstream["records"] == expected_records, "upstream adapter record denominator drift")
+    require(upstream["output_sha256"] == EXPECTED_ADAPTER_OUTPUT_SHA256, "upstream adapter output identity drift")
+    require(upstream["receipt_sha256"] == EXPECTED_ADAPTER_RECEIPT_SHA256, "upstream adapter receipt identity drift")
+    require(upstream["training_eligible"] is False, "upstream adapter cannot authorize training")
+    require(upstream["phase4_authorized"] is False, "upstream adapter cannot authorize Phase 4")
+
+    raw_path = raw_catalog_dir / RAW_OUTPUT_FILENAME
+    adapter_path = adapter_output_dir / ADAPTER_OUTPUT_FILENAME
+    adapter_receipt_path = adapter_output_dir / ADAPTER_RECEIPT_FILENAME
+    require(file_sha256(raw_path) == EXPECTED_RAW_OUTPUT_SHA256, "raw catalogue identity drift")
+    require(file_sha256(adapter_path) == EXPECTED_ADAPTER_OUTPUT_SHA256, "adapter output identity drift")
+    require(
+        file_sha256(adapter_receipt_path) == EXPECTED_ADAPTER_RECEIPT_FILE_SHA256,
+        "adapter receipt file identity drift",
+    )
+    require(file_sha256(mapping_evidence_path) == EXPECTED_MAPPING_EVIDENCE_SHA256, "mapping evidence identity drift")
+    raw_records = _load_jsonl_gzip(raw_path, description="raw catalogue JSONL")
+    normalized_records = _load_jsonl_gzip(adapter_path, description="glyph adapter JSONL")
+    require(file_sha256(raw_path) == EXPECTED_RAW_OUTPUT_SHA256, "raw catalogue changed while loading")
+    require(file_sha256(adapter_path) == EXPECTED_ADAPTER_OUTPUT_SHA256, "adapter output changed while loading")
+    require(len(raw_records) == len(normalized_records) == expected_records, "input record count drift")
+    require(
+        [record.get("graffito_number") for record in raw_records]
+        == [record.get("graffito_number") for record in normalized_records]
+        == list(range(1, expected_records + 1)),
+        "input record sequence drift",
+    )
+    page_layouts = extract_font_layout_pages(pdf_path)
+    output_records = [
+        build_layout_candidate_record(
+            raw_record,
+            normalized_record,
+            page_layouts,
+            adapter_output_sha256=EXPECTED_ADAPTER_OUTPUT_SHA256,
+        )
+        for raw_record, normalized_record in zip(raw_records, normalized_records, strict=True)
+    ]
+
+    records_with_bukyvede = sum(bool(record["font_spans"]) for record in output_records)
+    records_without_bukyvede = len(output_records) - records_with_bukyvede
+    bukyvede_runs = sum(record["denominator"]["bukyvede_font_spans"] for record in output_records)
+    bukyvede_characters = sum(record["denominator"]["bukyvede_characters"] for record in output_records)
+    bukyvede_nonspace = sum(record["denominator"]["bukyvede_nonspace_characters"] for record in output_records)
+    lines_with_bukyvede = sum(record["denominator"]["lines_with_bukyvede"] for record in output_records)
+    dominant_lines = sum(record["denominator"]["dominant_line_candidates"] for record in output_records)
+    dominant_record_ids = {
+        record["graffito_number"] for record in output_records if record["historic_script_dominant_line_candidates"]
+    }
+    trigger_record_ids: set[int] = set()
+    unresolved_record_ids: set[int] = set()
+    trigger_lines = 0
+    unresolved_lines = 0
+    for record in output_records:
+        for candidate in record["historic_script_dominant_line_candidates"]:
+            if candidate["classification"] == "author_reconstruction_trigger_candidate":
+                trigger_lines += 1
+                trigger_record_ids.add(record["graffito_number"])
+            else:
+                unresolved_lines += 1
+                unresolved_record_ids.add(record["graffito_number"])
+
+    observed = {
+        "records_with_bukyvede": records_with_bukyvede,
+        "records_without_bukyvede": records_without_bukyvede,
+        "bukyvede_font_spans": bukyvede_runs,
+        "bukyvede_characters": bukyvede_characters,
+        "bukyvede_nonspace_characters": bukyvede_nonspace,
+        "lines_with_bukyvede": lines_with_bukyvede,
+        "dominant_line_candidates": dominant_lines,
+        "records_with_dominant_candidates": len(dominant_record_ids),
+        "trigger_line_candidates": trigger_lines,
+        "records_with_trigger_candidates": len(trigger_record_ids),
+        "unresolved_dominant_line_candidates": unresolved_lines,
+        "records_with_unresolved_candidates": len(unresolved_record_ids),
+        "trigger_unresolved_record_overlap": len(trigger_record_ids & unresolved_record_ids),
+    }
+    expected = {
+        "records_with_bukyvede": expected_records_with_bukyvede,
+        "records_without_bukyvede": expected_records_without_bukyvede,
+        "bukyvede_font_spans": expected_bukyvede_runs,
+        "bukyvede_characters": expected_bukyvede_characters,
+        "bukyvede_nonspace_characters": expected_bukyvede_nonspace_characters,
+        "lines_with_bukyvede": expected_lines_with_bukyvede,
+        "dominant_line_candidates": expected_dominant_lines,
+        "records_with_dominant_candidates": expected_dominant_records,
+        "trigger_line_candidates": expected_trigger_lines,
+        "records_with_trigger_candidates": expected_trigger_records,
+        "unresolved_dominant_line_candidates": expected_unresolved_lines,
+        "records_with_unresolved_candidates": expected_unresolved_records,
+        "trigger_unresolved_record_overlap": expected_overlap_records,
+    }
+    require(observed == expected, "layout candidate denominator drift")
+
+    identity_manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "raw_context_sha256": record["raw_context_sha256"],
+            "normalized_context_sha256": record["normalized_context_sha256"],
+            "font_span_count": len(record["font_spans"]),
+            "candidate_line_count": len(record["historic_script_dominant_line_candidates"]),
+        }
+        for record in output_records
+    ]
+    page_layout_manifest = [
+        {
+            "pdf_page_number": page_number,
+            "native_text_sha256": page_layouts[page_number]["text_sha256"],
+            "native_text_characters": len(page_layouts[page_number]["text"]),
+        }
+        for page_number in sorted(page_layouts)
+    ]
+
+    staging_dir = Path(tempfile.mkdtemp(prefix=f".{private_output_dir.name}.staging-", dir=private_output_dir.parent))
+    try:
+        output_path = staging_dir / OUTPUT_FILENAME
+        output_count, output_bytes, output_sha256 = _write_jsonl_gzip(output_path, output_records)
+        body: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "implementation_version": IMPLEMENTATION_VERSION,
+            "mode": "source_font_layout_candidate_routing",
+            "text_free": True,
+            "inputs": {
+                "collection_id": COLLECTION_ID,
+                "source_pdf_sha256": SOURCE_PDF_SHA256,
+                "raw_catalog_sha256": EXPECTED_RAW_OUTPUT_SHA256,
+                "raw_materialization_receipt_file_sha256": EXPECTED_RAW_RECEIPT_FILE_SHA256,
+                "raw_materialization_receipt_sha256": EXPECTED_RAW_RECEIPT_SHA256,
+                "mapping_evidence_sha256": EXPECTED_MAPPING_EVIDENCE_SHA256,
+                "adapter_output_sha256": EXPECTED_ADAPTER_OUTPUT_SHA256,
+                "adapter_receipt_file_sha256": EXPECTED_ADAPTER_RECEIPT_FILE_SHA256,
+                "adapter_receipt_sha256": EXPECTED_ADAPTER_RECEIPT_SHA256,
+                "pypdf_version": importlib.metadata.version("pypdf"),
+                "implementation_sha256": file_sha256(Path(__file__)),
+                "receipt_schema_sha256": file_sha256(RECEIPT_SCHEMA_PATH),
+                "page_layout_manifest_sha256": sha256_value(page_layout_manifest),
+            },
+            "routing_contract": {
+                "font_base_name": BUKYVEDE_FONT_BASE_NAME,
+                "dominance_rule": "2 * bukyvede_nonspace_characters >= line_nonspace_characters",
+                "context_window_codepoints": CONTEXT_WINDOW_CODEPOINTS,
+                "required_text_cue": "whole_word:текст",
+                "shape_cues": list(SHAPE_CUES),
+                "trigger_classification": "author_reconstruction_trigger_candidate",
+                "fallback_classification": "dominant_historic_script_unresolved",
+                "classifications_are_semantic_gold": False,
+            },
+            "denominator": {
+                "input_records": len(raw_records),
+                "output_records": output_count,
+                **observed,
+            },
+            "output": {
+                "filename": OUTPUT_FILENAME,
+                "records": output_count,
+                "bytes": output_bytes,
+                "sha256": output_sha256,
+                "record_identity_manifest_sha256": sha256_value(identity_manifest),
+            },
+            "rights_and_scope": {
+                "inherits_upstream_accepted_operational_risk": True,
+                "private_review_queue_only": True,
+                "attribution_and_field_level_removal_preserved": True,
+                "binary_media_reuse_authorized": False,
+                "full_publication_training_export_authorized": False,
+                "adapt_on_substantiated_rights_notice": True,
+            },
+            "safeguards": {
+                "complete_record_context_preserved": True,
+                "raw_and_normalized_offsets_preserved": True,
+                "font_spans_source_derived": True,
+                "candidate_routing_only": True,
+                "commentary_and_inscription_layers_separated": False,
+                "qualified_historical_review_complete": False,
+                "semantic_gold": False,
+                "training_eligible": False,
+                "modern_correction_eligible": False,
+                "images_included": False,
+                "provider_calls": False,
+                "phase4_authorized": False,
+            },
+            "residuals": {
+                "all_dominant_line_candidates_require_review": True,
+                "candidate_review_denominator": dominant_lines,
+                "inline_or_nondominant_font_spans_remain_context_only": True,
+                "commentary_transcription_separation_pending": True,
+                "lavra_cave_corpus_gap_closed": False,
+            },
+        }
+        receipt = _receipt_with_hash(body)
+        _write_receipt(staging_dir / RECEIPT_FILENAME, receipt)
+        require(not private_output_dir.exists(), "immutable private output directory appeared during publication")
+        os.replace(staging_dir, private_output_dir)
+        return receipt
+    finally:
+        _remove_staging_dir(staging_dir)
+
+
+def _validate_candidate_record(record: Mapping[str, Any]) -> None:
+    require(record["schema_version"] == "phase3_spas_layout_candidate_record_v1", "candidate row schema drift")
+    require(record["collection_id"] == COLLECTION_ID, "candidate row collection drift")
+    require(record["source_pdf_sha256"] == SOURCE_PDF_SHA256, "candidate row PDF identity drift")
+    require(record["upstream_raw_catalog_sha256"] == EXPECTED_RAW_OUTPUT_SHA256, "candidate row raw identity drift")
+    require(
+        record["upstream_adapter_output_sha256"] == EXPECTED_ADAPTER_OUTPUT_SHA256,
+        "candidate row adapter identity drift",
+    )
+    require(record["raw_context_sha256"] == _sha256_text(record["raw_context"]), "candidate raw hash drift")
+    require(
+        record["normalized_context_sha256"] == _sha256_text(record["normalized_context"]),
+        "candidate normalized hash drift",
+    )
+    for field in (
+        "commentary_and_inscription_layers_separated",
+        "semantic_gold",
+        "training_eligible",
+        "modern_correction_eligible",
+        "provider_calls",
+        "phase4_authorized",
+    ):
+        require(record[field] is False, f"unsafe candidate row flag: {field}")
+    for span in record["font_spans"]:
+        raw_start, raw_end = span["raw_start_char"], span["raw_end_char"]
+        normalized_start, normalized_end = span["normalized_start_char"], span["normalized_end_char"]
+        require(record["raw_context"][raw_start:raw_end] == span["raw_text"], "font span raw offset drift")
+        require(
+            record["normalized_context"][normalized_start:normalized_end] == span["normalized_text"],
+            "font span normalized offset drift",
+        )
+        require(span["raw_text_sha256"] == _sha256_text(span["raw_text"]), "font span raw hash drift")
+        require(
+            span["normalized_text_sha256"] == _sha256_text(span["normalized_text"]),
+            "font span normalized hash drift",
+        )
+    for candidate in record["historic_script_dominant_line_candidates"]:
+        raw_start, raw_end = candidate["raw_start_char"], candidate["raw_end_char"]
+        normalized_start, normalized_end = candidate["normalized_start_char"], candidate["normalized_end_char"]
+        require(record["raw_context"][raw_start:raw_end] == candidate["raw_text"], "candidate raw offset drift")
+        require(
+            record["normalized_context"][normalized_start:normalized_end] == candidate["normalized_text"],
+            "candidate normalized offset drift",
+        )
+        require(candidate["raw_text_sha256"] == _sha256_text(candidate["raw_text"]), "candidate raw hash drift")
+        require(
+            candidate["normalized_text_sha256"] == _sha256_text(candidate["normalized_text"]),
+            "candidate normalized hash drift",
+        )
+        context_start = candidate["trigger_context_start_char"]
+        context_end = candidate["trigger_context_end_char"]
+        require(context_end == raw_start, "candidate trigger context end drift")
+        trigger_context = record["raw_context"][context_start:context_end]
+        require(
+            candidate["trigger_context_sha256"] == _sha256_text(trigger_context),
+            "candidate trigger context hash drift",
+        )
+        folded_context = trigger_context.casefold()
+        expected_text_cue = TEXT_CUE_RE.search(folded_context) is not None
+        expected_shape_cues = [cue for cue in SHAPE_CUES if cue in folded_context]
+        require(candidate["text_cue_present"] is expected_text_cue, "candidate text cue drift")
+        require(candidate["matched_shape_cues"] == expected_shape_cues, "candidate shape cue drift")
+        expected_classification = (
+            "author_reconstruction_trigger_candidate"
+            if expected_text_cue and expected_shape_cues
+            else "dominant_historic_script_unresolved"
+        )
+        require(candidate["classification"] == expected_classification, "candidate classification drift")
+        require(
+            2 * candidate["bukyvede_nonspace_characters"] >= candidate["line_nonspace_characters"],
+            "candidate dominance drift",
+        )
+        require(candidate["classification_is_semantic_gold"] is False, "candidate cannot be semantic gold")
+        require(candidate["qualified_historical_review_status"] == "pending", "candidate review status drift")
+        require(candidate["training_eligible"] is False, "candidate cannot authorize training")
+
+
+def validate_existing_layout_candidates(
+    *,
+    pdf_path: Path,
+    raw_catalog_dir: Path,
+    adapter_output_dir: Path,
+    mapping_evidence_path: Path,
+    private_output_dir: Path,
+) -> dict[str, Any]:
+    """Rebind an existing candidate queue to every current source input."""
+    receipt_path = private_output_dir / RECEIPT_FILENAME
+    output_path = private_output_dir / OUTPUT_FILENAME
+    receipt = _load_json_object(receipt_path, description="layout candidate receipt")
+    _validate_receipt(receipt)
+    inputs = receipt["inputs"]
+    denominator = receipt["denominator"]
+    exact_inputs = {
+        "collection_id": COLLECTION_ID,
+        "source_pdf_sha256": SOURCE_PDF_SHA256,
+        "raw_catalog_sha256": EXPECTED_RAW_OUTPUT_SHA256,
+        "raw_materialization_receipt_file_sha256": EXPECTED_RAW_RECEIPT_FILE_SHA256,
+        "raw_materialization_receipt_sha256": EXPECTED_RAW_RECEIPT_SHA256,
+        "mapping_evidence_sha256": EXPECTED_MAPPING_EVIDENCE_SHA256,
+        "adapter_output_sha256": EXPECTED_ADAPTER_OUTPUT_SHA256,
+        "adapter_receipt_file_sha256": EXPECTED_ADAPTER_RECEIPT_FILE_SHA256,
+        "adapter_receipt_sha256": EXPECTED_ADAPTER_RECEIPT_SHA256,
+        "pypdf_version": importlib.metadata.version("pypdf"),
+        "implementation_sha256": file_sha256(Path(__file__)),
+        "receipt_schema_sha256": file_sha256(RECEIPT_SCHEMA_PATH),
+    }
+    for key, expected_value in exact_inputs.items():
+        require(inputs[key] == expected_value, f"receipt input identity drift: {key}")
+    expected_denominator = {
+        "input_records": EXPECTED_CATALOG_RECORDS,
+        "output_records": EXPECTED_CATALOG_RECORDS,
+        "records_with_bukyvede": EXPECTED_RECORDS_WITH_BUKYVEDE,
+        "records_without_bukyvede": EXPECTED_RECORDS_WITHOUT_BUKYVEDE,
+        "bukyvede_font_spans": EXPECTED_BUKYVEDE_RUNS,
+        "bukyvede_characters": EXPECTED_BUKYVEDE_CHARACTERS,
+        "bukyvede_nonspace_characters": EXPECTED_BUKYVEDE_NONSPACE_CHARACTERS,
+        "lines_with_bukyvede": EXPECTED_LINES_WITH_BUKYVEDE,
+        "dominant_line_candidates": EXPECTED_DOMINANT_LINES,
+        "records_with_dominant_candidates": EXPECTED_DOMINANT_RECORDS,
+        "trigger_line_candidates": EXPECTED_TRIGGER_LINES,
+        "records_with_trigger_candidates": EXPECTED_TRIGGER_RECORDS,
+        "unresolved_dominant_line_candidates": EXPECTED_UNRESOLVED_LINES,
+        "records_with_unresolved_candidates": EXPECTED_UNRESOLVED_RECORDS,
+        "trigger_unresolved_record_overlap": EXPECTED_TRIGGER_UNRESOLVED_RECORD_OVERLAP,
+    }
+    require(denominator == expected_denominator, "receipt exact denominator drift")
+    upstream = validate_existing_glyph_adapter(
+        pdf_path=pdf_path,
+        raw_catalog_dir=raw_catalog_dir,
+        mapping_evidence_path=mapping_evidence_path,
+        private_output_dir=adapter_output_dir,
+    )
+    require(upstream["output_sha256"] == EXPECTED_ADAPTER_OUTPUT_SHA256, "upstream adapter identity drift")
+    require(output_path.is_file() and not output_path.is_symlink(), "candidate output is missing or unsafe")
+    require(file_sha256(output_path) == receipt["output"]["sha256"], "candidate output SHA-256 drift")
+    require(output_path.stat().st_size == receipt["output"]["bytes"], "candidate output byte count drift")
+    page_layouts = extract_font_layout_pages(pdf_path)
+    page_layout_manifest = [
+        {
+            "pdf_page_number": page_number,
+            "native_text_sha256": page_layouts[page_number]["text_sha256"],
+            "native_text_characters": len(page_layouts[page_number]["text"]),
+        }
+        for page_number in sorted(page_layouts)
+    ]
+    require(
+        sha256_value(page_layout_manifest) == inputs["page_layout_manifest_sha256"],
+        "page layout manifest drift",
+    )
+    raw_records = _load_jsonl_gzip(raw_catalog_dir / RAW_OUTPUT_FILENAME, description="raw catalogue JSONL")
+    normalized_records = _load_jsonl_gzip(
+        adapter_output_dir / ADAPTER_OUTPUT_FILENAME, description="glyph adapter JSONL"
+    )
+    output_records = _load_jsonl_gzip(output_path, description="layout candidate JSONL")
+    expected_records = [
+        build_layout_candidate_record(
+            raw_record,
+            normalized_record,
+            page_layouts,
+            adapter_output_sha256=EXPECTED_ADAPTER_OUTPUT_SHA256,
+        )
+        for raw_record, normalized_record in zip(raw_records, normalized_records, strict=True)
+    ]
+    require(output_records == expected_records, "candidate output does not equal deterministic source replay")
+    for record in output_records:
+        _validate_candidate_record(record)
+    identity_manifest = [
+        {
+            "graffito_number": record["graffito_number"],
+            "raw_context_sha256": record["raw_context_sha256"],
+            "normalized_context_sha256": record["normalized_context_sha256"],
+            "font_span_count": len(record["font_spans"]),
+            "candidate_line_count": len(record["historic_script_dominant_line_candidates"]),
+        }
+        for record in output_records
+    ]
+    require(
+        sha256_value(identity_manifest) == receipt["output"]["record_identity_manifest_sha256"],
+        "candidate identity manifest drift",
+    )
+    return {
+        "ok": True,
+        "records": len(output_records),
+        "candidate_lines": denominator["dominant_line_candidates"],
+        "trigger_lines": denominator["trigger_line_candidates"],
+        "unresolved_lines": denominator["unresolved_dominant_line_candidates"],
+        "output_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+        "phase4_authorized": False,
+    }
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf", type=Path, required=True)
+    parser.add_argument("--raw-catalog-dir", type=Path, required=True)
+    parser.add_argument("--adapter-output-dir", type=Path, required=True)
+    parser.add_argument("--mapping-evidence", type=Path, required=True)
+    parser.add_argument("--private-output-dir", type=Path, required=True)
+    parser.add_argument("--validate-existing", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.validate_existing:
+            result = validate_existing_layout_candidates(
+                pdf_path=args.pdf,
+                raw_catalog_dir=args.raw_catalog_dir,
+                adapter_output_dir=args.adapter_output_dir,
+                mapping_evidence_path=args.mapping_evidence,
+                private_output_dir=args.private_output_dir,
+            )
+            status = "layout_candidates_validated"
+        else:
+            receipt = materialize_layout_candidates(
+                pdf_path=args.pdf,
+                raw_catalog_dir=args.raw_catalog_dir,
+                adapter_output_dir=args.adapter_output_dir,
+                mapping_evidence_path=args.mapping_evidence,
+                private_output_dir=args.private_output_dir,
+            )
+            result = {
+                "records": receipt["output"]["records"],
+                "candidate_lines": receipt["denominator"]["dominant_line_candidates"],
+                "trigger_lines": receipt["denominator"]["trigger_line_candidates"],
+                "unresolved_lines": receipt["denominator"]["unresolved_dominant_line_candidates"],
+                "output_sha256": receipt["output"]["sha256"],
+                "receipt_sha256": receipt["receipt_sha256"],
+                "training_eligible": False,
+                "phase4_authorized": False,
+            }
+            status = "layout_candidates_materialized"
+    except (SpasLayoutCandidateError, SpasCatalogMaterializationError, SpasGlyphAdapterError) as exc:
+        print(canonical_json({"status": "blocked", "error": str(exc)}))
+        return 2
+    print(canonical_json({"status": status, **result}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_open_model_phase3_spas_catalog_materialization.py
+++ b/tests/test_open_model_phase3_spas_catalog_materialization.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import gzip
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_spas_catalog_materialization as materialization
+from scripts.projects.open_model_data.phase3_spas_catalog_materialization import (
+    SpasCatalogMaterializationError,
+    split_catalog_records,
+)
+
+
+def _pages() -> dict[int, str]:
+    return {
+        15: "Графіті № 1 (табл. I)\nПерший запис.\n",
+        16: (
+            "Продовження першого.\n"
+            "Графіті № 2 (табл. II)\nДругий \ue002 запис.\n"
+            "Графіті № 3 (табл. III)\nТретій запис."
+        ),
+    }
+
+
+def _patch_fixture_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = _pages()
+    monkeypatch.setattr(materialization, "SOURCE_PDF_SHA256", "a" * 64)
+    monkeypatch.setattr(materialization, "EXPECTED_PDF_PAGES", 2)
+    monkeypatch.setattr(materialization, "CATALOG_PDF_PAGE_START", 15)
+    monkeypatch.setattr(materialization, "CATALOG_PDF_PAGE_END", 16)
+    monkeypatch.setattr(materialization, "EXPECTED_CATALOG_RECORDS", 3)
+    monkeypatch.setattr(materialization, "EXPECTED_NATIVE_TEXT_CHARACTERS", sum(len(text) for text in pages.values()))
+    monkeypatch.setattr(materialization, "EXPECTED_PRIVATE_USE_COUNTS", {"U+E002": 1})
+
+
+def _materialize(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "private") -> dict[str, object]:
+    pages = _pages()
+    monkeypatch.setattr(materialization, "load_catalog_pages", lambda *_args, **_kwargs: deepcopy(pages))
+    output = tmp_path / name
+    return materialization.materialize_spas_catalog(
+        pdf_path=tmp_path / "not-read.pdf",
+        private_output_dir=output,
+        receipt_output=output / materialization.RECEIPT_FILENAME,
+        expected_pdf_sha256="a" * 64,
+        expected_pdf_pages=2,
+        catalog_pdf_page_start=15,
+        catalog_pdf_page_end=16,
+        expected_record_count=3,
+        expected_native_text_characters=sum(len(text) for text in pages.values()),
+        expected_private_use_counts={"U+E002": 1},
+    )
+
+
+def test_splits_exact_sequential_headings_and_preserves_page_offsets() -> None:
+    pages = _pages()
+    records = split_catalog_records(pages, expected_record_count=3, source_pdf_sha256="a" * 64)
+
+    assert [record["graffito_number"] for record in records] == [1, 2, 3]
+    assert records[0]["source_text"] == (
+        "Графіті № 1 (табл. I)\nПерший запис.\n\nПродовження першого.\n"
+    )
+    assert records[0]["source_page_fragments"] == [
+        {
+            "pdf_page_number": 15,
+            "start_char": 0,
+            "end_char": len(pages[15]),
+            "text_sha256": materialization.hashlib.sha256(pages[15].encode()).hexdigest(),
+        },
+        {
+            "pdf_page_number": 16,
+            "start_char": 0,
+            "end_char": pages[16].index("Графіті № 2"),
+            "text_sha256": materialization.hashlib.sha256("Продовження першого.\n".encode()).hexdigest(),
+        },
+    ]
+    assert records[1]["private_use_codepoint_counts"] == {"U+E002": 1}
+    assert records[1]["contains_private_use_glyphs"] is True
+    assert records[1]["normalization_status"] == "not_applied"
+    assert records[1]["training_eligible"] is False
+    assert records[1]["modern_correction_eligible"] is False
+    assert records[1]["ocr_used"] is False
+    assert records[1]["images_included"] is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Графіті № 1\nОдин.\nГрафіті № 3\nТри.",
+        "Графіті № 1\nОдин.\nГрафіті № 1\nЩе один.\nГрафіті № 2\nДва.",
+    ],
+)
+def test_rejects_missing_or_duplicate_record_numbers(text: str) -> None:
+    with pytest.raises(SpasCatalogMaterializationError, match="exact sequential range"):
+        split_catalog_records({15: text}, expected_record_count=2)
+
+
+def test_rejects_noncontiguous_catalogue_pages() -> None:
+    with pytest.raises(SpasCatalogMaterializationError, match="must be contiguous"):
+        split_catalog_records({15: "Графіті № 1\nОдин.", 17: "Графіті № 2\nДва."}, expected_record_count=2)
+
+
+def test_next_heading_at_page_start_does_not_create_an_empty_fragment() -> None:
+    pages = {
+        15: "Графіті № 1\nОдин.",
+        16: "Графіті № 2\nДва.",
+    }
+    records = split_catalog_records(pages, expected_record_count=2)
+
+    assert records[0]["source_text"] == pages[15]
+    assert [fragment["pdf_page_number"] for fragment in records[0]["source_page_fragments"]] == [15]
+    assert records[1]["source_text"] == pages[16]
+
+
+def test_rejects_replacement_characters() -> None:
+    with pytest.raises(SpasCatalogMaterializationError, match="replacement characters"):
+        split_catalog_records({15: "Графіті № 1\nПошкоджено \ufffd."}, expected_record_count=1)
+
+
+def test_materialization_writes_private_jsonl_and_text_free_sealed_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _materialize(tmp_path, monkeypatch)
+    output = tmp_path / "private"
+
+    with gzip.open(output / materialization.OUTPUT_FILENAME, "rt", encoding="utf-8") as handle:
+        rows = [json.loads(line) for line in handle]
+    persisted_receipt = json.loads((output / materialization.RECEIPT_FILENAME).read_text(encoding="utf-8"))
+
+    assert len(rows) == 3
+    assert rows[0]["source_pdf_sha256"] == "a" * 64
+    assert receipt == persisted_receipt
+    assert receipt["denominator"]["materialized_records"] == 3
+    assert receipt["private_use_audit"]["codepoint_counts"] == {"U+E002": 1}
+    assert receipt["rights_and_scope"]["bounded_text_first_use_decision"] == "accepted_operational_risk"
+    assert receipt["safeguards"]["training_eligible"] is False
+    assert receipt["safeguards"]["normalized_historical_text_emitted"] is False
+    assert receipt["residuals"]["lavra_cave_corpus_gap_closed"] is False
+    assert "Перший запис" not in json.dumps(receipt, ensure_ascii=False)
+    materialization._validate_receipt(receipt)
+
+
+def test_materialization_is_byte_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = _materialize(tmp_path, monkeypatch, name="first")
+    second = _materialize(tmp_path, monkeypatch, name="second")
+
+    assert first["output"]["sha256"] == second["output"]["sha256"]
+    assert first["output"]["record_identity_manifest_sha256"] == second["output"][
+        "record_identity_manifest_sha256"
+    ]
+    assert first["receipt_sha256"] == second["receipt_sha256"]
+
+
+def test_existing_materialization_rebinds_every_record_to_source_pages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    validation = materialization.validate_existing_materialization(
+        pdf_path=tmp_path / "not-read.pdf",
+        private_output_dir=tmp_path / "private",
+    )
+
+    assert validation == {
+        "ok": True,
+        "records": 3,
+        "source_pdf_sha256": "a" * 64,
+        "private_jsonl_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+    }
+
+
+def test_existing_materialization_rejects_private_output_tamper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    output = tmp_path / "private" / materialization.OUTPUT_FILENAME
+    output.write_bytes(output.read_bytes() + b"tamper")
+
+    with pytest.raises(SpasCatalogMaterializationError, match="byte count drift"):
+        materialization.validate_existing_materialization(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_existing_materialization_rejects_same_length_private_output_tamper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    output = tmp_path / "private" / materialization.OUTPUT_FILENAME
+    payload = bytearray(output.read_bytes())
+    payload[len(payload) // 2] ^= 1
+    output.write_bytes(payload)
+
+    with pytest.raises(SpasCatalogMaterializationError, match="SHA-256 drift"):
+        materialization.validate_existing_materialization(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_existing_materialization_rejects_receipt_source_identity_substitution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    receipt_path = tmp_path / "private" / materialization.RECEIPT_FILENAME
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["inputs"]["source_pdf_sha256"] = "b" * 64
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = materialization.sha256_value(body)
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(SpasCatalogMaterializationError, match="source PDF identity drift"):
+        materialization.validate_existing_materialization(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_existing_materialization_rejects_receipt_record_denominator_substitution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    receipt_path = tmp_path / "private" / materialization.RECEIPT_FILENAME
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    for field in ("expected_records", "materialized_records", "unique_record_numbers"):
+        receipt["denominator"][field] = 2
+    receipt["output"]["records"] = 2
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = materialization.sha256_value(body)
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(SpasCatalogMaterializationError, match="record-count identity drift"):
+        materialization.validate_existing_materialization(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_raw_record_fragment_hash_tamper_is_rejected() -> None:
+    pages = _pages()
+    record = split_catalog_records(pages, expected_record_count=3)[0]
+    record["source_page_fragments"][0]["text_sha256"] = "0" * 64
+
+    with pytest.raises(SpasCatalogMaterializationError, match="fragment hash drift"):
+        materialization._validate_raw_record(
+            record,
+            expected_number=1,
+            expected_pdf_sha256=materialization.SOURCE_PDF_SHA256,
+            page_texts=pages,
+        )
+
+
+def test_existing_materialization_rejects_manifest_hash_tamper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    _patch_fixture_identity(monkeypatch)
+    receipt_path = tmp_path / "private" / materialization.RECEIPT_FILENAME
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["output"]["record_identity_manifest_sha256"] = "0" * 64
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = materialization.sha256_value(body)
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(SpasCatalogMaterializationError, match="record identity manifest drift"):
+        materialization.validate_existing_materialization(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_materialization_refuses_to_overwrite_immutable_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialize(tmp_path, monkeypatch)
+    with pytest.raises(SpasCatalogMaterializationError, match="already exists"):
+        _materialize(tmp_path, monkeypatch)
+
+
+def test_materialization_refuses_directory_that_appears_during_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_write_receipt = materialization._write_receipt
+
+    def create_competing_output(path: Path, receipt: dict[str, object]) -> None:
+        original_write_receipt(path, receipt)
+        (tmp_path / "private").mkdir()
+
+    monkeypatch.setattr(materialization, "_write_receipt", create_competing_output)
+    with pytest.raises(SpasCatalogMaterializationError, match="appeared during publication"):
+        _materialize(tmp_path, monkeypatch)
+    assert list((tmp_path / "private").iterdir()) == []
+
+
+def test_materialization_rejects_private_output_inside_git_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    pages = _pages()
+    monkeypatch.setattr(materialization, "load_catalog_pages", lambda *_args, **_kwargs: deepcopy(pages))
+    output = tmp_path / "private"
+    with pytest.raises(SpasCatalogMaterializationError, match="cannot be inside a Git checkout"):
+        materialization.materialize_spas_catalog(
+            pdf_path=tmp_path / "not-read.pdf",
+            private_output_dir=output,
+            receipt_output=output / materialization.RECEIPT_FILENAME,
+            expected_record_count=3,
+            expected_native_text_characters=sum(len(text) for text in pages.values()),
+            expected_private_use_counts={"U+E002": 1},
+        )
+
+
+def test_load_catalog_pages_rejects_source_hash_drift(tmp_path: Path) -> None:
+    pdf = tmp_path / "source.pdf"
+    pdf.write_bytes(b"not the immutable source")
+    with pytest.raises(SpasCatalogMaterializationError, match="SHA-256 mismatch"):
+        materialization.load_catalog_pages(pdf, expected_pdf_sha256="0" * 64)
+
+
+def test_receipt_tamper_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt = _materialize(tmp_path, monkeypatch)
+    tampered = deepcopy(receipt)
+    tampered["safeguards"]["training_eligible"] = True
+    with pytest.raises(SpasCatalogMaterializationError, match="schema violation"):
+        materialization._validate_receipt(tampered)
+
+
+def test_receipt_cross_field_tamper_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt = _materialize(tmp_path, monkeypatch)
+    tampered = deepcopy(receipt)
+    tampered["denominator"]["unique_record_numbers"] = 2
+    body = {key: value for key, value in tampered.items() if key != "receipt_sha256"}
+    tampered["receipt_sha256"] = materialization.sha256_value(body)
+
+    with pytest.raises(SpasCatalogMaterializationError, match="record denominator drift"):
+        materialization._validate_receipt(tampered)

--- a/tests/test_open_model_phase3_spas_glyph_adapter.py
+++ b/tests/test_open_model_phase3_spas_glyph_adapter.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_spas_glyph_adapter as adapter
+from scripts.projects.open_model_data.phase3_linguistic_representation import canonical_json
+from scripts.projects.open_model_data.phase3_spas_glyph_adapter import (
+    SpasGlyphAdapterError,
+    apply_bukyvede_mapping,
+    reconstruct_raw_text,
+)
+
+
+def _mapped_text() -> str:
+    return "|".join(rule.raw * rule.expected_occurrences for rule in adapter.MAPPING_RULES)
+
+
+def _raw_record(number: int, text: str) -> dict[str, object]:
+    return {
+        "record_id": f"spas-na-berestovi:graffito:{number:04d}",
+        "collection_id": adapter.COLLECTION_ID,
+        "graffito_number": number,
+        "source_pdf_sha256": adapter.SOURCE_PDF_SHA256,
+        "source_text": text,
+        "source_text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "private_use_codepoint_counts": adapter._private_use_counts(text),
+    }
+
+
+def _write_raw(path: Path, records: list[dict[str, object]]) -> str:
+    with (
+        path.open("wb") as raw_handle,
+        gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as handle,
+    ):
+        for record in records:
+            handle.write(canonical_json(record).encode() + b"\n")
+    return adapter.file_sha256(path)
+
+
+def _mapping_evidence(raw_sha256: str, raw_receipt_sha256: str) -> dict[str, object]:
+    return {
+        "schema_version": "private_phase3_spas_bukyvede_glyph_mapping_evidence_v1",
+        "evidence_id": "fixture",
+        "text_free": True,
+        "source": {
+            "collection_id": adapter.COLLECTION_ID,
+            "source_pdf_sha256": adapter.SOURCE_PDF_SHA256,
+            "catalog_records": 2,
+            "raw_catalog_jsonl_sha256": raw_sha256,
+            "raw_materialization_receipt_sha256": raw_receipt_sha256,
+        },
+        "embedded_font": {
+            "font_sha256": adapter.EXPECTED_FONT_SHA256,
+            "to_unicode_sha256": adapter.EXPECTED_TO_UNICODE_SHA256,
+        },
+        "source_verified_mapping_candidates": [
+            {
+                "raw_pattern": adapter._codepoints(rule.raw),
+                "normalized_pattern": adapter._codepoints(rule.normalized),
+                "occurrences": rule.expected_occurrences,
+            }
+            for rule in adapter.MAPPING_RULES
+        ],
+        "denominator_checks": {
+            "private_use_occurrences": adapter.EXPECTED_MAPPING_EVENTS,
+            "raw_pattern_occurrence_sum": adapter.EXPECTED_MAPPING_EVENTS,
+            "unexpected_private_use_codepoints": 0,
+        },
+        "safeguards": {
+            "mapping_is_deterministic_source_adapter_not_semantic_gold": True,
+            "training_eligible": False,
+            "phase4_authorized": False,
+        },
+    }
+
+
+def _fixture_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    records = [_raw_record(1, _mapped_text()), _raw_record(2, "Без приватних символів.")]
+    raw_path = raw_dir / adapter.RAW_OUTPUT_FILENAME
+    raw_sha256 = _write_raw(raw_path, records)
+    raw_receipt_path = raw_dir / adapter.RAW_RECEIPT_FILENAME
+    raw_receipt_path.write_text('{"fixture":true}\n', encoding="utf-8")
+    raw_receipt_file_sha256 = adapter.file_sha256(raw_receipt_path)
+    raw_receipt_sha256 = "b" * 64
+
+    monkeypatch.setattr(adapter, "EXPECTED_RAW_OUTPUT_SHA256", raw_sha256)
+    monkeypatch.setattr(adapter, "EXPECTED_RAW_RECEIPT_FILE_SHA256", raw_receipt_file_sha256)
+    monkeypatch.setattr(adapter, "EXPECTED_RAW_RECEIPT_SHA256", raw_receipt_sha256)
+    monkeypatch.setattr(adapter, "EXPECTED_CATALOG_RECORDS", 2)
+    monkeypatch.setattr(
+        adapter,
+        "validate_existing_materialization",
+        lambda **_kwargs: {
+            "source_pdf_sha256": adapter.SOURCE_PDF_SHA256,
+            "records": 2,
+            "private_jsonl_sha256": raw_sha256,
+            "receipt_sha256": raw_receipt_sha256,
+            "training_eligible": False,
+        },
+    )
+    evidence_path = raw_dir / adapter.MAPPING_EVIDENCE_FILENAME
+    evidence_path.write_text(
+        json.dumps(_mapping_evidence(raw_sha256, raw_receipt_sha256), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    evidence_sha256 = adapter.file_sha256(evidence_path)
+    monkeypatch.setattr(adapter, "EXPECTED_MAPPING_EVIDENCE_SHA256", evidence_sha256)
+
+    raw_characters = sum(len(record["source_text"]) for record in records)
+    normalized_characters = sum(len(apply_bukyvede_mapping(record["source_text"])[0]) for record in records)
+    monkeypatch.setattr(adapter, "EXPECTED_RAW_RECORD_CHARACTERS", raw_characters)
+    monkeypatch.setattr(adapter, "EXPECTED_NORMALIZED_CHARACTERS", normalized_characters)
+    monkeypatch.setattr(adapter, "EXPECTED_RECORDS_WITH_MAPPINGS", 1)
+    return {
+        "raw_dir": raw_dir,
+        "records": records,
+        "raw_sha256": raw_sha256,
+        "raw_receipt_file_sha256": raw_receipt_file_sha256,
+        "raw_receipt_sha256": raw_receipt_sha256,
+        "evidence_path": evidence_path,
+        "evidence_sha256": evidence_sha256,
+        "raw_characters": raw_characters,
+        "normalized_characters": normalized_characters,
+    }
+
+
+def _adapt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "normalized") -> tuple[dict, dict]:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    output = tmp_path / name
+    receipt = adapter.adapt_spas_glyphs(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        mapping_evidence_path=fixture["evidence_path"],
+        private_output_dir=output,
+        expected_raw_output_sha256=fixture["raw_sha256"],
+        expected_raw_receipt_file_sha256=fixture["raw_receipt_file_sha256"],
+        expected_raw_receipt_sha256=fixture["raw_receipt_sha256"],
+        expected_mapping_evidence_sha256=fixture["evidence_sha256"],
+        expected_records=2,
+        expected_raw_characters=fixture["raw_characters"],
+        expected_normalized_characters=fixture["normalized_characters"],
+        expected_records_with_mappings=1,
+        expected_mapping_events=adapter.EXPECTED_MAPPING_EVENTS,
+    )
+    return receipt, fixture
+
+
+def test_maps_exact_frozen_bukyvede_patterns_and_reverses() -> None:
+    raw = "Початок " + _mapped_text() + " кінець"
+    normalized, events = apply_bukyvede_mapping(raw)
+
+    assert "\ue002" not in normalized
+    assert "\ue026" not in normalized
+    assert "\ue027" not in normalized
+    assert "\ue02e" not in normalized
+    assert "\ue02f" not in normalized
+    assert normalized.count("\u0483") == 13
+    assert normalized.count("\u0472") == 4
+    assert normalized.count("\u0473") == 10
+    assert normalized.count("\ua656") == 3
+    assert normalized.count("\ua657") == 27
+    assert len(events) == 57
+    assert reconstruct_raw_text(normalized, events) == raw
+
+
+def test_longest_patterns_consume_following_cyrillic_a() -> None:
+    normalized, events = apply_bukyvede_mapping("\ue02e\u0410|\ue02f\u0430")
+
+    assert normalized == "\ua656|\ua657"
+    assert events[0]["raw_end_char"] - events[0]["raw_start_char"] == 2
+    assert events[0]["normalized_end_char"] - events[0]["normalized_start_char"] == 1
+
+
+@pytest.mark.parametrize("text", ["\ue02eБ", "\ue02fб", "\ue099"])
+def test_rejects_unmapped_or_malformed_private_use_patterns(text: str) -> None:
+    with pytest.raises(SpasGlyphAdapterError, match="unmapped private-use character"):
+        apply_bukyvede_mapping(text)
+
+
+def test_record_preserves_raw_text_hashes_offsets_and_fail_closed_flags() -> None:
+    raw = _raw_record(1, "А\ue002Б \ue02fа")
+    record = adapter.build_normalized_record(raw, upstream_raw_sha256="a" * 64)
+
+    assert record["raw_source_text"] == raw["source_text"]
+    assert record["raw_source_text_sha256"] == raw["source_text_sha256"]
+    assert reconstruct_raw_text(record["normalized_text"], record["mapping_events"]) == raw["source_text"]
+    assert record["output_private_use_codepoint_counts"] == {}
+    assert record["commentary_and_inscription_layers_separated"] is False
+    assert record["training_eligible"] is False
+    assert record["modern_correction_eligible"] is False
+    assert record["inferred_character_repairs"] is False
+    assert record["provider_calls"] is False
+
+
+def test_mapping_event_tamper_is_rejected() -> None:
+    normalized, events = apply_bukyvede_mapping("А\ue002Б")
+    events[0]["normalized_pattern"] = ["U+0472"]
+
+    with pytest.raises(SpasGlyphAdapterError, match="normalized mapping pattern drift"):
+        reconstruct_raw_text(normalized, events)
+
+
+def test_mapping_event_raw_offset_tamper_is_rejected() -> None:
+    normalized, events = apply_bukyvede_mapping("А\ue002Б")
+    events[0]["raw_start_char"] += 1
+
+    with pytest.raises(SpasGlyphAdapterError, match="raw mapping event start offset drift"):
+        reconstruct_raw_text(normalized, events)
+
+
+def test_adapter_writes_deterministic_private_layer_and_text_free_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt, _fixture = _adapt(tmp_path, monkeypatch)
+    output = tmp_path / "normalized"
+    with gzip.open(output / adapter.OUTPUT_FILENAME, "rt", encoding="utf-8") as handle:
+        rows = [json.loads(line) for line in handle]
+
+    assert len(rows) == 2
+    assert rows[0]["raw_source_text"] == _mapped_text()
+    assert rows[0]["normalized_text"] != rows[0]["raw_source_text"]
+    assert receipt["denominator"]["mapping_events"] == 57
+    assert receipt["denominator"]["records_with_mappings"] == 1
+    assert receipt["denominator"]["output_private_use_occurrences"] == 0
+    assert receipt["safeguards"]["training_eligible"] is False
+    assert receipt["safeguards"]["phase4_authorized"] is False
+    assert receipt["residuals"]["commentary_transcription_separation_pending"] is True
+    assert receipt["residuals"]["lavra_cave_corpus_gap_closed"] is False
+    assert "Без приватних символів" not in json.dumps(receipt, ensure_ascii=False)
+    adapter._validate_receipt(receipt)
+
+
+def test_adapter_output_is_byte_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first, fixture = _adapt(tmp_path, monkeypatch, name="first")
+    second_output = tmp_path / "second"
+    second = adapter.adapt_spas_glyphs(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        mapping_evidence_path=fixture["evidence_path"],
+        private_output_dir=second_output,
+        expected_raw_output_sha256=fixture["raw_sha256"],
+        expected_raw_receipt_file_sha256=fixture["raw_receipt_file_sha256"],
+        expected_raw_receipt_sha256=fixture["raw_receipt_sha256"],
+        expected_mapping_evidence_sha256=fixture["evidence_sha256"],
+        expected_records=2,
+        expected_raw_characters=fixture["raw_characters"],
+        expected_normalized_characters=fixture["normalized_characters"],
+        expected_records_with_mappings=1,
+        expected_mapping_events=57,
+    )
+
+    assert first["output"]["sha256"] == second["output"]["sha256"]
+    assert first["output"]["record_identity_manifest_sha256"] == second["output"]["record_identity_manifest_sha256"]
+    assert first["receipt_sha256"] == second["receipt_sha256"]
+
+
+def test_existing_adapter_rebinds_pdf_raw_evidence_and_every_output_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt, fixture = _adapt(tmp_path, monkeypatch)
+    validation = adapter.validate_existing_glyph_adapter(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        mapping_evidence_path=fixture["evidence_path"],
+        private_output_dir=tmp_path / "normalized",
+    )
+
+    assert validation == {
+        "ok": True,
+        "records": 2,
+        "mapping_events": 57,
+        "output_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+        "phase4_authorized": False,
+    }
+
+
+def test_existing_adapter_rejects_output_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _receipt, fixture = _adapt(tmp_path, monkeypatch)
+    output_path = tmp_path / "normalized" / adapter.OUTPUT_FILENAME
+    payload = bytearray(output_path.read_bytes())
+    payload[len(payload) // 2] ^= 1
+    output_path.write_bytes(payload)
+
+    with pytest.raises(SpasGlyphAdapterError, match="SHA-256 drift"):
+        adapter.validate_existing_glyph_adapter(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            mapping_evidence_path=fixture["evidence_path"],
+            private_output_dir=tmp_path / "normalized",
+        )
+
+
+def test_receipt_rejects_mapping_rule_substitution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt, _fixture = _adapt(tmp_path, monkeypatch)
+    receipt["mapping_contract"]["rules"][0]["normalized_pattern"] = ["U+0472"]
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = adapter.sha256_value(body)
+
+    with pytest.raises(SpasGlyphAdapterError, match="mapping-rule contract drift"):
+        adapter._validate_receipt(receipt)
+
+
+def test_mapping_evidence_tamper_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    evidence = fixture["evidence_path"]
+    evidence.write_text(evidence.read_text(encoding="utf-8") + " ", encoding="utf-8")
+
+    with pytest.raises(SpasGlyphAdapterError, match="mapping evidence SHA-256 drift"):
+        adapter.validate_mapping_evidence(evidence)
+
+
+def test_adapter_refuses_existing_output_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    output = tmp_path / "normalized"
+    output.mkdir()
+
+    with pytest.raises(SpasGlyphAdapterError, match="already exists"):
+        adapter.adapt_spas_glyphs(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            mapping_evidence_path=fixture["evidence_path"],
+            private_output_dir=output,
+            expected_raw_output_sha256=fixture["raw_sha256"],
+            expected_raw_receipt_file_sha256=fixture["raw_receipt_file_sha256"],
+            expected_raw_receipt_sha256=fixture["raw_receipt_sha256"],
+            expected_mapping_evidence_sha256=fixture["evidence_sha256"],
+            expected_records=2,
+            expected_raw_characters=fixture["raw_characters"],
+            expected_normalized_characters=fixture["normalized_characters"],
+            expected_records_with_mappings=1,
+            expected_mapping_events=57,
+        )
+
+
+def test_adapter_refuses_private_output_inside_git_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").write_text("gitdir: fixture", encoding="utf-8")
+
+    with pytest.raises(SpasGlyphAdapterError, match="cannot be inside a Git checkout"):
+        adapter.adapt_spas_glyphs(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            mapping_evidence_path=fixture["evidence_path"],
+            private_output_dir=checkout / "private",
+        )

--- a/tests/test_open_model_phase3_spas_layout_candidates.py
+++ b/tests/test_open_model_phase3_spas_layout_candidates.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_spas_layout_candidates as candidates
+from scripts.projects.open_model_data.phase3_linguistic_representation import canonical_json
+from scripts.projects.open_model_data.phase3_spas_layout_candidates import SpasLayoutCandidateError
+
+
+def _texts() -> list[str]:
+    return [
+        (
+            "Графіті № 1\n"
+            "Опис: текст після відновлення виглядає таким чином:\n"
+            "СЛОВО\n"
+            "Довгий коментар з історичною літерою А всередині.\n"
+        ),
+        "Графіті № 2\nСЛОВО\nПодальший коментар.\n",
+        "Графіті № 3\nДовгий рядок з однією історичною літерою А у коментарі.\n",
+    ]
+
+
+def _raw_record(number: int, text: str, page_number: int) -> dict[str, object]:
+    return {
+        "record_id": f"spas-na-berestovi:graffito:{number:04d}",
+        "graffito_number": number,
+        "source_text": text,
+        "source_text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "source_page_fragments": [
+            {
+                "pdf_page_number": page_number,
+                "start_char": 0,
+                "end_char": len(text),
+                "text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+            }
+        ],
+    }
+
+
+def _normalized_record(number: int, text: str) -> dict[str, object]:
+    return {
+        "source_record_id": f"spas-na-berestovi:graffito:{number:04d}",
+        "graffito_number": number,
+        "raw_source_text": text,
+        "normalized_text": text,
+        "normalized_text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "mapping_events": [],
+    }
+
+
+def _tagged_layout(text: str, *, marks: list[str]) -> dict[str, object]:
+    tags = ["/Fixture+Times"] * len(text)
+    start = 0
+    for mark in marks:
+        position = text.index(mark, start)
+        tags[position : position + len(mark)] = [candidates.BUKYVEDE_FONT_BASE_NAME] * len(mark)
+        start = position + len(mark)
+    return {"text": text, "text_sha256": hashlib.sha256(text.encode()).hexdigest(), "font_tags": tags}
+
+
+def _page_layouts() -> dict[int, dict[str, object]]:
+    first, second, third = _texts()
+    return {
+        15: _tagged_layout(first, marks=["СЛОВО", "А"]),
+        16: _tagged_layout(second, marks=["СЛОВО"]),
+        17: _tagged_layout(third, marks=["А"]),
+    }
+
+
+def _records() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    texts = _texts()
+    raw = [_raw_record(index, text, 14 + index) for index, text in enumerate(texts, start=1)]
+    normalized = [_normalized_record(index, text) for index, text in enumerate(texts, start=1)]
+    return raw, normalized
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> str:
+    with (
+        path.open("wb") as raw_handle,
+        gzip.GzipFile(filename="", mode="wb", fileobj=raw_handle, mtime=0) as handle,
+    ):
+        for row in rows:
+            handle.write(canonical_json(row).encode() + b"\n")
+    return candidates.file_sha256(path)
+
+
+def _fixture_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    raw_records, normalized_records = _records()
+    layouts = _page_layouts()
+    raw_dir = tmp_path / "raw"
+    adapter_dir = tmp_path / "adapter"
+    raw_dir.mkdir()
+    adapter_dir.mkdir()
+    raw_path = raw_dir / candidates.RAW_OUTPUT_FILENAME
+    adapter_path = adapter_dir / candidates.ADAPTER_OUTPUT_FILENAME
+    raw_sha256 = _write_jsonl(raw_path, raw_records)
+    adapter_sha256 = _write_jsonl(adapter_path, normalized_records)
+    adapter_receipt_path = adapter_dir / candidates.ADAPTER_RECEIPT_FILENAME
+    adapter_receipt_path.write_text('{"fixture":true}\n', encoding="utf-8")
+    adapter_receipt_file_sha256 = candidates.file_sha256(adapter_receipt_path)
+    mapping_evidence_path = raw_dir / "bukyvede-glyph-mapping-evidence-v1.json"
+    mapping_evidence_path.write_text('{"fixture":true}\n', encoding="utf-8")
+    mapping_evidence_sha256 = candidates.file_sha256(mapping_evidence_path)
+
+    monkeypatch.setattr(candidates, "EXPECTED_CATALOG_RECORDS", 3)
+    monkeypatch.setattr(candidates, "EXPECTED_RAW_OUTPUT_SHA256", raw_sha256)
+    monkeypatch.setattr(candidates, "EXPECTED_ADAPTER_OUTPUT_SHA256", adapter_sha256)
+    monkeypatch.setattr(candidates, "EXPECTED_ADAPTER_RECEIPT_FILE_SHA256", adapter_receipt_file_sha256)
+    monkeypatch.setattr(candidates, "EXPECTED_ADAPTER_RECEIPT_SHA256", "c" * 64)
+    monkeypatch.setattr(candidates, "EXPECTED_MAPPING_EVIDENCE_SHA256", mapping_evidence_sha256)
+    monkeypatch.setattr(candidates, "extract_font_layout_pages", lambda *_args, **_kwargs: layouts)
+    monkeypatch.setattr(
+        candidates,
+        "validate_existing_glyph_adapter",
+        lambda **_kwargs: {
+            "records": 3,
+            "output_sha256": adapter_sha256,
+            "receipt_sha256": "c" * 64,
+            "training_eligible": False,
+            "phase4_authorized": False,
+        },
+    )
+    built = [
+        candidates.build_layout_candidate_record(
+            raw_record,
+            normalized_record,
+            layouts,
+            adapter_output_sha256=adapter_sha256,
+        )
+        for raw_record, normalized_record in zip(raw_records, normalized_records, strict=True)
+    ]
+    trigger_records = {
+        record["graffito_number"]
+        for record in built
+        if any(
+            item["classification"] == "author_reconstruction_trigger_candidate"
+            for item in record["historic_script_dominant_line_candidates"]
+        )
+    }
+    unresolved_records = {
+        record["graffito_number"]
+        for record in built
+        if any(
+            item["classification"] == "dominant_historic_script_unresolved"
+            for item in record["historic_script_dominant_line_candidates"]
+        )
+    }
+    expected = {
+        "records_with_bukyvede": sum(bool(record["font_spans"]) for record in built),
+        "records_without_bukyvede": sum(not record["font_spans"] for record in built),
+        "bukyvede_runs": sum(len(record["font_spans"]) for record in built),
+        "bukyvede_characters": sum(record["denominator"]["bukyvede_characters"] for record in built),
+        "bukyvede_nonspace": sum(record["denominator"]["bukyvede_nonspace_characters"] for record in built),
+        "lines_with_bukyvede": sum(record["denominator"]["lines_with_bukyvede"] for record in built),
+        "dominant_lines": sum(len(record["historic_script_dominant_line_candidates"]) for record in built),
+        "dominant_records": sum(bool(record["historic_script_dominant_line_candidates"]) for record in built),
+        "trigger_lines": sum(
+            item["classification"] == "author_reconstruction_trigger_candidate"
+            for record in built
+            for item in record["historic_script_dominant_line_candidates"]
+        ),
+        "trigger_records": len(trigger_records),
+        "unresolved_lines": sum(
+            item["classification"] == "dominant_historic_script_unresolved"
+            for record in built
+            for item in record["historic_script_dominant_line_candidates"]
+        ),
+        "unresolved_records": len(unresolved_records),
+        "overlap_records": len(trigger_records & unresolved_records),
+    }
+    for name, value in (
+        ("EXPECTED_RECORDS_WITH_BUKYVEDE", expected["records_with_bukyvede"]),
+        ("EXPECTED_RECORDS_WITHOUT_BUKYVEDE", expected["records_without_bukyvede"]),
+        ("EXPECTED_BUKYVEDE_RUNS", expected["bukyvede_runs"]),
+        ("EXPECTED_BUKYVEDE_CHARACTERS", expected["bukyvede_characters"]),
+        ("EXPECTED_BUKYVEDE_NONSPACE_CHARACTERS", expected["bukyvede_nonspace"]),
+        ("EXPECTED_LINES_WITH_BUKYVEDE", expected["lines_with_bukyvede"]),
+        ("EXPECTED_DOMINANT_LINES", expected["dominant_lines"]),
+        ("EXPECTED_DOMINANT_RECORDS", expected["dominant_records"]),
+        ("EXPECTED_TRIGGER_LINES", expected["trigger_lines"]),
+        ("EXPECTED_TRIGGER_RECORDS", expected["trigger_records"]),
+        ("EXPECTED_UNRESOLVED_LINES", expected["unresolved_lines"]),
+        ("EXPECTED_UNRESOLVED_RECORDS", expected["unresolved_records"]),
+        ("EXPECTED_TRIGGER_UNRESOLVED_RECORD_OVERLAP", expected["overlap_records"]),
+    ):
+        monkeypatch.setattr(candidates, name, value)
+    return {
+        "raw_dir": raw_dir,
+        "adapter_dir": adapter_dir,
+        "mapping_evidence_path": mapping_evidence_path,
+        "raw_records": raw_records,
+        "normalized_records": normalized_records,
+        "layouts": layouts,
+        "raw_sha256": raw_sha256,
+        "adapter_sha256": adapter_sha256,
+        "adapter_receipt_file_sha256": adapter_receipt_file_sha256,
+        "mapping_evidence_sha256": mapping_evidence_sha256,
+        "expected": expected,
+    }
+
+
+def _materialize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    name: str = "private",
+) -> tuple[dict, dict]:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    expected = fixture["expected"]
+    receipt = candidates.materialize_layout_candidates(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        adapter_output_dir=fixture["adapter_dir"],
+        mapping_evidence_path=fixture["mapping_evidence_path"],
+        private_output_dir=tmp_path / name,
+        expected_records=3,
+        expected_records_with_bukyvede=expected["records_with_bukyvede"],
+        expected_records_without_bukyvede=expected["records_without_bukyvede"],
+        expected_bukyvede_runs=expected["bukyvede_runs"],
+        expected_bukyvede_characters=expected["bukyvede_characters"],
+        expected_bukyvede_nonspace_characters=expected["bukyvede_nonspace"],
+        expected_lines_with_bukyvede=expected["lines_with_bukyvede"],
+        expected_dominant_lines=expected["dominant_lines"],
+        expected_dominant_records=expected["dominant_records"],
+        expected_trigger_lines=expected["trigger_lines"],
+        expected_trigger_records=expected["trigger_records"],
+        expected_unresolved_lines=expected["unresolved_lines"],
+        expected_unresolved_records=expected["unresolved_records"],
+        expected_overlap_records=expected["overlap_records"],
+    )
+    return receipt, fixture
+
+
+def test_builds_exact_font_spans_and_trigger_candidate() -> None:
+    raw_records, normalized_records = _records()
+    record = candidates.build_layout_candidate_record(
+        raw_records[0],
+        normalized_records[0],
+        _page_layouts(),
+        adapter_output_sha256="a" * 64,
+    )
+
+    assert record["raw_context"] == raw_records[0]["source_text"]
+    assert record["normalized_context"] == normalized_records[0]["normalized_text"]
+    assert len(record["font_spans"]) == 2
+    assert record["font_spans"][0]["raw_text"] == "СЛОВО"
+    assert record["font_spans"][0]["pdf_page_number"] == 15
+    assert len(record["historic_script_dominant_line_candidates"]) == 1
+    candidate = record["historic_script_dominant_line_candidates"][0]
+    assert candidate["classification"] == "author_reconstruction_trigger_candidate"
+    assert candidate["pdf_page_number"] == 15
+    assert candidate["page_start_char"] < candidate["page_end_char"]
+    assert candidate["text_cue_present"] is True
+    assert "вигляд" in candidate["matched_shape_cues"]
+    assert candidate["classification_is_semantic_gold"] is False
+    assert candidate["qualified_historical_review_status"] == "pending"
+    assert candidate["training_eligible"] is False
+    assert record["commentary_and_inscription_layers_separated"] is False
+    assert record["phase4_authorized"] is False
+
+
+def test_routes_dominant_line_without_cue_as_unresolved() -> None:
+    raw_records, normalized_records = _records()
+    record = candidates.build_layout_candidate_record(
+        raw_records[1],
+        normalized_records[1],
+        _page_layouts(),
+        adapter_output_sha256="a" * 64,
+    )
+
+    assert [item["classification"] for item in record["historic_script_dominant_line_candidates"]] == [
+        "dominant_historic_script_unresolved"
+    ]
+
+
+def test_context_substring_does_not_satisfy_whole_word_text_cue() -> None:
+    text = "Графіті № 4\nКонтекст після відновлення виглядає таким чином:\nСЛОВО\n"
+    raw_record = _raw_record(4, text, 18)
+    normalized_record = _normalized_record(4, text)
+    layout = {18: _tagged_layout(text, marks=["СЛОВО"])}
+
+    record = candidates.build_layout_candidate_record(
+        raw_record,
+        normalized_record,
+        layout,
+        adapter_output_sha256="a" * 64,
+    )
+
+    assert [item["classification"] for item in record["historic_script_dominant_line_candidates"]] == [
+        "dominant_historic_script_unresolved"
+    ]
+    assert record["historic_script_dominant_line_candidates"][0]["text_cue_present"] is False
+
+
+def test_inline_historic_font_remains_context_only() -> None:
+    raw_records, normalized_records = _records()
+    record = candidates.build_layout_candidate_record(
+        raw_records[2],
+        normalized_records[2],
+        _page_layouts(),
+        adapter_output_sha256="a" * 64,
+    )
+
+    assert len(record["font_spans"]) == 1
+    assert record["denominator"]["lines_with_bukyvede"] == 1
+    assert record["historic_script_dominant_line_candidates"] == []
+
+
+def test_raw_to_normalized_boundary_tracks_width_reducing_event() -> None:
+    record = {
+        "raw_source_text": "x\ue02fаy",
+        "normalized_text": "x\ua657y",
+        "mapping_events": [
+            {
+                "raw_start_char": 1,
+                "raw_end_char": 3,
+                "normalized_start_char": 1,
+                "normalized_end_char": 2,
+            }
+        ],
+    }
+
+    assert candidates._raw_boundary_to_normalized(record, 0) == 0
+    assert candidates._raw_boundary_to_normalized(record, 1) == 1
+    assert candidates._raw_boundary_to_normalized(record, 3) == 2
+    assert candidates._raw_boundary_to_normalized(record, 4) == 3
+    with pytest.raises(SpasLayoutCandidateError, match="splits a glyph mapping event"):
+        candidates._raw_boundary_to_normalized(record, 2)
+
+
+def test_materialization_writes_complete_private_queue_and_text_free_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt, fixture = _materialize(tmp_path, monkeypatch)
+    with gzip.open(tmp_path / "private" / candidates.OUTPUT_FILENAME, "rt", encoding="utf-8") as handle:
+        rows = [json.loads(line) for line in handle]
+
+    assert len(rows) == 3
+    assert rows[0]["raw_context"] == fixture["raw_records"][0]["source_text"]
+    assert receipt["denominator"]["dominant_line_candidates"] == 2
+    assert receipt["denominator"]["trigger_line_candidates"] == 1
+    assert receipt["denominator"]["unresolved_dominant_line_candidates"] == 1
+    assert receipt["routing_contract"]["classifications_are_semantic_gold"] is False
+    assert receipt["safeguards"]["training_eligible"] is False
+    assert receipt["safeguards"]["phase4_authorized"] is False
+    assert receipt["residuals"]["commentary_transcription_separation_pending"] is True
+    assert "СЛОВО" not in json.dumps(receipt, ensure_ascii=False)
+    candidates._validate_receipt(receipt)
+
+
+def test_materialization_is_byte_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first, fixture = _materialize(tmp_path, monkeypatch, name="first")
+    expected = fixture["expected"]
+    second = candidates.materialize_layout_candidates(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        adapter_output_dir=fixture["adapter_dir"],
+        mapping_evidence_path=fixture["mapping_evidence_path"],
+        private_output_dir=tmp_path / "second",
+        expected_records=3,
+        expected_records_with_bukyvede=expected["records_with_bukyvede"],
+        expected_records_without_bukyvede=expected["records_without_bukyvede"],
+        expected_bukyvede_runs=expected["bukyvede_runs"],
+        expected_bukyvede_characters=expected["bukyvede_characters"],
+        expected_bukyvede_nonspace_characters=expected["bukyvede_nonspace"],
+        expected_lines_with_bukyvede=expected["lines_with_bukyvede"],
+        expected_dominant_lines=expected["dominant_lines"],
+        expected_dominant_records=expected["dominant_records"],
+        expected_trigger_lines=expected["trigger_lines"],
+        expected_trigger_records=expected["trigger_records"],
+        expected_unresolved_lines=expected["unresolved_lines"],
+        expected_unresolved_records=expected["unresolved_records"],
+        expected_overlap_records=expected["overlap_records"],
+    )
+
+    assert first["output"]["sha256"] == second["output"]["sha256"]
+    assert first["receipt_sha256"] == second["receipt_sha256"]
+
+
+def test_existing_queue_rebinds_all_inputs_and_replays_every_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt, fixture = _materialize(tmp_path, monkeypatch)
+    validation = candidates.validate_existing_layout_candidates(
+        pdf_path=tmp_path / "fixture.pdf",
+        raw_catalog_dir=fixture["raw_dir"],
+        adapter_output_dir=fixture["adapter_dir"],
+        mapping_evidence_path=fixture["mapping_evidence_path"],
+        private_output_dir=tmp_path / "private",
+    )
+
+    assert validation == {
+        "ok": True,
+        "records": 3,
+        "candidate_lines": 2,
+        "trigger_lines": 1,
+        "unresolved_lines": 1,
+        "output_sha256": receipt["output"]["sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
+        "training_eligible": False,
+        "phase4_authorized": False,
+    }
+
+
+def test_existing_queue_rejects_output_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _receipt, fixture = _materialize(tmp_path, monkeypatch)
+    output = tmp_path / "private" / candidates.OUTPUT_FILENAME
+    payload = bytearray(output.read_bytes())
+    payload[len(payload) // 2] ^= 1
+    output.write_bytes(payload)
+
+    with pytest.raises(SpasLayoutCandidateError, match="SHA-256 drift"):
+        candidates.validate_existing_layout_candidates(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            adapter_output_dir=fixture["adapter_dir"],
+            mapping_evidence_path=fixture["mapping_evidence_path"],
+            private_output_dir=tmp_path / "private",
+        )
+
+
+def test_receipt_rejects_candidate_partition_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt, _fixture = _materialize(tmp_path, monkeypatch)
+    receipt["denominator"]["trigger_line_candidates"] += 1
+    body = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = candidates.sha256_value(body)
+
+    with pytest.raises(SpasLayoutCandidateError, match="classification partition drift"):
+        candidates._validate_receipt(receipt)
+
+
+def test_refuses_existing_or_git_checkout_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fixture = _fixture_inputs(tmp_path, monkeypatch)
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    with pytest.raises(SpasLayoutCandidateError, match="already exists"):
+        candidates.materialize_layout_candidates(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            adapter_output_dir=fixture["adapter_dir"],
+            mapping_evidence_path=fixture["mapping_evidence_path"],
+            private_output_dir=existing,
+        )
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").write_text("gitdir: fixture", encoding="utf-8")
+    with pytest.raises(SpasLayoutCandidateError, match="cannot be inside a Git checkout"):
+        candidates.materialize_layout_candidates(
+            pdf_path=tmp_path / "fixture.pdf",
+            raw_catalog_dir=fixture["raw_dir"],
+            adapter_output_dir=fixture["adapter_dir"],
+            mapping_evidence_path=fixture["mapping_evidence_path"],
+            private_output_dir=checkout / "private",
+        )


### PR DESCRIPTION
## Outcome

Adds a protected, complete-context review queue for separating historic inscription/transcription lines from Korniienko editorial prose. It binds pypdf native font identity to exact raw, normalized, record, and PDF-page offsets without treating any candidate as semantic gold.

## Frozen denominator

- 477 input/output records
- 302 records with Bukyvede spans; 175 without
- 883 font spans; 5,393 characters / 4,896 nonspace
- 637 lines with Bukyvede
- 101 historic-script-dominant candidates in 90 records
- 82 whole-word-text-cue trigger candidates in 81 records
- 19 unresolved candidates in 12 records
- 3 records contain both classes

## Safety boundary

All 101 lines still require qualified historical review. Inline/nondominant spans remain context-only. Commentary/transcription separation is not claimed complete; semantic gold, training admission, modern-correction use, and Phase 4 authorization remain false. This does not close the Lavra cave-graffiti gap. Private source/candidate text remains in Google Drive.

## Verification

- Ruff: pass
- 120 targeted/historical Phase 3 tests: pass
- live 477-record materialization + complete deterministic replay: pass
- independent Claude Sonnet 5 exact-head static review: PASS, no blocking findings

Stacked on #6667 (which is stacked on #6666). Issue: #6375