### PR TITLE
fix(deps): bump hf-xet to satisfy huggingface-hub (#6409)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -55,7 +55,7 @@ greenlet==3.5.1
 grpcio==1.82.1
 h11==0.16.0
 h2==4.4.1
-hf-xet==1.5.0
+hf-xet==1.5.1
 hpack==4.2.0
 httpcore==1.0.9
 httpcore2==2.9.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -53,7 +53,7 @@ greenlet==3.3.1
 grpcio==1.78.0
 h11==0.16.0
 h2==4.3.0
-hf-xet==1.2.0
+hf-xet==1.5.1
 hpack==4.1.0
 httpcore==1.0.9
 httpx==0.28.1


### PR DESCRIPTION
Closes #6409

## Problem
`requirements-lock.txt` pinned `hf-xet==1.5.0` (line 58) while `huggingface_hub==1.24.0` requires `hf-xet>=1.5.1,<2.0.0`. A pip resolve of the lockfile fails with `ResolutionImpossible` (verified).

## Change
- Bump `hf-xet==1.5.0` → `hf-xet==1.5.1` in `requirements-lock.txt` (smallest version satisfying `>=1.5.1`).
- Bump `requirements.lock`'s `hf-xet==1.2.0` → `hf-xet==1.5.1` so both generated lockfiles stay consistent on this pin (its `huggingface_hub==0.36.2` requires `>=1.1.3,<2.0.0`, so 1.5.1 satisfies it too).
- No unrelated packages touched.

No pip-compile/uv recipe exists in the repo (`requirements.in`/`uv.lock` absent; lockfiles are `pip freeze` snapshots — the established pattern is single-pin edits, e.g. dependabot PRs).

## Proof
- `pip install --dry-run hf-xet==1.5.0 huggingface-hub==1.24.0` → `ResolutionImpossible` (before)
- `pip install --dry-run hf-xet==1.5.1 huggingface-hub==1.24.0` → resolves (after)
- `pip install --dry-run hf-xet==1.5.1 huggingface-hub==0.36.2` → resolves
- `rg 'hf-xet|huggingface' requirements-lock.txt requirements.lock` → both files list `hf-xet==1.5.1`; no `hf-xet==1.5.0` remains in `requirements-lock.txt`.

## Out of scope
- CI installs `requirements-lock.txt` with `--no-deps`; no workflow change required.
- Do not merge (dispatch: no auto-merge armed).

X-Agent: deepseek/6409-hf-xet-lock