### PR TITLE
fix(phase3): tolerate Drive receipt identity latency

### DIFF
--- a/scripts/projects/open_model_data/phase3_vspu_db_cutover.py
+++ b/scripts/projects/open_model_data/phase3_vspu_db_cutover.py
@@ -21,6 +21,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -75,10 +76,16 @@ COUNTS_AFTER = {
     "university_source_count": 21,
 }
 PRIVATE_FILE_MODE = 0o600
+DRIVE_IDENTITY_TIMEOUT_SECONDS = 120.0
+DRIVE_IDENTITY_POLL_SECONDS = 1.0
 
 
 class VspuDatabaseCutoverError(ValueError):
     """The VSPU cutover inputs, rehearsal, or database state are unsafe."""
+
+
+class DriveIdentityPendingError(VspuDatabaseCutoverError):
+    """DriveFS has not assigned provider identity to an existing artifact yet."""
 
 
 def require(condition: bool, message: str) -> None:
@@ -160,11 +167,38 @@ def _drive_item_id(path: Path) -> str:
             capture_output=True,
             text=True,
         )
-    except (OSError, subprocess.CalledProcessError) as exc:
-        raise VspuDatabaseCutoverError("private artifact lacks Google Drive provider identity") from exc
+    except OSError as exc:
+        raise VspuDatabaseCutoverError("cannot inspect Google Drive provider identity") from exc
+    except subprocess.CalledProcessError as exc:
+        raise DriveIdentityPendingError("private artifact lacks Google Drive provider identity") from exc
     item_id = result.stdout.strip()
-    require(bool(item_id), "private artifact has an empty Google Drive provider identity")
+    if not item_id:
+        raise DriveIdentityPendingError("private artifact has an empty Google Drive provider identity")
     return item_id
+
+
+def _wait_for_drive_item_id(
+    path: Path,
+    *,
+    timeout_seconds: float = DRIVE_IDENTITY_TIMEOUT_SECONDS,
+    poll_seconds: float = DRIVE_IDENTITY_POLL_SECONDS,
+) -> str:
+    """Wait for DriveFS to assign identity to a newly created private receipt."""
+    require(timeout_seconds >= 0, "Google Drive identity timeout must be non-negative")
+    require(poll_seconds >= 0, "Google Drive identity poll interval must be non-negative")
+    deadline = time.monotonic() + timeout_seconds
+    last_error: DriveIdentityPendingError | None = None
+    while True:
+        try:
+            return _drive_item_id(path)
+        except DriveIdentityPendingError as exc:
+            last_error = exc
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise VspuDatabaseCutoverError(
+                f"private receipt did not acquire Google Drive provider identity within {timeout_seconds:g} seconds"
+            ) from last_error
+        time.sleep(min(poll_seconds, remaining))
 
 
 def _streamed_gzip_sha256(path: Path) -> str:
@@ -851,7 +885,7 @@ def reconcile(
         )
         _atomic_write_private(Path(output_receipt_path), receipt)
         if require_google_drive_output:
-            _drive_item_id(Path(output_receipt_path))
+            _wait_for_drive_item_id(Path(output_receipt_path))
         return receipt
     except BaseException as cutover_error:
         if cutover_started and rollback is not None:

