### PR TITLE
fix(api): recover dirty API snapshots; silence macOS services.sh /proc (#6738)

### DIFF
--- a/scripts/api/release_snapshot.py
+++ b/scripts/api/release_snapshot.py
@@ -235,6 +235,10 @@ def build_release(
     leave an orphaned, complete release directory. It is safe: ``current``
     still references the preceding release, and the next build for the same
     SHA verifies, reuses, and publishes that complete directory.
+
+    A dirty final directory that fails ``verify_release`` is removed and
+    rebuilt from ``git archive`` so launchd does not crash-loop on a
+    permanently corrupt snapshot. Staging failures still clean ``.staging-*``.
     """
     repo_root = repo_root.resolve()
     sha = _validate_sha(sha)
@@ -245,9 +249,14 @@ def build_release(
     if final_dir.exists():
         if not final_dir.is_dir() or final_dir.is_symlink():
             raise ReleaseSnapshotError(f"release path is not a directory: {final_dir}")
-        verify_release(final_dir, sha)
-        publish_current(releases_dir, sha)
-        return final_dir, True
+        try:
+            verify_release(final_dir, sha)
+        except ReleaseSnapshotError:
+            # Corrupt reuse would crash-loop launchd on every respawn.
+            shutil.rmtree(final_dir)
+        else:
+            publish_current(releases_dir, sha)
+            return final_dir, True
 
     staging_dir = releases_dir / f".staging-{os.getpid()}"
     if staging_dir.exists() or staging_dir.is_symlink():

--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -24,11 +24,11 @@ _ALLOWLIST: frozenset[str] = frozenset(
     {
         # services.sh: restart lockdir reclaim/release + Astro/Vite cache dirs
         # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
-        "services.sh:119",
-        "services.sh:138",
-        "services.sh:617",
-        "services.sh:627",
-        "services.sh:631",
+        "services.sh:121",
+        "services.sh:140",
+        "services.sh:633",
+        "services.sh:643",
+        "services.sh:647",
         # Scratch-dir EXIT traps for one-shot installer scripts.
         "scripts/entire/install_kimi_external_agent.sh:18",
         "scripts/entire/install_fleet_external_agent.sh:36",

--- a/services.sh
+++ b/services.sh
@@ -63,7 +63,9 @@ SVC_LOG[astro]="$LOGS_DIR/astro.log"
 SVC_DESC[astro]="Astro Course UI Dev Server"
 SVC_HEALTH[astro]="http://127.0.0.1:4321/"
 SVC_HEALTH_ALT[astro]="http://localhost:4321/"
-SVC_MATCH[astro]="astro.mjs dev"
+# Live ``npm run dev`` resolves to ``node …/.bin/astro dev``; older
+# installs still expose ``astro.mjs dev``. Match either argv form.
+SVC_MATCH[astro]=".bin/astro dev|astro.mjs dev"
 
 ALL_SERVICES="sources api astro"
 
@@ -158,19 +160,25 @@ _pid_on_port() {
 _cmdline_for_pid() {
     local pid="$1"
     local cmdline
+    local proc_cmdline="/proc/$pid/cmdline"
 
     # Linux exposes the argv vector directly.  Unlike ``ps -o args=``, this
     # does not depend on procps personality or command-width formatting, both
     # of which can alter the string used for our service identity match.
-    # macOS has no procfs equivalent, so it retains the established ps path.
-    if cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) && [ -n "$cmdline" ]; then
+    # Only open /proc when the file is readable: a bare ``tr < /proc/...``
+    # redirect lets bash itself print "No such file or directory" on macOS
+    # (``2>/dev/null`` was on ``tr``, not the redirect). Fall back to ``ps``.
+    if [[ -r "$proc_cmdline" ]] \
+        && cmdline=$(tr '\0' ' ' < "$proc_cmdline" 2>/dev/null) \
+        && [ -n "$cmdline" ]; then
         # The kernel terminates every argv element with NUL, including argv[0].
         # Remove only the terminal separator introduced by ``tr``.
         printf '%s\n' "${cmdline% }"
         return 0
     fi
 
-    ps -p "$pid" -o args= 2>/dev/null
+    # ``command ps`` avoids a shell alias such as ``ps=procs`` breaking identity.
+    command ps -p "$pid" -o args= 2>/dev/null
 }
 
 _pid_matches_service() {
@@ -178,13 +186,21 @@ _pid_matches_service() {
     local pid="$2"
     local match="${SVC_MATCH[$name]-}"
     local cmdline
+    local needle
+    local IFS='|'
 
     if [[ -z "$match" ]]; then
         return 1
     fi
 
     cmdline="$(_cmdline_for_pid "$pid")"
-    [[ -n "$cmdline" && "$cmdline" == *"$match"* ]]
+    [[ -z "$cmdline" ]] && return 1
+
+    # SVC_MATCH may list '|' alternatives (astro: .bin/astro vs astro.mjs).
+    for needle in $match; do
+        [[ -n "$needle" && "$cmdline" == *"$needle"* ]] && return 0
+    done
+    return 1
 }
 
 _verified_port_pid() {

--- a/tests/api/test_release_snapshot.py
+++ b/tests/api/test_release_snapshot.py
@@ -177,6 +177,30 @@ def test_release_reuse_is_idempotent_and_links_live_data(tmp_path: Path) -> None
     ] == [sha]
 
 
+def test_corrupt_release_dir_is_rebuilt_not_reused(tmp_path: Path) -> None:
+    """A dirty final release that fails verify must be deleted and rebuilt."""
+    repo_root, sha = _create_snapshot_repo(tmp_path)
+    first_release, reused = release_snapshot.build_release(repo_root, sha)
+    assert not reused
+
+    manifest_path = first_release / MANIFEST_NAME
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["file_count"] = int(payload["file_count"]) + 1
+    manifest_path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(release_snapshot.ReleaseSnapshotError, match="verification failed"):
+        release_snapshot.verify_release(first_release, sha)
+
+    rebuilt, reused_again = release_snapshot.build_release(repo_root, sha)
+
+    assert not reused_again
+    assert rebuilt == first_release
+    assert release_snapshot.verify_release(rebuilt, sha).sha == sha
+    assert (release_snapshot.releases_root(repo_root) / "current").resolve() == rebuilt
+
+
 def test_running_release_keeps_serving_archived_code_after_checkout_mutation(tmp_path: Path) -> None:
     repo_root, sha = _create_snapshot_repo(tmp_path, api_app=True)
     release_dir, _ = release_snapshot.build_release(repo_root, sha)

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -492,7 +492,10 @@ def test_status_does_not_print_proc_on_missing_procfs(temp_services_sh, mock_lso
         combined = f"{res.stdout}\n{res.stderr}"
         assert "/proc/" not in combined, combined
         assert "No such file or directory" not in combined, combined
-        assert "running" in res.stdout
+        # Dummy listener has no health endpoint → Linux CI reports degraded
+        # (PID resolved). Either degraded or running is fine; require the PID.
+        assert str(proc.pid) in res.stdout, res.stdout
+        assert "degraded" in res.stdout or "running" in res.stdout, res.stdout
     finally:
         if proc.poll() is None:
             proc.terminate()

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -13,15 +13,22 @@ from pathlib import Path
 
 import pytest
 
+from scripts.common.repo_root import main_checkout_root
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SERVICES_SH = PROJECT_ROOT / "services.sh"
 PIDS_DIR = PROJECT_ROOT / ".pids"
 LOGS_DIR = PROJECT_ROOT / "logs"
 # Service commands use the repository virtual environment in normal CI.  The
 # explicit override lets a dispatch worktree use the shared project interpreter
-# without creating a worktree-local virtual environment.
-VENV_PYTHON = Path(os.environ.get("SERVICES_TEST_PYTHON", PROJECT_ROOT / ".venv" / "bin" / "python"))
-
+# without creating a worktree-local virtual environment. Default to the primary
+# checkout interpreter so sparse worktrees without a local .venv still run.
+VENV_PYTHON = Path(
+    os.environ.get(
+        "SERVICES_TEST_PYTHON",
+        main_checkout_root(PROJECT_ROOT) / ".venv" / "bin" / "python",
+    )
+)
 def find_free_port() -> int:
     """Find a free TCP port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -382,6 +389,110 @@ def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
         assert proc.returncode is not None
         assert is_port_free(port)
 
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def _extract_bash_function(source: str, name: str) -> str:
+    """Return a top-level ``name() { ... }`` block from ``services.sh``."""
+    start = source.find(f"{name}() {{")
+    if start < 0:
+        raise AssertionError(f"function {name}() not found in services.sh")
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unclosed function {name}() in services.sh")
+
+
+def test_cmdline_for_pid_silent_when_procfs_missing() -> None:
+    """Missing /proc/$pid/cmdline must not print a bash redirect error."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    helper = _extract_bash_function(source, "_cmdline_for_pid")
+    # A pid that cannot exist: no /proc entry and no live process for ps.
+    dead_pid = 2_147_483_647
+    result = subprocess.run(
+        ["bash", "-c", f"{helper}\n_cmdline_for_pid {dead_pid}\n"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=30,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "/proc/" not in combined, combined
+    assert "No such file or directory" not in combined, combined
+
+
+def test_astro_match_accepts_bin_astro_dev() -> None:
+    """Astro identity must match the live ``node …/.bin/astro dev`` argv."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    match_line = next(
+        line for line in source.splitlines() if line.startswith("SVC_MATCH[astro]=")
+    )
+    assert ".bin/astro dev" in match_line
+
+    helper = "\n".join(
+        [
+            "declare -A SVC_MATCH",
+            match_line,
+            _extract_bash_function(source, "_cmdline_for_pid"),
+            _extract_bash_function(source, "_pid_matches_service"),
+            # Inject the observed live listener argv; skip real /proc and ps.
+            '_cmdline_for_pid() { printf "%s\\n" "$FAKE_CMDLINE"; }',
+            'FAKE_CMDLINE="node /repo/site/node_modules/.bin/astro dev --host 127.0.0.1 --port 4321 --force"',
+            "if _pid_matches_service astro 1; then echo MATCH_BIN; else echo MISS_BIN; fi",
+            'FAKE_CMDLINE="node /repo/site/node_modules/astro/astro.mjs dev --host 127.0.0.1 --port 4321"',
+            "if _pid_matches_service astro 1; then echo MATCH_MJS; else echo MISS_MJS; fi",
+            'FAKE_CMDLINE="node /repo/site/node_modules/.bin/vite --port 4321"',
+            "if _pid_matches_service astro 1; then echo MATCH_FOREIGN; else echo MISS_FOREIGN; fi",
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", helper],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "MATCH_BIN" in result.stdout
+    assert "MATCH_MJS" in result.stdout
+    assert "MISS_FOREIGN" in result.stdout
+
+
+def test_status_does_not_print_proc_on_missing_procfs(temp_services_sh, mock_lsof_env) -> None:
+    """``status`` must stay quiet about /proc even when resolving a live PID."""
+    script_path, port = temp_services_sh
+    set_pids, _, env = mock_lsof_env
+    api_pid_file = PIDS_DIR / "api.pid"
+
+    proc = subprocess.Popen([
+        str(VENV_PYTHON), "-c", "import time; time.sleep(30)",
+        "scripts.api.main:app", "--host", "0.0.0.0", "--port", str(port)
+    ])
+    reap_process_on_exit(proc)
+    try:
+        api_pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+        set_pids([proc.pid])
+        res = subprocess.run(
+            [str(script_path), "status", "api"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        combined = f"{res.stdout}\n{res.stderr}"
+        assert "/proc/" not in combined, combined
+        assert "No such file or directory" not in combined, combined
+        assert "running" in res.stdout
     finally:
         if proc.poll() is None:
             proc.terminate()


### PR DESCRIPTION
## Summary
- Guard `_cmdline_for_pid` so bash never redirects through missing `/proc/$pid/cmdline` on macOS; fall back via `command ps`.
- Match live Astro argv (`.bin/astro dev` and `astro.mjs dev`) so status reports a real PID.
- Rebuild corrupt `.runtime/api/releases/<sha>` trees instead of crash-looping launchd on verify failure.

## Changes
- `services.sh`: readable-procfs gate; `|`-alternatives in `SVC_MATCH` / `_pid_matches_service`
- `scripts/api/release_snapshot.py`: remove dirty `final_dir` and fall through to fresh `git archive`
- Tests for silent `/proc` fallback, Astro `.bin/astro` match, and corrupt-release rebuild

## Testing
- [x] `pytest tests/api/test_services_ops.py tests/api/test_release_snapshot.py -q --tb=short` — 22 passed, 1 skipped; `test_real_release_serves_live_data_routers_with_logical_paths` 503 in this sparse worktree (no `curriculum/`)
- [x] `ruff check scripts/api/release_snapshot.py tests/api/test_services_ops.py tests/api/test_release_snapshot.py`
- [ ] Modules pass audit (`scripts/audit_module.py`) — N/A (infra)
- [ ] Website builds without errors (`cd site && npm run build`) — N/A
- [ ] Ukrainian text reviewed for naturalness — N/A

## Related Issues
Closes #6738

Made with [Cursor](https://cursor.com)