### PR TITLE
fix(atlas): heal definition cards chopped by retired quote caps (#6736)

### DIFF
--- a/docs/runbooks/atlas-full-reenrich-campaign.md
+++ b/docs/runbooks/atlas-full-reenrich-campaign.md
@@ -17,6 +17,28 @@ Because the remote VPS repo checkout (`/home/ops/atlas-runner/repo`) is delibera
 
 ---
 
+## Healing chopped dictionary cards (#6736)
+
+Cards chopped mid-entry by the retired 900-char cap (pre-#6437) are provably
+stuck: the additive delta-merge (invariant 2) never overwrites a non-empty
+`definition_cards` field, so a re-enrich campaign alone cannot heal them.
+Before publishing, run the fail-closed repair, which rebuilds ONLY
+signature-chopped `vts`/`sum20` cards from the attested local slovnyk cache
+(read-only; no network, no invented text):
+
+```bash
+.venv/bin/python scripts/lexicon/repair_truncated_definition_cards.py --local --write
+```
+
+Verification output checks:
+- `repaired` — cards restored to the full cached article.
+- `residual_no_cache` — entries whose slovnyk cache row is absent on this
+  machine; rerun where the full cache lives (e.g. the runner) or refetch.
+- `residual_guard_mismatch` — rebuilt text fails the prefix guard (e.g.
+  «див.» cross-reference cards); left untouched, investigate individually.
+
+---
+
 ## Step-by-Step Operator Recipe
 
 ### 1. Pre-flight Positive-Control Canary Check

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1473,7 +1473,11 @@ def _parse_slovnyk_entry(
         "word": headword,
         "source_url": parser.canonical_url or url,
         "title": title,
-        "text": _truncate_text(article_text, 5000),
+        # Store the full attested article (#6736): the former 5000-char cap
+        # amputated the longest multi-sense VTS/СУМ-20 articles mid-text, and
+        # card builders can only quote what the cache kept. Display-length
+        # decisions belong to the consumers, not to raw ingestion.
+        "text": article_text,
         "query": lemma,
         "lookup_word": lookup_word,
     }

--- a/scripts/lexicon/repair_truncated_definition_cards.py
+++ b/scripts/lexicon/repair_truncated_definition_cards.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Restore Atlas definition cards chopped by the retired 900-char cap (#6736).
+
+Pre-#6437 ``_definition_body`` hard-capped dictionary card text at 900 chars,
+amputating multi-sense ВТС/СУМ-20 articles mid-word (e.g. подаватися sense 8
+ends «Става…»). The cap is gone, but the published manifest still carries the
+chopped payloads: the translation-delta merge is additive-only by contract and
+never overwrites a non-empty ``definition_cards`` field, so re-enrichment alone
+cannot heal them.
+
+This script rebuilds ONLY provably-chopped ``vts``/``sum20`` cards from the
+attested local slovnyk.me cache (schema-current rows, read-only). It never
+fetches from the network, never invents text, and is fail-closed: a card is
+replaced only when the rebuilt body is strictly longer and the chopped body is
+a prefix of it modulo whitespace (cross-reference-resolved cards fail this
+check and are reported, not touched).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.manifest_io import load_manifest
+from scripts.lexicon.publish_manifest import (
+    DEFAULT_GZIP,
+    DEFAULT_POINTER,
+    build_pointer_payload,
+    evaluate_manifest_pointer_write_gate,
+    gzip_manifest,
+    write_pointer,
+)
+
+# Signature of the pre-#6437 cap: ``_truncate_text(body, 900)`` emitted
+# ``cleaned[:899].rstrip() + "…"``, so a chopped body is exactly 899 or 900
+# chars long and ends with the ellipsis the cutter appended. Legitimate
+# dictionary prose never lands on this exact length + ellipsis pair.
+CHOP_SIGNATURE_LENGTHS = (899, 900)
+ELLIPSIS = "…"
+
+# Manifest card id → slovnyk.me cache slug. Only slovnyk-backed cards can be
+# restored from the local cache; grinchenko cards come from sources.db and are
+# out of scope here (none are chopped at 900 in practice).
+_CARD_ID_TO_SLOVNYK_SLUG = {"vts": "vts", "sum20": "newsum"}
+
+
+def _is_chopped(text: object) -> bool:
+    return isinstance(text, str) and len(text) in CHOP_SIGNATURE_LENGTHS and text.endswith(ELLIPSIS)
+
+
+def find_chopped_cards(manifest: dict[str, Any]) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Return ``(entry, card)`` pairs whose single definition carries the chop signature."""
+    hits: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for entry in manifest.get("entries") or []:
+        if not isinstance(entry, dict):
+            continue
+        enrichment = entry.get("enrichment")
+        if not isinstance(enrichment, dict):
+            continue
+        cards = enrichment.get("definition_cards")
+        if not isinstance(cards, list):
+            continue
+        for card in cards:
+            if not isinstance(card, dict):
+                continue
+            if card.get("id") not in _CARD_ID_TO_SLOVNYK_SLUG:
+                continue
+            definitions = card.get("definitions")
+            if isinstance(definitions, list) and len(definitions) == 1 and _is_chopped(definitions[0]):
+                hits.append((entry, card))
+    return hits
+
+
+def _cached_slovnyk_row(lemma: str, slug: str) -> dict[str, Any] | None:
+    """Read the lemma's (or its unambiguous base's) cached slovnyk row.
+
+    Read-only: uses the no-fetch cache reader so a cache miss is a residual,
+    never a network call or a cache write.
+    """
+    cache = enrich_manifest._read_cached_slovnyk_rows(lemma)
+    row = enrich_manifest._cache_lookup(cache, slug)
+    if row:
+        return row
+    base = enrich_manifest._vesum_base_lemma(lemma)
+    if base:
+        base_cache = enrich_manifest._read_cached_slovnyk_rows(base)
+        return enrich_manifest._cache_lookup(base_cache, slug)
+    return None
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _squash(text: str) -> str:
+    """Whitespace-free form for the prefix guard.
+
+    Cache rows re-normalized by newer fetch code (#6465 empty-string join) can
+    differ from the published chopped body only in inline-tag spacing
+    («невідм. ,» vs «невідм.,»). The underlying attested article is the same,
+    so the guard compares with whitespace squashed.
+    """
+    return _WHITESPACE_RE.sub("", text)
+
+
+def rebuild_card_body(lemma: str, card_id: str, chopped: str) -> str | None:
+    """Rebuild one chopped card body from the local slovnyk cache.
+
+    Returns the full body, or ``None`` when no attested local source exists or
+    the rebuilt body fails the prefix guard (fail-closed).
+    """
+    slug = _CARD_ID_TO_SLOVNYK_SLUG.get(card_id)
+    if slug is None:
+        return None
+    row = _cached_slovnyk_row(lemma, slug)
+    if not row:
+        return None
+    lookup_word = enrich_manifest._slovnyk_lookup_word(lemma)
+    body = enrich_manifest._definition_body(
+        row.get("text"),
+        headword=str(row.get("word") or lookup_word),
+        strip_leading_headword=True,
+    )
+    if not body:
+        return None
+    # Prefix guard: the chopped body was produced by cutting the same article,
+    # so it must be a verbatim prefix (minus the appended ellipsis), allowing
+    # only whitespace drift from fetch-side re-normalization — including the
+    # retired letter-spaced join (#6465), which also means raw character length
+    # cannot gate the swap (the clean body can be shorter in chars while
+    # carrying strictly more content). Compare squashed forms and require the
+    # rebuilt body to continue past the chop point. A real mismatch means the
+    # published card came from a different resolution path (e.g. a «див.»
+    # cross-reference) — leave it untouched.
+    chopped_prefix = _squash(chopped[: -len(ELLIPSIS)])
+    body_squashed = _squash(body)
+    if len(body_squashed) <= len(chopped_prefix):
+        return None
+    if not body_squashed.startswith(chopped_prefix):
+        return None
+    return body
+
+
+def repair_truncated_cards(
+    manifest: dict[str, Any],
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Restore chopped vts/sum20 cards in place from the local slovnyk cache."""
+    hits = find_chopped_cards(manifest)
+    if limit is not None:
+        hits = hits[:limit]
+    repaired = 0
+    residual_no_cache: list[str] = []
+    residual_guard: list[str] = []
+    for entry, card in hits:
+        lemma = str(entry.get("lemma") or "")
+        chopped = card["definitions"][0]
+        body = rebuild_card_body(lemma, str(card.get("id")), chopped)
+        if body is None:
+            row = _cached_slovnyk_row(lemma, _CARD_ID_TO_SLOVNYK_SLUG[str(card.get("id"))])
+            (residual_no_cache if row is None else residual_guard).append(f"{lemma}:{card.get('id')}")
+            continue
+        card["definitions"] = [body]
+        repaired += 1
+    return {
+        "chopped_cards": len(hits),
+        "repaired": repaired,
+        "residual_no_cache": residual_no_cache,
+        "residual_guard_mismatch": residual_guard,
+    }
+
+
+def _refresh_manifest_fingerprint(manifest: dict[str, Any]) -> None:
+    fingerprint_payload = enrich_manifest.write_fingerprint(enrich_manifest.DEFAULT_FINGERPRINT, root=ROOT)
+    manifest["manifest_fingerprint"] = {
+        "schema_version": fingerprint_payload["schema_version"],
+        "fingerprint": fingerprint_payload["fingerprint"],
+    }
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_default_release_pointer(
+    manifest_path: Path,
+    *,
+    bootstrap_no_baseline: bool = False,
+    allow_richness_regression_reason: str | None = None,
+) -> dict[str, Any] | None:
+    if manifest_path.resolve() != DEFAULT_MANIFEST.resolve():
+        return None
+    richness_gate = evaluate_manifest_pointer_write_gate(
+        manifest_path,
+        bootstrap_no_baseline=bootstrap_no_baseline,
+        allow_richness_regression_reason=allow_richness_regression_reason,
+    )
+    gzip_manifest(manifest_path, DEFAULT_GZIP)
+    pointer = build_pointer_payload(
+        manifest_path=manifest_path,
+        gzip_path=DEFAULT_GZIP,
+        richness_gate=richness_gate,
+    )
+    write_pointer(DEFAULT_POINTER, pointer)
+    return pointer
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Restore 900-char-chopped Atlas definition cards from the local slovnyk cache (#6736)."
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Read manifest path directly instead of hydrating the canonical release asset.",
+    )
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--allow-richness-regression",
+        metavar="REASON",
+        help="Record an operator decision to permit a richness regression while writing the pointer.",
+    )
+    parser.add_argument(
+        "--bootstrap-no-baseline",
+        action="store_true",
+        help="Write only an initial pointer when no canonical release asset exists; records bootstrap=true.",
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if args.local else load_manifest(manifest_path)
+
+    summary = repair_truncated_cards(manifest, limit=args.limit)
+    printable = {
+        **summary,
+        "residual_no_cache_count": len(summary["residual_no_cache"]),
+        "residual_guard_mismatch_count": len(summary["residual_guard_mismatch"]),
+    }
+    print(json.dumps(printable, ensure_ascii=False, indent=2))
+
+    if args.write:
+        if summary["repaired"]:
+            _refresh_manifest_fingerprint(manifest)
+            _write_manifest(manifest_path, manifest)
+            pointer = _write_default_release_pointer(
+                manifest_path,
+                bootstrap_no_baseline=args.bootstrap_no_baseline,
+                allow_richness_regression_reason=args.allow_richness_regression,
+            )
+            if pointer:
+                print(
+                    f"Updated local atlas-manifest pointer {pointer['manifest_fingerprint']} {pointer['json_sha256']}"
+                )
+        else:
+            print("Nothing repaired; manifest left untouched.")
+    else:
+        print("Dry run only; pass --write to update the manifest.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -91,7 +91,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "0176d05c390564c55220a660414b2babed85d802c61294b5c03d2441732985cd"
+        "sha256": "d8db8c533821f69abbacf6f7e679e81501c5de208257a2d60016c46a7b52ed7e"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -228,6 +228,10 @@
       {
         "path": "scripts/lexicon/repair_plural_noun_aliases.py",
         "sha256": "212d5d59061e2b3709e6f62b0861ccf0c98dfa4e1d63922efa8c5fce3d356416"
+      },
+      {
+        "path": "scripts/lexicon/repair_truncated_definition_cards.py",
+        "sha256": "45704ca1f8326c817d201a2068a7a312dfc61dfa3cc79eae4afb819d19afbde4"
       },
       {
         "path": "scripts/lexicon/source_attribution.py",

--- a/tests/test_repair_truncated_definition_cards.py
+++ b/tests/test_repair_truncated_definition_cards.py
@@ -1,0 +1,197 @@
+"""Tests for scripts/lexicon/repair_truncated_definition_cards.py (#6736)."""
+
+import json
+
+import pytest
+
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon import repair_truncated_definition_cards as repair
+
+
+def _long_body() -> str:
+    body = (
+        "1》 Відправлятися, вирушати куди-небудь. "
+        "2》 Приступати до якої-небудь служби, діяльності. "
+        "3》 Переміщуватися, відхилятися в якому-небудь напрямку. "
+        "4》 Піддаватися дії чого-небудь. "
+        "5》 Прогинатися, вгинатися під дією чого-небудь. "
+        "6》 перен. Відступати від чого-небудь, поступатися чимсь кому-небудь. "
+        "7》 Худнути, марніти, занепадати здоров'ям. "
+        "8》 розм. Ставати на місце, заступати. "
+    )
+    while len(body) <= 901:
+        body += "|| Додаткове значення з прикладами вживання. "
+    return body.strip()
+
+
+def _chopped(body: str) -> str:
+    """Reproduce the pre-#6437 cut: ``cleaned[:899].rstrip() + "…"``."""
+    return body[:899].rstrip() + "…"
+
+
+def _entry_with_card(lemma: str, card_id: str, definitions: list[str]) -> dict:
+    return {
+        "lemma": lemma,
+        "url_slug": lemma,
+        "enrichment": {
+            "definition_cards": [
+                {
+                    "id": card_id,
+                    "source": "Великий тлумачний словник сучасної української мови",
+                    "source_pill": "ВТС",
+                    "definitions": definitions,
+                    "source_url": f"https://slovnyk.me/dict/vts/{lemma}",
+                }
+            ]
+        },
+    }
+
+
+def _write_cache(cache_dir, lemma: str, slug: str, text: str, *, schema_version: int = 3) -> None:
+    payload = {
+        "schema_version": schema_version,
+        "lookups": {slug: {"text": text, "word": lemma, "source_url": f"https://slovnyk.me/dict/{slug}/{lemma}"}},
+    }
+    (cache_dir / f"{lemma}.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+@pytest.fixture
+def slovnyk_cache_dir(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "slovnyk_cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(enrich_manifest, "SLOVNYK_CACHE", cache_dir)
+    monkeypatch.setattr(enrich_manifest, "_vesum_base_lemma", lambda word: None)
+    return cache_dir
+
+
+def test_find_chopped_cards_matches_only_the_cap_signature() -> None:
+    body = _long_body()
+    manifest = {
+        "entries": [
+            _entry_with_card("подаватися", "vts", [_chopped(body)]),
+            _entry_with_card("повний", "vts", [body]),
+            _entry_with_card("короткий", "sum20", ["Те саме, що інше…"]),
+            _entry_with_card("грінченко", "grinchenko", [_chopped(body)]),
+            _entry_with_card("два", "vts", [_chopped(body), "other"]),
+        ]
+    }
+    hits = repair.find_chopped_cards(manifest)
+    assert [entry["lemma"] for entry, _card in hits] == ["подаватися"]
+
+
+def test_repair_restores_full_body_from_local_cache(slovnyk_cache_dir) -> None:
+    body = _long_body()
+    chopped = _chopped(body)
+    _write_cache(slovnyk_cache_dir, "подаватися", "vts", body)
+    manifest = {"entries": [_entry_with_card("подаватися", "vts", [chopped])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    card = manifest["entries"][0]["enrichment"]["definition_cards"][0]
+    assert card["definitions"] == [body]
+    # Only the chopped text changes; card metadata is preserved.
+    assert card["source_pill"] == "ВТС"
+    assert card["source_url"] == "https://slovnyk.me/dict/vts/подаватися"
+    assert summary["repaired"] == 1
+    assert summary["residual_no_cache"] == []
+    assert summary["residual_guard_mismatch"] == []
+
+
+def test_repair_uses_unambiguous_base_lemma_cache(slovnyk_cache_dir, monkeypatch) -> None:
+    body = _long_body()
+    _write_cache(slovnyk_cache_dir, "мій", "newsum", body)
+    monkeypatch.setattr(enrich_manifest, "_vesum_base_lemma", lambda word: {"моєму": "мій"}.get(word))
+    manifest = {"entries": [_entry_with_card("моєму", "sum20", [_chopped(body)])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    assert manifest["entries"][0]["enrichment"]["definition_cards"][0]["definitions"] == [body]
+    assert summary["repaired"] == 1
+
+
+def test_repair_is_fail_closed_on_prefix_mismatch(slovnyk_cache_dir) -> None:
+    chopped = _chopped(_long_body())
+    _write_cache(slovnyk_cache_dir, "подаватися", "vts", "1》 Зовсім інша стаття. " * 40)
+    manifest = {"entries": [_entry_with_card("подаватися", "vts", [chopped])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    assert manifest["entries"][0]["enrichment"]["definition_cards"][0]["definitions"] == [chopped]
+    assert summary["repaired"] == 0
+    assert summary["residual_guard_mismatch"] == ["подаватися:vts"]
+
+
+def test_repair_reports_residual_when_cache_row_missing(slovnyk_cache_dir) -> None:
+    chopped = _chopped(_long_body())
+    manifest = {"entries": [_entry_with_card("подаватися", "vts", [chopped])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    assert manifest["entries"][0]["enrichment"]["definition_cards"][0]["definitions"] == [chopped]
+    assert summary["repaired"] == 0
+    assert summary["residual_no_cache"] == ["подаватися:vts"]
+
+
+def test_repair_ignores_stale_schema_cache(slovnyk_cache_dir) -> None:
+    chopped = _chopped(_long_body())
+    _write_cache(slovnyk_cache_dir, "подаватися", "vts", _long_body(), schema_version=2)
+    manifest = {"entries": [_entry_with_card("подаватися", "vts", [chopped])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    assert summary["repaired"] == 0
+    assert summary["residual_no_cache"] == ["подаватися:vts"]
+
+
+def test_repair_limit_bounds_targets(slovnyk_cache_dir) -> None:
+    body = _long_body()
+    _write_cache(slovnyk_cache_dir, "перше", "vts", body)
+    _write_cache(slovnyk_cache_dir, "друге", "vts", body)
+    manifest = {
+        "entries": [
+            _entry_with_card("перше", "vts", [_chopped(body)]),
+            _entry_with_card("друге", "vts", [_chopped(body)]),
+        ]
+    }
+
+    summary = repair.repair_truncated_cards(manifest, limit=1)
+
+    assert summary["chopped_cards"] == 1
+    assert summary["repaired"] == 1
+
+
+def test_repair_tolerates_whitespace_drift_from_renormalized_cache(slovnyk_cache_dir) -> None:
+    body = _long_body()
+    chopped = _chopped(body)
+    # Cache row re-normalized by newer fetch code: extra spaces around punctuation.
+    drifted = body.replace(". ", " . ").replace(", ", " , ")
+    _write_cache(slovnyk_cache_dir, "подаватися", "vts", drifted)
+    manifest = {"entries": [_entry_with_card("подаватися", "vts", [chopped])]}
+
+    summary = repair.repair_truncated_cards(manifest)
+
+    card = manifest["entries"][0]["enrichment"]["definition_cards"][0]
+    assert card["definitions"] == [drifted.strip()]
+    assert summary["repaired"] == 1
+
+
+def test_parse_slovnyk_entry_keeps_articles_beyond_the_retired_fetch_cap() -> None:
+    """#6736: the 5000-char fetch cap chopped the longest VTS/СУМ-20 articles at
+    ingest; raw ingestion now stores the full attested article text."""
+    long_text = "Дуже довга стаття. " * 400  # ~7600 chars > old 5000 cap
+    html = (
+        '<html><body><section id="dictionary-article"><article>'
+        "<h1>слово</h1>"
+        f"<p><span>{long_text}</span></p>"
+        "</article></section></body></html>"
+    )
+    row = enrich_manifest._parse_slovnyk_entry(
+        html,
+        lemma="слово",
+        lookup_word="слово",
+        slug="vts",
+        url="https://slovnyk.me/dict/vts/слово",
+    )
+    assert row is not None
+    assert len(row["text"]) > 5000
+    assert long_text.strip() in row["text"]


### PR DESCRIPTION
## What

Atlas «Значення» cards for [подаватися](https://learn-ukrainian.github.io/lexicon/%D0%BF%D0%BE%D0%B4%D0%B0%D0%B2%D0%B0%D1%82%D0%B8%D1%81%D1%8F/) quote ВТС and СУМ-20 **cut off mid-entry** (`8》 розм. Става…`). This PR fixes the truncation class; see "Residual" for what still needs an operator run.

Refs #6736 #4387 (both intentionally left open — the published payload heals only when the repair runs where the full slovnyk cache lives).

## Root cause: ingest + payload, not render

- **Render is clean.** `site/src/lexicon/WordAtlasArticle.tsx:334` renders `card.definitions` in full; the only ellipsized previews are usage notes (unrelated).
- **Ingest cap #1 (already retired):** pre-#6437 `_definition_body(limit=900)` amputated multi-sense ВТС/СУМ-20 articles mid-word. Lifted in 797e075d9c (2026-08-08) — but the **published 2026-08-13 manifest still carries 2532 cards chopped at exactly 899/900 chars + `…`** (ВТС 656, СУМ-20 1878). The translation-delta merge is additive-only by contract (`merge_translation_delta.py` invariant: never overwrites non-empty fields), so re-enrichment alone can never heal a chopped card.
- **Ingest cap #2 (still live):** `_parse_slovnyk_entry` capped fetched articles at 5000 chars; 31 longest articles are chopped there. Lifted here — raw ingestion now stores the full attested article; display-length decisions stay with consumers.

## Fix

- **`scripts/lexicon/repair_truncated_definition_cards.py` (new):** fail-closed, read-only repair. Detects the exact 900-cap signature (899/900 chars + trailing `…`), rebuilds the card body **only from the attested local slovnyk.me cache** (schema-current rows; never fetches, never invents text), and swaps it in only when the chopped body is a prefix of the rebuilt body modulo whitespace. The squash guard tolerates #6465 fetch-side re-normalization (incl. letter-spaced rows whose clean body is shorter in raw chars yet carries strictly more content); «див.» cross-reference-resolved and source-drifted cards fail the guard and are reported, not touched. `--write` refreshes the manifest + fingerprint and updates the local release pointer through the existing richness gate.
- **`enrich_manifest.py`:** dropped the 5000-char fetch cap.
- **Fingerprint sidecar refreshed** (CI freshness gate passes locally); runbook `atlas-full-reenrich-campaign.md` documents the repair step.

## Verification

- `pytest tests/test_repair_truncated_definition_cards.py` — 9 new tests pass (signature detection, cache/base-lemma restore, prefix guard, stale-schema skip, limit, lifted fetch cap).
- `pytest tests/test_lexicon_enrich_manifest.py tests/test_reenrich_thin_manifest_entries.py tests/test_publish_manifest.py` — 218 passed.
- `ruff check` + `ruff format --check` clean; `check_manifest_freshness.py` OK (64 files).
- **Real-payload dry run** against the published 2026-08-13 release manifest: `chopped_cards: 2532`, `repaired: 807` from this machine's partial cache, `residual_guard_mismatch: 0`, `residual_no_cache: 1725` (cache rows, incl. подаватися, live on the runner/operator machine, not this one). No Ukrainian dictionary text was invented — every restored byte comes from the attested slovnyk cache.

## Residual (owner: operator)

- Run `python scripts/lexicon/repair_truncated_definition_cards.py --local --write` where the full `data/lexicon/slovnyk_cache` lives (the runner), then publish via the normal `publish_manifest.py` flow. That heals подаватися and the remaining ~1725 no-cache cards.
- 31 fetch-capped (>5000-char) articles heal on next slovnyk refetch now that the fetch cap is lifted.

## Automation note

Opened by a worker dispatch; NOT to be auto-merged — human review + required CI, per repository gates.
