### PR TITLE
fix(practice): one round denominator, matching miss feedback, live stats tiles (#6720, #6721, #6723)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: e72adab990be126ea7b38053d65b37d633f00fb9fde71de3278ec411805a5d14
+  components_sha256: c4a6d01b4d495c0286952770e514c2fd0f5a93543566f72013a5fc3602236946
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1813,6 +1813,10 @@ components:
       - name: lapsed
         type: number
         description: lapsed prop.
+        ukrainian_text: 'false'
+      - name: roundSize
+        type: number
+        description: roundSize prop.
         ukrainian_text: 'false'
       - name: advancedToReview
         type: string[]

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1,5 +1,6 @@
-import { type CSSProperties, type ReactElement, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import MatchUp from './MatchUp';
+import { type CSSProperties, type ReactElement, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import MatchUp, { type MatchPair } from './MatchUp';
+import { parseMarkdown, shuffle } from '../../../packages/activity-kit/src/components/utils';
 import PracticeDailyDeck from './PracticeDailyDeck';
 import PracticeErrorBoundary from './PracticeErrorBoundary';
 import PracticeFlashcard from './PracticeFlashcard';
@@ -1484,6 +1485,242 @@ function casePhraseAccusative(caseLabel: string): string {
   return `у ${caseLabel} відмінок`;
 }
 
+/** Convert a 1-based match order to a circled digit string. Supports 1–50. */
+function circledNumber(n: number): string {
+  if (n >= 1 && n <= 20) return String.fromCodePoint(0x245f + n);
+  if (n >= 21 && n <= 35) return String.fromCodePoint(0x3250 + n);
+  if (n >= 36 && n <= 50) return String.fromCodePoint(0x32a0 + n);
+  return String(n);
+}
+
+const PRACTICE_MATCH_TOKENS = ['teal', 'orange', 'purple', 'yellow'] as const;
+const PRACTICE_MATCH_PAIR_CODING_CLASS = 'match-pair-coded';
+/**
+ * #6721: long enough for the red shake on a wrong pair to actually register —
+ * the shared activity-kit board clears it after 240ms, which read as "tiles just
+ * deselect" (silent swallowed error) in the production learner pass.
+ */
+const PRACTICE_MATCH_MISS_FLASH_MS = 700;
+
+/**
+ * #6721: practice-owned matching board. The shared activity-kit MatchUp swallows
+ * a wrong pair — a sub-visible flicker, no copy, no feedback — so a mismatch
+ * trained nothing. This board keeps the same DOM contract (match-up.css classes,
+ * data-activity/data-pair-coding attributes, semantic-four pair coding and miss
+ * → good/hard/again rating) but makes every mismatch explicit: a red shake on
+ * both tiles plus a «Спробуйте ще раз» notice that stays until the learner acts.
+ */
+function PracticeMatchBoard({
+  pairs,
+  instruction,
+  isUkrainian,
+  onComplete,
+  onMatch,
+}: {
+  pairs: MatchPair[];
+  instruction?: ReactNode;
+  isUkrainian: boolean;
+  onComplete(): void;
+  onMatch?: (pairIndex: number, rating: PracticeRating) => void;
+}) {
+  const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
+  const [matched, setMatched] = useState<ReadonlySet<number>>(() => new Set());
+  const [matchedOrder, setMatchedOrder] = useState<ReadonlyMap<number, number>>(() => new Map());
+  const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
+  const [misses, setMisses] = useState<Record<number, number>>({});
+  const [missNotice, setMissNotice] = useState(false);
+  const completedRef = useRef(false);
+  const missTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (missTimerRef.current !== null) window.clearTimeout(missTimerRef.current);
+    },
+    [],
+  );
+
+  // Deterministic right-column order (content-seeded), stable across re-renders.
+  const shuffledRight = useMemo(() => shuffle(pairs.map((_, index) => index)), [pairs]);
+
+  const allMatched = pairs.length > 0 && matched.size === pairs.length;
+  useEffect(() => {
+    if (allMatched && !completedRef.current) {
+      completedRef.current = true;
+      onComplete();
+    }
+  }, [allMatched, onComplete]);
+
+  function handleLeftClick(index: number) {
+    if (matched.has(index) || wrongPair) return;
+    setSelectedLeft(index);
+    setMissNotice(false);
+  }
+
+  function handleRightClick(originalIndex: number) {
+    if (selectedLeft === null || matched.has(originalIndex) || wrongPair) return;
+    if (selectedLeft === originalIndex) {
+      const nextMatched = new Set(matched);
+      nextMatched.add(originalIndex);
+      const nextOrder = new Map(matchedOrder);
+      nextOrder.set(originalIndex, nextMatched.size);
+      const currentMisses = misses[selectedLeft] ?? 0;
+      const rating: PracticeRating =
+        currentMisses === 0 ? 'good' : currentMisses === 1 ? 'hard' : 'again';
+      setMatched(nextMatched);
+      setMatchedOrder(nextOrder);
+      setSelectedLeft(null);
+      setMissNotice(false);
+      onMatch?.(selectedLeft, rating);
+      return;
+    }
+    // Wrong pair: count the miss (feeds the eventual rating), flash red, and
+    // keep a visible «try again» notice — never silently deselect (#6721).
+    setMisses((prev) => ({ ...prev, [selectedLeft]: (prev[selectedLeft] ?? 0) + 1 }));
+    setWrongPair({ left: selectedLeft, right: originalIndex });
+    setMissNotice(true);
+    if (missTimerRef.current !== null) window.clearTimeout(missTimerRef.current);
+    missTimerRef.current = window.setTimeout(() => {
+      setWrongPair(null);
+      setSelectedLeft(null);
+    }, PRACTICE_MATCH_MISS_FLASH_MS);
+  }
+
+  const pairTag = (originalIndex: number): string | null => {
+    const order = matchedOrder.get(originalIndex);
+    return order === undefined ? null : circledNumber(order);
+  };
+
+  const pairAccessibleName = (
+    originalIndex: number,
+    side: 'left' | 'right',
+  ): string | undefined => {
+    if (!matched.has(originalIndex)) return undefined;
+    const pair = pairs[originalIndex];
+    if (!pair) return undefined;
+    const order = matchedOrder.get(originalIndex);
+    const tag = order ? circledNumber(order) : '';
+    const partner = side === 'left' ? pair.right : pair.left;
+    if (isUkrainian) {
+      return `${pair.left} — ${pair.right}, пара ${tag}, з’єднано з ${partner}`;
+    }
+    return `${pair.left} — ${pair.right}, pair ${tag}, matched with ${partner}`;
+  };
+
+  return (
+    <div data-activity="match-up">
+      {instruction ? (
+        <p aria-live="polite">
+          <strong>{instruction}</strong>
+        </p>
+      ) : null}
+      <div
+        aria-live="polite"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+      >
+        {isUkrainian
+          ? `З’єднано ${matched.size} з ${pairs.length}`
+          : `Matched ${matched.size} of ${pairs.length}`}
+      </div>
+      <div className="matchUpContainer" data-pair-coding="semantic-four">
+        <div className="matchColumn" data-activity="match-left-column">
+          {pairs.map((pair, index) => (
+            <button
+              key={`left-${index}`}
+              className={`matchItem ${matched.has(index) ? 'matched' : ''} ${
+                selectedLeft === index ? 'selected' : ''
+              } ${wrongPair?.left === index ? 'wrong' : ''} ${
+                matched.has(index) ? PRACTICE_MATCH_PAIR_CODING_CLASS : ''
+              }`}
+              data-activity="match-left-tile"
+              data-matched={matched.has(index) ? 'true' : 'false'}
+              data-pair-coding="semantic-four"
+              data-pair-token={index % PRACTICE_MATCH_TOKENS.length}
+              data-selected={selectedLeft === index ? 'true' : 'false'}
+              data-original-index={index}
+              aria-pressed={selectedLeft === index}
+              aria-label={pairAccessibleName(index, 'left')}
+              style={
+                {
+                  '--match-pair-token': PRACTICE_MATCH_TOKENS[index % PRACTICE_MATCH_TOKENS.length],
+                } as CSSProperties
+              }
+              onClick={() => handleLeftClick(index)}
+              disabled={matched.has(index)}
+            >
+              {parseMarkdown(pair.left)}
+              {pairTag(index) ? (
+                <span className="matchPairTag" aria-hidden="true">
+                  {pairTag(index)}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+        <div className="matchColumn" data-activity="match-right-column">
+          {shuffledRight.map((originalIndex, displayIndex) => (
+            <button
+              key={`right-${displayIndex}`}
+              className={`matchItem ${matched.has(originalIndex) ? 'matched' : ''} ${
+                wrongPair?.right === originalIndex ? 'wrong' : ''
+              } ${matched.has(originalIndex) ? PRACTICE_MATCH_PAIR_CODING_CLASS : ''}`}
+              data-activity="match-right-tile"
+              data-matched={matched.has(originalIndex) ? 'true' : 'false'}
+              data-original-index={originalIndex}
+              data-pair-coding="semantic-four"
+              data-pair-token={originalIndex % PRACTICE_MATCH_TOKENS.length}
+              aria-label={pairAccessibleName(originalIndex, 'right')}
+              style={
+                {
+                  '--match-pair-token':
+                    PRACTICE_MATCH_TOKENS[originalIndex % PRACTICE_MATCH_TOKENS.length],
+                } as CSSProperties
+              }
+              onClick={() => handleRightClick(originalIndex)}
+              disabled={matched.has(originalIndex)}
+            >
+              {parseMarkdown(pairs[originalIndex]!.right)}
+              {pairTag(originalIndex) ? (
+                <span className="matchPairTag" aria-hidden="true">
+                  {pairTag(originalIndex)}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </div>
+      {missNotice ? (
+        <p
+          className="lexicon-practice-warning practice-match-miss"
+          role="status"
+          data-testid="practice-match-miss"
+        >
+          <ChromeDual uk="✗ Спробуйте ще раз" en="✗ Try again" />
+        </p>
+      ) : null}
+      {allMatched ? (
+        <p
+          className="lexicon-practice-muted practice-match-success"
+          role="status"
+          data-activity="match-feedback"
+          data-correct="true"
+        >
+          <ChromeDual uk="✓ Все з’єднано правильно!" en="All matched correctly!" />
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 /** Digit 1–n shortcuts for multiple-choice option lists (drill/choice). */
 function DigitChoiceShortcuts({
   options,
@@ -1679,6 +1916,14 @@ function LexiconPracticeIsland({
 
   const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
   const [dailySnapshot, setDailySnapshot] = useState<DailyPracticeDeckSnapshot | null>(null);
+  // #6723: the daily snapshot is rebuilt every time the learner re-enters idle
+  // (after a session, a level switch, a re-roll). `deriveDailyPracticeRows` only
+  // counts reviews NEWER than `snapshot.createdAt`, so a fresh `createdAt` on every
+  // rebuild hid the just-finished session from the stats tiles (ВИВЧЕНО stayed 0,
+  // НОВІ stayed 12). Pin the day's baseline to the FIRST build so today's earlier
+  // reviews survive later rebuilds. Keyed by calendar day, not level/deck: a level
+  // switch must not erase this morning's progress from the tiles either.
+  const dailySnapshotBaselineRef = useRef<{ date: string; createdAt: number } | null>(null);
   const [dailyLexemes, setDailyLexemes] = useState<Map<string, PracticeLexeme>>(() => new Map());
   const [dailySnapshotLoading, setDailySnapshotLoading] = useState(false);
   const [dailyReRollCount, setDailyReRollCount] = useState(() => readDailyReRollCount(todayKey()));
@@ -2220,12 +2465,16 @@ function LexiconPracticeIsland({
             : pickDaily(fallbackPool, dateSeed(now) + reRollSeed(dailyReRollCount), DAILY_PRACTICE_DECK_SIZE);
         }
 
+        const baseline = dailySnapshotBaselineRef.current;
+        const createdAt = baseline && baseline.date === dateKey ? baseline.createdAt : now.getTime();
+        dailySnapshotBaselineRef.current = { date: dateKey, createdAt };
+
         const snapshot: DailyPracticeDeckSnapshot = {
           version: 2,
           date: dateKey,
           level: learnerLevel,
           deckVersion: deckLemmaKeys !== null ? selectedDeckFilter : 'daily-pool',
-          createdAt: now.getTime(),
+          createdAt,
           items: displayablePicks.map((word) => ({
             lemmaId: word.slug,
             origin: classifyDailyPracticeOrigin(word.slug, indexSource, state.cards, now),
@@ -2866,8 +3115,15 @@ function LexiconPracticeIsland({
     setResumeSnapshots((snapshots) => ({ ...snapshots, [mode]: snapshot }));
   }
 
+  /**
+   * #6720: ONE denominator for the whole round. The target is frozen at session
+   * start (or restored from a resume snapshot). Lapsed-card re-serves still extend
+   * the round internally (`resolveSessionCompletion`/`extensionUsed`), but they
+   * must never move the badge denominator mid-round (live: 1/6 → 10/11 while the
+   * summary said 8/10).
+   */
   function effectiveSessionTarget(): number {
-    return plannedTotal + extensionUsed;
+    return plannedTotal;
   }
 
   function openSummary(deferred: PracticeLexeme[] = deferredLemmas) {
@@ -3465,7 +3721,9 @@ function LexiconPracticeIsland({
     mode === 'mixed' && selection && visibleStageMode !== 'mixed'
       ? `Mixed · ${MODE_META[visibleStageMode].en}`
       : MODE_META[visibleStageMode].en;
-  const progressLabel = `${sessionCompleted}/${effectiveSessionTarget()}`;
+  // #6720: re-served lapsed cards push `sessionCompleted` past the frozen target —
+  // clamp the numerator so the badge never overshoots its own denominator.
+  const progressLabel = `${Math.min(sessionCompleted, effectiveSessionTarget())}/${effectiveSessionTarget()}`;
   const dailySnapshotIds = useMemo(
     () => new Set(dailySnapshot?.items.map((item) => item.lemmaId) ?? []),
     [dailySnapshot],
@@ -3473,6 +3731,7 @@ function LexiconPracticeIsland({
   const summaryStats: SessionSummaryStats = {
     correct: sessionCorrect,
     lapsed: sessionLapsed,
+    roundSize: effectiveSessionTarget(),
     advancedToReview: advancedToReview.filter((lemma) =>
       dailySnapshotIds.size === 0
         ? true
@@ -4636,7 +4895,7 @@ function PracticeItem({
     const totalPairs = pairs.length;
     return (
       <div data-testid="practice-matching">
-        <MatchUp
+        <PracticeMatchBoard
           key={selection.cardKey}
           pairs={pairs}
           instruction={(
@@ -4646,7 +4905,6 @@ function PracticeItem({
             />
           )}
           isUkrainian={chromeLocale === 'uk'}
-          matchedPairCoding="semantic-four"
           onComplete={onMatchingComplete}
           onMatch={(pairIndex, rating) => {
             matchedPairIndexesRef.current.add(pairIndex);

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -5,6 +5,12 @@ import type { PracticeLexeme } from '../lib/lexicon/srs';
 export interface SessionSummaryStats {
   correct: number;
   lapsed: number;
+  /**
+   * #6720: the frozen session target planned at round start. The score ratio uses
+   * this one denominator so the summary agrees with the in-session progress badge
+   * (lapsed-card re-serves extend the round but never move the denominator).
+   */
+  roundSize: number;
   advancedToReview: string[];
   streak: number;
   nextDueLabel: { uk: string; en: string } | null;
@@ -28,7 +34,9 @@ export default function PracticeSessionSummary({
   // chromeLocale is the caller's pure-locale contract; ChromeText/ChromeDual
   // render both locales and CSS on html[data-chrome-locale] shows one.
   void chromeLocale;
-  const total = stats.correct + stats.lapsed;
+  // Score against the frozen round size, not raw rating counts: re-served lapsed
+  // cards earn a second correct rating, so `correct` can exceed the round size.
+  const scoreCorrect = Math.min(stats.correct, stats.roundSize);
   return (
     <div className="lexicon-session-summary" data-testid="practice-session-summary">
       <h2 className="lexicon-session-summary-title">
@@ -58,7 +66,7 @@ export default function PracticeSessionSummary({
             <ChromeText k="practice.score" />
           </dt>
           <dd>
-            {stats.correct}/{total}
+            {scoreCorrect}/{stats.roundSize}
           </dd>
         </div>
       </dl>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -4417,6 +4417,7 @@ describe('LexiconPractice', () => {
     const stats: SessionSummaryStats = {
       correct: 18,
       lapsed: 2,
+      roundSize: 20,
       advancedToReview: [],
       streak: 5,
       nextDueLabel: null,
@@ -4870,6 +4871,159 @@ describe('LexiconPractice', () => {
       await user.click(screen.getByRole('button', { name: 'До колод' }));
       expect(screen.getByTestId('practice-dashboard-hero')).toBeInTheDocument();
       expect(screen.getByTestId('practice-mode-count-zno-stress')).toHaveTextContent(String(znoStressDeck.items.length));
+    });
+  });
+
+  describe('#6720/#6721/#6723 practice UX regressions', () => {
+    function threeFlashcardDeck(): PracticeDeckData {
+      const lexemes = [
+        lexeme('knyha', 'книга', 'book', { nominative: 'книга', accusative: 'книгу', locative: 'книзі' }),
+        lexeme('robota', 'робота', 'work', { nominative: 'робота', accusative: 'роботу', locative: 'роботі' }),
+        lexeme('misto', 'місто', 'city', { nominative: 'місто', accusative: 'місто', locative: 'місті' }),
+      ];
+      return {
+        deckVersion: 'test-6720',
+        level: 'A1',
+        lexemes,
+        index: lexemes.map((entry, index) => ({
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['flashcards'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: index,
+        })),
+        cloze: [],
+      };
+    }
+
+    test('#6720 session badge keeps one denominator for the whole round and the summary agrees', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <LexiconPractice initialDeck={threeFlashcardDeck()} autoStart initialMode="flashcards" />,
+      );
+      expect(await screen.findByTestId('practice-session-progress')).toHaveTextContent('0/3');
+
+      const answerCurrent = async (rating: 'again' | 'good') => {
+        const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
+        expect(flashcard).toBeInTheDocument();
+        await user.click(flashcard!);
+        await user.click(container.querySelector<HTMLButtonElement>(`[data-rate="${rating}"]`)!);
+        await user.click(await screen.findByTestId('practice-advance-button'));
+      };
+
+      await answerCurrent('again'); // lapsed — re-served later as a round extension
+      expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('1/3');
+      await answerCurrent('good');
+      expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('2/3');
+      await answerCurrent('good');
+      // The extension must not grow the denominator mid-round (was 3/4 → 4/5 …).
+      expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('3/3');
+
+      // Answer whatever the extension re-serves until the round closes; the badge
+      // denominator must stay frozen the whole time.
+      for (let i = 0; i < 8; i += 1) {
+        if (screen.queryByTestId('practice-session-summary')) break;
+        await answerCurrent('good');
+        if (screen.queryByTestId('practice-session-summary')) break;
+        expect(screen.getByTestId('practice-session-progress')).toHaveTextContent(/^\d+\/3$/);
+      }
+
+      const summary = await screen.findByTestId('practice-session-summary');
+      // Same denominator as the badge: the score is against the frozen round size.
+      expect(summary).toHaveTextContent('3/3');
+    });
+
+    test('#6721 matching wrong pair flashes red and shows «Спробуйте ще раз» instead of silently deselecting', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <LexiconPractice initialDeck={matchingDeck()} autoStart initialMode="matching" />,
+      );
+      const leftCol = container.querySelector('[data-activity="match-left-column"]') as HTMLElement;
+      const rightCol = container.querySelector('[data-activity="match-right-column"]') as HTMLElement;
+      expect(leftCol).toBeInTheDocument();
+      expect(rightCol).toBeInTheDocument();
+
+      const firstLeft = within(leftCol).getAllByRole('button')[0]!;
+      const wrongRight = within(rightCol)
+        .getAllByRole('button')
+        .find((b) => b.getAttribute('data-original-index') !== '0')!;
+
+      await user.click(firstLeft);
+      await user.click(wrongRight);
+
+      // The mismatch is visible: both tiles marked wrong + a persistent notice.
+      expect(firstLeft.className).toContain('wrong');
+      expect(wrongRight.className).toContain('wrong');
+      expect(screen.getByTestId('practice-match-miss')).toBeInTheDocument();
+      expect(screen.getByTestId('practice-match-miss')).toHaveTextContent('Спробуйте ще раз');
+
+      // After the flash, the pair can still be completed and the notice clears.
+      await new Promise((resolve) => setTimeout(resolve, 900));
+      await user.click(within(leftCol).getAllByRole('button')[0]!);
+      expect(screen.queryByTestId('practice-match-miss')).not.toBeInTheDocument();
+      const correctRight = within(rightCol)
+        .getAllByRole('button')
+        .find((b) => b.getAttribute('data-original-index') === '0')!;
+      await user.click(correctRight);
+      expect(screen.queryByTestId('practice-match-miss')).not.toBeInTheDocument();
+      expect(within(leftCol).getAllByRole('button')[0]).toHaveAttribute('data-matched', 'true');
+    });
+
+    test('#6723 stats tiles reflect the just-played session on return home', async () => {
+      document.documentElement.dataset.chromeLocale = 'en';
+      localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+      const { fn } = mockShardFetch({ A1: 12 });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice />);
+
+      const statValues = () =>
+        Array.from(
+          container.querySelectorAll('[data-testid="practice-dashboard-stats"] .k3-stat-value'),
+        ).map((el) => el.textContent);
+
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '12', '0']));
+
+      // Play one flashcard and rate it «Good».
+      await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+      const flashcard = await waitFor(() => {
+        const el = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
+        expect(el).toBeInTheDocument();
+        return el!;
+      });
+      await user.click(flashcard);
+      await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!);
+
+      // Back home: the done/new tiles must reflect the rating immediately.
+      await user.click(container.querySelector<HTMLButtonElement>('button.stage-back')!);
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '11', '1']));
+    });
+
+    test('#6723 deck chip follows the accepted level switch after going home', async () => {
+      document.documentElement.dataset.chromeLocale = 'en';
+      localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+      const { fn } = mockShardFetch({ A1: 15, B1: 15 });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice />);
+
+      await user.click(await screen.findByTestId('practice-start-session'));
+      await screen.findByTestId('practice-session-progress');
+      // Abort home mid-session: the stored snapshot makes the next level tap an offer.
+      await user.click(container.querySelector<HTMLButtonElement>('button.stage-back')!);
+      expect(await screen.findByTestId('practice-active-deck-chip')).toHaveTextContent(
+        'All Words (A1)',
+      );
+
+      await user.click(screen.getByRole('button', { name: 'B1' }));
+      await user.click(await screen.findByTestId('practice-switch-session-accept'));
+      await screen.findByTestId('practice-session-progress');
+      await user.click(container.querySelector<HTMLButtonElement>('button.stage-back')!);
+      expect(await screen.findByTestId('practice-active-deck-chip')).toHaveTextContent(
+        'All Words (B1)',
+      );
     });
   });
 });


### PR DESCRIPTION
## What

One PR for three Practice Mix UX bugs from the 2026-08-13 production learner pass. Scope: `site/src/components/LexiconPractice.tsx`, `PracticeSessionSummary.tsx`, and their tests only.

### #6720 — session counter disagrees with itself
The badge denominator was `plannedTotal + extensionUsed`, so every lapsed-card extension grew it mid-round (live: `1/6 → 10/11` while the summary said `8/10`). Now:
- The denominator is frozen at session start (`plannedTotal`, restored from the resume snapshot) — one denominator for the whole round.
- The numerator is clamped so re-served lapsed cards never overshoot it.
- The summary score uses the same frozen `roundSize` (`min(correct, roundSize)/roundSize`), so badge and summary agree.

Note: when SRS pacing plans fewer items than the chosen size (e.g. 6 of size 10 under the daily-new cap), the honest round is 6 — the badge stays `n/6` end-to-end and matches the home scope line («0 до повторення + 6 нових»).

### #6721 — matching swallows wrong pairs
The shared activity-kit `MatchUp` flashed red for 240ms with no copy — read as "tiles just deselect". Practice now renders its own `PracticeMatchBoard` (same DOM contract: `match-up.css` classes, `data-activity`/`data-pair-coding` attrs, semantic-four coding, circled order tags, miss → good/hard/again rating) that:
- flashes both tiles red for 700ms, and
- shows a persistent «✗ Спробуйте ще раз / ✗ Try again» notice until the learner's next action.

The shared `MatchUp` still serves lesson activities and the heritage match-up variant — untouched.

### #6723 — stats tiles / deck chip stale after a session
The daily snapshot is rebuilt on every idle re-entry with a fresh `createdAt`, and `deriveDailyPracticeRows` only counts reviews newer than `max(midnight, createdAt)` — so the just-finished session's own reviews were filtered out (tiles stuck at «НОВІ 12 · ВИВЧЕНО 0»). `createdAt` is now pinned to the day's first build, so stats update immediately on return home.

The B1 deck-chip path (accept level switch → new session → «← Додому») is correct at HEAD; it is now locked by a regression test so it can't silently regress.

## Tests

- 4 new tests in `site/tests/unit/LexiconPractice.test.tsx`, one per bug (+ chip regression).
- Verified the #6720 / #6721 / #6723-stats tests **fail on the pre-fix code** and pass with the fix.
- `LexiconPractice.test.tsx`: 153/153 pass. Related suites (locale-purity, k3-chrome, first-paint, distractors, MatchUp): 55/55.
- Full `test:unit`: **65 files, 1001 passed, 4 skipped**.
- No new `tsc --noEmit` errors (14 vs 15 pre-existing) and no new eslint errors (56 pre-existing in this file, unchanged).

Refs #4387 (stays open). Non-goals per dispatch: #6722 teaching sentences / results review (follow-up).

X-Agent: kimi/6720-21-23-practice-ux