### PR TITLE
fix(site): practice first paint is not a blank main (#6715)

### DIFF
--- a/site/src/lexicon/LexiconPracticeMount.astro
+++ b/site/src/lexicon/LexiconPracticeMount.astro
@@ -3,6 +3,26 @@ import LexiconPractice from '../components/LexiconPractice';
 ---
 
 <div id="lexicon-practice-mount" data-lexicon-practice-island>
+  <!--
+    #6715: client:only renders nothing until the bundle downloads and hydrates,
+    so first paint used to be an empty <main>. This static shell is SSR'd with
+    the page and hidden by the inline script once React content appears (or the
+    fallback takes over), keeping session behavior after hydrate unchanged.
+  -->
+  <div
+    id="lexicon-practice-shell"
+    class="lexicon-practice-shell"
+    role="status"
+    aria-busy="true"
+  >
+    <div class="lexicon-practice-shell-skeleton" aria-hidden="true">
+      <div class="lexicon-practice-skel-line wide"></div>
+      <div class="lexicon-practice-skel-line"></div>
+      <div class="lexicon-practice-skel-block"></div>
+      <div class="lexicon-practice-skel-line mid"></div>
+    </div>
+    <p>Завантаження практики…</p>
+  </div>
   <LexiconPractice client:only="react" />
 </div>
 
@@ -20,16 +40,23 @@ import LexiconPractice from '../components/LexiconPractice';
 <script is:inline>
 (() => {
   const MOUNT_SEL = '#lexicon-practice-mount';
+  const SHELL_ID = 'lexicon-practice-shell';
   const FALLBACK_ID = 'lexicon-practice-fallback';
   const SUCCESS_SEL = '.lexicon-practice';
   const TIMEOUT_MS = 10000;
   let done = false;
+
+  function hideShell() {
+    const shell = document.getElementById(SHELL_ID);
+    if (shell) shell.setAttribute('hidden', '');
+  }
 
   function showFallback() {
     if (done) return;
     done = true;
     const mount = document.querySelector(MOUNT_SEL);
     const fb = document.getElementById(FALLBACK_ID);
+    hideShell();
     if (mount) mount.setAttribute('hidden', '');
     if (fb) {
       fb.removeAttribute('hidden');
@@ -39,6 +66,7 @@ import LexiconPractice from '../components/LexiconPractice';
   function markSuccess() {
     if (done) return;
     done = true;
+    hideShell();
   }
 
   function isOurIsland(target) {
@@ -113,6 +141,65 @@ import LexiconPractice from '../components/LexiconPractice';
 </script>
 
 <style is:global>
+.lexicon-practice-shell {
+  display: grid;
+  gap: 0.85rem;
+  max-width: 760px;
+  padding: 1rem 0;
+}
+.lexicon-practice-shell[hidden] {
+  display: none;
+}
+.lexicon-practice-shell-skeleton {
+  display: grid;
+  gap: 0.65rem;
+}
+.lexicon-practice-skel-line,
+.lexicon-practice-skel-block {
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--lu-border, #ddd) 65%, transparent),
+    color-mix(in srgb, var(--lu-border, #ddd) 35%, transparent),
+    color-mix(in srgb, var(--lu-border, #ddd) 65%, transparent)
+  );
+  background-size: 200% 100%;
+  animation: lexicon-practice-shimmer 1.2s ease-in-out infinite;
+}
+.lexicon-practice-skel-line {
+  height: 0.9rem;
+  width: 70%;
+}
+.lexicon-practice-skel-line.wide {
+  width: 92%;
+}
+.lexicon-practice-skel-line.mid {
+  width: 55%;
+}
+.lexicon-practice-skel-block {
+  height: 9rem;
+  width: 100%;
+}
+@keyframes lexicon-practice-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lexicon-practice-skel-line,
+  .lexicon-practice-skel-block {
+    animation: none;
+  }
+}
+.lexicon-practice-shell p {
+  margin: 0;
+  color: var(--lu-text-muted);
+  font-weight: 700;
+  line-height: 1.5;
+}
 .lexicon-practice-fallback {
   display: grid;
   gap: 0.75rem;

--- a/site/tests/unit/practice-first-paint.test.ts
+++ b/site/tests/unit/practice-first-paint.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Practice first paint (#6715).
+ *
+ * `/words-of-the-day/practice/` mounts LexiconPractice with client:only, so
+ * without an SSR shell the <main> is empty until the bundle downloads and
+ * hydrates. The mount must ship a visible static shell, and the inline script
+ * must hide it on both the success (hydrated content) and fallback paths.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const ROOT = process.cwd();
+
+function readSrc(rel: string): string {
+  return readFileSync(resolve(ROOT, rel), 'utf8');
+}
+
+describe('practice first-paint shell (#6715)', () => {
+  const src = readSrc('src/lexicon/LexiconPracticeMount.astro');
+
+  test('mount contains a visible (non-hidden) status shell before the island', () => {
+    const mountStart = src.indexOf('id="lexicon-practice-mount"');
+    const islandStart = src.indexOf('client:only="react"');
+    expect(mountStart).toBeGreaterThan(-1);
+    expect(islandStart).toBeGreaterThan(-1);
+
+    const preIsland = src.slice(mountStart, islandStart);
+    expect(preIsland).toContain('id="lexicon-practice-shell"');
+    expect(preIsland).toContain('role="status"');
+    expect(preIsland).toContain('aria-busy="true"');
+    // Visible at first paint: the shell itself must not start hidden.
+    const shellTag = preIsland.slice(
+      preIsland.indexOf('id="lexicon-practice-shell"'),
+      preIsland.indexOf('>', preIsland.indexOf('id="lexicon-practice-shell"')),
+    );
+    expect(shellTag).not.toContain('hidden');
+    expect(preIsland).toContain('lexicon-practice-skel-line');
+    expect(preIsland).toContain('Завантаження практики…');
+  });
+
+  test('inline script hides the shell on success and on fallback', () => {
+    expect(src).toContain("const SHELL_ID = 'lexicon-practice-shell';");
+    expect(src).toMatch(/function hideShell\(\)[\s\S]{0,200}setAttribute\('hidden', ''\)/);
+    expect(src).toMatch(/function markSuccess\(\)[\s\S]{0,150}hideShell\(\)/);
+    expect(src).toMatch(/function showFallback\(\)[\s\S]{0,300}hideShell\(\)/);
+  });
+
+  test('fallback remains hidden at first paint; shell hides via [hidden] rule', () => {
+    expect(src).toMatch(/id="lexicon-practice-fallback"[^>]*hidden/);
+    expect(src).toContain('.lexicon-practice-shell[hidden]');
+  });
+});


### PR DESCRIPTION
## Bug
`/words-of-the-day/practice/` first paint rendered header+footer with an empty `<main>` — `LexiconPractice` mounts with `client:only="react"`, so nothing is SSR'd and slow networks look blank until the bundle downloads and hydrates.

Live repro (pre-fix): https://learn-ukrainian.github.io/words-of-the-day/practice/?lemmaId=%D0%BC%D0%B0%D0%BC%D0%B0 — the `#lexicon-practice-mount` div contained only the astro-island bootstrap script.

## Fix
- `site/src/lexicon/LexiconPracticeMount.astro`: SSR a visible first-paint shell (`role="status"`, `aria-busy`, shimmer skeleton + «Завантаження практики…») inside the mount, before the island.
- The existing inline script now hides the shell via `hideShell()` on both terminal paths: `markSuccess()` (React content detected / `astro:hydrate`) and `showFallback()` (hydration error or 10s watchdog). No new blocking on client-only data — the 10s watchdog/fallback behavior is unchanged, as is all session behavior after hydrate.
- Skeleton shimmer respects `prefers-reduced-motion`.

## Test
- New `site/tests/unit/practice-first-paint.test.ts` (3 tests): shell present + visible before the island, hidden on both script paths, fallback stays hidden at first paint.

## Verification
- `vitest run tests/unit/practice-first-paint.test.ts` — 3/3 pass.
- `vitest run tests/unit/LexiconPractice.test.tsx tests/unit/practice-locale-purity.test.ts tests/unit/practice-distractors.test.ts` — 158/158 pass.
- `PYTHON=<primary .venv> npm run build` — 20542 pages built; verified `dist/words-of-the-day/practice/index.html` ships the visible shell (no `hidden`) before the `astro-island`.

Refs #6715