### PR TITLE
fix(fleet-comms): cold-start tells live plane mode (stop false off/degraded)

### DIFF
--- a/docs/runbooks/driver-cold-start-board.md
+++ b/docs/runbooks/driver-cold-start-board.md
@@ -10,6 +10,8 @@ The **Driver Cold Start Board** provides a fail-open, read-only diagnostic brief
 
 The board operates strictly read-only: it **never** claims session leases, writes to databases, or posts to external APIs.
 
+Drivers should treat the markdown board as the **first** cold-start surface: live plane mode and `board_status` appear in the Summary before any probe dump. Injected drive-epic clauses must resolve live plane mode (never hardcode `mode=off` when live default is `authority`).
+
 ---
 
 ## CLI Usage
@@ -17,11 +19,11 @@ The board operates strictly read-only: it **never** claims session leases, write
 Run the cold start board using the `fleet_comms` CLI module:
 
 ```bash
+# First command for drivers: Markdown Summary + probes
+.venv/bin/python -m scripts.fleet_comms cold-start-board --format markdown
+
 # Default JSON briefing to stdout
 .venv/bin/python -m scripts.fleet_comms cold-start-board
-
-# Formatted Markdown briefing for agent context injection
-.venv/bin/python -m scripts.fleet_comms cold-start-board --format markdown
 
 # Scoped to specific stream, agent, and single-token search needle
 .venv/bin/python -m scripts.fleet_comms cold-start-board \
@@ -44,20 +46,38 @@ Run the cold start board using the `fleet_comms` CLI module:
 
 ---
 
+## Markdown Summary (first screen)
+
+Markdown output leads with a six-line **Summary** before the probe dump:
+
+1. `plane_mode` — live resolved mode (`resolve_plane_mode(None)` / plane-status)
+2. `schema_version` — applied (or known) message-plane schema version
+3. `inbox_pending` — pending/dispatched delivery count for the target agent
+4. `board_status` — headline `ok` or `degraded`
+5. `stream_id`
+6. `agent`
+
+---
+
 ## Diagnostic Probes & Fail-Open Contract
 
 The board executes 10 diagnostic probes. Each probe measures execution timing (`elapsed_ms`) and returns a fail-open status (`ok`, `degraded`, `error`, or `skipped`):
 
-1. **`capsule_session_env`**: Session env vars (`SESSION_STREAM_ID`, `SESSION_HANDOFF_AGENT`, `LU_AGENT_COMM_TRANSPORT`, `FLEET_COMMS_PLANE_MODE`, `CAPSULE_ID`, `SESSION_ID`, `TASK_ID`, `CORRELATION_ID`).
-2. **`plane_status`**: Fleet-comms message plane mode, schema version, and parity telemetry.
-3. **`backlog_and_dead_letters`**: Message delivery backlog and dead-letter inventory metadata.
+1. **`capsule_session_env`**: Session env vars plus **live** `plane_mode` from `resolve_plane_mode(None)` (env override still honored inside that helper; never hardcode `off`).
+2. **`plane_status`**: Fleet-comms message plane mode, schema version, and parity telemetry. **Load-bearing.**
+3. **`backlog_and_dead_letters`**: Message delivery backlog and dead-letter inventory metadata. **Load-bearing.**
 4. **`bottleneck_slice`**: Per-stream dispatch and lifecycle bottleneck metrics (uses fast local lookup without external network latency).
-5. **`orient_lean`**: Fast local query to Monitor API `/api/orient` (0.5s timeout) with fail-open fallback to local `git` branch and head commit SHA.
-6. **`issues_streams_membership`**: Top open issues and stream memberships.
-7. **`session_streams_and_handoff`**: Stream digest entries (pinned/recent) and read-only handoff diagnosis (`diagnose_handoff`).
-8. **`inbox_check`**: Pending message deliveries addressed to the target agent.
-9. **`gh_pr_list`**: Best-effort query via `gh pr list` (if `gh` CLI tool is present on `PATH`).
-10. **`needle_search`**: Single-token substring search across all collected probe data.
+5. **`orient_lean`**: Fast local query to Monitor API `/api/orient?lean=true` (0.5s timeout). On timeout/unreachable: status **`skipped`** with `reason=monitor_unreachable` and local `git` branch/head fallback — does **not** poison `board_status`.
+6. **`issues_streams_membership`**: Top open issues and stream memberships (from orient when reachable).
+7. **`session_streams_and_handoff`**: Stream digest entries (pinned/recent) and read-only handoff diagnosis (`diagnose_handoff`). DB path resolves via git common-dir / primary checkout `.agent/session-streams/v1/session-streams.sqlite3` (dispatch worktrees must not false-miss). Missing DB / no `stream_id` → `skipped`. **Load-bearing only when the DB exists and the probe degrades/errors.**
+8. **`inbox_check`**: Pending message deliveries addressed to the target agent. **Load-bearing.**
+9. **`gh_pr_list`**: Best-effort query via `gh pr list` (if `gh` CLI tool is present on `PATH`). Never flips the headline.
+10. **`needle_search`**: Single-token substring search across all collected probe data. Never flips the headline.
+
+### `board_status` rules
+
+- Headline is **`degraded`** only when a **load-bearing** probe is `degraded` or `error`: `plane_status`, `inbox_check`, `backlog_and_dead_letters`, and `session_streams_and_handoff` when `db_exists` and the probe raised.
+- `skipped` / `orient_lean` / `needle_search` / `gh_pr_list` (and other optional probes) must **not** flip the headline to DEGRADED.
 
 ### Size Capping & Safety Guarantees
 
@@ -65,6 +85,16 @@ The board executes 10 diagnostic probes. Each probe measures execution timing (`
 - **List Length Cap:** Data lists are capped at **5 items** (truncated with `{"_truncated": "N items omitted"}`).
 - **Overall Board Cap:** Total board output is strictly capped at **16KiB (16,384 bytes)**. Oversized payloads apply stricter truncation and append `"_board_truncated": true`.
 - **Zero Side-Effects:** Exit code is `0` whenever a board is emitted (even if degraded). No leases are claimed, no SQLite databases are mutated, and no HTTP `POST` requests are made.
