### PR TITLE
fix(reaper): reap follow-up CI branches whose head differs from the merged PR (#6696)

### DIFF
--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -283,6 +283,54 @@ def _best_pr(prs: list[PullRequestState]) -> PullRequestState | None:
     return prs[0] if prs else None
 
 
+def _query_prs_by_head_sha(
+    repo_root: Path,
+    head_sha: str | None,
+) -> list[PullRequestState]:
+    """Find PRs that introduced ``head_sha`` by GitHub commit-SHA search.
+
+    Follow-up CI branches carry a different branch name than the MERGED PR head
+    they fix, so ``gh pr list --head <branch>`` misses them.  A search hit means
+    ``head_sha`` is a commit added by that PR, i.e. it equals the PR head or is
+    an ancestor of it.  Failures are swallowed: this lookup is supplementary to
+    the authoritative ``gh pr list --head`` guard and must never fabricate a
+    PR-guard error on its own.
+    """
+    if not head_sha:
+        return []
+    try:
+        proc = _run(
+            ["gh", "search", "prs", head_sha, "--json", "number,state"],
+            cwd=repo_root,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        raw_items = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+
+    states: list[PullRequestState] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        state = str(item.get("state") or "").upper()
+        if not state:
+            continue
+        number = item.get("number")
+        states.append(
+            PullRequestState(
+                number=number if isinstance(number, int) else None,
+                state=state,
+                head_sha=head_sha,
+            )
+        )
+    return states
+
+
 def _pr_dict(pr_state: PullRequestState | None) -> dict[str, Any] | None:
     if pr_state is None:
         return None
@@ -1096,18 +1144,27 @@ def reap_worktrees(
             candidates = _candidate_branches_for_worktree(repo_root, info)
             pr_state = None
             pr_error = None
+            all_pr_states: list[PullRequestState] = []
+            errors: list[str] = []
             if candidates:
-                all_pr_states: list[PullRequestState] = []
-                errors: list[str] = []
                 for cand_branch in candidates:
                     st, err = _query_pr_states(repo_root, cand_branch)
                     if err:
                         errors.append(err)
                     all_pr_states.extend(st)
-                if errors and not all_pr_states:
-                    pr_error = "; ".join(errors)
-                else:
-                    pr_state = _best_pr(all_pr_states)
+
+            # Follow-up CI branches carry a different branch name than the PR
+            # head they fix.  Find the MERGED PR that introduced the worktree
+            # HEAD by SHA, but only when that commit is not already on
+            # origin/main — otherwise a fresh branch sitting on a merged main
+            # tip would be mistaken for a squash-merged follow-up commit.
+            if info.head and not _is_ancestor_of_origin_main(info.path):
+                all_pr_states.extend(_query_prs_by_head_sha(repo_root, info.head))
+
+            if errors and not all_pr_states:
+                pr_error = "; ".join(errors)
+            else:
+                pr_state = _best_pr(all_pr_states)
 
             if (merged_pr_only or include_terminal_dispatches) and pr_error is not None:
                 results.append(

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -76,8 +76,48 @@ def patch_gh(
 ) -> list[str]:
     calls: list[str] = []
 
+    def _resolve_head(cwd: Path, branch: str, item: dict[str, Any]) -> str | None:
+        head = item.get("headRefOid")
+        if head:
+            return head
+        proc = _REAL_RUN(
+            ["git", "rev-parse", f"refs/heads/{branch}"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=git_env(),
+        )
+        return proc.stdout.strip() if proc.returncode == 0 else None
+
+    def _ancestor(cwd: Path, sha: str, head: str) -> bool:
+        if sha == head:
+            return True
+        proc = _REAL_RUN(
+            ["git", "merge-base", "--is-ancestor", sha, head],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=git_env(),
+        )
+        return proc.returncode == 0
+
     def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         if args and args[0] == "gh":
+            if args[1:3] == ["search", "prs"]:
+                sha = args[3]
+                calls.append(f"search:{sha}")
+                payload = []
+                for branch, items in states_by_branch.items():
+                    for item in items:
+                        head = _resolve_head(kwargs["cwd"], branch, item)
+                        if head is None or not _ancestor(kwargs["cwd"], sha, head):
+                            continue
+                        payload.append(
+                            {"number": item.get("number"), "state": item.get("state")}
+                        )
+                return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
             branch = args[args.index("--head") + 1]
             calls.append(branch)
             payload = [dict(item) for item in states_by_branch.get(branch, [])]
@@ -713,6 +753,7 @@ def test_class_b_fail_safe_skips(
     old = now - 25 * 3600
     os.utime(worktree_path, (old, old))
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    patch_gh(monkeypatch, {})
 
     results = rw.reap_worktrees(repo_root=repo, apply=True, now=now, merged_pr_only=False)
     assert result_for(results, worktree_path).action == "skipped"
@@ -1247,6 +1288,103 @@ def test_detached_worktree_with_open_pr_is_preserved(
             live_cwds=set(),
             merged_pr_only=True,
         ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert worktree.exists()
+
+
+def test_followup_branch_ancestor_of_merged_pr_head_reaps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A follow-up CI branch whose name differs from the MERGED PR head reaps."""
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/6687-hermes-test")
+    git(worktree, "commit", "--allow-empty", "-m", "first follow-up fix")
+    ancestor_head = git(worktree, "rev-parse", "HEAD")
+    git(worktree, "commit", "--allow-empty", "-m", "PR head follow-up fix")
+    pr_head = git(worktree, "rev-parse", "HEAD")
+    git(worktree, "reset", "--hard", ancestor_head)
+
+    patch_gh(
+        monkeypatch,
+        {
+            "kimi/routing-defaults": [
+                {"number": 6687, "state": "MERGED", "headRefOid": pr_head}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.reason == "PR #6687 MERGED"
+    assert not worktree.exists()
+
+
+def test_detached_worktree_with_different_pr_head_branch_reaps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detached dispatch worktree reaps when its HEAD matches a MERGED PR head
+    whose branch name differs from the path-derived candidate."""
+    repo = init_repo(tmp_path)
+    task_id = "6690-ci-fix"
+    worktree = repo / ".worktrees" / "dispatch" / "kimi" / task_id
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "--detach", str(worktree), "main")
+    git(worktree, "commit", "--allow-empty", "-m", "ci fix")
+    head = git(worktree, "rev-parse", "HEAD")
+
+    patch_gh(
+        monkeypatch,
+        {
+            "agy/delegate-active-timeout": [
+                {"number": 6690, "state": "MERGED", "headRefOid": head}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "removed"
+    assert result.reason == "PR #6690 MERGED"
+    assert not worktree.exists()
+
+
+def test_fresh_branch_on_main_tip_is_not_sha_reaped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A branch sitting on a merged main tip is not reaped via SHA search."""
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/fresh-at-tip")
+    main_tip = git(worktree, "rev-parse", "HEAD")
+
+    patch_gh(
+        monkeypatch,
+        {
+            "agy/original": [
+                {"number": 1, "state": "MERGED", "headRefOid": main_tip}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set()),
         worktree,
     )
 


### PR DESCRIPTION
## Symptom

After #6696 these still SKIP:

- `codex/6687-hermes-test` `no reap condition matched` (follow-up branch; PR #6687 head was `kimi/routing-defaults-2026-08-13`)
- `cursor/6687-ci-fix`, `deepseek/6687-two-tests`, `deepseek/6696-ruff-sim102` (same class: follow-up branch ≠ PR head)
- `kimi/6690-ci-fix` `detached or missing branch`

## Change

A clean dispatch worktree now reaps when its HEAD is the head of a MERGED PR (or an ancestor of that head), even when the worktree branch name is not the PR head. We look up the MERGED PR that introduced the worktree HEAD via `gh search prs <sha>`, but only when that commit is not already on `origin/main` — so a fresh branch sitting on a merged main tip is never mistaken for a squash-merged follow-up commit. The same lookup reaps detached HEADs matching a merged PR under a different branch name.

Guards (live-process, dirty, open-PR, first-class cap) are unchanged.

## Tests

- `test_followup_branch_ancestor_of_merged_pr_head_reaps`
- `test_detached_worktree_with_different_pr_head_branch_reaps`
- `test_fresh_branch_on_main_tip_is_not_sha_reaped`

X-Agent: deepseek/canary-ds-pro-reaper