### PR TITLE
feat(api): orient idle out-of-lane PR feed (#4728)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -2018,8 +2018,8 @@ reconciliation or maintenance.
 
 ### `GET /api/orient`
 
-One-call agent orientation: git, issues, pipeline, runtime, delegate, rollovers,
-wiki, health, and session hints.
+One-call agent orientation: git, issues, the cache-first idle PR feed, pipeline,
+runtime, delegate, rollovers, wiki, health, and session hints.
 
 Query params:
 
@@ -2028,8 +2028,8 @@ Query params:
   `pipeline`, `issues`, and `wiki` sections. An explicit `sections` list wins.
 - `sections=git,runtime` — comma-separated subset of section keys to
   collect. Valid keys: `git`, `issues`, `pipeline`, `runtime`,
-  `delegate`, `bridge_pending`, `rollovers`, `wiki`, `governance`, `health`,
-  `session_hints`. Unknown keys return `400`. Omitted = full payload
+  `idle_prs`, `delegate`, `bridge_pending`, `rollovers`, `wiki`, `governance`,
+  `health`, `session_hints`. Unknown keys return `400`. Omitted = full payload
   (back-compat). Skipped sections are not collected and are omitted
   from both the top-level payload and `meta`.
 - `role=<role>` — **opt-in** ADR-011 P3 cold-start research (see
@@ -2054,6 +2054,7 @@ Query params:
     }
   },
   "issues": [{"number": 1186, "title": "feat(api): refresh monitor API..."}],
