### PR TITLE
fix(wotd): card chrome flips flashcard; lemma opens Atlas

### DIFF
--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -55,17 +55,15 @@ const dailyCount = Math.max(1, Math.floor(count));
 <script>
   import { dateSeed, pickDaily, type DailyWord } from "../lib/lexicon/daily";
   import {
+    bindDailyCardInteractions,
+    renderDailyCardHtml,
+  } from "../lib/lexicon/daily-card";
+  import {
     filterByCumulativeLevel,
     LEARNER_LEVEL_STORAGE_KEY,
     normalizeCefrLevel,
     type CefrLevel,
   } from "../lib/lexicon/levels";
-
-  const dwEsc = (value: unknown): string =>
-    String(value ?? "").replace(
-      /[&<>"]/g,
-      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c] ?? c,
-    );
 
   const readLearnerLevel = (): CefrLevel => {
     try {
@@ -83,38 +81,6 @@ const dailyCount = Math.max(1, Math.floor(count));
     }
   };
 
-  const renderChips = (word: DailyWord): string => {
-    const chips: string[] = [];
-    if (word.k === "avoid") {
-      chips.push('<span class="lexicon-daily-chip danger">остерігайтеся</span>');
-    }
-    if (word.cefr) {
-      chips.push(`<span class="lexicon-daily-chip">${dwEsc(word.cefr)}</span>`);
-    }
-    return chips.length > 0 ? `<span class="lexicon-daily-chips">${chips.join("")}</span>` : "";
-  };
-
-  const renderExample = (word: DailyWord): string => {
-    const example = word.example?.trim();
-    if (!example) return "";
-    const exampleEn = word.exampleEn?.trim();
-    return `<span class="lexicon-daily-example" data-testid="daily-example-${dwEsc(word.slug)}" lang="uk">
-      ${dwEsc(example)}${exampleEn ? `<span class="lexicon-daily-example-en" lang="en">${dwEsc(exampleEn)}</span>` : ""}
-    </span>`;
-  };
-
-  const renderCard = (word: DailyWord): string => {
-    const href = `/lexicon/${encodeURIComponent(String(word.slug))}/`;
-    return `<li class="lexicon-daily-item">
-      <a class="lexicon-daily-card" href="${href}">
-        <span class="lexicon-daily-lemma">${dwEsc(word.lemma)}</span>
-        ${word.gloss ? `<span class="lexicon-daily-gloss">${dwEsc(word.gloss)}</span>` : ""}
-        ${renderExample(word)}
-        ${renderChips(word)}
-      </a>
-    </li>`;
-  };
-
   const hydrateDailySection = (dailySection: HTMLElement) => {
     const dailyList = dailySection.querySelector<HTMLUListElement>("[data-daily-list]");
     const dailyStatus = dailySection.querySelector<HTMLElement>("[data-daily-status]");
@@ -126,6 +92,7 @@ const dailyCount = Math.max(1, Math.floor(count));
 
     let activeLevel = readLearnerLevel();
     let pool: DailyWord[] = [];
+    let interactionsBound = false;
 
     if (useLevelSelector) {
       storeLearnerLevel(activeLevel);
@@ -159,7 +126,11 @@ const dailyCount = Math.max(1, Math.floor(count));
         return;
       }
 
-      dailyList.innerHTML = picks.map(renderCard).join("");
+      dailyList.innerHTML = picks.map(renderDailyCardHtml).join("");
+      if (!interactionsBound) {
+        bindDailyCardInteractions(dailyList);
+        interactionsBound = true;
+      }
       if (dailyStatus) {
         dailyStatus.hidden = false;
         dailyStatus.textContent = useLevelSelector
@@ -308,6 +279,32 @@ const dailyCount = Math.max(1, Math.floor(count));
   }
 
   :global(.lexicon-daily-card) {
+    perspective: 900px;
+    min-height: 7.25rem;
+    height: 100%;
+    cursor: pointer;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+  }
+
+  :global(.lexicon-daily-card-inner) {
+    display: grid;
+    min-height: 7.25rem;
+    height: 100%;
+    transition: transform 0.45s cubic-bezier(0.2, 0.7, 0.2, 1);
+    transform-style: preserve-3d;
+  }
+
+  :global(.lexicon-daily-card[data-flipped="true"] .lexicon-daily-card-inner) {
+    transform: rotateY(180deg);
+  }
+
+  :global(.lexicon-daily-face) {
+    grid-area: 1 / 1;
     display: flex;
     min-height: 7.25rem;
     height: 100%;
@@ -318,32 +315,61 @@ const dailyCount = Math.max(1, Math.floor(count));
     border-radius: 8px;
     background: var(--lu-surface);
     color: var(--lu-text);
-    text-decoration: none;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
   }
 
-  :global(.lexicon-daily-card:hover),
-  :global(.lexicon-daily-card:focus-visible) {
+  :global(.lexicon-daily-back) {
+    transform: rotateY(180deg);
+  }
+
+  :global(.lexicon-daily-card:hover .lexicon-daily-face),
+  :global(.lexicon-daily-card:focus-visible .lexicon-daily-face) {
     border-color: var(--lu-primary);
     outline: none;
     box-shadow: 0 0 0 3px var(--lu-state-active);
+  }
+
+  :global(.lexicon-daily-card:focus-visible) {
+    outline: none;
   }
 
   :global(.lexicon-daily-lemma) {
     color: var(--lu-blue);
     font-weight: 900;
     line-height: 1.25;
+    text-decoration: none;
+  }
+
+  :global(a.lexicon-daily-lemma:hover),
+  :global(a.lexicon-daily-lemma:focus-visible) {
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+    outline: none;
+  }
+
+  :global(.lexicon-daily-flip-hint) {
+    color: var(--lu-text-muted);
+    font-size: 0.82rem;
+    line-height: 1.4;
   }
 
   :global(.lexicon-daily-gloss) {
-    color: var(--lu-text-muted);
-    font-size: 0.92rem;
+    color: var(--lu-text);
+    font-size: 0.98rem;
+    font-weight: 700;
     line-height: 1.45;
+  }
+
+  :global(.lexicon-daily-gloss-empty) {
+    color: var(--lu-text-muted);
+    font-weight: 600;
   }
 
   :global(.lexicon-daily-example) {
     display: block;
-    margin-top: 0.25rem;
+    margin-top: 0.15rem;
     color: var(--lu-text);
     font-size: 0.95rem;
     font-style: italic;
@@ -383,6 +409,12 @@ const dailyCount = Math.max(1, Math.floor(count));
     background: var(--lu-state-wrong-bg);
     color: var(--lu-state-wrong-fg);
     text-transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.lexicon-daily-card-inner) {
+      transition: none;
+    }
   }
 
   @media (max-width: 680px) {

--- a/site/src/lib/lexicon/daily-card.ts
+++ b/site/src/lib/lexicon/daily-card.ts
@@ -1,0 +1,124 @@
+import type { DailyWord } from "./daily";
+
+/** Escape text for safe interpolation into Daily Words card HTML. */
+export function escapeDailyCardHtml(value: unknown): string {
+  return String(value ?? "").replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c] ?? c,
+  );
+}
+
+export function dailyCardAtlasHref(slug: string): string {
+  return `/lexicon/${encodeURIComponent(String(slug))}/`;
+}
+
+function renderChips(word: DailyWord): string {
+  const chips: string[] = [];
+  if (word.k === "avoid") {
+    chips.push('<span class="lexicon-daily-chip danger">остерігайтеся</span>');
+  }
+  if (word.cefr) {
+    chips.push(
+      `<span class="lexicon-daily-chip">${escapeDailyCardHtml(word.cefr)}</span>`,
+    );
+  }
+  return chips.length > 0
+    ? `<span class="lexicon-daily-chips">${chips.join("")}</span>`
+    : "";
+}
+
+function renderExample(word: DailyWord): string {
+  const example = word.example?.trim();
+  if (!example) return "";
+  const exampleEn = word.exampleEn?.trim();
+  return `<span class="lexicon-daily-example" data-testid="daily-example-${escapeDailyCardHtml(word.slug)}" lang="uk">
+      ${escapeDailyCardHtml(example)}${exampleEn ? `<span class="lexicon-daily-example-en" lang="en">${escapeDailyCardHtml(exampleEn)}</span>` : ""}
+    </span>`;
+}
+
+function renderLemma(word: DailyWord): string {
+  const lemma = escapeDailyCardHtml(word.lemma);
+  const hasAtlas = word.hasAtlasEntry !== false;
+  if (!hasAtlas) {
+    return `<span class="lexicon-daily-lemma">${lemma}</span>`;
+  }
+  const href = dailyCardAtlasHref(word.slug);
+  return `<a class="lexicon-daily-lemma" data-daily-atlas-link href="${href}">${lemma}</a>`;
+}
+
+/**
+ * Hub daily card: chrome flips the flashcard; lemma text opens Atlas (#6726).
+ * Front = lemma prompt; back = gloss / example (SRS face).
+ */
+export function renderDailyCardHtml(word: DailyWord): string {
+  const lemmaLabel = escapeDailyCardHtml(word.lemma);
+  const chips = renderChips(word);
+  const gloss = word.gloss
+    ? `<span class="lexicon-daily-gloss">${escapeDailyCardHtml(word.gloss)}</span>`
+    : `<span class="lexicon-daily-gloss lexicon-daily-gloss-empty">—</span>`;
+
+  return `<li class="lexicon-daily-item">
+      <div
+        class="lexicon-daily-card"
+        data-daily-card
+        data-flipped="false"
+        role="button"
+        tabindex="0"
+        aria-pressed="false"
+        aria-label="${lemmaLabel} — торкніться картки, щоб перевернути"
+      >
+        <div class="lexicon-daily-card-inner">
+          <div class="lexicon-daily-face lexicon-daily-front">
+            ${renderLemma(word)}
+            <span class="lexicon-daily-flip-hint">Торкніться картки, щоб побачити значення</span>
+            ${chips}
+          </div>
+          <div class="lexicon-daily-face lexicon-daily-back" aria-hidden="true">
+            ${gloss}
+            ${renderExample(word)}
+            ${chips}
+          </div>
+        </div>
+      </div>
+    </li>`;
+}
+
+/** True when the event target is (inside) the lemma → Atlas link. */
+export function isDailyCardAtlasLinkTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(target.closest("[data-daily-atlas-link]"));
+}
+
+export function toggleDailyCardFlip(card: HTMLElement): void {
+  const next = card.getAttribute("data-flipped") !== "true";
+  card.setAttribute("data-flipped", next ? "true" : "false");
+  card.setAttribute("aria-pressed", next ? "true" : "false");
+  const back = card.querySelector<HTMLElement>(".lexicon-daily-back");
+  if (back) back.setAttribute("aria-hidden", next ? "false" : "true");
+  const front = card.querySelector<HTMLElement>(".lexicon-daily-front");
+  if (front) front.setAttribute("aria-hidden", next ? "true" : "false");
+}
+
+/**
+ * Event delegation for a daily-words list: chrome click/keyboard flips;
+ * lemma link navigates and must not flip.
+ */
+export function bindDailyCardInteractions(list: HTMLElement): void {
+  list.addEventListener("click", (event) => {
+    if (isDailyCardAtlasLinkTarget(event.target)) return;
+    const card = (event.target as Element | null)?.closest?.("[data-daily-card]");
+    if (!(card instanceof HTMLElement) || !list.contains(card)) return;
+    event.preventDefault();
+    toggleDailyCardFlip(card);
+  });
+
+  list.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    if (isDailyCardAtlasLinkTarget(event.target)) return;
+    const card = event.target;
+    if (!(card instanceof HTMLElement) || !card.hasAttribute("data-daily-card")) return;
+    if (!list.contains(card)) return;
+    event.preventDefault();
+    toggleDailyCardFlip(card);
+  });
+}

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -29,7 +29,7 @@ const frontmatter = {
     {/* Practice daily set density (#5502): 12 first — atlas daily-pool.json unchanged. */}
     <DailyWords
       title="Добірка на сьогодні"
-      description="Слова оновлюються за календарною датою; кожна картка веде до повної статті Атласу."
+      description="Слова оновлюються за календарною датою; торкніться картки, щоб перевернути, або самого слова — щоб відкрити статтю в Атласі."
       count={12}
       showLevelSelector
     />

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -5,26 +5,50 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
 import type { DailyWord } from "@site/src/lib/lexicon/daily";
+import {
+  bindDailyCardInteractions,
+  dailyCardAtlasHref,
+  isDailyCardAtlasLinkTarget,
+  renderDailyCardHtml,
+  toggleDailyCardFlip,
+} from "@site/src/lib/lexicon/daily-card";
 
 const dailyWordsSource = readFileSync(
   resolve(process.cwd(), "src/lexicon/DailyWords.astro"),
   "utf8",
 );
+const wordsOfTheDaySource = readFileSync(
+  resolve(process.cwd(), "src/pages/words-of-the-day.astro"),
+  "utf8",
+);
+
+const sampleWord: DailyWord = {
+  lemma: "кошик",
+  slug: "кошик",
+  gloss: "basket",
+  cefr: "A1",
+  example: "У кошику яблука.",
+  exampleEn: "There are apples in the basket.",
+};
 
 describe("DailyWords list example sentence (GH #5434)", () => {
   test("DailyWords Astro renders an example slot with bilingual scaffolding", () => {
-    expect(dailyWordsSource).toContain("word.example?.trim()");
-    expect(dailyWordsSource).toContain('data-testid="daily-example-');
-    expect(dailyWordsSource).toContain('class="lexicon-daily-example"');
-    expect(dailyWordsSource).toContain('class="lexicon-daily-example-en"');
-    expect(dailyWordsSource).toContain('lang="uk"');
-    expect(dailyWordsSource).toContain('lang="en"');
+    expect(dailyWordsSource).toContain("renderDailyCardHtml");
+    const html = renderDailyCardHtml(sampleWord);
+    expect(html).toContain('data-testid="daily-example-кошик"');
+    expect(html).toContain('class="lexicon-daily-example"');
+    expect(html).toContain('class="lexicon-daily-example-en"');
+    expect(html).toContain('lang="uk"');
+    expect(html).toContain('lang="en"');
   });
 
   test("DailyWords card omits example markup when no example is present", () => {
-    // renderExample returns an empty string for missing data, so the card does
-    // not create an empty element.
-    expect(dailyWordsSource).toContain("if (!example) return \"\";");
+    const html = renderDailyCardHtml({
+      lemma: "хліб",
+      slug: "хліб",
+      gloss: "bread",
+    });
+    expect(html).not.toContain("lexicon-daily-example");
   });
 
   test("daily pool API route exposes optional example fields", async () => {
@@ -34,8 +58,6 @@ describe("DailyWords list example sentence (GH #5434)", () => {
     expect(Array.isArray(pool)).toBe(true);
     expect(pool.length).toBeGreaterThan(0);
 
-    // Schema is permissive: examples may not be populated yet, but every row
-    // must remain a valid DailyWord with the new optional fields.
     for (const row of pool) {
       expect(row).toHaveProperty("lemma");
       expect(row).toHaveProperty("slug");
@@ -49,5 +71,75 @@ describe("DailyWords list example sentence (GH #5434)", () => {
         expect(row.exampleEn.trim()).toBe(row.exampleEn);
       }
     }
+  });
+});
+
+describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
+  test("hub copy no longer claims every card goes to Atlas", () => {
+    expect(wordsOfTheDaySource).not.toContain("кожна картка веде до повної статті Атласу");
+    expect(wordsOfTheDaySource).toContain("торкніться картки, щоб перевернути");
+    expect(wordsOfTheDaySource).toContain("Атласі");
+  });
+
+  test("card chrome is a flip control, not a single Atlas anchor", () => {
+    const html = renderDailyCardHtml(sampleWord);
+    expect(html).not.toMatch(/<a class="lexicon-daily-card"/);
+    expect(html).toContain('data-daily-card');
+    expect(html).toContain('data-flipped="false"');
+    expect(html).toContain('role="button"');
+    expect(html).toContain("lexicon-daily-front");
+    expect(html).toContain("lexicon-daily-back");
+  });
+
+  test("lemma text is the Atlas link; gloss lives on the back face", () => {
+    document.body.innerHTML = renderDailyCardHtml(sampleWord);
+    const lemma = document.querySelector<HTMLAnchorElement>("[data-daily-atlas-link]")!;
+    const front = document.querySelector(".lexicon-daily-front")!;
+    const back = document.querySelector(".lexicon-daily-back")!;
+
+    expect(lemma.href).toContain(dailyCardAtlasHref("кошик"));
+    expect(lemma.textContent).toBe("кошик");
+    expect(front.querySelector(".lexicon-daily-gloss")).toBeNull();
+    expect(back.querySelector(".lexicon-daily-gloss")?.textContent).toBe("basket");
+    expect(front.querySelector(".lexicon-daily-flip-hint")).not.toBeNull();
+  });
+
+  test("lemma without Atlas entry is plain text, not a link", () => {
+    const html = renderDailyCardHtml({
+      ...sampleWord,
+      hasAtlasEntry: false,
+    });
+    expect(html).toContain('<span class="lexicon-daily-lemma">кошик</span>');
+    expect(html).not.toContain("data-daily-atlas-link");
+  });
+
+  test("chrome click flips; lemma click target is ignored for flip", () => {
+    document.body.innerHTML = `<ul>${renderDailyCardHtml(sampleWord)}</ul>`;
+    const list = document.querySelector("ul")!;
+    bindDailyCardInteractions(list);
+
+    const card = list.querySelector<HTMLElement>("[data-daily-card]")!;
+    const lemma = list.querySelector<HTMLAnchorElement>("[data-daily-atlas-link]")!;
+    const gloss = list.querySelector(".lexicon-daily-gloss")!;
+
+    expect(card).toHaveAttribute("data-flipped", "false");
+    expect(isDailyCardAtlasLinkTarget(lemma)).toBe(true);
+    expect(isDailyCardAtlasLinkTarget(gloss)).toBe(false);
+
+    gloss.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(card).toHaveAttribute("data-flipped", "true");
+    expect(card).toHaveAttribute("aria-pressed", "true");
+
+    lemma.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(card).toHaveAttribute("data-flipped", "true");
+
+    toggleDailyCardFlip(card);
+    expect(card).toHaveAttribute("data-flipped", "false");
+  });
+
+  test("DailyWords wires the shared card helpers", () => {
+    expect(dailyWordsSource).toContain('from "../lib/lexicon/daily-card"');
+    expect(dailyWordsSource).toContain("bindDailyCardInteractions");
+    expect(dailyWordsSource).toContain("renderDailyCardHtml");
   });
 });


### PR DESCRIPTION
## Summary

- Words of the Day hub cards are no longer a single Atlas `<a>` — card chrome flips an in-place flashcard (lemma front / gloss+example back).
- Lemma text is the Atlas link (`/lexicon/{slug}/`); chrome click and keyboard Enter/Space toggle flip without navigating.
- Hub helper copy no longer says every card goes to Atlas.

## Changes

- Extract `site/src/lib/lexicon/daily-card.ts` (render + flip + event delegation).
- Update `DailyWords.astro` flip CSS/a11y (`data-flipped`, reduced-motion).
- Update `words-of-the-day.astro` description line.
- Extend unit tests for chrome-vs-lemma click targets.

## Testing

- [x] `vitest run tests/unit/daily-words-example.test.ts` (9 passed)
- [ ] Website builds without errors (`cd site && npm run build`) — not run in sparse dispatch (hydrate/deps)
- [x] Ukrainian hub copy updated for the new interaction

## Related Issues

This PR leaves #6726 open.
This PR leaves #4387 open.
Refs #6726 (native sub-issue of #4387 / atlas-practice).


Made with [Cursor](https://cursor.com)