### PR TITLE
feat(phase3): gate VSPU database cutover

### DIFF
--- a/data/projects/open_model_data/admission/phase3_vspu_additive_university_source_policy_v3.json
+++ b/data/projects/open_model_data/admission/phase3_vspu_additive_university_source_policy_v3.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "phase3_university_source_policy_v3",
+  "status": "ACTIVE_DEFAULT_DENY",
+  "default_disposition": "QUARANTINE_UNTIL_AUDIENCE_AND_CONTENT_CLASSIFIED",
+  "source_count": 1,
+  "sources": [
+    {
+      "source_file": "uni-ukrmova-sulm-attestation-vspu-2021",
+      "audience_class": "A_ukrainian_university_audience",
+      "subject_role": "ukrainian_linguistics",
+      "content_disposition": "contextual_only",
+      "allowed_lanes": [
+        "contextual_retrieval",
+        "corpus_ingest"
+      ],
+      "evidence": {
+        "kind": "jsonl_front_matter",
+        "jsonl_sha256": "babb8a266a7d6720d68fb960f7848aace03f646f1ede5b30de2831f7cbb85dc8",
+        "page_start": 1,
+        "page_end": 4,
+        "rows_sha256": "5b5998a9dbdc636358f5e28a0c20aa7f604b1f571bc330fd53061b6f096f86e2",
+        "summary": "Vinnytsia State Pedagogical University front matter identifies a native-university attestation handbook for specialty 014 Secondary Education (Ukrainian Language and Literature); the additive policy permits private contextual retrieval and corpus ingest but grants no source-wide normative authority or semantic-gold role."
+      }
+    }
+  ]
+}

--- a/data/projects/open_model_data/contracts/phase3_vspu_db_cutover_v1.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_vspu_db_cutover_v1.schema.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/contracts/phase3_vspu_db_cutover_v1.schema.json",
+  "title": "Phase 3 VSPU one-source database cutover receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "text_free",
+    "provider_calls",
+    "mode",
+    "source_id",
+    "bindings",
+    "preimage_backup",
+    "copied_database_rehearsal",
+    "database",
+    "safeguards",
+    "rights_and_authority",
+    "phase_boundaries",
+    "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_vspu_db_cutover_v1"},
+    "text_free": {"const": true},
+    "provider_calls": {"const": false},
+    "mode": {"enum": ["dry_run", "in_place_sqlite_backup"]},
+    "source_id": {"const": "uni-ukrmova-sulm-attestation-vspu-2021"},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementation_sha256",
+        "schema_sha256",
+        "incremental_ingest_implementation_sha256",
+        "phase3_reboot_prompt_v3_sha256",
+        "phase3_recovery_prompt_v2_sha256",
+        "complete_source_policy_v4_sha256",
+        "vspu_materialization_receipt_sha256",
+        "vspu_additive_policy_sha256",
+        "private_jsonl_sha256",
+        "preimage_backup_receipt_sha256",
+        "compressed_preimage_database_sha256"
+      ],
+      "properties": {
+        "implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "schema_sha256": {"$ref": "#/$defs/sha256"},
+        "incremental_ingest_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "phase3_reboot_prompt_v3_sha256": {"const": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"},
+        "phase3_recovery_prompt_v2_sha256": {"const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"},
+        "complete_source_policy_v4_sha256": {"const": "98e7a80f8fdc1274a190cda793699aceaa79741ebf2145669d73e4c8a2236559"},
+        "vspu_materialization_receipt_sha256": {"const": "f023fab75ebc82ecb84a88a487f2ef2d477722035a82c5c23c18431b11e8b45c"},
+        "vspu_additive_policy_sha256": {"const": "c2d2d094931751fefba0dd14143a83b344dc59f52b36414b165be920d29309f5"},
+        "private_jsonl_sha256": {"const": "babb8a266a7d6720d68fb960f7848aace03f646f1ede5b30de2831f7cbb85dc8"},
+        "preimage_backup_receipt_sha256": {"const": "e53355f2d6c221c7bfe9cbba63b4055982f286b26d72618e8b9a393231febb0a"},
+        "compressed_preimage_database_sha256": {"const": "ba41ce56eabb2d72856c906cd498ec168b3036bbe79b9264bb074dbc87831d81"}
+      }
+    },
+    "preimage_backup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "database_sha256",
+        "compressed_sha256",
+        "streamed_restore_sha256",
+        "gzip_integrity",
+        "google_drive_provider_identity_present",
+        "predecessor_backup_preserved"
+      ],
+      "properties": {
+        "status": {"const": "VERIFIED_UPLOADED_SUCCESSOR_DATABASE"},
+        "database_sha256": {"const": "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"},
+        "compressed_sha256": {"const": "ba41ce56eabb2d72856c906cd498ec168b3036bbe79b9264bb074dbc87831d81"},
+        "streamed_restore_sha256": {"const": "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"},
+        "gzip_integrity": {"const": true},
+        "google_drive_provider_identity_present": {"const": true},
+        "predecessor_backup_preserved": {"const": true}
+      }
+    },
+    "copied_database_rehearsal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_scope",
+        "status",
+        "database_sha256_before",
+        "database_sha256_after",
+        "ingest_receipt_sha256",
+        "inserted_rows",
+        "section_rows",
+        "linked_rows",
+        "fts_rows",
+        "integrity_check",
+        "foreign_key_failures_unchanged",
+        "existing_corpus_fingerprint_unchanged"
+      ],
+      "properties": {
+        "execution_scope": {"const": "copied_database_rehearsal"},
+        "status": {"const": "committed"},
+        "database_sha256_before": {"const": "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"},
+        "database_sha256_after": {"$ref": "#/$defs/sha256"},
+        "ingest_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "inserted_rows": {"const": 158},
+        "section_rows": {"const": 158},
+        "linked_rows": {"const": 158},
+        "fts_rows": {"const": 158},
+        "integrity_check": {"const": "ok"},
+        "foreign_key_failures_unchanged": {"const": true},
+        "existing_corpus_fingerprint_unchanged": {"const": true}
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_locator",
+        "pre_sha256",
+        "post_sha256",
+        "counts_before",
+        "counts_after",
+        "target_absent_before",
+        "target_rows_after",
+        "target_fts_rows_after",
+        "target_section_rows_after",
+        "target_linked_rows_after",
+        "foreign_key_failure_count_before",
+        "foreign_key_failure_count_after",
+        "foreign_key_failure_sha256_before",
+        "foreign_key_failure_sha256_after",
+        "existing_corpus_fingerprint_before",
+        "existing_corpus_fingerprint_after",
+        "integrity_check",
+        "journal_mode",
+        "live_inode_preserved"
+      ],
+      "properties": {
+        "target_locator": {"const": "primary_checkout:data/sources.db"},
+        "pre_sha256": {"const": "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"},
+        "post_sha256": {"$ref": "#/$defs/sha256"},
+        "counts_before": {"$ref": "#/$defs/counts_before"},
+        "counts_after": {"$ref": "#/$defs/counts_after"},
+        "target_absent_before": {"const": true},
+        "target_rows_after": {"const": 158},
+        "target_fts_rows_after": {"const": 158},
+        "target_section_rows_after": {"const": 158},
+        "target_linked_rows_after": {"const": 158},
+        "foreign_key_failure_count_before": {"const": 134836},
+        "foreign_key_failure_count_after": {"const": 134836},
+        "foreign_key_failure_sha256_before": {"const": "9938f7cbab6cca94bfd0a360eec114fdef404a357e02b24161da0f7cf5c6d9bb"},
+        "foreign_key_failure_sha256_after": {"const": "9938f7cbab6cca94bfd0a360eec114fdef404a357e02b24161da0f7cf5c6d9bb"},
+        "existing_corpus_fingerprint_before": {"$ref": "#/$defs/sha256"},
+        "existing_corpus_fingerprint_after": {"$ref": "#/$defs/sha256"},
+        "integrity_check": {"const": "ok"},
+        "journal_mode": {"const": "wal"},
+        "live_inode_preserved": {"const": true}
+      }
+    },
+    "safeguards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact_preimage_required",
+        "exact_one_source_set_required",
+        "copied_database_rehearsal_passed",
+        "recoverable_google_drive_preimage_verified",
+        "rollback_copy_created_before_cutover",
+        "automatic_exact_prestate_restore_on_failure",
+        "existing_corpus_unchanged",
+        "global_textbook_fts_parity",
+        "private_receipt_0600"
+      ],
+      "properties": {
+        "exact_preimage_required": {"const": true},
+        "exact_one_source_set_required": {"const": true},
+        "copied_database_rehearsal_passed": {"const": true},
+        "recoverable_google_drive_preimage_verified": {"const": true},
+        "rollback_copy_created_before_cutover": {"const": true},
+        "automatic_exact_prestate_restore_on_failure": {"const": true},
+        "existing_corpus_unchanged": {"const": true},
+        "global_textbook_fts_parity": {"const": true},
+        "private_receipt_0600": {"const": true}
+      }
+    },
+    "rights_and_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "private_operator_authorized_use_only",
+        "public_redistribution_authorized",
+        "unrestricted_reuse_authorized",
+        "normative_rule_authority",
+        "semantic_gold",
+        "role_layer_conversion_complete",
+        "adapt_or_remove_on_substantiated_complaint"
+      ],
+      "properties": {
+        "private_operator_authorized_use_only": {"const": true},
+        "public_redistribution_authorized": {"const": false},
+        "unrestricted_reuse_authorized": {"const": false},
+        "normative_rule_authority": {"const": false},
+        "semantic_gold": {"const": false},
+        "role_layer_conversion_complete": {"const": false},
+        "adapt_or_remove_on_substantiated_complaint": {"const": true}
+      }
+    },
+    "phase_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "database_ingest_complete",
+        "source_universe_frozen",
+        "source_coverage_ready",
+        "phase3_complete",
+        "phase4_blocked",
+        "post_ingest_backup_required"
+      ],
+      "properties": {
+        "database_ingest_complete": {"const": true},
+        "source_universe_frozen": {"const": false},
+        "source_coverage_ready": {"const": false},
+        "phase3_complete": {"const": false},
+        "phase4_blocked": {"const": true},
+        "post_ingest_backup_required": {"const": true}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "counts_before": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["textbook_rows", "fts_rows", "section_rows", "source_count", "university_rows", "university_source_count"],
+      "properties": {
+        "textbook_rows": {"const": 50153},
+        "fts_rows": {"const": 50153},
+        "section_rows": {"const": 36322},
+        "source_count": {"const": 187},
+        "university_rows": {"const": 4078},
+        "university_source_count": {"const": 20}
+      }
+    },
+    "counts_after": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["textbook_rows", "fts_rows", "section_rows", "source_count", "university_rows", "university_source_count"],
+      "properties": {
+        "textbook_rows": {"const": 50311},
+        "fts_rows": {"const": 50311},
+        "section_rows": {"const": 36480},
+        "source_count": {"const": 188},
+        "university_rows": {"const": 4236},
+        "university_source_count": {"const": 21}
+      }
+    }
+  }
+}

