### PR TITLE
feat(atlas): LINT-004 UNVETTED_EN_SOURCE advisory (#6437 PR4)

### DIFF
--- a/docs/runbooks/word-atlas-entry-model.md
+++ b/docs/runbooks/word-atlas-entry-model.md
@@ -283,21 +283,21 @@ Field notes:
   the `learner_uk`/`learner_en` drill content itself) and labels a sense with
   no recorded dictionary `source` as `ai_minimum`.
 
-### Lint gate (PR1 + PR2 scope)
+### Lint gate (PR1 + PR2 + PR3 + PR4 scope)
 
-`scripts/audit/lint_word_atlas.py` implements three read-only, advisory rules:
+`scripts/audit/lint_word_atlas.py` implements four read-only, advisory rules:
 
 | ID | Name | Checks |
 | --- | --- | --- |
 | LINT-001 | `TRUNCATED_TEXT_CUTOFF` | A learner-facing sense field ends `...`/`…` while `completeness != "truncated"`. |
 | LINT-002 | `AMBIGUOUS_BARE_EN` | `learner_en` is a single-item list, the word is in a high-risk polysemy denylist, and `en_disambiguation` is empty. |
 | LINT-003 | `DRILL_SENSE_ID_MISSING` | A practice binding / deck item references a lemma without a non-empty `senseId` / `sense_id` (no `en[0]` fallback). |
+| LINT-004 | `UNVETTED_EN_SOURCE` | Published non-empty `learner_en` while `source` is missing, blank, or outside `SENSE_SOURCE_SOURCED ∪ {ai_minimum}` (`sum20_vetted`, `btc`, `dmklinger`, `manual_native`, `rag_verified`, `ai_minimum`). Honest `ai_minimum` does not fire. |
 
