### PR TITLE
feat(agent-runtime): new fleet default models/efforts (operator GO 2026-08-13)

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -51,8 +51,9 @@ Record the harness fallback explicitly; it is a transport fallback, not a model 
   * **Codex seat**: `gpt-5.6-terra` (standard practical review)
   * **GLM seat**: `glm-5.2` (local-only)
   * **Gemini seat**: `gemini-3.6-flash-high`
-  * **DeepSeek seat**: `deepseek-v4-flash` through first-party OpenCode at `high` effort for
-    review/research, preserving native Entire capture. Tool-heavy implementation stays on Hermes,
+  * **DeepSeek seat**: `deepseek-v4-flash` through first-party OpenCode (`deepseek-direct/*`) at
+    `high` effort for review/research AND dispatch, preserving native Entire capture (operator
+    2026-08-13: OpenCode is the dispatch default). Hermes remains for `ask-hermes` only,
     whose shared `agent.reasoning_effort` is also `high`. The current Arena evidence is preliminary
     and frontend-specific, so this promotion does not grant critical or advisory authority.
 * **Complex Tasks, Deep Reviews & Anthropic Advisory Consultations**:
@@ -94,8 +95,8 @@ or count as a formal review.
   the same utilization PR so Auto can execute. If a future adapter regression returns
   plan-only rc=0, substitute with NOTE to AGY / DeepSeek Flash / Kimi k3-256k / Z.AI GLM. `composer-2.5-fast` stays retired.
 * **deepseek** (operator 2026-08-02; hold 2026-08-06; **reaffirmed 2026-08-08**): use
-  **`deepseek-v4-flash` only** (first-party OpenCode at `high` for review/research; Hermes for
-  tool-heavy implement). **`deepseek-v4-pro` is DO NOT USE** — older SKU; Flash currently
+  **`deepseek-v4-flash` only** (first-party OpenCode `deepseek-direct/*` at `high` — the dispatch
+  default since 2026-08-13, with native Entire capture; Hermes remains for `ask-hermes` only). **`deepseek-v4-pro` is DO NOT USE** — older SKU; Flash currently
   outperforms Pro on the workloads we run (operator: “fast is better than pro atm”). Do not
   dispatch, pin, ladder-select, or recommend Pro. Neither is a language, folk-content, or
   approval-authority seat. Prefer Flash for **code/infra CF volume** when Codex/Claude are hot.
@@ -123,7 +124,7 @@ or count as a formal review.
 | --- | --- |
 | Inline code edit ≤5 LOC, fixing a CI failure I just caused | Me, current model |
 | Claude-side ROUTINE work — formulaic reviews, config/fixture edits, monitoring-only sessions, wiki fixes, mechanical PR babysitting | **Sonnet 5** (user 2026-07-07: "use Sonnet more often for routine work") — dispatch `--model sonnet` / Sonnet session. Reserve the frontier Claude tier (Opus 5 / whatever frontier model is active) for judgment work: architecture, adversarial review, pedagogy, hard bugs. **Route by TIER-FIT, not model name — the Claude lane rotates** (Fable 5 was temporary). **Motive = SAVE THE FRONTIER WINDOW** (user-confirmed 2026-07-07): if Sonnet is busy, QUEUE routine work or reroute to agy/codex — do not burn the frontier window on it. |
