### PR TITLE
fix(kimi): kimicc telemetry and harness polish (#5938)

### DIFF
--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -111,6 +111,9 @@ class KimiAdapter:
             )
         if harness not in (None, "native"):
             raise ValueError(f"KimiAdapter: unsupported harness {harness!r}; expected 'native' or 'kimicc'")
+        # harness="native" reaches the same code path as an omitted flag by
+        # design: it exists only so dispatch can record an explicit
+        # harness=native attribution in task state (#5938 F2).
         if mode not in self.supported_modes:
             raise ValueError(
                 f"KimiAdapter: unsupported mode {mode!r} "

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -176,7 +176,6 @@ def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | Non
     if agent_name == "kimi" and plan.metadata.get("harness") == "kimicc":
         alias = plan.metadata.get("kimicc_alias")
         return str(alias).strip() if isinstance(alias, str) and alias.strip() else None
-    del agent_name
     return _arg_after(plan.cmd, "-m", "--model")
 
 
@@ -207,6 +206,27 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
     return None
 
 
+def _kimicc_alias(requested_model: str | None) -> str | None:
+    """Resolve the KimiCC route alias the harness would run for a request.
+
+    KimiccHarness defaults an omitted model to its own ``default_model``
+    (k3-256k), so pre-spawn telemetry must resolve through the same catalog
+    rather than assuming full k3 (#5938 F1).
+    """
+    from scripts.review.model_catalog import ModelCatalogError, resolve_kimi_model
+
+    from .adapters.kimicc import KimiccHarness
+
+    candidate = (requested_model or KimiccHarness.default_model).strip()
+    try:
+        _, route = resolve_kimi_model(candidate)
+    except ModelCatalogError:
+        # An unresolvable request fails later at adapter build time; report
+        # the raw candidate here so telemetry never invents an alias.
+        return candidate
+    return route.get("kimicc_alias")
+
+
 def _resolve_model_from_defaults(
     agent_name: str,
     requested_model: str | None,
@@ -214,7 +234,9 @@ def _resolve_model_from_defaults(
     harness: str | None = None,
 ) -> str | None:
     if agent_name == "kimi" and harness == "kimicc":
-        return requested_model or "k3"
+        from .adapters.kimicc import KimiccHarness
+
+        return requested_model or KimiccHarness.default_model
     if requested_model:
         return requested_model
     if agent_name == "codex":
@@ -262,7 +284,11 @@ def _resolve_effort_from_defaults(
         if harness == "kimicc":
             if requested_effort:
                 return requested_effort
-            return "high" if (requested_model or "k3") == "k3" else _NOT_EXPOSED
+            # Gate the default on the requested model exactly like
+            # KimiccHarness.build_invocation does: only the full-k3 route
+            # gets an implicit --effort high; the k3-256k harness default
+            # and the k2.7 routes run with no effort flag (#5938 F1).
+            return "high" if _kimicc_alias(requested_model) == "k3" else _NOT_EXPOSED
         # Without a plan the resolved model is unknowable (K3 is always-max,
         # the k2.7 models expose no effort knob) — report the honest marker
         # rather than guessing.

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -198,7 +198,7 @@ def _warn_kimicc_oauth_token_life(harness: str | None, hard_timeout: int) -> Non
         return
     print(
         f"⚠️  --harness kimicc with --hard-timeout {hard_timeout}s exceeds the ~{_KIMICC_OAUTH_TOKEN_LIFE_S}s "
-        "Kimi OAuth access-token lifetime; the wrapper refreshes the token only at spawn, "
+        "Kimi OAuth session lifetime; the wrapper refreshes credentials only at spawn, "
         "so calls still running past ~15 minutes may fail auth. Prefer shorter dispatches "
         "and relaunch instead of one long call.",
         file=sys.stderr,
@@ -292,9 +292,10 @@ DEFAULT_SILENCE_TIMEOUT_S = 3600
 # before their first token; the old 180s killed healthy workers mid-thought
 # (observed: deepseek review dispatch reaped at 181s, 1s over the limit).
 DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 600
-# KimiCC headless calls authenticate with a Kimi OAuth access token whose
-# lifetime is roughly 15 minutes (~840s). The wrapper refreshes it only at
-# spawn, so a worker still running past that point can start failing auth.
+# KimiCC headless calls authenticate with a Kimi OAuth session whose
+# lifetime is roughly 15 minutes (~840s). The wrapper refreshes credentials
+# only at spawn, so a worker still running past that point can start failing
+# auth.
 _KIMICC_OAUTH_TOKEN_LIFE_S = 840
 
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -193,11 +193,11 @@ def _resolve_dispatch_harness(agent: str, harness: str | None) -> str | None:
 
 
 def _warn_kimicc_oauth_token_life(harness: str | None, hard_timeout: int) -> None:
-    """Pre-flight note when a KimiCC dispatch can outlive its OAuth token (#5938 F4)."""
-    if harness != "kimicc" or hard_timeout <= _KIMICC_OAUTH_TOKEN_LIFE_S:
+    """Pre-flight note when a KimiCC dispatch can outlive its OAuth session (#5938 F4)."""
+    if harness != "kimicc" or hard_timeout <= _KIMICC_OAUTH_SESSION_LIFE_S:
         return
     print(
-        f"⚠️  --harness kimicc with --hard-timeout {hard_timeout}s exceeds the ~{_KIMICC_OAUTH_TOKEN_LIFE_S}s "
+        f"⚠️  --harness kimicc with --hard-timeout {hard_timeout}s exceeds the ~{_KIMICC_OAUTH_SESSION_LIFE_S}s "
         "Kimi OAuth session lifetime; the wrapper refreshes credentials only at spawn, "
         "so calls still running past ~15 minutes may fail auth. Prefer shorter dispatches "
         "and relaunch instead of one long call.",
@@ -296,7 +296,7 @@ DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 600
 # lifetime is roughly 15 minutes (~840s). The wrapper refreshes credentials
 # only at spawn, so a worker still running past that point can start failing
 # auth.
-_KIMICC_OAUTH_TOKEN_LIFE_S = 840
+_KIMICC_OAUTH_SESSION_LIFE_S = 840
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -164,6 +164,9 @@ _DISPATCH_AGENT_CHOICES = (
     "cursor",
     "glm",
 )
+# "native" is accepted for explicit task-state attribution but is
+# observability-only: KimiAdapter treats it identically to an omitted flag
+# (#5938 F2). Only "kimicc" changes the transport.
 _KIMI_HARNESSES = frozenset({"native", "kimicc"})
 # Dispatch agent → effort validator. Keep this mapping at the dispatch
 # boundary so an effort unsupported by a provider fails before a task state,
@@ -187,6 +190,19 @@ def _resolve_dispatch_harness(agent: str, harness: str | None) -> str | None:
     if harness not in _KIMI_HARNESSES:
         raise ValueError(f"unsupported Kimi harness {harness!r}; expected one of {sorted(_KIMI_HARNESSES)}")
     return harness
+
+
+def _warn_kimicc_oauth_token_life(harness: str | None, hard_timeout: int) -> None:
+    """Pre-flight note when a KimiCC dispatch can outlive its OAuth token (#5938 F4)."""
+    if harness != "kimicc" or hard_timeout <= _KIMICC_OAUTH_TOKEN_LIFE_S:
+        return
+    print(
+        f"⚠️  --harness kimicc with --hard-timeout {hard_timeout}s exceeds the ~{_KIMICC_OAUTH_TOKEN_LIFE_S}s "
+        "Kimi OAuth access-token lifetime; the wrapper refreshes the token only at spawn, "
+        "so calls still running past ~15 minutes may fail auth. Prefer shorter dispatches "
+        "and relaunch instead of one long call.",
+        file=sys.stderr,
+    )
 
 
 def _validate_dispatch_effort(agent: str, effort: str | None) -> None:
@@ -276,6 +292,10 @@ DEFAULT_SILENCE_TIMEOUT_S = 3600
 # before their first token; the old 180s killed healthy workers mid-thought
 # (observed: deepseek review dispatch reaped at 181s, 1s over the limit).
 DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 600
+# KimiCC headless calls authenticate with a Kimi OAuth access token whose
+# lifetime is roughly 15 minutes (~840s). The wrapper refreshes it only at
+# spawn, so a worker still running past that point can start failing auth.
+_KIMICC_OAUTH_TOKEN_LIFE_S = 840
 
 
 # ---------------------------------------------------------------------------
@@ -4219,6 +4239,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         )
         return 2
 
+    _warn_kimicc_oauth_token_life(requested_harness, args.hard_timeout)
+
     _check_capacity_hint(dispatch_agent, args=args)
 
     try:
@@ -5420,7 +5442,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Opt-in Kimi transport. Only valid with --agent kimi; use kimicc "
-            "for Kimi through headless Claude Code. Omit to keep native Kimi Code."
+            "for Kimi through headless Claude Code. Omit to keep native Kimi Code. "
+            "'native' is observability-only: it records harness=native in task "
+            "state and is functionally identical to omitting the flag (#5938)."
         ),
     )
     d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2888,10 +2888,10 @@ def test_kimicc_harness_rejects_other_agent_seats():
 
 
 def test_warn_kimicc_oauth_token_life_only_when_timeout_exceeds_token(capsys):
-    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S + 1)
+    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_SESSION_LIFE_S + 1)
     assert "OAuth session lifetime" in capsys.readouterr().err
 
