### PR TITLE
feat(practice): unused attested thin-mode source inventory (#4387 #4700)

### DIFF
--- a/scripts/practice/thin_mode_source_inventory.py
+++ b/scripts/practice/thin_mode_source_inventory.py
@@ -214,22 +214,25 @@ def collect_shard_state(
         shard_lemmas = index_lemmas
         source = "practice-index" if prefer_index or not items else source
     synonym_pairs: set[tuple[str, str, str]] = set()
-    glosses: set[str] = set()
+    # Curated thin modes emit one lemmaId per item + distinction_gloss_uk.
+    # Pair identity is (legs, gloss); match when gloss matches and lemma ∈ legs.
+    curated_hits: set[tuple[str, str]] = set()
     for item in items:
         gloss = _plain(item.get("distinction_gloss_uk"))
-        if gloss:
-            glosses.add(gloss)
+        lemma = _lemma_from_item(item)
+        if gloss and lemma:
+            curated_hits.add((lemma, gloss))
         if mode == "synonym":
-            lemma = item.get("lemmaId")
+            lemma_raw = item.get("lemmaId")
             target = item.get("targetLemmaId")
             polarity = item.get("polarity")
-            if lemma and target and polarity:
-                synonym_pairs.add(_synonym_pair_key(lemma, target, polarity))
+            if lemma_raw and target and polarity:
+                synonym_pairs.add(_synonym_pair_key(lemma_raw, target, polarity))
     return {
         "item_count": len(items),
         "unique_lemmas": shard_lemmas,
         "synonym_pairs": synonym_pairs,
-        "glosses": glosses,
+        "curated_hits": curated_hits,
         "lemma_source": source,
         "shard_files_present": bool(items) or bool(index_lemmas),
     }
@@ -250,6 +253,15 @@ def _unique_from_curated_pairs(pairs: list[tuple[frozenset[str], str]]) -> set[s
     return lemmas
 
 
+def _curated_pair_used(
+    legs: frozenset[str],
+    gloss: str,
+    curated_hits: set[tuple[str, str]],
+) -> bool:
+    """True when a shard item shares this gloss and a lemma from these legs."""
+    return any((lemma, gloss) in curated_hits for lemma in legs)
+
+
 def inventory_mode(
     mode: str,
     *,
@@ -265,7 +277,8 @@ def inventory_mode(
         pairs = list(attested_pairs)
         attested_count = len(pairs)
         source_lemmas = _unique_from_curated_pairs(pairs)
-        used = sum(1 for _legs, gloss in pairs if gloss in shard["glosses"])
+        hits = shard["curated_hits"]
+        used = sum(1 for legs, gloss in pairs if _curated_pair_used(legs, gloss, hits))
 
     unused = attested_count - used
     shard_unique = len(shard["unique_lemmas"])
@@ -340,13 +353,62 @@ def format_table(report: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+_CLI_EPILOG = """\
+Usage:
+  .venv/bin/python scripts/practice/thin_mode_source_inventory.py
+  .venv/bin/python scripts/practice/thin_mode_source_inventory.py --table
+  .venv/bin/python scripts/practice/thin_mode_source_inventory.py --stdout-json --no-table
+  .venv/bin/python scripts/practice/thin_mode_source_inventory.py --json-out /tmp/inventory.json
+
+Output:
+  Human-readable unused-pair table on stdout by default.
+  Optional JSON via --json-out and/or --stdout-json.
+  Curated modes match shards by pair identity (legs + distinction_gloss_uk),
+  not gloss alone.
+
+Exit codes:
+  0 on success
+  2 on argparse usage errors
+  non-zero if a required source file is missing or malformed
+"""
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
-    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
-    parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS)
-    parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
-    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_CLI_EPILOG,
+    )
+    parser.add_argument(
+        "--practice-dir",
+        type=Path,
+        default=DEFAULT_PRACTICE_DIR,
+        help="Directory with practice-*.json shards (default: site/public/lexicon).",
+    )
+    parser.add_argument(
+        "--synonym-verdicts",
+        type=Path,
+        default=DEFAULT_SYNONYM_VERDICTS,
+        help="Path to synonym_pair_verdicts.yaml.",
+    )
+    parser.add_argument(
+        "--antonym-pairs",
+        type=Path,
+        default=DEFAULT_ANTONYM_PAIRS,
+        help="Path to antonym_pairs.yaml.",
+    )
+    parser.add_argument(
+        "--paronym-pairs",
+        type=Path,
+        default=DEFAULT_PARONYM_PAIRS,
+        help="Path to paronym_pairs.yaml.",
+    )
+    parser.add_argument(
+        "--homonym-pairs",
+        type=Path,
+        default=DEFAULT_HOMONYM_PAIRS,
+        help="Path to homonym_pairs.yaml.",
+    )
     parser.add_argument(
         "--prefer-index",
         action="store_true",

--- a/scripts/practice/thin_mode_source_inventory.py
+++ b/scripts/practice/thin_mode_source_inventory.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Inventory unused attested thin-mode practice sources vs live shards.
+
+Reports, for synonym / antonym / paronym / homonym:
+
+- attested source pair count
+- unique lemmas if all source pairs were emitted
+- unique lemmas in current practice shards
+- unused attested pairs still not in shards
+- whether ≥1000 unique lemmas is possible from current attested files
+
+Does not invent pairs, regenerate decks, or touch heritage sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+SCHEMA = "thin-mode-source-inventory.v1"
+UNIQUE_LEMMA_BAR = 1000
+THIN_MODES = ("synonym", "antonym", "paronym", "homonym")
+
+DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
+DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
+DEFAULT_ANTONYM_PAIRS = ROOT / "data" / "lexicon" / "antonym_pairs.yaml"
+DEFAULT_PARONYM_PAIRS = ROOT / "data" / "lexicon" / "paronym_pairs.yaml"
+DEFAULT_HOMONYM_PAIRS = ROOT / "data" / "lexicon" / "homonym_pairs.yaml"
+
+MODE_SHARD_RE = {
+    "synonym": "practice-synonym.*.json",
+    "antonym": "practice-antonym.*.json",
+    "paronym": "practice-paronym.*.json",
+    "homonym": "practice-homonym.*.json",
+}
+INDEX_GLOB = "practice-index.*.json"
+
+
+def _plain(value: Any) -> str:
+    text = str(value or "")
+    return (
+        text.casefold()
+        .replace("\u0301", "")
+        .replace("́", "")
+        .replace("’", "'")
+        .replace("ʼ", "'")
+        .strip()
+    )
+
+
+def _load_yaml(path: Path) -> Any:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _synonym_pair_key(a: Any, b: Any, polarity: Any) -> tuple[str, str, str]:
+    left = _plain(a)
+    right = _plain(b)
+    if left > right:
+        left, right = right, left
+    return (left, right, _plain(polarity))
+
+
+def _pair_leg_key(slug_a: Any, slug_b: Any) -> frozenset[str]:
+    return frozenset({_plain(slug_a), _plain(slug_b)})
+
+
+def _lemma_from_item(item: dict[str, Any]) -> str:
+    raw = item.get("lemmaId")
+    if raw is None or str(raw).strip() == "":
+        raw = item.get("lemma")
+    return _plain(raw)
+
+
+def _lemmas_from_mode_item(mode: str, item: dict[str, Any]) -> set[str]:
+    lemmas: set[str] = set()
+    primary = _lemma_from_item(item)
+    if primary:
+        lemmas.add(primary)
+    if mode == "synonym":
+        target = _plain(item.get("targetLemmaId"))
+        if target:
+            lemmas.add(target)
+    return lemmas
+
+
+def load_synonym_attested_pairs(path: Path) -> list[tuple[str, str, str]]:
+    """Approved synonym-verdict pairs (both polarities feed the synonym deck)."""
+    if not path.is_file():
+        raise FileNotFoundError(f"synonym verdicts not found: {path}")
+    payload = _load_yaml(path)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected mapping with approved list")
+    out: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for row in payload.get("approved") or []:
+        if not isinstance(row, dict):
+            continue
+        a = _plain(row.get("a"))
+        b = _plain(row.get("b"))
+        polarity = _plain(row.get("polarity"))
+        if not a or not b or not polarity:
+            continue
+        key = _synonym_pair_key(a, b, polarity)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def load_curated_attested_pairs(path: Path) -> list[tuple[frozenset[str], str]]:
+    """Curated antonym/paronym/homonym pairs keyed by legs + distinction gloss."""
+    if not path.is_file():
+        raise FileNotFoundError(f"pair YAML not found: {path}")
+    payload = _load_yaml(path) or []
+    rows = payload.get("pairs") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError(f"{path}: expected list or object with pairs list")
+    out: list[tuple[frozenset[str], str]] = []
+    seen: set[tuple[frozenset[str], str]] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        slug_a = _plain(row.get("slugA"))
+        slug_b = _plain(row.get("slugB"))
+        gloss = _plain(row.get("distinction_gloss_uk"))
+        if not slug_a or not slug_b or not gloss:
+            continue
+        key = (_pair_leg_key(slug_a, slug_b), gloss)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def _iter_mode_items(practice_dir: Path, mode: str) -> list[dict[str, Any]]:
+    if not practice_dir.is_dir():
+        return []
+    items: list[dict[str, Any]] = []
+    for path in sorted(practice_dir.glob(MODE_SHARD_RE[mode])):
+        if not path.is_file():
+            continue
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            raise ValueError(f"{path}: expected object")
+        rows = payload.get(mode)
+        if rows is None:
+            rows = payload.get("items")
+        if rows is None:
+            continue
+        if not isinstance(rows, list):
+            raise ValueError(f"{path}: {mode}/items must be a list")
+        for row in rows:
+            if isinstance(row, dict):
+                items.append(row)
+    return items
+
+
+def _lemmas_from_index(practice_dir: Path, mode: str) -> set[str]:
+    """Fallback lemma set from practice-index.*.json mode membership."""
+    if not practice_dir.is_dir():
+        return set()
+    lemmas: set[str] = set()
+    for path in sorted(practice_dir.glob(INDEX_GLOB)):
+        if not path.is_file():
+            continue
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            raise ValueError(f"{path}: expected object")
+        rows = payload.get("items")
+        if not isinstance(rows, list):
+            raise ValueError(f"{path}: items must be a list")
+        for item in rows:
+            if not isinstance(item, dict):
+                continue
+            modes = item.get("modes")
+            if not isinstance(modes, list):
+                continue
+            if mode not in {str(m).strip() for m in modes}:
+                continue
+            key = _lemma_from_item(item)
+            if key:
+                lemmas.add(key)
+    return lemmas
+
+
+def collect_shard_state(
+    practice_dir: Path,
+    mode: str,
+    *,
+    prefer_index: bool = False,
+) -> dict[str, Any]:
+    items = _iter_mode_items(practice_dir, mode)
+    shard_lemmas: set[str] = set()
+    for item in items:
+        shard_lemmas.update(_lemmas_from_mode_item(mode, item))
+    index_lemmas = _lemmas_from_index(practice_dir, mode)
+    source = "mode-shards"
+    if prefer_index or (not items and index_lemmas):
+        shard_lemmas = index_lemmas
+        source = "practice-index" if prefer_index or not items else source
+    synonym_pairs: set[tuple[str, str, str]] = set()
+    glosses: set[str] = set()
+    for item in items:
+        gloss = _plain(item.get("distinction_gloss_uk"))
+        if gloss:
+            glosses.add(gloss)
+        if mode == "synonym":
+            lemma = item.get("lemmaId")
+            target = item.get("targetLemmaId")
+            polarity = item.get("polarity")
+            if lemma and target and polarity:
+                synonym_pairs.add(_synonym_pair_key(lemma, target, polarity))
+    return {
+        "item_count": len(items),
+        "unique_lemmas": shard_lemmas,
+        "synonym_pairs": synonym_pairs,
+        "glosses": glosses,
+        "lemma_source": source,
+        "shard_files_present": bool(items) or bool(index_lemmas),
+    }
+
+
+def _unique_from_synonym_pairs(pairs: list[tuple[str, str, str]]) -> set[str]:
+    lemmas: set[str] = set()
+    for a, b, _polarity in pairs:
+        lemmas.add(a)
+        lemmas.add(b)
+    return lemmas
+
+
+def _unique_from_curated_pairs(pairs: list[tuple[frozenset[str], str]]) -> set[str]:
+    lemmas: set[str] = set()
+    for legs, _gloss in pairs:
+        lemmas.update(legs)
+    return lemmas
+
+
+def inventory_mode(
+    mode: str,
+    *,
+    attested_pairs: list[Any],
+    shard: dict[str, Any],
+) -> dict[str, Any]:
+    if mode == "synonym":
+        pairs = list(attested_pairs)
+        attested_count = len(pairs)
+        source_lemmas = _unique_from_synonym_pairs(pairs)
+        used = sum(1 for key in pairs if key in shard["synonym_pairs"])
+    else:
+        pairs = list(attested_pairs)
+        attested_count = len(pairs)
+        source_lemmas = _unique_from_curated_pairs(pairs)
+        used = sum(1 for _legs, gloss in pairs if gloss in shard["glosses"])
+
+    unused = attested_count - used
+    shard_unique = len(shard["unique_lemmas"])
+    source_unique = len(source_lemmas)
+    return {
+        "mode": mode,
+        "attested_pair_count": attested_count,
+        "unique_lemmas_if_all_emitted": source_unique,
+        "unique_lemmas_in_shards": shard_unique,
+        "unused_attested_pairs": unused,
+        "used_attested_pairs": used,
+        "possible_ge_1000_from_attested": source_unique >= UNIQUE_LEMMA_BAR,
+        "lemma_source": shard["lemma_source"],
+        "shard_item_count": shard["item_count"],
+        "shard_files_present": shard["shard_files_present"],
+    }
+
+
+def build_inventory(
+    *,
+    practice_dir: Path = DEFAULT_PRACTICE_DIR,
+    synonym_verdicts: Path = DEFAULT_SYNONYM_VERDICTS,
+    antonym_pairs: Path = DEFAULT_ANTONYM_PAIRS,
+    paronym_pairs: Path = DEFAULT_PARONYM_PAIRS,
+    homonym_pairs: Path = DEFAULT_HOMONYM_PAIRS,
+    prefer_index: bool = False,
+) -> dict[str, Any]:
+    attested = {
+        "synonym": load_synonym_attested_pairs(synonym_verdicts),
+        "antonym": load_curated_attested_pairs(antonym_pairs),
+        "paronym": load_curated_attested_pairs(paronym_pairs),
+        "homonym": load_curated_attested_pairs(homonym_pairs),
+    }
+    modes: dict[str, Any] = {}
+    for mode in THIN_MODES:
+        shard = collect_shard_state(practice_dir, mode, prefer_index=prefer_index)
+        modes[mode] = inventory_mode(mode, attested_pairs=attested[mode], shard=shard)
+    return {
+        "schema": SCHEMA,
+        "unique_lemma_bar": UNIQUE_LEMMA_BAR,
+        "practice_dir": str(practice_dir),
+        "sources": {
+            "synonym": str(synonym_verdicts),
+            "antonym": str(antonym_pairs),
+            "paronym": str(paronym_pairs),
+            "homonym": str(homonym_pairs),
+        },
+        "modes": modes,
+    }
+
+
+def format_table(report: dict[str, Any]) -> str:
+    bar = int(report.get("unique_lemma_bar") or UNIQUE_LEMMA_BAR)
+    lines = [
+        f"schema={report.get('schema')}  bar>={bar}",
+        "",
+        "Mode       Attested  SrcLemmas  ShardLemmas  Unused  ≥1000 possible?",
+        "-" * 72,
+    ]
+    modes = report.get("modes") or {}
+    for mode in THIN_MODES:
+        row = modes.get(mode) or {}
+        possible = "YES" if row.get("possible_ge_1000_from_attested") else "no"
+        lines.append(
+            f"{mode:<10} {int(row.get('attested_pair_count', 0)):8d}  "
+            f"{int(row.get('unique_lemmas_if_all_emitted', 0)):9d}  "
+            f"{int(row.get('unique_lemmas_in_shards', 0)):11d}  "
+            f"{int(row.get('unused_attested_pairs', 0)):6d}  {possible}"
+        )
+    lines.append("")
+    lines.append(f"practice_dir={report.get('practice_dir')}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
+    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
+    parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS)
+    parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
+    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS)
+    parser.add_argument(
+        "--prefer-index",
+        action="store_true",
+        help="Count shard lemmas from practice-index.*.json instead of mode shards.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Optional path to write the inventory JSON.",
+    )
+    parser.add_argument(
+        "--stdout-json",
+        action="store_true",
+        help="Print the JSON report to stdout.",
+    )
+    parser.add_argument(
+        "--table",
+        action="store_true",
+        default=True,
+        help="Print the human-readable table (default).",
+    )
+    parser.add_argument(
+        "--no-table",
+        action="store_true",
+        help="Suppress the human-readable table.",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_inventory(
+        practice_dir=args.practice_dir,
+        synonym_verdicts=args.synonym_verdicts,
+        antonym_pairs=args.antonym_pairs,
+        paronym_pairs=args.paronym_pairs,
+        homonym_pairs=args.homonym_pairs,
+        prefer_index=args.prefer_index,
+    )
+    serialized = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(serialized, encoding="utf-8")
+
+    show_table = args.table and not args.no_table
+    if show_table:
+        print(format_table(report), end="")
+    if args.stdout_json or (args.no_table and not show_table):
+        print(serialized, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_thin_mode_source_inventory.py
+++ b/tests/test_thin_mode_source_inventory.py
@@ -234,9 +234,73 @@ def test_index_fallback_for_lemma_counts(tmp_path: Path) -> None:
 
     assert report["modes"]["antonym"]["unique_lemmas_in_shards"] == 2
     assert report["modes"]["homonym"]["unique_lemmas_in_shards"] == 1
-    # Without mode shards, gloss matching finds no used pairs.
+    # Without mode shards, pair-safe matching finds no used pairs.
     assert report["modes"]["antonym"]["unused_attested_pairs"] == 2
     assert report["modes"]["antonym"]["lemma_source"] == "practice-index"
+
+
+def test_gloss_collision_requires_leg_match(tmp_path: Path) -> None:
+    """Shared distinction_gloss_uk must not mark distinct pairs as used."""
+    sources = _seed_sources(tmp_path / "sources")
+    shared_gloss = "Спільний глос для колізії."
+    _write_yaml(
+        sources["antonym"],
+        {
+            "schema_version": 1,
+            "pairs": [
+                {
+                    "slugA": "день",
+                    "slugB": "ніч",
+                    "distinction_gloss_uk": shared_gloss,
+                },
+                {
+                    "slugA": "тепло",
+                    "slugB": "холод",
+                    "distinction_gloss_uk": shared_gloss,
+                },
+            ],
+        },
+    )
+    practice_dir = tmp_path / "lexicon"
+    _write_json(
+        practice_dir / "practice-antonym.A1.json",
+        {
+            "level": "A1",
+            "antonym": [
+                {
+                    "lemmaId": "ніч",
+                    "lemma": "ніч",
+                    "distinction_gloss_uk": shared_gloss,
+                }
+            ],
+        },
+    )
+
+    report = build_inventory(
+        practice_dir=practice_dir,
+        synonym_verdicts=sources["synonym"],
+        antonym_pairs=sources["antonym"],
+        paronym_pairs=sources["paronym"],
+        homonym_pairs=sources["homonym"],
+    )
+    antonym = report["modes"]["antonym"]
+    # Gloss-only matching would report used=2 / unused=0.
+    assert antonym["attested_pair_count"] == 2
+    assert antonym["used_attested_pairs"] == 1
+    assert antonym["unused_attested_pairs"] == 1
+
+
+def test_cli_help_documents_usage_output_exit(capsys) -> None:
+    try:
+        main(["--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+    captured = capsys.readouterr()
+    assert "--practice-dir" in captured.out
+    assert "Directory with practice" in captured.out
+    assert "Usage:" in captured.out
+    assert "Output:" in captured.out
+    assert "Exit codes:" in captured.out
 
 
 def test_cli_prints_unused_table(tmp_path: Path, capsys) -> None:

--- a/tests/test_thin_mode_source_inventory.py
+++ b/tests/test_thin_mode_source_inventory.py
@@ -1,0 +1,271 @@
+"""Tests for scripts.practice.thin_mode_source_inventory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.practice.thin_mode_source_inventory import (
+    SCHEMA,
+    UNIQUE_LEMMA_BAR,
+    build_inventory,
+    format_table,
+    main,
+)
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_sources(base: Path) -> dict[str, Path]:
+    synonym = base / "synonym_pair_verdicts.yaml"
+    antonym = base / "antonym_pairs.yaml"
+    paronym = base / "paronym_pairs.yaml"
+    homonym = base / "homonym_pairs.yaml"
+    _write_yaml(
+        synonym,
+        {
+            "schema_version": 1,
+            "approved": [
+                {"a": "вода", "b": "рідина", "polarity": "synonym"},
+                {"a": "вхід", "b": "вихід", "polarity": "antonym"},
+                {"a": "кіт", "b": "мурчик", "polarity": "synonym"},
+            ],
+            "rejected": [
+                {"a": "а", "b": "б", "polarity": "synonym"},
+            ],
+        },
+    )
+    _write_yaml(
+        antonym,
+        {
+            "schema_version": 1,
+            "pairs": [
+                {
+                    "slugA": "день",
+                    "slugB": "ніч",
+                    "distinction_gloss_uk": "День проти ночі.",
+                },
+                {
+                    "slugA": "тепло",
+                    "slugB": "холод",
+                    "distinction_gloss_uk": "Тепло проти холоду.",
+                },
+            ],
+        },
+    )
+    _write_yaml(
+        paronym,
+        {
+            "schema_version": 1,
+            "pairs": [
+                {
+                    "slugA": "адресант",
+                    "slugB": "адресат",
+                    "distinction_gloss_uk": "Адресант vs адресат.",
+                },
+                {
+                    "slugA": "біліти",
+                    "slugB": "білити",
+                    "distinction_gloss_uk": "Біліти vs білити.",
+                },
+            ],
+        },
+    )
+    _write_yaml(
+        homonym,
+        {
+            "schema_version": 1,
+            "pairs": [
+                {
+                    "slugA": "атлас",
+                    "slugB": "атлас",
+                    "distinction_gloss_uk": "Атлас карта vs тканина.",
+                },
+                {
+                    "slugA": "замок",
+                    "slugB": "замок",
+                    "distinction_gloss_uk": "Замок будівля vs механізм.",
+                },
+            ],
+        },
+    )
+    return {
+        "synonym": synonym,
+        "antonym": antonym,
+        "paronym": paronym,
+        "homonym": homonym,
+    }
+
+
+def _seed_shards(practice_dir: Path) -> None:
+    _write_json(
+        practice_dir / "practice-synonym.B1.json",
+        {
+            "level": "B1",
+            "synonym": [
+                {
+                    "lemmaId": "вода",
+                    "targetLemmaId": "рідина",
+                    "polarity": "synonym",
+                },
+                {
+                    "lemmaId": "вихід",
+                    "targetLemmaId": "вхід",
+                    "polarity": "antonym",
+                },
+            ],
+        },
+    )
+    _write_json(
+        practice_dir / "practice-antonym.A1.json",
+        {
+            "level": "A1",
+            "antonym": [
+                {
+                    "lemmaId": "ніч",
+                    "lemma": "ніч",
+                    "distinction_gloss_uk": "День проти ночі.",
+                }
+            ],
+        },
+    )
+    _write_json(
+        practice_dir / "practice-paronym.A1.json",
+        {
+            "level": "A1",
+            "paronym": [
+                {
+                    "lemmaId": "адресант",
+                    "lemma": "адресант",
+                    "distinction_gloss_uk": "Адресант vs адресат.",
+                }
+            ],
+        },
+    )
+    _write_json(
+        practice_dir / "practice-homonym.A1.json",
+        {
+            "level": "A1",
+            "homonym": [
+                {
+                    "lemmaId": "атлас",
+                    "lemma": "атлас",
+                    "distinction_gloss_uk": "Атлас карта vs тканина.",
+                }
+            ],
+        },
+    )
+
+
+def test_build_inventory_counts_unused_pairs(tmp_path: Path) -> None:
+    sources = _seed_sources(tmp_path / "sources")
+    practice_dir = tmp_path / "lexicon"
+    _seed_shards(practice_dir)
+
+    report = build_inventory(
+        practice_dir=practice_dir,
+        synonym_verdicts=sources["synonym"],
+        antonym_pairs=sources["antonym"],
+        paronym_pairs=sources["paronym"],
+        homonym_pairs=sources["homonym"],
+    )
+
+    assert report["schema"] == SCHEMA
+    assert report["unique_lemma_bar"] == UNIQUE_LEMMA_BAR
+
+    synonym = report["modes"]["synonym"]
+    assert synonym["attested_pair_count"] == 3
+    assert synonym["unique_lemmas_if_all_emitted"] == 6  # вода рідина вхід вихід кіт мурчик
+    assert synonym["unique_lemmas_in_shards"] == 4  # вода/рідина + вихід/вхід
+    assert synonym["unused_attested_pairs"] == 1  # кіт/мурчик
+    assert synonym["possible_ge_1000_from_attested"] is False
+
+    antonym = report["modes"]["antonym"]
+    assert antonym["attested_pair_count"] == 2
+    assert antonym["unique_lemmas_if_all_emitted"] == 4
+    assert antonym["unique_lemmas_in_shards"] == 1
+    assert antonym["unused_attested_pairs"] == 1
+    assert antonym["possible_ge_1000_from_attested"] is False
+
+    paronym = report["modes"]["paronym"]
+    assert paronym["attested_pair_count"] == 2
+    assert paronym["unique_lemmas_if_all_emitted"] == 4
+    assert paronym["unused_attested_pairs"] == 1
+
+    homonym = report["modes"]["homonym"]
+    assert homonym["attested_pair_count"] == 2
+    assert homonym["unique_lemmas_if_all_emitted"] == 2
+    assert homonym["unused_attested_pairs"] == 1
+
+
+def test_index_fallback_for_lemma_counts(tmp_path: Path) -> None:
+    sources = _seed_sources(tmp_path / "sources")
+    practice_dir = tmp_path / "lexicon"
+    _write_json(
+        practice_dir / "practice-index.A1.json",
+        {
+            "level": "A1",
+            "items": [
+                {"lemmaId": "день", "modes": ["antonym", "flashcards"]},
+                {"lemmaId": "ніч", "modes": ["antonym"]},
+                {"lemmaId": "атлас", "modes": ["homonym"]},
+            ],
+        },
+    )
+
+    report = build_inventory(
+        practice_dir=practice_dir,
+        synonym_verdicts=sources["synonym"],
+        antonym_pairs=sources["antonym"],
+        paronym_pairs=sources["paronym"],
+        homonym_pairs=sources["homonym"],
+        prefer_index=True,
+    )
+
+    assert report["modes"]["antonym"]["unique_lemmas_in_shards"] == 2
+    assert report["modes"]["homonym"]["unique_lemmas_in_shards"] == 1
+    # Without mode shards, gloss matching finds no used pairs.
+    assert report["modes"]["antonym"]["unused_attested_pairs"] == 2
+    assert report["modes"]["antonym"]["lemma_source"] == "practice-index"
+
+
+def test_cli_prints_unused_table(tmp_path: Path, capsys) -> None:
+    sources = _seed_sources(tmp_path / "sources")
+    practice_dir = tmp_path / "lexicon"
+    _seed_shards(practice_dir)
+    out = tmp_path / "inventory.json"
+
+    rc = main(
+        [
+            "--practice-dir",
+            str(practice_dir),
+            "--synonym-verdicts",
+            str(sources["synonym"]),
+            "--antonym-pairs",
+            str(sources["antonym"]),
+            "--paronym-pairs",
+            str(sources["paronym"]),
+            "--homonym-pairs",
+            str(sources["homonym"]),
+            "--json-out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Unused" in captured.out
+    assert "synonym" in captured.out
+    assert "antonym" in captured.out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["modes"]["synonym"]["unused_attested_pairs"] == 1
+    assert "synonym" in format_table(payload)


### PR DESCRIPTION
## Summary
- Adds `scripts/practice/thin_mode_source_inventory.py`: deterministic CLI comparing attested synonym/antonym/paronym/homonym YAML to live `practice-{mode}.*.json` shards (index fallback optional).
- Reports attested pair count, source unique lemmas, shard unique lemmas, unused attested pairs, and whether ≥1000 unique is possible from **current** attested files (no invented pairs; heritage untouched).
- Fixture-backed pytest coverage in `tests/test_thin_mode_source_inventory.py`.

## #M-4 — live inventory (primary published shards, 2026-08-13)

| Mode | Attested pairs | Src unique lemmas | Shard unique lemmas | Unused attested pairs | ≥1000 possible? |
| --- | ---: | ---: | ---: | ---: | --- |
| synonym | 551 | 790 | 681 | 94 | **no** |
| antonym | 392 | 640 | 209 | 275 | **no** |
| paronym | 102 | 192 | 32 | 84 | **no** |
| homonym | 75 | 75 | 22 | 53 | **no** |

Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.practice.thin_mode_source_inventory \
  --practice-dir /Users/krisztiankoos/projects/learn-ukrainian/site/public/lexicon
```

Closes nothing (inventory-only). Refs #4387 #4700.

## Test plan
- [x] `pytest tests/test_thin_mode_source_inventory.py`
- [x] Live CLI table against published practice shards
- [ ] CI green on this PR
- [ ] Independent cross-family review before merge (no auto-merge)


Made with [Cursor](https://cursor.com)