### PR TITLE
fix(hygiene): path-guard remaining script deleters (#6013)

### DIFF
--- a/scripts/hygiene/codex_rollout_reconcile.py
+++ b/scripts/hygiene/codex_rollout_reconcile.py
@@ -23,7 +23,16 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+try:
+    from scripts.path_safety import assert_delete_target
+except ImportError:  # pragma: no cover - direct file invocation
+    _SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from path_safety import assert_delete_target  # type: ignore[no-redef]
+
 SCHEMA = "codex.rollout-reconcile.v1"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 STATE_PATTERN = re.compile(r"state_[A-Za-z0-9][A-Za-z0-9._-]*\.sqlite\Z")
 ROLLOUT_PATTERN = re.compile(r"rollout-[^/]+\.jsonl\Z")
 REQUIRED_COLUMNS = frozenset({"id", "rollout_path", "created_at", "updated_at", "archived"})
@@ -348,7 +357,15 @@ def _create_backup(database: Path, backup_dir: Path) -> Path:
                 raise ReconcileError(f"backup integrity check failed: {integrity}")
         os.chmod(path, 0o600)
     except Exception:
-        path.unlink(missing_ok=True)
+        try:
+            guarded = assert_delete_target(
+                path,
+                repo_root=_REPO_ROOT,
+                approved_temp_roots=(backup_dir,),
+            )
+            guarded.unlink(missing_ok=True)
+        except ValueError:
+            pass
         raise
     return path
 

--- a/scripts/hygiene/inventory_home_sessions.py
+++ b/scripts/hygiene/inventory_home_sessions.py
@@ -19,6 +19,16 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal
 
+# Dual-flavor import: pytest / package loads use ``scripts.*``; direct file
+# invocation of this CLI has only ``scripts/hygiene/`` on ``sys.path[0]``.
+try:
+    from scripts.path_safety import assert_delete_target
+except ImportError:  # pragma: no cover - direct ``scripts/hygiene/*.py`` invocation
+    _SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from path_safety import assert_delete_target  # type: ignore[no-redef]
+
 DEFAULT_RETENTION_DAYS = 14.0
 DEFAULT_ARCHIVE_ROOT = (
     Path.home()
@@ -28,6 +38,7 @@ DEFAULT_ARCHIVE_ROOT = (
     / "home-session-archives"
 )
 APPLY_ENV = "LU_HOME_SESSION_APPLY"
+_DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(frozen=True)
@@ -201,11 +212,13 @@ def apply_retention(
     archive_root: Path,
     action: Literal["archive", "delete"],
     retention_days: float,
+    repo_root: Path | None = None,
 ) -> list[dict[str, object]]:
     """Archive or delete freshly revalidated allowlisted session files."""
     if os.environ.get(APPLY_ENV) != "1":
         raise PermissionError(f"--apply requires {APPLY_ENV}=1")
 
+    resolved_repo = (repo_root or _DEFAULT_REPO_ROOT).resolve()
     store_by_provider = {store.provider: store for store in SESSION_STORES}
     results: list[dict[str, object]] = []
     for candidate in candidates:
@@ -235,8 +248,25 @@ def apply_retention(
                 {"path": candidate.path, "action": "skipped", "reason": "file is no longer stale"}
             )
             continue
+        try:
+            # Session trees live under $HOME, not ``.worktrees/`` — approve only
+            # the already-validated session subdirectory, never the home root.
+            target = assert_delete_target(
+                path,
+                repo_root=resolved_repo,
+                approved_temp_roots=(allowed_root,),
+            )
+        except ValueError as exc:
+            results.append(
+                {
+                    "path": candidate.path,
+                    "action": "skipped",
+                    "reason": f"delete guard refused: {exc}",
+                }
+            )
+            continue
         if action == "delete":
-            path.unlink()
+            target.unlink()
             results.append({"path": candidate.path, "action": "deleted"})
             continue
 
@@ -247,7 +277,7 @@ def apply_retention(
                 {"path": candidate.path, "action": "skipped", "reason": "archive destination exists"}
             )
             continue
-        shutil.move(str(path), str(destination))
+        shutil.move(str(target), str(destination))
         results.append({"path": candidate.path, "action": "archived", "archive_path": str(destination)})
     return results
 

--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Lint scripts/ (and services.sh) for raw ``rm -rf`` invocations (#6013).
+
+Python deleters must go through ``assert_delete_target``. Shell ``rm -rf`` is
+still used for a small set of already-scoped lockdirs/caches; those paths are
+allowlisted here rather than rewritten. New unscoped ``rm -rf`` lines fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Match ``rm -rf``, ``rm -fr``, and compact flag forms such as ``rm -rfv``.
+_RM_RF_RE = re.compile(r"(?:^|[\s;|&])rm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b")
+
+# Exact ``path:line`` allowlist for already-scoped shell cleanups. Do not expand
+# this to cover new recursive deletes — route those through a guarded helper.
+_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # services.sh: restart lockdir reclaim/release + Astro/Vite cache dirs
+        # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
+        "services.sh:119",
+        "services.sh:138",
+        "services.sh:617",
+        "services.sh:627",
+        "services.sh:631",
+        # Scratch-dir EXIT traps for one-shot installer scripts.
+        "scripts/entire/install_kimi_external_agent.sh:18",
+        "scripts/entire/install_fleet_external_agent.sh:36",
+        # Actionlint download cleanup (scoped under a local temp dir).
+        "scripts/audit/check_workflows.sh:50",
+    }
+)
+
+_SCAN_GLOBS: tuple[str, ...] = (
+    "scripts/**/*.sh",
+    "scripts/**/*.bash",
+    "services.sh",
+)
+
+# Test harnesses may use ``rm -rf`` under their own temp roots.
+_SKIP_PATH_PREFIXES: tuple[str, ...] = (
+    "scripts/audit/test_",
+    "tests/",
+)
+
+
+def _rel(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def iter_scan_paths(repo_root: Path | None = None) -> list[Path]:
+    root = (repo_root or REPO_ROOT).resolve()
+    found: list[Path] = []
+    for pattern in _SCAN_GLOBS:
+        found.extend(root.glob(pattern))
+    unique = sorted({path.resolve() for path in found if path.is_file()})
+    return [
+        path
+        for path in unique
+        if not any(_rel(path, root).startswith(prefix) for prefix in _SKIP_PATH_PREFIXES)
+    ]
+
+
+def find_raw_rm_rf(repo_root: Path | None = None) -> list[tuple[str, str]]:
+    """Return ``(path:line, snippet)`` findings not covered by the allowlist."""
+    root = (repo_root or REPO_ROOT).resolve()
+    findings: list[tuple[str, str]] = []
+    for path in iter_scan_paths(root):
+        rel = _rel(path, root)
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line_no, line in enumerate(lines, start=1):
+            if not _RM_RF_RE.search(line):
+                continue
+            key = f"{rel}:{line_no}"
+            if key in _ALLOWLIST:
+                continue
+            findings.append((key, line.strip()))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+    findings = find_raw_rm_rf()
+    if not findings:
+        print("OK: no unscoped raw rm -rf in scripts/ or services.sh")
+        return 0
+    print("Unscoped raw rm -rf (route through a guarded deleter or allowlist):", file=sys.stderr)
+    for key, snippet in findings:
+        print(f"  {key}: {snippet}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -50,6 +50,7 @@ from scripts.orchestration.reap_worktrees import (
     reap_worktrees,
     resolve_repo_root,
 )
+from scripts.path_safety import assert_delete_target
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -284,8 +285,15 @@ def record_gate5_observation(
             os.replace(tmp_path, log_path)
         finally:
             if tmp_path.exists():
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink()
+                with contextlib.suppress(OSError, ValueError):
+                    # Observation log lives under batch_state/fleet-comms/, not
+                    # batch_state/tmp/ — approve only the log's parent directory.
+                    guarded = assert_delete_target(
+                        tmp_path,
+                        repo_root=REPO_ROOT,
+                        approved_temp_roots=(log_path.parent,),
+                    )
+                    guarded.unlink()
         try:
             import fcntl
 

--- a/scripts/orchestration/tmp_leak_sweep.py
+++ b/scripts/orchestration/tmp_leak_sweep.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.path_safety import assert_delete_target
+
 # 2h normal; 30m under disk pressure.
 DEFAULT_MIN_AGE_S = 2 * 60 * 60
 DEFAULT_PRESSURE_MIN_AGE_S = 30 * 60
@@ -193,11 +195,16 @@ def discover_candidates(
     return found
 
 
-def _remove_path(path: Path) -> None:
-    if path.is_symlink() or path.is_file():
-        path.unlink(missing_ok=True)
+def _remove_path(path: Path, *, repo_root: Path, approved_temp_roots: tuple[Path, ...]) -> None:
+    target = assert_delete_target(
+        path,
+        repo_root=repo_root,
+        approved_temp_roots=approved_temp_roots,
+    )
+    if target.is_symlink() or target.is_file():
+        target.unlink(missing_ok=True)
         return
-    shutil.rmtree(path, ignore_errors=True)
+    shutil.rmtree(target, ignore_errors=True)
 
 
 def sweep_tmp_leaks(
@@ -208,6 +215,7 @@ def sweep_tmp_leaks(
     min_age_s: float = DEFAULT_MIN_AGE_S,
     pressure_min_age_s: float = DEFAULT_PRESSURE_MIN_AGE_S,
     min_free_gb: float = DEFAULT_MIN_FREE_GB,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     """Discover and optionally delete age-gated LU temp leaks.
 
@@ -215,6 +223,8 @@ def sweep_tmp_leaks(
     """
     current = time.time() if now is None else now
     roots = list(tmp_roots) if tmp_roots is not None else default_tmp_roots()
+    resolved_repo = (repo_root or Path(__file__).resolve().parents[2]).resolve()
+    approved_roots = tuple(roots)
     free_gb: float | None = None
     for root in roots:
         free_gb = free_space_gb(root)
@@ -258,7 +268,11 @@ def sweep_tmp_leaks(
             continue
         try:
             size = candidate.size_bytes or _entry_size_bytes(candidate.path)
-            _remove_path(candidate.path)
+            _remove_path(
+                candidate.path,
+                repo_root=resolved_repo,
+                approved_temp_roots=approved_roots,
+            )
             # Confirm gone; if still present count as error.
             if candidate.path.exists():
                 result["errors"] += 1
@@ -275,6 +289,11 @@ def sweep_tmp_leaks(
                     "age_s": int(candidate.age_s),
                     "action": "reaped",
                 }
+            )
+        except ValueError:
+            result["errors"] += 1
+            result["skipped"].append(
+                {"path": str(candidate.path), "reason": "delete_guard_refused"}
             )
         except OSError:
             result["errors"] += 1

--- a/tests/test_inventory_home_sessions.py
+++ b/tests/test_inventory_home_sessions.py
@@ -159,6 +159,7 @@ def test_apply_delete_removes_only_stale_allowlisted_session_file(
         archive_root=tmp_path / "archive",
         action="delete",
         retention_days=14,
+        repo_root=tmp_path / "repo",
     )
 
     assert results == [{"path": str(old), "action": "deleted"}]
@@ -166,6 +167,39 @@ def test_apply_delete_removes_only_stale_allowlisted_session_file(
     assert config.exists()
     assert recent.exists()
     assert not (tmp_path / "archive").exists()
+
+
+def test_apply_delete_skips_when_delete_guard_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """assert_delete_target refusal must leave the session file untouched."""
+    old = _old_file(tmp_path / ".codex" / "sessions" / "old.jsonl")
+    _roots, candidates = inventory.inventory_home_sessions(home=tmp_path, retention_days=14)
+    monkeypatch.setenv(inventory.APPLY_ENV, "1")
+
+    def _refuse(*_args, **_kwargs):
+        raise ValueError("outside approved deletion roots")
+
+    monkeypatch.setattr(inventory, "assert_delete_target", _refuse)
+
+    results = inventory.apply_retention(
+        candidates=candidates,
+        home=tmp_path,
+        archive_root=tmp_path / "archive",
+        action="delete",
+        retention_days=14,
+        repo_root=tmp_path / "repo",
+    )
+
+    assert results == [
+        {
+            "path": str(old),
+            "action": "skipped",
+            "reason": "delete guard refused: outside approved deletion roots",
+        }
+    ]
+    assert old.exists()
 
 
 def test_main_apply_refused_without_environment_gate(

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.hygiene import lint_raw_rm_rf
 from scripts.path_safety import assert_delete_target
 
 
@@ -93,3 +94,40 @@ def test_delete_guard_refuses_filesystem_root_as_a_temp_root(
             repo_root=repo_root,
             approved_temp_roots=approved_temp_roots,
         )
+
+
+def test_delete_guard_refuses_path_outside_allowed_delete_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller-owned temps must still be under an explicit approved root."""
+    # Clear process TMPDIR so pytest's temp hierarchy cannot become an
+    # accidental allowlist root for this refusal case.
+    monkeypatch.delenv("TMPDIR", raising=False)
+    repo_root = tmp_path / "repo"
+    outside = tmp_path / "not-approved" / "payload"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("x\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside approved"):
+        assert_delete_target(
+            outside,
+            repo_root=repo_root,
+            approved_temp_roots=(tmp_path / "other-root",),
+        )
+
+
+def test_raw_rm_rf_lint_allowlists_scoped_shell_cleanups() -> None:
+    """services.sh lockdirs/caches stay allowlisted; new unscoped hits fail."""
+    findings = lint_raw_rm_rf.find_raw_rm_rf()
+    assert findings == [], f"unscoped raw rm -rf: {findings}"
+
+
+def test_raw_rm_rf_lint_detects_unscoped_line(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "evil.sh").write_text('rm -rf "$HOME"\n', encoding="utf-8")
+    (tmp_path / "services.sh").write_text("# no rm\n", encoding="utf-8")
+
+    findings = lint_raw_rm_rf.find_raw_rm_rf(repo_root=tmp_path)
+    assert findings == [("scripts/evil.sh:1", 'rm -rf "$HOME"')]


### PR DESCRIPTION
## Summary
- Route remaining hygiene/temp deleters through `assert_delete_target` (home-session inventory, retention observation-log cleanup, Codex rollout backup rollback, `/tmp` leak sweep).
- Add `scripts/hygiene/lint_raw_rm_rf.py` to fail new unscoped shell `rm -rf`; allowlist already-scoped `services.sh` lockdirs/caches and installer scratch traps (not rewritten).
- Tests: refuse paths outside approved delete roots; inventory skips when the delete guard refuses; lint detects unscoped hits.

## Non-goals / residual (#6013 stays open)
- APFS localsnapshot LaunchAgent (operator GO)
- Nightly local-state backup rotation beyond #6095
- launchd inventory doc
- Do not merge-close #6013 on this PR alone

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_path_safety.py tests/test_fleet_post_task_reap.py -q --tb=short`
- [x] Also: `tests/test_inventory_home_sessions.py` + `tests/orchestration/test_tmp_leak_sweep.py` (53 passed together)
- [x] Ruff on touched files

Refs #6013


Made with [Cursor](https://cursor.com)