### PR TITLE
feat(hygiene): schedule home session retention checks

### DIFF
--- a/docs/runbooks/home-session-inventory.md
+++ b/docs/runbooks/home-session-inventory.md
@@ -19,6 +19,26 @@ The fixed provider allowlist is intentionally small:
 The default retention boundary is 14 days. Missing roots are reported; they are
 not created. Symlinked homes, session roots, and files are skipped.
 
+## Scheduled policy check
+
+The existing local Git-hygiene LaunchAgent runs every four hours and now invokes
+the inventory in read-only mode. Its receipt reports, for each provider lane,
+the total allowlisted session-file count and provider-root bytes plus stale
+file count and stale bytes. The #4956 policy threshold is **14 days** and the
+allowed stale budget is **0 files / 0 bytes**: any stale allowlisted session
+file prints a `HARD WARNING`. An existing but unmeasurable provider root also
+prints a hard warning rather than being treated as compliant.
+
+Run the same observation manually:
+
+```bash
+.venv/bin/python scripts/hygiene/home_session_retention_check.py --json
+```
+
+This check has no apply option, does not read `LU_HOME_SESSION_APPLY`, and never
+archives or deletes anything. Applying archive or deletion remains exclusively
+behind the inventory command's `--apply` plus `LU_HOME_SESSION_APPLY=1` gate.
+
 ## Apply
 
 Apply is deliberately double-gated. It requires both `--apply` and the exact