+
+---
+
+## Injected drive-epic clause (launchers)
+
+`scripts/lib/fleet_comms_cold_start.sh` / `launcher_bind_drive_epic`:
+
+- Export `FLEET_COMMS_PLANE_MODE="${FLEET_COMMS_PLANE_MODE:-$(fleet_comms_resolve_plane_mode)}"` before building the clause.
+- `fleet_comms_cold_clause` resolves live mode when the env var is unset/empty (same as the banner). Never default the injected sentence to `off` when live mode is `authority`.
+- Plane-mode resolve uses the checkout `.venv` or the primary interpreter via `git rev-parse --git-common-dir` so sparse dispatch worktrees still tell the truth.
 
 ---
 
@@ -97,5 +127,5 @@ When drivers record or consume entire-context handoffs during session transition
 To run the suite of unit tests for the cold start board:
 
 ```bash
-.venv/bin/pytest tests/fleet_comms/test_cold_start_board.py
+.venv/bin/pytest tests/fleet_comms/test_cold_start_board.py tests/test_fleet_comms_launcher_awareness.py
 ```

--- a/scripts/fleet_comms/cold_start_board.py
+++ b/scripts/fleet_comms/cold_start_board.py
@@ -30,10 +30,17 @@ from scripts.fleet_comms.efficiency_metrics import (
     collect_stream_bottleneck_metrics,
     resolve_metrics_source,
 )
-from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
+from scripts.fleet_comms.message_plane import (
+    default_plane_root,
+    read_plane_status,
+    resolve_plane_mode,
+)
 
 try:
-    from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+    from agents_extensions.shared.session_streams.db import (
+        SessionStreamDatabase,
+        default_database_path,
+    )
     from agents_extensions.shared.session_streams.handoff import diagnose_handoff
     from agents_extensions.shared.session_streams.model import entry_as_dict
     from agents_extensions.shared.session_streams.store import SessionStreamStore