-LINT-004 (`UNVETTED_EN_SOURCE`) and the P1 advisory rules
-(`MULTI_SENSE_UK_SINGLE_EN`, `POS_TRANSFORMATION_MISMATCH`) remain for later PRs
-against this same issue. No CI gate is wired to `lint_word_atlas.py` yet —
-it runs as a standalone advisory check until a residual-count policy is
-agreed (issue #6437 D6-7).
+The P1 advisory rules (`MULTI_SENSE_UK_SINGLE_EN`, `POS_TRANSFORM_MISMATCH`)
+remain for later PRs against this same issue. No CI gate is wired to
+`lint_word_atlas.py` yet — it runs as a standalone advisory check until a
+residual-count policy is agreed (issue #6437 D6-7).
 
 ## Open Decisions
 

--- a/scripts/audit/lint_word_atlas.py
+++ b/scripts/audit/lint_word_atlas.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Sense-first Word Atlas entry lint (#6437): LINT-001 + LINT-002 + LINT-003.
+"""Sense-first Word Atlas entry lint (#6437): LINT-001 … LINT-004.
 
 Read-only, advisory lint over the `senses[]` array and practice bindings
 documented in ``docs/runbooks/word-atlas-entry-model.md`` (§ Sense-Level
@@ -18,14 +18,17 @@ Rules implemented
   references a lemma (``lemmaId`` / ``lemma``) without a non-empty
   ``senseId`` / ``sense_id``. This prohibits silent ``en[0]`` drill
   fallbacks once sense-first wiring is present.
+- **LINT-004** ``UNVETTED_EN_SOURCE`` — a sense has published non-empty
+  ``learner_en`` while ``source`` is missing, blank, or outside the
+  enrich vocabulary ``SENSE_SOURCE_SOURCED ∪ {ai_minimum}``. Honest
+  ``ai_minimum`` does not fire (that tag is already the vetted-thin label).
 
 Rules NOT implemented here (tracked against issue #6437, later PRs):
-LINT-004 ``UNVETTED_EN_SOURCE``, LINT-101 ``MULTI_SENSE_UK_SINGLE_EN``,
-LINT-102 ``POS_TRANSFORM_MISMATCH``.
+LINT-101 ``MULTI_SENSE_UK_SINGLE_EN``, LINT-102 ``POS_TRANSFORM_MISMATCH``.
 
 Scope
 =====
-- LINT-001/002: entries without a ``senses`` array are silently skipped —
+- LINT-001/002/004: entries without a ``senses`` array are silently skipped —
   most of the production manifest predates this schema.
 - LINT-003: inspects explicit practice bindings on the manifest
   (``practice_items`` / per-entry ``practice_bindings``) and optional
@@ -72,7 +75,20 @@ from pathlib import Path
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# Reuse enrich honesty vocabulary — do not invent a parallel source set (#6437).
+from scripts.lexicon.enrich_manifest import (
+    SENSE_SOURCE_AI_MINIMUM,
+    SENSE_SOURCE_SOURCED,
+)
+
 DEFAULT_FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "atlas" / "sense_lint_sample.json"
+
+# Allowed ``source`` values for published ``learner_en`` (LINT-004). Sourced
+# dictionary provenance plus the honest AI-minimum thin-gloss label.
+_ALLOWED_EN_SOURCES = SENSE_SOURCE_SOURCED | {SENSE_SOURCE_AI_MINIMUM}
 
 # Learner-facing string fields checked by LINT-001. `uk_source_def` is raw
 # ingestion text (immutable — see schema doc) but a dishonest completeness
@@ -147,7 +163,8 @@ _PRACTICE_CARD_LIST_KEYS = (
 LINT_001 = "LINT-001"
 LINT_002 = "LINT-002"
 LINT_003 = "LINT-003"
-IMPLEMENTED_RULE_IDS = (LINT_001, LINT_002, LINT_003)
+LINT_004 = "LINT-004"
+IMPLEMENTED_RULE_IDS = (LINT_001, LINT_002, LINT_003, LINT_004)
 
 
 @dataclass(frozen=True)
@@ -260,6 +277,60 @@ def _check_ambiguous_bare_en(
     ]
 
 
+def _published_learner_en(sense: dict[str, Any]) -> list[str] | None:
+    """Return non-blank published EN strings, or None when EN is not published."""
+    learner_en = sense.get("learner_en")
+    if not isinstance(learner_en, list) or not learner_en:
+        return None
+    published = [item.strip() for item in learner_en if isinstance(item, str) and item.strip()]
+    if not published:
+        return None
+    return published
+
+
+def _source_label(sense: dict[str, Any]) -> str | None:
+    """Normalize ``source`` to a non-blank string, or None when absent/blank."""
+    source = sense.get("source")
+    if source is None:
+        return None
+    if isinstance(source, str):
+        stripped = source.strip()
+        return stripped or None
+    return str(source)
+
+
+def _check_unvetted_en_source(
+    entry_slug: str, sense_id: str, sense: dict[str, Any]
+) -> list[LintFinding]:
+    """LINT-004: published learner_en without a known enrich ``source`` label.
+
+    Fires when ``learner_en`` is a non-empty list of non-blank strings AND
+    ``source`` is absent, blank, or outside ``SENSE_SOURCE_SOURCED ∪
+    {ai_minimum}``. Honest ``ai_minimum`` is allowed (vetted-thin honesty tag).
+    """
+    if _published_learner_en(sense) is None:
+        return []
+
+    source = _source_label(sense)
+    if source is not None and source in _ALLOWED_EN_SOURCES:
+        return []
+
+    detail_source = "missing" if source is None else repr(source)
+    return [
+        LintFinding(
+            rule_id=LINT_004,
+            rule_name="UNVETTED_EN_SOURCE",
+            entry_slug=entry_slug,
+            sense_id=sense_id,
+            field="source",
+            detail=(
+                f"published learner_en with unvetted source ({detail_source}); "
+                f"expected one of {sorted(_ALLOWED_EN_SOURCES)}"
+            ),
+        )
+    ]
+
+
 def _binding_lemma(item: dict[str, Any]) -> str | None:
     for key in ("lemmaId", "lemma_id", "lemma", "entry_slug", "slug"):
         value = item.get(key)
@@ -335,11 +406,12 @@ def lint_practice_items(items: list[dict[str, Any]]) -> list[LintFinding]:
 
 
 def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
-    """Return LINT-001/002/003 findings for a manifest.
+    """Return LINT-001/002/003/004 findings for a manifest.
 
-    Entries without a ``senses`` array are skipped for LINT-001/002 (see module
-    docstring). LINT-003 reads explicit practice bindings even when senses are
-    absent, so residual legacy decks stay visible during the advisory soak.
+    Entries without a ``senses`` array are skipped for LINT-001/002/004 (see
+    module docstring). LINT-003 reads explicit practice bindings even when
+    senses are absent, so residual legacy decks stay visible during the
+    advisory soak.
     """
     findings: list[LintFinding] = []
     for entry in _entries(manifest):
@@ -348,6 +420,7 @@ def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
             sense_id = _sense_id(sense)
             findings.extend(_check_truncated_text_cutoff(slug, sense_id, sense))
             findings.extend(_check_ambiguous_bare_en(slug, sense_id, sense))
+            findings.extend(_check_unvetted_en_source(slug, sense_id, sense))
     findings.extend(lint_practice_items(_practice_bindings_from_manifest(manifest)))
     return findings
 
@@ -370,7 +443,10 @@ def _load_manifest(path: Path) -> dict[str, Any]:
 
 def print_report(findings: list[LintFinding]) -> None:
     if not findings:
-        print("No LINT-001/LINT-002/LINT-003 findings — sense-first entries lint clean.")
+        print(
+            "No LINT-001/LINT-002/LINT-003/LINT-004 findings — "
+            "sense-first entries lint clean."
+        )
         return
 
     rows = [
@@ -416,7 +492,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Advisory sense-first Word Atlas lint: LINT-001 TRUNCATED_TEXT_CUTOFF + "
-            "LINT-002 AMBIGUOUS_BARE_EN + LINT-003 DRILL_SENSE_ID_MISSING (issue #6437)."
+            "LINT-002 AMBIGUOUS_BARE_EN + LINT-003 DRILL_SENSE_ID_MISSING + "
+            "LINT-004 UNVETTED_EN_SOURCE (issue #6437)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,

--- a/tests/fixtures/atlas/sense_lint_sample.json
+++ b/tests/fixtures/atlas/sense_lint_sample.json
@@ -131,6 +131,51 @@
       ]
     },
     {
+      "slug": "unvetted-en-entry-example",
+      "lemma": "гліф",
+      "entry_type": "lemma",
+      "senses": [
+        {
+          "id": "hlif_unvetted_en",
+          "pos": "noun",
+          "uk_source_def": "графічний знак у шрифті",
+          "learner_uk": "гліф",
+          "learner_en": ["glyph"],
+          "en_disambiguation": "typographic character shape",
+          "completeness": "draft"
+        },
+        {
+          "id": "hlif_invalid_source",
+          "pos": "noun",
+          "uk_source_def": "графічний знак з невідомим ярликом джерела",
+          "learner_uk": "гліф",
+          "learner_en": ["glyph mark"],
+          "en_disambiguation": "",
+          "source": "web_scrape",
+          "completeness": "draft"
+        },
+        {
+          "id": "hlif_empty_en_no_source",
+          "pos": "noun",
+          "uk_source_def": "сенс без опублікованого EN — LINT-004 не спрацьовує",
+          "learner_uk": "гліф",
+          "learner_en": [],
+          "en_disambiguation": "",
+          "completeness": "draft"
+        },
+        {
+          "id": "hlif_blank_en_only",
+          "pos": "noun",
+          "uk_source_def": "сенс з порожніми EN рядками — не опублікований EN",
+          "learner_uk": "гліф",
+          "learner_en": ["", "  "],
+          "en_disambiguation": "",
+          "source": "mystery",
+          "completeness": "draft"
+        }
+      ]
+    },
+    {
       "slug": "no-senses-entry-example",
       "lemma": "легасі",
       "entry_type": "lemma"

--- a/tests/test_lint_word_atlas.py
+++ b/tests/test_lint_word_atlas.py
@@ -18,19 +18,26 @@ def _manifest(*senses: dict, practice_items: list[dict] | None = None) -> dict:
 
 
 def test_default_fixture_flags_exactly_the_known_cases(capsys) -> None:
-    """Fixture covers LINT-001/002 sense cases plus two LINT-003 practice misses."""
+    """Fixture covers LINT-001/002/004 sense cases plus two LINT-003 practice misses."""
     assert lint_word_atlas.main([]) == 0
     output = capsys.readouterr().out
 
     assert "LINT-001" in output
     assert "LINT-002" in output
     assert "LINT-003" in output
+    assert "LINT-004" in output
     assert "tsytata_quote" in output
     assert "tsytata_honest_truncation" not in output
+    assert "tsytata_ai_minimum" not in output
     assert "sekunda_time_unit" in output
     assert "sekunda_disambiguated" not in output
+    assert "hlif_unvetted_en" in output
+    assert "hlif_invalid_source" in output
+    assert "hlif_empty_en_no_source" not in output
+    assert "hlif_blank_en_only" not in output
     assert "брак" in output
-    assert "4 finding(s)" in output
+    # LINT-001×1 + LINT-002×1 + LINT-003×2 + LINT-004×2
+    assert "6 finding(s)" in output
 
 
 def test_truncated_text_cutoff_fires_without_honest_tag() -> None:
@@ -39,6 +46,7 @@ def test_truncated_text_cutoff_fires_without_honest_tag() -> None:
             "id": "sense-1",
             "uk_source_def": "довге визначення без кінця...",
             "learner_en": ["example"],
+            "source": "sum20_vetted",
             "completeness": "complete",
         }
     )
@@ -54,6 +62,7 @@ def test_truncated_text_cutoff_suppressed_by_honest_tag() -> None:
             "id": "sense-1",
             "uk_source_def": "довге визначення без кінця...",
             "learner_en": ["example"],
+            "source": "sum20_vetted",
             "completeness": "truncated",
         }
     )