--- a/scripts/hygiene/home_session_retention_check.py
+++ b/scripts/hygiene/home_session_retention_check.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Check the #4956 home-session retention policy without mutating any files.
+
+The policy boundary is 14 days: every allowlisted session file at or beyond
+that age must be archived before local deletion. The checker deliberately does
+not accept ``--apply`` and never reads ``LU_HOME_SESSION_APPLY``; it is a
+scheduled observation and warning surface, not a second reaper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.hygiene import inventory_home_sessions
+
+SCHEMA_VERSION = "home-session-retention-check.v1"
+
+
+def build_report(*, retention_days: float = inventory_home_sessions.DEFAULT_RETENTION_DAYS) -> dict[str, Any]:
+    """Measure allowlisted session stores and flag stale or unmeasurable lanes."""
+    roots, candidates = inventory_home_sessions.inventory_home_sessions(
+        retention_days=retention_days
+    )
+    candidates_by_provider: dict[str, list[inventory_home_sessions.SessionCandidate]] = defaultdict(list)
+    for candidate in candidates:
+        candidates_by_provider[candidate.provider].append(candidate)
+
+    lanes: list[dict[str, Any]] = []
+    violations: list[dict[str, Any]] = []
+    for root in roots:
+        stale = candidates_by_provider[root.provider]
+        stale_bytes = sum(candidate.size_bytes for candidate in stale)
+        lane = {
+            "provider": root.provider,
+            "exists": root.exists,
+            "session_files": root.session_files,
+            "root_bytes": root.size_bytes,
+            "stale_files": len(stale),
+            "stale_bytes": stale_bytes,
+            "skipped_reason": root.skipped_reason,
+        }
+        lanes.append(lane)
+        if root.exists and root.size_bytes is None:
+            violations.append(
+                {
+                    "provider": root.provider,
+                    "kind": "unmeasurable_root",
+                    "detail": root.skipped_reason or "provider root size could not be measured",
+                }
+            )
+        if stale:
+            violations.append(
+                {
+                    "provider": root.provider,
+                    "kind": "stale_sessions",
+                    "stale_files": len(stale),
+                    "stale_bytes": stale_bytes,
+                }
+            )
+
+    return {
+        "schema": SCHEMA_VERSION,
+        "mode": "read_only",
+        "policy": {
+            "retention_days": retention_days,
+            "max_stale_files": 0,
+            "max_stale_bytes": 0,
+        },
+        "lanes": lanes,
+        "summary": {
+            "lanes": len(lanes),
+            "session_files": sum(lane["session_files"] for lane in lanes),
+            "root_bytes": sum(lane["root_bytes"] or 0 for lane in lanes),
+            "stale_files": sum(lane["stale_files"] for lane in lanes),
+            "stale_bytes": sum(lane["stale_bytes"] for lane in lanes),
+            "violations": len(violations),
+        },
+        "violations": violations,
+    }
+
+
+def warning_lines(report: dict[str, Any]) -> list[str]:
+    """Return actionable warnings for a failed policy observation."""
+    retention_days = report["policy"]["retention_days"]
+    lines: list[str] = []
+    for violation in report["violations"]:
+        provider = violation["provider"]
+        if violation["kind"] == "stale_sessions":
+            lines.append(
+                "HARD WARNING: "
+                f"{provider} has {violation['stale_files']} allowlisted session file(s) "
+                f"({violation['stale_bytes']} bytes) at least {retention_days:g} days old; "
+                "archive them before any local deletion."
+            )
+        else:
+            lines.append(
+                "HARD WARNING: "
+                f"cannot verify {provider} home-session retention: {violation['detail']}."
+            )
+    return lines
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--retention-days",
+        type=float,
+        default=inventory_home_sessions.DEFAULT_RETENTION_DAYS,
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.retention_days < 0:
+        raise SystemExit("--retention-days must be non-negative")
+    report = build_report(retention_days=args.retention_days)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(
+            "Home-session retention check "
+            f"(read-only; stale >= {args.retention_days:g} days)"
+        )
+        for lane in report["lanes"]:
+            root_bytes = "unknown" if lane["root_bytes"] is None else lane["root_bytes"]
+            print(
+                f"  {lane['provider']}: sessions={lane['session_files']} root_bytes={root_bytes} "
+                f"stale_files={lane['stale_files']} stale_bytes={lane['stale_bytes']}"
+            )
+    for line in warning_lines(report):
+        print(line, file=sys.stderr)
+    return 1 if report["violations"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -27,6 +27,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.hygiene import home_session_retention_check
 from scripts.orchestration import reap_worktrees
 from scripts.orchestration.tmp_leak_sweep import sweep_tmp_leaks
 from scripts.review.isolation import sweep_review_temp_orphans
@@ -621,6 +622,10 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     repo_roots = args.repo_root or args.default_repo_roots
     receipt = build_receipt(repo_roots, apply=bool(args.apply))
+    home_session_retention = home_session_retention_check.build_report()
+    receipt["home_session_retention"] = home_session_retention
+    for line in home_session_retention_check.warning_lines(home_session_retention):
+        sys.stderr.write(f"{line}\n")
     receipt_path = write_receipt(receipt, args.receipt_dir.expanduser().resolve())
     payload = {**receipt, "receipt_path": str(receipt_path)}
     print(json.dumps(payload, ensure_ascii=False, sort_keys=True))

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -485,6 +485,40 @@ def test_receipt_aggregates_both_repositories(tmp_path: Path, monkeypatch) -> No
     assert receipt["mode"] == "apply"
 
 
+def test_main_records_read_only_home_session_policy_and_prints_hard_warning(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    receipt = {"summary": {"errors": 0}}
+    home_report = {
+        "mode": "read_only",
+        "policy": {"retention_days": 14},
+        "lanes": [],
+        "violations": [
+            {
+                "provider": "codex",
+                "kind": "stale_sessions",
+                "stale_files": 1,
+                "stale_bytes": 2,
+            }
+        ],
+    }
+    monkeypatch.setattr(cleanup, "build_receipt", lambda *_args, **_kwargs: receipt)
+    monkeypatch.setattr(cleanup.home_session_retention_check, "build_report", lambda: home_report)
+    monkeypatch.setattr(
+        cleanup.home_session_retention_check,
+        "warning_lines",
+        lambda _report: ["HARD WARNING: stale home session"],
+    )
+    monkeypatch.setattr(cleanup, "write_receipt", lambda *_args: tmp_path / "receipt.json")
+
+    assert cleanup.main(["--repo-root", str(tmp_path), "--receipt-dir", str(tmp_path)]) == 0
+
+    assert receipt["home_session_retention"] is home_report
+    assert "HARD WARNING: stale home session" in capsys.readouterr().err
+
+
 def test_git_maintenance_failure_is_reported(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_home_session_retention_check.py
+++ b/tests/test_home_session_retention_check.py
@@ -1,0 +1,111 @@
+"""Tests for the read-only scheduled home-session retention check (#4956)."""
+
+from __future__ import annotations
+
+from scripts.hygiene import home_session_retention_check as check
+from scripts.hygiene.inventory_home_sessions import SessionCandidate, SessionRootReport
+
+
+def test_build_report_measures_each_lane_and_flags_stale_bytes(monkeypatch) -> None:
+    roots = [
+        SessionRootReport("codex", "/home/.codex", True, 200, 1.0, 3),
+        SessionRootReport("claude", "/home/.claude", False, 0, None, 0),
+    ]
+    candidates = [
+        SessionCandidate("codex", "/home/.codex/sessions/old.jsonl", "sessions/old.jsonl", 75, 14.0)
+    ]
+    monkeypatch.setattr(
+        check.inventory_home_sessions,
+        "inventory_home_sessions",
+        lambda *, retention_days: (roots, candidates),
+    )
+
+    report = check.build_report(retention_days=14)
+
+    assert report["mode"] == "read_only"
+    assert report["policy"] == {
+        "retention_days": 14,
+        "max_stale_files": 0,
+        "max_stale_bytes": 0,
+    }
+    assert report["lanes"] == [
+        {
+            "provider": "codex",
+            "exists": True,
+            "session_files": 3,
+            "root_bytes": 200,
+            "stale_files": 1,
+            "stale_bytes": 75,
+            "skipped_reason": None,
+        },
+        {
+            "provider": "claude",
+            "exists": False,
+            "session_files": 0,
+            "root_bytes": 0,
+            "stale_files": 0,
+            "stale_bytes": 0,
+            "skipped_reason": None,
+        },
+    ]
+    assert report["summary"] == {
+        "lanes": 2,
+        "session_files": 3,
+        "root_bytes": 200,
+        "stale_files": 1,
+        "stale_bytes": 75,
+        "violations": 1,
+    }
+    assert check.warning_lines(report) == [
+        "HARD WARNING: codex has 1 allowlisted session file(s) (75 bytes) at least 14 days old; "
+        "archive them before any local deletion."
+    ]
+
+
+def test_build_report_fails_closed_when_an_existing_root_cannot_be_measured(monkeypatch) -> None:
+    roots = [
+        SessionRootReport(
+            "cursor",
+            "/home/.cursor",
+            True,
+            None,
+            None,
+            0,
+            "provider home is not a real directory",
+        )
+    ]
+    monkeypatch.setattr(
+        check.inventory_home_sessions,
+        "inventory_home_sessions",
+        lambda *, retention_days: (roots, []),
+    )
+
+    report = check.build_report()
+
+    assert report["violations"] == [
+        {
+            "provider": "cursor",
+            "kind": "unmeasurable_root",
+            "detail": "provider home is not a real directory",
+        }
+    ]
+
+
+def test_main_never_enables_apply_and_returns_nonzero_for_policy_violation(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        check,
+        "build_report",
+        lambda *, retention_days: {
+            "policy": {"retention_days": retention_days},
+            "lanes": [],
+            "violations": [
+                {"provider": "grok", "kind": "stale_sessions", "stale_files": 2, "stale_bytes": 9}
+            ],
+        },
+    )
+
+    assert check.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert "read-only" in captured.out
+    assert "HARD WARNING" in captured.err


### PR DESCRIPTION
Refs #4956

## What changed
- Adds a read-only home-session retention check to the existing four-hour local Git-hygiene runner.
- Reports total and stale file/byte counts for each provider lane and emits hard warnings at the existing 14-day policy boundary.
- Keeps archive/delete exclusively behind `inventory_home_sessions.py --apply` plus `LU_HOME_SESSION_APPLY=1`.

## Validation
- `pytest tests/test_home_session_retention_check.py tests/test_inventory_home_sessions.py tests/orchestration/test_scheduled_worktree_cleanup.py -q`
- `ruff check scripts/hygiene/home_session_retention_check.py scripts/orchestration/scheduled_worktree_cleanup.py tests/test_home_session_retention_check.py tests/orchestration/test_scheduled_worktree_cleanup.py`