### PR TITLE
fix(deploy): allowlist practice-deck pointer for Pages auto-deploy

### DIFF
--- a/scripts/deploy/auto_deploy_eligibility.py
+++ b/scripts/deploy/auto_deploy_eligibility.py
@@ -22,9 +22,20 @@ CONTENT_PATH_PREFIXES = (
     "site/src/data/",
 )
 
+# Exact release-pointer files under ``site/src/data/``.  A pointer bump only
+# retargets an already-published Release asset; it is not curriculum/content
+# drift.  Everything else under ``site/src/data/`` stays denied (#6733).
+SITE_CODE_PATH_EXCEPTIONS = frozenset(
+    {
+        "site/src/data/lexicon-practice-deck.pointer.json",
+        "site/src/data/lexicon-manifest.pointer.json",
+    }
+)
+
 # This is deliberately broad enough for regular Astro UI, style, asset, and
 # dependency changes, but it does not grant permission to any path outside the
-# site tree.  ``CONTENT_PATH_PREFIXES`` is always evaluated first.
+# site tree.  ``CONTENT_PATH_PREFIXES`` is always evaluated first unless the
+# path is an exact ``SITE_CODE_PATH_EXCEPTIONS`` entry.
 SITE_CODE_PATH_PREFIXES = ("site/",)
 
 
@@ -47,6 +58,12 @@ def decide_auto_deploy(changed_paths: Iterable[str]) -> AutoDeployDecision:
         return AutoDeployDecision(deploy=False, reason="no_changed_paths")
 
     for path in paths:
+        if path in SITE_CODE_PATH_EXCEPTIONS:
+            # Still require the site-code prefix so a typo'd exception cannot
+            # open non-site paths.
+            if not _has_prefix(path, SITE_CODE_PATH_PREFIXES):
+                return AutoDeployDecision(deploy=False, reason="unknown_path")
+            continue
         if _has_prefix(path, CONTENT_PATH_PREFIXES):
             return AutoDeployDecision(deploy=False, reason="content_drift")
         if not _has_prefix(path, SITE_CODE_PATH_PREFIXES):

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -87,6 +87,31 @@ def test_auto_deploy_accepts_only_site_code_since_last_successful_deployment(tmp
     )
 
 
+def test_auto_deploy_allows_release_pointer_bumps_not_bulk_data() -> None:
+    """#6733: practice-deck / manifest pointers are site-code; other data is drift."""
+    practice_pointer = "site/src/data/lexicon-practice-deck.pointer.json"
+    manifest_pointer = "site/src/data/lexicon-manifest.pointer.json"
+
+    practice_only = decide_auto_deploy([practice_pointer])
+    assert practice_only.deploy is True
+    assert practice_only.reason == "site_code_only"
+
+    manifest_only = decide_auto_deploy([manifest_pointer])
+    assert manifest_only.deploy is True
+    assert manifest_only.reason == "site_code_only"
+
+    mixed = decide_auto_deploy([practice_pointer, "site/src/components/Practice.tsx"])
+    assert mixed.deploy is True
+    assert mixed.reason == "site_code_only"
+
+    with_scripts = decide_auto_deploy([practice_pointer, "scripts/practice_deck/publish.py"])
+    assert with_scripts.deploy is False
+    assert with_scripts.reason == "unknown_path"
+
+    assert decide_auto_deploy(["site/src/data/lexicon-manifest.json"]).reason == "content_drift"
+    assert decide_auto_deploy(["site/src/data/lexicon-search-index.json"]).reason == "content_drift"
+
+
 def test_pages_workflow_uses_fail_closed_auto_deploy_preflight() -> None:
     """The manual certification route remains available beside the push preflight."""
     workflow_text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Exact-path allowlist for `site/src/data/lexicon-practice-deck.pointer.json` and `lexicon-manifest.pointer.json` so pointer-only pushes classify as `site_code_only` (#6733).
- All other `site/src/data/` (including `lexicon-manifest.json`), `curriculum/`, and `site/src/content/` stay `content_drift`; any `scripts/` path still `unknown_path`.
- Force-deploy already unstuck live Pages: https://github.com/learn-ukrainian/learn-ukrainian.github.io/actions/runs/31720792891 (`conclusion: success`).

## Test plan
- [x] `ruff check scripts/deploy/auto_deploy_eligibility.py tests/test_deploy_pages_workflow.py` → All checks passed
- [x] `pytest tests/test_deploy_pages_workflow.py` → 6 passed
- [ ] CI green on this PR

Closes #6733

Made with [Cursor](https://cursor.com)