@@ -65,6 +74,7 @@ def test_truncated_text_cutoff_checks_learner_en_list_items() -> None:
         {
             "id": "sense-1",
             "learner_en": ["defect", "flaw…"],
+            "source": "sum20_vetted",
             "completeness": "draft",
         }
     )
@@ -80,6 +90,7 @@ def test_ambiguous_bare_en_fires_for_denylisted_single_word() -> None:
             "id": "sense-1",
             "learner_en": ["second"],
             "en_disambiguation": "",
+            "source": "sum20_vetted",
         }
     )
     findings = lint_word_atlas.lint_manifest(manifest)
@@ -94,6 +105,7 @@ def test_ambiguous_bare_en_suppressed_with_disambiguation() -> None:
             "id": "sense-1",
             "learner_en": ["second"],
             "en_disambiguation": "unit of time (not ordinal position)",
+            "source": "sum20_vetted",
         }
     )
     assert lint_word_atlas.lint_manifest(manifest) == []
@@ -105,6 +117,7 @@ def test_ambiguous_bare_en_ignores_multi_word_lists() -> None:
             "id": "sense-1",
             "learner_en": ["second", "moment"],
             "en_disambiguation": "",
+            "source": "sum20_vetted",
         }
     )
     assert lint_word_atlas.lint_manifest(manifest) == []
