### PR TITLE
fix(catalog): resolve k3-256k alias so ask-kimi validates for ACP

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -2995,7 +2995,7 @@ def _validate_catalog_model(
 ) -> None:
     """Require a current active catalog model on the adapter's real route."""
     try:
-        from scripts.review.model_catalog import load_model_catalog
+        from scripts.review.model_catalog import load_model_catalog, model_aliases
 
         catalog = load_model_catalog()
     except (ImportError, OSError, ValueError) as exc:
@@ -3004,7 +3004,7 @@ def _validate_catalog_model(
         ) from exc
 
     try:
-        model_entry = catalog["models"][model]
+        model_entry = catalog["models"][model_aliases(catalog)[model]]
         catalog_transport = ACPX_PARTICIPANT_CATALOG_TRANSPORTS[participant]
     except (KeyError, TypeError) as exc:
         raise InterAgentTransportError(

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -142,7 +142,7 @@ review_scheduler:
     kimicc:
       formal_review_eligible: false
       formal_review_exclusion_reason: authenticated K3 sealed MCP canary has not completed
-      models: [kimi-code/k3]
+      models: [kimi-code/k3, kimi-code/k3-256k]
       participant: kimicc
       adapter_transport: acp
       catalog_transport: native_kimi

--- a/scripts/review/model_catalog.py
+++ b/scripts/review/model_catalog.py
@@ -396,6 +396,21 @@ def load_model_catalog(path: Path = CATALOG_PATH) -> dict[str, Any]:
     return validate_catalog(raw)
 
 
+def model_aliases(catalog: dict[str, Any] | None = None) -> dict[str, str]:
+    """Return every supported model input alias mapped to its canonical catalog id.
+
+    Unlike the transport-specific alias helpers below, this covers *all* models
+    so that a transport-agnostic validator (e.g. the ACP catalog gate) can
+    resolve any caller-supplied alias before the catalog dict lookup.
+    """
+    models = (catalog or load_model_catalog())["models"]
+    aliases: dict[str, str] = {}
+    for model_id, model in models.items():
+        aliases[model_id] = model_id
+        aliases.update({alias: model_id for alias in model.get("aliases", [])})
+    return aliases
+
+
 def kimi_model_aliases(catalog: dict[str, Any] | None = None) -> dict[str, str]:
     """Return every supported Kimi input alias mapped to its native CLI model id."""
     models = (catalog or load_model_catalog())["models"]

--- a/tests/test_agent_runtime_acp_transport_cutover.py
+++ b/tests/test_agent_runtime_acp_transport_cutover.py
@@ -362,3 +362,16 @@ def test_discussion_uses_normal_transport_for_three_participants_with_pins(
     assert all(kwargs["model"] == "kimi-code/k3" for kwargs in kimicc_calls)
     assert all(kwargs["model"] == "glm-5.2" for kwargs in glm_calls)
     assert all(kwargs["effort"] == "high" for kwargs in glm_calls)
+
+
+@pytest.mark.parametrize("model", ["k3-256k", "kimi-k3-256k", "kimi-code/k3-256k"])
+def test_resolve_inter_agent_route_accepts_k3_256k_alias_for_kimi(model: str) -> None:
+    """ask-kimi --to-model k3-256k must validate through the catalog alias gate."""
+    route = runner.resolve_inter_agent_route("kimi", model=model)
+    assert route.participant == "kimi"
+    assert route.model == model
+
+
+def test_resolve_inter_agent_route_rejects_an_unknown_kimi_model() -> None:
+    with pytest.raises(runner.InterAgentTransportError, match="no enabled catalog route"):
+        runner.resolve_inter_agent_route("kimi", model="k3-nonexistent")

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -17,6 +17,7 @@ from scripts.review.model_catalog import (
     glm_model_aliases,
     kimi_model_aliases,
     load_model_catalog,
+    model_aliases,
     resolve_glm_model,
     resolve_kimi_model,
     validate_catalog,
@@ -140,6 +141,16 @@ def test_kimi_aliases_and_routes_are_catalog_backed() -> None:
         "context_profile": "kimicc_k3",
     }
     validate_kimi_alias_consumers()
+
+
+def test_generic_model_aliases_resolve_k3_256k_and_kimicc_endpoint_lists_it() -> None:
+    """The transport-agnostic alias map must resolve every Kimi alias, including 256k."""
+    aliases = model_aliases()
+    assert aliases["kimi-code/k3-256k"] == "kimi-code/k3-256k"
+    assert aliases["k3-256k"] == "kimi-code/k3-256k"
+    assert aliases["kimi-k3-256k"] == "kimi-code/k3-256k"
+    endpoints = load_model_catalog()["review_scheduler"]["endpoints"]
+    assert "kimi-code/k3-256k" in endpoints["kimicc"]["models"]
 
 
 def test_glm_model_aliases_and_consumer_lint() -> None:


### PR DESCRIPTION
## Problem

`ask-kimi --to-model k3-256k` raised:
```
ACP participant 'kimi' has no enabled catalog route for model 'k3-256k'
```

The ACP catalog gate (`_validate_catalog_model` in `runner.py`) did a direct `catalog["models"][model]` lookup without resolving aliases. The canonical key `kimi-code/k3-256k` has alias `k3-256k`, but the dict lookup missed it.

## Fix

1. **`scripts/review/model_catalog.py`** — add transport-agnostic `model_aliases()` that maps every alias (across all models) to its canonical catalog id. This mirrors the existing `kimi_model_aliases()` / `glm_model_aliases()` pattern but covers all transports.

2. **`scripts/agent_runtime/runner.py`** — route `_validate_catalog_model`'s lookup through `model_aliases(catalog)[model]` so any caller-supplied alias resolves before the catalog dict lookup. The existing `except (KeyError, TypeError)` still catches unknown models.

3. **`scripts/config/model_catalog.yaml`** — list `kimi-code/k3-256k` on the `kimicc` review-scheduler endpoint for catalog accuracy (participant `kimi` is an unpinned launcher; `kimicc` is the concrete K3 endpoint).

## Test

> `test_resolve_inter_agent_route_accepts_k3_256k_alias_for_kimi[k3-256k]`
> `route.participant == "kimi"`

Parametrized over `k3-256k`, `kimi-k3-256k`, and `kimi-code/k3-256k`. Also adds a negative test that an unknown model still raises `"no enabled catalog route"`.

## Constraints

- Does NOT touch dispatch defaults (#6687 owns that).
- Does NOT touch `scripts/hygiene`, `scripts/api`, or `agent_runtime/adapters/`.

X-Agent: glm/kimi-acp-256k