### PR TITLE
fix(site): Наголос tiles sit under the prompt (#6716)

### DIFF
--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1972,6 +1972,10 @@ const frontmatter = {
   :global(.lexicon-stress) {
     display: grid;
     gap: 1rem;
+    /* #6716: keep rows content-sized instead of stretching to fill the stage's
+       420px min-height, which inflated the prompt box ~110px and pushed the
+       stressed-vowel tiles ~150px below the question. Same rhythm as choice. */
+    align-content: start;
   }
 
   :global(.practice-stress-word) {


### PR DESCRIPTION
## What

Наголос stress tiles rendered ~150px below the question text. Вибір layout was fine.

**Root cause:** the practice stage pins itself to `min-height: 420px` and its grid rows stretch by default (`align-content: normal → stretch`). On the short Наголос question, the stretched prompt row inflated the prompt box ~110px, so the stressed-vowel tiles sat ~150px below the question. Вибір's taller option list filled the stage, so it looked fine.

**Fix:** pin `.lexicon-stress` rows to their content size with `align-content: start`. The tiles now sit directly under the question with the same rhythm as Вибір. CSS-only, scoped to the stress question layout.

## Verification

Reproduced in Chromium against the dev server (practice lemma → Мікс · Наголос):

- Desktop 1366×768: prompt box 151px → 44px (content height); tiles sit 44px below the prompt box (directly under the question) instead of ~150px below the question text.
- Narrow 390×844: prompt box 162px → 65px; tiles directly under the question.
- Answered state unchanged (verdict + correct/wrong tiles still render).
- `npx astro check`: no new errors in the changed file (30 pre-existing errors in LexiconPractice.tsx/tests are unrelated).
- Stress unit tests pass (`LexiconPractice.test.tsx -t stress`: 3 passed).

## Notes

No merge — this is a dispatch deliverable for review.