-    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S)
+    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_SESSION_LIFE_S)
     delegate._warn_kimicc_oauth_token_life("native", 7200)
     delegate._warn_kimicc_oauth_token_life(None, 7200)
     assert capsys.readouterr().err == ""

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2889,7 +2889,7 @@ def test_kimicc_harness_rejects_other_agent_seats():
 
 def test_warn_kimicc_oauth_token_life_only_when_timeout_exceeds_token(capsys):
     delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S + 1)
-    assert "OAuth access-token lifetime" in capsys.readouterr().err
+    assert "OAuth session lifetime" in capsys.readouterr().err
 
     delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S)
     delegate._warn_kimicc_oauth_token_life("native", 7200)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2887,6 +2887,16 @@ def test_kimicc_harness_rejects_other_agent_seats():
         delegate._resolve_dispatch_harness("codex", "kimicc")
 
 
+def test_warn_kimicc_oauth_token_life_only_when_timeout_exceeds_token(capsys):
+    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S + 1)
+    assert "OAuth access-token lifetime" in capsys.readouterr().err
+
+    delegate._warn_kimicc_oauth_token_life("kimicc", delegate._KIMICC_OAUTH_TOKEN_LIFE_S)
+    delegate._warn_kimicc_oauth_token_life("native", 7200)
+    delegate._warn_kimicc_oauth_token_life(None, 7200)
+    assert capsys.readouterr().err == ""
+
+
 def test_run_worker_forwards_output_schema_to_runtime(tmp_tasks_dir, tmp_path):
     state_path = delegate._state_path("worker-schema")
     delegate._write_state_atomic(state_path, {"task_id": "worker-schema"})

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -348,7 +348,7 @@ def test_kimicc_telemetry_records_the_headless_k3_route(tmp_path):
     with patch("agent_runtime.telemetry.claude_cli_version", return_value="2.1.220"):
         at_dispatch = resolve_dispatch_start_telemetry(
             agent_name="kimi",
-            requested_model=None,
+            requested_model="k3",
             requested_effort=None,
             harness="kimicc",
         )
