### PR TITLE
fix(atlas): remove Russian -ться infinitive from short forms (#6735)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3186,6 +3186,9 @@ def _morphology(
         if not form:
             continue
         raw_tag = row.get("tags") or ""
+        tag_tokens = set(raw_tag.split(":"))
+        if "inf" in tag_tokens and form.endswith("ться"):
+            continue
         label = _decode_tag(raw_tag)
         markers = _style_markers_in_tag(raw_tag)
         if markers:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -91,7 +91,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "487ffd0bd677eb287b41945bda85f3fdf623758db0386b92fe5b3700ac17c779"
+        "sha256": "0176d05c390564c55220a660414b2babed85d802c61294b5c03d2441732985cd"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4907,14 +4907,26 @@ def test_resolve_primary_checkout_matches_git_common_dir() -> None:
     assert "/Users/krisztiankoos/projects/learn-ukrainian" not in src
 
 
-def test_morphology_filters_russian_infinitive_tsya_form() -> None:
+def test_morphology_filters_russian_infinitive_tsya_form(monkeypatch) -> None:
     """Fix #6735: Atlas entry подаватися must not list Russian infinitive подаваться as a short form.
 
-    Ukrainian short infinitive is подаватись (one с).
-    VESUM-verifies that подаватись has tag verb:rev:imperf:inf and подаваться has
-    tag verb:rev:imperf:inf:short, and that _morphology excludes the Russian -ться form
-    from marked_forms while preserving the Ukrainian short infinitive in the paradigm.
+    Ukrainian short infinitive is подаватись (one с). Fixture mirrors VESUM tags:
+    подаватись → verb:rev:imperf:inf; подаваться → verb:rev:imperf:inf:short.
+    Monkeypatch verify_lemma like sibling _morphology tests — data/vesum.db is
+    gitignored and absent in CI.
     """
+    rows = [
+        {"word_form": "подаватися", "tags": "verb:rev:imperf:inf", "pos": "verb"},
+        {"word_form": "подаватись", "tags": "verb:rev:imperf:inf", "pos": "verb"},
+        {"word_form": "подаваться", "tags": "verb:rev:imperf:inf:short", "pos": "verb"},
+        {"word_form": "подавався", "tags": "verb:rev:imperf:past:m", "pos": "verb"},
+        {"word_form": "подавалась", "tags": "verb:rev:imperf:past:f", "pos": "verb"},
+        {"word_form": "подавалось", "tags": "verb:rev:imperf:past:n", "pos": "verb"},
+        {"word_form": "подавались", "tags": "verb:rev:imperf:past:p", "pos": "verb"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
     morphology = _morphology("подаватися")
     assert morphology is not None
 
@@ -4922,6 +4934,11 @@ def test_morphology_filters_russian_infinitive_tsya_form() -> None:
     paradigm = morphology.get("paradigm", {})
     assert paradigm.get("kind") == "verb"
     assert paradigm.get("infinitive") == "подаватися / подаватись"
+
+    modern_forms = {row["form"] for row in morphology["forms"]}
+    assert "подаватися" in modern_forms
+    assert "подаватись" in modern_forms
+    assert "подаваться" not in modern_forms
 
     # Marked forms must not list Russian подаваться as a short form
     marked_forms = morphology.get("marked_forms", [])

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4905,3 +4905,26 @@ def test_resolve_primary_checkout_matches_git_common_dir() -> None:
     # primary checkout dynamically rather than embed an operator's absolute path.
     src = Path(enrich_manifest_module.__file__).read_text(encoding="utf-8")
     assert "/Users/krisztiankoos/projects/learn-ukrainian" not in src
+
+
+def test_morphology_filters_russian_infinitive_tsya_form() -> None:
+    """Fix #6735: Atlas entry подаватися must not list Russian infinitive подаваться as a short form.
+
+    Ukrainian short infinitive is подаватись (one с).
+    VESUM-verifies that подаватись has tag verb:rev:imperf:inf and подаваться has
+    tag verb:rev:imperf:inf:short, and that _morphology excludes the Russian -ться form
+    from marked_forms while preserving the Ukrainian short infinitive in the paradigm.
+    """
+    morphology = _morphology("подаватися")
+    assert morphology is not None
+
+    # Paradigm infinitive must include Ukrainian full (подаватися) and short (подаватись) forms
+    paradigm = morphology.get("paradigm", {})
+    assert paradigm.get("kind") == "verb"
+    assert paradigm.get("infinitive") == "подаватися / подаватись"
+
+    # Marked forms must not list Russian подаваться as a short form
+    marked_forms = morphology.get("marked_forms", [])
+    marked_form_words = {row["form"] for row in marked_forms}
+    assert "подаваться" not in marked_form_words
+


### PR DESCRIPTION
Refs #6735.

AGY implement already pushed `39df195aa3` but never opened the PR. Infra driver opened it so the fleet can CF/merge.

No merge by this opener.