### PR TITLE
fix(fleet-comms): cold-start board inbox/backlog authority probes

### DIFF
--- a/scripts/fleet_comms/cold_start_board.py
+++ b/scripts/fleet_comms/cold_start_board.py
@@ -20,9 +20,15 @@ from pathlib import Path
 from typing import Any
 
 from scripts.fleet_comms.efficiency_metrics import (
+    _AUTHORITY_BACKLOG_STATES,
+    _column_names,
+    _table_exists,
     collect_dead_letters,
+    collect_dead_letters_authority,
     collect_delivery_backlog,
+    collect_delivery_backlog_authority,
     collect_stream_bottleneck_metrics,
+    resolve_metrics_source,
 )
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 
@@ -145,19 +151,41 @@ def _resolve_broker_db_ro(root: Path | None, repo_root: Path | None) -> Path:
 def _probe_backlog_and_dead_letters(
     root: Path | None, repo_root: Path | None
 ) -> dict[str, Any]:
-    db_path = _resolve_broker_db_ro(root, repo_root)
+    """Backlog + dead-letters; prefer authority tables when plane mode is authority."""
+    source = resolve_metrics_source()
+    plane_root = root if root is not None else default_plane_root(repo_root=repo_root)
 
-    if not db_path.is_file():
-        return {
-            "db_missing": True,
-            "db_path": str(db_path),
-            "backlog_total": 0,
-            "dead_letters_total": 0,
-        }
+    if source == "authority":
+        db_path = plane_root / "comms.sqlite3"
+        if not db_path.is_file():
+            return {
+                "source": source,
+                "db_missing": True,
+                "db_path": str(db_path),
+                "backlog_total": 0,
+                "dead_letters_total": 0,
+            }
+        backlog = collect_delivery_backlog_authority(
+            db_path, limit=5, exclude_retired=True
+        )
+        dead_letters = collect_dead_letters_authority(db_path, limit=5)
+        label = "authority"
+    else:
+        db_path = _resolve_broker_db_ro(root, repo_root)
+        if not db_path.is_file():
+            return {
+                "source": "legacy",
+                "db_missing": True,
+                "db_path": str(db_path),
+                "backlog_total": 0,
+                "dead_letters_total": 0,
+            }
+        backlog = collect_delivery_backlog(db_path, limit=5, exclude_retired=True)
+        dead_letters = collect_dead_letters(db_path, limit=5)
+        label = "legacy"
 