--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -57,6 +57,9 @@ from projects.open_model_data.university_source_policy import (
     DEFAULT_POLICY_PATH as DEFAULT_UNIVERSITY_POLICY,
 )
 from projects.open_model_data.university_source_policy import (
+    V3_SCHEMA_VERSION as UNIVERSITY_POLICY_V3_SCHEMA_VERSION,
+)
+from projects.open_model_data.university_source_policy import (
     UniversitySourcePolicyError,
     load_policy,
     require_source_admission,
@@ -82,6 +85,16 @@ from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
 CHUNKS_DIR = TEXTBOOK_CHUNKS_DIR
 PRIMARY_ROOT = resolve_main_root(PROJECT_ROOT) or PROJECT_ROOT
 DEFAULT_DB = PRIMARY_ROOT / "data" / "sources.db"
+
+# These sources have a dedicated, fail-closed database cutover. The generic
+# ingest entry point may build a dry-run plan for them and may populate a
+# disposable rehearsal database only when the dedicated caller pins the exact
+# reviewed v3 policy bytes. It must never mutate a live database for them
+# directly, because that would bypass the dedicated preimage, rollback, and
+# receipt checks.
+DEDICATED_DATABASE_CUTOVER_SOURCES = frozenset(
+    {"uni-ukrmova-sulm-attestation-vspu-2021"}
+)
 
 # Author map: single source of truth in wiki.textbook_subjects (PR #4650).
 AUTHOR_UK = AUTHOR_UK_BY_TRANSLIT
@@ -170,6 +183,7 @@ def build_rows(
     *,
     chunks_root: Path | None = None,
     university_policy_path: Path = DEFAULT_UNIVERSITY_POLICY,
+    loaded_university_policy: tuple[dict[str, Any], str] | None = None,
 ) -> list[tuple]:
     jsonl_path = find_jsonl(slug, chunks_root=chunks_root)
     university_source = slug.startswith("uni-")
@@ -180,6 +194,7 @@ def build_rows(
                 jsonl_path=jsonl_path,
                 policy_path=university_policy_path,
                 lane="corpus_ingest",
+                loaded_policy=loaded_university_policy,
             )
         except UniversitySourcePolicyError as exc:
             raise IngestError(str(exc)) from exc
@@ -397,6 +412,7 @@ def ingest(
     receipt_path: Path | None = None,
     university_policy_path: Path = DEFAULT_UNIVERSITY_POLICY,
     copied_database_rehearsal: bool = False,
+    additional_rehearsal_policy_sha256: str | None = None,
     live_ingest_gate_path: Path | None = None,
 ) -> dict[str, int]:
     """Run one atomic replace/quarantine/FTS-resync cycle.
@@ -420,6 +436,11 @@ def ingest(
             policy_document, policy_sha256 = load_policy(university_policy_path)
         except UniversitySourcePolicyError as exc:
             raise IngestError(str(exc)) from exc
+    loaded_university_policy = (
+        (policy_document, policy_sha256)
+        if policy_document is not None and policy_sha256 is not None
+        else None
+    )
     live_ingest_gate_sha256: str | None = None
     if live_ingest_gate_path is not None:
         if policy_document is None or policy_document["schema_version"] != "phase3_complete_source_policy_v4":
@@ -438,11 +459,33 @@ def ingest(
             )
         except LiveIngestGateError as exc:
             raise IngestError(str(exc)) from exc
+    dedicated_replacements = set(slugs) & DEDICATED_DATABASE_CUTOVER_SOURCES
+    dedicated_quarantines = set(quarantine_slugs) & DEDICATED_DATABASE_CUTOVER_SOURCES
+    dedicated_cutover_sources = sorted(dedicated_replacements | dedicated_quarantines)
+    dedicated_rehearsal = copied_database_rehearsal and not dedicated_quarantines
+    if dedicated_cutover_sources and not dry_run and not dedicated_rehearsal:
+        raise IngestError(
+            "source requires its dedicated database cutover: "
+            f"{dedicated_cutover_sources}"
+        )
     if copied_database_rehearsal:
         if dry_run:
             raise IngestError("copied-database rehearsal must commit to the disposable database copy")
-        if policy_document is None or policy_document["schema_version"] != "phase3_complete_source_policy_v4":
-            raise IngestError("copied-database rehearsal requires the complete v4 source policy")
+        complete_v4_policy = (
+            policy_document is not None
+            and policy_document["schema_version"] == "phase3_complete_source_policy_v4"
+        )
+        exact_caller_pinned_v3_policy = (
+            policy_document is not None
+            and policy_document["schema_version"] == UNIVERSITY_POLICY_V3_SCHEMA_VERSION
+            and additional_rehearsal_policy_sha256 is not None
+            and policy_sha256 == additional_rehearsal_policy_sha256
+        )
+        if not (complete_v4_policy or exact_caller_pinned_v3_policy):
+            raise IngestError(
+                "copied-database rehearsal requires the complete v4 policy "
+                "or an exact caller-pinned v3 policy"
+            )
         if not db_path.is_file():
             raise IngestError("copied-database rehearsal target does not exist")
         same_as_live = db_path.resolve() == DEFAULT_DB.resolve()
@@ -468,6 +511,7 @@ def ingest(
             slug,
             chunks_root=chunks_root,
             university_policy_path=university_policy_path,
+            loaded_university_policy=loaded_university_policy,
         )
         for slug in slugs
     }  # fail fast, pre-tx
@@ -482,6 +526,7 @@ def ingest(
                 jsonl_path=jsonl_path,
                 policy_path=university_policy_path,
                 lane="corpus_ingest",
+                loaded_policy=loaded_university_policy,
             )
         except UniversitySourcePolicyError as exc:
             raise IngestError(str(exc)) from exc
@@ -495,6 +540,7 @@ def ingest(
                 source_file=slug,
                 jsonl_path=jsonl_path,
                 policy_path=university_policy_path,
+                loaded_policy=loaded_university_policy,
             )
         except UniversitySourcePolicyError as exc:
             raise IngestError(str(exc)) from exc
@@ -626,9 +672,7 @@ def ingest(
         "requested_replace_sources": sorted(slugs),
         "requested_quarantine_sources": sorted(quarantine_slugs),
         "university_source_policy_sha256": (
-            sha256_file(Path(university_policy_path))
-            if university_admissions or university_quarantines
-            else None
+            policy_sha256 if university_admissions or university_quarantines else None
         ),
         "live_ingest_gate_sha256": live_ingest_gate_sha256,
         "before": before,

--- a/scripts/projects/open_model_data/phase3_vspu_db_cutover.py
+++ b/scripts/projects/open_model_data/phase3_vspu_db_cutover.py
@@ -1,0 +1,922 @@
+#!/usr/bin/env python3
+"""Rehearse and apply the exact one-source VSPU ``sources.db`` cutover.
+
+The default is a read-only plan. ``--apply-in-place`` first rebuilds the exact
+postimage on a disposable SQLite copy, validates the complete VSPU source and
+the recoverable Google Drive preimage, then copies the rehearsed postimage into
+the existing live inode. Any failure after cutover starts restores an exact
+private predecessor copy before returning an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from scripts.guardrails.worktree_containment import resolve_main_root
+from scripts.ingest import incremental_textbook_ingest as textbook_ingest
+from scripts.projects.open_model_data import phase3_vspu_source_materialization as materialization
+from scripts.projects.open_model_data import university_source_policy
+
+ROOT = Path(__file__).resolve().parents[3]
+PRIMARY_ROOT = resolve_main_root(ROOT) or ROOT
+SCHEMA_VERSION = "phase3_vspu_db_cutover_v1"
+SCHEMA_PATH = ROOT / "data/projects/open_model_data/contracts/phase3_vspu_db_cutover_v1.schema.json"
+MATERIALIZATION_PATH = ROOT / "data/projects/open_model_data/admission/phase3_vspu_source_materialization_v1.json"
+ADDITIVE_POLICY_PATH = (
+    ROOT / "data/projects/open_model_data/admission/phase3_vspu_additive_university_source_policy_v3.json"
+)
+DEFAULT_LIVE_DB = PRIMARY_ROOT / "data/sources.db"
+
+SOURCE_ID = "uni-ukrmova-sulm-attestation-vspu-2021"
+EXPECTED_SOURCE_ROWS = 158
+EXPECTED_PRE_DB_SHA256 = "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"
+EXPECTED_FOREIGN_KEY_COUNT = 134_836
+EXPECTED_FOREIGN_KEY_SHA256 = "9938f7cbab6cca94bfd0a360eec114fdef404a357e02b24161da0f7cf5c6d9bb"
+EXPECTED_MATERIALIZATION_FILE_SHA256 = "f023fab75ebc82ecb84a88a487f2ef2d477722035a82c5c23c18431b11e8b45c"
+EXPECTED_ADDITIVE_POLICY_SHA256 = "c2d2d094931751fefba0dd14143a83b344dc59f52b36414b165be920d29309f5"
+EXPECTED_PRIVATE_JSONL_SHA256 = "babb8a266a7d6720d68fb960f7848aace03f646f1ede5b30de2831f7cbb85dc8"
+EXPECTED_PREIMAGE_BACKUP_RECEIPT_SHA256 = "e53355f2d6c221c7bfe9cbba63b4055982f286b26d72618e8b9a393231febb0a"
+EXPECTED_COMPRESSED_PREIMAGE_SHA256 = "ba41ce56eabb2d72856c906cd498ec168b3036bbe79b9264bb074dbc87831d81"
+EXPECTED_COMPLETE_POLICY_V4_SHA256 = "98e7a80f8fdc1274a190cda793699aceaa79741ebf2145669d73e4c8a2236559"
+EXPECTED_PROMPT_V3_SHA256 = "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"
+EXPECTED_PROMPT_V2_SHA256 = "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
+COUNTS_BEFORE = {
+    "textbook_rows": 50_153,
+    "fts_rows": 50_153,
+    "section_rows": 36_322,
+    "source_count": 187,
+    "university_rows": 4_078,
+    "university_source_count": 20,
+}
+COUNTS_AFTER = {
+    "textbook_rows": 50_311,
+    "fts_rows": 50_311,
+    "section_rows": 36_480,
+    "source_count": 188,
+    "university_rows": 4_236,
+    "university_source_count": 21,
+}
+PRIVATE_FILE_MODE = 0o600
+
+
+class VspuDatabaseCutoverError(ValueError):
+    """The VSPU cutover inputs, rehearsal, or database state are unsafe."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VspuDatabaseCutoverError(message)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (canonical_json(value) + "\n").encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with Path(path).open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise VspuDatabaseCutoverError(f"cannot read file: {path}") from exc
+    return digest.hexdigest()
+
+
+def receipt_sha256(value: Mapping[str, Any]) -> str:
+    body = {key: item for key, item in value.items() if key != "receipt_sha256"}
+    return sha256_bytes(canonical_bytes(body))
+
+
+def _regular_file(path: Path, label: str, *, private: bool = False) -> None:
+    try:
+        result = Path(path).lstat()
+    except OSError as exc:
+        raise VspuDatabaseCutoverError(f"missing {label}: {path}") from exc
+    require(
+        stat.S_ISREG(result.st_mode) and not Path(path).is_symlink(),
+        f"{label} must be a regular file",
+    )
+    if private:
+        require(
+            stat.S_IMODE(result.st_mode) == PRIVATE_FILE_MODE,
+            f"{label} must be mode 0600",
+        )
+
+
+def _read_json(path: Path, label: str, *, private: bool = False) -> dict[str, Any]:
+    _regular_file(path, label, private=private)
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise VspuDatabaseCutoverError(f"cannot read {label}") from exc
+    require(isinstance(value, dict), f"{label} must be a JSON object")
+    return value
+
+
+def _drive_item_id(path: Path) -> str:
+    resolved = Path(path).resolve()
+    cloud_storage = Path.home() / "Library/CloudStorage"
+    try:
+        roots = [
+            candidate.resolve()
+            for candidate in cloud_storage.glob("GoogleDrive-*")
+            if candidate.is_dir() and (candidate / "My Drive").is_dir()
+        ]
+    except OSError as exc:
+        raise VspuDatabaseCutoverError("cannot inspect configured Google Drive mounts") from exc
+    matches = [root for root in roots if resolved.is_relative_to(root)]
+    require(len(matches) == 1, "private artifact is not inside exactly one Google Drive mount")
+    try:
+        result = subprocess.run(
+            ["xattr", "-p", "com.google.drivefs.item-id#S", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise VspuDatabaseCutoverError("private artifact lacks Google Drive provider identity") from exc
+    item_id = result.stdout.strip()
+    require(bool(item_id), "private artifact has an empty Google Drive provider identity")
+    return item_id
+
+
+def _streamed_gzip_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with gzip.open(path, "rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except (OSError, EOFError, gzip.BadGzipFile) as exc:
+        raise VspuDatabaseCutoverError("compressed preimage is not a readable gzip stream") from exc
+    return digest.hexdigest()
+
+
+def _validate_materialization_and_policy(
+    *,
+    materialization_path: Path,
+    additive_policy_path: Path,
+    private_jsonl_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    require(
+        sha256_file(materialization_path) == EXPECTED_MATERIALIZATION_FILE_SHA256,
+        "VSPU materialization receipt byte drift",
+    )
+    try:
+        materialization_receipt = materialization.validate_receipt(
+            _read_json(materialization_path, "VSPU materialization receipt")
+        )
+    except materialization.VspuSourceMaterializationError as exc:
+        raise VspuDatabaseCutoverError(str(exc)) from exc
+    require(
+        materialization_receipt["source_id"] == SOURCE_ID,
+        "VSPU materialization source identity drift",
+    )
+    require(
+        materialization_receipt["private_artifact"]["source_unit_count"] == EXPECTED_SOURCE_ROWS,
+        "VSPU materialization row denominator drift",
+    )
+    require(
+        materialization_receipt["gates"]["database_ingest_authorized"] is False,
+        "materialization receipt unexpectedly authorizes database mutation",
+    )
+
+    require(
+        sha256_file(additive_policy_path) == EXPECTED_ADDITIVE_POLICY_SHA256,
+        "VSPU additive policy byte drift",
+    )
+    try:
+        policy, policy_sha256 = university_source_policy.load_policy(additive_policy_path)
+    except university_source_policy.UniversitySourcePolicyError as exc:
+        raise VspuDatabaseCutoverError(str(exc)) from exc
+    require(policy_sha256 == EXPECTED_ADDITIVE_POLICY_SHA256, "VSPU additive policy hash drift")
+    require(policy["source_count"] == 1, "VSPU additive policy is not a one-source policy")
+    entry = policy["sources"][0]
+    require(entry["source_file"] == SOURCE_ID, "VSPU additive policy source drift")
+    require(entry["content_disposition"] == "contextual_only", "VSPU disposition drift")
+    require(
+        entry["allowed_lanes"] == ["contextual_retrieval", "corpus_ingest"],
+        "VSPU allowed-lane drift",
+    )
+
+    _regular_file(private_jsonl_path, "private VSPU JSONL", private=True)
+    require(
+        Path(private_jsonl_path).name == f"{SOURCE_ID}.jsonl",
+        "private VSPU JSONL filename drift",
+    )
+    require(
+        sha256_file(private_jsonl_path) == EXPECTED_PRIVATE_JSONL_SHA256,
+        "private VSPU JSONL byte drift",
+    )
+    _drive_item_id(private_jsonl_path)
+    try:
+        rows = university_source_policy.load_jsonl_rows(private_jsonl_path)
+        admission = university_source_policy.require_source_admission(
+            source_file=SOURCE_ID,
+            jsonl_path=private_jsonl_path,
+            policy_path=additive_policy_path,
+            lane="corpus_ingest",
+        )
+    except university_source_policy.UniversitySourcePolicyError as exc:
+        raise VspuDatabaseCutoverError(str(exc)) from exc
+    require(len(rows) == EXPECTED_SOURCE_ROWS, "private VSPU JSONL row denominator drift")
+    require(admission["content_disposition"] == "contextual_only", "VSPU admission drift")
+    require("linguistic_rule_evidence" not in admission["allowed_lanes"], "VSPU policy grants rule authority")
+    return materialization_receipt, policy
+
+
+def _validate_preimage_backup(*, receipt_path: Path, compressed_path: Path) -> dict[str, Any]:
+    require(
+        sha256_file(receipt_path) == EXPECTED_PREIMAGE_BACKUP_RECEIPT_SHA256,
+        "preimage backup receipt byte drift",
+    )
+    receipt = _read_json(receipt_path, "preimage backup receipt", private=True)
+    _regular_file(compressed_path, "compressed preimage database", private=True)
+    require(
+        sha256_file(compressed_path) == EXPECTED_COMPRESSED_PREIMAGE_SHA256,
+        "compressed preimage database byte drift",
+    )
+    _drive_item_id(receipt_path)
+    _drive_item_id(compressed_path)
+    database = receipt.get("database", {})
+    custody = receipt.get("custody", {})
+    require(
+        receipt.get("schema_version") == "phase3_saint_sophia_db_drive_backup_receipt_v1",
+        "preimage backup receipt schema drift",
+    )
+    require(
+        receipt.get("status") == "VERIFIED_UPLOADED_SUCCESSOR_DATABASE",
+        "preimage backup is not provider-verified",
+    )
+    require(database.get("successor_sha256") == EXPECTED_PRE_DB_SHA256, "backup database identity drift")
+    require(
+        database.get("compressed_sha256") == EXPECTED_COMPRESSED_PREIMAGE_SHA256,
+        "backup compressed identity drift",
+    )
+    require(
+        database.get("streamed_restore_sha256") == EXPECTED_PRE_DB_SHA256,
+        "backup receipt restore identity drift",
+    )
+    require(database.get("gzip_integrity") is True, "backup receipt lacks gzip integrity")
+    require(database.get("integrity_check") == "ok", "backed-up database integrity is not ok")
+    expected_receipt_counts = {
+        "textbook_rows": database.get("textbook_rows"),
+        "fts_rows": database.get("textbook_fts_rows"),
+        "section_rows": database.get("textbook_section_rows"),
+        "source_count": database.get("textbook_sources"),
+        "university_rows": database.get("university_rows"),
+        "university_source_count": database.get("university_sources"),
+    }
+    require(expected_receipt_counts == COUNTS_BEFORE, "backup database count drift")
+    require(
+        database.get("foreign_key_failures") == EXPECTED_FOREIGN_KEY_COUNT
+        and database.get("foreign_key_failure_sha256") == EXPECTED_FOREIGN_KEY_SHA256,
+        "backup foreign-key baseline drift",
+    )
+    require(custody.get("all_new_files_uploaded") is True, "preimage backup is not uploaded")
+    require(custody.get("all_new_files_uploading") is False, "preimage backup is still uploading")
+    require(custody.get("all_new_files_readback_hash_match") is True, "backup read-back proof failed")
+    require(custody.get("predecessor_backup_preserved") is True, "predecessor backup was not preserved")
+    require(
+        _streamed_gzip_sha256(compressed_path) == EXPECTED_PRE_DB_SHA256,
+        "compressed preimage streamed restore hash drift",
+    )
+    return receipt
+
+
+def _foreign_key_evidence(connection: sqlite3.Connection) -> tuple[int, str]:
+    failures = sorted(tuple(row) for row in connection.execute("PRAGMA foreign_key_check"))
+    return len(failures), sha256_bytes(canonical_json(failures).encode("utf-8"))
+
+
+def _database_counts(connection: sqlite3.Connection) -> dict[str, int]:
+    return {
+        "textbook_rows": connection.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0],
+        "fts_rows": connection.execute("SELECT COUNT(*) FROM textbooks_fts").fetchone()[0],
+        "section_rows": connection.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0],
+        "source_count": connection.execute("SELECT COUNT(DISTINCT source_file) FROM textbooks").fetchone()[0],
+        "university_rows": connection.execute("SELECT COUNT(*) FROM textbooks WHERE grade='university'").fetchone()[0],
+        "university_source_count": connection.execute(
+            "SELECT COUNT(DISTINCT source_file) FROM textbooks WHERE grade='university'"
+        ).fetchone()[0],
+    }
+
+
+def _hash_rows(digest: Any, label: str, rows: Iterable[Sequence[Any]]) -> None:
+    digest.update(f"{label}\n".encode())
+    for row in rows:
+        digest.update(canonical_bytes(list(row)))
+
+
+def _existing_corpus_fingerprint(connection: sqlite3.Connection) -> str:
+    """Hash every pre-existing textbook row plus unrelated table structure/counts."""
+    digest = hashlib.sha256()
+    schema_rows = connection.execute(
+        "SELECT type,name,tbl_name,sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name"
+    )
+    _hash_rows(digest, "schema", schema_rows)
+    _hash_rows(
+        digest,
+        "existing_textbooks",
+        connection.execute(
+            "SELECT * FROM textbooks WHERE source_file<>? ORDER BY id",
+            (SOURCE_ID,),
+        ),
+    )
+    _hash_rows(
+        digest,
+        "existing_textbook_sections",
+        connection.execute(
+            "SELECT * FROM textbook_sections WHERE source_file<>? ORDER BY section_id",
+            (SOURCE_ID,),
+        ),
+    )
+    unrelated_tables = [
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' "
+            "AND name NOT IN ('textbooks','textbook_sections') "
+            "AND name NOT LIKE 'textbooks_fts%' ORDER BY name"
+        )
+    ]
+    counts = []
+    for table in unrelated_tables:
+        quoted = table.replace('"', '""')
+        counts.append((table, connection.execute(f'SELECT COUNT(*) FROM "{quoted}"').fetchone()[0]))
+    _hash_rows(digest, "unrelated_table_counts", counts)
+    return digest.hexdigest()
+
+
+def _database_evidence(path: Path) -> dict[str, Any]:
+    _regular_file(path, "database")
+    uri = f"file:{Path(path).resolve()}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True, timeout=30.0) as connection:
+            counts = _database_counts(connection)
+            target_rows = connection.execute(
+                "SELECT COUNT(*) FROM textbooks WHERE source_file=?",
+                (SOURCE_ID,),
+            ).fetchone()[0]
+            target_fts_rows = connection.execute(
+                "SELECT COUNT(*) FROM textbooks_fts AS f JOIN textbooks AS t ON t.id=f.rowid WHERE t.source_file=?",
+                (SOURCE_ID,),
+            ).fetchone()[0]
+            target_sections = connection.execute(
+                "SELECT COUNT(*) FROM textbook_sections WHERE source_file=?",
+                (SOURCE_ID,),
+            ).fetchone()[0]
+            target_links = connection.execute(
+                "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NOT NULL",
+                (SOURCE_ID,),
+            ).fetchone()[0]
+            foreign_count, foreign_hash = _foreign_key_evidence(connection)
+            integrity_rows = [str(row[0]) for row in connection.execute("PRAGMA integrity_check")]
+            return {
+                "sha256": sha256_file(path),
+                "counts": counts,
+                "target_rows": target_rows,
+                "target_fts_rows": target_fts_rows,
+                "target_section_rows": target_sections,
+                "target_linked_rows": target_links,
+                "foreign_key_failure_count": foreign_count,
+                "foreign_key_failure_sha256": foreign_hash,
+                "existing_corpus_fingerprint": _existing_corpus_fingerprint(connection),
+                "integrity_check": "ok" if integrity_rows == ["ok"] else integrity_rows,
+                "journal_mode": str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower(),
+            }
+    except sqlite3.Error as exc:
+        raise VspuDatabaseCutoverError(f"cannot inspect database: {exc}") from exc
+
+
+def _validate_pre_database(evidence: Mapping[str, Any]) -> None:
+    require(evidence["sha256"] == EXPECTED_PRE_DB_SHA256, "live database preimage SHA-256 drift")
+    require(evidence["counts"] == COUNTS_BEFORE, "live database pre-count drift")
+    require(evidence["target_rows"] == 0, "single-use cutover is stale: VSPU rows already exist")
+    require(evidence["target_fts_rows"] == 0, "single-use cutover is stale: VSPU FTS rows exist")
+    require(evidence["target_section_rows"] == 0, "single-use cutover is stale: VSPU sections exist")
+    require(evidence["target_linked_rows"] == 0, "single-use cutover is stale: VSPU links exist")
+    require(evidence["integrity_check"] == "ok", "live database integrity check is not ok")
+    require(evidence["journal_mode"] == "wal", "live database journal-mode drift")
+    require(
+        evidence["foreign_key_failure_count"] == EXPECTED_FOREIGN_KEY_COUNT
+        and evidence["foreign_key_failure_sha256"] == EXPECTED_FOREIGN_KEY_SHA256,
+        "live database foreign-key baseline drift",
+    )
+
+
+def _validate_post_database(after: Mapping[str, Any], before: Mapping[str, Any]) -> None:
+    require(after["counts"] == COUNTS_AFTER, "VSPU post-count drift")
+    require(after["target_rows"] == EXPECTED_SOURCE_ROWS, "VSPU row denominator drift")
+    require(after["target_fts_rows"] == EXPECTED_SOURCE_ROWS, "VSPU FTS parity drift")
+    require(after["target_section_rows"] == EXPECTED_SOURCE_ROWS, "VSPU section denominator drift")
+    require(after["target_linked_rows"] == EXPECTED_SOURCE_ROWS, "VSPU section-link parity drift")
+    require(after["integrity_check"] == "ok", "post-ingest database integrity check is not ok")
+    require(after["journal_mode"] == "wal", "post-ingest database journal-mode drift")
+    require(
+        (
+            after["foreign_key_failure_count"],
+            after["foreign_key_failure_sha256"],
+        )
+        == (
+            before["foreign_key_failure_count"],
+            before["foreign_key_failure_sha256"],
+        ),
+        "VSPU ingest changed the foreign-key baseline",
+    )
+    require(
+        after["existing_corpus_fingerprint"] == before["existing_corpus_fingerprint"],
+        "VSPU ingest changed pre-existing corpus evidence",
+    )
+
+
+def _candidate_path(live_path: Path) -> Path:
+    fd, candidate = tempfile.mkstemp(
+        dir=live_path.parent,
+        prefix=f".{live_path.name}.vspu-",
+        suffix=".candidate",
+    )
+    os.close(fd)
+    os.chmod(candidate, PRIVATE_FILE_MODE)
+    return Path(candidate)
+
+
+def _sidecars(path: Path) -> tuple[Path, Path]:
+    return path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm")
+
+
+def _reject_nonempty_wal(path: Path) -> None:
+    wal, _ = _sidecars(path)
+    require(not wal.exists() or wal.stat().st_size == 0, "database has a non-empty WAL")
+
+
+def _require_empty_or_absent_wal(path: Path) -> None:
+    wal, _ = _sidecars(path)
+    require(not wal.exists() or wal.stat().st_size == 0, "database WAL remains non-empty")
+
+
+def _cleanup_sidecars(path: Path) -> None:
+    for sidecar in _sidecars(path):
+        sidecar.unlink(missing_ok=True)
+
+
+def _sqlite_backup(source: Path, target: Path) -> None:
+    source_uri = f"file:{Path(source).resolve()}?mode=ro"
+    try:
+        with sqlite3.connect(source_uri, uri=True) as source_connection, sqlite3.connect(target) as target_connection:
+            source_connection.backup(target_connection)
+            target_connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.Error as exc:
+        raise VspuDatabaseCutoverError(f"SQLite online backup failed: {exc}") from exc
+
+
+def _restore_exact_prestate(rollback: Path, target: Path, expected_sha256: str) -> None:
+    _sqlite_backup(rollback, target)
+    _require_empty_or_absent_wal(target)
+    if sha256_file(target) != expected_sha256:
+        with rollback.open("rb") as source, target.open("r+b") as destination:
+            destination.seek(0)
+            destination.truncate(0)
+            shutil.copyfileobj(source, destination)
+            destination.flush()
+            os.fsync(destination.fileno())
+    _require_empty_or_absent_wal(target)
+    require(sha256_file(target) == expected_sha256, "rollback did not restore exact prestate")
+
+
+def _atomic_write_private(path: Path, value: Mapping[str, Any]) -> None:
+    path = Path(path)
+    parent = path.parent
+    require(parent.is_dir() and not parent.is_symlink(), "receipt parent must be a real directory")
+    require(not path.is_symlink(), "receipt output must not be a symlink")
+    payload = canonical_bytes(value)
+    if path.exists():
+        _regular_file(path, "existing private receipt", private=True)
+        require(path.read_bytes() == payload, "refusing to overwrite an immutable private receipt")
+        return
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, PRIVATE_FILE_MODE)
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _validate_rehearsal_receipt(path: Path) -> dict[str, Any]:
+    receipt = _read_json(path, "copied-database rehearsal receipt", private=True)
+    require(receipt.get("schema_version") == "incremental-textbook-ingest.v2", "rehearsal schema drift")
+    require(receipt.get("status") == "committed", "copied-database rehearsal did not commit")
+    require(
+        receipt.get("execution_scope") == "copied_database_rehearsal",
+        "receipt is not a copied-database rehearsal",
+    )
+    require(receipt.get("requested_replace_sources") == [SOURCE_ID], "rehearsal source-set drift")
+    require(receipt.get("requested_quarantine_sources") == [], "rehearsal quarantined a source")
+    require(
+        receipt.get("university_source_policy_sha256") == EXPECTED_ADDITIVE_POLICY_SHA256,
+        "rehearsal policy binding drift",
+    )
+    require(
+        receipt.get("before") == {key: COUNTS_BEFORE[key] for key in ("textbook_rows", "fts_rows", "section_rows")},
+        "rehearsal pre-count drift",
+    )
+    require(
+        receipt.get("after_transaction")
+        == {key: COUNTS_AFTER[key] for key in ("textbook_rows", "fts_rows", "section_rows")},
+        "rehearsal post-count drift",
+    )
+    require(receipt.get("integrity_check") == "ok", "rehearsal integrity check failed")
+    require(receipt.get("foreign_key_failures_unchanged") is True, "rehearsal foreign-key baseline changed")
+    require(
+        receipt.get("foreign_key_failure_count_before") == EXPECTED_FOREIGN_KEY_COUNT
+        and receipt.get("foreign_key_failure_count_after") == EXPECTED_FOREIGN_KEY_COUNT,
+        "rehearsal foreign-key count drift",
+    )
+    require(
+        receipt.get("foreign_key_failure_hash_before") == EXPECTED_FOREIGN_KEY_SHA256
+        and receipt.get("foreign_key_failure_hash_after") == EXPECTED_FOREIGN_KEY_SHA256,
+        "rehearsal foreign-key hash drift",
+    )
+    per_source = receipt.get("per_source")
+    require(isinstance(per_source, list) and len(per_source) == 1, "rehearsal per-source shape drift")
+    source = per_source[0]
+    require(source.get("source_file") == SOURCE_ID, "rehearsal per-source identity drift")
+    require(source.get("inserted_rows") == EXPECTED_SOURCE_ROWS, "rehearsal row-count drift")
+    require(source.get("section_rows") == EXPECTED_SOURCE_ROWS, "rehearsal section-count drift")
+    require(source.get("linked_rows") == EXPECTED_SOURCE_ROWS, "rehearsal linkage drift")
+    require(source.get("section_policy") == "exact_page_labels", "rehearsal section-policy drift")
+    require(source.get("fts", {}).get("indexed_rows") == EXPECTED_SOURCE_ROWS, "rehearsal FTS-count drift")
+    require(source.get("fts", {}).get("parity") is True, "rehearsal FTS parity failed")
+    admission = source.get("university_source_policy", {})
+    require(admission.get("content_disposition") == "contextual_only", "rehearsal disposition drift")
+    require(
+        "linguistic_rule_evidence" not in admission.get("allowed_lanes", []),
+        "rehearsal grants rule-authority lane",
+    )
+    return receipt
+
+
+def _build_receipt(
+    *,
+    rehearsal_receipt_path: Path,
+    rehearsal: Mapping[str, Any],
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    inode_preserved: bool,
+) -> dict[str, Any]:
+    source = rehearsal["per_source"][0]
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "text_free": True,
+        "provider_calls": False,
+        "mode": "in_place_sqlite_backup",
+        "source_id": SOURCE_ID,
+        "bindings": {
+            "implementation_sha256": sha256_file(Path(__file__).resolve()),
+            "schema_sha256": sha256_file(SCHEMA_PATH),
+            "incremental_ingest_implementation_sha256": sha256_file(Path(textbook_ingest.__file__).resolve()),
+            "phase3_reboot_prompt_v3_sha256": EXPECTED_PROMPT_V3_SHA256,
+            "phase3_recovery_prompt_v2_sha256": EXPECTED_PROMPT_V2_SHA256,
+            "complete_source_policy_v4_sha256": EXPECTED_COMPLETE_POLICY_V4_SHA256,
+            "vspu_materialization_receipt_sha256": EXPECTED_MATERIALIZATION_FILE_SHA256,
+            "vspu_additive_policy_sha256": EXPECTED_ADDITIVE_POLICY_SHA256,
+            "private_jsonl_sha256": EXPECTED_PRIVATE_JSONL_SHA256,
+            "preimage_backup_receipt_sha256": EXPECTED_PREIMAGE_BACKUP_RECEIPT_SHA256,
+            "compressed_preimage_database_sha256": EXPECTED_COMPRESSED_PREIMAGE_SHA256,
+        },
+        "preimage_backup": {
+            "status": "VERIFIED_UPLOADED_SUCCESSOR_DATABASE",
+            "database_sha256": EXPECTED_PRE_DB_SHA256,
+            "compressed_sha256": EXPECTED_COMPRESSED_PREIMAGE_SHA256,
+            "streamed_restore_sha256": EXPECTED_PRE_DB_SHA256,
+            "gzip_integrity": True,
+            "google_drive_provider_identity_present": True,
+            "predecessor_backup_preserved": True,
+        },
+        "copied_database_rehearsal": {
+            "execution_scope": "copied_database_rehearsal",
+            "status": "committed",
+            "database_sha256_before": rehearsal["db_sha256_before"],
+            "database_sha256_after": rehearsal["db_sha256_after"],
+            "ingest_receipt_sha256": sha256_file(rehearsal_receipt_path),
+            "inserted_rows": source["inserted_rows"],
+            "section_rows": source["section_rows"],
+            "linked_rows": source["linked_rows"],
+            "fts_rows": source["fts"]["indexed_rows"],
+            "integrity_check": rehearsal["integrity_check"],
+            "foreign_key_failures_unchanged": rehearsal["foreign_key_failures_unchanged"],
+            "existing_corpus_fingerprint_unchanged": (
+                before["existing_corpus_fingerprint"] == after["existing_corpus_fingerprint"]
+            ),
+        },
+        "database": {
+            "target_locator": "primary_checkout:data/sources.db",
+            "pre_sha256": before["sha256"],
+            "post_sha256": after["sha256"],
+            "counts_before": before["counts"],
+            "counts_after": after["counts"],
+            "target_absent_before": before["target_rows"] == 0,
+            "target_rows_after": after["target_rows"],
+            "target_fts_rows_after": after["target_fts_rows"],
+            "target_section_rows_after": after["target_section_rows"],
+            "target_linked_rows_after": after["target_linked_rows"],
+            "foreign_key_failure_count_before": before["foreign_key_failure_count"],
+            "foreign_key_failure_count_after": after["foreign_key_failure_count"],
+            "foreign_key_failure_sha256_before": before["foreign_key_failure_sha256"],
+            "foreign_key_failure_sha256_after": after["foreign_key_failure_sha256"],
+            "existing_corpus_fingerprint_before": before["existing_corpus_fingerprint"],
+            "existing_corpus_fingerprint_after": after["existing_corpus_fingerprint"],
+            "integrity_check": after["integrity_check"],
+            "journal_mode": after["journal_mode"],
+            "live_inode_preserved": inode_preserved,
+        },
+        "safeguards": {
+            "exact_preimage_required": True,
+            "exact_one_source_set_required": True,
+            "copied_database_rehearsal_passed": True,
+            "recoverable_google_drive_preimage_verified": True,
+            "rollback_copy_created_before_cutover": True,
+            "automatic_exact_prestate_restore_on_failure": True,
+            "existing_corpus_unchanged": True,
+            "global_textbook_fts_parity": after["counts"]["textbook_rows"] == after["counts"]["fts_rows"],
+            "private_receipt_0600": True,
+        },
+        "rights_and_authority": {
+            "private_operator_authorized_use_only": True,
+            "public_redistribution_authorized": False,
+            "unrestricted_reuse_authorized": False,
+            "normative_rule_authority": False,
+            "semantic_gold": False,
+            "role_layer_conversion_complete": False,
+            "adapt_or_remove_on_substantiated_complaint": True,
+        },
+        "phase_boundaries": {
+            "database_ingest_complete": True,
+            "source_universe_frozen": False,
+            "source_coverage_ready": False,
+            "phase3_complete": False,
+            "phase4_blocked": True,
+            "post_ingest_backup_required": True,
+        },
+    }
+    return {**body, "receipt_sha256": receipt_sha256(body)}
+
+
+def _schema_validator() -> Draft202012Validator:
+    schema = _read_json(SCHEMA_PATH, "VSPU cutover schema")
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def validate_receipt(value: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = dict(value)
+    errors = sorted(_schema_validator().iter_errors(receipt), key=lambda error: list(error.path))
+    if errors:
+        location = "/".join(str(part) for part in errors[0].absolute_path) or "receipt"
+        raise VspuDatabaseCutoverError(f"VSPU cutover schema violation at {location}: {errors[0].message}")
+    require(receipt["receipt_sha256"] == receipt_sha256(receipt), "cutover receipt body hash drift")
+    bindings = receipt["bindings"]
+    require(
+        bindings["implementation_sha256"] == sha256_file(Path(__file__).resolve()),
+        "cutover implementation binding drift",
+    )
+    require(bindings["schema_sha256"] == sha256_file(SCHEMA_PATH), "cutover schema binding drift")
+    require(
+        bindings["incremental_ingest_implementation_sha256"] == sha256_file(Path(textbook_ingest.__file__).resolve()),
+        "incremental ingest implementation binding drift",
+    )
+    require(
+        receipt["database"]["existing_corpus_fingerprint_before"]
+        == receipt["database"]["existing_corpus_fingerprint_after"],
+        "receipt reports changed pre-existing corpus evidence",
+    )
+    require(
+        receipt["phase_boundaries"]["database_ingest_complete"] is True,
+        "receipt reports database_ingest_complete=false",
+    )
+    require(receipt["phase_boundaries"]["phase4_blocked"] is True, "receipt opens Phase 4")
+    require(receipt["rights_and_authority"]["semantic_gold"] is False, "receipt grants semantic gold")
+    return receipt
+
+
+def reconcile(
+    *,
+    database_path: Path,
+    private_jsonl_path: Path,
+    preimage_backup_receipt_path: Path,
+    compressed_preimage_path: Path,
+    output_receipt_path: Path | None = None,
+    materialization_path: Path = MATERIALIZATION_PATH,
+    additive_policy_path: Path = ADDITIVE_POLICY_PATH,
+    apply_in_place: bool = False,
+    expected_live_db_path: Path | None = None,
+    require_google_drive_output: bool = True,
+) -> dict[str, Any]:
+    """Plan or run the exact one-source copied-rehearsal/live cutover."""
+    target = Path(database_path)
+    expected_target = Path(expected_live_db_path or DEFAULT_LIVE_DB)
+    _regular_file(target, "database")
+    require(not target.is_symlink(), "database target must not be a symlink")
+    require(target.resolve() == expected_target.resolve(), "cutover is restricted to the live sources database")
+    require(os.path.samefile(target, expected_target), "cutover target is not the live database inode")
+    _validate_materialization_and_policy(
+        materialization_path=Path(materialization_path),
+        additive_policy_path=Path(additive_policy_path),
+        private_jsonl_path=Path(private_jsonl_path),
+    )
+    _validate_preimage_backup(
+        receipt_path=Path(preimage_backup_receipt_path),
+        compressed_path=Path(compressed_preimage_path),
+    )
+    before = _database_evidence(target)
+    _validate_pre_database(before)
+    plan = {
+        "text_free": True,
+        "provider_calls": False,
+        "mode": "dry_run",
+        "source_id": SOURCE_ID,
+        "pre_database_sha256": before["sha256"],
+        "source_rows": EXPECTED_SOURCE_ROWS,
+        "recoverable_google_drive_preimage_verified": True,
+        "phase3_complete": False,
+        "phase4_blocked": True,
+    }
+    if not apply_in_place:
+        return plan
+    require(output_receipt_path is not None, "private output receipt is required for apply")
+    if require_google_drive_output:
+        # The receipt does not exist yet, so prove the output directory through a
+        # provider-backed sibling already bound by this cutover.
+        output_parent = Path(output_receipt_path).parent.resolve()
+        backup_parent = Path(preimage_backup_receipt_path).parent.resolve()
+        require(
+            output_parent.is_relative_to(backup_parent.parent.parent.parent),
+            "private cutover receipt must remain in the Phase 3 Google Drive backup tree",
+        )
+    require(not Path(output_receipt_path).exists(), "refusing to overwrite a cutover receipt")
+
+    candidate: Path | None = None
+    rollback: Path | None = None
+    rehearsal_receipt_path: Path | None = None
+    cutover_started = False
+    rollback_retained = False
+    live_inode_before = target.stat().st_ino
+    try:
+        _reject_nonempty_wal(target)
+        require(sha256_file(target) == before["sha256"], "database bytes drifted before rehearsal")
+        rollback = _candidate_path(target)
+        shutil.copy2(target, rollback)
+        os.chmod(rollback, PRIVATE_FILE_MODE)
+        candidate = _candidate_path(target)
+        shutil.copy2(target, candidate)
+        os.chmod(candidate, PRIVATE_FILE_MODE)
+        require(sha256_file(candidate) == EXPECTED_PRE_DB_SHA256, "candidate preimage byte drift")
+        rehearsal_receipt_path = candidate.with_suffix(".ingest-receipt.json")
+        try:
+            textbook_ingest.ingest(
+                [SOURCE_ID],
+                db_path=candidate,
+                dry_run=False,
+                chunks_root=Path(private_jsonl_path).parent.parent,
+                receipt_path=rehearsal_receipt_path,
+                university_policy_path=Path(additive_policy_path),
+                copied_database_rehearsal=True,
+                additional_rehearsal_policy_sha256=EXPECTED_ADDITIVE_POLICY_SHA256,
+            )
+        except (textbook_ingest.IngestError, OSError, sqlite3.Error) as exc:
+            raise VspuDatabaseCutoverError(str(exc)) from exc
+        os.chmod(rehearsal_receipt_path, PRIVATE_FILE_MODE)
+        rehearsal = _validate_rehearsal_receipt(rehearsal_receipt_path)
+        after_candidate = _database_evidence(candidate)
+        _validate_post_database(after_candidate, before)
+
+        require(sha256_file(target) == before["sha256"], "live database drifted during rehearsal")
+        _reject_nonempty_wal(target)
+        cutover_started = True
+        _sqlite_backup(candidate, target)
+        _require_empty_or_absent_wal(target)
+        after = _database_evidence(target)
+        _validate_post_database(after, before)
+        require(
+            {key: item for key, item in after.items() if key != "sha256"}
+            == {key: item for key, item in after_candidate.items() if key != "sha256"},
+            "live postconditions differ from the rehearsed candidate",
+        )
+        receipt = validate_receipt(
+            _build_receipt(
+                rehearsal_receipt_path=rehearsal_receipt_path,
+                rehearsal=rehearsal,
+                before=before,
+                after=after,
+                inode_preserved=target.stat().st_ino == live_inode_before,
+            )
+        )
+        _atomic_write_private(Path(output_receipt_path), receipt)
+        if require_google_drive_output:
+            _drive_item_id(Path(output_receipt_path))
+        return receipt
+    except BaseException as cutover_error:
+        if cutover_started and rollback is not None:
+            try:
+                _restore_exact_prestate(rollback, target, before["sha256"])
+            except BaseException as restore_error:
+                rollback_retained = True
+                raise VspuDatabaseCutoverError(
+                    "VSPU cutover and exact rollback both failed; "
+                    f"private predecessor retained at {rollback}: {restore_error}"
+                ) from cutover_error
+        if output_receipt_path is not None:
+            Path(output_receipt_path).unlink(missing_ok=True)
+        raise
+    finally:
+        if candidate is not None:
+            candidate.unlink(missing_ok=True)
+            _cleanup_sidecars(candidate)
+        if rehearsal_receipt_path is not None:
+            rehearsal_receipt_path.unlink(missing_ok=True)
+        if rollback is not None and not rollback_retained:
+            rollback.unlink(missing_ok=True)
+            _cleanup_sidecars(rollback)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database", type=Path, default=DEFAULT_LIVE_DB)
+    parser.add_argument("--private-jsonl", type=Path, required=True)
+    parser.add_argument("--preimage-backup-receipt", type=Path, required=True)
+    parser.add_argument("--compressed-preimage", type=Path, required=True)
+    parser.add_argument("--output-receipt", type=Path)
+    parser.add_argument("--materialization-receipt", type=Path, default=MATERIALIZATION_PATH)
+    parser.add_argument("--additive-policy", type=Path, default=ADDITIVE_POLICY_PATH)
+    parser.add_argument("--apply-in-place", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = reconcile(
+            database_path=args.database,
+            private_jsonl_path=args.private_jsonl,
+            preimage_backup_receipt_path=args.preimage_backup_receipt,
+            compressed_preimage_path=args.compressed_preimage,
+            output_receipt_path=args.output_receipt,
+            materialization_path=args.materialization_receipt,
+            additive_policy_path=args.additive_policy,
+            apply_in_place=args.apply_in_place,
+        )
+        print(
+            canonical_json(
+                {
+                    "ok": True,
+                    "mode": result["mode"],
+                    "receipt_sha256": result.get("receipt_sha256"),
+                }
+            )
+        )
+    except VspuDatabaseCutoverError as exc:
+        print(canonical_json({"ok": False, "error": str(exc)}))
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/projects/open_model_data/university_source_policy.py
+++ b/scripts/projects/open_model_data/university_source_policy.py
@@ -315,10 +315,11 @@ def require_source_admission(
     jsonl_path: Path,
     policy_path: Path = DEFAULT_POLICY_PATH,
     lane: str = "corpus_ingest",
+    loaded_policy: tuple[dict[str, Any], str] | None = None,
 ) -> dict[str, Any]:
     """Return hash-bound admission metadata or fail before DB mutation."""
     _require(lane in ALLOWED_LANES, f"unsupported university source lane: {lane}")
-    document, policy_sha256 = load_policy(policy_path)
+    document, policy_sha256 = loaded_policy or load_policy(policy_path)
     entry = next(
         (item for item in document["sources"] if _entry_source_id(item) == source_file),
         None,
@@ -372,9 +373,10 @@ def require_source_quarantine(
     source_file: str,
     jsonl_path: Path,
     policy_path: Path,
+    loaded_policy: tuple[dict[str, Any], str] | None = None,
 ) -> dict[str, Any]:
     """Return hash-bound v3 quarantine metadata or refuse source removal."""
-    document, policy_sha256 = load_policy(policy_path)
+    document, policy_sha256 = loaded_policy or load_policy(policy_path)
     _require(
         document["schema_version"] in {V3_SCHEMA_VERSION, V4_SCHEMA_VERSION},
         f"{source_file}: source-level content quarantine requires a v3 or v4 policy",

--- a/tests/ingest/test_incremental_textbook_ingest.py
+++ b/tests/ingest/test_incremental_textbook_ingest.py
@@ -452,6 +452,147 @@ def _write_v3_university_policy(
     return path
 
 
+def test_copied_rehearsal_rejects_legacy_university_policy(tmp_path):
+    slug = "uni-ukrmova-legacy-policy-2026"
+    jsonl = tmp_path / "grade-00" / f"{slug}.jsonl"
+    jsonl.parent.mkdir(parents=True)
+    jsonl.write_text(
+        json.dumps(
+            {
+                "chunk_id": f"{slug}_s0000",
+                "text": "Перевірений титульний аркуш.",
+                "page_start": 1,
+                "page_end": 1,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    policy = _write_university_policy(
+        tmp_path / "legacy-policy.json",
+        slug=slug,
+        jsonl=jsonl,
+    )
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(
+        iti.IngestError,
+        match="requires the complete v4 policy or an exact caller-pinned v3 policy",
+    ):
+        iti.ingest(
+            [slug],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path,
+            university_policy_path=policy,
+            copied_database_rehearsal=True,
+        )
+
+
+@pytest.mark.parametrize("provided_sha256", [None, "0" * 64])
+def test_copied_rehearsal_rejects_unpinned_or_mismatched_v3_policy(
+    tmp_path,
+    provided_sha256,
+):
+    slug = "uni-ukrmova-unpinned-v3-2026"
+    jsonl = tmp_path / "grade-00" / f"{slug}.jsonl"
+    jsonl.parent.mkdir(parents=True)
+    jsonl.write_text(
+        json.dumps(
+            {
+                "chunk_id": f"{slug}_s0000",
+                "text": "Перевірений титульний аркуш.",
+                "page_start": 1,
+                "page_end": 1,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    policy = _write_v3_university_policy(
+        tmp_path / "v3-policy.json",
+        slug=slug,
+        jsonl=jsonl,
+        content_disposition="contextual_only",
+        allowed_lanes=["contextual_retrieval", "corpus_ingest"],
+    )
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(
+        iti.IngestError,
+        match="requires the complete v4 policy or an exact caller-pinned v3 policy",
+    ):
+        iti.ingest(
+            [slug],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path,
+            university_policy_path=policy,
+            copied_database_rehearsal=True,
+            additional_rehearsal_policy_sha256=provided_sha256,
+        )
+
+
+def test_copied_rehearsal_uses_one_loaded_policy_snapshot(tmp_path, monkeypatch):
+    from projects.open_model_data import university_source_policy as usp
+
+    slug = "uni-ukrmova-loaded-policy-snapshot-2026"
+    root = tmp_path / "chunks"
+    jsonl = root / "grade-00" / f"{slug}.jsonl"
+    jsonl.parent.mkdir(parents=True)
+    jsonl.write_text(
+        json.dumps(
+            {
+                "chunk_id": f"{slug}_s0000",
+                "section_title": "Сторінка 1",
+                "text": "Український університетський текст.",
+                "author": "haluzynska",
+                "author_uk": None,
+                "grade": 0,
+                "page_start": 1,
+                "page_end": 1,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    policy = _write_v3_university_policy(
+        tmp_path / "v3-policy.json",
+        slug=slug,
+        jsonl=jsonl,
+        content_disposition="contextual_only",
+        allowed_lanes=["contextual_retrieval", "corpus_ingest"],
+    )
+    _, expected_policy_sha256 = usp.load_policy(policy)
+    database = tmp_path / "copy.db"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(SCHEMA)
+
+    real_load_policy = iti.load_policy
+
+    def load_then_replace_policy(path):
+        loaded = real_load_policy(path)
+        Path(path).write_text("{}\n", encoding="utf-8")
+        return loaded
+
+    monkeypatch.setattr(iti, "load_policy", load_then_replace_policy)
+
+    assert iti.ingest(
+        [slug],
+        db_path=database,
+        dry_run=False,
+        chunks_root=root,
+        university_policy_path=policy,
+        copied_database_rehearsal=True,
+        additional_rehearsal_policy_sha256=expected_policy_sha256,
+    ) == {slug: 1}
+
+
 def test_tracked_university_policy_is_closed_and_default_deny():
     from projects.open_model_data import university_source_policy as usp
 

--- a/tests/test_open_model_phase3_vspu_db_cutover.py
+++ b/tests/test_open_model_phase3_vspu_db_cutover.py
@@ -1,0 +1,558 @@
+"""Hermetic tests for the one-source VSPU database cutover."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.projects.open_model_data import phase3_vspu_db_cutover as cutover
+from scripts.projects.open_model_data import university_source_policy
+from scripts.wiki.extract_sections import ensure_schema
+
+TEXTBOOK_SCHEMA = """
+CREATE TABLE textbooks (
+    id INTEGER PRIMARY KEY,
+    chunk_id TEXT,
+    title TEXT,
+    text TEXT,
+    source_file TEXT,
+    subject TEXT,
+    grade TEXT,
+    author TEXT,
+    author_uk TEXT DEFAULT '',
+    char_count INTEGER,
+    parent_section_id INTEGER REFERENCES textbook_sections(section_id)
+);
+CREATE VIRTUAL TABLE textbooks_fts USING fts5(
+    title, text, content='textbooks', content_rowid='id', tokenize='unicode61'
+);
+CREATE TRIGGER textbooks_ai AFTER INSERT ON textbooks BEGIN
+    INSERT INTO textbooks_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+END;
+"""
+
+
+def _jsonl_row(page: int) -> dict[str, object]:
+    text = f"Навчальний текст сторінки {page}."
+    return {
+        "schema_version": "phase3-vspu-page-unit.v1",
+        "chunk_id": f"{cutover.SOURCE_ID}_p{page:04d}",
+        "title": f"Сторінка {page}",
+        "section_title": f"Сторінка {page}",
+        "text": text,
+        "text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "source_file": cutover.SOURCE_ID,
+        "source_pdf_sha256": "a" * 64,
+        "subject": "ukrmova",
+        "grade": "university",
+        "author": "Гороф’янюк та ін.",
+        "author_uk": "Гороф’янюк І. В. та ін.",
+        "page_start": page,
+        "page_end": page,
+        "extraction_mode": "native_pdf_text",
+        "page_extraction_mode": "native_pdf_text",
+        "exactness": {
+            "normalization_applied": False,
+            "ocr_used": False,
+            "repairs_applied": False,
+        },
+    }
+
+
+def _write_policy(path: Path, jsonl: Path) -> str:
+    rows = university_source_policy.load_jsonl_rows(jsonl)
+    policy = {
+        "schema_version": university_source_policy.V3_SCHEMA_VERSION,
+        "status": university_source_policy.STATUS,
+        "default_disposition": university_source_policy.V3_DEFAULT_DISPOSITION,
+        "source_count": 1,
+        "sources": [
+            {
+                "source_file": cutover.SOURCE_ID,
+                "audience_class": "A_ukrainian_university_audience",
+                "subject_role": "ukrainian_linguistics",
+                "content_disposition": "contextual_only",
+                "allowed_lanes": ["contextual_retrieval", "corpus_ingest"],
+                "evidence": {
+                    "kind": "jsonl_front_matter",
+                    "jsonl_sha256": cutover.sha256_file(jsonl),
+                    "page_start": 1,
+                    "page_end": 2,
+                    "rows_sha256": university_source_policy.evidence_rows_sha256(
+                        rows,
+                        page_start=1,
+                        page_end=2,
+                    ),
+                    "summary": "Fixture native-university front matter.",
+                },
+            }
+        ],
+    }
+    path.write_text(json.dumps(policy, ensure_ascii=False), encoding="utf-8")
+    return cutover.sha256_file(path)
+
+
+def _create_database(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        connection.executescript(TEXTBOOK_SCHEMA)
+        ensure_schema(connection)
+        connection.execute(
+            "INSERT INTO textbooks "
+            "(chunk_id,title,text,source_file,subject,grade,author,author_uk,char_count) "
+            "VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                "existing_s0001",
+                "Сторінка 1",
+                "Наявний корпусний текст.",
+                "9-klas-ukrmova-existing-2024",
+                "ukrmova",
+                "grade-09",
+                "Автор",
+                "Автор",
+                len("Наявний корпусний текст."),
+            ),
+        )
+        cursor = connection.execute(
+            "INSERT INTO textbook_sections "
+            "(source_file,grade,section_title,section_number,page_start,page_end,chunk_count,full_text) "
+            "VALUES (?,?,?,?,?,?,?,?)",
+            (
+                "9-klas-ukrmova-existing-2024",
+                9,
+                "Сторінка 1",
+                None,
+                1,
+                1,
+                1,
+                "Наявний корпусний текст.",
+            ),
+        )
+        connection.execute(
+            "UPDATE textbooks SET parent_section_id=? WHERE chunk_id='existing_s0001'",
+            (cursor.lastrowid,),
+        )
+        connection.execute("INSERT INTO textbooks_fts(textbooks_fts) VALUES('rebuild')")
+        connection.commit()
+        assert connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (0, 0, 0)
+
+
+def _fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path, Path, str]:
+    database = tmp_path / "sources.db"
+    _create_database(database)
+    expected_pre_sha256 = cutover.sha256_file(database)
+
+    chunks = tmp_path / "private" / "grade-00"
+    chunks.mkdir(parents=True)
+    jsonl = chunks / f"{cutover.SOURCE_ID}.jsonl"
+    jsonl.write_text(
+        "".join(json.dumps(_jsonl_row(page), ensure_ascii=False, separators=(",", ":")) + "\n" for page in (1, 2)),
+        encoding="utf-8",
+    )
+    os.chmod(jsonl, 0o600)
+    policy = tmp_path / "policy.json"
+    policy_sha256 = _write_policy(policy, jsonl)
+
+    before_counts = {
+        "textbook_rows": 1,
+        "fts_rows": 1,
+        "section_rows": 1,
+        "source_count": 1,
+        "university_rows": 0,
+        "university_source_count": 0,
+    }
+    after_counts = {
+        "textbook_rows": 3,
+        "fts_rows": 3,
+        "section_rows": 3,
+        "source_count": 2,
+        "university_rows": 2,
+        "university_source_count": 1,
+    }
+    empty_foreign_hash = hashlib.sha256(b"[]").hexdigest()
+    monkeypatch.setattr(cutover, "EXPECTED_SOURCE_ROWS", 2)
+    monkeypatch.setattr(cutover, "EXPECTED_PRE_DB_SHA256", expected_pre_sha256)
+    monkeypatch.setattr(cutover, "EXPECTED_PRIVATE_JSONL_SHA256", cutover.sha256_file(jsonl))
+    monkeypatch.setattr(cutover, "EXPECTED_ADDITIVE_POLICY_SHA256", policy_sha256)
+    monkeypatch.setattr(cutover, "EXPECTED_FOREIGN_KEY_COUNT", 0)
+    monkeypatch.setattr(cutover, "EXPECTED_FOREIGN_KEY_SHA256", empty_foreign_hash)
+    monkeypatch.setattr(cutover, "COUNTS_BEFORE", before_counts)
+    monkeypatch.setattr(cutover, "COUNTS_AFTER", after_counts)
+    monkeypatch.setattr(
+        cutover,
+        "_validate_materialization_and_policy",
+        lambda **_kwargs: ({}, {}),
+    )
+    monkeypatch.setattr(cutover, "_validate_preimage_backup", lambda **_kwargs: {})
+    monkeypatch.setattr(cutover, "_schema_validator", lambda: Draft202012Validator({}))
+    return database, jsonl, policy, expected_pre_sha256
+
+
+def _reconcile(
+    *,
+    database: Path,
+    jsonl: Path,
+    policy: Path,
+    output: Path | None = None,
+    apply: bool = False,
+) -> dict[str, object]:
+    return cutover.reconcile(
+        database_path=database,
+        private_jsonl_path=jsonl,
+        preimage_backup_receipt_path=jsonl,
+        compressed_preimage_path=jsonl,
+        output_receipt_path=output,
+        additive_policy_path=policy,
+        apply_in_place=apply,
+        expected_live_db_path=database,
+        require_google_drive_output=False,
+    )
+
+
+def test_tracked_additive_policy_is_exactly_one_contextual_source() -> None:
+    policy, policy_sha256 = university_source_policy.load_policy(cutover.ADDITIVE_POLICY_PATH)
+    assert policy_sha256 == cutover.EXPECTED_ADDITIVE_POLICY_SHA256
+    assert policy["source_count"] == 1
+    source = policy["sources"][0]
+    assert source["source_file"] == cutover.SOURCE_ID
+    assert source["content_disposition"] == "contextual_only"
+    assert source["allowed_lanes"] == ["contextual_retrieval", "corpus_ingest"]
+    assert "linguistic_rule_evidence" not in source["allowed_lanes"]
+
+
+def test_cutover_schema_is_valid_and_closes_receipt_shape() -> None:
+    schema = json.loads(cutover.SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["phase_boundaries"]["additionalProperties"] is False
+
+
+def test_dry_run_is_text_free_and_does_not_mutate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    result = _reconcile(database=database, jsonl=jsonl, policy=policy)
+    assert result["mode"] == "dry_run"
+    assert result["text_free"] is True and result["provider_calls"] is False
+    assert cutover.sha256_file(database) == expected
+    with sqlite3.connect(database) as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM textbooks WHERE source_file=?",
+                (cutover.SOURCE_ID,),
+            ).fetchone()[0]
+            == 0
+        )
+
+
+def test_generic_ingest_cannot_bypass_the_dedicated_vspu_cutover(tmp_path: Path) -> None:
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(
+        cutover.textbook_ingest.IngestError,
+        match="requires its dedicated database cutover",
+    ):
+        cutover.textbook_ingest.ingest(
+            [cutover.SOURCE_ID],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path / "missing-chunks",
+            university_policy_path=cutover.ADDITIVE_POLICY_PATH,
+        )
+
+
+def test_generic_ingest_cannot_delete_vspu_via_direct_quarantine(tmp_path: Path) -> None:
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(
+        cutover.textbook_ingest.IngestError,
+        match="requires its dedicated database cutover",
+    ):
+        cutover.textbook_ingest.ingest(
+            [],
+            quarantine_slugs=[cutover.SOURCE_ID],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path / "missing-chunks",
+            university_policy_path=cutover.ADDITIVE_POLICY_PATH,
+        )
+
+
+def test_vspu_quarantine_is_refused_even_during_copied_rehearsal(tmp_path: Path) -> None:
+    disposable_db = tmp_path / "copy.db"
+    disposable_db.touch()
+
+    with pytest.raises(
+        cutover.textbook_ingest.IngestError,
+        match="requires its dedicated database cutover",
+    ):
+        cutover.textbook_ingest.ingest(
+            [],
+            quarantine_slugs=[cutover.SOURCE_ID],
+            db_path=disposable_db,
+            dry_run=False,
+            chunks_root=tmp_path / "missing-chunks",
+            university_policy_path=cutover.ADDITIVE_POLICY_PATH,
+            copied_database_rehearsal=True,
+            additional_rehearsal_policy_sha256=(cutover.EXPECTED_ADDITIVE_POLICY_SHA256),
+        )
+
+
+def test_in_place_cutover_rehearses_copy_preserves_inode_and_cleans_temps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, _ = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "cutover-receipt.json"
+    inode = database.stat().st_ino
+    receipt = _reconcile(
+        database=database,
+        jsonl=jsonl,
+        policy=policy,
+        output=output,
+        apply=True,
+    )
+    assert receipt["mode"] == "in_place_sqlite_backup"
+    assert receipt["copied_database_rehearsal"]["execution_scope"] == ("copied_database_rehearsal")
+    assert receipt["database"]["live_inode_preserved"] is True
+    assert database.stat().st_ino == inode
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    with sqlite3.connect(database) as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM textbooks WHERE source_file=?",
+                (cutover.SOURCE_ID,),
+            ).fetchone()[0]
+            == 2
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM textbook_sections WHERE source_file=?",
+                (cutover.SOURCE_ID,),
+            ).fetchone()[0]
+            == 2
+        )
+    assert not list(tmp_path.glob(".sources.db.vspu-*"))
+
+
+def test_candidate_ingest_failure_keeps_live_database_and_receipt_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "never.json"
+    monkeypatch.setattr(
+        cutover.textbook_ingest,
+        "ingest",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(cutover.textbook_ingest.IngestError("fixture ingest failure")),
+    )
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="fixture ingest failure"):
+        _reconcile(
+            database=database,
+            jsonl=jsonl,
+            policy=policy,
+            output=output,
+            apply=True,
+        )
+    assert cutover.sha256_file(database) == expected
+    assert not output.exists()
+    assert not list(tmp_path.glob(".sources.db.vspu-*"))
+
+
+def test_live_postcondition_failure_restores_exact_prestate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    original_validate = cutover._validate_post_database
+    calls = 0
+
+    def fail_live(after: dict[str, object], before: dict[str, object]) -> None:
+        nonlocal calls
+        calls += 1
+        original_validate(after, before)
+        if calls == 2:
+            raise cutover.VspuDatabaseCutoverError("fixture live postcondition failure")
+
+    monkeypatch.setattr(cutover, "_validate_post_database", fail_live)
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="live postcondition failure"):
+        _reconcile(
+            database=database,
+            jsonl=jsonl,
+            policy=policy,
+            output=tmp_path / "never.json",
+            apply=True,
+        )
+    assert cutover.sha256_file(database) == expected
+    assert not list(tmp_path.glob(".sources.db.vspu-*"))
+
+
+def test_receipt_write_failure_restores_exact_prestate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        cutover,
+        "_atomic_write_private",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("fixture write failure")),
+    )
+    with pytest.raises(OSError, match="fixture write failure"):
+        _reconcile(
+            database=database,
+            jsonl=jsonl,
+            policy=policy,
+            output=tmp_path / "never.json",
+            apply=True,
+        )
+    assert cutover.sha256_file(database) == expected
+    assert not (tmp_path / "never.json").exists()
+
+
+def test_restore_failure_retains_private_predecessor_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    original_backup = cutover._sqlite_backup
+    interrupted = False
+
+    def copy_then_fail(source: Path, target: Path) -> None:
+        nonlocal interrupted
+        original_backup(source, target)
+        if target == database and not interrupted:
+            interrupted = True
+            raise cutover.VspuDatabaseCutoverError("fixture cutover failure")
+
+    def fail_restore(*_args: object, **_kwargs: object) -> None:
+        raise cutover.VspuDatabaseCutoverError("fixture restore failure")
+
+    monkeypatch.setattr(cutover, "_sqlite_backup", copy_then_fail)
+    monkeypatch.setattr(cutover, "_restore_exact_prestate", fail_restore)
+    with pytest.raises(
+        cutover.VspuDatabaseCutoverError,
+        match="private predecessor retained",
+    ) as caught:
+        _reconcile(
+            database=database,
+            jsonl=jsonl,
+            policy=policy,
+            output=tmp_path / "never.json",
+            apply=True,
+        )
+    retained = list(tmp_path.glob(".sources.db.vspu-*.candidate"))
+    assert len(retained) == 1
+    assert str(retained[0]) in str(caught.value)
+    assert cutover.sha256_file(retained[0]) == expected
+    assert stat.S_IMODE(retained[0].stat().st_mode) == 0o600
+
+
+def test_preimage_drift_is_rechecked_before_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, _ = _fixture(tmp_path, monkeypatch)
+    original_evidence = cutover._database_evidence
+    calls = 0
+
+    def mutate_after_initial_evidence(path: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        evidence = original_evidence(path)
+        if calls == 1:
+            with sqlite3.connect(path) as connection:
+                connection.execute("UPDATE textbooks SET text='Змінено.' WHERE chunk_id='existing_s0001'")
+                connection.commit()
+                assert connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (
+                    0,
+                    0,
+                    0,
+                )
+        return evidence
+
+    monkeypatch.setattr(cutover, "_database_evidence", mutate_after_initial_evidence)
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="drifted before rehearsal"):
+        _reconcile(
+            database=database,
+            jsonl=jsonl,
+            policy=policy,
+            output=tmp_path / "never.json",
+            apply=True,
+        )
+    assert not list(tmp_path.glob(".sources.db.vspu-*"))
+
+
+def test_receipt_rejects_semantic_authority_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, _ = _fixture(tmp_path, monkeypatch)
+    receipt = _reconcile(
+        database=database,
+        jsonl=jsonl,
+        policy=policy,
+        output=tmp_path / "receipt.json",
+        apply=True,
+    )
+    broken = copy.deepcopy(receipt)
+    broken["rights_and_authority"]["semantic_gold"] = True
+    broken["receipt_sha256"] = cutover.receipt_sha256(broken)
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="semantic gold"):
+        cutover.validate_receipt(broken)
+
+
+def test_receipt_rejects_incomplete_database_ingest_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, _ = _fixture(tmp_path, monkeypatch)
+    receipt = _reconcile(
+        database=database,
+        jsonl=jsonl,
+        policy=policy,
+        output=tmp_path / "receipt.json",
+        apply=True,
+    )
+    broken = copy.deepcopy(receipt)
+    broken["phase_boundaries"]["database_ingest_complete"] = False
+    broken["receipt_sha256"] = cutover.receipt_sha256(broken)
+    with pytest.raises(
+        cutover.VspuDatabaseCutoverError,
+        match="database_ingest_complete",
+    ):
+        cutover.validate_receipt(broken)
+
+    real_schema = json.loads(cutover.SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_errors = list(Draft202012Validator(real_schema).iter_errors(broken))
+    assert any(
+        list(error.absolute_path) == ["phase_boundaries", "database_ingest_complete"] and error.validator == "const"
+        for error in schema_errors
+    )
+
+
+def test_private_receipt_is_immutable_and_rejects_symlink(tmp_path: Path) -> None:
+    receipt = tmp_path / "receipt.json"
+    cutover._atomic_write_private(receipt, {"ok": True})
+    cutover._atomic_write_private(receipt, {"ok": True})
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="immutable"):
+        cutover._atomic_write_private(receipt, {"ok": False})
+    receipt.unlink()
+    target = tmp_path / "target.json"
+    target.write_text("target", encoding="utf-8")
+    receipt.symlink_to(target)
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="symlink"):
+        cutover._atomic_write_private(receipt, {"ok": True})