@@ -116,6 +129,7 @@ def test_ambiguous_bare_en_ignores_non_denylisted_words() -> None:
             "id": "sense-1",
             "learner_en": ["example"],
             "en_disambiguation": "",
+            "source": "sum20_vetted",
         }
     )
     assert lint_word_atlas.lint_manifest(manifest) == []
@@ -123,6 +137,77 @@ def test_ambiguous_bare_en_ignores_non_denylisted_words() -> None:
 
 def test_entries_without_senses_are_skipped() -> None:
     manifest = {"entries": [{"slug": "legacy-entry", "lemma": "легасі"}]}
+    assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def test_unvetted_en_source_fires_when_source_missing() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": ["glyph"],
+        }
+    )
+    findings = lint_word_atlas.lint_manifest(manifest)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "LINT-004"
+    assert findings[0].rule_name == "UNVETTED_EN_SOURCE"
+    assert findings[0].field == "source"
+
+
+def test_unvetted_en_source_fires_for_unknown_source_label() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": ["glyph"],
+            "source": "web_scrape",
+        }
+    )
+    findings = lint_word_atlas.lint_manifest(manifest)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "LINT-004"
+    assert "web_scrape" in findings[0].detail
+
+
+def test_unvetted_en_source_suppressed_for_ai_minimum() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": ["quote"],
+            "source": "ai_minimum",
+        }
+    )
+    assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def test_unvetted_en_source_suppressed_for_sum20_vetted() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": ["example"],
+            "source": "sum20_vetted",
+        }
+    )
+    assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def test_unvetted_en_source_ignores_empty_learner_en() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": [],
+        }
+    )
+    assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def test_unvetted_en_source_ignores_blank_only_learner_en() -> None:
+    manifest = _manifest(
+        {
+            "id": "sense-1",
+            "learner_en": ["", "  "],
+            "source": "mystery",
+        }
+    )
     assert lint_word_atlas.lint_manifest(manifest) == []
 
 