--- a/tests/test_open_model_phase3_vspu_db_cutover.py
+++ b/tests/test_open_model_phase3_vspu_db_cutover.py
@@ -349,6 +349,35 @@ def test_in_place_cutover_rehearses_copy_preserves_inode_and_cleans_temps(
     assert not list(tmp_path.glob(".sources.db.vspu-*"))
 
 
+def test_in_place_cutover_waits_for_new_receipt_drive_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, _ = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "cutover-receipt.json"
+    observed: list[Path] = []
+
+    def record_identity_wait(path: Path) -> str:
+        observed.append(path)
+        assert path.is_file()
+        return "drive-item-id"
+
+    monkeypatch.setattr(cutover, "_wait_for_drive_item_id", record_identity_wait)
+    cutover.reconcile(
+        database_path=database,
+        private_jsonl_path=jsonl,
+        preimage_backup_receipt_path=jsonl,
+        compressed_preimage_path=jsonl,
+        output_receipt_path=output,
+        additive_policy_path=policy,
+        apply_in_place=True,
+        expected_live_db_path=database,
+        require_google_drive_output=True,
+    )
+
+    assert observed == [output]
+
+
 def test_candidate_ingest_failure_keeps_live_database_and_receipt_absent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -556,3 +585,116 @@ def test_private_receipt_is_immutable_and_rejects_symlink(tmp_path: Path) -> Non
     receipt.symlink_to(target)
     with pytest.raises(cutover.VspuDatabaseCutoverError, match="symlink"):
         cutover._atomic_write_private(receipt, {"ok": True})
+
+
+def test_new_drive_receipt_identity_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def delayed_identity(_path: Path) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise cutover.DriveIdentityPendingError("private artifact lacks Google Drive provider identity")
+        return "drive-item-id"
+
+    monkeypatch.setattr(cutover, "_drive_item_id", delayed_identity)
+    monkeypatch.setattr(cutover.time, "sleep", lambda _seconds: None)
+
+    assert (
+        cutover._wait_for_drive_item_id(
+            Path("receipt.json"),
+            timeout_seconds=1,
+            poll_seconds=0,
+        )
+        == "drive-item-id"
+    )
+    assert attempts == 3
+
+
+def test_new_drive_receipt_identity_timeout_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cutover,
+        "_drive_item_id",
+        lambda _path: (_ for _ in ()).throw(
+            cutover.DriveIdentityPendingError("private artifact lacks Google Drive provider identity")
+        ),
+    )
+
+    with pytest.raises(
+        cutover.VspuDatabaseCutoverError,
+        match="did not acquire Google Drive provider identity within 0 seconds",
+    ):
+        cutover._wait_for_drive_item_id(
+            Path("receipt.json"),
+            timeout_seconds=0,
+            poll_seconds=0,
+        )
+
+
+def test_new_drive_receipt_structural_error_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def structural_failure(_path: Path) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise cutover.VspuDatabaseCutoverError("private artifact is not inside exactly one Google Drive mount")
+
+    monkeypatch.setattr(cutover, "_drive_item_id", structural_failure)
+    monkeypatch.setattr(
+        cutover.time,
+        "sleep",
+        lambda _seconds: pytest.fail("structural errors must not be retried"),
+    )
+
+    with pytest.raises(cutover.VspuDatabaseCutoverError, match="not inside exactly one"):
+        cutover._wait_for_drive_item_id(
+            Path("receipt.json"),
+            timeout_seconds=120,
+            poll_seconds=1,
+        )
+    assert attempts == 1
+
+
+def test_drive_identity_timeout_restores_exact_prestate_and_removes_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, jsonl, policy, expected = _fixture(tmp_path, monkeypatch)
+    output = tmp_path / "never.json"
+    original_wait = cutover._wait_for_drive_item_id
+    monkeypatch.setattr(
+        cutover,
+        "_drive_item_id",
+        lambda _path: (_ for _ in ()).throw(
+            cutover.DriveIdentityPendingError("private artifact lacks Google Drive provider identity")
+        ),
+    )
+    monkeypatch.setattr(
+        cutover,
+        "_wait_for_drive_item_id",
+        lambda path: original_wait(path, timeout_seconds=0, poll_seconds=0),
+    )
+
+    with pytest.raises(
+        cutover.VspuDatabaseCutoverError,
+        match="did not acquire Google Drive provider identity within 0 seconds",
+    ):
+        cutover.reconcile(
+            database_path=database,
+            private_jsonl_path=jsonl,
+            preimage_backup_receipt_path=jsonl,
+            compressed_preimage_path=jsonl,
+            output_receipt_path=output,
+            additive_policy_path=policy,
+            apply_in_place=True,
+            expected_live_db_path=database,
+            require_google_drive_output=True,
+        )
+
+    assert cutover.sha256_file(database) == expected
+    assert not output.exists()
+    assert not list(tmp_path.glob(".sources.db.vspu-*"))


### PR DESCRIPTION
## Outcome

Fixes the production-observed Google DriveFS metadata race in the guarded VSPU database cutover. A newly written private cutover receipt may exist before DriveFS assigns its provider item identity.

- wait up to 120 seconds only for the transient identity-pending state
- fail permanent mount/configuration errors immediately
- retain the existing exact-prestate rollback if identity never arrives
- add reconcile-level proof that timeout restores the exact DB hash, removes the receipt, and cleans temporary copies

## Proof

- 64 focused tests passed
- Ruff check and format check passed
- diff check passed
- independent cross-family local review: PASS with no material findings and zero checkout mutations (`phase3-6375-vspu-drive-id-review-v4`)

No source-policy, corpus-content, database-schema, backup-format, phase-boundary, or Phase 4 change.

Closes no issue; continues #6375.