### PR TITLE
fix(reaper): reap squash-merged and detached worktrees

### DIFF
--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -566,20 +566,18 @@ def _qualifying_reason(
         ):
             return f"{pr_label} CLOSED"
 
-    if info.branch is not None:
+    if info.branch is not None and not safe_only:
+        if info.branch.startswith("build/"):
+            age_hours = _worktree_age_hours(info.path, now=now)
+            if age_hours is not None and age_hours > build_age_hours:
+                return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"
 
-        if not safe_only:
-            if info.branch.startswith("build/"):
-                age_hours = _worktree_age_hours(info.path, now=now)
-                if age_hours is not None and age_hours > build_age_hours:
-                    return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"
-
-            # Never treat "matches remote tip" as reaped-while-OPEN: open PR
-            # worktrees commonly match origin/<branch> and must stay mounted.
-            if (pr_state is None or pr_state.state != "OPEN") and _origin_matches_head(
-                info.path, info.branch
-            ):
-                return f"HEAD matches origin/{info.branch}"
+        # Never treat "matches remote tip" as reaped-while-OPEN: open PR
+        # worktrees commonly match origin/<branch> and must stay mounted.
+        if (pr_state is None or pr_state.state != "OPEN") and _origin_matches_head(
+            info.path, info.branch
+        ):
+            return f"HEAD matches origin/{info.branch}"
 
     if merged_pr_only and not include_terminal_dispatches:
         return None

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -293,16 +293,48 @@ def _pr_dict(pr_state: PullRequestState | None) -> dict[str, Any] | None:
     }
 
 
+def _candidate_branches_for_worktree(repo_root: Path, info: WorktreeInfo) -> list[str]:
+    if info.branch is not None:
+        return [info.branch]
+
+    candidates: list[str] = []
+    dispatch_root = (repo_root / ".worktrees" / "dispatch").resolve()
+    try:
+        rel = info.path.resolve().relative_to(dispatch_root)
+        if len(rel.parts) == 2:
+            candidates.append(f"{rel.parts[0]}/{rel.parts[1]}")
+    except ValueError:
+        pass
+
+    wt_root = _worktrees_root(repo_root)
+    try:
+        rel_wt = info.path.resolve().relative_to(wt_root)
+        rel_str = str(rel_wt)
+        if rel_str and rel_str not in candidates:
+            candidates.append(rel_str)
+        if "-" in rel_str and "/" not in rel_str:
+            slash_conv = rel_str.replace("-", "/", 1)
+            if slash_conv not in candidates:
+                candidates.append(slash_conv)
+    except ValueError:
+        pass
+
+    return candidates
+
+
 def _pr_matches_worktree_head(
     info: WorktreeInfo,
     pr_state: PullRequestState | None,
 ) -> bool:
