### PR TITLE
fix(ci): integration sweep must not use branch-protection admin API (#6717)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ CI, security, and deploy automation for the learn-ukrainian curriculum.
 | `ci-gate-queue-recovery.yml` | Re-run cancelled CI Gate once when upstream jobs succeeded (runner-queue starvation) | Every 15 min / manual | Stopgap for #4811; scans recent CI runs via `gh api` (no `workflow_run` — zizmor); never re-runs genuine failures; default-branch logic only. |
 | `content-ci.yml` | Advisory content gates (bio dossier Section-7 xref, dossier word-count) | PR | Non-blocking; unfiltered `pull_request` so it never wedges as "expected". |
 | `hygiene.yml` | Advisory radon / prompt lint / postmortem / agent-config / scripts-root checks | PR | Composite `hygiene-checks` job (#4811 slot cut); not in CI Gate. |
-| `integration-sweep.yml` | Arms auto-merge for abandoned reviewed PRs | Every 15 min / manual | Fail-closed membership, current-head approval, required-CI, and idle-owner checks; manual runs default to dry-run. |
+| `integration-sweep.yml` | Arms auto-merge for abandoned reviewed PRs | Every 15 min / manual | Fail-closed membership, current-head approval, required-CI (`CI Gate` via rollup/`isRequired`, not admin protection API), and idle-owner checks; manual runs default to dry-run; schedule soft-skips HTTP 403. |
 | `security-audit.yml` | Advisory dependency-vuln report (`pip-audit` + `npm audit`) | PR / weekly | Report-only; visibility layer over the dependabot backlog. Does not block. |
 | `zizmor.yml` | Static security analysis of all workflow YAML | PR / push / weekly | SARIF → Security tab. Runs `--offline`. |
 | `validate-yaml.yml` | YAML syntax / schema validation | PR / push | |

--- a/.github/workflows/integration-sweep.yml
+++ b/.github/workflows/integration-sweep.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   issues: read
   pull-requests: write
+  # Required-context discovery via GraphQL rollup isRequired (#6717). Never
+  # request administration — branch-protection REST is off-limits to GITHUB_TOKEN.
+  checks: read
+  statuses: read
 
 jobs:
   sweep:

--- a/scripts/orchestration/integration_sweep.py
+++ b/scripts/orchestration/integration_sweep.py
@@ -59,10 +59,7 @@ def _is_github_http_403(message: str) -> bool:
 def _is_schedule_event() -> bool:
     """True for Actions ``schedule`` runs (workflow sets EVENT_NAME / GITHUB_EVENT_NAME)."""
 
-    for key in ("EVENT_NAME", "GITHUB_EVENT_NAME"):
-        if os.environ.get(key) == "schedule":
-            return True
-    return False
+    return any(os.environ.get(key) == "schedule" for key in ("EVENT_NAME", "GITHUB_EVENT_NAME"))
 
 
 def _parse_timestamp(value: object) -> datetime | None:

--- a/scripts/orchestration/integration_sweep.py
+++ b/scripts/orchestration/integration_sweep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
@@ -23,6 +24,10 @@ from typing import Any
 from scripts.orchestration import issue_stream_audit
 
 IDLE_THRESHOLD = timedelta(hours=1)
+# Documented sole required status check (.github/workflows/README.md). Never read
+# GET /repos/.../branches/.../protection — that endpoint needs administration,
+# which GITHUB_TOKEN cannot grant (#6717).
+DOCUMENTED_REQUIRED_CHECK_CONTEXTS = ("CI Gate",)
 _REFS_LINE = re.compile(r"(?im)^\s*(?:[-*]\s*)?refs?\s*:?\s*#([1-9][0-9]*)\b")
 _FORMAL_REVIEW_HEADING = re.compile(r"(?im)^#{1,6}\s+cross-family review\b")
 _FORMAL_REVIEW_HEAD = re.compile(r"(?im)^\s*\*{0,2}head:\*{0,2}\s*`?([0-9a-f]{40})`?\s*$")
@@ -43,6 +48,21 @@ class Decision:
 
 class SweepError(RuntimeError):
     """An unavailable authoritative GitHub input that must stop the sweep."""
+
+
+def _is_github_http_403(message: str) -> bool:
+    """True when gh/API refused with the classic integration permission hole."""
+
+    return "HTTP 403" in message or "Resource not accessible by integration" in message
+
+
+def _is_schedule_event() -> bool:
+    """True for Actions ``schedule`` runs (workflow sets EVENT_NAME / GITHUB_EVENT_NAME)."""
+
+    for key in ("EVENT_NAME", "GITHUB_EVENT_NAME"):
+        if os.environ.get(key) == "schedule":
+            return True
+    return False
 
 
 def _parse_timestamp(value: object) -> datetime | None:
@@ -271,16 +291,101 @@ class GitHubAdapter:
         return payload
 
     def required_check_contexts(self, repository: str, branch: str = "main") -> list[str]:
-        payload = self._json(["gh", "api", f"repos/{repository}/branches/{branch}/protection"])
-        required = payload.get("required_status_checks") if isinstance(payload, Mapping) else None
-        contexts = required.get("contexts") if isinstance(required, Mapping) else None
-        if (
-            not isinstance(contexts, list)
-            or not contexts
-            or not all(isinstance(item, str) and item for item in contexts)
-        ):
-            raise SweepError("protected branch has no readable required status checks")
-        return contexts
+        """Return required check names without the admin-only protection API.
+
+        Prefer GraphQL / PR rollup ``isRequired`` when the token can read checks;
+        otherwise fail closed to the documented sole required context ``CI Gate``.
+        Never call ``GET /repos/.../branches/.../protection`` (#6717).
+        """
+
+        del branch  # retained for call-site compatibility
+        try:
+            discovered = self._required_contexts_from_pr_rollup(repository)
+        except SweepError as exc:
+            if _is_github_http_403(str(exc)):
+                # Token cannot read check metadata — documented default, not a crash.
+                return list(DOCUMENTED_REQUIRED_CHECK_CONTEXTS)
+            raise
+        if discovered:
+            return discovered
+        return list(DOCUMENTED_REQUIRED_CHECK_CONTEXTS)
+
+    def _required_contexts_from_pr_rollup(self, repository: str) -> list[str]:
+        """Collect ``isRequired`` check names from open PR status rollups via GraphQL."""
+
+        owner, _, name = repository.partition("/")
+        if not owner or not name:
+            raise SweepError(f"invalid repository slug: {repository!r}")
+        # Compact single-line query — same style as issue_stream_audit GraphQL calls.
+        query = (
+            "query($owner:String!,$name:String!){"
+            "repository(owner:$owner,name:$name){"
+            "pullRequests(first:20,states:OPEN){nodes{"
+            "commits(last:1){nodes{commit{statusCheckRollup{"
+            "contexts(first:100){nodes{"
+            "__typename "
+            "... on CheckRun{name isRequired} "
+            "... on StatusContext{context isRequired}"
+            "}}}}}}}}}}"
+        )
+        payload = self._json(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+            ]
+        )
+        if not isinstance(payload, Mapping):
+            return []
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            messages = "; ".join(
+                str(item.get("message") or item) for item in errors if isinstance(item, Mapping)
+            )
+            if _is_github_http_403(messages) or "Resource not accessible" in messages:
+                raise SweepError(messages[:1000] or "GraphQL required-check lookup HTTP 403")
+            # Non-permission GraphQL failures: fall through to documented default.
+            return []
+        data = payload.get("data")
+        repository_node = data.get("repository") if isinstance(data, Mapping) else None
+        if not isinstance(repository_node, Mapping):
+            return []
+        pull_requests = repository_node.get("pullRequests")
+        nodes = pull_requests.get("nodes") if isinstance(pull_requests, Mapping) else None
+        if not isinstance(nodes, list):
+            return []
+        required: list[str] = []
+        seen: set[str] = set()
+        for pr_node in nodes:
+            if not isinstance(pr_node, Mapping):
+                continue
+            commits = pr_node.get("commits")
+            commit_nodes = commits.get("nodes") if isinstance(commits, Mapping) else None
+            if not isinstance(commit_nodes, list):
+                continue
+            for commit_node in commit_nodes:
+                if not isinstance(commit_node, Mapping):
+                    continue
+                commit = commit_node.get("commit")
+                rollup = commit.get("statusCheckRollup") if isinstance(commit, Mapping) else None
+                contexts = rollup.get("contexts") if isinstance(rollup, Mapping) else None
+                context_nodes = contexts.get("nodes") if isinstance(contexts, Mapping) else None
+                if not isinstance(context_nodes, list):
+                    continue
+                for raw in context_nodes:
+                    if not isinstance(raw, Mapping) or raw.get("isRequired") is not True:
+                        continue
+                    label = raw.get("name") or raw.get("context")
+                    if isinstance(label, str) and label and label not in seen:
+                        seen.add(label)
+                        required.append(label)
+        return required
 
     def comments(self, repository: str, number: int) -> list[dict[str, Any]]:
         payload = self._json(["gh", "api", f"repos/{repository}/issues/{number}/comments", "--paginate"])
@@ -347,6 +452,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         decisions = run(GitHubAdapter(args.repo_root), args.repo, apply=args.apply)
     except SweepError as exc:
+        message = str(exc)
+        # Scheduled runs must not paint main red for GITHUB_TOKEN permission holes
+        # (e.g. residual required-context lookup 403). Logic bugs still exit 1.
+        if _is_github_http_403(message) and _is_schedule_event():
+            print(f"integration sweep skipped: {message}")
+            return 0
         print(f"integration sweep refused: {exc}")
         return 1
     print(json.dumps([decision.__dict__ for decision in decisions], sort_keys=True))

--- a/tests/orchestration/test_integration_sweep.py
+++ b/tests/orchestration/test_integration_sweep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -158,3 +159,130 @@ def test_run_is_read_only_without_apply(monkeypatch) -> None:
     decisions = integration_sweep.run(FakeAdapter(), "org/repo", apply=False, now=NOW)
 
     assert decisions == [integration_sweep.Decision(99, True, "stream_epic_4707")]
+
+
+def test_required_check_contexts_never_calls_branch_protection() -> None:
+    """GITHUB_TOKEN cannot call branches/.../protection (administration / HTTP 403)."""
+
+    def runner(args: list[str]) -> str:
+        joined = " ".join(args)
+        assert "/branches/" not in joined and "/protection" not in joined, joined
+        assert "graphql" in args
+        return json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [
+                                {
+                                    "commits": {
+                                        "nodes": [
+                                            {
+                                                "commit": {
+                                                    "statusCheckRollup": {
+                                                        "contexts": {
+                                                            "nodes": [
+                                                                {
+                                                                    "__typename": "CheckRun",
+                                                                    "name": "CI Gate",
+                                                                    "isRequired": True,
+                                                                },
+                                                                {
+                                                                    "__typename": "CheckRun",
+                                                                    "name": "advisory",
+                                                                    "isRequired": False,
+                                                                },
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        )
+
+    adapter = integration_sweep.GitHubAdapter(Path("."), runner=runner)
+
+    assert adapter.required_check_contexts("org/repo") == ["CI Gate"]
+
+
+def test_required_check_contexts_falls_back_to_ci_gate_on_graphql_403() -> None:
+    """Adapter 403 on required-context lookup must not crash; CI Gate remains."""
+
+    def runner(args: list[str]) -> str:
+        joined = " ".join(args)
+        assert "/branches/" not in joined and "/protection" not in joined, joined
+        raise integration_sweep.SweepError(
+            "gh: Resource not accessible by integration (HTTP 403)"
+        )
+
+    adapter = integration_sweep.GitHubAdapter(Path("."), runner=runner)
+
+    assert adapter.required_check_contexts("org/repo") == ["CI Gate"]
+
+
+def test_run_survives_required_context_403_via_documented_default(monkeypatch) -> None:
+    class SoftAdapter:
+        repo_root = Path(".")
+
+        def required_check_contexts(self, repository: str) -> list[str]:
+            # Simulate the real adapter falling back after a 403.
+            return integration_sweep.GitHubAdapter(
+                Path("."),
+                runner=lambda _args: (_ for _ in ()).throw(
+                    integration_sweep.SweepError(
+                        "gh: Resource not accessible by integration (HTTP 403)"
+                    )
+                ),
+            ).required_check_contexts(repository)
+
+        def list_open_prs(self, _repository: str) -> list[dict]:
+            return [_pr()]
+
+        def arm_auto_merge(self, _repository: str, _number: int) -> None:
+            raise AssertionError("dry run must not mutate GitHub")
+
+    monkeypatch.setattr(integration_sweep.issue_stream_audit, "run_audit", lambda _root: _report())
+
+    decisions = integration_sweep.run(SoftAdapter(), "org/repo", apply=False, now=NOW)
+
+    assert decisions == [integration_sweep.Decision(99, True, "stream_epic_4707")]
+
+
+def test_main_schedule_soft_skips_http_403(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("EVENT_NAME", "schedule")
+
+    def boom(*_args, **_kwargs):
+        raise integration_sweep.SweepError(
+            "gh: Resource not accessible by integration (HTTP 403)"
+        )
+
+    monkeypatch.setattr(integration_sweep, "run", boom)
+
+    assert integration_sweep.main(["--repo", "org/repo", "--apply"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("integration sweep skipped:")
+    assert "HTTP 403" in out
+
+
+def test_main_non_schedule_still_refuses_http_403(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+
+    def boom(*_args, **_kwargs):
+        raise integration_sweep.SweepError(
+            "gh: Resource not accessible by integration (HTTP 403)"
+        )
+
+    monkeypatch.setattr(integration_sweep, "run", boom)
+
+    assert integration_sweep.main(["--repo", "org/repo"]) == 1
+    out = capsys.readouterr().out
+    assert out.startswith("integration sweep refused:")
+    assert "HTTP 403" in out


### PR DESCRIPTION
**Found by grok-bot** (#6717). Implement follow-through only.

## Summary
- Stop calling admin-only `GET /repos/.../branches/main/protection` from the integration sweep (`GITHUB_TOKEN` cannot grant `administration`).
- Resolve required contexts via GraphQL PR rollup `isRequired`, falling back to the documented sole required check `CI Gate`.
- On `schedule`, soft-skip residual HTTP 403 (`integration sweep skipped: …`) with exit 0 so main is not painted red; real logic bugs still exit 1.
- Add `checks: read` / `statuses: read` (no PAT, no `administration`); update workflow README.

Fixes #6717

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/orchestration/test_integration_sweep.py -q --tb=short` (13 passed)
- [ ] Confirm next scheduled `Abandoned PR liveness sweep` exits 0 (or arms eligible PRs) without `branches/.../protection` 403


Made with [Cursor](https://cursor.com)
