### PR TITLE
feat(phase3): bind VSPU successor prefreeze chain

### DIFF
--- a/data/projects/open_model_data/contracts/phase3_v3_prefreeze_readiness_v2.schema.json
+++ b/data/projects/open_model_data/contracts/phase3_v3_prefreeze_readiness_v2.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/contracts/phase3_v3_prefreeze_readiness_v2.schema.json",
+  "title": "Phase 3 v3 additive pre-freeze successor readiness receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "status", "text_free", "provider_calls", "bindings", "denominators",
+    "additive_sources", "cycle002", "semantic_canary", "readiness", "gates", "receipt_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "phase3_v3_prefreeze_readiness_v2"},
+    "status": {"const": "PREFREEZE_BLOCKED_PENDING_COMPLETE_EVALUATION_PACKAGE"},
+    "text_free": {"const": true},
+    "provider_calls": {"const": false},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase3_recovery_prompt_v2_sha256", "phase3_reboot_prompt_v3_sha256",
+        "v2_compatibility_matrix_sha256", "v2_evaluation_contract_sha256",
+        "v2_functional_role_contract_sha256", "near_duplicate_policy_sha256",
+        "linguistic_representation_implementation_sha256", "linguistic_representation_schema_sha256",
+        "linguistic_canary_implementation_sha256", "ua_gec_complete_context_receipt_file_sha256",
+        "ua_gec_complete_context_receipt_sha256", "university_content_audit_freeze_file_sha256",
+        "university_content_audit_freeze_receipt_sha256", "historical_full_gate_file_sha256",
+        "historical_full_gate_receipt_sha256", "historical_full_receipt_file_sha256",
+        "historical_full_receipt_sha256", "historical_evidence_spine_v2_file_sha256",
+        "historical_evidence_spine_v2_receipt_sha256", "historical_evidence_spine_v2_implementation_sha256",
+        "historical_evidence_spine_v2_schema_sha256", "sources_database_sha256",
+        "prefreeze_implementation_sha256", "prefreeze_schema_sha256"
+      ],
+      "properties": {
+        "phase3_recovery_prompt_v2_sha256": {"const": "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"},
+        "phase3_reboot_prompt_v3_sha256": {"const": "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"},
+        "v2_compatibility_matrix_sha256": {"$ref": "#/$defs/sha256"},
+        "v2_evaluation_contract_sha256": {"$ref": "#/$defs/sha256"},
+        "v2_functional_role_contract_sha256": {"$ref": "#/$defs/sha256"},
+        "near_duplicate_policy_sha256": {"$ref": "#/$defs/sha256"},
+        "linguistic_representation_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "linguistic_representation_schema_sha256": {"$ref": "#/$defs/sha256"},
+        "linguistic_canary_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "ua_gec_representation_adapter_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "ua_gec_complete_context_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "ua_gec_complete_context_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "university_content_audit_freeze_file_sha256": {"$ref": "#/$defs/sha256"},
+        "university_content_audit_freeze_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_gate_file_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_gate_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_full_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_evidence_spine_v2_file_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_evidence_spine_v2_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_evidence_spine_v2_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "historical_evidence_spine_v2_schema_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_receipt_file_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "saint_sophia_reconciliation_schema_sha256": {"$ref": "#/$defs/sha256"},
+        "vspu_post_ingest_audit_file_sha256": {"$ref": "#/$defs/sha256"},
+        "vspu_post_ingest_audit_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "vspu_post_ingest_audit_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "vspu_post_ingest_audit_schema_sha256": {"$ref": "#/$defs/sha256"},
+        "vspu_additive_policy_sha256": {"$ref": "#/$defs/sha256"},
+        "sources_database_sha256": {"$ref": "#/$defs/sha256"},
+        "prefreeze_implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "prefreeze_schema_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "denominators": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["v2", "ua_gec_complete_context", "university", "historical", "v3_evaluation"],
+      "properties": {
+        "v2": {
+          "type": "object", "additionalProperties": false,
+          "required": ["source_units", "evaluation_identities", "ua_gec_units"],
+          "properties": {
+            "source_units": {"const": 67041}, "evaluation_identities": {"const": 9392},
+            "ua_gec_units": {"const": 8937}
+          }
+        },
+        "ua_gec_complete_context": {
+          "type": "object", "additionalProperties": false,
+          "required": ["eligible_records", "represented_v2_units", "excluded_v2_units"],
+          "properties": {
+            "eligible_records": {"type": "integer", "minimum": 1},
+            "represented_v2_units": {"type": "integer", "minimum": 1, "maximum": 8937},
+            "excluded_v2_units": {"type": "integer", "minimum": 0, "maximum": 8937}
+          }
+        },
+        "university": {
+          "type": "object", "additionalProperties": false,
+          "required": ["candidate_sources", "database_sources", "mandatory_conversion_sources", "partial_topics", "sufficient_topics"],
+          "properties": {
+            "candidate_sources": {"const": 30}, "database_sources": {"const": 20},
+            "mandatory_conversion_sources": {"const": 11}, "partial_topics": {"const": 21},
+            "sufficient_topics": {"const": 5}
+          }
+        },
+        "vspu_additive_university": {
+          "type": "object", "additionalProperties": false,
+          "required": [
+            "policy_sources", "database_sources", "database_rows", "database_fts_rows",
+            "database_section_rows", "database_linked_rows"
+          ],
+          "properties": {
+            "policy_sources": {"const": 1}, "database_sources": {"const": 1},
+            "database_rows": {"const": 158}, "database_fts_rows": {"const": 158},
+            "database_section_rows": {"const": 158}, "database_linked_rows": {"const": 158}
+          }
+        },
+        "historical": {
+          "type": "object", "additionalProperties": false,
+          "required": ["ud_documents", "ud_sentences", "ud_token_rows", "plug2_uk_documents", "plug2_uk_metadata_tokens"],
+          "properties": {
+            "ud_documents": {"const": 82}, "ud_sentences": {"const": 1311},
+            "ud_token_rows": {"const": 35081}, "plug2_uk_documents": {"const": 56080},
+            "plug2_uk_metadata_tokens": {"const": 71802066}
+          }
+        },
+        "v3_evaluation": {
+          "type": "object", "additionalProperties": false,
+          "required": ["required_evidence_backed_labels", "frozen_evidence_backed_labels"],
+          "properties": {
+            "required_evidence_backed_labels": {"const": 9392},
+            "frozen_evidence_backed_labels": {"const": 0}
+          }
+        }
+      }
+    },
+    "additive_sources": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "university_and_historical_outside_v2_totals", "v2_denominators_unchanged",
+        "historical_forms_protected", "historical_modern_correction_eligible", "conversion_started",
+        "vspu_contextual_source_ingested", "vspu_normative_rule_authority", "vspu_semantic_gold",
+        "vspu_public_redistribution_authorized"
+      ],
+      "properties": {
+        "university_and_historical_outside_v2_totals": {"const": true},
+        "v2_denominators_unchanged": {"const": true},
+        "historical_forms_protected": {"const": true},
+        "historical_modern_correction_eligible": {"const": false},
+        "conversion_started": {"const": false},
+        "vspu_contextual_source_ingested": {"type": "boolean"},
+        "vspu_normative_rule_authority": {"const": false},
+        "vspu_semantic_gold": {"const": false},
+        "vspu_public_redistribution_authorized": {"const": false}
+      }
+    },
+    "cycle002": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "identities", "agreements", "disagreements", "rows_with_ua_gec_evidence",
+        "rows_without_authoritative_evidence", "provider_independent", "semantic_gold", "disposition"
+      ],
+      "properties": {
+        "identities": {"const": 9392}, "agreements": {"const": 6462},
+        "disagreements": {"const": 2930}, "rows_with_ua_gec_evidence": {"const": 906},
+        "rows_without_authoritative_evidence": {"const": 8486}, "provider_independent": {"const": false},
+        "semantic_gold": {"const": false}, "disposition": {"const": "diagnostic_only"}
+      }
+    },
+    "semantic_canary": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "packet_count", "edit_shapes", "ua_gec_commit", "battery_sha256", "verification_sha256",
+        "documents_verified", "retrievals_verified", "complete_context", "provider_calls",
+        "operator_display_required_before_provider", "operator_display_confirmed"
+      ],
+      "properties": {
+        "packet_count": {"const": 6},
+        "edit_shapes": {"const": ["substitution", "insertion", "deletion", "reordering", "punctuation_only", "multi_edit"]},
+        "ua_gec_commit": {"const": "4757f72f192c4a41e4c8fb1d9690a948f87cf6d6"},
+        "battery_sha256": {"$ref": "#/$defs/sha256"},
+        "verification_sha256": {"$ref": "#/$defs/sha256"},
+        "documents_verified": {"const": 12}, "retrievals_verified": {"const": 12},
+        "complete_context": {"const": true}, "provider_calls": {"const": false},
+        "operator_display_required_before_provider": {"const": true},
+        "operator_display_confirmed": {"const": true}
+      }
+    },
+    "readiness": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "inventory_compatibility_ready", "university_content_audit_ready", "university_source_freeze_ready",
+        "historical_full_materialization_ready", "historical_evidence_gap_matrix_current",
+        "vspu_post_ingest_audit_ready", "linguistic_representation_ready", "semantic_canary_ready",
+        "functional_role_contract_ready", "complete_evaluation_package_ready", "overall_source_freeze_ready",
+        "missing_requirements"
+      ],
+      "properties": {
+        "inventory_compatibility_ready": {"const": true},
+        "university_content_audit_ready": {"const": true},
+        "university_source_freeze_ready": {"const": true},
+        "historical_full_materialization_ready": {"const": true},
+        "historical_evidence_gap_matrix_current": {"const": true},
+        "saint_sophia_db_reconciliation_ready": {"type": "boolean"},
+        "vspu_post_ingest_audit_ready": {"type": "boolean"},
+        "linguistic_representation_ready": {"const": true},
+        "semantic_canary_ready": {"const": true},
+        "functional_role_contract_ready": {"const": true},
+        "complete_evaluation_package_ready": {"const": false},
+        "overall_source_freeze_ready": {"const": false},
+        "missing_requirements": {
+          "const": [
+            "university_topic_coverage_21_partial",
+            "historical_periodization_and_document_level_review_pending",
+            "additive_source_role_membership_not_frozen",
+            "evidence_backed_v3_heldout_labels_and_sealed_evaluation_package_missing"
+          ]
+        }
+      }
+    },
+    "gates": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "new_train_development_extraction_authorized", "broad_provider_run_authorized",
+        "source_authoring_authorized", "evaluation_partition_frozen", "source_coverage_ready",
+        "source_freeze_ready", "phase3_complete", "phase4_blocked"
+      ],
+      "properties": {
+        "new_train_development_extraction_authorized": {"const": false},
+        "broad_provider_run_authorized": {"const": false},
+        "source_authoring_authorized": {"const": false},
+        "evaluation_partition_frozen": {"const": false},
+        "source_coverage_ready": {"const": false},
+        "source_freeze_ready": {"const": false},
+        "phase3_complete": {"const": false},
+        "phase4_blocked": {"const": true}
+      }
+    },
+    "receipt_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
+++ b/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
@@ -310,6 +310,10 @@ def build_readiness(
     vspu_policy_sha256: str | None = None
     pre_vspu_database_sha256 = sources_database_sha256
     if vspu_post_ingest_audit_path is not None:
+        require(
+            saint_sophia_reconciliation_receipt_path is not None,
+            "VSPU successor evidence requires the Saint Sophia predecessor receipt",
+        )
         vspu_receipt, vspu_receipt_file_sha256, vspu_policy_sha256 = _validate_vspu_post_ingest_audit(
             Path(vspu_post_ingest_audit_path),
             current_database_sha256=sources_database_sha256,

--- a/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
+++ b/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
@@ -48,6 +48,10 @@ UNIVERSITY_FREEZE_PATH = DATA / "admission/phase3_university_content_audit_freez
 VSPU_ADDITIVE_POLICY_PATH = DATA / "admission/phase3_vspu_additive_university_source_policy_v3.json"
 V2_PROMPT_SHA256 = "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
 V3_PROMPT_SHA256 = "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"
+SAINT_SOPHIA_RECONCILIATION_FILE_SHA256 = "3e5188580413261e67a3b94e884113dd932b7054bebeccd4fe9a21b8012e4997"
+SAINT_SOPHIA_RECONCILIATION_RECEIPT_SHA256 = "50f35150acb9e4840e3474e1c6a889bd357eeeb246cb3498a46c7cbc00fec0d4"
+SAINT_SOPHIA_PRE_DATABASE_SHA256 = "de9a46838be3a4a6a2eb979ebdaf64b4d3d9984134b0074281d01b9cfd384876"
+SAINT_SOPHIA_POST_DATABASE_SHA256 = "9fc3bd9e8b5692b5a4f4f0974268ba8031e2ba46099670b1461130be39d61a29"
 PRIVATE_FILE_MODE = 0o600
 
 
@@ -570,13 +574,41 @@ def validate_readiness(value: Mapping[str, Any]) -> dict[str, Any]:
     vspu_denominator = receipt["denominators"].get("vspu_additive_university")
     require((vspu_denominator is not None) is vspu_bound, "VSPU denominator does not equal binding presence")
     if vspu_bound:
+        require(sophia_keys.issubset(bindings), "VSPU successor chain lacks Saint Sophia reconciliation binding")
         require(
             bindings["sources_database_sha256"] == _validate_sources_database(vspu_audit.cutover.DEFAULT_LIVE_DB),
             "live VSPU successor database binding drift",
         )
+        current_university, current_university_file_sha256 = _validate_university_freeze()
+        require(
+            bindings["university_content_audit_freeze_file_sha256"] == current_university_file_sha256,
+            "university freeze file binding drift",
+        )
+        require(
+            bindings["university_content_audit_freeze_receipt_sha256"] == current_university["receipt_sha256"],
+            "university freeze receipt binding drift",
+        )
+        require(
+            current_university["database"]["sha256"] == SAINT_SOPHIA_PRE_DATABASE_SHA256,
+            "university freeze does not equal Saint Sophia predecessor",
+        )
+        expected_sophia_bindings = {
+            "saint_sophia_reconciliation_receipt_file_sha256": SAINT_SOPHIA_RECONCILIATION_FILE_SHA256,
+            "saint_sophia_reconciliation_receipt_sha256": SAINT_SOPHIA_RECONCILIATION_RECEIPT_SHA256,
+            "saint_sophia_reconciliation_implementation_sha256": sha256_file(
+                Path(sophia_reconciliation.__file__).resolve()
+            ),
+            "saint_sophia_reconciliation_schema_sha256": sha256_file(sophia_reconciliation.SCHEMA_PATH),
+        }
+        for key, expected in expected_sophia_bindings.items():
+            require(bindings[key] == expected, f"{key} drift")
         current_vspu, current_file_sha256, current_policy_sha256 = _validate_vspu_post_ingest_audit(
             vspu_audit.DEFAULT_RECEIPT_PATH,
             current_database_sha256=bindings["sources_database_sha256"],
+        )
+        require(
+            current_vspu["database"]["pre_sha256"] == SAINT_SOPHIA_POST_DATABASE_SHA256,
+            "VSPU predecessor does not equal Saint Sophia successor",
         )
         expected_vspu_bindings = {
             "vspu_post_ingest_audit_file_sha256": current_file_sha256,

--- a/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
+++ b/scripts/projects/open_model_data/phase3_v3_prefreeze_readiness.py
@@ -33,16 +33,19 @@ from scripts.projects.open_model_data import phase3_saint_sophia_db_reconciliati
 from scripts.projects.open_model_data import phase3_ua_gec_complete_context as ua_context
 from scripts.projects.open_model_data import phase3_university_content_audit_freeze as university
 from scripts.projects.open_model_data import phase3_v2_compatibility as compatibility
+from scripts.projects.open_model_data import phase3_vspu_post_ingest_audit as vspu_audit
+from scripts.projects.open_model_data import university_source_policy
 
 ROOT = Path(__file__).resolve().parents[3]
 DATA = ROOT / "data/projects/open_model_data"
 SCRIPT_PATH = Path(__file__).resolve()
-SCHEMA_PATH = DATA / "contracts/phase3_v3_prefreeze_readiness_v1.schema.json"
+SCHEMA_PATH = DATA / "contracts/phase3_v3_prefreeze_readiness_v2.schema.json"
 V2_COMPATIBILITY_MATRIX_PATH = DATA / "evidence/phase3_v2_compatibility_matrix_v1.json"
 V2_EVALUATION_CONTRACT_PATH = DATA / "evidence/correction_protection_evaluation_contract_v1.json"
 V2_FUNCTIONAL_ROLE_CONTRACT_PATH = DATA / "evidence/correction_protection_functional_role_contract_v2_1.json"
 NEAR_DUPLICATE_POLICY_PATH = DATA / "evidence/correction_protection_near_duplicate_policy_v1.json"
 UNIVERSITY_FREEZE_PATH = DATA / "admission/phase3_university_content_audit_freeze_v1.json"
+VSPU_ADDITIVE_POLICY_PATH = DATA / "admission/phase3_vspu_additive_university_source_policy_v3.json"
 V2_PROMPT_SHA256 = "298591094d1281629ea444707909b679d1a5368f3ad8afddf39120bc0c34532b"
 V3_PROMPT_SHA256 = "5f22c7fc84ce6ca6d497fcf0437d72274a0bdb3aa1cf48cfebfe196e67dbd11d"
 PRIVATE_FILE_MODE = 0o600
@@ -193,6 +196,49 @@ def _validate_saint_sophia_reconciliation_receipt(
     return receipt, sha256_file(path)
 
 
+def _validate_vspu_post_ingest_audit(path: Path, *, current_database_sha256: str) -> tuple[dict[str, Any], str, str]:
+    value = _read_json(path, "VSPU post-ingest audit receipt")
+    try:
+        receipt = vspu_audit.validate_receipt(value)
+    except vspu_audit.VspuPostIngestAuditError as exc:
+        raise PrefreezeReadinessError(str(exc)) from exc
+    database = receipt["database"]
+    require(
+        database["post_sha256"] == current_database_sha256,
+        "VSPU post-database hash does not equal current sources database",
+    )
+    require(database["pre_sha256"] != database["post_sha256"], "VSPU database chain did not advance")
+    require(database["target_rows"] == 158, "VSPU row denominator drift")
+    require(database["target_fts_rows"] == 158, "VSPU FTS denominator drift")
+    require(database["target_section_rows"] == 158, "VSPU section denominator drift")
+    require(database["target_linked_rows"] == 158, "VSPU linkage denominator drift")
+    require(
+        receipt["phase_boundaries"]["source_universe_frozen"] is False,
+        "VSPU audit overclaims source-universe freeze",
+    )
+    require(receipt["phase_boundaries"]["source_coverage_ready"] is False, "VSPU audit overclaims coverage")
+    require(receipt["phase_boundaries"]["phase3_complete"] is False, "VSPU audit overclaims Phase 3")
+    require(receipt["phase_boundaries"]["phase4_blocked"] is True, "VSPU audit opens Phase 4")
+    try:
+        policy, policy_sha256 = university_source_policy.load_policy(VSPU_ADDITIVE_POLICY_PATH)
+    except university_source_policy.UniversitySourcePolicyError as exc:
+        raise PrefreezeReadinessError(str(exc)) from exc
+    require(
+        policy_sha256 == vspu_audit.cutover.EXPECTED_ADDITIVE_POLICY_SHA256,
+        "VSPU additive policy byte drift",
+    )
+    require(policy["source_count"] == 1 and len(policy["sources"]) == 1, "VSPU additive policy denominator drift")
+    source = policy["sources"][0]
+    authority = receipt["authority"]
+    require(source["source_file"] == authority["source_id"], "VSPU policy/audit source identity drift")
+    require(source["content_disposition"] == authority["content_disposition"], "VSPU disposition drift")
+    require(source["allowed_lanes"] == authority["allowed_lanes"], "VSPU allowed-lane drift")
+    require(authority["normative_rule_authority"] is False, "VSPU gained normative rule authority")
+    require(authority["semantic_gold"] is False, "VSPU gained semantic-gold authority")
+    require(authority["public_redistribution_authorized"] is False, "VSPU gained redistribution authority")
+    return receipt, sha256_file(path), policy_sha256
+
+
 def _validate_university_freeze() -> tuple[dict[str, Any], str]:
     value = _read_json(UNIVERSITY_FREEZE_PATH, "university content-audit freeze")
     try:
@@ -234,6 +280,7 @@ def build_readiness(
     ua_gec_context_receipt_path: Path,
     historical_full_receipt_path: Path,
     saint_sophia_reconciliation_receipt_path: Path | None = None,
+    vspu_post_ingest_audit_path: Path | None = None,
 ) -> dict[str, Any]:
     """Build and validate the deterministic, explicitly incomplete receipt."""
     _validate_reboot_prompt(Path(phase3_reboot_prompt_path))
@@ -250,26 +297,36 @@ def build_readiness(
     require(compatibility_result["source_authoring_blocked"] is True, "v2 compatibility opens source authoring")
     require(compatibility_result["phase4_blocked"] is True, "v2 compatibility opens Phase 4")
 
-    ua_receipt, ua_receipt_file_sha256 = _validate_ua_context_receipt(
-        Path(ua_gec_context_receipt_path), sources_database_sha256
-    )
     university_freeze, university_file_sha256 = _validate_university_freeze()
     historical_receipt, historical_receipt_file_sha256 = _validate_historical_receipt(
         Path(historical_full_receipt_path), historical_gate_file_sha256
     )
+    vspu_receipt: dict[str, Any] | None = None
+    vspu_receipt_file_sha256: str | None = None
+    vspu_policy_sha256: str | None = None
+    pre_vspu_database_sha256 = sources_database_sha256
+    if vspu_post_ingest_audit_path is not None:
+        vspu_receipt, vspu_receipt_file_sha256, vspu_policy_sha256 = _validate_vspu_post_ingest_audit(
+            Path(vspu_post_ingest_audit_path),
+            current_database_sha256=sources_database_sha256,
+        )
+        pre_vspu_database_sha256 = vspu_receipt["database"]["pre_sha256"]
     sophia_receipt: dict[str, Any] | None = None
     sophia_receipt_file_sha256: str | None = None
     if saint_sophia_reconciliation_receipt_path is not None:
         sophia_receipt, sophia_receipt_file_sha256 = _validate_saint_sophia_reconciliation_receipt(
             Path(saint_sophia_reconciliation_receipt_path),
             university_database_sha256=university_freeze["database"]["sha256"],
-            current_database_sha256=sources_database_sha256,
+            current_database_sha256=pre_vspu_database_sha256,
         )
     else:
         require(
-            university_freeze["database"]["sha256"] == sources_database_sha256,
-            "university freeze and sources database hash disagree",
+            university_freeze["database"]["sha256"] == pre_vspu_database_sha256,
+            "university freeze and next database-chain state disagree",
         )
+    ua_receipt, ua_receipt_file_sha256 = _validate_ua_context_receipt(
+        Path(ua_gec_context_receipt_path), pre_vspu_database_sha256
+    )
     battery, canary_verification = _validate_canary(Path(ua_gec_root))
     historical_evidence_spine = historical_evidence.load_spine()
 
@@ -282,7 +339,7 @@ def build_readiness(
     require(6_462 + 2_930 == 9_392 and 906 + 8_486 == 9_392, "Cycle 002 diagnostic accounting drift")
 
     body: dict[str, Any] = {
-        "schema_version": "phase3_v3_prefreeze_readiness_v1",
+        "schema_version": "phase3_v3_prefreeze_readiness_v2",
         "status": "PREFREEZE_BLOCKED_PENDING_COMPLETE_EVALUATION_PACKAGE",
         "text_free": True,
         "provider_calls": False,
@@ -325,6 +382,17 @@ def build_readiness(
                 if sophia_receipt is not None
                 else {}
             ),
+            **(
+                {
+                    "vspu_post_ingest_audit_file_sha256": vspu_receipt_file_sha256,
+                    "vspu_post_ingest_audit_receipt_sha256": vspu_receipt["receipt_sha256"],
+                    "vspu_post_ingest_audit_implementation_sha256": sha256_file(Path(vspu_audit.__file__).resolve()),
+                    "vspu_post_ingest_audit_schema_sha256": sha256_file(vspu_audit.SCHEMA_PATH),
+                    "vspu_additive_policy_sha256": vspu_policy_sha256,
+                }
+                if vspu_receipt is not None
+                else {}
+            ),
             "sources_database_sha256": sources_database_sha256,
             "prefreeze_implementation_sha256": sha256_file(SCRIPT_PATH),
             "prefreeze_schema_sha256": sha256_file(SCHEMA_PATH),
@@ -343,6 +411,20 @@ def build_readiness(
                 "partial_topics": university_topics["partial"],
                 "sufficient_topics": university_topics["sufficient"],
             },
+            **(
+                {
+                    "vspu_additive_university": {
+                        "policy_sources": 1,
+                        "database_sources": 1,
+                        "database_rows": vspu_receipt["database"]["target_rows"],
+                        "database_fts_rows": vspu_receipt["database"]["target_fts_rows"],
+                        "database_section_rows": vspu_receipt["database"]["target_section_rows"],
+                        "database_linked_rows": vspu_receipt["database"]["target_linked_rows"],
+                    }
+                }
+                if vspu_receipt is not None
+                else {}
+            ),
             "historical": {
                 "ud_documents": historical_denominators["ud_explicit_orv_uk"]["documents"],
                 "ud_sentences": historical_denominators["ud_explicit_orv_uk"]["sentences"],
@@ -358,6 +440,10 @@ def build_readiness(
             "historical_forms_protected": True,
             "historical_modern_correction_eligible": False,
             "conversion_started": False,
+            "vspu_contextual_source_ingested": vspu_receipt is not None,
+            "vspu_normative_rule_authority": False,
+            "vspu_semantic_gold": False,
+            "vspu_public_redistribution_authorized": False,
         },
         "cycle002": {
             "identities": 9_392,
@@ -389,6 +475,7 @@ def build_readiness(
             "historical_full_materialization_ready": True,
             "historical_evidence_gap_matrix_current": True,
             "saint_sophia_db_reconciliation_ready": sophia_receipt is not None,
+            "vspu_post_ingest_audit_ready": vspu_receipt is not None,
             "linguistic_representation_ready": True,
             "semantic_canary_ready": True,
             "functional_role_contract_ready": True,
@@ -460,6 +547,62 @@ def validate_readiness(value: Mapping[str, Any]) -> dict[str, Any]:
             readiness_value is sophia_keys.issubset(bindings),
             "Saint Sophia readiness does not equal reconciliation binding presence",
         )
+    vspu_keys = {
+        "vspu_post_ingest_audit_file_sha256",
+        "vspu_post_ingest_audit_receipt_sha256",
+        "vspu_post_ingest_audit_implementation_sha256",
+        "vspu_post_ingest_audit_schema_sha256",
+        "vspu_additive_policy_sha256",
+    }
+    require(
+        vspu_keys.issubset(bindings) or not vspu_keys.intersection(bindings),
+        "partial VSPU post-ingest binding",
+    )
+    vspu_bound = vspu_keys.issubset(bindings)
+    require(
+        receipt["readiness"]["vspu_post_ingest_audit_ready"] is vspu_bound,
+        "VSPU readiness does not equal post-ingest binding presence",
+    )
+    require(
+        receipt["additive_sources"]["vspu_contextual_source_ingested"] is vspu_bound,
+        "VSPU ingest state does not equal post-ingest binding presence",
+    )
+    vspu_denominator = receipt["denominators"].get("vspu_additive_university")
+    require((vspu_denominator is not None) is vspu_bound, "VSPU denominator does not equal binding presence")
+    if vspu_bound:
+        require(
+            bindings["sources_database_sha256"] == _validate_sources_database(vspu_audit.cutover.DEFAULT_LIVE_DB),
+            "live VSPU successor database binding drift",
+        )
+        current_vspu, current_file_sha256, current_policy_sha256 = _validate_vspu_post_ingest_audit(
+            vspu_audit.DEFAULT_RECEIPT_PATH,
+            current_database_sha256=bindings["sources_database_sha256"],
+        )
+        expected_vspu_bindings = {
+            "vspu_post_ingest_audit_file_sha256": current_file_sha256,
+            "vspu_post_ingest_audit_receipt_sha256": current_vspu["receipt_sha256"],
+            "vspu_post_ingest_audit_implementation_sha256": sha256_file(Path(vspu_audit.__file__).resolve()),
+            "vspu_post_ingest_audit_schema_sha256": sha256_file(vspu_audit.SCHEMA_PATH),
+            "vspu_additive_policy_sha256": current_policy_sha256,
+        }
+        for key, expected in expected_vspu_bindings.items():
+            require(bindings[key] == expected, f"{key} drift")
+        require(
+            current_vspu["database"]["post_sha256"] == bindings["sources_database_sha256"],
+            "VSPU successor/database binding drift",
+        )
+        require(
+            vspu_denominator
+            == {
+                "policy_sources": 1,
+                "database_sources": 1,
+                "database_rows": current_vspu["database"]["target_rows"],
+                "database_fts_rows": current_vspu["database"]["target_fts_rows"],
+                "database_section_rows": current_vspu["database"]["target_section_rows"],
+                "database_linked_rows": current_vspu["database"]["target_linked_rows"],
+            },
+            "VSPU additive denominator drift",
+        )
     return receipt
 
 
@@ -485,6 +628,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--ua-gec-context-receipt", type=Path, required=True)
     parser.add_argument("--historical-full-receipt", type=Path, required=True)
     parser.add_argument("--saint-sophia-reconciliation-receipt", type=Path)
+    parser.add_argument("--vspu-post-ingest-audit", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args(argv)
 
@@ -499,6 +643,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ua_gec_context_receipt_path=args.ua_gec_context_receipt,
             historical_full_receipt_path=args.historical_full_receipt,
             saint_sophia_reconciliation_receipt_path=args.saint_sophia_reconciliation_receipt,
+            vspu_post_ingest_audit_path=args.vspu_post_ingest_audit,
         )
         _atomic_write(args.output, canonical_bytes(receipt))
         print(canonical_json({"ok": True, "output": str(args.output), "receipt_sha256": receipt["receipt_sha256"]}))

--- a/tests/test_open_model_phase3_v3_prefreeze_readiness.py
+++ b/tests/test_open_model_phase3_v3_prefreeze_readiness.py
@@ -65,6 +65,49 @@ def _build(monkeypatch: pytest.MonkeyPatch) -> dict:
     )
 
 
+def _with_current_vspu_chain(monkeypatch: pytest.MonkeyPatch) -> dict:
+    receipt = _build(monkeypatch)
+    tracked_vspu = json.loads(readiness.vspu_audit.DEFAULT_RECEIPT_PATH.read_text(encoding="utf-8"))
+    receipt["bindings"].update(
+        {
+            "saint_sophia_reconciliation_receipt_file_sha256": (readiness.SAINT_SOPHIA_RECONCILIATION_FILE_SHA256),
+            "saint_sophia_reconciliation_receipt_sha256": (readiness.SAINT_SOPHIA_RECONCILIATION_RECEIPT_SHA256),
+            "saint_sophia_reconciliation_implementation_sha256": readiness.sha256_file(
+                Path(readiness.sophia_reconciliation.__file__).resolve()
+            ),
+            "saint_sophia_reconciliation_schema_sha256": readiness.sha256_file(
+                readiness.sophia_reconciliation.SCHEMA_PATH
+            ),
+            "vspu_post_ingest_audit_file_sha256": readiness.sha256_file(readiness.vspu_audit.DEFAULT_RECEIPT_PATH),
+            "vspu_post_ingest_audit_receipt_sha256": tracked_vspu["receipt_sha256"],
+            "vspu_post_ingest_audit_implementation_sha256": readiness.sha256_file(
+                Path(readiness.vspu_audit.__file__).resolve()
+            ),
+            "vspu_post_ingest_audit_schema_sha256": readiness.sha256_file(readiness.vspu_audit.SCHEMA_PATH),
+            "vspu_additive_policy_sha256": readiness.vspu_audit.cutover.EXPECTED_ADDITIVE_POLICY_SHA256,
+            "sources_database_sha256": readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
+        }
+    )
+    receipt["denominators"]["vspu_additive_university"] = {
+        "policy_sources": 1,
+        "database_sources": 1,
+        "database_rows": 158,
+        "database_fts_rows": 158,
+        "database_section_rows": 158,
+        "database_linked_rows": 158,
+    }
+    receipt["additive_sources"]["vspu_contextual_source_ingested"] = True
+    receipt["readiness"]["saint_sophia_db_reconciliation_ready"] = True
+    receipt["readiness"]["vspu_post_ingest_audit_ready"] = True
+    receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
+    monkeypatch.setattr(
+        readiness,
+        "_validate_sources_database",
+        lambda _path: readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
+    )
+    return receipt
+
+
 def test_build_is_deterministic_text_free_and_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     first = _build(monkeypatch)
     second = readiness.build_readiness(
@@ -462,6 +505,46 @@ def test_validator_rejects_fabricated_saint_sophia_binding_in_vspu_chain(
     receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
 
     with pytest.raises(readiness.PrefreezeReadinessError, match="saint_sophia_reconciliation_receipt_sha256 drift"):
+        readiness.validate_readiness(receipt)
+
+
+def test_validator_rejects_university_to_saint_sophia_boundary_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _with_current_vspu_chain(monkeypatch)
+    university_freeze, university_file_sha256 = readiness._validate_university_freeze()
+    drifted_university = copy.deepcopy(university_freeze)
+    drifted_university["database"]["sha256"] = "f" * 64
+    drifted_university["receipt_sha256"] = SHA_A
+    receipt["bindings"]["university_content_audit_freeze_receipt_sha256"] = SHA_A
+    receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
+    monkeypatch.setattr(
+        readiness,
+        "_validate_university_freeze",
+        lambda: (drifted_university, university_file_sha256),
+    )
+
+    with pytest.raises(readiness.PrefreezeReadinessError, match="does not equal Saint Sophia predecessor"):
+        readiness.validate_readiness(receipt)
+
+
+def test_validator_rejects_saint_sophia_to_vspu_boundary_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _with_current_vspu_chain(monkeypatch)
+    tracked_vspu, vspu_file_sha256, policy_sha256 = readiness._validate_vspu_post_ingest_audit(
+        readiness.vspu_audit.DEFAULT_RECEIPT_PATH,
+        current_database_sha256=readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
+    )
+    drifted_vspu = copy.deepcopy(tracked_vspu)
+    drifted_vspu["database"]["pre_sha256"] = "f" * 64
+    monkeypatch.setattr(
+        readiness,
+        "_validate_vspu_post_ingest_audit",
+        lambda _path, *, current_database_sha256: (drifted_vspu, vspu_file_sha256, policy_sha256),
+    )
+
+    with pytest.raises(readiness.PrefreezeReadinessError, match="does not equal Saint Sophia successor"):
         readiness.validate_readiness(receipt)
 
 

--- a/tests/test_open_model_phase3_v3_prefreeze_readiness.py
+++ b/tests/test_open_model_phase3_v3_prefreeze_readiness.py
@@ -370,12 +370,12 @@ def test_vspu_receipt_extends_sophia_and_ua_context_chain_without_opening_gates(
     assert receipt["gates"]["phase4_blocked"] is True
 
 
-def test_vspu_chain_requires_sophia_when_university_hash_is_not_its_predecessor(
+def test_vspu_chain_requires_sophia_even_when_predecessor_hash_aligns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_external_receipts(monkeypatch)
     post_sha = "c" * 64
-    predecessor_sha = "d" * 64
+    predecessor_sha = readiness.university.EXPECTED_DATABASE["sha256"]
     monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: post_sha)
     monkeypatch.setattr(
         readiness,
@@ -397,7 +397,7 @@ def test_vspu_chain_requires_sophia_when_university_hash_is_not_its_predecessor(
         ),
     )
 
-    with pytest.raises(readiness.PrefreezeReadinessError, match="next database-chain state"):
+    with pytest.raises(readiness.PrefreezeReadinessError, match="requires the Saint Sophia predecessor receipt"):
         readiness.build_readiness(
             phase3_reboot_prompt_path=Path("unused"),
             sources_database_path=Path("unused"),

--- a/tests/test_open_model_phase3_v3_prefreeze_readiness.py
+++ b/tests/test_open_model_phase3_v3_prefreeze_readiness.py
@@ -76,6 +76,7 @@ def test_build_is_deterministic_text_free_and_fail_closed(monkeypatch: pytest.Mo
     )
 
     assert first == second
+    assert first["schema_version"] == "phase3_v3_prefreeze_readiness_v2"
     assert first["text_free"] is True
     assert first["provider_calls"] is False
     assert first["denominators"]["v2"] == {
@@ -95,6 +96,9 @@ def test_build_is_deterministic_text_free_and_fail_closed(monkeypatch: pytest.Mo
     assert first["cycle002"]["disposition"] == "diagnostic_only"
     assert first["cycle002"]["semantic_gold"] is False
     assert first["additive_sources"]["university_and_historical_outside_v2_totals"] is True
+    assert first["additive_sources"]["vspu_contextual_source_ingested"] is False
+    assert first["additive_sources"]["vspu_normative_rule_authority"] is False
+    assert first["readiness"]["vspu_post_ingest_audit_ready"] is False
     assert first["semantic_canary"]["packet_count"] == 6
     assert first["semantic_canary"]["operator_display_confirmed"] is True
     assert first["readiness"]["complete_evaluation_package_ready"] is False
@@ -235,6 +239,181 @@ def test_optional_saint_sophia_receipt_allows_distinct_pre_and_post_database_has
     )
     assert captured == {"pre": pre_sha, "post": post_sha}
     assert receipt["bindings"]["sources_database_sha256"] == post_sha
+
+
+def test_vspu_receipt_extends_sophia_and_ua_context_chain_without_opening_gates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_external_receipts(monkeypatch)
+    university_sha = readiness.university.EXPECTED_DATABASE["sha256"]
+    sophia_sha = "c" * 64
+    vspu_sha = "d" * 64
+    policy_sha = "e" * 64
+    monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: vspu_sha)
+    vspu_receipt = {
+        "receipt_sha256": SHA_A,
+        "database": {
+            "pre_sha256": sophia_sha,
+            "post_sha256": vspu_sha,
+            "target_rows": 158,
+            "target_fts_rows": 158,
+            "target_section_rows": 158,
+            "target_linked_rows": 158,
+        },
+    }
+    vspu_calls: list[tuple[str, str]] = []
+    sophia_calls: list[tuple[str, str]] = []
+    ua_database_bindings: list[str] = []
+
+    def validate_vspu(path: Path, *, current_database_sha256: str) -> tuple[dict, str, str]:
+        vspu_calls.append((str(path), current_database_sha256))
+        return vspu_receipt, SHA_B, policy_sha
+
+    def validate_sophia(
+        _path: Path, *, university_database_sha256: str, current_database_sha256: str
+    ) -> tuple[dict, str]:
+        sophia_calls.append((university_database_sha256, current_database_sha256))
+        return {"receipt_sha256": SHA_B}, SHA_A
+
+    def validate_ua(_path: Path, database_sha256: str) -> tuple[dict, str]:
+        ua_database_bindings.append(database_sha256)
+        return (
+            {
+                "receipt_sha256": SHA_A,
+                "complete_context": {
+                    "eligible_context_record_count": 6_698,
+                    "eligible_v2_unit_count": 8_934,
+                    "excluded_v2_unit_count_by_reason": {"target_sentence_not_exactly_aligned": 3},
+                },
+            },
+            SHA_A,
+        )
+
+    monkeypatch.setattr(readiness, "_validate_vspu_post_ingest_audit", validate_vspu)
+    monkeypatch.setattr(readiness, "_validate_saint_sophia_reconciliation_receipt", validate_sophia)
+    monkeypatch.setattr(readiness, "_validate_ua_context_receipt", validate_ua)
+    receipt = readiness.build_readiness(
+        phase3_reboot_prompt_path=Path("unused"),
+        sources_database_path=Path("unused"),
+        ua_gec_root=Path("unused"),
+        ua_gec_context_receipt_path=Path("unused"),
+        historical_full_receipt_path=Path("unused"),
+        saint_sophia_reconciliation_receipt_path=Path("sophia.json"),
+        vspu_post_ingest_audit_path=Path("vspu.json"),
+    )
+
+    assert vspu_calls == [("vspu.json", vspu_sha), (str(readiness.vspu_audit.DEFAULT_RECEIPT_PATH), vspu_sha)]
+    assert sophia_calls == [(university_sha, sophia_sha)]
+    assert ua_database_bindings == [sophia_sha]
+    assert receipt["bindings"]["sources_database_sha256"] == vspu_sha
+    assert receipt["bindings"]["vspu_additive_policy_sha256"] == policy_sha
+    assert receipt["denominators"]["vspu_additive_university"] == {
+        "policy_sources": 1,
+        "database_sources": 1,
+        "database_rows": 158,
+        "database_fts_rows": 158,
+        "database_section_rows": 158,
+        "database_linked_rows": 158,
+    }
+    assert receipt["additive_sources"]["vspu_contextual_source_ingested"] is True
+    assert receipt["additive_sources"]["vspu_normative_rule_authority"] is False
+    assert receipt["additive_sources"]["vspu_semantic_gold"] is False
+    assert receipt["readiness"]["vspu_post_ingest_audit_ready"] is True
+    assert receipt["gates"]["source_freeze_ready"] is False
+    assert receipt["gates"]["phase3_complete"] is False
+    assert receipt["gates"]["phase4_blocked"] is True
+
+
+def test_vspu_chain_requires_sophia_when_university_hash_is_not_its_predecessor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_external_receipts(monkeypatch)
+    post_sha = "c" * 64
+    predecessor_sha = "d" * 64
+    monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: post_sha)
+    monkeypatch.setattr(
+        readiness,
+        "_validate_vspu_post_ingest_audit",
+        lambda _path, *, current_database_sha256: (
+            {
+                "receipt_sha256": SHA_A,
+                "database": {
+                    "pre_sha256": predecessor_sha,
+                    "post_sha256": current_database_sha256,
+                    "target_rows": 158,
+                    "target_fts_rows": 158,
+                    "target_section_rows": 158,
+                    "target_linked_rows": 158,
+                },
+            },
+            SHA_B,
+            SHA_A,
+        ),
+    )
+
+    with pytest.raises(readiness.PrefreezeReadinessError, match="next database-chain state"):
+        readiness.build_readiness(
+            phase3_reboot_prompt_path=Path("unused"),
+            sources_database_path=Path("unused"),
+            ua_gec_root=Path("unused"),
+            ua_gec_context_receipt_path=Path("unused"),
+            historical_full_receipt_path=Path("unused"),
+            vspu_post_ingest_audit_path=Path("vspu.json"),
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["partial_binding", "readiness_without_binding", "denominator_without_binding"],
+)
+def test_validator_rejects_incomplete_vspu_claims(
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    receipt = _build(monkeypatch)
+    if mutation == "partial_binding":
+        receipt["bindings"]["vspu_post_ingest_audit_file_sha256"] = SHA_A
+    elif mutation == "readiness_without_binding":
+        receipt["readiness"]["vspu_post_ingest_audit_ready"] = True
+    else:
+        receipt["denominators"]["vspu_additive_university"] = {
+            "policy_sources": 1,
+            "database_sources": 1,
+            "database_rows": 158,
+            "database_fts_rows": 158,
+            "database_section_rows": 158,
+            "database_linked_rows": 158,
+        }
+    receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
+
+    with pytest.raises(readiness.PrefreezeReadinessError):
+        readiness.validate_readiness(receipt)
+
+
+def test_tracked_vspu_receipt_and_policy_validate_against_successor() -> None:
+    receipt, file_sha256, policy_sha256 = readiness._validate_vspu_post_ingest_audit(
+        readiness.vspu_audit.DEFAULT_RECEIPT_PATH,
+        current_database_sha256=readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
+    )
+
+    assert file_sha256 == readiness.sha256_file(readiness.vspu_audit.DEFAULT_RECEIPT_PATH)
+    assert policy_sha256 == readiness.vspu_audit.cutover.EXPECTED_ADDITIVE_POLICY_SHA256
+    assert receipt["database"]["pre_sha256"] == readiness.vspu_audit.cutover.EXPECTED_PRE_DB_SHA256
+    assert receipt["database"]["post_sha256"] == readiness.vspu_audit.EXPECTED_POST_DB_SHA256
+
+
+def test_vspu_validator_rejects_resealed_authority_escalation(tmp_path: Path) -> None:
+    receipt = json.loads(readiness.vspu_audit.DEFAULT_RECEIPT_PATH.read_text(encoding="utf-8"))
+    receipt["authority"]["semantic_gold"] = True
+    receipt["receipt_sha256"] = readiness.vspu_audit.receipt_sha256(receipt)
+    path = tmp_path / "tampered-vspu.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(readiness.PrefreezeReadinessError):
+        readiness._validate_vspu_post_ingest_audit(
+            path,
+            current_database_sha256=readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
+        )
 
 
 def test_validator_rejects_saint_sophia_readiness_without_matching_bindings(

--- a/tests/test_open_model_phase3_v3_prefreeze_readiness.py
+++ b/tests/test_open_model_phase3_v3_prefreeze_readiness.py
@@ -246,7 +246,7 @@ def test_vspu_receipt_extends_sophia_and_ua_context_chain_without_opening_gates(
 ) -> None:
     _stub_external_receipts(monkeypatch)
     university_sha = readiness.university.EXPECTED_DATABASE["sha256"]
-    sophia_sha = "c" * 64
+    sophia_sha = readiness.SAINT_SOPHIA_POST_DATABASE_SHA256
     vspu_sha = "d" * 64
     policy_sha = "e" * 64
     monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: vspu_sha)
@@ -273,7 +273,10 @@ def test_vspu_receipt_extends_sophia_and_ua_context_chain_without_opening_gates(
         _path: Path, *, university_database_sha256: str, current_database_sha256: str
     ) -> tuple[dict, str]:
         sophia_calls.append((university_database_sha256, current_database_sha256))
-        return {"receipt_sha256": SHA_B}, SHA_A
+        return (
+            {"receipt_sha256": readiness.SAINT_SOPHIA_RECONCILIATION_RECEIPT_SHA256},
+            readiness.SAINT_SOPHIA_RECONCILIATION_FILE_SHA256,
+        )
 
     def validate_ua(_path: Path, database_sha256: str) -> tuple[dict, str]:
         ua_database_bindings.append(database_sha256)
@@ -414,6 +417,52 @@ def test_vspu_validator_rejects_resealed_authority_escalation(tmp_path: Path) ->
             path,
             current_database_sha256=readiness.vspu_audit.EXPECTED_POST_DB_SHA256,
         )
+
+
+def test_validator_rejects_fabricated_saint_sophia_binding_in_vspu_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_external_receipts(monkeypatch)
+    vspu_sha = "d" * 64
+    vspu_receipt = {
+        "receipt_sha256": SHA_A,
+        "database": {
+            "pre_sha256": readiness.SAINT_SOPHIA_POST_DATABASE_SHA256,
+            "post_sha256": vspu_sha,
+            "target_rows": 158,
+            "target_fts_rows": 158,
+            "target_section_rows": 158,
+            "target_linked_rows": 158,
+        },
+    }
+    monkeypatch.setattr(readiness, "_validate_sources_database", lambda _path: vspu_sha)
+    monkeypatch.setattr(
+        readiness,
+        "_validate_vspu_post_ingest_audit",
+        lambda _path, *, current_database_sha256: (vspu_receipt, SHA_B, SHA_A),
+    )
+    monkeypatch.setattr(
+        readiness,
+        "_validate_saint_sophia_reconciliation_receipt",
+        lambda _path, *, university_database_sha256, current_database_sha256: (
+            {"receipt_sha256": readiness.SAINT_SOPHIA_RECONCILIATION_RECEIPT_SHA256},
+            readiness.SAINT_SOPHIA_RECONCILIATION_FILE_SHA256,
+        ),
+    )
+    receipt = readiness.build_readiness(
+        phase3_reboot_prompt_path=Path("unused"),
+        sources_database_path=Path("unused"),
+        ua_gec_root=Path("unused"),
+        ua_gec_context_receipt_path=Path("unused"),
+        historical_full_receipt_path=Path("unused"),
+        saint_sophia_reconciliation_receipt_path=Path("sophia.json"),
+        vspu_post_ingest_audit_path=Path("vspu.json"),
+    )
+    receipt["bindings"]["saint_sophia_reconciliation_receipt_sha256"] = SHA_A
+    receipt["receipt_sha256"] = readiness.receipt_sha256(receipt)
+
+    with pytest.raises(readiness.PrefreezeReadinessError, match="saint_sophia_reconciliation_receipt_sha256 drift"):
+        readiness.validate_readiness(receipt)
 
 
 def test_validator_rejects_saint_sophia_readiness_without_matching_bindings(


### PR DESCRIPTION
## Outcome

Binds the exact university baseline → Saint Sophia → VSPU successor database chain in the Phase 3 v3 prefreeze readiness receipt.

- validates the tracked contextual-only VSPU policy and exact 158-row/FTS/section/linkage denominator
- re-derives both database-chain boundaries during standalone validation
- requires the Saint Sophia predecessor receipt whenever VSPU successor evidence is supplied
- pins the VSPU audit implementation/schema without changing immutable v2 totals
- keeps source freeze, authoring, broad provider work, and Phase 3 completion false; Phase 4 remains blocked

Part of #6375 and #6321.

## Verification

- Ruff check and format check: passed
- git diff --check: passed
- 172 neighboring Phase 3 tests: passed
- real text-free v2 prefreeze receipt generated against the live database and byte-pinned Drive evidence: passed
- independent cross-family exact-head review by Claude Sonnet 5: clean, no findings

## Non-goals

This PR does not close university topic gaps, freeze final source/role membership, create semantic gold, complete Phase 3, or authorize Phase 4.