-    return bool(
-        pr_state is not None
-        and pr_state.head_sha
-        and info.head
-        and pr_state.head_sha == info.head
+    if pr_state is None or not pr_state.head_sha or not info.head:
+        return False
+    if pr_state.head_sha == info.head:
+        return True
+    proc = _run(
+        ["git", "merge-base", "--is-ancestor", info.head, pr_state.head_sha],
+        cwd=info.path,
     )
+    return proc.returncode == 0
 
 
 def _live_cwd_paths(repo_root: Path) -> set[Path] | None:
@@ -522,17 +554,19 @@ def _qualifying_reason(
     merged_pr_only: bool = False,
     include_terminal_dispatches: bool = False,
 ) -> str | None:
+    if pr_state is not None:
+        pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
+        if pr_state.state == "MERGED" and _pr_matches_worktree_head(info, pr_state):
+            return f"{pr_label} MERGED"
+        if (
+            not merged_pr_only
+            and pr_state.state == "CLOSED"
+            and info.branch is not None
+            and _pr_matches_worktree_head(info, pr_state)
+        ):
+            return f"{pr_label} CLOSED"
+
     if info.branch is not None:
-        if pr_state is not None:
-            pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
-            if pr_state.state == "MERGED" and _pr_matches_worktree_head(info, pr_state):
-                return f"{pr_label} MERGED"
-            if (
-                not merged_pr_only
-                and pr_state.state == "CLOSED"
-                and _pr_matches_worktree_head(info, pr_state)
-            ):
-                return f"{pr_label} CLOSED"
 
         if not safe_only:
             if info.branch.startswith("build/"):
@@ -932,9 +966,10 @@ def _reap_qualified_worktree(
         branch_pruned = False
         if (
             prune_merged_branches
+            and info.branch is not None
             and pr_state is not None
             and pr_state.state == "MERGED"
-            and pr_state.head_sha == current_head
+            and _pr_matches_worktree_head(info, pr_state)
         ):
             branch_prune_error = _prune_branch(
                 repo_root,
@@ -1060,11 +1095,21 @@ def reap_worktrees(
             dirty_state = _worktree_clean(info.path)
             dirty = None if dirty_state is None else not dirty_state
 
+            candidates = _candidate_branches_for_worktree(repo_root, info)
             pr_state = None
             pr_error = None
-            if info.branch is not None:
-                pr_states, pr_error = _query_pr_states(repo_root, info.branch)
-                pr_state = _best_pr(pr_states)
+            if candidates:
+                all_pr_states: list[PullRequestState] = []
+                errors: list[str] = []
+                for cand_branch in candidates:
+                    st, err = _query_pr_states(repo_root, cand_branch)
+                    if err:
+                        errors.append(err)
+                    all_pr_states.extend(st)
+                if errors and not all_pr_states:
+                    pr_error = "; ".join(errors)
+                else:
+                    pr_state = _best_pr(all_pr_states)
 
             if (merged_pr_only or include_terminal_dispatches) and pr_error is not None:
                 results.append(

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1148,3 +1148,107 @@ def test_adoption_journals_existing_dispatch_worktree(tmp_path: Path) -> None:
         }
     ]
     assert '"event": "adopt"' in reaper_lifecycle.journal_path(repo).read_text(encoding="utf-8")
+
+
+def test_merged_pr_ancestor_head_reaps_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worktree whose local HEAD is an ancestor of the MERGED PR head is reaped."""
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/ancestor-head")
+    ancestor_head = git(worktree, "rev-parse", "HEAD")
+    # Add a follow-up commit to the branch so PR head is ahead of local worktree HEAD
+    git(worktree, "commit", "--allow-empty", "-m", "followup commit on PR branch")
+    pr_head = git(worktree, "rev-parse", "HEAD")
+    # Reset worktree back to ancestor HEAD
+    git(worktree, "reset", "--hard", ancestor_head)
+
+    patch_gh(
+        monkeypatch,
+        {
+            "codex/ancestor-head": [
+                {"number": 201, "state": "MERGED", "headRefOid": pr_head}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.reason == "PR #201 MERGED"
+    assert not worktree.exists()
+
+
+def test_detached_worktree_matching_merged_pr_reaps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detached dispatch worktree whose HEAD matches a MERGED PR's head is reaped."""
+    repo = init_repo(tmp_path)
+    task_id = "6690-ci-fix"
+    worktree = repo / ".worktrees" / "dispatch" / "kimi" / task_id
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "--detach", str(worktree), "main")
+    head = git(worktree, "rev-parse", "HEAD")
+
+    patch_gh(
+        monkeypatch,
+        {
+            "kimi/6690-ci-fix": [
+                {"number": 6690, "state": "MERGED", "headRefOid": head}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.reason == "PR #6690 MERGED"
+    assert not worktree.exists()
+
+
+def test_detached_worktree_with_open_pr_is_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detached dispatch worktree with an OPEN PR is not reaped."""
+    repo = init_repo(tmp_path)
+    task_id = "open-detached"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "--detach", str(worktree), "main")
+    head = git(worktree, "rev-parse", "HEAD")
+
+    patch_gh(
+        monkeypatch,
+        {
+            "codex/open-detached": [
+                {"number": 301, "state": "OPEN", "headRefOid": head}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert worktree.exists()


### PR DESCRIPTION
Reaper cannot reclaim squash-merged dispatch worktrees because local HEAD ≠ GitHub squash SHA. Disk is 94%.

AGY implement (spread wave). Commit already on the branch:

- Reap a clean worktree whose GitHub PR is MERGED when local HEAD is the PR branch head (or an ancestor), not only when HEAD equals the squash merge commit.
- Also reap detached HEADs that match a MERGED PR's last branch head.
- Tests in `tests/orchestration/test_reap_worktrees.py`.
- Does not weaken live-process / dirty / open-PR guards.

X-Agent: agy/reaper-squash-head

Driver pushed + opened this PR after the worker committed (`264ddb2f87`) and did not publish. Worker task still `running`.