### PR TITLE
docs(governance): reconcile sys.executable rule for tests (#4926)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,10 @@ non-skippable:
   run the repository deployment check or command required by the full rules;
   never hand-edit deployed `.claude/`, `.codex/`, `.agent/`, or `.gemini/`
   copies.
-- Use the project interpreter prescribed by the task/worktree contract; never use bare `python`,
-  `python3`, or `sys.executable` for project commands.
+- Use the project interpreter prescribed by the task/worktree contract for project, shell, and
+  production commands; never use bare `python`, `python3`, or `sys.executable` there. Tests that
+  spawn a Python subprocess MUST use `sys.executable` (it is the interpreter running under
+  `.venv/bin/python -m pytest`).
 - Never modify `.python-version`, `.yamllint`, or `.markdownlint.json` to make
   work pass. Fix source instead. Do not commit generated status, audit, review,
   or telemetry artifacts; keep one PR to one concern and under the file cap.

--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -109,8 +109,9 @@ tie-breakers.
     process, or working-model decision** (see item 12).
 11. **Repo mechanics are part of the contract.** The hard gates codified in `AGENTS.md` and
     `/api/rules` bind as if written here — notably: dispatch worktree subtree layout
-    (`.worktrees/dispatch/<agent>/<task>/`); `.venv/bin/python` only (never bare
-    `python`/`sys.executable`); no generated `status/`, `audit/`, `review/`, or telemetry
+    (`.worktrees/dispatch/<agent>/<task>/`); project interpreter for shell/production
+    (never bare `python`/`python3`/`sys.executable`; tests spawning a Python child MUST use
+    `sys.executable`); no generated `status/`, `audit/`, `review/`, or telemetry
     artifacts in code PRs; no `.python-version`/linter-config drive-bys; builds only in
     worktrees; `Monitor` for event streams (never polling loops); never print secrets.
     This contract references them instead of duplicating them; violating them violates the


### PR DESCRIPTION
## Summary
- Rewrites the AGENTS.md offline digest so project/shell/production commands still ban bare `python`/`python3`/`sys.executable`, while tests that spawn a Python child **must** use `sys.executable`.
- Mirrors the same clarification in `agents_extensions/shared/rules/operator-expectations.md` item 11 (canonical contract source).
- Closes the adjudicated docs-only gap from #4926: agents were “fixing” tests away from `sys.executable` and breaking worktree pytest.

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_operator_contract_wiring.py -q`
- [x] `bash scripts/check_rules_deployment.sh --tracked-mirrors-only`
- [ ] Skim AGENTS.md + operator-expectations wording once more for accidental ban weakening

Closes #4926

Made with [Cursor](https://cursor.com)