### PR TITLE
fix(site): A1 hub module cards are real links (#6712)

### DIFF
--- a/site/src/components/LevelLanding.module.css
+++ b/site/src/components/LevelLanding.module.css
@@ -113,6 +113,18 @@
   background: var(--sl-color-bg, white);
   transition: all 0.2s;
   cursor: default;
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Linked module cards: real <a.moduleItem> — pointer + focus ring for keyboard (#6712) */
+.moduleLink {
+  cursor: pointer;
+}
+
+.moduleLink:focus-visible {
+  outline: 2px solid var(--sl-color-accent-high, #0057B8);
+  outline-offset: 2px;
 }
 
 .moduleItem:hover {

--- a/site/src/components/LevelLanding.tsx
+++ b/site/src/components/LevelLanding.tsx
@@ -55,6 +55,7 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
   const moduleStatus = shouldHideLink && (mod.status === 'done' || mod.status === 'active')
     ? 'locked'
     : mod.status;
+  const isLinked = (moduleStatus === 'done' || moduleStatus === 'active') && !shouldHideLink;
   const statusIcons: Record<string, string> = {
     done: '\u2705',
     active: '\u25B6\uFE0F',
@@ -71,6 +72,7 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
 
   const itemClass = [
     styles.moduleItem,
+    isLinked ? styles.moduleLink : '',
     moduleStatus === 'locked' ? styles.moduleLocked : '',
   ].filter(Boolean).join(' ');
 
@@ -80,8 +82,18 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
     ? {}
     : {};
 
-  const inner = (
-    <div className={itemClass}>
+  // Status icons are visual only when the card is a real link — otherwise
+  // LiveStatus's role="img" aria-label can steal the accessible name (#6712).
+  const status = (
+    <div className={styles.moduleStatus} aria-hidden={isLinked || undefined}>
+      {levelKey === 'a1' && (moduleStatus === 'done' || moduleStatus === 'active')
+        ? <LiveStatus track={levelKey} num={mod.num} fallback={moduleStatus} />
+        : statusIcons[moduleStatus]}
+    </div>
+  );
+
+  const body = (
+    <>
       <div className={numClass} style={numStyle}>
         {String(mod.num).padStart(2, '0')}
       </div>
@@ -93,18 +105,20 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
         {mod.sub && <div className={styles.moduleSub}>{mod.sub}</div>}
         {mod.subEn && <div className={styles.moduleSubEn}>{mod.subEn}</div>}
       </div>
-      <div className={styles.moduleStatus}>
-        {levelKey === 'a1' && (moduleStatus === 'done' || moduleStatus === 'active')
-          ? <LiveStatus track={levelKey} num={mod.num} fallback={moduleStatus} />
-          : statusIcons[moduleStatus]}
-      </div>
-    </div>
+      {status}
+    </>
   );
 
-  if ((moduleStatus === 'done' || moduleStatus === 'active') && !shouldHideLink) {
-    return <a href={`/${levelKey}/${mod.slug}/`} style={{ textDecoration: 'none', color: 'inherit' }}>{inner}</a>;
+  // The card itself must be the <a> (not a nested div) so keyboard focus,
+  // Enter activation, and SR "link" role all land on the module row (#6712).
+  if (isLinked) {
+    return (
+      <a className={itemClass} href={`/${levelKey}/${mod.slug}/`}>
+        {body}
+      </a>
+    );
   }
-  return inner;
+  return <div className={itemClass}>{body}</div>;
 }
 
 export default function LevelLanding(props: LevelLandingProps): ReactNode {

--- a/site/tests/unit/LevelLanding.test.tsx
+++ b/site/tests/unit/LevelLanding.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import LevelLanding from '@site/src/components/LevelLanding';
+
+describe('LevelLanding module cards', () => {
+  it('renders available modules as real links (role=link + href)', () => {
+    // Use a non-A1 level so LiveStatus is not mounted; the link contract is
+    // the same for every track that uses ModuleCard (#6712).
+    render(
+      <LevelLanding
+        level="A2"
+        modules={[
+          {
+            unit: 'Unit 1',
+            items: [
+              {
+                num: 1,
+                slug: 'sounds-letters-and-hello',
+                title: 'Звуки, літери та привіт',
+                sub: 'First module',
+                status: 'active',
+              },
+              {
+                num: 2,
+                slug: 'reading-ukrainian',
+                title: 'Читаємо українською',
+                status: 'done',
+              },
+              {
+                num: 3,
+                slug: 'not-ready-yet',
+                title: 'Ще не готово',
+                status: 'locked',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const active = screen.getByRole('link', { name: /Звуки, літери та привіт/ });
+    expect(active.tagName).toBe('A');
+    expect(active).toHaveAttribute('href', '/a2/sounds-letters-and-hello/');
+
+    const done = screen.getByRole('link', { name: /Читаємо українською/ });
+    expect(done).toHaveAttribute('href', '/a2/reading-ukrainian/');
+
+    expect(screen.queryByRole('link', { name: /Ще не готово/ })).toBeNull();
+    expect(screen.getByText('Ще не готово')).toBeInTheDocument();
+  });
+
+  it('keeps A1 module rows as links whose accessible name is the title', () => {
+    render(
+      <LevelLanding
+        level="A1"
+        modules={[
+          {
+            unit: 'A1.1',
+            items: [
+              {
+                num: 1,
+                slug: 'sounds-letters-and-hello',
+                title: 'Звуки, літери та привіт',
+                status: 'active',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /Звуки, літери та привіт/ });
+    expect(link).toHaveAttribute('href', '/a1/sounds-letters-and-hello/');
+    // Status chrome must not become a separate named control inside the link.
+    expect(within(link).queryByRole('img')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Make each hub module card the `<a>` itself (`<a class="moduleItem">`) so click, Enter, and screen-reader "link" all work on the row.
- Hide status chrome from the accessibility tree when the card is linked so LiveStatus `role="img"` cannot steal the accessible name.
- Add Vitest/RTL regression coverage that cards expose `role=link` with the correct `href`.

## Changes
- `site/src/components/LevelLanding.tsx` — ModuleCard uses a real anchor as the card
- `site/src/components/LevelLanding.module.css` — link cursor + `:focus-visible` ring
- `site/tests/unit/LevelLanding.test.tsx` — link-role assertions for available vs locked modules

## Testing
- [x] `./node_modules/.bin/vitest run tests/unit/LevelLanding.test.tsx` (2 passed)
- [ ] Website builds without errors (`cd site && npm run build`)
- [ ] Ukrainian text reviewed for naturalness (N/A — no content change)

## Related Issues
Fixes #6712

Made with [Cursor](https://cursor.com)