### PR TITLE
fix(wotd): filter daily set by CEFR level instead of re-ranking (#6727)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: c4a6d01b4d495c0286952770e514c2fd0f5a93543566f72013a5fc3602236946
+  components_sha256: d5ddc1fa296505e39a0719c8e7be6a959501bf3cdc85efd4e71a0639a98455d0
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -86,12 +86,12 @@ import {
 import {
   CEFR_LEVELS,
   LEARNER_LEVEL_STORAGE_KEY,
-  prioritizeByLearnerLevel,
   normalizeCefrLevel,
   parseCefrLevel,
   type CefrLevel,
 } from '../lib/lexicon/levels';
 import { dateSeed, deckSeed, pickDaily, reRollSeed, type DailyWord } from '../lib/lexicon/daily';
+import { pickDailyForLevel } from '../lib/lexicon/daily-card';
 import {
   filterTeacherClozeItems,
   getCachedLowercaseLemmaKeySet,
@@ -2267,8 +2267,9 @@ function LexiconPracticeIsland({
   }, [deck, learnerLevel, shardBaseUrl]);
 
   // D2 (design delta 2026-07-26): the Words-of-the-Day zone renders the SAME 12
-  // lemmas as /words-of-the-day/ — pickDaily(prioritizeByLearnerLevel(pool, level),
-  // dateSeed(now), 12) over /lexicon/daily-pool.json. This is recomputed fresh
+  // lemmas as /words-of-the-day/ — pickDailyForLevel(pool, level, dateSeed(now), 12)
+  // over /lexicon/daily-pool.json (#6727: filter to the selected CEFR, then shuffle
+  // only that subset — never re-rank-and-reshuffle the full 300). Recomputed fresh
   // from (pool, level, date) on every run rather than reused from a persisted
   // snapshot, so there is no stale cache to silently pin the carousel on one
   // word across days (confirmed live bug: борщ every visit, while the page
@@ -2323,9 +2324,9 @@ function LexiconPracticeIsland({
             '/lexicon/daily-pool.json',
             shardJsonCacheRef.current,
           );
-          const eligiblePool = prioritizeByLearnerLevel(pool, learnerLevel);
-          picks = pickDaily(
-            eligiblePool,
+          picks = pickDailyForLevel(
+            pool,
+            learnerLevel,
             dateSeed(now) + reRollSeed(dailyReRollCount),
             DAILY_PRACTICE_DECK_SIZE,
           );

--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -56,10 +56,10 @@ const dailyCount = Math.max(1, Math.floor(count));
   import { dateSeed, pickDaily, type DailyWord } from "../lib/lexicon/daily";
   import {
     bindDailyCardInteractions,
+    pickDailyForLevel,
     renderDailyCardHtml,
   } from "../lib/lexicon/daily-card";
   import {
-    filterByCumulativeLevel,
     LEARNER_LEVEL_STORAGE_KEY,
     normalizeCefrLevel,
     type CefrLevel,
@@ -114,8 +114,12 @@ const dailyCount = Math.max(1, Math.floor(count));
 
     const renderDailyWords = () => {
       if (!dailyList) return;
-      const eligiblePool = useLevelSelector ? filterByCumulativeLevel(pool, activeLevel) : pool;
-      const picks = pickDaily(eligiblePool, dateSeed(new Date()), count);
+      // #6727: level tabs filter the pool to the selected CEFR, then shuffle
+      // only that subset — never re-rank-and-reshuffle the full 300.
+      const seed = dateSeed(new Date());
+      const picks = useLevelSelector
+        ? pickDailyForLevel(pool, activeLevel, seed, count)
+        : pickDaily(pool, seed, count);
 
       if (picks.length === 0) {
         dailyList.innerHTML = "";

--- a/site/src/lib/lexicon/daily-card.ts
+++ b/site/src/lib/lexicon/daily-card.ts
@@ -1,4 +1,19 @@
-import type { DailyWord } from "./daily";
+import { pickDaily, type DailyWord } from "./daily";
+import { filterByCumulativeLevel } from "./levels";
+
+/**
+ * Shared WotD / practice daily draw (#6727): filter the pool to the selected
+ * CEFR first, then Fisher–Yates only that subset. Never re-rank-and-reshuffle
+ * the full daily pool — that produced mixed-level grids under a level status.
+ */
+export function pickDailyForLevel(
+  pool: readonly DailyWord[],
+  selectedLevel: unknown,
+  seed: number,
+  count: number,
+): DailyWord[] {
+  return pickDaily(filterByCumulativeLevel(pool, selectedLevel), seed, count);
+}
 
 /** Escape text for safe interpolation into Daily Words card HTML. */
 export function escapeDailyCardHtml(value: unknown): string {

--- a/site/src/lib/lexicon/levels.ts
+++ b/site/src/lib/lexicon/levels.ts
@@ -127,14 +127,23 @@ export function prioritizeByLearnerLevel<T extends DailyLevelRow>(
 }
 
 /**
- * Backward-compatible name for callers outside practice. Practice itself uses
- * `prioritizeByLearnerLevel`; this function no longer applies a hard cap.
+ * Narrow daily-pool rows to the exact selected CEFR (#6727).
+ *
+ * WotD level tabs and the practice Words-of-the-Day zone must *filter*, not
+ * re-rank: selecting B2 shows only B2 rows from the pool. Soft CEFR preference
+ * (`prioritizeByLearnerLevel`) still applies to practice *session* scheduling;
+ * this helper is the hard tab/status filter. Unknown CEFR rows are excluded.
+ * Invalid selections normalize to A1 via `normalizeCefrLevel`.
+ *
+ * Historical name: once meant ≤ selected level; WotD status copy (`B2 · N слів`)
+ * requires exact match so the count is not a lie.
  */
 export function filterByCumulativeLevel<T extends DailyLevelRow>(
   rows: readonly T[],
   selectedLevel: unknown,
 ): T[] {
-  return prioritizeByLearnerLevel(rows, selectedLevel);
+  const level = normalizeCefrLevel(selectedLevel);
+  return rows.filter((row) => parseCefrLevel(row.cefr) === level);
 }
 
 export function filterRowsByLevel<T extends { c?: string }>(

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -33,7 +33,8 @@ import {
   type PracticeRating,
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
-import { LEARNER_LEVEL_STORAGE_KEY, prioritizeByLearnerLevel, type CefrLevel } from '@site/src/lib/lexicon/levels';
+import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
+import { pickDailyForLevel } from '@site/src/lib/lexicon/daily-card';
 import {
   CUSTOM_SETS_STORAGE_KEY,
   filterTeacherClozeItems,
@@ -41,7 +42,7 @@ import {
   getTeacherLessonVirtualDeck,
   type CustomSet,
 } from '@site/src/lib/lexicon/custom-decks';
-import { dateSeed, pickDaily, type DailyWord } from '@site/src/lib/lexicon/daily';
+import { dateSeed, type DailyWord } from '@site/src/lib/lexicon/daily';
 import { selectHeritagePracticePresentation } from '@site/src/lib/lexicon/practice-activity-adapters';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
@@ -1407,9 +1408,9 @@ describe('LexiconPractice', () => {
       });
 
       const dayOnePool = dailyPoolFixture({ A1: 24 });
-      const eligiblePool = prioritizeByLearnerLevel(dayOnePool, 'A1');
-      const expectedDayTwoDefaultIds = pickDaily(
-        eligiblePool,
+      const expectedDayTwoDefaultIds = pickDailyForLevel(
+        dayOnePool,
+        'A1',
         dateSeed(new Date(2026, 5, 24)),
         DAILY_PRACTICE_DECK_SIZE,
       )
@@ -1876,6 +1877,37 @@ describe('LexiconPractice', () => {
     expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(true);
+  });
+
+  test('#6727: level tabs filter the daily zone to the selected CEFR (B2 is only B2)', async () => {
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'B2');
+    // Mirror post-#6749 pool shape: plenty of A1–C1, including a B2 band large enough for 12.
+    const { fn } = mockShardFetch({ A1: 24, A2: 24, B1: 24, B2: 40, C1: 24 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    const user = userEvent.setup();
+    render(<LexiconPractice />);
+
+    await screen.findByTestId('practice-daily-deck');
+    const summary = screen.getByTestId('practice-daily-summary');
+    if (summary.getAttribute('aria-expanded') !== 'true') {
+      await user.click(summary);
+    }
+
+    const featuredIds = Array.from(document.querySelectorAll('.daily-deck-row'))
+      .map((row) => row.querySelector('[data-testid^="practice-daily-why-"]')?.getAttribute('data-testid'))
+      .filter((id): id is string => Boolean(id))
+      .map((id) => id.replace('practice-daily-why-', ''));
+
+    expect(featuredIds).toHaveLength(DAILY_PRACTICE_DECK_SIZE);
+    expect(featuredIds.every((id) => id.startsWith('B2-'))).toBe(true);
+
+    const expected = pickDailyForLevel(
+      dailyPoolFixture({ A1: 24, A2: 24, B1: 24, B2: 40, C1: 24 }),
+      'B2',
+      dateSeed(new Date()),
+      DAILY_PRACTICE_DECK_SIZE,
+    ).map((word) => word.slug);
+    expect(featuredIds.sort()).toEqual([...expected].sort());
   });
 
   test('flashcard rating persists mode-specific SRS progress', async () => {

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -9,6 +9,7 @@ import {
   bindDailyCardInteractions,
   dailyCardAtlasHref,
   isDailyCardAtlasLinkTarget,
+  pickDailyForLevel,
   renderDailyCardHtml,
   toggleDailyCardFlip,
 } from "@site/src/lib/lexicon/daily-card";
@@ -141,5 +142,11 @@ describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
     expect(dailyWordsSource).toContain('from "../lib/lexicon/daily-card"');
     expect(dailyWordsSource).toContain("bindDailyCardInteractions");
     expect(dailyWordsSource).toContain("renderDailyCardHtml");
+  });
+
+  test("DailyWords filters by level via pickDailyForLevel (#6727)", () => {
+    expect(dailyWordsSource).toContain("pickDailyForLevel");
+    expect(dailyWordsSource).not.toContain("filterByCumulativeLevel");
+    expect(dailyWordsSource).not.toContain("prioritizeByLearnerLevel");
   });
 });

--- a/site/tests/unit/lexicon-daily.test.ts
+++ b/site/tests/unit/lexicon-daily.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { dateSeed, deckSeed, pickDaily, reRollSeed } from '@site/src/lib/lexicon/daily';
+import { dateSeed, deckSeed, pickDaily, reRollSeed, type DailyWord } from '@site/src/lib/lexicon/daily';
+import { pickDailyForLevel } from '@site/src/lib/lexicon/daily-card';
+import { prioritizeByLearnerLevel } from '@site/src/lib/lexicon/levels';
 
 describe('dateSeed', () => {
   test('uses the local calendar date', () => {
@@ -27,6 +29,50 @@ describe('pickDaily', () => {
     const pool = [{ slug: 'a' }, { slug: 'b' }];
 
     expect(pickDaily(pool, 20260623, 24)).toHaveLength(pool.length);
+  });
+});
+
+describe('pickDailyForLevel (#6727 filter-not-reshuffle)', () => {
+  const pool: DailyWord[] = (
+    [
+      ['A1', 73],
+      ['A2', 75],
+      ['B1', 72],
+      ['B2', 40],
+      ['C1', 40],
+    ] as const
+  ).flatMap(([level, n]) =>
+    Array.from({ length: n }, (_, i) => ({
+      lemma: `слово-${level}-${i}`,
+      slug: `${level}-${i}`,
+      gloss: `gloss ${level} ${i}`,
+      cefr: level,
+    })),
+  );
+
+  test('B2 draws only B2 rows — does not reshuffle the whole 300', () => {
+    const seed = dateSeed(new Date(2026, 7, 13));
+    const picks = pickDailyForLevel(pool, 'B2', seed, 12);
+
+    expect(picks).toHaveLength(12);
+    expect(picks.every((word) => word.cefr === 'B2')).toBe(true);
+
+    // Contrast: soft re-rank + full-pool shuffle admits other levels (the #6727 bug).
+    const reshuffledWholePool = pickDaily(prioritizeByLearnerLevel(pool, 'B2'), seed, 12);
+    expect(reshuffledWholePool.some((word) => word.cefr !== 'B2')).toBe(true);
+  });
+
+  test('A1/A2/B1/C1 each stay within their own CEFR band', () => {
+    const seed = dateSeed(new Date(2026, 7, 13));
+    for (const level of ['A1', 'A2', 'B1', 'C1'] as const) {
+      const picks = pickDailyForLevel(pool, level, seed, 12);
+      expect(picks).toHaveLength(12);
+      expect(picks.every((word) => word.cefr === level)).toBe(true);
+    }
+  });
+
+  test('C2 with an empty band returns no cards (honest empty — #6728 residual)', () => {
+    expect(pickDailyForLevel(pool, 'C2', dateSeed(new Date(2026, 7, 13)), 12)).toEqual([]);
   });
 });
 

--- a/site/tests/unit/lexicon-levels.test.ts
+++ b/site/tests/unit/lexicon-levels.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  filterByCumulativeLevel,
   filterRowsByLevel,
   populatedUkrainianLetters,
   prioritizeByLearnerLevel,
@@ -28,6 +29,32 @@ describe('prioritizeByLearnerLevel', () => {
       'ранок',
       'невідоме',
     ]);
+  });
+});
+
+describe('filterByCumulativeLevel (#6727 exact CEFR filter)', () => {
+  const rows = [
+    { lemma: 'ранок', cefr: 'A1' },
+    { lemma: 'площа', cefr: 'A2' },
+    { lemma: 'громада', cefr: 'B1' },
+    { lemma: 'відтінок', cefr: 'B2' },
+    { lemma: 'архітектоніка', cefr: 'C1' },
+    { lemma: 'невідоме' },
+  ];
+
+  test('keeps only rows at the selected CEFR — does not re-rank the full pool', () => {
+    expect(filterByCumulativeLevel(rows, 'B2').map((row) => row.lemma)).toEqual(['відтінок']);
+    expect(filterByCumulativeLevel(rows, 'A1').map((row) => row.lemma)).toEqual(['ранок']);
+    expect(filterByCumulativeLevel(rows, 'C1').map((row) => row.lemma)).toEqual(['архітектоніка']);
+  });
+
+  test('excludes unknown CEFR and returns empty when the level is absent from the pool', () => {
+    expect(filterByCumulativeLevel(rows, 'C2')).toEqual([]);
+    expect(filterByCumulativeLevel(rows, 'B2').every((row) => row.cefr === 'B2')).toBe(true);
+  });
+
+  test('normalizes invalid selections to A1 without admitting other levels', () => {
+    expect(filterByCumulativeLevel(rows, 'C0').map((row) => row.lemma)).toEqual(['ранок']);
   });
 });
 


### PR DESCRIPTION
## Summary
- WotD level tabs now **filter** `/lexicon/daily-pool.json` to the selected CEFR before `pickDaily`, instead of soft-re-ranking then shuffling the full 300.
- Shared `pickDailyForLevel` keeps `/words-of-the-day/` and the practice Words-of-the-Day zone on the same draw.
- B2 shows only B2 rows; A1/A2/B1/C1 stay band-local. C2 with 0 pool rows stays honestly empty.

## Changes
- `filterByCumulativeLevel` restores an exact-CEFR hard filter (WotD tab/status semantics).
- `pickDailyForLevel` in `daily-card.ts`; wired from `DailyWords.astro` + `LexiconPractice.tsx`.
- Tests for filter-not-reshuffle (unit + LexiconPractice B2 regression).

## Testing
- [x] `vitest run` on `lexicon-levels`, `lexicon-daily`, `daily-words-example`, `LexiconPractice` — 184 passed
- [ ] Website builds without errors (`cd site && npm run build`)
- [ ] Ukrainian text reviewed for naturalness

## Related Issues
Refs #6727 — This PR leaves #6727 open (awaiting cross-family review / merge ownership).
This PR leaves #4387 open.
This PR leaves #6728 open (C2 still 0 in the pool; empty-tab UX residual).


Made with [Cursor](https://cursor.com)