### PR TITLE
fix(site): translate readings chrome (hero, breadcrumbs, search) on УКР toggle

### DIFF
--- a/site/src/layouts/CourseLayout.astro
+++ b/site/src/layouts/CourseLayout.astro
@@ -6,6 +6,7 @@ import type { ChromeKey } from '../lib/i18n/chrome';
 type NavItem = {
   href: string;
   label: string;
+  labelKey?: ChromeKey;
 };
 
 type SidebarLink = {
@@ -18,9 +19,11 @@ type SidebarLink = {
 type Sidebar = {
   backHref: string;
   backLabel: string;
+  backLabelKey?: ChromeKey;
   positionLabel: string;
   positionLabelEn?: string;
   titleLabel?: string;
+  titleLabelKey?: ChromeKey;
   navLabel?: string;
   progressDone: number;
   progressTotal: number;
@@ -29,10 +32,12 @@ type Sidebar = {
 
 type Props = {
   title: string;
+  titleKey?: ChromeKey;
   description?: string;
   eyebrow?: string;
   eyebrowKey?: ChromeKey;
   subtitle?: string;
+  subtitleKey?: ChromeKey;
   currentPath?: string;
   heroVariant?: 'core' | 'folk' | 'lexicon' | 'seminar' | 'lit' | 'history' | 'readings' | 'unavailable';
   wide?: boolean;
@@ -43,10 +48,12 @@ type Props = {
 
 const {
   title,
+  titleKey,
   description,
   eyebrow = 'Learn Ukrainian',
   eyebrowKey,
   subtitle = description,
+  subtitleKey,
   currentPath = '/',
   heroVariant = 'core',
   wide = false,
@@ -155,13 +162,31 @@ const isActive = (href: string) => {
           const primary = String(langs[0] || '').toLowerCase().split('-')[0];
           return primary === 'uk' ? 'uk' : 'en';
         };
+        // Attribute values (e.g. <input placeholder>) can't be dual-rendered
+        // via the .lu-i18n CSS trick — sync them from JS instead. Any element
+        // tagged data-i18n-placeholder='{"en":"…","uk":"…"}' gets its
+        // placeholder swapped on load and on every toggle click.
+        const applyPlaceholders = (locale) => {
+          document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+            try {
+              const variants = JSON.parse(el.dataset.i18nPlaceholder);
+              el.placeholder = variants[locale] ?? variants.en ?? el.placeholder;
+            } catch {
+              // Malformed variants JSON — leave the static placeholder attribute as-is.
+            }
+          });
+        };
         document.documentElement.dataset.chromeLocale = detect();
+        document.addEventListener('DOMContentLoaded', () => {
+          applyPlaceholders(document.documentElement.dataset.chromeLocale);
+        });
         // Delegated toggle — works regardless of when the button mounts.
         document.addEventListener('click', (event) => {
           const toggle = event.target.closest?.('#lu-locale-toggle');
           if (!toggle) return;
           const next = document.documentElement.dataset.chromeLocale === 'uk' ? 'en' : 'uk';
           document.documentElement.dataset.chromeLocale = next;
+          applyPlaceholders(next);
           try {
             window.localStorage.setItem(KEY, next);
           } catch {
@@ -291,8 +316,8 @@ const isActive = (href: string) => {
           ]}>
             <div class="lu-hero-inner">
               <span class="lu-badge">{eyebrowKey ? <ChromeText k={eyebrowKey} /> : eyebrow}</span>
-              <h1>{title}</h1>
-              {subtitle && <p>{subtitle}</p>}
+              <h1>{titleKey ? <ChromeText k={titleKey} /> : title}</h1>
+              {(subtitleKey || subtitle) && <p>{subtitleKey ? <ChromeText k={subtitleKey} /> : subtitle}</p>}
             </div>
           </section>
         )}
@@ -302,7 +327,15 @@ const isActive = (href: string) => {
             {navItems.map((item, index) => (
               <>
                 {index > 0 && <span>/</span>}
-                <a href={item.href}>{item.label === 'Home' ? <ChromeText k="nav.home" /> : item.label}</a>
+                <a href={item.href}>
+                  {item.labelKey ? (
+                    <ChromeText k={item.labelKey} />
+                  ) : item.label === 'Home' ? (
+                    <ChromeText k="nav.home" />
+                  ) : (
+                    item.label
+                  )}
+                </a>
               </>
             ))}
           </nav>
@@ -312,10 +345,16 @@ const isActive = (href: string) => {
           {sidebar && (
             <details class="lu-sidebar" open>
               <summary class="lu-sidebar-toggle">
-                {sidebar.titleLabel ? sidebar.titleLabel : <ChromeText k="sidebar.lessons" />} · <span class="lu-i18n"><span data-loc="en">{sidebar.positionLabelEn ?? sidebar.positionLabel}</span><span data-loc="uk">{sidebar.positionLabel}</span></span>
+                {sidebar.titleLabelKey ? (
+                  <ChromeText k={sidebar.titleLabelKey} />
+                ) : sidebar.titleLabel ? (
+                  sidebar.titleLabel
+                ) : (
+                  <ChromeText k="sidebar.lessons" />
+                )} · <span class="lu-i18n"><span data-loc="en">{sidebar.positionLabelEn ?? sidebar.positionLabel}</span><span data-loc="uk">{sidebar.positionLabel}</span></span>
               </summary>
               <div class="lu-sidebar-body">
-                <a class="lu-sidebar-back" href={sidebar.backHref}>← {sidebar.backLabel}</a>
+                <a class="lu-sidebar-back" href={sidebar.backHref}>← {sidebar.backLabelKey ? <ChromeText k={sidebar.backLabelKey} /> : sidebar.backLabel}</a>
                 <div class="lu-sidebar-progress">
                   <div><span class="lu-i18n"><span data-loc="en">{sidebar.positionLabelEn ?? sidebar.positionLabel}</span><span data-loc="uk">{sidebar.positionLabel}</span></span></div>
                   <div class="lu-mini-bar">

--- a/site/src/pages/readings/[...slug].astro
+++ b/site/src/pages/readings/[...slug].astro
@@ -23,7 +23,8 @@ export async function getStaticPaths() {
 const { entry, readings, docs } = Astro.props;
 const { Content } = await render(entry);
 
-const pluralTexts = (n: number) => (n === 1 ? 'text' : 'texts');
+const pluralTextsEn = (n: number) => (n === 1 ? 'text' : 'texts');
+const pluralTextsUk = (n: number) => (n === 1 ? 'текст' : 'тексти');
 
 const sorted = [...readings].sort(
   (a, b) => (a.data.order ?? 999) - (b.data.order ?? 999) || a.data.title.localeCompare(b.data.title, 'uk'),
@@ -51,9 +52,12 @@ const taughtInLinks = (entry.data.taught_in ?? [])
 const sidebar = {
   backHref: '/readings/',
   backLabel: 'Reading reference',
+  backLabelKey: 'nav.readings' as const,
   titleLabel: 'Reading reference',
+  titleLabelKey: 'nav.readings' as const,
   navLabel: 'Primary sources',
-  positionLabel: `${links.length} ${pluralTexts(links.length)}`,
+  positionLabel: `${links.length} ${pluralTextsUk(links.length)}`,
+  positionLabelEn: `${links.length} ${pluralTextsEn(links.length)}`,
   progressDone: 0,
   progressTotal: links.length,
   links,
@@ -64,12 +68,13 @@ const sidebar = {
   title={entry.data.title}
   description={entry.data.excerpt}
   eyebrow="Reading reference"
+  eyebrowKey="nav.readings"
   subtitle={entry.data.excerpt}
   currentPath={`/readings/${entry.id}/`}
   heroVariant="readings"
   navItems={[
-    { href: '/', label: 'Home' },
-    { href: '/readings/', label: 'Reading reference' },
+    { href: '/', label: 'Home', labelKey: 'nav.home' },
+    { href: '/readings/', label: 'Reading reference', labelKey: 'nav.readings' },
     { href: `/readings/${entry.id}/`, label: entry.data.title },
   ]}
   sidebar={sidebar}

--- a/site/src/pages/readings/index.astro
+++ b/site/src/pages/readings/index.astro
@@ -30,13 +30,17 @@ const TRACK_LABELS: Record<string, string> = {
 
 <CourseLayout
   title="Reading reference"
+  titleKey="nav.readings"
   description="The full original primary-source texts the seminars teach from — for reading and close study."
   eyebrowKey="readings.eyebrow"
-  subtitle="The full original texts the seminars teach from. Lessons study excerpts and link here for the complete work."
+  subtitleKey="readings.subtitle"
   currentPath="/readings/"
   heroVariant="readings"
   wide
-  navItems={[{ href: '/', label: 'Home' }, { href: '/readings/', label: 'Reading reference' }]}
+  navItems={[
+    { href: '/', label: 'Home', labelKey: 'nav.home' },
+    { href: '/readings/', label: 'Reading reference', labelKey: 'nav.readings' },
+  ]}
 >
   <section class="readings-home">
     <p class="readings-intro">
@@ -45,7 +49,16 @@ const TRACK_LABELS: Record<string, string> = {
 
     <div class="readings-search">
       <label for="readings-q" class="sr-only"><ChromeText k="readings.searchLabel" /></label>
-      <input id="readings-q" type="search" placeholder={CHROME_STRINGS.en['readings.searchPlaceholder']} autocomplete="off" />
+      <input
+        id="readings-q"
+        type="search"
+        placeholder={CHROME_STRINGS.en['readings.searchPlaceholder']}
+        data-i18n-placeholder={JSON.stringify({
+          en: CHROME_STRINGS.en['readings.searchPlaceholder'],
+          uk: CHROME_STRINGS.uk['readings.searchPlaceholder'],
+        })}
+        autocomplete="off"
+      />
       <p class="readings-count" data-readings-count role="status" aria-live="polite" aria-atomic="true">
         <span class="lu-i18n">
           <span data-loc="en">{sorted.length} {sorted.length === 1 ? 'text' : 'texts'}</span>


### PR DESCRIPTION
## What
Fixes the readings-page half of #6711: after clicking УКР on `/readings/`, the hero title, subtitle, and search placeholder stayed English no matter what the chrome-locale dictionary held.

## Root cause
`CourseLayout`'s hero `<h1>`/`<p>` and breadcrumb labels rendered plain strings, not the dual-render `ChromeText` spans the CSS toggle depends on — so no `ChromeKey` prop existed to translate them. `<input placeholder>` can't use the CSS show/hide trick at all (it's an attribute, not text nodes), so it was hardcoded to the English string.

## Fix
- `CourseLayout`: added optional `titleKey` / `subtitleKey` / `labelKey` (breadcrumbs) / `backLabelKey` / `titleLabelKey` (sidebar) `ChromeKey` props that dual-render through `ChromeText` when passed, falling back to the existing plain-string props otherwise (fully backward compatible — every other page keeps working unchanged).
- `/readings/`: wired hero title/subtitle and breadcrumb to `nav.readings` / `readings.subtitle`; search input now carries a `data-i18n-placeholder` JSON attribute that a small addition to the existing Chrome Locale Runtime script syncs on load and on toggle.
- `/readings/{slug}/`: same eyebrow/breadcrumb/sidebar fix. Also found and fixed the sidebar's "N texts" count, which was always the English plural regardless of locale (`positionLabel`/`positionLabelEn` were never split).

## Scope decision
Home hero title/subtitle (`Learn Ukrainian` / `A practical English interface for learning Ukrainian.`) is **left as English by design** — issue #6711's own notes flag this as the intentional English-interface product-line copy, not a bug. Happy to revisit if that reading is wrong.

## Verified
- `astro check`: no new errors (30 pre-existing errors, all in unrelated test files, confirmed present before this change too).
- `astro build`: 431 pages build clean; inspected `dist/readings/index.html` and a reading detail page — hero, eyebrow, breadcrumbs, sidebar, and the "40 texts"/"40 тексти" count all dual-render correctly per locale.
- `vitest run`: same 4 pre-existing failures with and without this diff (missing `.venv`/`atlas.db`/hydrated shards in this worktree — unrelated to i18n).

Leaves #6711 and #4387 open per dispatch (home hero ambiguity + parent epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