### PR DESCRIPTION
## Outcome

Adds the fail-closed one-source VSPU database cutover for issue #6375. The 158 private page units may enter only through an exact policy-pinned disposable rehearsal followed by a recoverable in-place SQLite backup. Direct generic insertion and quarantine are both refused.

The VSPU source remains contextual-only: no linguistic-rule authority, semantic gold, public redistribution, source-universe freeze, Phase 3 completion, or Phase 4 execution.

## Safety and proof

- exact live preimage and existing Google Drive backup identities pinned
- streamed compressed-backup restore hash verified in the real dry-run
- rollback copy created before cutover and exact prestate restored on failure
- existing corpus fingerprint, FTS/section/link parity, integrity, WAL, and known FK baseline checked
- loaded policy document/SHA is reused throughout authorization; no mutable path re-read
- closed receipt schema with `database_ingest_complete=true` and `phase4_blocked=true`

## Verification

- `75 passed` across cutover, shared ingest, and complete-v4 policy tests
- Ruff clean
- `git diff --check` clean
- real source-blind dry plan against live DB/private JSONL/Drive backup: `{"mode":"dry_run","ok":true}`
- independent Claude Sonnet 5 local closeout review: PASS, no material findings

Closes no issue; advances #6375 while Phase 4 remains blocked.