-| Code change >5 LOC, mechanical / pattern-applying / fixtures | Clearly bounded with exact owned paths + an objective scope ceiling → `delegate.py dispatch --agent codex --model gpt-5.6-luna --effort max --mode danger --worktree --base origin/main`. Missing ceiling, broader integration, or consequential ambiguity → omit `--model` and retain the Terra @ `high` default. |
+| Code change >5 LOC, mechanical / pattern-applying / fixtures | Clearly bounded with exact owned paths + an objective scope ceiling → `delegate.py dispatch --agent codex --mode danger --worktree --base origin/main` (omitted flags default to **Luna @ `max`**, operator 2026-08-13). Missing ceiling, broader integration, or consequential ambiguity → pass `--model gpt-5.6-terra` explicitly (Terra @ `high`). |
 | Code Review (PR diff) | Resolve with `.venv/bin/python -m scripts.review.closeout_cli ... resolve-reviewer --author-model <exact-model> --review-profile code --risk <low\|medium\|high\|critical>`. The resolver applies hard filters first, then the #5293 quality prior above for every formal review; risk remains recorded in the receipt but does not allow a lower tier to leapfrog an eligible higher one. Execute the returned `invocation`; preserve its concrete model, family, `route`, `transport`, health trace, and `requires_silence_timeout` receipt. Do not hand-pick Flash while an eligible higher-tier reviewer remains usable. |
 | Content Review with VESUM verification (load-bearing) | **LANGUAGE-LANES RULE binds (user 2026-07-17): agy / codex / claude / grok-4.5 only** — dispatch the reviewer on one of the four with the `sources` MCP (`verify_words`, `query_cefr_level`, `check_russian_shadow`). ~~deepseek-v4-pro default (#4358)~~ RETIRED for language seats by the same order; the #2112/# 4358 validation history stands as evidence only |
 | Wiki / content writing · content / pedagogy / factual **review** | agy — `delegate.py dispatch --agent agy` (write) or `ab ask-agy --to-model gemini-3.1-pro-high` (review). **Use agy actively here** (user 2026-06-24): the §7/factual-fabrication fence is LIFTED (cleared 2026-06-13 — it grounds in the `sources` MCP and abstains "NO SOURCE"), and its pedagogy/CEFR review is strong — it LED the 2026-06-24 practice-hub panel. **Metered** → be cost-aware, but do NOT under-use it where it's strong. NOT for cross-file architecture / security-concurrency / auth-heavy git / mass-mechanical (→ codex/claude). Caveat: agy `--data` truncates large/binary attachments → paste trimmed content or use codex `--data`. |
@@ -177,9 +178,10 @@ native OAuth subscription lane (`kimi-code/k3`, max effort, tool/image/video inp
 context-size claim until the native provider documents it). API-billed lanes such as DeepSeek may be absent from CodexBar by design; absence is unknown
 headroom, not unavailability. Shed load only to models that meet the same task-risk quality floor.
 
-**Kimi lane:** native Kimi Code OAuth only. Use K3 (`kimi-code/k3`, always-thinking,
-max effort) for consequential coding, strong cross-family review, long-context debugging, and deep
-asks. Use `k2.7-coding` / `k2.7-coding-highspeed` for routine or bulk coding. Do not demote K3 merely
+**Kimi lane:** native Kimi Code OAuth only. Dispatch/native default is **`k3-256k`** (`kimi-code/k3-256k`,
+everyday coding/impl, no forced effort — operator 2026-08-13). Use K3 (`kimi-code/k3`, high/max
+effort) for consequential coding, strong cross-family review, long-context debugging, and deep
+asks. Use `k2.7-coding` / `k2.7-coding-highspeed` only as legacy routine/bulk pins. Do not demote K3 merely
 because the cheaper model exists; risk and fit establish the quality floor first. Kimi is Moonshot
 family. Composer 2.5 is Cursor-trained from a Kimi K2.5 checkpoint, so conservatively treat Composer
 and Kimi as the same Moonshot independence family. Neither is currently a Ukrainian factual/folk gate.
@@ -351,7 +353,7 @@ df -h /; du -sh "$repo_root/.worktrees"
 | Prefer when free / behind | Typical fit | Never / caveats |
 | --- | --- | --- |
 | **cursor** (`--model auto` default) | code/infra CI, ruff/fixtures, bounded refactors, mechanical-with-judgment | not formal CF identity; not language seats; `concurrency_limit: 1` |
-| **deepseek** (`deepseek-v4-flash` only) | code/infra CF volume, tool-heavy implement (Hermes), PR diffs | **Pro DO NOT USE**; not language/folk; not critical authority |
+| **deepseek** (`deepseek-v4-flash` only) | code/infra CF volume, tool-heavy implement (OpenCode first-party default), PR diffs | **Pro DO NOT USE**; not language/folk; not critical authority |
 | **claude** (Sonnet routine; Fable summoned only) | hard judgment, CF, architecture briefs | don't burn Fable on queue grind |
 | **agy** (Gemini 3.6 Flash default) | agentic scripts, content (language lanes); **worker with complete briefs** (#5737) — not self-decomposing micro-PR spray | metered — cost-aware, not absent; complete brief required |
 | **pool** (`laguna-s-2.1` default) | free CF volume + web-verify volume | not language; bridge `ask-pool` |
@@ -415,7 +417,7 @@ lane's current strengths/caveats live in the catalog, the per-task table, and th
 
 **Advisor (on-demand, HARD calls only): `gpt-5.6-sol @ high` by default** — architecture, high-stakes design/ADR review, difficult debugging, final synthesis, or a bounded advisory envelope. Raise effort only for an explicit escalation; never use Sol for routine work. **Excluded:** qwen (cost). **LOCAL-ONLY:** glm (China-egress, never CI). **Cross-family review gate holds:** the reviewer must be outside the author's model family.
 
-**Kimi onboarding (native `kimi`):** dispatch with `.venv/bin/python scripts/delegate.py dispatch --agent kimi`; explicitly select `--model k3` whenever the task is consequential. K3 is the frontier-practical Moonshot seat (max-only effort); `k2.7-coding` and its high-speed variant are routine workers. Current quota affects selection only among models that clear the task's quality floor. Kimi is a clean cross-family reviewer for GPT/Google/Claude/xAI authors, but not for Composer 2.5 because both conservatively share Moonshot lineage.
+**Kimi onboarding (native `kimi`):** dispatch with `.venv/bin/python scripts/delegate.py dispatch --agent kimi` — omitted flags default to **`k3-256k`** (everyday coding/impl; no forced effort, operator 2026-08-13). Explicitly select `--model k3 --effort high|max` whenever the task is consequential. K3 is the frontier-practical Moonshot seat (high/max effort, 1M window); `k2.7-coding` and its high-speed variant remain available as legacy routine workers. Current quota affects selection only among models that clear the task's quality floor. Kimi is a clean cross-family reviewer for GPT/Google/Claude/xAI authors, but not for Composer 2.5 because both conservatively share Moonshot lineage.
 
 ## Fleet discussion panels — actively involve ≥1 other agent before committing (user order 2026-06-23)
 
@@ -424,7 +426,7 @@ Drive high-judgment work (design, architecture, in-the-loop review, brief author
 * **Module-content panel** (writers, content review — LANGUAGE-LANES RULE binds): **agy** (Gemini 3.6 Flash default; Gemini 3.1 Pro for deep) · **GPT-5.6 Terra/Sol by risk** · **claude** · **grok-4.5**. ~~cursor seat~~ removed (excluded from language seats, user 2026-07-17). Prefer a bake-off + cross-family verification. Folk content review stays **cross-family (GPT↔Claude)** per `docs/folk-epic/folk-review-rubric.md` — **NO DeepSeek for folk culture** (lacks intrinsic Ukrainian-culture knowledge).
 * **Infra panel** (code, gates, pipeline, tooling, schemas, Atlas/lexicon): **agy** (Gemini 3.6 Flash top default / agentic / **orchestrator seat**; 3.1 Pro deep; 3.5 Flash back-compat) · **GPT-5.6 Terra/Sol** · **cursor Auto** (impl default) / **Composer 2.5** (pinned when family independence matters) · **native Grok 4.5** · **Kimi K3** · **DeepSeek V4 Flash @ high only** (OpenCode review/Entire continuity; Hermes tool-heavy; **Pro DO NOT USE**) · **Pool Laguna S 2.1** (free review volume) · **GLM-5.2 / Z.AI** (deep security/bug review + large-context coherence audits; LOCAL-ONLY) · **Gemma 4** (surface review only; often via OpenRouter). Pin Cursor's concrete model whenever family independence matters — never `auto` as CF identity.
 
-Invocation (`scripts/ai_agent_bridge/__main__.py`): `ask-codex` · `ask-agy --to-model gemini-3.6-flash-high` (orchestrator/routine default; `--to-model gemini-3.1-pro-high` only for deep) · `ask-cursor --model auto` (or `--model composer-2.5`) · `ask-grok` (alias `ask-grok-build`) · `ask-pool [--variant high|max]` · `ask-glm` (LOCAL-ONLY) · `ask-gemma` (cheap; ⚠️ not a sole seminar writer / factual reviewer) · `discuss <channel> "<topic>" --with <a,b,c>` for a bounded multi-round. **deepseek has NO `ask-*`** — route it via `delegate.py dispatch --agent deepseek --model deepseek-v4-flash` (first-party by default; OpenCode for review/research; **Pro DO NOT USE — reaffirmed 2026-08-08**). Bridge `ask-*` replies arrive as INBOX MESSAGES (`ab read <id>`), not stdout.
+Invocation (`scripts/ai_agent_bridge/__main__.py`): `ask-codex` · `ask-agy --to-model gemini-3.6-flash-high` (orchestrator/routine default; `--to-model gemini-3.1-pro-high` only for deep) · `ask-cursor --model auto` (or `--model composer-2.5`) · `ask-grok` (alias `ask-grok-build`) · `ask-pool [--variant high|max]` · `ask-glm` (LOCAL-ONLY) · `ask-gemma` (cheap; ⚠️ not a sole seminar writer / factual reviewer) · `discuss <channel> "<topic>" --with <a,b,c>` for a bounded multi-round. **deepseek has NO `ask-*`** — route it via `delegate.py dispatch --agent deepseek` (default = OpenCode first-party `deepseek-direct/deepseek-v4-flash` `--variant high`, with native Entire capture; Hermes only via `ask-hermes`; **Pro DO NOT USE — reaffirmed 2026-08-08**). Bridge `ask-*` replies arrive as INBOX MESSAGES (`ab read <id>`), not stdout.
 
 **opencode-routed cross-family reviewers (pool · glm · gemma):** opencode is a multi-provider ROUTER — the fleet member is the MODEL, not "opencode". **OpenRouter is mainly for Pool + Gemma access** (operator 2026-08-08); the catalog can reach more models through OpenRouter, but **we do not need to** — prefer native/first-party seats (DeepSeek first-party Flash, Cursor, Claude, AGY, Z.AI GLM, Codex, Kimi, Grok). Do not invent OpenRouter as a general multi-model fallback bus when a native lane exists (`ask-opencode <model>` is the generic escape hatch; `ask-pool`/`ask-glm`/`ask-gemma` are the named members). **Live web fact-checking is a HARNESS property (opencode + lightpanda MCP), NOT a model trait — any opencode-hosted model browses** (kubedojo-verified incl. deepseek); don't treat it as unique to pool/glm. Since the coding floor is uniformly high across the fleet, route by the DIFFERENTIATOR (kubedojo 5-agent scorecard 2026-07-04): **pool** = **free** cross-family code review + web-verify *volume*; **glm** = deep security/bug review + **large-context cross-file coherence audits**; grok = sharpest final code-review gate; deepseek = cheap all-rounder (+ browses when opencode-hosted); **gemma** (Google Gemma 4 via **`google-ais/gemma-4-31b-it`, $0 DEFAULT** — AIS-direct with the user's key, no paid SKU exists for Gemma on the Gemini API; TOOLLESS `chat` agent; paid OR `-it` via `--model` fallback only, note the spend; OR `:free` pool-starved, avoid) = a metered-lane OFFLOAD for **(a) cheap SURFACE review** — reliably flags russicisms/calques, Latin-letter leakage, imperial/decolonization framing — — **(b) wiki drafting RETIRED from gemma (LANGUAGE-LANES RULE 2026-07-17: wiki prose is language work → agy/codex/claude/grok-4.5 only; the 2026-07-05 source-citation probe evidence stands in `docs/projects/qg-quality-gate/model-evidence.md`). ** ⚠️ it is **NOT a sole seminar writer** (adds unsupported details beyond the source packet) and **NOT a sole factual reviewer** (not trustworthy on accuracy yet) — gate seminar/factual work behind a **non-Gemma** source/factual check; Google-family → not a clean reviewer of agy/Gemini work. **pool and glm are NOT for Ukrainian content / prose / pedagogy** — both are code models (glm anglicizes/code-switches, pool is worse); for UK content see the "Ukrainian CONTENT" row above (we author, not translate; cursor is NOT russicism-safe on long UK text). **pool** = poolside.ai **`laguna-s-2.1`** (default gen-2 S; also `laguna-xs-2.1` / fallback `laguna-m.1`), **free** (watch weekly limits on bursts). ⚠️ **glm** = Zhipu `glm-5.2`, **China-hosted (Zhipu/z.ai) → prompt data egresses to China → LOCAL-ONLY: never in CI / automated pipelines or with sensitive data** (`ask-glm` refuses under any CI env var as a backstop); prefer a Western-lab reviewer for top-stakes. Bridge (consult/review) only today — no `delegate.py --agent pool|glm|gemma` dispatch adapter yet, and no V7 `--writer gemma-tools` yet (the opencode→delegate adapter + tool-calling writer harness are scoped follow-ups; a plain OpenRouter chat model has no `sources`-MCP harness).
 
@@ -518,7 +520,9 @@ There is NO `ask-deepseek`: one-shot review/research defaults to
 `opencode run --model deepseek-direct/<deepseek-model> --variant high` so the host gets native
 Entire capture (the legacy `ask-opencode` ACP route is not enabled); use
 `ask-hermes --model <deepseek-model>` when Hermes-specific skills/MCPs matter.
-Tool-heavy execution remains `delegate.py dispatch --agent deepseek`. `openrouter/deepseek/*` is **guard-REFUSED** (user order
+Tool-heavy execution is `delegate.py dispatch --agent deepseek` → OpenCode first-party
+`deepseek-direct/deepseek-v4-flash` `--variant high` by default (operator 2026-08-13); the Hermes
+adapter remains for `ask-hermes` only. `openrouter/deepseek/*` is **guard-REFUSED** (user order
 2026-07-07 — the OR account was drained by deepseek bakeoff cells; deepseek runs FIRST-PARTY only.
 The user's OR BYOK now bills deepseek underneath, so transport-comparison runs (#4321/#4358) are
 billing-safe behind `LU_ROUTING_GUARD_OVERRIDE=1` — deliberate, user-authorized only).
@@ -576,7 +580,7 @@ All three tiers expose **272K context (~258.4K effectively usable before the con
 | Terra | `gpt-5.6-terra` | Balanced default: normal implementation, scoped planning, investigations, standard reviews (≈5.5-level quality, cheaper) | default `high`; `xhigh` for the hardest cells |
 | Luna | `gpt-5.6-luna` | Default high-volume bounded worker: focused implementation/investigation, recon, test/log triage, mechanical checks, and draft summaries with exact owned paths + an objective scope ceiling. **NEVER sole authority** on consequential decisions or release approval | `max` for bounded work; add a Sol envelope when task boundaries need authority judgment |
 
-Policy: **prefer 5.6 for NEW work**; retain 5.5/5.4 only for pinned workflows (qg_bakeoff arms, the V7 pipeline reviewer seat until spot-checked post-reset), proven compatibility, or quota pressure. Codex dispatch + `ask-codex` defaults = `gpt-5.6-terra`.
+Policy: **prefer 5.6 for NEW work**; retain 5.5/5.4 only for pinned workflows (qg_bakeoff arms, the V7 pipeline reviewer seat until spot-checked post-reset), proven compatibility, or quota pressure. Codex dispatch (`delegate.py` / `start-codex*.sh`) defaults = **`gpt-5.6-luna` @ `max`** (operator 2026-08-13); pass `--model gpt-5.6-terra` / `--effort` explicitly to override. `ask-codex` keeps its own pinned `gpt-5.6-terra` default.
 
 **Luna economics refresh (operator directive 2026-08-01):** OpenAI currently
 positions Luna for cost-sensitive, high-volume workloads, and its published

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -170,6 +170,9 @@ class ClaudeAdapter:
 
     name: str = "claude"
     default_model: str = "claude-sonnet-5"
+    # Operator 2026-08-13: headless/print defaults to high when the caller
+    # omits effort; interactive start-claude.sh keeps empty (last session).
+    default_effort: str = "high"
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
     def build_invocation(
@@ -199,7 +202,8 @@ class ClaudeAdapter:
             - ``max_budget_usd: float`` — optional Claude Code print-mode
               API spend cap, emitted as ``--max-budget-usd <amount>``
 
-        ``effort``: optional reasoning-level string. When non-None and the
+        ``effort``: optional reasoning-level string. When None, the headless
+        lane default ``high`` is applied (operator 2026-08-13). When the
         probed Claude binary supports ``--effort`` (CC 2.1.98+), the flag
         is appended as ``--effort <level>``. Otherwise we log a warning
         and proceed without the flag. Claude CLI versions below 2.1.116
@@ -330,8 +334,10 @@ class ClaudeAdapter:
             # adapter always uses -p, so the constraint is satisfied here.
             cmd.extend(["--max-budget-usd", f"{float(max_budget_usd):.2f}"])
 
-        # Effort (reasoning level) — version-gated. See #1396.
-        if effort is not None and not review_isolation:
+        # Effort (reasoning level) — version-gated. See #1396. Omitted effort
+        # defaults to the headless lane default (high, operator 2026-08-13).
+        effective_effort = effort if effort is not None else self.default_effort
+        if not review_isolation:
             # Use the `utils.claude_version.supports_effort` helper so tests
             # can patch the decision at a single point. Inline version
             # comparison bypassed the helper and left CI runs (no Claude CLI
@@ -343,12 +349,12 @@ class ClaudeAdapter:
 
             effort_supported = supports_effort(probe_prefix)
             if effort_supported:
-                cmd.extend(["--effort", effort])
+                cmd.extend(["--effort", effective_effort])
             else:
                 _logger.warning(
                     "Claude CLI at %s does not support --effort; ignoring effort=%r and using CLI default (#1396)",
                     probe_prefix,
-                    effort,
+                    effective_effort,
                 )
 
         # Output format

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -338,16 +338,23 @@ class ClaudeAdapter:
         # defaults to the headless lane default (high, operator 2026-08-13).
         effective_effort = effort if effort is not None else self.default_effort
         if not review_isolation:
-            # Use the `utils.claude_version.supports_effort` helper so tests
-            # can patch the decision at a single point. Inline version
-            # comparison bypassed the helper and left CI runs (no Claude CLI
-            # installed → cli_version=None) silently dropping --effort even
-            # though the test patched supports_effort=True. Root cause of the
-            # test_claude_adapter_emits_effort_when_supported CI failure on
-            # PR #1474.
-            from utils.claude_version import supports_effort
+            # Prefer the already-probed cli_version from
+            # ``_ensure_supported_claude_cli_version`` above. Re-calling
+            # ``supports_effort`` would spawn a second ``claude --version``
+            # via subprocess.run→Popen; tests that patch runner Popen then
+            # capture the probe as argv[0] and miss the real agent command
+            # (writer-isolation CI failure after the 2026-08-13 default-effort
+            # change, which made the probe unconditional). When cli_version
+            # is unknown, fall back to the patchable supports_effort helper
+            # (root cause of test_claude_adapter_emits_effort_when_supported
+            # on PR #1474).
+            if cli_version is not None:
+                # Min supported CLI is 2.1.116; --effort landed at 2.1.98.
+                effort_supported = True
+            else:
+                from utils.claude_version import supports_effort
 
-            effort_supported = supports_effort(probe_prefix)
+                effort_supported = supports_effort(probe_prefix)
             if effort_supported:
                 cmd.extend(["--effort", effective_effort])
             else:

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -338,23 +338,21 @@ class ClaudeAdapter:
         # defaults to the headless lane default (high, operator 2026-08-13).
         effective_effort = effort if effort is not None else self.default_effort
         if not review_isolation:
-            # Prefer the already-probed cli_version from
-            # ``_ensure_supported_claude_cli_version`` above. Re-calling
-            # ``supports_effort`` would spawn a second ``claude --version``
-            # via subprocess.run→Popen; tests that patch runner Popen then
-            # capture the probe as argv[0] and miss the real agent command
-            # (writer-isolation CI failure after the 2026-08-13 default-effort
-            # change, which made the probe unconditional). When cli_version
-            # is unknown, fall back to the patchable supports_effort helper
-            # (root cause of test_claude_adapter_emits_effort_when_supported
-            # on PR #1474).
-            if cli_version is not None:
-                # Min supported CLI is 2.1.116; --effort landed at 2.1.98.
-                effort_supported = True
-            else:
-                from utils.claude_version import supports_effort
+            # ``supports_effort`` is the single patchable decision point for
+            # --effort: tests patch it to simulate an unsupported CLI, and the
+            # default-high lane default must ALSO omit the flag when the CLI
+            # lacks it. To avoid a second ``claude --version`` subprocess —
+            # which broke writer-isolation CI when tests patch runner Popen
+            # and capture the probe as argv[0] instead of the real agent
+            # command — seed the shared per-prefix cache from the
+            # already-probed cli_version so the ``supports_effort`` call is a
+            # cache hit in production. Min supported CLI is 2.1.116; --effort
+            # landed at 2.1.98 (_EFFORT_MIN_VERSION).
+            from utils.claude_version import remember_support, supports_effort
 
-                effort_supported = supports_effort(probe_prefix)
+            if cli_version is not None:
+                remember_support(probe_prefix, cli_version >= _EFFORT_MIN_VERSION)
+            effort_supported = supports_effort(probe_prefix)
             if effort_supported:
                 cmd.extend(["--effort", effective_effort])
             else:

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -144,7 +144,10 @@ class CodexAdapter:
     """Adapter for ``codex exec`` (OpenAI ChatGPT Codex CLI)."""
 
     name: str = "codex"
-    default_model: str = "gpt-5.6-terra"
+    default_model: str = "gpt-5.6-luna"
+    # Operator 2026-08-13: omitted effort defaults to max for the Codex lane;
+    # an explicit --effort always wins.
+    default_effort: str = "max"
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
     # Per-invocation scoped $CODEX_HOME path. Set by ``build_invocation``
@@ -176,10 +179,9 @@ class CodexAdapter:
               → ``-c 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"'``
             - Unknown top-level keys are ignored (forward-compatible).
 
-        ``effort``: when non-None, appended as
-        ``-c model_reasoning_effort=<level>`` so it overrides
-        ``~/.codex/config.toml`` for this invocation only. When None,
-        Codex falls through to the config default (currently ``high``).
+        ``effort``: appended as ``-c model_reasoning_effort=<level>`` so it
+        overrides ``~/.codex/config.toml`` for this invocation only. When
+        None, the lane default ``max`` is applied (operator 2026-08-13).
         See #1396.
         """
         tc_early = tool_config or {}
@@ -278,9 +280,10 @@ class CodexAdapter:
         cmd: list[str] = [codex_bin, "exec"]
         if has_session_to_resume:
             cmd.append("resume")
-        if effort is not None:
-            # Per-invocation override of ~/.codex/config.toml (#1396).
-            cmd.extend(["-c", f"model_reasoning_effort={effort}"])
+        effective_effort = effort if effort is not None else self.default_effort
+        # Per-invocation override of ~/.codex/config.toml (#1396); the lane
+        # default is max when the caller omits effort (operator 2026-08-13).
+        cmd.extend(["-c", f"model_reasoning_effort={effective_effort}"])
         cmd.append("--skip-git-repo-check")
         if not has_session_to_resume:
             # ``codex exec resume`` does not accept -C or --color. It resumes

--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -1,53 +1,47 @@
-"""GlmAdapter — wraps opencode CLI for Zhipu GLM-5.2 (glm-5.2).
+"""DeepSeekAdapter — wraps opencode CLI for first-party DeepSeek (deepseek-direct).
 
-GLM-5.2 is a strong cross-family code and review model.
-LOCAL-ONLY: prompt data egresses to China — forbidden in CI.
+Operator 2026-08-13: DeepSeek dispatch routes through OpenCode to first-party
+``api.deepseek.com`` (``deepseek-direct/<model>``) with ``--variant high`` by
+default, replacing the Hermes dispatch default so runs get native Entire
+capture. ``deepseek-v4-flash`` is the default; ``deepseek-v4-pro`` remains
+DO NOT USE for dispatch. The Hermes adapter (``hermes_deepseek.py``) stays
+available for ``ask-hermes`` only.
+
+LOCAL-ONLY: prompt data egresses to China — forbidden in CI (same guard as
+the Hermes route, via ``scripts.agent_runtime.routes``).
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import shutil
 from pathlib import Path
 
-from ..errors import AgentRuntimeError
 from ..result import ParseResult
+from ..routes import (
+    deepseek_first_party_error,
+    is_deepseek_first_party_forbidden_in_ci,
+)
 from ..trail_isolation import TrailIsolationError, trail_isolation_requested
 from .base import InvocationPlan
 
 _logger = logging.getLogger(__name__)
 
-# Bare catalog model id → subscription-pinned opencode provider route.
-_OPENCODE_MODEL_ROUTES: dict[str, str] = {"glm-5.2": "zai-coding-plan/glm-5.2"}
-
-# Env vars whose presence indicates an automated/CI context where the
-# China-egress constraint forbids invoking GLM (matches ask-glm backstop).
-_CI_ENV_VARS: tuple[str, ...] = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "JENKINS_URL")
+# Bare catalog model id → first-party opencode provider route. Flash is the
+# dispatch default; Pro stays reachable only via an explicit --model override.
+_OPENCODE_MODEL_ROUTES: dict[str, str] = {
+    "deepseek-v4-flash": "deepseek-direct/deepseek-v4-flash",
+    "deepseek-v4-pro": "deepseek-direct/deepseek-v4-pro",
+}
 
 _RATE_LIMIT_RE = re.compile(
     r"rate limit|rate_limit|usage limit|quota exceeded|too many requests|resource_exhausted|\b429\b",
     re.IGNORECASE,
 )
 
-
-class GlmEgressForbiddenError(AgentRuntimeError, ValueError):
-    """Refuse to run China-hosted GLM in a CI / automated context (data egress)."""
-
-
-def assert_glm_egress_allowed(verb: str = "glm adapter") -> None:
-    """Refuse to run China-hosted GLM in a CI / automated context (data egress)."""
-    for var in _CI_ENV_VARS:
-        if var in os.environ:
-            raise GlmEgressForbiddenError(
-                f"{verb}: refusing to run under {var}={os.environ[var]!r}. GLM is "
-                "China-hosted (Zhipu/z.ai) → prompt data egresses to China; it "
-                "is LOCAL-ONLY and must never run in CI / automated pipelines."
-            )
-
-
+# Same uniform-effort → opencode variant mapping as GlmAdapter.
 _EFFORT_TO_VARIANT: dict[str, str] = {
     "low": "minimal",
     "medium": "high",
@@ -74,14 +68,14 @@ def _extract_text_from_stdout(stdout: str) -> str:
     return text
 
 
-class GlmAdapter:
-    """Adapter for the opencode CLI with glm-5.2."""
+class DeepSeekAdapter:
+    """Adapter for the opencode CLI with first-party DeepSeek v4."""
 
-    name: str = "glm"
-    # Fleet MODEL identity (must resolve in model_catalog.yaml). The Z.AI
-    # Coding Plan provider pin is an opencode INVOCATION detail — applied in
-    # build_invocation via _OPENCODE_MODEL_ROUTES, not stored as identity.
-    default_model: str = "glm-5.2"
+    name: str = "deepseek"
+    # Fleet MODEL identity (bare catalog id). The deepseek-direct provider pin
+    # is an opencode INVOCATION detail — applied in build_invocation via
+    # _OPENCODE_MODEL_ROUTES, not stored as identity.
+    default_model: str = "deepseek-v4-flash"
     # Operator 2026-08-13: omitted effort defaults to high (--variant high);
     # an explicit --effort always wins.
     default_effort: str = "high"
@@ -101,21 +95,36 @@ class GlmAdapter:
     ) -> InvocationPlan:
         if trail_isolation_requested(tool_config):
             raise TrailIsolationError(
-                "trail isolation refused for GLM: opencode does not enforce tool restrictions"
+                "trail isolation refused for DeepSeek: opencode does not enforce tool restrictions"
             )
-        assert_glm_egress_allowed("GlmAdapter")
 
         if mode not in self.supported_modes:
-            raise ValueError(f"GlmAdapter: unsupported mode {mode!r} (supported: {sorted(self.supported_modes)})")
+            raise ValueError(f"DeepSeekAdapter: unsupported mode {mode!r} (supported: {sorted(self.supported_modes)})")
+
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
 
         binary = shutil.which("opencode") or "opencode"
         target_model = model or self.default_model
-        # Route bare catalog ids to the subscription-pinned opencode provider —
-        # a bare "glm-5.2" would leave provider resolution to opencode and can
-        # land off the Z.AI Coding Plan sub. Explicit provider-prefixed ids
-        # pass through untouched. Keep in sync with
-        # scripts/ai_agent_bridge/_opencode.py GLM_MODEL.
+        # Route bare catalog ids to the first-party opencode provider — a bare
+        # "deepseek-v4-flash" would leave provider resolution to opencode and
+        # can land off the api.deepseek.com account. Explicit provider-prefixed
+        # ids pass through untouched.
         invocation_model = _OPENCODE_MODEL_ROUTES.get(target_model, target_model)
+
+        if is_deepseek_first_party_forbidden_in_ci("deepseek-direct", invocation_model):
+            raise ValueError(
+                deepseek_first_party_error(
+                    provider="deepseek-direct",
+                    model=invocation_model,
+                    source="opencode deepseek adapter",
+                )
+            )
 
         cmd: list[str] = [binary, "run", "--model", invocation_model]
 
@@ -130,7 +139,7 @@ class GlmAdapter:
         cmd.append(prompt)
 
         _logger.debug(
-            "glm invocation: task=%s mode=%s model=%s effort=%s",
+            "deepseek invocation: task=%s mode=%s model=%s effort=%s",
             task_id,
             mode,
             target_model,

--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -31,14 +31,16 @@ from .kimicc import KimiccHarness
 
 _logger = logging.getLogger(__name__)
 
-KIMI_DEFAULT_MODEL = "k2.7-coding"
+KIMI_DEFAULT_MODEL = "k3-256k"
 KIMI_BRIDGE_DEFAULT_MODEL = "k3"
-KIMI_DEFAULT_EFFORT = "max"
+# Operator 2026-08-13: dispatch/native default is k3-256k (everyday coding)
+# with NO forced effort — max is the full-K3 advisor behavior, so effort is
+# omitted unless the caller passes --effort / LAUNCHER_EFFORT.
+KIMI_DEFAULT_EFFORT: str | None = None
 KIMI_PROJECT_SKILLS_RELATIVE = Path("agents_extensions") / "shared" / "skills"
 # Catalog-backed aliases keep dispatch, the native launcher, and KimiCC in
-# lockstep. The managed seat's usage window depletes fast (operator,
-# 2026-07-16), so dispatch defaults to the coding model; K3 (always-max
-# reasoning) is reserved for deep asks.
+# lockstep. Dispatch defaults to the window-frugal k3-256k; full K3
+# (high/max reasoning, 1M window) is reserved for consequential work.
 KIMI_MODEL_ALIASES: dict[str, str] = kimi_model_aliases()
 KIMI_ALLOWED_MODELS: frozenset[str] = frozenset(KIMI_MODEL_ALIASES)
 
@@ -75,7 +77,7 @@ class KimiAdapter:
 
     name: str = "kimi"
     default_model: str = KIMI_DEFAULT_MODEL
-    default_effort: str = KIMI_DEFAULT_EFFORT
+    default_effort: str | None = KIMI_DEFAULT_EFFORT
     supported_modes: frozenset[str] = frozenset(_MODE_FLAGS)
 
     def build_invocation(
@@ -119,7 +121,7 @@ class KimiAdapter:
 
         requested_model = resolve_kimi_model(model)
 
-        if effort and requested_model == KIMI_MODEL_ALIASES["k3"] and effort != self.default_effort:
+        if effort and requested_model == KIMI_MODEL_ALIASES["k3"] and effort != "max":
             _logger.warning(
                 "Kimi K3 exposes max effort only; ignoring requested effort=%s",
                 effort,

--- a/scripts/agent_runtime/adapters/kimicc.py
+++ b/scripts/agent_runtime/adapters/kimicc.py
@@ -57,7 +57,7 @@ class KimiccHarness:
     """Build a stateless Claude Code invocation routed through KimiCC."""
 
     name = "kimicc"
-    default_model = "k3"
+    default_model = "k3-256k"
     supported_modes = frozenset({"read-only", "workspace-write", "danger"})
 
     def build_invocation(

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -143,6 +143,10 @@ _PROVIDER_SAFE_NAME_ALLOWLIST = {
     "deepseek": {
         "HERMES_HOME",
     },
+    # ask-hermes seat (OpenCode owns the bare ``deepseek`` dispatch key).
+    "hermes-deepseek": {
+        "HERMES_HOME",
+    },
     # Demoted Hermes Grok path (was bare "grok" before the native-seat rename).
     "grok-hermes": {
         "HERMES_HOME",

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -176,8 +176,9 @@ AGENTS: dict[str, AgentEntry] = {
         # OpenCode → first-party api.deepseek.com (deepseek-direct/*) is the
         # dispatch default (operator 2026-08-13): Flash only, --variant high,
         # native Entire capture. Pro stays DO NOT USE; the Hermes adapter
-        # (hermes_deepseek.py) remains for ask-hermes only. First-party
-        # DeepSeek is China-hosted → CI runs are refused by the adapter.
+        # (hermes_deepseek.py) remains for ask-hermes only via the
+        # hermes-deepseek seat below. First-party DeepSeek is China-hosted →
+        # CI runs are refused by the adapter.
         "adapter": "scripts.agent_runtime.adapters.deepseek:DeepSeekAdapter",
         "default_model": "deepseek-v4-flash",
         "default_effort": "high",
@@ -186,6 +187,23 @@ AGENTS: dict[str, AgentEntry] = {
             {
                 "code_writing",
                 "code_review",
+                "content_writing",
+                "content_review",
+                "adversarial_review",
+            }
+        ),
+        "cli_available": True,
+        "resume_policy": "never",
+    },
+    "hermes-deepseek": {
+        # Bridge-only Hermes seat for ask-hermes. Must not be the dispatch
+        # default (that is OpenCode DeepSeekAdapter on ``deepseek`` above).
+        # Kept as its own registry key so ask-hermes never spawns opencode.
+        "adapter": "scripts.agent_runtime.adapters.hermes_deepseek:HermesDeepSeekAdapter",
+        "default_model": "deepseek-v4-flash",
+        "cost_tier": "low",
+        "capabilities": frozenset(
+            {
                 "content_writing",
                 "content_review",
                 "adversarial_review",

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -40,7 +40,10 @@ class AgentEntry(TypedDict):
 AGENTS: dict[str, AgentEntry] = {
     "codex": {
         "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",
-        "default_model": "gpt-5.6-terra",
+        # Operator 2026-08-13: dispatch default is Luna @ max; explicit
+        # --model gpt-5.6-terra|gpt-5.6-sol / --effort always win.
+        "default_model": "gpt-5.6-luna",
+        "default_effort": "max",
         "cost_tier": "medium",
         "capabilities": frozenset(
             {
@@ -170,8 +173,14 @@ AGENTS: dict[str, AgentEntry] = {
         "resume_policy": "never",
     },
     "deepseek": {
-        "adapter": "scripts.agent_runtime.adapters.hermes_deepseek:HermesDeepSeekAdapter",
-        "default_model": "deepseek-v4-pro",
+        # OpenCode → first-party api.deepseek.com (deepseek-direct/*) is the
+        # dispatch default (operator 2026-08-13): Flash only, --variant high,
+        # native Entire capture. Pro stays DO NOT USE; the Hermes adapter
+        # (hermes_deepseek.py) remains for ask-hermes only. First-party
+        # DeepSeek is China-hosted → CI runs are refused by the adapter.
+        "adapter": "scripts.agent_runtime.adapters.deepseek:DeepSeekAdapter",
+        "default_model": "deepseek-v4-flash",
+        "default_effort": "high",
         "cost_tier": "low",
         "capabilities": frozenset(
             {
@@ -224,6 +233,7 @@ AGENTS: dict[str, AgentEntry] = {
         # Catalog model id; the Z.AI Coding Plan provider pin is applied at
         # invocation time by the adapter (_OPENCODE_MODEL_ROUTES).
         "default_model": "glm-5.2",
+        "default_effort": "high",
         "cost_tier": "low",
         "capabilities": frozenset(
             {
@@ -251,14 +261,12 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "kimi": {
         # Native Kimi Code OAuth subscription lane (no proxy-provider route).
-        # K3 is the max-effort consequential-coding/review seat. Its public
-        # provider docs do not currently substantiate a context-size claim,
-        # so keep that number out of routing policy. Dispatch defaults to the
-        # window-frugal coding model; callers select K3 when risk warrants it.
+        # Operator 2026-08-13: dispatch/native default is k3-256k (everyday
+        # coding) with no forced effort; full K3 (high/max, 1M window) is the
+        # advisor/complex seat selected via --model k3 --effort high|max.
         # Ukrainian content capabilities remain separately gated.
         "adapter": "scripts.agent_runtime.adapters.kimi:KimiAdapter",
-        "default_model": "k2.7-coding",
-        "default_effort": "max",
+        "default_model": "k3-256k",
         "cost_tier": "medium",
         "capabilities": frozenset(
             {

--- a/scripts/agent_runtime/routes.py
+++ b/scripts/agent_runtime/routes.py
@@ -52,7 +52,9 @@ def is_deepseek_first_party_forbidden_in_ci(provider: Any, model: Any) -> bool:
     if os.environ.get("PYTEST_CURRENT_TEST"):
         return False
     provider_text = normalize_route_part(provider).lower()
-    if provider_text == "deepseek":
+    # "deepseek-direct" is the first-party api.deepseek.com provider id used by
+    # the OpenCode dispatch route (operator 2026-08-13); same China-egress rule.
+    if provider_text in ("deepseek", "deepseek-direct"):
         return any(os.environ.get(v) for v in _CI_ENV_VARS)
     return False
 
@@ -65,7 +67,7 @@ def deepseek_first_party_error(
 ) -> str:
     """Build the explicit hard-fail text for first-party DeepSeek in CI."""
     return (
-        f"{DEEPSEEK_FIRST_PARTY_FORBIDDEN_MARKER}: automated Hermes run refused "
+        f"{DEEPSEEK_FIRST_PARTY_FORBIDDEN_MARKER}: automated run refused "
         f"China-hosted first-party DeepSeek (local-only, never CI) from {source}: "
         f"provider={normalize_route_part(provider)!r} "
         f"model={normalize_route_part(model)!r}"

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -189,7 +189,7 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
         return _arg_after(plan.cmd, "--effort")
     if agent_name == "gemini":
         return None
-    if agent_name in ("deepseek", "qwen") or is_hermes_grok_seat(agent_name):
+    if agent_name in ("deepseek", "hermes-deepseek", "qwen") or is_hermes_grok_seat(agent_name):
         # Hermes -z mode: effort is config-scoped (~/.hermes/config.yaml),
         # not surfaced on the command line. Adapter logs a warning when the
         # caller's request disagrees with the config — telemetry has nothing
@@ -235,7 +235,7 @@ def _resolve_model_from_defaults(
             _gemini_settings(),
             ("model", "defaultModel", "selectedModel", "modelName", "default_model"),
         )
-    if agent_name in ("grok-hermes", "deepseek", "qwen"):
+    if agent_name in ("grok-hermes", "deepseek", "hermes-deepseek", "qwen"):
         return _default_model_for(agent_name)
     if agent_name == "claude":
         return _default_model_for(agent_name)
@@ -256,7 +256,7 @@ def _resolve_effort_from_defaults(
 
     if agent_name in {"agy", "cursor", "gemini"}:
         return _NOT_EXPOSED
-    if agent_name in {"deepseek", "qwen"} or is_hermes_grok_seat(agent_name):
+    if agent_name in {"deepseek", "hermes-deepseek", "qwen"} or is_hermes_grok_seat(agent_name):
         return _hermes_configured_effort() or _NOT_EXPOSED
     if agent_name == "kimi":
         if harness == "kimicc":
@@ -443,7 +443,7 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
     if is_native_grok_seat(agent_name):
         # Native `grok` CLI — NOT hermes-backed; probe it directly.
         return _probe_version_at(("grok",), probe_cwd)
-    if agent_name == "deepseek" or is_hermes_grok_seat(agent_name):
+    if agent_name in ("deepseek", "hermes-deepseek") or is_hermes_grok_seat(agent_name):
         # Hermes-backed seats share one version probe.
         prefix = _hermes_version_prefix(plan.cmd) if plan is not None else ("hermes",)
         return _probe_version_at(prefix, probe_cwd)

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -57,6 +57,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return NATIVE_GROK_SEAT
     if agent.startswith("glm"):
         return "glm"
+    if agent.startswith("hermes-deepseek"):
+        return "hermes-deepseek"
     if agent.startswith("deepseek"):
         return "deepseek"
     if agent.startswith("qwen"):
@@ -75,6 +77,7 @@ def _canonical_agent_name(agent: str) -> str | None:
         NATIVE_GROK_SEAT,
         HERMES_GROK_SEAT,
         "deepseek",
+        "hermes-deepseek",
         "glm",
         "qwen",
         "agy",
@@ -391,10 +394,10 @@ def build_mcp_tool_config(
             missing_server_names=mcp_servers,
         )
 
-    if canonical_agent in ("grok-hermes", "deepseek", "qwen"):
-        # Hermes-backed seats (grok-hermes / DeepSeek / Qwen): tool_config
-        # translation is identical (Hermes reads MCP servers from
-        # ~/.hermes/config.yaml, not from the per-call payload).
+    if canonical_agent in ("grok-hermes", "deepseek", "hermes-deepseek", "qwen"):
+        # Hermes-backed seats (grok-hermes / DeepSeek / ask-hermes /
+        # Qwen): tool_config translation is identical (Hermes reads MCP
+        # servers from ~/.hermes/config.yaml, not from the per-call payload).
         if not mcp_servers:
             return None, _basic_diagnostics(
                 mcp_config_path=Path.home() / ".hermes" / "config.yaml",

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -303,8 +303,11 @@ def _run_hermes_subprocess(
 
     hard_timeout = timeout or 86_400
     try:
+        # Route through the Hermes seat, not the OpenCode ``deepseek``
+        # dispatch default — ask-hermes must keep HermesDeepSeekAdapter
+        # (hermes CLI) and must not require an opencode binary.
         result = agent_runner.invoke(
-            "deepseek",
+            "hermes-deepseek",
             prompt,
             mode="read-only",
             cwd=cwd,

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -114,6 +114,7 @@ _EFFORT_TO_VARIANT = {
 # pipelines or with sensitive data; prefer a Western-lab reviewer for
 # top-stakes work. ``ask_glm`` refuses to run under CI as a runtime backstop.
 GLM_MODEL = "zai-coding-plan/glm-5.2"
+GLM_DEFAULT_VARIANT = "high"  # reasoning effort when --effort is omitted (operator 2026-08-13)
 GLM_DEFAULT_TIMEOUT_S = 1800
 # Env vars whose presence indicates an automated/CI context where the
 # China-egress constraint forbids invoking GLM.
@@ -822,6 +823,7 @@ def ask_glm(
         lane="ask-glm", to_model=to_model, model=model, default=GLM_MODEL
     )
     effective_variant, effort_reason = _resolve_opencode_effort(lane="ask-glm", effort=effort)
+    effective_variant = effective_variant or GLM_DEFAULT_VARIANT
     msg_id = send_message(
         content,
         task_id,

--- a/scripts/launchers/glm.sh
+++ b/scripts/launchers/glm.sh
@@ -16,6 +16,9 @@ launcher_adapter_preflight() {
 launcher_adapter_canary() { return 0; }
 launcher_adapter_exec() {
   local cmd=(claude --model "$LEAD_MODEL")
+  if [ -n "${LC_EFFORT:-}" ]; then
+    cmd+=(--effort "$LC_EFFORT")
+  fi
   cmd+=("${LC_FORWARD_ARGS[@]}")
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
   exec "${cmd[@]}"

--- a/scripts/launchers/kimi.sh
+++ b/scripts/launchers/kimi.sh
@@ -13,7 +13,7 @@ launcher_adapter_preflight() {
     # resolve every alias to the configured native model id before exec.
     if ! LC_MODEL="$("$LC_ROOT/.venv/bin/python" "$LC_ROOT/scripts/review/model_catalog.py" \
         --resolve-kimi-model "$LC_MODEL" --format native)"; then
-      launcher_error "unknown --model '$LC_MODEL' (use k3, k2.7, k2.7-highspeed)."
+      launcher_error "unknown --model '$LC_MODEL' (use k3-256k, k3, k2.7, k2.7-highspeed)."
       exit 2
     fi
     return

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -147,7 +147,7 @@ launcher_defaults() {
       LC_HARNESS="${LAUNCHER_HARNESS:-claude-code}"
       ;;
     codex)
-      LC_MODEL="${LAUNCHER_MODEL:-gpt-5.6-terra}"
+      LC_MODEL="${LAUNCHER_MODEL:-gpt-5.6-luna}"
       LC_HARNESS="${LAUNCHER_HARNESS:-codex}"
       ;;
     gemini)
@@ -162,7 +162,7 @@ launcher_defaults() {
       LC_HARNESS="${LAUNCHER_HARNESS:-grok}"
       ;;
     kimi)
-      LC_MODEL="${LAUNCHER_MODEL:-k3}"
+      LC_MODEL="${LAUNCHER_MODEL:-k3-256k}"
       LC_HARNESS="${LAUNCHER_HARNESS:-kimi-code}"
       ;;
     glm)
@@ -363,7 +363,7 @@ launcher_validate_driver_certification() {
     return 0
   fi
   case "$LC_PROVIDER:$LC_MODEL" in
-    claude:claude-opus-5|claude:claude-fable-5|claude:claude-sonnet-5|codex:gpt-5.6-terra|codex:gpt-5.6-sol|gemini:gemini-3.6-flash-high|gemini:gemini-3.1-pro-high|grok:grok-4.5)
+    claude:claude-opus-5|claude:claude-fable-5|claude:claude-sonnet-5|codex:gpt-5.6-terra|codex:gpt-5.6-luna|codex:gpt-5.6-sol|gemini:gemini-3.6-flash-high|gemini:gemini-3.1-pro-high|grok:grok-4.5)
       return 0
       ;;
     *)

--- a/scripts/utils/claude_version.py
+++ b/scripts/utils/claude_version.py
@@ -217,6 +217,32 @@ def supports_effort(cmd_prefix: Sequence[str] | str) -> bool:
     return supports_exclude_dynamic_system_prompt_sections(cmd_prefix)
 
 
+def remember_support(cmd_prefix: Sequence[str] | str, supported: bool) -> None:
+    """Record a definitive per-prefix support verdict WITHOUT probing.
+
+    Callers that already probed the CLI version by another path (e.g. the
+    ClaudeAdapter's ``_ensure_supported_claude_cli_version`` gate, which
+    caches ``claude --version`` per prefix) use this to seed the shared
+    cache so a later ``supports_*`` call is a cache hit instead of
+    spawning a second ``--version`` subprocess.
+
+    Args:
+        cmd_prefix: Same semantics as
+            :func:`supports_exclude_dynamic_system_prompt_sections`.
+        supported: The support verdict for that prefix. Overwrites any
+            cached entry (used by tests to simulate an old CLI).
+
+    This mirrors the caching contract of the probing functions: the
+    verdict is stored keyed by ``tuple(cmd_prefix)`` and is permanent for
+    the process (call ``_reset_cache_for_tests`` to clear).
+    """
+    if isinstance(cmd_prefix, str):
+        cmd_prefix = [cmd_prefix]
+    key = tuple(cmd_prefix)
+    with _CACHE_LOCK:
+        _CACHE[key] = bool(supported)
+
+
 def _reset_cache_for_tests() -> None:
     """Clear the cache. Tests only — do NOT call from production code."""
     with _CACHE_LOCK:

--- a/tests/agent_runtime/adapters/test_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_deepseek_adapter.py
@@ -1,0 +1,91 @@
+"""Tests for DeepSeekAdapter — the OpenCode first-party dispatch default.
+
+Operator 2026-08-13: DeepSeek dispatch routes through opencode to
+``deepseek-direct/*`` (api.deepseek.com) with ``--variant high`` by default.
+The Hermes adapter remains for ``ask-hermes`` only and must not appear in the
+default dispatch command. First-party DeepSeek is China-hosted → CI refused.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from agent_runtime.adapters.deepseek import DeepSeekAdapter
+from agent_runtime.routes import DEEPSEEK_FIRST_PARTY_FORBIDDEN_MARKER
+
+FAKE_OPENCODE = "/usr/local/bin/opencode"
+
+
+def _build(prompt: str, tmp_path: Path, **kw):
+    with patch("agent_runtime.adapters.deepseek.shutil.which", return_value=FAKE_OPENCODE):
+        return DeepSeekAdapter().build_invocation(
+            prompt=prompt,
+            mode=kw.pop("mode", "read-only"),
+            cwd=tmp_path,
+            model=kw.pop("model", None),
+            task_id=kw.pop("task_id", None),
+            session_id=kw.pop("session_id", None),
+            tool_config=kw.pop("tool_config", None),
+            effort=kw.pop("effort", None),
+        )
+
+
+def test_default_dispatch_plan_is_opencode_first_party_flash_at_high(tmp_path):
+    """Omitted --model/--effort → opencode run --model
+    deepseek-direct/deepseek-v4-flash --variant high; no hermes anywhere."""
+    plan = _build("Review this diff.", tmp_path)
+
+    assert plan.cmd[0] == FAKE_OPENCODE
+    assert plan.cmd[1] == "run"
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "deepseek-direct/deepseek-v4-flash"
+    assert plan.cmd[plan.cmd.index("--variant") + 1] == "high"
+    assert plan.cmd[-2] == "--"
+    assert plan.cmd[-1] == "Review this diff."
+    assert "hermes" not in " ".join(plan.cmd).lower()
+    assert plan.env_overrides.get("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX") == "131072"
+
+
+def test_explicit_model_and_effort_overrides_win(tmp_path):
+    """--model deepseek-v4-pro routes to the first-party Pro pin (reachable
+    only via explicit override); --effort max maps to --variant max."""
+    plan = _build("Deep pass.", tmp_path, model="deepseek-v4-pro", effort="max")
+
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "deepseek-direct/deepseek-v4-pro"
+    assert plan.cmd[plan.cmd.index("--variant") + 1] == "max"
+
+
+def test_provider_prefixed_model_passes_through(tmp_path):
+    plan = _build("Check.", tmp_path, model="deepseek-direct/deepseek-v4-flash")
+
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "deepseek-direct/deepseek-v4-flash"
+
+
+def test_mode_mapping_adds_auto_for_write_modes(tmp_path):
+    assert "--auto" not in _build("x", tmp_path, mode="read-only").cmd
+    assert "--auto" in _build("x", tmp_path, mode="workspace-write").cmd
+    assert "--auto" in _build("x", tmp_path, mode="danger").cmd
+
+    with pytest.raises(ValueError, match="unsupported mode"):
+        _build("x", tmp_path, mode="invalid_mode")
+
+
+def test_trail_isolation_is_refused(tmp_path):
+    from agent_runtime.trail_isolation import TrailIsolationError
+
+    with pytest.raises(TrailIsolationError, match="trail isolation refused for DeepSeek"):
+        _build("x", tmp_path, tool_config={"trail_isolation": True})
+
+
+def test_ci_refusal_for_first_party_route(tmp_path, monkeypatch):
+    """The same first-party CI refuse as the Hermes route must hold."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    with pytest.raises(ValueError, match=DEEPSEEK_FIRST_PARTY_FORBIDDEN_MARKER):
+        _build("Should fail in CI", tmp_path)

--- a/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
@@ -240,8 +240,8 @@ def test_registry_lists_deepseek_with_opencode_adapter():
     """Registry dispatch default: OpenCode first-party adapter, Flash @ high.
 
     Operator 2026-08-13: dispatch routes through ``DeepSeekAdapter``
-    (opencode → deepseek-direct); the Hermes adapter below remains
-    importable for ``ask-hermes`` only.
+    (opencode → deepseek-direct); the Hermes adapter remains reachable
+    only via the ``hermes-deepseek`` seat used by ``ask-hermes``.
     """
     from agent_runtime.registry import get_agent_entry
 
@@ -251,6 +251,12 @@ def test_registry_lists_deepseek_with_opencode_adapter():
     assert entry["default_effort"] == "high"
     assert entry["adapter"].endswith(":DeepSeekAdapter")
     assert entry["resume_policy"] == "never"
+
+    hermes_entry = get_agent_entry("hermes-deepseek")
+    assert hermes_entry["cli_available"] is True
+    assert hermes_entry["default_model"] == "deepseek-v4-flash"
+    assert hermes_entry["adapter"].endswith(":HermesDeepSeekAdapter")
+    assert hermes_entry["resume_policy"] == "never"
 
 
 def test_deepseek_adapter_inband_http_error_is_not_ok():

--- a/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
@@ -236,14 +236,20 @@ def test_runner_preserves_unknown_deepseek_tool_call_total(tmp_path, monkeypatch
     assert result.tool_calls_total is None
 
 
-def test_registry_lists_deepseek_with_hermes_adapter():
-    """Sanity check: registry entry is wired to the new adapter class."""
+def test_registry_lists_deepseek_with_opencode_adapter():
+    """Registry dispatch default: OpenCode first-party adapter, Flash @ high.
+
+    Operator 2026-08-13: dispatch routes through ``DeepSeekAdapter``
+    (opencode → deepseek-direct); the Hermes adapter below remains
+    importable for ``ask-hermes`` only.
+    """
     from agent_runtime.registry import get_agent_entry
 
     entry = get_agent_entry("deepseek")
     assert entry["cli_available"] is True
-    assert entry["default_model"] == "deepseek-v4-pro"
-    assert entry["adapter"].endswith(":HermesDeepSeekAdapter")
+    assert entry["default_model"] == "deepseek-v4-flash"
+    assert entry["default_effort"] == "high"
+    assert entry["adapter"].endswith(":DeepSeekAdapter")
     assert entry["resume_policy"] == "never"
 
 

--- a/tests/agent_runtime/adapters/test_kimi_adapter.py
+++ b/tests/agent_runtime/adapters/test_kimi_adapter.py
@@ -150,11 +150,13 @@ def test_kimicc_harness_is_opt_in_and_native_kimi_remains_default(tmp_path, monk
 
     assert native.cmd[0] == str(tmp_path / "kimi")
     assert kimicc.cmd[0].endswith("scripts/agent_runtime/kimicc_headless.sh")
-    assert kimicc.cmd[kimicc.cmd.index("--model") + 1] == "k3"
-    assert kimicc.cmd[kimicc.cmd.index("--effort") + 1] == "high"
+    # Operator 2026-08-13: the kimicc default model is k3-256k; only full k3
+    # gets the default --effort high injection.
+    assert kimicc.cmd[kimicc.cmd.index("--model") + 1] == "k3-256k"
+    assert "--effort" not in kimicc.cmd
     assert kimicc.metadata["harness"] == "kimicc"
     assert kimicc.env_overrides["KIMICC_CLAUDE_BIN"] == str(claude)
-    assert kimicc.env_overrides["KIMICC_EFFORT_LEVEL"] == "high"
+    assert "KIMICC_EFFORT_LEVEL" not in kimicc.env_overrides
     assert "CLAUDE_CONFIG_DIR" in kimicc.env_unsets
 
 
@@ -194,7 +196,9 @@ def test_kimicc_harness_default_and_override_effort_are_concrete_child_argv(tmp_
         tool_config=None,
     )
 
-    assert KIMI_DEFAULT_EFFORT == "max"
+    # Operator 2026-08-13: native dispatch no longer forces max; effort is
+    # omitted unless the caller passes it explicitly.
+    assert KIMI_DEFAULT_EFFORT is None
     assert "--effort" not in native_k3.cmd
     assert default.cmd[default.cmd.index("--effort") + 1] == "high"
     assert default.env_overrides["KIMICC_EFFORT_LEVEL"] == "high"
@@ -251,6 +255,9 @@ def test_short_names_and_full_aliases_resolve_and_unknown_models_reject(tmp_path
         ("k3", "kimi-code/k3"),
         ("kimi-k3", "kimi-code/k3"),
         ("kimi-k3[1m]", "kimi-code/k3"),
+        ("k3-256k", "kimi-code/k3-256k"),
+        ("kimi-k3-256k", "kimi-code/k3-256k"),
+        ("kimi-code/k3-256k", "kimi-code/k3-256k"),
         ("k2.7-coding", "kimi-code/kimi-for-coding"),
         ("k2.7", "kimi-code/kimi-for-coding"),
         ("kimi-for-coding", "kimi-code/kimi-for-coding"),
@@ -271,7 +278,7 @@ def test_short_names_and_full_aliases_resolve_and_unknown_models_reject(tmp_path
 def test_effort_warning_fires_only_for_k3(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     plan = _build(tmp_path, monkeypatch, model="k3", effort="high")
-    assert KIMI_DEFAULT_EFFORT == "max"
+    assert KIMI_DEFAULT_EFFORT is None
     assert "max effort only" in caplog.text
     assert "--effort" not in plan.cmd
 
@@ -416,7 +423,7 @@ def test_invocation_telemetry_is_model_aware_and_reports_native_cli_version(tmp_
     assert k3_telemetry.effort == "max"  # K3 is always-max; caller request never mislabeled
     assert k3_telemetry.cli_version == "0.26.0"
 
-    coding_plan = _build(tmp_path, monkeypatch, effort="medium")  # default: k2.7-coding
+    coding_plan = _build(tmp_path, monkeypatch, effort="medium")  # default: k3-256k
     with patch("scripts.agent_runtime.telemetry.kimi_cli_version", return_value="0.26.0"):
         coding_telemetry = resolve_invocation_telemetry(
             agent_name="kimi",
@@ -426,7 +433,18 @@ def test_invocation_telemetry_is_model_aware_and_reports_native_cli_version(tmp_
         )
 
     assert coding_telemetry.model == KIMI_MODEL_ALIASES[KIMI_DEFAULT_MODEL]
-    assert coding_telemetry.effort == "not-exposed"  # k2.7 models have no effort knob
+    assert coding_telemetry.effort == "not-exposed"  # k3-256k effort is not forced by the adapter
+
+
+def test_default_model_resolves_k3_256k_and_explicit_k3_max_wins(tmp_path, monkeypatch):
+    """Operator 2026-08-13: omitted --model/--effort → k3-256k, no forced max;
+    explicit --model k3 --effort max still wins."""
+    default = _build(tmp_path, monkeypatch)
+    assert default.cmd[default.cmd.index("-m") + 1] == "kimi-code/k3-256k"
+    assert "--effort" not in default.cmd
+
+    override = _build(tmp_path, monkeypatch, model="k3", effort="max")
+    assert override.cmd[override.cmd.index("-m") + 1] == "kimi-code/k3"
 
 
 def test_binary_resolution_prefers_hermes_over_legacy(tmp_path, monkeypatch):

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -198,6 +198,7 @@ def test_registry_has_known_agents():
         "glm",
         "kimi",
         "deepseek",
+        "hermes-deepseek",
         "qwen",
         "agy",
         "cursor",

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -382,8 +382,10 @@ def test_agy_entry_is_well_formed():
 def test_kimi_entry_is_well_formed():
     entry = get_agent_entry("kimi")
     assert entry["adapter"] == "scripts.agent_runtime.adapters.kimi:KimiAdapter"
-    assert entry["default_model"] == "k2.7-coding"
-    assert entry["default_effort"] == "max"
+    # Operator 2026-08-13: k3-256k everyday default; no forced default effort
+    # (max is the full-K3 advisor behavior, selected via explicit flags).
+    assert entry["default_model"] == "k3-256k"
+    assert entry.get("default_effort") is None
     assert entry["cli_available"] is True
     assert entry["resume_policy"] == "bridge_only"
     assert entry["cost_tier"] == "medium"
@@ -435,7 +437,7 @@ def test_claude_entry_has_bridge_only_resume_policy():
 def test_load_adapter_codex():
     adapter = _load_adapter("codex")
     assert adapter.name == "codex"
-    assert adapter.default_model == "gpt-5.6-terra"
+    assert adapter.default_model == "gpt-5.6-luna"
     assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
 
 
@@ -449,7 +451,7 @@ def test_load_adapter_cursor():
 def test_load_adapter_kimi():
     adapter = _load_adapter("kimi")
     assert adapter.name == "kimi"
-    assert adapter.default_model == "k2.7-coding"
+    assert adapter.default_model == "k3-256k"
     assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
 
 
@@ -636,7 +638,10 @@ def test_codex_adapter_build_invocation_read_only(tmp_path):
     assert plan.stdin_payload == "hello"
     assert plan.output_file is not None
     assert "test-task" in plan.output_file.name
-    assert "-c" not in plan.cmd  # tool_config=None preserves prior behavior
+    # tool_config=None: no MCP -c overrides; the lane-default
+    # model_reasoning_effort=max (operator 2026-08-13) is the only -c flag.
+    config_values = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "-c"]
+    assert config_values == ["model_reasoning_effort=max"]
     # Liveness paths should include the output file
     assert plan.output_file in plan.liveness_paths
 
@@ -723,8 +728,8 @@ def test_codex_adapter_mcp_tool_config(tmp_path):
         },
     )
     assert "-c" in plan.cmd
-    idx = plan.cmd.index("-c")
-    assert plan.cmd[idx + 1] == 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"'
+    config_values = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "-c"]
+    assert 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"' in config_values
 
 
 def test_codex_adapter_mcp_tool_config_multiple(tmp_path):

--- a/tests/test_agent_runtime_effort.py
+++ b/tests/test_agent_runtime_effort.py
@@ -336,8 +336,9 @@ def test_claude_adapter_skips_effort_when_unsupported(tmp_path, caplog):
     )
 
 
-def test_claude_adapter_no_effort_arg_means_no_flag(tmp_path):
-    """Default (effort=None) must NOT emit --effort regardless of version."""
+def test_claude_adapter_no_effort_arg_means_default_high(tmp_path):
+    """Default (effort=None) emits the headless lane default --effort high
+    when the CLI supports it (operator 2026-08-13)."""
     adapter = ClaudeAdapter()
     with patch(
         "utils.claude_version.supports_effort", return_value=True,
@@ -351,7 +352,9 @@ def test_claude_adapter_no_effort_arg_means_no_flag(tmp_path):
             session_id=None,
             tool_config=None,
         )
-    assert "--effort" not in plan.cmd
+    assert "--effort" in plan.cmd
+    i = plan.cmd.index("--effort")
+    assert plan.cmd[i + 1] == "high"
 
 
 # ---------------------------------------------------------------------------
@@ -383,9 +386,10 @@ def test_codex_adapter_emits_effort_as_config_override(tmp_path):
     )
 
 
-def test_codex_adapter_no_effort_means_no_config_override(tmp_path):
-    """effort=None (default) must fall through to ~/.codex/config.toml —
-    no -c model_reasoning_effort=... override in the argv."""
+def test_codex_adapter_no_effort_means_default_max_override(tmp_path):
+    """effort=None (default) applies the lane default
+    ``-c model_reasoning_effort=max`` (operator 2026-08-13); an explicit
+    --effort still wins over the default."""
     adapter = CodexAdapter()
     plan = adapter.build_invocation(
         prompt="hi",
@@ -396,10 +400,14 @@ def test_codex_adapter_no_effort_means_no_config_override(tmp_path):
         session_id=None,
         tool_config=None,
     )
-    joined = " ".join(plan.cmd)
-    assert "model_reasoning_effort" not in joined, (
-        f"plan.cmd must not contain a model_reasoning_effort override when "
-        f"effort is unset; plan.cmd={plan.cmd}"
+    flag_pairs = [
+        (plan.cmd[i], plan.cmd[i + 1])
+        for i in range(len(plan.cmd) - 1)
+        if plan.cmd[i] == "-c"
+    ]
+    assert ("-c", "model_reasoning_effort=max") in flag_pairs, (
+        f"expected ('-c', 'model_reasoning_effort=max') in flag pairs; "
+        f"plan.cmd={plan.cmd}"
     )
 
 

--- a/tests/test_agent_runtime_effort.py
+++ b/tests/test_agent_runtime_effort.py
@@ -336,6 +336,38 @@ def test_claude_adapter_skips_effort_when_unsupported(tmp_path, caplog):
     )
 
 
+def test_claude_adapter_default_high_skips_when_unsupported(tmp_path, caplog):
+    """Default (effort=None → headless lane default ``high``) must STILL
+    omit ``--effort`` when the CLI does not support it (operator 2026-08-13
+    default-high must not force the flag on old CLIs)."""
+    adapter = ClaudeAdapter()
+    with patch(
+        "utils.claude_version.supports_effort", return_value=False,
+    ), patch(
+        "utils.claude_version.supports_exclude_dynamic_system_prompt_sections",
+        return_value=False,
+    ), caplog.at_level(logging.WARNING, logger="agent_runtime.adapters.claude"):
+        plan = adapter.build_invocation(
+            prompt="hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-opus-4-7",
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+    assert "--effort" not in plan.cmd, (
+        f"default-high must be omitted when the CLI does not support --effort; "
+        f"plan.cmd={plan.cmd}"
+    )
+    assert any(
+        "does not support --effort" in rec.message for rec in caplog.records
+    ), (
+        f"expected a WARNING log about effort being unsupported; "
+        f"records={[r.message for r in caplog.records]}"
+    )
+
+
 def test_claude_adapter_no_effort_arg_means_default_high(tmp_path):
     """Default (effort=None) emits the headless lane default --effort high
     when the CLI supports it (operator 2026-08-13)."""

--- a/tests/test_agent_runtime_glm_adapter.py
+++ b/tests/test_agent_runtime_glm_adapter.py
@@ -49,6 +49,7 @@ def test_glm_registry_and_choices_wiring():
     entry = registry.get_agent_entry("glm")
     assert entry["cli_available"] is True
     assert entry["default_model"] == "glm-5.2"
+    assert entry["default_effort"] == "high"
     assert entry["resume_policy"] == "never"
     assert "glm" in delegate._DISPATCH_AGENT_CHOICES
 
@@ -90,6 +91,17 @@ def test_glm_adapter_model_override_and_effort(tmp_path):
     assert "--variant" in plan.cmd
     variant_idx = plan.cmd.index("--variant")
     assert plan.cmd[variant_idx + 1] == "high"
+
+
+def test_glm_adapter_omitted_effort_defaults_to_variant_high(tmp_path):
+    """Operator 2026-08-13: omitted effort → --variant high."""
+    plan = _build("Analyze code", tmp_path)
+    assert plan.cmd[plan.cmd.index("--variant") + 1] == "high"
+
+
+def test_glm_adapter_explicit_effort_max_wins(tmp_path):
+    plan = _build("Analyze code", tmp_path, effort="max")
+    assert plan.cmd[plan.cmd.index("--variant") + 1] == "max"
 
 
 def test_glm_adapter_ci_refusal_guard(tmp_path, monkeypatch):

--- a/tests/test_ask_hermes.py
+++ b/tests/test_ask_hermes.py
@@ -895,7 +895,7 @@ def test_invoke_hermes_uses_shared_runtime():
     ) as invoke_mock:
         assert _invoke_hermes("hello", "deepseek-v4-flash", task_id="task-1") == "response body"
     args, kwargs = invoke_mock.call_args
-    assert args == ("deepseek", "hello")
+    assert args == ("hermes-deepseek", "hello")
     assert kwargs["model"] == "deepseek-v4-flash"
     assert kwargs["task_id"] == "task-1"
     assert kwargs["entrypoint"] == "bridge"

--- a/tests/test_ask_pool.py
+++ b/tests/test_ask_pool.py
@@ -345,3 +345,19 @@ def test_ask_glm_and_pool_invoke_on_message_created_callback(monkeypatch):
         ):
             fn("hi", task_id="t", on_message_created=seen.append)
         assert seen == [41], f"{name}: on_message_created not invoked with the message id"
+
+
+def test_ask_glm_omitted_effort_defaults_to_variant_high(monkeypatch):
+    """Operator 2026-08-13: ask-glm without --effort invokes opencode with
+    variant=high; an explicit --effort max still wins (maps to variant max)."""
+    for var in _CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for effort, expected_variant in ((None, "high"), ("max", "max")):
+        with (
+            patch("scripts.ai_agent_bridge._opencode.send_message", return_value=41),
+            patch("scripts.ai_agent_bridge._opencode.acknowledge"),
+            patch("scripts.ai_agent_bridge._opencode.record_ask_reply"),
+            patch("scripts.ai_agent_bridge._opencode._invoke_opencode", return_value="ok") as inv,
+        ):
+            ask_glm("hi", task_id="t", effort=effort)
+        assert inv.call_args.kwargs["variant"] == expected_variant

--- a/tests/test_claude_version.py
+++ b/tests/test_claude_version.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from utils.claude_version import (
     _parse_claude_semver,
     _reset_cache_for_tests,
+    remember_support,
     supports_exclude_dynamic_system_prompt_sections,
 )
 
@@ -280,3 +281,24 @@ def test_reset_cache_clears_all_entries():
         _reset_cache_for_tests()
         supports_exclude_dynamic_system_prompt_sections(["claude"])
     assert mock.call_count == 2, "reset should force a re-probe"
+
+
+def test_remember_support_seeds_cache_without_probing():
+    """remember_support records a verdict for a prefix so a later
+    supports_* call is a cache hit instead of a second --version probe."""
+    mock = MagicMock(return_value=_mock_run(stdout="2.1.98"))
+    with patch("utils.claude_version.subprocess.run", mock):
+        remember_support(["claude"], True)
+        assert supports_exclude_dynamic_system_prompt_sections(["claude"]) is True
+        assert mock.call_count == 0, "seeded verdict must not spawn a probe"
+
+
+def test_remember_support_overwrites_cached_verdict():
+    """remember_support overwrites a cached entry (tests simulate old CLIs)."""
+    mock = MagicMock(return_value=_mock_run(stdout="2.1.98"))
+    with patch("utils.claude_version.subprocess.run", mock):
+        supports_exclude_dynamic_system_prompt_sections(["claude"])
+        assert mock.call_count == 1
+        remember_support(["claude"], False)
+        assert supports_exclude_dynamic_system_prompt_sections(["claude"]) is False
+        assert mock.call_count == 1, "overwritten verdict must be served from cache"

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -417,7 +417,7 @@ def test_agents_endpoint_returns_known_adapters():
     assert not any(name.startswith("acpx-") for name in names)
     codex = next(agent for agent in agents if agent["name"] == "codex")
     assert codex["binary"] == "codex"
-    assert codex["default_model"] == "gpt-5.6-terra"
+    assert codex["default_model"] == "gpt-5.6-luna"
 
 
 def test_agents_endpoint_refreshes_registry_defaults_after_mtime_update(tmp_path, monkeypatch):

--- a/tests/test_start_codex_claude_code.py
+++ b/tests/test_start_codex_claude_code.py
@@ -30,7 +30,7 @@ def test_codex_claude_code_harness_dry_run_uses_local_proxy_contract() -> None:
     result = run_launcher("start-codex.sh", "--harness", "claude-code")
     assert result.returncode == 0, result.stderr
     assert "credential_source=local-proxy-placeholder" in result.stdout
-    assert "would exec claude --model gpt-5.6-terra" in result.stdout
+    assert "would exec claude --model gpt-5.6-luna" in result.stdout
 
 
 @pytest.mark.parametrize("base", ("http://127.0.0.1:8317", "http://localhost:8317"))

--- a/tests/test_start_kimi_claude_code.py
+++ b/tests/test_start_kimi_claude_code.py
@@ -66,10 +66,14 @@ def test_kimi_catalog_aliases_use_the_endpoint_allowlist(endpoint: str, alias: s
 def test_kimicc_interactive_dry_run_reports_k3_high_and_explicit_override(tmp_path: Path) -> None:
     env = {**_KIMI_CREDENTIALS, "KIMICC_AUTH_TOKEN": "test-key", "HOME": str(tmp_path / "home")}
     default = run_launcher("start-kimicc.sh", env=env)
+    k3 = run_launcher("start-kimicc.sh", "--model", "k3", env=env)
     override = run_launcher("start-kimicc.sh", env={**env, "KIMICC_EFFORT_LEVEL": "max"})
 
-    assert default.returncode == override.returncode == 0
-    assert "KimiCC route: effort=high" in default.stdout
+    assert default.returncode == k3.returncode == override.returncode == 0
+    # Operator 2026-08-13: the default model is k3-256k with no forced effort;
+    # the k3-high default applies only when full k3 is explicitly selected.
+    assert "KimiCC route: effort=not-exposed" in default.stdout
+    assert "KimiCC route: effort=high" in k3.stdout
     assert "KimiCC route: effort=max" in override.stdout
 
 

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -12,7 +12,8 @@ def test_kimi_native_is_default_and_interactive_rejects_epic() -> None:
     epic = run_launcher("start-kimi.sh", "--epic", "devops")
     assert interactive.returncode == 0, interactive.stderr
     # Catalog-resolved native id, never the bare alias (review finding, #5958 r3).
-    assert "would exec kimi --model kimi-code/k3" in interactive.stdout
+    # Operator 2026-08-13: the omitted-model default is k3-256k.
+    assert "would exec kimi --model kimi-code/k3-256k" in interactive.stdout
     assert epic.returncode == 2
     assert "interactive launchers reject --epic" in epic.stderr
 


### PR DESCRIPTION
## What

Operator GO 2026-08-13: new fleet default models/efforts. Omitted `--model`/`--effort` resolve to the new defaults; explicit flags always win.

| Lane | New default when flags omitted | Override |
|---|---|---|
| kimi dispatch + `start-kimi.sh` native | `k3-256k` (catalog alias → `kimi-code/k3-256k`); effort omitted (no forced max) | `--model k3` / `--effort high\|max` |
| glm dispatch + `ask-glm` | `glm-5.2` @ `--variant high` | `--model` / `--effort` |
| deepseek dispatch | OpenCode first-party `deepseek-direct/deepseek-v4-flash` @ `--variant high` (new `DeepSeekAdapter`, mirrors `glm.py`) | `--model deepseek-v4-pro` / `--effort` |
| codex dispatch + `start-codex*.sh` | `gpt-5.6-luna` @ `-c model_reasoning_effort=max` | `--model gpt-5.6-terra\|gpt-5.6-sol` / `--effort` |
| claude headless (`ClaudeAdapter`) | `claude-sonnet-5` @ `--effort high` (when CLI supports it) | `--model claude-fable-5\|claude-opus-5` / `--effort` |

Not changed (per GO): interactive Grok, interactive Claude TUI (`start-claude.sh` keeps empty model/effort), Cursor stays on cursor-agent, GLM LOCAL-ONLY rail, no new drivers.

## Details

- `registry.py`: kimi → `k3-256k` (default_effort dropped); glm → `default_effort: high`; codex → `gpt-5.6-luna` + `default_effort: max`; deepseek → `DeepSeekAdapter`, `deepseek-v4-flash` @ high.
- `routes.py`: first-party CI refuse now also trips on the `deepseek-direct` provider id (same env vars, same marker).
- `hermes_deepseek.py` retained for `ask-hermes` only; its adapter tests still pass unchanged.
- `launcher_core.sh`: kimi default `k3` → `k3-256k`, codex `gpt-5.6-terra` → `gpt-5.6-luna`, `codex:gpt-5.6-luna` added to driver certification allowlist.
- `glm.sh`: injects `--effort` when `LC_EFFORT` is set (mirrors `claude.sh`).
- `kimicc.py`: default `k3` → `k3-256k`; full-k3 `--effort high` injection now applies only when k3 is explicitly selected.
- `model-assignment.md`: live-default sentences updated (Codex dispatch, Kimi onboarding/lane, DeepSeek OpenCode dispatch default for Entire capture). Roster/topology projections untouched.

## Consequence to flag

`deepseek-tools` (V7 writer) normalizes to the `deepseek` registry seat (`agent_identity.py:91`), so it now routes through OpenCode first-party too — with its explicit `deepseek-v4-pro`/`medium` pins from `linear_pipeline.py` intact. Hermes MCP (`sources`) wiring no longer applies to that path. This follows from the registry rewire in the GO; flagged for operator awareness, not silently worked around.

## Verification

- `pytest` on touched + focused files: **510 passed**, 2 failed — both pre-existing worktree-environment failures, verified failing identically on base via `git stash` (missing `.venv` in dispatch worktree / ambient env leak):
  - `tests/test_agent_runtime.py::test_usage_attribution_detects_codex_desktop`
  - `tests/test_start_codex_claude_code.py::test_codex_claude_code_clears_foreign_ambient_auth_before_exec`
- Wider sweep (34 files incl. `tests/agent_runtime/`, launcher profiles, kimi oauth, ua_eval): remaining failures verified **identical failure sets** on base (`diff` of sorted FAILED lists → IDENTICAL_FAILURE_SETS).
- New tests: `tests/agent_runtime/adapters/test_deepseek_adapter.py` (6 tests: default plan = `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`, no hermes in cmd, explicit overrides win, CI refuse marker); GLM default/explicit variant tests; kimi default `kimi-code/k3-256k` + `--model k3 --effort max` wins; claude omitted-effort → `--effort high`; codex omitted-effort → `model_reasoning_effort=max`; ask-glm default variant high.
- End-to-end loader smoke (registry → `_load_adapter` → `build_invocation`) confirms all five lanes' resolved argv.
- `ruff check` on all touched Python files: clean. `bash -n` + shellcheck on touched launchers: clean.
- Deploy-mirror check (`scripts/check_rules_deployment.sh`) fails identically on base in this worktree (gitignored `.gemini/`/`.claude/` deploy targets don't exist in dispatch worktrees); only canonical `agents_extensions/` sources were edited.

X-Agent: kimi/routing-defaults-2026-08-13