@@ -41,10 +48,22 @@ try:
     HAS_SESSION_STREAMS = True
 except ImportError:
     HAS_SESSION_STREAMS = False
+    default_database_path = None  # type: ignore[assignment]
 
 MAX_STRING_LEN = 200
 MAX_LIST_LEN = 5
 MAX_BOARD_BYTES = 16384  # 16KiB
+
+# Probes that may flip board_status to degraded. Optional/best-effort probes
+# (orient_lean, gh_pr_list, needle_search, bottleneck_slice, …) must not.
+LOAD_BEARING_PROBES = frozenset(
+    {
+        "plane_status",
+        "inbox_check",
+        "backlog_and_dead_letters",
+    }
+)
+SESSION_STREAMS_REL = Path(".agent/session-streams/v1/session-streams.sqlite3")
 
 
 @dataclass
@@ -118,11 +137,16 @@ def _probe_capsule_session_env(
         or os.environ.get("AGENT")
         or os.environ.get("X_AGENT")
     )
+    try:
+        plane_mode: str = resolve_plane_mode(None)
+    except Exception:
+        # Fail-open: never crash the board on a bad env/config value.
+        plane_mode = "off"
     return {
         "stream_id": resolved_stream,
         "agent": resolved_agent,
         "transport": os.environ.get("LU_AGENT_COMM_TRANSPORT", "acp"),
-        "plane_mode": os.environ.get("FLEET_COMMS_PLANE_MODE", "off"),
+        "plane_mode": plane_mode,
         "capsule_id": os.environ.get("CAPSULE_ID"),
         "session_id": os.environ.get("SESSION_ID"),
         "task_id": os.environ.get("TASK_ID"),
@@ -253,7 +277,8 @@ def _probe_orient_lean(
     timeout_s: float = 0.5,
 ) -> ProbeResult:
     start = time.perf_counter()
-    url = f"{base_url}/api/orient"
+    # drive-epic contract: lean orient (do not pull the full briefing).
+    url = f"{base_url}/api/orient?lean=true"
     try:
         req = urllib.request.Request(
             url, headers={"User-Agent": "fleet-comms-cold-start/1.0"}
@@ -269,11 +294,16 @@ def _probe_orient_lean(
     except Exception as exc:
         elapsed = (time.perf_counter() - start) * 1000.0
         git_info = _get_local_git_info()
+        # Optional Monitor probe: skip (do not poison board_status).
         return ProbeResult(
-            status="degraded",
+            status="skipped",
             elapsed_ms=elapsed,
             error=f"monitor_api_unreachable: {type(exc).__name__}",
-            data={"api_reachable": False, "git_fallback": git_info},
+            data={
+                "api_reachable": False,
+                "reason": "monitor_unreachable",
+                "git_fallback": git_info,
+            },
         )
 
 
@@ -296,6 +326,34 @@ def _probe_issues_streams_membership(orient_result: ProbeResult) -> dict[str, An
     }
 
 
+def _resolve_session_streams_db(repo_root: Path | None) -> Path:
+    """Resolve primary-checkout session-streams DB (not worktree-local Path.cwd())."""
+    if HAS_SESSION_STREAMS and default_database_path is not None:
+        try:
+            return default_database_path(repo_root)
+        except Exception:
+            pass
+
+    active = (repo_root or Path.cwd()).resolve()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=active,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        common_dir_text = result.stdout.strip()
+        if result.returncode == 0 and common_dir_text:
+            common_dir = Path(common_dir_text)
+            if common_dir.is_absolute() and common_dir.name == ".git":
+                return common_dir.parent.resolve() / SESSION_STREAMS_REL
+    except Exception:
+        pass
+    return active / SESSION_STREAMS_REL
+
+
 def _probe_session_streams_and_handoff(
     repo_root: Path | None,
     stream_id: str | None,
@@ -312,23 +370,23 @@ def _probe_session_streams_and_handoff(
     if not HAS_SESSION_STREAMS:
         elapsed = (time.perf_counter() - start) * 1000.0
         return ProbeResult(
-            status="degraded",
+            status="skipped",
             elapsed_ms=elapsed,
             error="session_streams_module_unavailable",
-            data={"stream_id": stream_id},
+            data={"stream_id": stream_id, "reason": "module_unavailable"},
         )
 
-    r_root = repo_root or Path.cwd()
-    db_path = r_root / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    db_path = _resolve_session_streams_db(repo_root)
     if not db_path.is_file():
         elapsed = (time.perf_counter() - start) * 1000.0
         return ProbeResult(
-            status="degraded",
+            status="skipped",
             elapsed_ms=elapsed,
             data={
                 "stream_id": stream_id,
                 "db_exists": False,
                 "db_path": str(db_path),
+                "reason": "session_streams_db_missing",
             },
         )
 
@@ -349,6 +407,7 @@ def _probe_session_streams_and_handoff(
             data={
                 "stream_id": stream_id,
                 "db_exists": True,
+                "db_path": str(db_path),
                 "handoff": handoff_data,
                 "digest": digest_data,
             },
@@ -359,7 +418,7 @@ def _probe_session_streams_and_handoff(
             status="degraded",
             elapsed_ms=elapsed,
             error=str(exc),
-            data={"stream_id": stream_id, "db_exists": True},
+            data={"stream_id": stream_id, "db_exists": True, "db_path": str(db_path)},
         )
 
 
@@ -740,6 +799,26 @@ def _probe_needle_search(
     )
 
 
+def compute_board_status(probes: dict[str, Any]) -> str:
+    """Headline status from load-bearing probes only.
+
+    Optional probes (orient_lean, gh_pr_list, needle_search, …) never flip the
+    headline. session_streams_and_handoff is load-bearing only when the DB exists
+    and the probe degraded/errored (missing DB / no stream_id stay skipped).
+    """
+    for name in LOAD_BEARING_PROBES:
+        status = (probes.get(name) or {}).get("status")
+        if status in {"degraded", "error"}:
+            return "degraded"
+
+    ss = probes.get("session_streams_and_handoff") or {}
+    if ss.get("status") in {"degraded", "error"}:
+        data = ss.get("data") or {}
+        if data.get("db_exists"):
+            return "degraded"
+    return "ok"
+
+
 def build_cold_start_board(
     stream_id: str | None = None,
     agent: str | None = None,
@@ -813,10 +892,7 @@ def build_cold_start_board(
     )
     probes["needle_search"] = needle_probe.to_dict()
 
-    statuses = [p["status"] for p in probes.values()]
-    board_status = (
-        "degraded" if ("error" in statuses or "degraded" in statuses) else "ok"
-    )
+    board_status = compute_board_status(probes)
 
     capped_probes = cap_data(probes, max_str=MAX_STRING_LEN, max_list=MAX_LIST_LEN)
 
@@ -838,19 +914,57 @@ def build_cold_start_board(
     return board
 
 
+def _summary_fields(board_data: dict[str, Any]) -> dict[str, str]:
+    """Extract the six lead Summary fields drivers see first."""
+    probes = board_data.get("probes") or {}
+    plane_data = (probes.get("plane_status") or {}).get("data") or {}
+    env_data = (probes.get("capsule_session_env") or {}).get("data") or {}
+    inbox_data = (probes.get("inbox_check") or {}).get("data") or {}
+
+    plane_mode = plane_data.get("mode") or env_data.get("plane_mode") or "unknown"
+    schema = plane_data.get("schema") or {}
+    schema_version: Any
+    if isinstance(schema, dict):
+        schema_version = schema.get("applied_version")
+        if schema_version is None:
+            schema_version = schema.get("known_version")
+        if schema_version is None:
+            schema_version = schema.get("version")
+    else:
+        schema_version = schema
+    if schema_version is None:
+        schema_version = "unknown"
+
+    inbox_pending = inbox_data.get("inbox_pending_count")
+    if inbox_pending is None:
+        inbox_pending = "n/a"
+
+    return {
+        "plane_mode": str(plane_mode),
+        "schema_version": str(schema_version),
+        "inbox_pending": str(inbox_pending),
+        "board_status": str(board_data.get("board_status", "unknown")),
+        "stream_id": str(board_data.get("stream_id") or "N/A"),
+        "agent": str(board_data.get("agent") or "N/A"),
+    }
+
+
 def render_markdown_board(board_data: dict[str, Any]) -> str:
     """Render board data dictionary as a readable Markdown briefing."""
     lines: list[str] = []
-    status = str(board_data.get("board_status", "unknown")).upper()
-    stream_id = board_data.get("stream_id") or "N/A"
-    agent = board_data.get("agent") or "N/A"
+    summary = _summary_fields(board_data)
     ts = board_data.get("timestamp") or "N/A"
 
     lines.append("# Driver Cold Start Board\n")
-    lines.append(f"- **Status:** `{status}`")
+    lines.append("## Summary\n")
+    lines.append(f"- **plane_mode:** `{summary['plane_mode']}`")
+    lines.append(f"- **schema_version:** `{summary['schema_version']}`")
+    lines.append(f"- **inbox_pending:** `{summary['inbox_pending']}`")
+    lines.append(f"- **board_status:** `{summary['board_status']}`")
+    lines.append(f"- **stream_id:** `{summary['stream_id']}`")
+    lines.append(f"- **agent:** `{summary['agent']}`")
+    lines.append("")
     lines.append(f"- **Timestamp:** `{ts}`")
-    lines.append(f"- **Stream ID:** `{stream_id}`")
-    lines.append(f"- **Agent:** `{agent}`")
 
     needle = board_data.get("needle")
     if needle:

--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -21,16 +21,39 @@ fleet_comms_rule_relpath() {
   printf '%s' "agents_extensions/shared/rules/fleet-comms-coordination.md"
 }
 
+# Resolve the project interpreter (checkout .venv, else primary via git common-dir).
+fleet_comms_resolve_python() {
+  local root="${1:-${PROJECT_DIR:-${LC_ROOT:-.}}}"
+  local git_common=""
+  if [ -x "$root/.venv/bin/python" ]; then
+    printf '%s' "$root/.venv/bin/python"
+    return 0
+  fi
+  git_common="$(
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR \
+      git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true
+  )"
+  if [ -n "$git_common" ] && [ -x "$(dirname "$git_common")/.venv/bin/python" ]; then
+    printf '%s' "$(dirname "$git_common")/.venv/bin/python"
+    return 0
+  fi
+  return 1
+}
+
 # Resolve plane mode once (fail-open → off).
 fleet_comms_resolve_plane_mode() {
   local mode="off"
-  local root="${PROJECT_DIR:-.}"
-  if [ -x "$root/.venv/bin/python" ] \
-      && [ -f "$root/scripts/fleet_comms/message_plane.py" ]; then
+  local root="${PROJECT_DIR:-${LC_ROOT:-.}}"
+  local py=""
+  if [ -f "$root/scripts/fleet_comms/message_plane.py" ] \
+      && py="$(fleet_comms_resolve_python "$root")"; then
     mode="$(
-      "$root/.venv/bin/python" -c \
-        'from scripts.fleet_comms.message_plane import resolve_plane_mode; print(resolve_plane_mode(None))' \
-        2>/dev/null || true
+      (
+        cd "$root" || exit 0
+        "$py" -c \
+          'from scripts.fleet_comms.message_plane import resolve_plane_mode; print(resolve_plane_mode(None))' \
+          2>/dev/null || true
+      )
     )"
     case "${mode}" in
       off|shadow|dual_write|authority) ;;
@@ -42,7 +65,10 @@ fleet_comms_resolve_plane_mode() {
 
 # Compact authority-aware clause for injected cold-start prompts.
 fleet_comms_cold_clause() {
-  local plane_mode="${FLEET_COMMS_PLANE_MODE:-off}"
+  local plane_mode="${FLEET_COMMS_PLANE_MODE:-}"
+  if [ -z "$plane_mode" ]; then
+    plane_mode="$(fleet_comms_resolve_plane_mode)"
+  fi
   local rule
   rule="$(fleet_comms_rule_relpath)"
   printf '%s' \

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -492,6 +492,10 @@ launcher_bind_drive_epic() {
     # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
     source "$LC_ROOT/scripts/lib/fleet_comms_cold_start.sh"
   fi
+  if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+    # shellcheck disable=SC2155  # export of resolved plane mode is intentional
+    export FLEET_COMMS_PLANE_MODE="${FLEET_COMMS_PLANE_MODE:-$(fleet_comms_resolve_plane_mode)}"
+  fi
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     fleet_clause="$(fleet_comms_cold_clause)"
   else

--- a/tests/fleet_comms/test_cold_start_board.py
+++ b/tests/fleet_comms/test_cold_start_board.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,10 +13,12 @@ from scripts.fleet_comms.cli import EXIT_OK
 from scripts.fleet_comms.cli import main as cli_main
 from scripts.fleet_comms.cold_start_board import (
     MAX_BOARD_BYTES,
+    ProbeResult,
     _probe_backlog_and_dead_letters,
     _probe_inbox,
     build_cold_start_board,
     cap_data,
+    compute_board_status,
     render_markdown_board,
     run_fail_open_probe,
 )
@@ -208,8 +210,139 @@ def test_no_claim_or_write_calls(monkeypatch):
     assert board["board_status"] in {"ok", "degraded"}
 
 
+def test_capsule_reports_live_plane_mode(monkeypatch):
+    """capsule_session_env uses resolve_plane_mode(None), not a hardcoded off default."""
+    monkeypatch.delenv("FLEET_COMMS_PLANE_MODE", raising=False)
+    monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
+
+    with patch(
+        "scripts.fleet_comms.cold_start_board.resolve_plane_mode",
+        return_value="authority",
+    ) as resolve:
+        board = build_cold_start_board(agent="grok-infra")
+        resolve.assert_called()
+        assert board["probes"]["capsule_session_env"]["data"]["plane_mode"] == "authority"
+
+
+def test_orient_timeout_skipped_does_not_degrade_board():
+    """Monitor timeout → orient_lean skipped; board_status stays ok if load-bearing ok."""
+    ok_payload = {"mode": "authority", "schema": {"applied_version": 7}}
+
+    with (
+        patch(
+            "scripts.fleet_comms.cold_start_board.urllib.request.urlopen",
+            side_effect=TimeoutError("monitor slow"),
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_plane_status",
+            return_value=ok_payload,
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_backlog_and_dead_letters",
+            return_value={"backlog_total": 0, "dead_letters_total": 0},
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_inbox",
+            return_value=ProbeResult(
+                status="ok",
+                elapsed_ms=1.0,
+                data={"agent": "grok-infra", "inbox_pending_count": 0},
+            ),
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_gh_pr_list",
+            return_value=ProbeResult(
+                status="degraded",
+                elapsed_ms=1.0,
+                error="gh flaky",
+                data={"gh_available": True, "prs": []},
+            ),
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_session_streams_and_handoff",
+            return_value=ProbeResult(
+                status="skipped",
+                elapsed_ms=1.0,
+                data={"reason": "no_stream_id_provided"},
+            ),
+        ),
+        patch(
+            "scripts.fleet_comms.cold_start_board._probe_bottleneck_slice",
+            return_value={"total_streams": 0, "slice": {}},
+        ),
+    ):
+        board = build_cold_start_board(agent="grok-infra")
+
+    orient = board["probes"]["orient_lean"]
+    assert orient["status"] == "skipped"
+    assert orient["data"]["reason"] == "monitor_unreachable"
+    assert "git_fallback" in orient["data"]
+    assert board["board_status"] == "ok"
+    assert board["probes"]["gh_pr_list"]["status"] == "degraded"
+
+
+def test_compute_board_status_load_bearing_only():
+    probes = {
+        "plane_status": {"status": "ok"},
+        "inbox_check": {"status": "ok"},
+        "backlog_and_dead_letters": {"status": "ok"},
+        "session_streams_and_handoff": {
+            "status": "skipped",
+            "data": {"db_exists": False},
+        },
+        "orient_lean": {"status": "skipped"},
+        "gh_pr_list": {"status": "degraded"},
+        "needle_search": {"status": "error"},
+    }
+    assert compute_board_status(probes) == "ok"
+
+    probes["session_streams_and_handoff"] = {
+        "status": "degraded",
+        "data": {"db_exists": True},
+    }
+    assert compute_board_status(probes) == "degraded"
+
+    probes["session_streams_and_handoff"] = {
+        "status": "degraded",
+        "data": {"db_exists": False},
+    }
+    probes["inbox_check"] = {"status": "ok"}
+    assert compute_board_status(probes) == "ok"
+
+    probes["inbox_check"] = {"status": "degraded"}
+    assert compute_board_status(probes) == "degraded"
+
+
+def test_session_streams_db_uses_primary_checkout(tmp_path: Path):
+    """Dispatch worktree cwd must not make session-streams look missing."""
+    from scripts.fleet_comms import cold_start_board as board_mod
+
+    primary = tmp_path / "primary"
+    worktree = tmp_path / "worktree"
+    primary.mkdir()
+    worktree.mkdir()
+    db = primary / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"")
+
+    git_common = primary / ".git"
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = str(git_common) + "\n"
+    completed.stderr = ""
+
+    with (
+        patch.object(board_mod, "HAS_SESSION_STREAMS", False),
+        patch.object(board_mod, "default_database_path", None),
+        patch("scripts.fleet_comms.cold_start_board.subprocess.run", return_value=completed),
+    ):
+        resolved = board_mod._resolve_session_streams_db(worktree)
+    assert resolved == db
+    assert resolved.is_file()
+
+
 def test_markdown_path():
-    """Verify markdown output path renders structured briefing."""
+    """Verify markdown output path renders Summary then probe dump."""
     board = build_cold_start_board(
         stream_id="epic:4707",
         agent="agy/cold-start-pr2-board",
@@ -218,10 +351,16 @@ def test_markdown_path():
     md = render_markdown_board(board)
 
     assert "# Driver Cold Start Board" in md
-    assert "- **Stream ID:** `epic:4707`" in md
-    assert "- **Agent:** `agy/cold-start-pr2-board`" in md
+    assert "## Summary" in md
+    assert "- **plane_mode:**" in md
+    assert "- **schema_version:**" in md
+    assert "- **inbox_pending:**" in md
+    assert "- **board_status:**" in md
+    assert "- **stream_id:** `epic:4707`" in md
+    assert "- **agent:** `agy/cold-start-pr2-board`" in md
     assert "## Diagnostic Probes" in md
     assert "### `capsule_session_env`" in md
+    assert md.index("## Summary") < md.index("## Diagnostic Probes")
     assert len(md.encode("utf-8")) <= MAX_BOARD_BYTES
 
 
@@ -254,6 +393,7 @@ def test_cli_cold_start_board_markdown(capsys):
 
     captured = capsys.readouterr()
     assert "# Driver Cold Start Board" in captured.out
+    assert "## Summary" in captured.out
     assert "epic:4707" in captured.out
 
 
@@ -332,3 +472,22 @@ def test_probe_backlog_labels_legacy_source(tmp_path: Path, monkeypatch) -> None
     assert data["source"] == "legacy"
     assert data["backlog_total"] == 2
     assert data["backlog_by_agent"].get("claude") == 2
+
+
+def test_orient_lean_requests_lean_true():
+    """orient probe must hit /api/orient?lean=true (drive-epic contract)."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b'{"ok": true}'
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
+
+    with patch(
+        "scripts.fleet_comms.cold_start_board.urllib.request.urlopen",
+        return_value=mock_resp,
+    ) as urlopen:
+        from scripts.fleet_comms.cold_start_board import _probe_orient_lean
+
+        result = _probe_orient_lean()
+        assert result.status == "ok"
+        req = urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/orient?lean=true")

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -64,6 +66,10 @@ def test_prompt_injecting_launchers_include_plane_and_cf_surfaces() -> None:
     assert "fleet_comms_cold_clause" in text or "plane-status" in text
     assert "fleet-comms" in text
     assert 'source "$LC_ROOT/scripts/lib/fleet_comms_cold_start.sh"' in text
+    assert (
+        'FLEET_COMMS_PLANE_MODE="${FLEET_COMMS_PLANE_MODE:-$(fleet_comms_resolve_plane_mode)}"'
+        in text
+    )
 
 
 def test_shared_launcher_clause_onboards_authority_and_acp_layers() -> None:
@@ -121,3 +127,64 @@ def test_driver_wrappers_use_the_shared_core() -> None:
         assert "launcher_core.sh" in text
     core = (REPO / "scripts/lib/launcher_core.sh").read_text(encoding="utf-8")
     assert "drive-epic" in core
+
+
+def test_cold_clause_resolves_live_mode_when_env_unset() -> None:
+    """Unset FLEET_COMMS_PLANE_MODE must not hardcode mode=off when live is authority."""
+    env = os.environ.copy()
+    env.pop("FLEET_COMMS_PLANE_MODE", None)
+    env.pop("FLEET_COMMS_MESSAGE_PLANE", None)
+    env["PROJECT_DIR"] = str(REPO)
+    env["LC_ROOT"] = str(REPO)
+
+    script = f"""
+set -euo pipefail
+source "{HELPER}"
+resolved="$(fleet_comms_resolve_plane_mode)"
+clause="$(fleet_comms_cold_clause)"
+printf 'resolved=%s\\n' "$resolved"
+printf 'clause=%s\\n' "$clause"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+    assert "resolved=authority" in out or "resolved=dual_write" in out or "resolved=shadow" in out
+    # When resolve returns authority, clause must carry it (not a hardcoded off).
+    if "resolved=authority" in out:
+        assert "mode=authority" in out
+        assert "current mode=off" not in out
+
+
+def test_cold_clause_does_not_force_off_when_resolve_returns_authority() -> None:
+    """Helper must call resolve when env empty; mock authority must appear in clause."""
+    env = os.environ.copy()
+    env.pop("FLEET_COMMS_PLANE_MODE", None)
+    env["PROJECT_DIR"] = str(REPO)
+
+    script = f"""
+set -euo pipefail
+source "{HELPER}"
+fleet_comms_resolve_plane_mode() {{ printf '%s' 'authority'; }}
+clause="$(fleet_comms_cold_clause)"
+printf '%s\\n' "$clause"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "mode=authority" in proc.stdout
+    assert "current mode=off" not in proc.stdout


### PR DESCRIPTION
## Summary
- Follow-up to a live grok-infra cold-start failure: injected drive-epic clause said `mode=off` while live `plane-status` is `authority` (schema v7), so the driver treated the plane as off and chased a closed cutover with a false DEGRADED board.
- Resolve live plane mode in `fleet_comms_cold_clause` / `launcher_bind_drive_epic` (export + no hardcoded `off`); capsule probe uses `resolve_plane_mode(None)`; optional Monitor `/api/orient?lean=true` timeouts become `skipped` and no longer poison `board_status`.
- Markdown board leads with a 6-line Summary (plane mode, schema, inbox, board_status, stream, agent); session-streams DB resolves via primary checkout / git common-dir so dispatch worktrees do not false-miss.

## Test plan
- [x] `pytest tests/test_fleet_comms_launcher_awareness.py tests/fleet_comms/test_cold_start_board.py -q`
- [x] `ruff check` on changed Python files
- [x] Unset `FLEET_COMMS_PLANE_MODE`; `fleet_comms_cold_clause` contains `mode=authority`
- [x] `cold-start-board --agent grok-infra --format markdown` Summary shows `plane_mode: authority`, `board_status: ok`
- [ ] CI green; independent cross-family review before merge (no auto-merge)

Related: does not duplicate inbox/authority probe work in #6673.


Made with [Cursor](https://cursor.com)