@@ -365,6 +365,34 @@ def test_kimicc_telemetry_records_the_headless_k3_route(tmp_path):
         "high",
         "2.1.220",
     )
+
+
+def test_kimicc_telemetry_omitted_model_defaults_to_k3_256k_without_effort(tmp_path):
+    """An omitted --model runs the harness default k3-256k with no --effort
+    flag (adapters/kimicc.py only defaults full-k3 to high), so dispatch-time
+    telemetry must not label it "high" (#5938 F1)."""
+    plan = InvocationPlan(
+        cmd=["kimicc_headless.sh", "--model", "k3-256k"],
+        cwd=tmp_path,
+        metadata={"harness": "kimicc", "kimicc_alias": "k3-256k", "claude_bin": "claude"},
+    )
+
+    with patch("agent_runtime.telemetry.claude_cli_version", return_value="2.1.220"):
+        at_dispatch = resolve_dispatch_start_telemetry(
+            agent_name="kimi",
+            requested_model=None,
+            requested_effort=None,
+            harness="kimicc",
+        )
+        after_spawn = resolve_invocation_telemetry(
+            agent_name="kimi",
+            plan=plan,
+            requested_model=None,
+            requested_effort=None,
+        )
+
+    assert (at_dispatch.model, at_dispatch.effort) == ("k3-256k", "not-exposed")
+    assert (after_spawn.model, after_spawn.effort) == ("k3-256k", "not-exposed")
 
 
 def test_kimicc_telemetry_prefers_explicit_effort_and_does_not_default_k2_7(tmp_path):


### PR DESCRIPTION
Closes #5938.

Post-merge polish for the kimicc headless route (findings from the PR #5937 review):

- **F3**: removed the stale `del agent_name` in `_resolve_model_from_plan` after the kimicc branch (`scripts/agent_runtime/telemetry.py`).
- **F1**: dispatch-time telemetry no longer mislabels kimicc effort. An omitted `--model` now resolves through the same catalog path as `KimiccHarness.build_invocation`: harness default is `k3-256k`, which runs with **no** `--effort` flag — telemetry now reports `k3-256k` / `not-exposed` instead of `k3` / `high`. Only the explicit full-k3 route keeps the implicit `high` default; an explicit `--effort` always wins.
- **F2**: `--harness native` documented as observability-only (records `harness=native` in task state; functionally identical to omitting the flag) — in `--help`, the `_KIMI_HARNESSES` comment, and `KimiAdapter`.
- **F4**: new pre-flight warning when a kimicc dispatch `--hard-timeout` exceeds the ~840s Kimi OAuth access-token lifetime (the wrapper refreshes the token only at spawn).

No changes to GLM/DeepSeek/Codex adapters.

## Verification
- `pytest tests/agent_runtime tests/test_delegate.py tests/test_dispatch_telemetry.py -q --tb=short -k "kimi or kimicc or telemetry or harness"` → 53 passed
- Full files: `tests/test_dispatch_telemetry.py`, `test_kimi_adapter.py`, `test_kimicc_headless.py` → 40 passed
- `ruff check` on all touched files → clean

X-Agent: kimi/5938-kimicc-polish