### PR TITLE
fix(launchers): stop pinning Grok model and effort by default

### DIFF
--- a/scripts/launchers/grok.sh
+++ b/scripts/launchers/grok.sh
@@ -7,7 +7,15 @@ launcher_adapter_canary() {
   return 0
 }
 launcher_adapter_exec() {
-  local cmd=(grok --model "$LC_MODEL")
+  local cmd=(grok)
+  # Only pin --model / --reasoning-effort when the caller asked for them;
+  # otherwise the Grok TUI keeps whatever was selected last in the session.
+  if [ -n "${LC_MODEL:-}" ]; then
+    cmd+=(--model "$LC_MODEL")
+  fi
+  if [ -n "${LC_EFFORT:-}" ]; then
+    cmd+=(--reasoning-effort "$LC_EFFORT")
+  fi
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
   launcher_exec_command "${cmd[@]}"

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -49,9 +49,10 @@ $driver_mode
 
 Options:
   -h, --help                 Show this help and exit.
-  --model MODEL              Provider model. Claude: omit to keep last TUI/session model.
-  --effort LEVEL             Claude Code effort for this session (e.g. high, xhigh).
-                             Omit to keep last session effort. Other providers ignore.
+  --model MODEL              Provider model. Claude/Grok: omit to keep last TUI/session model.
+  --effort LEVEL             Session effort when supported (Claude Code --effort; Grok
+                             --reasoning-effort). Omit to keep last session selection.
+                             Other providers ignore.
   --harness HARNESS          Provider harness (default: ${LC_HARNESS}).
   --epic SELECTOR            Driver lane only; for example: devops or atlas.
   --governor SELECTOR        Codex driver only; one lease-free Sol cycle (AUTO allowed).
@@ -62,9 +63,9 @@ Options:
 
 Environment:
   LAUNCHER_DRY_RUN=1         Validate the route and print a redacted exact would-exec argv.
-  LAUNCHER_MODEL             Default model when --model is omitted (empty for Claude =
+  LAUNCHER_MODEL             Default model when --model is omitted (empty for Claude/Grok =
                              last session).
-  LAUNCHER_EFFORT            Default Claude effort when --effort is omitted (empty =
+  LAUNCHER_EFFORT            Default effort when --effort is omitted (empty for Claude/Grok =
                              last session).
   LAUNCHER_HARNESS           Default harness when --harness is omitted.
 $provider_env
@@ -154,7 +155,10 @@ launcher_defaults() {
       LC_HARNESS="${LAUNCHER_HARNESS:-agy}"
       ;;
     grok)
-      LC_MODEL="${LAUNCHER_MODEL:-grok-4.5}"
+      # Both interactive and driver leave model/effort alone unless the caller
+      # sets --model / --effort or LAUNCHER_MODEL / LAUNCHER_EFFORT. Empty means
+      # the Grok TUI keeps the last session selection.
+      LC_MODEL="${LAUNCHER_MODEL:-}"
       LC_HARNESS="${LAUNCHER_HARNESS:-grok}"
       ;;
     kimi)
@@ -354,8 +358,8 @@ launcher_validate_mode() {
 launcher_validate_driver_certification() {
   [ "$LC_MODE" = "driver" ] || return 0
   [ "$LC_GOVERNOR" = "0" ] || return 0
-  # Claude may omit --model so the TUI keeps the last session selection.
-  if [ "$LC_PROVIDER" = "claude" ] && [ -z "${LC_MODEL:-}" ]; then
+  # Claude/Grok may omit --model so the TUI keeps the last session selection.
+  if { [ "$LC_PROVIDER" = "claude" ] || [ "$LC_PROVIDER" = "grok" ]; } && [ -z "${LC_MODEL:-}" ]; then
     return 0
   fi
   case "$LC_PROVIDER:$LC_MODEL" in

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -11,18 +11,40 @@ def test_grok_interactive_defaults_to_native_harness_and_rejects_epic() -> None:
     interactive = run_launcher("start-grok.sh")
     epic = run_launcher("start-grok.sh", "--epic", "atlas")
     assert interactive.returncode == 0, interactive.stderr
-    assert "would exec grok --model grok-4.5" in interactive.stdout
+    assert "would exec grok" in interactive.stdout
+    assert "--model grok-4.5" not in interactive.stdout
+    assert "--model" not in interactive.stdout
+    assert "--reasoning-effort" not in interactive.stdout
+    assert "--effort" not in interactive.stdout
     assert epic.returncode == 2
     assert "interactive launchers reject --epic" in epic.stderr
 
 
-@pytest.mark.parametrize("selector", ("atlas", "practice", "infra.devops", "seminars-folk"))
+def test_grok_explicit_model_still_pins() -> None:
+    result = run_launcher("start-grok.sh", "--model", "grok-4.5")
+    assert result.returncode == 0, result.stderr
+    assert "--model grok-4.5" in result.stdout
+
+
+def test_grok_effort_injects_reasoning_effort_only_when_set() -> None:
+    with_effort = run_launcher("start-grok.sh", "--effort", "high")
+    without = run_launcher("start-grok.sh")
+    assert with_effort.returncode == 0, with_effort.stderr
+    assert "--reasoning-effort high" in with_effort.stdout
+    assert without.returncode == 0, without.stderr
+    assert "--reasoning-effort" not in without.stdout
+    assert "--effort" not in without.stdout
+
+
+@pytest.mark.parametrize("selector", ("atlas", "practice", "infra.devops", "seminars-folk", "infra"))
 def test_grok_driver_claims_a_lease_for_supported_selectors(selector: str) -> None:
     result = run_launcher("start-grok-driver.sh", "--epic", selector)
     assert result.returncode == 0, result.stderr
     assert "would claim lease" in result.stdout
     assert "would run provider canary" in result.stdout
     assert "would bind drive-epic" in result.stdout
+    assert "--model grok-4.5" not in result.stdout
+    assert "--model" not in result.stdout
 
 
 def test_grok_driver_rejects_uncertified_model_and_non_grok_harness() -> None:


### PR DESCRIPTION
## Summary
- Grok interactive/driver launchers no longer stick `--model grok-4.5`; empty model/effort keeps the last Grok TUI session selection (same contract as Claude).
- Adapter injects `--model` / `--reasoning-effort` only when the caller (or `LAUNCHER_MODEL` / `LAUNCHER_EFFORT`) sets them; driver certification skips the pin check when model is empty.
- Catalog still certifies only `grok:grok-4.5` (no inventing `grok-4.6`); uncertified models still exit 4.

## Proof (dry-run argv)

```text
$ LAUNCHER_DRY_RUN=1 ./start-grok.sh
would exec grok

$ LAUNCHER_DRY_RUN=1 ./start-grok-driver.sh --epic infra
would claim lease … / would run provider canary / would bind drive-epic
would exec grok <drive-epic binding prompt…>
# no --model, no --effort / --reasoning-effort

$ LAUNCHER_DRY_RUN=1 ./start-grok.sh --model grok-4.5
would exec grok --model grok-4.5

$ LAUNCHER_DRY_RUN=1 ./start-grok.sh --effort high
would exec grok --reasoning-effort high

$ LAUNCHER_DRY_RUN=1 ./start-grok-driver.sh --epic devops --model grok-unknown
exit 4
```

## Test plan
- [x] `pytest tests/test_start_grok_launcher.py` (10 passed)
- [x] `ruff check` + `ruff format --check` on the test file
- [x] Dry-run acceptance commands above


Made with [Cursor](https://cursor.com)