### PR TITLE
fix(practice): A1 empty synonym no longer opens 0/0 antonym sessions (#6734)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: a47ff4a5546155369e0f733ab957e38ee5a360469abd4dacc1a18ff78f184774
+  components_sha256: e72adab990be126ea7b38053d65b37d633f00fb9fde71de3278ec411805a5d14
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1344,13 +1344,22 @@ function sessionScopeIndexForMode(
  * selected level first. Counting higher-level synonym lemmas on an A1 home made
  * Синоніми look stocked (live: 287) while the A1 plan was 0/0 and then briefly
  * served a bled-in antonym-polarity item. Mode-card honesty follows the selected
- * learner level's CEFR — empty stays empty even when antonym (or higher-level
- * synonym) inventory exists elsewhere.
+ * learner level's CEFR when the index mixes levels — empty stays empty even when
+ * antonym (or higher-level synonym) inventory exists elsewhere.
+ *
+ * Single-CEFR indexes (a level shard, or an `initialDeck` fixture) are left intact
+ * so a learnerLevel/deckLevel mismatch cannot zero out a real mode card.
  */
 function indexForModeCounts(
   index: PracticeIndexItem[],
   learnerLevel: CefrLevel,
 ): PracticeIndexItem[] {
+  const levels = new Set<CefrLevel>();
+  for (const item of index) {
+    const level = parseCefrLevel(item.cefr);
+    if (level) levels.add(level);
+  }
+  if (levels.size <= 1) return index;
   return index.filter((item) => parseCefrLevel(item.cefr) === learnerLevel);
 }
 
@@ -1901,11 +1910,19 @@ function LexiconPracticeIsland({
       }
     }
 
-    const plan = computeSessionScope(
-      sessionScopeIndexForMode(filterIndexByDeckFilter(deck.index, deckLemmaKeySet), mode),
-      sessionBudget,
-      { dailyNewCount },
+    const scopedIndex = sessionScopeIndexForMode(
+      filterIndexByDeckFilter(deck.index, deckLemmaKeySet),
+      mode,
     );
+    // #6734: autoStart must not open an empty-mode session that later bleeds
+    // antonym-polarity synonym rows (beginSession already refuses this path).
+    if (scopedIndex.length === 0) {
+      setPlannedTotal(0);
+      setExtensionUsed(0);
+      setSessionCompleted(0);
+      return;
+    }
+    const plan = computeSessionScope(scopedIndex, sessionBudget, { dailyNewCount });
     resetSessionTracking(plan, sessionBudget);
 
     // Persist an initial snapshot for this newly started session so it is resumable.
@@ -2316,9 +2333,15 @@ function LexiconPracticeIsland({
 
   const selection = useMemo(() => {
     if (!selectionDeck || sessionPhase !== 'active') return null;
-    // #6734: a session that planned zero work must not serve cross-level bleed
-    // (empty A1 synonym plan + later A2 antonym-polarity synonym item → 0/0 then 1/1).
-    if (plannedTotal + extensionUsed <= 0) return null;
+    // #6734: refuse selection only when this mode's scoped index is empty (e.g. A1
+    // synonym with antonym-only inventory). Keying off plannedTotal was too broad —
+    // autoStart remounts and borrowed-due picks can have plannedTotal 0 while real
+    // mode inventory still exists, which starved heritage / remount flows.
+    const scopedIndex = sessionScopeIndexForMode(
+      filterIndexByDeckFilter(selectionDeck.index, deckLemmaKeySet),
+      mode,
+    );
+    if (scopedIndex.length === 0) return null;
     const fresh = selectNextPracticeItem(selectionDeck, {
       history,
       modeFilter: mode,
@@ -2343,10 +2366,9 @@ function LexiconPracticeIsland({
     }
     return fresh;
   }, [
-    extensionUsed,
+    deckLemmaKeySet,
     history,
     mode,
-    plannedTotal,
     poolFilter,
     revision,
     selectionDeck,

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -87,6 +87,7 @@ import {
   LEARNER_LEVEL_STORAGE_KEY,
   prioritizeByLearnerLevel,
   normalizeCefrLevel,
+  parseCefrLevel,
   type CefrLevel,
 } from '../lib/lexicon/levels';
 import { dateSeed, deckSeed, pickDaily, reRollSeed, type DailyWord } from '../lib/lexicon/daily';
@@ -1337,6 +1338,22 @@ function sessionScopeIndexForMode(
     .map((item) => ({ ...item, modes: [modeFilter] }));
 }
 
+/**
+ * #6734: idle modeCounts load every published level's index (learner level is a
+ * preference, not a shard cap), but a newly started session plans against the
+ * selected level first. Counting higher-level synonym lemmas on an A1 home made
+ * Синоніми look stocked (live: 287) while the A1 plan was 0/0 and then briefly
+ * served a bled-in antonym-polarity item. Mode-card honesty follows the selected
+ * learner level's CEFR — empty stays empty even when antonym (or higher-level
+ * synonym) inventory exists elsewhere.
+ */
+function indexForModeCounts(
+  index: PracticeIndexItem[],
+  learnerLevel: CefrLevel,
+): PracticeIndexItem[] {
+  return index.filter((item) => parseCefrLevel(item.cefr) === learnerLevel);
+}
+
 /** Shared match test for the Selected Deck filter (Teacher Lesson or a Custom Set),
  * keyed on lemmaId/lemma the same way for both index-level planning and per-candidate
  * selection — a single definition so the two can never drift apart. */
@@ -2243,14 +2260,17 @@ function LexiconPracticeIsland({
   // — instead of mixed silently collapsing toward whichever modes happen to have
   // content and leaving an empty tap as the only way to discover a mode has nothing.
   const modeCounts = useMemo(() => {
-    const filtered = filterIndexByDeckFilter(indexForStats, deckLemmaKeySet);
+    const filtered = filterIndexByDeckFilter(
+      indexForModeCounts(indexForStats, learnerLevel),
+      deckLemmaKeySet,
+    );
     const counts: Partial<Record<VisiblePracticeModeFilter, number>> = { mixed: filtered.length };
     for (const visibleMode of MODE_CARD_ORDER) {
       if (visibleMode === 'mixed') continue;
       counts[visibleMode] = filtered.filter((item) => item.modes.includes(visibleMode)).length;
     }
     return counts;
-  }, [deckLemmaKeySet, indexForStats]);
+  }, [deckLemmaKeySet, indexForStats, learnerLevel]);
   // P0-3: a mode is only disabled once the index has actually loaded and confirms
   // zero content — not during the transient pre-load tick where every count is 0.
   // A real custom deck's synthesized items (`ensureDeckCustomSetCoverage`) only exist
@@ -2296,6 +2316,9 @@ function LexiconPracticeIsland({
 
   const selection = useMemo(() => {
     if (!selectionDeck || sessionPhase !== 'active') return null;
+    // #6734: a session that planned zero work must not serve cross-level bleed
+    // (empty A1 synonym plan + later A2 antonym-polarity synonym item → 0/0 then 1/1).
+    if (plannedTotal + extensionUsed <= 0) return null;
     const fresh = selectNextPracticeItem(selectionDeck, {
       history,
       modeFilter: mode,
@@ -2319,7 +2342,17 @@ function LexiconPracticeIsland({
       return committed.selection;
     }
     return fresh;
-  }, [history, mode, poolFilter, revision, selectionDeck, sessionPhase, sessionSeed]);
+  }, [
+    extensionUsed,
+    history,
+    mode,
+    plannedTotal,
+    poolFilter,
+    revision,
+    selectionDeck,
+    sessionPhase,
+    sessionSeed,
+  ]);
 
   // Pin the board for the life of the selection to avoid mid-board changes.
   const pairsRef = useRef<{ itemId: string; pairs: ReturnType<typeof matchingPairs> } | null>(null);
@@ -2894,6 +2927,17 @@ function LexiconPracticeIsland({
       nextMode,
     );
     const plan = computeSessionScope(index, budget, { dailyNewCount });
+    // #6734: never open a 0/0 synonym (or any mode) session when the selected-level
+    // scope is empty — even if background shards later bleed higher-level items in.
+    if (!resume && index.length === 0) {
+      setFeedback({
+        uk: CHROME_STRINGS.uk['practice.modeNoExercises'],
+        en: CHROME_STRINGS.en['practice.modeNoExercises'],
+      });
+      clearResumeSnapshot(nextMode);
+      setSessionPhase('idle');
+      return;
+    }
     const nextSeed = resume?.sessionSeed ?? makePracticeSessionSeed();
     const seededHistory = resume ? resume.history : seedCrossSessionHistory(new Date());
     if (resume) {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -4684,6 +4684,164 @@ describe('LexiconPractice', () => {
       expect(screen.getByTestId('practice-mode-count-cloze')).toHaveTextContent('0');
     });
 
+    test('#6734 A1 empty synonym stays 0 (disabled) even when antonym + higher-level synonym exist', async () => {
+      // Live bug: idle dueIndex flattened every CEFR shard, so Синоніми showed 287 while
+      // A1 modeCounts.synonym was 0 and antonym was 138. Tapping opened a 0/0 session that
+      // then served one bled-in A2 antonym-polarity synonym item and died at 1/1.
+      localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+      const forms = { nominative: 'вхід', accusative: 'вхід', locative: 'вході' };
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('daily-pool.json')) return okJson([]);
+        if (url.includes('practice-index.A1.json')) {
+          return okJson({
+            deckVersion: 'a1-antonym-only',
+            level: 'A1',
+            items: [
+              {
+                lemmaId: 'vkhid',
+                lemma: 'вхід',
+                cefr: 'A1',
+                modes: ['flashcards', 'matching', 'choice', 'antonym'],
+                hasCloze: false,
+                clozeIds: [],
+                newOrder: 0,
+              },
+            ],
+          });
+        }
+        if (url.includes('practice-index.A2.json')) {
+          return okJson({
+            deckVersion: 'a2-synonym-antonym-polarity',
+            level: 'A2',
+            items: [
+              {
+                lemmaId: 'vkhid-a2',
+                lemma: 'вхід',
+                cefr: 'A2',
+                modes: ['flashcards', 'synonym'],
+                hasCloze: false,
+                clozeIds: [],
+                newOrder: 0,
+              },
+            ],
+          });
+        }
+        if (url.includes('practice-index.')) {
+          return okJson({ deckVersion: 'empty', level: 'B1', items: [] });
+        }
+        if (url.includes('practice-lexemes.A1.json')) {
+          return okJson({
+            deckVersion: 'a1-antonym-only',
+            level: 'A1',
+            lexemes: [lexeme('vkhid', 'вхід', 'entrance', forms, { cefr: 'A1' })],
+          });
+        }
+        if (url.includes('practice-lexemes.A2.json')) {
+          return okJson({
+            deckVersion: 'a2-synonym-antonym-polarity',
+            level: 'A2',
+            lexemes: [lexeme('vkhid-a2', 'вхід', 'entrance', forms, { cefr: 'A2' })],
+          });
+        }
+        if (url.includes('practice-synonym.A2.json')) {
+          return okJson({
+            synonym: [
+              {
+                synonymId: 'vkhid-ant',
+                lemmaId: 'vkhid-a2',
+                targetLemmaId: 'vykhid',
+                polarity: 'antonym',
+                prompt: 'вхід',
+                answer: 'вихід',
+                options: [
+                  { label: 'автор', lemmaId: 'avtor', kind: 'distractor' },
+                  { label: 'банка', lemmaId: 'banka', kind: 'distractor' },
+                  { label: 'вихід', lemmaId: 'vykhid', kind: 'answer' },
+                  { label: 'боєць', lemmaId: 'boyets', kind: 'distractor' },
+                ],
+                source: 'fixture',
+              },
+            ],
+          });
+        }
+        if (url.match(/practice-(lexemes|cloze|stress|classify|paradigm|synonym|paronym|heritage|antonym)\./)) {
+          return okJson({});
+        }
+        return notFoundResponse();
+      });
+
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice autoStart={false} />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('practice-mode-count-flashcards')).toHaveTextContent('1'),
+      );
+      // Selected-level honesty: A1 synonym is empty despite A2 synonym + A1 antonym inventory.
+      expect(screen.getByTestId('practice-mode-count-synonym')).toHaveTextContent('0');
+      const synonymCard = container.querySelector<HTMLButtonElement>('[data-mode="synonym"]');
+      expect(synonymCard).toHaveAttribute('data-mode-empty', 'true');
+      expect(synonymCard).toBeDisabled();
+
+      await user.click(synonymCard!);
+      expect(screen.queryByTestId('practice-session-progress')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Оберіть антонім до/)).not.toBeInTheDocument();
+      expect(screen.getByTestId('practice-dashboard-hero')).toBeInTheDocument();
+    });
+
+    test('#6734 empty synonym + non-empty antonym autoStart stays itemless at 0/0', async () => {
+      // Companion to the mode-card test: even if a harness forces synonym autoStart on an
+      // A1 deck that only has antonym modes (and an empty synonym shard), the session must
+      // not surface an antonym-polarity MC item. Counter stays 0/0 with the catch-all empty
+      // state — never a one-shot «Оберіть антонім» round.
+      localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+      const forms = { nominative: 'вхід', accusative: 'вхід', locative: 'вході' };
+      const a1Deck: PracticeDeckData = {
+        deckVersion: 'a1-empty-synonym',
+        level: 'A1',
+        lexemes: [lexeme('vkhid', 'вхід', 'entrance', forms, { cefr: 'A1' })],
+        index: [
+          {
+            lemmaId: 'vkhid',
+            lemma: 'вхід',
+            cefr: 'A1',
+            modes: ['flashcards', 'antonym'],
+            hasCloze: false,
+            clozeIds: [],
+            newOrder: 0,
+          },
+        ],
+        cloze: [],
+        synonym: [
+          // Poison pill: an antonym-polarity row whose lemma is NOT synonym-scoped in the
+          // index. Before #6734 a zero-plan session could still pick bled-in rows like this.
+          {
+            synonymId: 'vkhid-ant',
+            lemmaId: 'vkhid',
+            targetLemmaId: 'vykhid',
+            polarity: 'antonym',
+            prompt: 'вхід',
+            answer: 'вихід',
+            options: [
+              { label: 'автор', lemmaId: 'avtor', kind: 'distractor' },
+              { label: 'банка', lemmaId: 'banka', kind: 'distractor' },
+              { label: 'вихід', lemmaId: 'vykhid', kind: 'answer' },
+              { label: 'боєць', lemmaId: 'boyets', kind: 'distractor' },
+            ],
+            source: 'fixture',
+          },
+        ],
+      };
+
+      render(<LexiconPractice initialDeck={a1Deck} autoStart initialMode="synonym" />);
+
+      expect(await screen.findByTestId('practice-all-caught-up')).toBeInTheDocument();
+      expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('0/0');
+      expect(screen.queryByText(/Оберіть антонім до/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /вихід/ })).not.toBeInTheDocument();
+    });
+
     test('#6530 embeds level-independent ЗНО/НМТ decks in the modes grid and session frame', async () => {
       const user = userEvent.setup();
       const { container } = render(<LexiconPractice initialDeck={sampleDeck()} autoStart={false} />);


### PR DESCRIPTION
## Summary
- Idle mode-card counts are scoped to the selected learner CEFR, so A1 **Синоніми** shows **0** (disabled) when A1 has no synonym items — even if antonym inventory or higher-level synonym rows exist (live badge was the cumulative **287**).
- `beginSession` refuses an empty mode scope instead of opening a **0/0** round that later bleeds in one antonym-polarity item.
- Zero-plan sessions no longer select bled-in synonym rows.

## Changes
- Level-filter `modeCounts` via `indexForModeCounts`
- Empty-scope guard in `beginSession`
- Selection guard when `plannedTotal + extensionUsed <= 0`
- Regression tests for empty-synonym + non-empty-antonym

## Testing
- [x] `vitest run tests/unit/LexiconPractice.test.tsx -t "6734|6132 mode grid"` (3 passed)
- [ ] Website builds without errors (`cd site && npm run build`)
- [ ] Ukrainian text reviewed for naturalness

## Related Issues
Refs #6734
This PR leaves #6734 #4387 open.


Made with [Cursor](https://cursor.com)