-    backlog = collect_delivery_backlog(db_path, limit=5, exclude_retired=True)
-    dead_letters = collect_dead_letters(db_path, limit=5)
     return {
+        "source": label,
         "db_path": str(db_path),
         "db_exists": True,
         "backlog_total": backlog.get("total", 0),
@@ -335,6 +363,248 @@ def _probe_session_streams_and_handoff(
         )
 
 
+def _inbox_agent_candidates(agent: str) -> list[str]:
+    """Exact agent first; cheap slash/hyphen base aliases as fallbacks."""
+    candidates = [agent]
+    if "/" in agent:
+        base = agent.split("/", 1)[0].strip()
+        if base and base not in candidates:
+            candidates.append(base)
+    if "-" in agent:
+        base = agent.split("-", 1)[0].strip()
+        if base and base not in candidates:
+            candidates.append(base)
+    return candidates
+
+
+def _probe_inbox_authority(
+    plane_db: Path,
+    agent: str,
+) -> dict[str, Any]:
+    """Body-free pending inbox rows from authority_deliveries (queued/running)."""
+    import sqlite3
+
+    if not plane_db.is_file():
+        return {
+            "source": "authority",
+            "agent": agent,
+            "inbox_pending_count": 0,
+            "db_missing": True,
+            "db_path": str(plane_db),
+            "recent_deliveries": [],
+        }
+
+    placeholders = ",".join("?" for _ in _AUTHORITY_BACKLOG_STATES)
+    matched_agent = agent
+    deliveries: list[dict[str, Any]] = []
+    total = 0
+
+    conn = sqlite3.connect(f"file:{plane_db.resolve().as_posix()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        if not _table_exists(conn, "authority_deliveries"):
+            return {
+                "source": "authority",
+                "agent": agent,
+                "inbox_pending_count": 0,
+                "db_path": str(plane_db),
+                "table_missing": True,
+                "recent_deliveries": [],
+            }
+        for candidate in _inbox_agent_candidates(agent):
+            count_row = conn.execute(
+                f"""
+                SELECT COUNT(*) AS cnt FROM authority_deliveries
+                WHERE recipient = ? AND state IN ({placeholders})
+                """,
+                (candidate, *_AUTHORITY_BACKLOG_STATES),
+            ).fetchone()
+            candidate_total = int(count_row["cnt"] if count_row else 0)
+            if candidate_total == 0:
+                continue
+            rows = conn.execute(
+                f"""
+                SELECT delivery_id, message_id, recipient, state,
+                       attempt_count, created_at, updated_at
+                FROM authority_deliveries
+                WHERE recipient = ? AND state IN ({placeholders})
+                ORDER BY COALESCE(updated_at, created_at, '') DESC
+                LIMIT 5
+                """,
+                (candidate, *_AUTHORITY_BACKLOG_STATES),
+            ).fetchall()
+            matched_agent = candidate
+            total = candidate_total
+            deliveries = [
+                {
+                    "delivery_id": r["delivery_id"],
+                    "message_id": r["message_id"],
+                    "recipient": r["recipient"],
+                    "to_agent": r["recipient"],
+                    "state": r["state"],
+                    "status": r["state"],
+                    "attempt_count": int(r["attempt_count"] or 0),
+                    "created_at": r["created_at"],
+                    "updated_at": r["updated_at"],
+                }
+                for r in rows
+            ]
+            break
+    finally:
+        conn.close()
+
+    return {
+        "source": "authority",
+        "agent": agent,
+        "matched_agent": matched_agent,
+        "inbox_pending_count": total,
+        "db_path": str(plane_db),
+        "recent_deliveries": deliveries,
+    }
+
+
+def _probe_inbox_legacy(db_path: Path, agent: str) -> dict[str, Any]:
+    """Body-free pending inbox from legacy broker deliveries (schema-tolerant)."""
+    import sqlite3
+
+    if not db_path.is_file():
+        return {
+            "source": "legacy",
+            "agent": agent,
+            "inbox_pending_count": 0,
+            "db_missing": True,
+            "db_path": str(db_path),
+            "recent_deliveries": [],
+        }
+
+    status_filter = ("pending", "dispatched", "processing")
+    status_placeholders = ",".join("?" for _ in status_filter)
+    matched_agent = agent
+    deliveries: list[dict[str, Any]] = []
+    total = 0
+
+    conn = sqlite3.connect(f"file:{db_path.resolve().as_posix()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        if not _table_exists(conn, "deliveries"):
+            return {
+                "source": "legacy",
+                "agent": agent,
+                "inbox_pending_count": 0,
+                "db_path": str(db_path),
+                "table_missing": True,
+                "recent_deliveries": [],
+            }
+        cols = _column_names(conn, "deliveries")
+        agent_col = "to_agent" if "to_agent" in cols else (
+            "recipient" if "recipient" in cols else None
+        )
+        if agent_col is None:
+            return {
+                "source": "legacy",
+                "agent": agent,
+                "inbox_pending_count": 0,
+                "db_path": str(db_path),
+                "schema_unsupported": True,
+                "recent_deliveries": [],
+            }
+        if "status" not in cols:
+            return {
+                "source": "legacy",
+                "agent": agent,
+                "inbox_pending_count": 0,
+                "db_path": str(db_path),
+                "schema_unsupported": True,
+                "recent_deliveries": [],
+            }
+
+        select_parts = [
+            c
+            for c in (
+                "delivery_id",
+                "message_id",
+                agent_col,
+                "status",
+                "attempt_count",
+                "dispatched_at",
+                "created_at",
+            )
+            if c in cols
+        ]
+        order_col = (
+            "dispatched_at"
+            if "dispatched_at" in cols
+            else ("created_at" if "created_at" in cols else select_parts[0])
+        )
+
+        join_sql = ""
+        extra_select: list[str] = []
+        if _table_exists(conn, "channel_messages") and "message_id" in cols:
+            cm_cols = _column_names(conn, "channel_messages")
+            join_sql = " LEFT JOIN channel_messages cm ON cm.message_id = d.message_id"
+            for alias, expr in (
+                ("channel", "cm.channel" if "channel" in cm_cols else None),
+                ("sender", "cm.from_agent" if "from_agent" in cm_cols else None),
+                ("kind", "cm.kind" if "kind" in cm_cols else None),
+                (
+                    "created_at",
+                    "cm.created_at"
+                    if "created_at" in cm_cols and "created_at" not in cols
+                    else None,
+                ),
+            ):
+                if expr is not None:
+                    extra_select.append(f"{expr} AS {alias}")
+
+        select_sql = ", ".join([f"d.{c}" for c in select_parts] + extra_select)
+
+        for candidate in _inbox_agent_candidates(agent):
+            count_row = conn.execute(
+                f"""
+                SELECT COUNT(*) AS cnt FROM deliveries
+                WHERE {agent_col} = ? AND status IN ({status_placeholders})
+                """,
+                (candidate, *status_filter),
+            ).fetchone()
+            candidate_total = int(count_row["cnt"] if count_row else 0)
+            if candidate_total == 0:
+                continue
+            rows = conn.execute(
+                f"""
+                SELECT {select_sql}
+                FROM deliveries d
+                {join_sql}
+                WHERE d.{agent_col} = ? AND d.status IN ({status_placeholders})
+                ORDER BY COALESCE(d.{order_col}, '') DESC
+                LIMIT 5
+                """,
+                (candidate, *status_filter),
+            ).fetchall()
+            matched_agent = candidate
+            total = candidate_total
+            deliveries = []
+            for r in rows:
+                row = dict(r)
+                # Normalize recipient alias without inventing bodies.
+                if "to_agent" not in row and agent_col in row:
+                    row["to_agent"] = row[agent_col]
+                if "recipient" not in row and agent_col in row:
+                    row["recipient"] = row[agent_col]
+                deliveries.append(row)
+            break
+    finally:
+        conn.close()
+
+    return {
+        "source": "legacy",
+        "agent": agent,
+        "matched_agent": matched_agent,
+        "inbox_pending_count": total,
+        "db_path": str(db_path),
+        "recent_deliveries": deliveries,
+    }
+
+
 def _probe_inbox(
     root: Path | None,
     repo_root: Path | None,
@@ -349,47 +619,22 @@ def _probe_inbox(
             data={"reason": "no_agent_specified"},
         )
 
-    db_path = _resolve_broker_db_ro(root, repo_root)
-    if not db_path.is_file():
-        elapsed = (time.perf_counter() - start) * 1000.0
-        return ProbeResult(
-            status="ok",
-            elapsed_ms=elapsed,
-            data={"agent": agent, "inbox_pending_count": 0, "db_missing": True},
-        )
-
     try:
-        import sqlite3
-
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-        conn.row_factory = sqlite3.Row
-        try:
-            rows = conn.execute(
-                """SELECT message_id, channel, sender, kind, created_at
-                   FROM deliveries
-                   WHERE recipient = ? AND status IN ('pending', 'dispatched')
-                   ORDER BY created_at DESC LIMIT 5""",
-                (agent,),
-            ).fetchall()
-            deliveries = [dict(r) for r in rows]
-            count_row = conn.execute(
-                "SELECT COUNT(*) as cnt FROM deliveries WHERE recipient = ? AND status IN ('pending', 'dispatched')",
-                (agent,),
-            ).fetchone()
-            total = count_row["cnt"] if count_row else len(deliveries)
-        finally:
-            conn.close()
+        source = resolve_metrics_source()
+        plane_root = root if root is not None else default_plane_root(repo_root=repo_root)
+        if source == "authority":
+            plane_db = plane_root / "comms.sqlite3"
+            if plane_db.is_file():
+                data = _probe_inbox_authority(plane_db, agent)
+            else:
+                # Authority preferred but plane DB missing → legacy fallback.
+                data = _probe_inbox_legacy(_resolve_broker_db_ro(root, repo_root), agent)
+                data["authority_db_missing"] = True
+        else:
+            data = _probe_inbox_legacy(_resolve_broker_db_ro(root, repo_root), agent)
 
         elapsed = (time.perf_counter() - start) * 1000.0
-        return ProbeResult(
-            status="ok",
-            elapsed_ms=elapsed,
-            data={
-                "agent": agent,
-                "inbox_pending_count": total,
-                "recent_deliveries": deliveries,
-            },
-        )
+        return ProbeResult(status="ok", elapsed_ms=elapsed, data=data)
     except Exception as exc:
         elapsed = (time.perf_counter() - start) * 1000.0
         return ProbeResult(

--- a/tests/fleet_comms/test_cold_start_board.py
+++ b/tests/fleet_comms/test_cold_start_board.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -11,11 +13,96 @@ from scripts.fleet_comms.cli import EXIT_OK
 from scripts.fleet_comms.cli import main as cli_main
 from scripts.fleet_comms.cold_start_board import (
     MAX_BOARD_BYTES,
+    _probe_backlog_and_dead_letters,
+    _probe_inbox,
     build_cold_start_board,
     cap_data,
     render_markdown_board,
     run_fail_open_probe,
 )
+
+
+def _seed_legacy_broker(db: Path) -> None:
+    """Real legacy broker schema: deliveries has no channel/recipient/sender/kind."""
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE channel_messages (
+          message_id TEXT PRIMARY KEY,
+          channel TEXT,
+          from_agent TEXT,
+          kind TEXT,
+          body TEXT,
+          created_at TEXT
+        );
+        CREATE TABLE deliveries (
+          delivery_id TEXT PRIMARY KEY,
+          message_id TEXT,
+          to_agent TEXT,
+          to_model TEXT,
+          status TEXT,
+          dispatched_at TEXT,
+          delivered_at TEXT,
+          attempt_count INTEGER DEFAULT 0
+        );
+        INSERT INTO channel_messages VALUES
+          ('m1','fleet','codex','task','SECRET_BODY_SHOULD_NOT_LEAK','2026-08-01T10:00:00Z'),
+          ('m2','fleet','claude','notice','also-secret','2026-08-01T11:00:00Z');
+        INSERT INTO deliveries VALUES
+          ('d1','m1','claude',NULL,'pending',NULL,NULL,0),
+          ('d2','m2','claude',NULL,'dispatched','2026-08-01T11:01:00Z',NULL,1),
+          ('d3','m2','codex',NULL,'delivered','2026-08-01T11:02:00Z','2026-08-01T11:03:00Z',1);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_authority_plane(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    plane_db = root / "comms.sqlite3"
+    conn = sqlite3.connect(plane_db)
+    conn.executescript(
+        """
+        CREATE TABLE authority_deliveries (
+          delivery_id TEXT PRIMARY KEY,
+          message_id TEXT NOT NULL,
+          recipient TEXT NOT NULL,
+          state TEXT NOT NULL,
+          deadline_at TEXT,
+          lease_owner TEXT,
+          lease_expires_at TEXT,
+          fence_token INTEGER NOT NULL DEFAULT 0,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          acknowledgment_artifact_id TEXT,
+          terminal_sha256 TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          completed_at TEXT
+        );
+        CREATE TABLE authority_dead_letters (
+          dead_letter_id TEXT PRIMARY KEY,
+          delivery_id TEXT UNIQUE,
+          job_id TEXT UNIQUE,
+          reason_code TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        );
+        INSERT INTO authority_deliveries VALUES
+          ('auth-d1','auth-m1','claude','queued',NULL,NULL,NULL,0,0,NULL,NULL,
+           '2026-08-01T12:00:00Z','2026-08-01T12:00:00Z',NULL),
+          ('auth-d2','auth-m2','claude','running',NULL,'worker',NULL,1,2,NULL,NULL,
+           '2026-08-01T12:01:00Z','2026-08-01T12:02:00Z',NULL),
+          ('auth-d3','auth-m3','codex','queued',NULL,NULL,NULL,0,0,NULL,NULL,
+           '2026-08-01T12:03:00Z','2026-08-01T12:03:00Z',NULL),
+          ('auth-d4','auth-m4','claude','acknowledged',NULL,NULL,NULL,0,1,NULL,'sha',
+           '2026-08-01T11:00:00Z','2026-08-01T11:05:00Z','2026-08-01T11:05:00Z');
+        INSERT INTO authority_dead_letters VALUES
+          ('auth-dl1','auth-d4',NULL,'attempts_exhausted','2026-08-01T11:06:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+    return plane_db
 
 
 def test_all_probes_board_structure():
@@ -168,3 +255,80 @@ def test_cli_cold_start_board_markdown(capsys):
     captured = capsys.readouterr()
     assert "# Driver Cold Start Board" in captured.out
     assert "epic:4707" in captured.out
+
+
+def test_probe_inbox_legacy_schema_ok(tmp_path: Path, monkeypatch) -> None:
+    """Legacy deliveries without channel/recipient columns must not degrade."""
+    broker = tmp_path / "messages.db"
+    _seed_legacy_broker(broker)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")
+    monkeypatch.setenv("AB_DB_PATH", str(broker))
+
+    result = _probe_inbox(root=None, repo_root=tmp_path, agent="claude")
+    assert result.status == "ok"
+    assert result.error is None
+    assert result.data["source"] == "legacy"
+    assert result.data["inbox_pending_count"] == 2
+    assert result.data["matched_agent"] == "claude"
+    recent = result.data["recent_deliveries"]
+    assert len(recent) == 2
+    assert {r["delivery_id"] for r in recent} == {"d1", "d2"}
+    blob = json.dumps(result.data)
+    assert "SECRET_BODY" not in blob
+    assert "also-secret" not in blob
+
+
+def test_probe_inbox_authority_counts_agent(tmp_path: Path, monkeypatch) -> None:
+    """Authority path counts queued/running rows for the exact recipient."""
+    plane_root = tmp_path / "plane"
+    _seed_authority_plane(plane_root)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+
+    result = _probe_inbox(root=plane_root, repo_root=tmp_path, agent="claude")
+    assert result.status == "ok"
+    assert result.error is None
+    assert result.data["source"] == "authority"
+    assert result.data["inbox_pending_count"] == 2
+    assert result.data["matched_agent"] == "claude"
+    states = {r["state"] for r in result.data["recent_deliveries"]}
+    assert states == {"queued", "running"}
+    assert all("body" not in r for r in result.data["recent_deliveries"])
+
+
+def test_probe_inbox_authority_hyphen_alias(tmp_path: Path, monkeypatch) -> None:
+    """Cheap hyphen base alias matches when exact recipient is absent."""
+    plane_root = tmp_path / "plane"
+    _seed_authority_plane(plane_root)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+
+    result = _probe_inbox(root=plane_root, repo_root=tmp_path, agent="claude-infra")
+    assert result.status == "ok"
+    assert result.data["inbox_pending_count"] == 2
+    assert result.data["matched_agent"] == "claude"
+
+
+def test_probe_backlog_labels_authority_source(tmp_path: Path, monkeypatch) -> None:
+    """Backlog probe uses authority collectors and labels source under authority mode."""
+    plane_root = tmp_path / "plane"
+    _seed_authority_plane(plane_root)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+
+    data = _probe_backlog_and_dead_letters(root=plane_root, repo_root=tmp_path)
+    assert data["source"] == "authority"
+    # exclude_retired keeps non-gemini; fixture has claude×2 + codex×1 = 3
+    assert data["backlog_total"] == 3
+    assert data["dead_letters_total"] == 1
+    assert "claude" in data["backlog_by_agent"]
+
+
+def test_probe_backlog_labels_legacy_source(tmp_path: Path, monkeypatch) -> None:
+    """Backlog probe falls back to broker DB and labels source=legacy when plane is off."""
+    broker = tmp_path / "messages.db"
+    _seed_legacy_broker(broker)
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")
+    monkeypatch.setenv("AB_DB_PATH", str(broker))
+
+    data = _probe_backlog_and_dead_letters(root=tmp_path / "missing-plane", repo_root=tmp_path)
+    assert data["source"] == "legacy"
+    assert data["backlog_total"] == 2
+    assert data["backlog_by_agent"].get("claude") == 2


### PR DESCRIPTION
## Summary
- Route `_probe_inbox` through `authority_deliveries` when plane mode is `authority` (queued/running), with schema-tolerant legacy `deliveries` + optional `channel_messages` join fallback.
- Mirror CLI WP-C in `_probe_backlog_and_dead_letters`: authority collectors against plane `comms.sqlite3`, labeled `"source": "authority"|"legacy"`.
- Residual post-#6159 cold-start board health: live board no longer degrades on `no such column: channel`. Related residual context only: #6106 Broker Ops retirement remains out of scope.

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/fleet_comms/test_cold_start_board.py -q`
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/fleet_comms/cold_start_board.py tests/fleet_comms/test_cold_start_board.py`
- [x] Live cold-start board under authority plane: inbox ok + backlog `source=authority`
- [ ] Independent cross-family review (driver-owned; no auto-merge)

## Evidence (#M-4)

### Unit tests
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/fleet_comms/test_cold_start_board.py -q
```
Quoted output:
```
collected 12 items
tests/fleet_comms/test_cold_start_board.py ............                  [100%]
============================== 12 passed in 7.62s ==============================
```

### Ruff
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/fleet_comms/cold_start_board.py tests/fleet_comms/test_cold_start_board.py
```
Quoted output:
```
All checks passed!
```

### Live plane mode
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -c "from scripts.fleet_comms.message_plane import resolve_plane_mode; print(resolve_plane_mode())"
```
Quoted output:
```
authority
```

### Live cold-start board (inbox + backlog)
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.fleet_comms cold-start-board --agent grok-infra
```
Quoted extracted fields:
```
inbox_status ok
inbox_error None
inbox_source authority
inbox_count 2
inbox_matched grok-infra
backlog_status ok
backlog_source authority
backlog_total 5
no_such_column False
```


Made with [Cursor](https://cursor.com)