@@ -218,7 +303,16 @@ def test_practice_deck_lexemes_shard_flags_lexeme_without_sense_id(tmp_path: Pat
 def test_report_mode_writes_json_and_stays_advisory(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(
-        json.dumps(_manifest({"id": "sense-1", "learner_en": ["second"], "en_disambiguation": ""})),
+        json.dumps(
+            _manifest(
+                {
+                    "id": "sense-1",
+                    "learner_en": ["second"],
+                    "en_disambiguation": "",
+                    "source": "sum20_vetted",
+                }
+            )
+        ),
         encoding="utf-8",
     )
     report_path = tmp_path / "residual.json"
@@ -232,12 +326,22 @@ def test_report_mode_writes_json_and_stays_advisory(tmp_path: Path) -> None:
     assert payload["finding_count"] == 1
     assert payload["findings"][0]["rule_id"] == "LINT-002"
     assert "LINT-003" in payload["rule_ids"]
+    assert "LINT-004" in payload["rule_ids"]
 
 
 def test_strict_mode_fails_on_findings(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(
-        json.dumps(_manifest({"id": "sense-1", "learner_en": ["second"], "en_disambiguation": ""})),
+        json.dumps(
+            _manifest(
+                {
+                    "id": "sense-1",
+                    "learner_en": ["second"],
+                    "en_disambiguation": "",
+                    "source": "sum20_vetted",
+                }
+            )
+        ),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- Implements advisory **LINT-004** `UNVETTED_EN_SOURCE` in `scripts/audit/lint_word_atlas.py`: fires when a sense has published non-empty `learner_en` and `source` is missing/blank/outside `SENSE_SOURCE_SOURCED ∪ {ai_minimum}` (imports vocabulary from `enrich_manifest.py`; honest `ai_minimum` does not fire).
- Extends the sense lint fixture + unit tests (unvetted fires; `ai_minimum` / empty EN / `sum20_vetted` do not) and marks LINT-004 as implemented (advisory) in the runbook lint table.
- Remains read-only advisory (exit 0 unless `--strict`); no CI fail-all wiring. Does not claim #6437 closed — LINT-101/102 + residual policy remain.

Closes nothing on #6437 (PR4 slice only). Epic: #4387.

## Semantics note
Allowed sources are exactly `SENSE_SOURCE_SOURCED` (`sum20_vetted|btc|dmklinger|manual_native|rag_verified`) plus `SENSE_SOURCE_AI_MINIMUM` (`ai_minimum`) from `scripts/lexicon/enrich_manifest.py` — no parallel vocabulary invented.

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_lint_word_atlas.py -q` → 24 passed
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/lint_word_atlas.py tests/test_lint_word_atlas.py` → clean
- [x] Fixture residual report (gitignored): `batch_state/atlas-drive/lint-004-residual.json` → 6 findings incl. 2× LINT-004


Made with [Cursor](https://cursor.com)