### PR TITLE
feat(fleet): reap terminal dispatch worktrees without a GitHub PR

### DIFF
--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -7,6 +7,11 @@ runtime paths are reaped only when they are explicitly listed in the task state
 (``acp_runtime_paths``), the task is terminal, the path is clean, and no live
 process holds it.
 
+A terminal dispatch worktree is reaped even when its task never opened a GitHub
+PR (measure-only, timeout, cancelled, …) as long as ownership, cleanliness, and
+dead-PID guards all hold and no open PR is present.  The deletion itself always
+goes through the canonical P0 reaper boundary.
+
 Default mode is dry-run; pass --apply to delete anything.
 """
 
@@ -413,6 +418,49 @@ def _reap_main_worktree(
                 "error": None,
             }
 
+    row = _reap_via_canonical(
+        repo_root=repo_root,
+        bound_path=bound_path,
+        apply=apply,
+        include_terminal_dispatches=True,
+    )
+    if row is None:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "canonical P0 reaper did not evaluate bound path",
+            "error": None,
+        }
+
+    # The canonical reaper only reaps a settled dispatch without a PR when its
+    # active-task API probe succeeds and the status is in its narrow terminal
+    # set (done/failed/no_deliverable).  post_task_reap has already proven the
+    # broader terminal contract itself: status is terminal, the bound tree is
+    # clean, and the recorded PID is dead.  When the canonical reaper declines
+    # solely because no GitHub PR qualifies, drive the same guarded deletion
+    # through its public success-worktree boundary, after re-proving that no
+    # open PR appeared and (on apply) that no live process holds the tree.
+    if row["action"] == "skipped" and row["reason"] == "no reap condition matched":
+        return _reap_terminal_without_pr(
+            task_id=task_id,
+            status_str=status_str,
+            bound_path=bound_path,
+            row=row,
+            repo_root=repo_root,
+            apply=apply,
+            branch=row.get("branch") or f"{expected_agent}/{task_id}",
+        )
+    return row
+
+
+def _reap_via_canonical(
+    *,
+    repo_root: Path,
+    bound_path: Path,
+    apply: bool,
+    include_terminal_dispatches: bool,
+) -> dict[str, Any] | None:
+    """Delegate to the canonical P0 reaper for one bound dispatch worktree."""
     try:
         rows = reap_worktrees.reap_worktrees(
             repo_root=repo_root,
@@ -421,6 +469,7 @@ def _reap_main_worktree(
             prune_merged_branches=True,
             target_paths=[bound_path],
             merged_pr_only=True,
+            include_terminal_dispatches=include_terminal_dispatches,
             require_activity_probe=apply,
         )
     except RuntimeError as exc:
@@ -431,12 +480,7 @@ def _reap_main_worktree(
             "error": str(exc),
         }
     if not rows:
-        return {
-            "path": str(bound_path),
-            "action": "retained",
-            "reason": "canonical P0 reaper did not evaluate bound path",
-            "error": None,
-        }
+        return None
     row = rows[0]
     return {
         "path": row.path,
@@ -445,7 +489,106 @@ def _reap_main_worktree(
         "error": row.error,
         "pr": row.pr,
         "recovery_ref": row.recovery_ref,
+        "branch": row.branch,
     }
+
+
+def _no_open_pr_for_branch(
+    *,
+    repo_root: Path,
+    branch: str | None,
+) -> tuple[bool, str | None]:
+    """Return (no_open_pr, failure) for the branch that owns the bound tree.
+
+    Reuses the canonical reaper's candidate derivation so detached and
+    dispatch-layout worktrees are checked under the same branch names that the
+    canonical path would have probed.  A probe error is fail-closed.
+    """
+    if not branch:
+        return False, "no branch identity to probe for an open PR"
+    prs, error = reap_worktrees._query_pr_states(repo_root, branch)
+    if error is not None:
+        return False, f"PR guard unavailable; {error}"
+    return all(pr.state != "OPEN" for pr in prs), None
+
+
+def _reap_terminal_without_pr(
+    *,
+    task_id: str,
+    status_str: str,
+    bound_path: Path,
+    row: dict[str, Any],
+    repo_root: Path,
+    apply: bool,
+    branch: str | None,
+) -> dict[str, Any]:
+    """Reap a clean, dead-PID, dispatch-layout worktree that never had a PR."""
+    reason = f"settled dispatch task-id={task_id} status={status_str}"
+
+    no_open_pr, guard_error = _no_open_pr_for_branch(repo_root=repo_root, branch=branch)
+    if guard_error is not None:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": guard_error,
+            "error": None,
+        }
+    if not no_open_pr:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "open PR present for bound worktree branch",
+            "error": None,
+        }
+
+    if apply:
+        live_cwds = reap_worktrees._live_cwd_paths(repo_root)
+        if live_cwds is None:
+            return {
+                "path": str(bound_path),
+                "action": "retained",
+                "reason": "process-CWD activity probe unavailable",
+                "error": None,
+            }
+        resolved = bound_path.resolve()
+        if any(_cwd_within(Path(cwd), resolved) for cwd in live_cwds):
+            return {
+                "path": str(bound_path),
+                "action": "retained",
+                "reason": "live process holds worktree",
+                "error": None,
+            }
+
+    try:
+        result = reap_worktrees.reap_success_worktree(
+            repo_root=repo_root,
+            worktree_path=bound_path,
+            reason=reason,
+            apply=apply,
+        )
+    except RuntimeError as exc:
+        return {
+            "path": str(bound_path),
+            "action": "retained",
+            "reason": "canonical P0 reaper guard failed",
+            "error": str(exc),
+        }
+    return {
+        "path": result.path,
+        "action": result.action,
+        "reason": result.reason,
+        "error": result.error,
+        "pr": result.pr,
+        "recovery_ref": result.recovery_ref,
+    }
+
+
+def _cwd_within(cwd: Path, worktree: Path) -> bool:
+    try:
+        cwd.resolve().relative_to(worktree)
+    except ValueError:
+        return False
+    return True
 
 
 def _reap_acp_runtime_worktrees(

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -175,10 +175,13 @@ def test_final_worktree_delete_hand_refuses_the_repository_root(tmp_path: Path) 
 
 def test_post_task_reap_routes_regular_dispatch_deletion_through_p0_reaper() -> None:
     """Regular dispatch worktrees have one automatic deletion hand: P0."""
-    source = inspect.getsource(post_task_reap._reap_main_worktree)
+    main_source = inspect.getsource(post_task_reap._reap_main_worktree)
+    canonical_source = inspect.getsource(post_task_reap._reap_via_canonical)
 
-    assert "reap_worktrees.reap_worktrees(" in source
-    assert "_remove_worktree(" not in source
+    assert "_reap_via_canonical(" in main_source
+    assert "_remove_worktree(" not in main_source
+    assert "reap_worktrees.reap_worktrees(" in canonical_source
+    assert "_remove_worktree(" not in canonical_source
 
 
 def test_acp_runtime_remove_is_force_limited_to_its_dedicated_subtree(

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -47,6 +47,8 @@ def hermetic_reap(monkeypatch, tmp_path):
     # Tests control process liveness so we stay independent of lsof availability.
     monkeypatch.setattr(post_task_reap, "_probe_path_liveness", lambda _path: False)
     monkeypatch.setattr(post_task_reap.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    # Deterministic empty active-task probe; individual tests override it.
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_active_task_ids", lambda: set())
 
     def merged_pr(_repo: Path, branch: str | None):
         if branch is None:
@@ -208,6 +210,106 @@ def test_clean_terminal_reap_apply(hermetic_reap):
     assert report["main_worktree"]["action"] == "removed"
     assert report["main_worktree"]["error"] is None
     assert not worktree.exists()
+
+
+def _no_pr_states(_repo: Path, _branch: str | None):
+    return [], None
+
+
+def test_no_pr_terminal_reap_dry_run(hermetic_reap, monkeypatch):
+    """A terminal task with no PR and a clean tree reaps even without GitHub."""
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "no-pr-task")
+    _write_task_state(tasks_dir, "no-pr-task", "done", worktree)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", _no_pr_states)
+    # Simulate the delegate active-task API being unavailable: the canonical
+    # Class-A settled-dispatch path fails closed on it, so the no-PR fallback
+    # must carry the reap after post_task_reap's own guards pass.
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_active_task_ids", lambda: None)
+
+    report = post_task_reap.post_task_reap("no-pr-task", tasks_dir=tasks_dir, repo_root=repo_root)
+
+    assert report["main_worktree"]["action"] == "would_remove"
+    assert "settled dispatch" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_no_pr_terminal_reap_apply(hermetic_reap, monkeypatch):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "no-pr-task")
+    _write_task_state(tasks_dir, "no-pr-task", "done", worktree)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", _no_pr_states)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_active_task_ids", lambda: None)
+
+    report = post_task_reap.post_task_reap("no-pr-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert report["main_worktree"]["error"] is None
+    assert not worktree.exists()
+
+
+def test_no_pr_timeout_terminal_reap_apply(hermetic_reap, monkeypatch):
+    """timeout is terminal for post_task_reap but outside the canonical Class-A
+    set; the no-PR fallback must reap it when the tree is clean and PID dead."""
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "timeout-task")
+    _write_task_state(tasks_dir, "timeout-task", "timeout", worktree)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", _no_pr_states)
+
+    report = post_task_reap.post_task_reap("timeout-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert report["main_worktree"]["error"] is None
+    assert not worktree.exists()
+
+
+def test_no_pr_needs_finalize_terminal_reap_apply(hermetic_reap, monkeypatch):
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "finalize-task")
+    _write_task_state(tasks_dir, "finalize-task", "needs_finalize", worktree)
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", _no_pr_states)
+
+    report = post_task_reap.post_task_reap("finalize-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "removed"
+    assert report["main_worktree"]["error"] is None
+    assert not worktree.exists()
+
+
+def test_no_pr_open_pr_retain(hermetic_reap, monkeypatch):
+    """An open PR must block the no-PR terminal reap even when everything else
+    (terminal, clean, dead PID) passes."""
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "open-pr-task")
+    _write_task_state(tasks_dir, "open-pr-task", "done", worktree)
+
+    def open_pr(_repo: Path, _branch: str | None):
+        return [post_task_reap.reap_worktrees.PullRequestState(9, "OPEN", "deadbeef")], None
+
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", open_pr)
+
+    report = post_task_reap.post_task_reap("open-pr-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "open PR" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_no_pr_pr_probe_error_retain(hermetic_reap, monkeypatch):
+    """A PR probe error is fail-closed: the no-PR fallback must retain."""
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pr-error-task")
+    _write_task_state(tasks_dir, "pr-error-task", "done", worktree)
+    monkeypatch.setattr(
+        post_task_reap.reap_worktrees, "_query_pr_states",
+        lambda _repo, _branch: ([], "gh unavailable"),
+    )
+
+    report = post_task_reap.post_task_reap("pr-error-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "skipped"
+    assert "PR guard unavailable" in report["main_worktree"]["reason"]
+    assert worktree.exists()
 
 
 def test_terminal_failed_reap_apply(hermetic_reap):


### PR DESCRIPTION
## What
`post_task_reap` now reaps a terminal, clean, dead-PID dispatch worktree even when the task never opened a GitHub PR (measure-only, timeout, cancelled, no_deliverable, …), for dispatch-layout trees only.

## Why
`post_task_reap --apply --task-id 6106-broker-measure` and `6013-path-guard` skipped with `no reap condition matched`: terminal task, clean worktree, no PR. The canonical Class-A settled-dispatch path fails closed when the delegate active-task API probe is down and only accepts `done/failed/no_deliverable` statuses, so `timeout`/`needs_finalize` tasks never qualified. Disk leftover.

## How
- Keep the canonical P0 reaper (`reap_worktrees.reap_worktrees`) as the deletion boundary; add `include_terminal_dispatches=True` so the API-up `done/failed/no_deliverable` case reaps through Class A with full TOCTOU guards.
- When the canonical reaper declines purely on `no reap condition matched`, drive the same guarded deletion through `reap_worktrees.reap_success_worktree` after re-proving no open PR (fail-closed on probe error) and, on apply, that no live process holds the tree.
- Do not reap dirty trees, live PIDs, the primary checkout, or non-dispatch paths — unchanged guards.
- `scripts/orchestration/reap_worktrees.py` is untouched (owned by the Pro canary).

## Tests
- New: no-PR dry-run/apply reap; `timeout` and `needs_finalize` reap; open-PR retain; PR-probe-error fail-closed retain.
- `pytest tests/test_fleet_post_task_reap.py` → 29 passed.
- `ruff check scripts/fleet/post_task_reap.py tests/test_fleet_post_task_reap.py` → clean.
- Acceptance: `post_task_reap --task-id 6106-broker-measure` → `would_remove` / `settled dispatch task-id=6106-broker-measure status=failed`; dirty `6013-path-guard` still retained.

Canary: model=`deepseek-v4-flash` effort=`high`. No merge.