+  "idle_prs": [{"number": 1234, "branch": "cursor/ready-for-sweep", "minutes_idle": 93}],
   "runtime": {"agents": ["claude", "gemini", "codex"]},
   "health": {"api": true, "mcp_rag": false},
   "meta": {
@@ -2079,6 +2080,7 @@ failure retries on the next call.
 |---|---:|---|---|
 | `git` | 30 | `git` | branch, head, ahead_of_origin, recent_commits |
 | `issues` | 120 | `gh` | top 10 open issues; slow API, rare updates |
+| `idle_prs` | 60 | `gh` | green, reviewed, open PRs idle for more than one hour; detached refresh |
 | `pipeline` | 0 | `fs` | wraps `/api/state/summary`, which carries its **own** 60 s cache. Caching again at the orient layer would stack windows and label up-to-119 s-old data as fresh (#1309 reviewer BLOCKER B2). |
 | `runtime` | 60 | `fs` | agent registry + headroom + recent outcomes |
 | `delegate` | 30 | `fs` | active delegate/codex tasks |
@@ -2158,6 +2160,16 @@ fallback (e.g. `git: {"error": "..."}`) while every other section
 still populates. A single wedged collector never takes down the
 whole response — this fixed the incident logged in the first entry
 of `docs/monitor-api/cold-start-baseline.md`.
+
+#### Idle PR feed (#4728)
+
+The full response includes `idle_prs`, a compact list of open PRs whose latest
+non-advisory checks are green, review-gate evidence is present, and GitHub
+activity has been idle for more than one hour. Each row contains `number`, the
+head `branch`, and `minutes_idle`. The `gh` refresh is cache-first and detached:
+the request serves the last successful value or an empty list immediately when
+GitHub is slow or unavailable. `?lean=true` omits this section; request
+`?sections=idle_prs` when it is needed explicitly.
 
 If the `issues` collector returns `issues_error` or the GitHub
 subsection times out, run

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -566,7 +566,7 @@ def _eligible_idle_pr(pr: dict[str, Any], *, now: datetime) -> dict[str, Any] | 
     if pr.get("state") is not None and str(pr.get("state")).upper() != "OPEN":
         return None
     merge_state = pr.get("mergeStateStatus")
-    if merge_state is not None and str(merge_state).upper() != "CLEAN":
+    if merge_state is not None and str(merge_state).upper() == "DIRTY":
         return None
     if pr.get("isDraft") is True or not _idle_pr_checks_green(pr):
         return None

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -13,10 +13,12 @@ import asyncio
 import json
 import logging
 import os
+import re
 import socket
 import sqlite3
 import subprocess
 import threading
+import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -232,12 +234,15 @@ SESSION_STATE_DIR = PROJECT_ROOT / "docs" / "session-state"
 #   - ``runtime``, ``delegate``, ``wiki``, ``health``, ``session_hints``
 #                            — pure-Python / filesystem, no inner
 #                              timeout; they rely on being cheap.
+#   - ``idle_prs``           — cache-first detached worker; ``gh`` never runs
+#                              in the request path.
 # If a sync collector ever starts to block (e.g. a network FS hang), it
 # will tie up a threadpool slot past the hard timeout. See
 # MONITOR-API.md for the full breakdown.
 ORIENT_SECTION_TTLS: dict[str, float] = {
     "git": 30.0,
     "issues": 120.0,
+    "idle_prs": 60.0,
     # Pipeline has TTL 0 on purpose — ``_collect_pipeline_orient_data``
     # calls ``state_summary()`` which has its own 60 s cache. Stacking
     # caches produced staleness up to 119 s with ``generated_at``
@@ -257,6 +262,7 @@ ORIENT_SECTION_TTLS: dict[str, float] = {
 ORIENT_SECTION_SOURCES: dict[str, str] = {
     "git": "git",
     "issues": "gh",
+    "idle_prs": "gh",
     "pipeline": "fs",
     "runtime": "fs",
     "delegate": "fs",
@@ -270,6 +276,23 @@ ORIENT_SECTION_SOURCES: dict[str, str] = {
 }
 
 ORIENT_SECTION_HARD_TIMEOUT_S = 5.0
+
+IDLE_PR_THRESHOLD_S = 60 * 60
+IDLE_PR_FETCH_TIMEOUT_S = 4.0
+IDLE_PR_REPOSITORY = "learn-ukrainian/learn-ukrainian.github.io"
+IDLE_PR_CACHE_KEY = "orient_idle_prs"
+IDLE_PR_SUCCESSFUL_CONCLUSIONS = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
+IDLE_PR_ADVISORY_MARKER = "advisory"
+_CROSS_FAMILY_REVIEW_RE = re.compile(r"\bcross[- ]family\b", re.IGNORECASE)
+_REVIEW_PASS_RE = re.compile(r"\b(?:approve(?:d)?|pass(?:ed)?)\b", re.IGNORECASE)
+_REVIEW_BLOCK_RE = re.compile(
+    r"\b(?:changes?[- ]requested|needs?[- ]work|blocked|fail(?:ed|ure)?)\b",
+    re.IGNORECASE,
+)
+_REVIEW_HEAD_RE = re.compile(
+    r"\b(?:at\s+)?head\b\s*[:=]?\s*`?([0-9a-f]{40})`?",
+    re.IGNORECASE,
+)
 
 ORIENT_SECTION_KEYS: tuple[str, ...] = tuple(ORIENT_SECTION_TTLS.keys())
 
@@ -300,6 +323,15 @@ _ORIENT_SYNC_EXECUTOR = ThreadPoolExecutor(
     max_workers=8,
     thread_name_prefix="orient-sync",
 )
+
+# The idle-PR feed is deliberately cache-first. A live GitHub request is run by
+# one detached daemon worker, never by the ASGI request path. The last successful
+# result remains available as a stale fallback when GitHub is slow or unavailable.
+_idle_pr_refresh_lock = threading.Lock()
+_idle_pr_refresh_thread: threading.Thread | None = None
+_idle_pr_last_good: tuple[dict[str, Any], str] | None = None
+_idle_pr_last_error: str | None = None
+_idle_pr_next_retry_at = 0.0
 
 
 def _parse_iso_datetime(value: str | None) -> datetime | None:
@@ -440,6 +472,253 @@ def _collect_issues_orient_data() -> dict:
             }
         )
     return {"issues": issues}
+
+
+def _pr_check_timestamp(check: dict[str, Any]) -> datetime | None:
+    for field in ("startedAt", "createdAt", "updatedAt", "completedAt"):
+        parsed = _parse_iso_datetime(check.get(field))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _idle_pr_checks_green(pr: dict[str, Any]) -> bool:
+    """Return whether every latest non-advisory check for a PR is green.
+
+    ``statusCheckRollup`` contains historical runs when a check has been
+    restarted. Grouping by context and selecting the newest timestamp avoids
+    resurrecting an old green run after a newer run went red or pending.
+    Missing or malformed status data fails closed. Explicitly advisory checks
+    follow the repository merge-hook convention and do not block eligibility.
+    """
+    rollup = pr.get("statusCheckRollup")
+    if not isinstance(rollup, list) or not rollup:
+        return False
+
+    latest: dict[str, tuple[datetime, dict[str, Any]]] = {}
+    for raw in rollup:
+        if not isinstance(raw, dict):
+            return False
+        name = raw.get("name") or raw.get("context")
+        timestamp = _pr_check_timestamp(raw)
+        if not isinstance(name, str) or not name.strip() or timestamp is None:
+            return False
+        current = latest.get(name)
+        if current is None or timestamp >= current[0]:
+            latest[name] = (timestamp, raw)
+
+    blocking_count = 0
+    for name, (_timestamp, check) in latest.items():
+        if IDLE_PR_ADVISORY_MARKER in name.casefold():
+            continue
+        blocking_count += 1
+        status = str(check.get("status") or "").upper()
+        if status and status not in {"COMPLETED", "SUCCESS"}:
+            return False
+        outcome = str(check.get("conclusion") or check.get("state") or "").upper()
+        if outcome not in IDLE_PR_SUCCESSFUL_CONCLUSIONS:
+            return False
+
+    return blocking_count > 0
+
+
+def _idle_pr_has_review_gate(pr: dict[str, Any]) -> bool:
+    """Return whether GitHub or a review comment proves a passed review gate."""
+    if str(pr.get("reviewDecision") or "").upper() == "APPROVED":
+        return True
+
+    head_sha = pr.get("headRefOid")
+    reviews = pr.get("reviews")
+    if isinstance(reviews, list):
+        for review in reviews:
+            if not isinstance(review, dict) or str(review.get("state") or "").upper() != "APPROVED":
+                continue
+            commit = review.get("commit")
+            commit_sha = commit.get("oid") if isinstance(commit, dict) else commit
+            if not isinstance(head_sha, str) or not commit_sha or commit_sha == head_sha:
+                return True
+
+    comments = pr.get("comments")
+    if not isinstance(comments, list):
+        return False
+    ordered_comments = sorted(
+        (comment for comment in comments if isinstance(comment, dict)),
+        key=lambda comment: _parse_iso_datetime(comment.get("createdAt")) or datetime.min.replace(tzinfo=UTC),
+    )
+    for comment in reversed(ordered_comments):
+        body = comment.get("body")
+        if not isinstance(body, str) or not _CROSS_FAMILY_REVIEW_RE.search(body):
+            continue
+        head_match = _REVIEW_HEAD_RE.search(body)
+        if (
+            head_match is not None
+            and isinstance(head_sha, str)
+            and head_match.group(1).casefold() != head_sha.casefold()
+        ):
+            continue
+        if _REVIEW_BLOCK_RE.search(body):
+            return False
+        return _REVIEW_PASS_RE.search(body) is not None
+    return False
+
+
+def _eligible_idle_pr(pr: dict[str, Any], *, now: datetime) -> dict[str, Any] | None:
+    if pr.get("state") is not None and str(pr.get("state")).upper() != "OPEN":
+        return None
+    merge_state = pr.get("mergeStateStatus")
+    if merge_state is not None and str(merge_state).upper() != "CLEAN":
+        return None
+    if pr.get("isDraft") is True or not _idle_pr_checks_green(pr):
+        return None
+    if not _idle_pr_has_review_gate(pr):
+        return None
+
+    number = pr.get("number")
+    branch = pr.get("headRefName")
+    updated_at = _parse_iso_datetime(pr.get("updatedAt"))
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or number <= 0
+        or not isinstance(branch, str)
+        or not branch
+        or updated_at is None
+    ):
+        return None
+
+    idle_seconds = (now - updated_at).total_seconds()
+    if idle_seconds <= IDLE_PR_THRESHOLD_S:
+        return None
+    return {
+        "number": number,
+        "branch": branch,
+        "minutes_idle": max(0, int(idle_seconds // 60)),
+    }
+
+
+def _collect_idle_prs_orient_data() -> dict[str, Any]:
+    """Fetch and filter the compact green+reviewed+idle PR projection.
+
+    This function is only called by the detached refresh worker. The endpoint
+    itself uses ``_cached_idle_pr_section`` and never waits for this ``gh``
+    subprocess.
+    """
+    proc = _run_command(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            IDLE_PR_REPOSITORY,
+            "--state",
+            "open",
+            "--limit",
+            "1000",
+            "--json",
+            "number,state,isDraft,headRefName,headRefOid,updatedAt,reviewDecision,reviews,comments,statusCheckRollup,mergeStateStatus",
+        ],
+        timeout=IDLE_PR_FETCH_TIMEOUT_S,
+    )
+    if proc.returncode != 0:
+        error = proc.stderr.strip() or proc.stdout.strip() or "gh pr list failed"
+        raise RuntimeError(error)
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid gh json: {exc}") from exc
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned a non-list payload")
+
+    now = datetime.now(UTC)
+    rows = [
+        row
+        for item in payload
+        if isinstance(item, dict)
+        if (row := _eligible_idle_pr(item, now=now)) is not None
+    ]
+    rows.sort(key=lambda row: (-row["minutes_idle"], row["number"]))
+    return {"idle_prs": rows}
+
+
+def _run_idle_pr_refresh(collector: Callable[[], Any]) -> None:
+    global _idle_pr_last_error, _idle_pr_last_good, _idle_pr_next_retry_at
+    try:
+        value = collector()
+        if not isinstance(value, dict) or not isinstance(value.get("idle_prs"), list):
+            raise RuntimeError("idle PR collector returned an invalid payload")
+    except subprocess.TimeoutExpired:
+        _idle_pr_last_error = "gh_timeout"
+        _idle_pr_next_retry_at = time.monotonic() + 30.0
+        return
+    except Exception:
+        _idle_pr_last_error = "gh_unavailable"
+        _idle_pr_next_retry_at = time.monotonic() + 30.0
+        return
+
+    generated_at = _isoformat_z(datetime.now(UTC))
+    cache_set(IDLE_PR_CACHE_KEY, (value, generated_at))
+    _idle_pr_last_good = (value, generated_at)
+    _idle_pr_last_error = None
+    _idle_pr_next_retry_at = 0.0
+
+
+def _schedule_idle_pr_refresh(collector: Callable[[], Any]) -> None:
+    global _idle_pr_refresh_thread
+    if time.monotonic() < _idle_pr_next_retry_at:
+        return
+    with _idle_pr_refresh_lock:
+        if _idle_pr_refresh_thread is not None and _idle_pr_refresh_thread.is_alive():
+            return
+        _idle_pr_refresh_thread = threading.Thread(
+            target=_run_idle_pr_refresh,
+            args=(collector,),
+            daemon=True,
+            name="orient-idle-pr-refresh",
+        )
+        _idle_pr_refresh_thread.start()
+
+
+def _cached_idle_pr_section(
+    collector: Callable[[], Any],
+    fallback: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    ttl = ORIENT_SECTION_TTLS["idle_prs"]
+    cached = cache_get(IDLE_PR_CACHE_KEY, ttl=ttl)
+    if isinstance(cached, tuple) and len(cached) == 2:
+        value, generated_at = cached
+        if isinstance(value, dict) and isinstance(generated_at, str):
+            return value, {
+                "generated_at": generated_at,
+                "stale_after_s": ttl,
+                "source": "gh",
+                "cache": "hit",
+            }
+
+    _schedule_idle_pr_refresh(collector)
+    if _idle_pr_last_good is not None:
+        value, generated_at = _idle_pr_last_good
+        meta: dict[str, Any] = {
+            "generated_at": generated_at,
+            "stale_after_s": ttl,
+            "source": "gh",
+            "cache": "miss",
+            "stale": True,
+            "refreshing": _idle_pr_refresh_thread is not None and _idle_pr_refresh_thread.is_alive(),
+        }
+        if _idle_pr_last_error is not None:
+            meta["error"] = _idle_pr_last_error
+        return value, meta
+
+    meta = {
+        "generated_at": _isoformat_z(datetime.now(UTC)),
+        "stale_after_s": ttl,
+        "source": "gh",
+        "cache": "miss",
+        "refreshing": _idle_pr_refresh_thread is not None and _idle_pr_refresh_thread.is_alive(),
+    }
+    if _idle_pr_last_error is not None:
+        meta["error"] = _idle_pr_last_error
+    return fallback, meta
 
 
 async def _collect_pipeline_orient_data() -> dict:
@@ -791,6 +1070,9 @@ async def _cached_orient_section(
     Errors are NOT cached — the next call retries. This is intentional:
     a transient git/gh hiccup shouldn't poison a 2-minute TTL window.
     """
+    if key == "idle_prs":
+        return _cached_idle_pr_section(collector, fallback)  # type: ignore[arg-type]
+
     ttl = ORIENT_SECTION_TTLS.get(key, 60.0)
     source = ORIENT_SECTION_SOURCES.get(key, "fs")
     cache_key = f"orient_{key}"
@@ -880,6 +1162,7 @@ def _orient_section_specs() -> dict[str, tuple[Callable[..., Any], Any, bool]]:
     return {
         "git": (_collect_git_orient_data, {}, False),
         "issues": (_collect_issues_orient_data, {"issues": []}, False),
+        "idle_prs": (_collect_idle_prs_orient_data, {"idle_prs": []}, False),
         "pipeline": (_collect_pipeline_orient_data, {"summary": {}}, True),
         "runtime": (_collect_runtime_orient_data, {}, False),
         "delegate": (_collect_delegate_orient_data, {"active_count": 0, "recent": []}, False),
@@ -916,7 +1199,7 @@ async def orient(
         False,
         description="Lean cold-start preset: return only the lightweight sections "
         "(git, runtime, delegate, bridge_pending, rollovers, governance, health, session_hints), "
-        "skipping the heavy pipeline/issues/wiki. Ignored when 'sections' is given.",
+        "skipping the heavy pipeline/issues/wiki and idle_prs. Ignored when 'sections' is given.",
     ),
     sections: str | None = Query(
         None,
@@ -935,7 +1218,8 @@ async def orient(
             gathering. Use it when an agent just committed, renamed a
             file, or otherwise needs to see a change it made moments
             ago without waiting for the longest section TTL (up to
-            120 s for ``issues``/``wiki``). Reviewer BLOCKER B3 / #1309.
+            120 s for ``issues``/``wiki``). The idle-PR refresh remains
+            cache-first and detached. Reviewer BLOCKER B3 / #1309.
         sections: comma-separated list of section keys to collect. Unknown
             keys return 400. Omitted = full payload (back-compat).
         role: ADR-011 P3 opt-in. Absent → the response is byte-identical to
@@ -984,6 +1268,9 @@ async def orient(
     if "issues" in section_data:
         issues_info = section_data["issues"]
         response["issues"] = issues_info.get("issues", []) if isinstance(issues_info, dict) else []
+    if "idle_prs" in section_data:
+        idle_prs_info = section_data["idle_prs"]
+        response["idle_prs"] = idle_prs_info.get("idle_prs", []) if isinstance(idle_prs_info, dict) else []
     if "pipeline" in section_data:
         response["pipeline"] = section_data["pipeline"]
     if "runtime" in section_data:
@@ -1011,6 +1298,10 @@ async def orient(
         issues_info = section_data["issues"]
         if isinstance(issues_info, dict) and issues_info.get("error"):
             response["issues_error"] = issues_info["error"]
+    if "idle_prs" in section_data:
+        idle_prs_info = section_data["idle_prs"]
+        if isinstance(idle_prs_info, dict) and idle_prs_info.get("error"):
+            response["idle_prs_error"] = idle_prs_info["error"]
 
     _attach_cold_start_research(response, role)
     return add_json_telemetry(response, session_id=session_id_from_request(request))

--- a/tests/api/test_delegate_active.py
+++ b/tests/api/test_delegate_active.py
@@ -49,6 +49,7 @@ def _reset_orient_cache() -> None:
 def _patch_non_delegate_orient_sources(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "_collect_git_orient_data", lambda: {"branch": "main"})
     monkeypatch.setattr(api_main, "_collect_issues_orient_data", lambda: {"issues": []})
+    monkeypatch.setattr(api_main, "_collect_idle_prs_orient_data", lambda: {"idle_prs": []})
 
     async def fake_pipeline():
         return {"summary": {}}

--- a/tests/api/test_orient_idle_prs.py
+++ b/tests/api/test_orient_idle_prs.py
@@ -141,6 +141,35 @@ def test_latest_red_check_blocks_an_old_green_run():
     assert api_main._eligible_idle_pr(pr, now=NOW) is None
 
 
+def test_blocked_merge_state_with_green_cf_review_is_eligible():
+    pr = _pr(
+        107,
+        updated_at=NOW - timedelta(hours=2),
+        reviewDecision="",
+        mergeStateStatus="BLOCKED",
+        comments=[
+            {
+                "body": (
+                    "## Cross-family CF (Grok / xAI)\n"
+                    f"**VERDICT: APPROVE** at head `{107:040x}`."
+                )
+            }
+        ],
+    )
+
+    assert api_main._eligible_idle_pr(pr, now=NOW) == {
+        "number": 107,
+        "branch": "codex/pr-107",
+        "minutes_idle": 120,
+    }
+
+
+def test_dirty_merge_state_remains_ineligible():
+    pr = _pr(108, updated_at=NOW - timedelta(hours=2), mergeStateStatus="DIRTY")
+
+    assert api_main._eligible_idle_pr(pr, now=NOW) is None
+
+
 def test_timeout_refresh_degrades_to_absent_cache():
     def timed_out():
         raise subprocess.TimeoutExpired(cmd=["gh", "pr", "list"], timeout=api_main.IDLE_PR_FETCH_TIMEOUT_S)

--- a/tests/api/test_orient_idle_prs.py
+++ b/tests/api/test_orient_idle_prs.py
@@ -1,0 +1,179 @@
+"""Tests for the cache-first idle pull-request orient section (#4728)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import scripts.api.main as api_main
+import scripts.api.state_helpers as state_helpers
+
+NOW = datetime(2026, 8, 13, 12, tzinfo=UTC)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _pr(number: int, *, updated_at: datetime, **changes: object) -> dict:
+    result: dict[str, object] = {
+        "number": number,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefName": f"codex/pr-{number}",
+        "headRefOid": f"{number:040x}",
+        "updatedAt": _iso(updated_at),
+        "reviewDecision": "APPROVED",
+        "reviews": [],
+        "comments": [],
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": [
+            {
+                "name": "CI Gate",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": _iso(updated_at),
+                "completedAt": _iso(updated_at + timedelta(minutes=10)),
+            }
+        ],
+    }
+    result.update(changes)
+    return result
+
+
+@pytest.fixture(autouse=True)
+def _reset_idle_pr_state():
+    state_helpers.cache_invalidate(api_main.IDLE_PR_CACHE_KEY)
+    api_main._idle_pr_last_good = None
+    api_main._idle_pr_last_error = None
+    api_main._idle_pr_next_retry_at = 0.0
+    thread = api_main._idle_pr_refresh_thread
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=2.0)
+    api_main._idle_pr_refresh_thread = None
+    yield
+    thread = api_main._idle_pr_refresh_thread
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=2.0)
+    state_helpers.cache_invalidate(api_main.IDLE_PR_CACHE_KEY)
+    api_main._idle_pr_last_good = None
+    api_main._idle_pr_last_error = None
+    api_main._idle_pr_next_retry_at = 0.0
+    api_main._idle_pr_refresh_thread = None
+
+
+def test_idle_pr_collector_excludes_fresh_red_and_unreviewed_prs(monkeypatch):
+    now = datetime.now(UTC)
+    approved_by_comment = _pr(
+        102,
+        updated_at=now - timedelta(hours=2),
+        reviewDecision="",
+        comments=[
+            {
+                "body": (
+                    "## Cross-family CF (Grok / xAI)\n"
+                    f"**VERDICT: APPROVE** at head `{102:040x}`."
+                )
+            }
+        ],
+    )
+    payload = [
+        _pr(101, updated_at=now - timedelta(hours=2)),
+        approved_by_comment,
+        _pr(103, updated_at=now - timedelta(minutes=45)),
+        _pr(
+            104,
+            updated_at=now - timedelta(hours=2),
+            statusCheckRollup=[
+                {
+                    "name": "CI Gate",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "startedAt": _iso(now - timedelta(hours=2)),
+                    "completedAt": _iso(now - timedelta(hours=1, minutes=50)),
+                }
+            ],
+        ),
+        _pr(105, updated_at=now - timedelta(hours=2), reviewDecision="", comments=[]),
+    ]
+
+    monkeypatch.setattr(
+        api_main,
+        "_run_command",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0], returncode=0, stdout=json.dumps(payload), stderr=""
+        ),
+    )
+    result = api_main._collect_idle_prs_orient_data()
+
+    assert [row["number"] for row in result["idle_prs"]] == [101, 102]
+    assert all(set(row) == {"number", "branch", "minutes_idle"} for row in result["idle_prs"])
+    assert all(row["minutes_idle"] > 60 for row in result["idle_prs"])
+
+
+def test_latest_red_check_blocks_an_old_green_run():
+    pr = _pr(
+        106,
+        updated_at=NOW - timedelta(hours=2),
+        statusCheckRollup=[
+            {
+                "name": "CI Gate",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": _iso(NOW - timedelta(hours=2)),
+                "completedAt": _iso(NOW - timedelta(hours=1, minutes=50)),
+            },
+            {
+                "name": "CI Gate",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "startedAt": _iso(NOW - timedelta(hours=1)),
+                "completedAt": _iso(NOW - timedelta(minutes=50)),
+            },
+        ],
+    )
+
+    assert api_main._eligible_idle_pr(pr, now=NOW) is None
+
+
+def test_timeout_refresh_degrades_to_absent_cache():
+    def timed_out():
+        raise subprocess.TimeoutExpired(cmd=["gh", "pr", "list"], timeout=api_main.IDLE_PR_FETCH_TIMEOUT_S)
+
+    api_main._run_idle_pr_refresh(timed_out)
+
+    assert state_helpers.cache_get(api_main.IDLE_PR_CACHE_KEY, ttl=api_main.ORIENT_SECTION_TTLS["idle_prs"]) is None
+    assert api_main._idle_pr_last_error == "gh_timeout"
+
+    result, meta = api_main._cached_idle_pr_section(timed_out, {"idle_prs": []})
+
+    assert result == {"idle_prs": []}
+    assert meta["error"] == "gh_timeout"
+
+
+def test_idle_pr_request_path_only_schedules_slow_gh_refresh(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_collector():
+        started.set()
+        release.wait(timeout=2.0)
+        return {"idle_prs": []}
+
+    start = time.perf_counter()
+    result, meta = api_main._cached_idle_pr_section(slow_collector, {"idle_prs": []})
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.2
+    assert result == {"idle_prs": []}
+    assert meta["refreshing"] is True
+    assert started.wait(timeout=1.0)
+
+    release.set()
+    assert api_main._idle_pr_refresh_thread is not None
+    api_main._idle_pr_refresh_thread.join(timeout=2.0)

--- a/tests/api/test_worktree_gc_sweep.py
+++ b/tests/api/test_worktree_gc_sweep.py
@@ -19,6 +19,7 @@ def _patch_orient_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     # Patch non-runtime sources to keep orient fast and hermetic
     monkeypatch.setattr(api_main, "_collect_git_orient_data", lambda: {"branch": "main"})
     monkeypatch.setattr(api_main, "_collect_issues_orient_data", lambda: {"issues": []})
+    monkeypatch.setattr(api_main, "_collect_idle_prs_orient_data", lambda: {"idle_prs": []})
 
     async def fake_pipeline():
         return {"summary": {}}

--- a/tests/test_orient.py
+++ b/tests/test_orient.py
@@ -1,0 +1,11 @@
+"""Small acceptance-path checks for the #4728 orient section."""
+
+from __future__ import annotations
+
+import scripts.api.main as api_main
+
+
+def test_idle_prs_are_full_orient_only_by_default():
+    assert "idle_prs" in api_main.ORIENT_SECTION_KEYS
+    assert "idle_prs" not in api_main.LEAN_ORIENT_SECTIONS
+    assert api_main._parse_orient_sections(None, lean=False)[0:3] == ["git", "issues", "idle_prs"]

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -49,6 +49,7 @@ def _patch_orient_sources(monkeypatch) -> None:
             monkeypatch.delenv(key, raising=False)
     monkeypatch.setattr(api_main, "_collect_git_orient_data", lambda: {"branch": "main", "head": "abc123"})
     monkeypatch.setattr(api_main, "_collect_issues_orient_data", lambda: {"issues": [{"number": 1186}]})
+    monkeypatch.setattr(api_main, "_collect_idle_prs_orient_data", lambda: {"idle_prs": []})
 
     async def fake_pipeline():
         return {"summary": {"totals": {"total": 1}}}
@@ -144,6 +145,7 @@ def test_orient_returns_all_top_level_keys(monkeypatch):
         "generated_at",
         "git",
         "issues",
+        "idle_prs",
         "pipeline",
         "runtime",
         "delegate",


### PR DESCRIPTION
## Summary

- Add the full `/api/orient` `idle_prs` section with compact number, branch, and minutes-idle rows.
- Fail closed on fresh, red/pending, malformed, or unreviewed PRs; accept green checks plus approval or cross-family review evidence.
- Use a 60-second TTL and a detached, single-flight `gh` refresh so requests serve cache/LKG/empty immediately.
- Add eligibility, latest-check, timeout-degrade, slow-refresh, lean/full-orient tests and API documentation.

Refs #4728

## Validation

- Focused orient/API tests: 37 passed.
- Ruff: passed.
- Requested suite: 111 passed, 1 skipped, 7 unrelated environment/service failures. Six failures require the absent worktree `.venv/bin/python` (forbidden by the dispatch contract); one live release snapshot test received HTTP 503 from the unavailable release service.
- Live collector probe completed successfully and returned no currently eligible rows.

Merge and auto-merge are intentionally not enabled.