### PR TITLE
test(site): skip etymology dist-HTML gate when dist missing (#6766)

### DIFF
--- a/site/tests/unit/etymology-handler-built-output.test.ts
+++ b/site/tests/unit/etymology-handler-built-output.test.ts
@@ -32,6 +32,9 @@ const ETY_HANDLER_MARKERS = [
   "dataset.etyNote",
 ] as const;
 
+const distLexicon = resolve(process.cwd(), "dist/lexicon");
+const hasDist = existsSync(distLexicon);
+
 const stubRecord = articleProps({
   lemma: "прапор",
   url_slug: "прапор",
@@ -70,13 +73,7 @@ describe("etymology inline handler on prerendered lexicon pages", () => {
     }
   });
 
-  test("built dist lexicon HTML keeps the etymology handler when dist/ is present", () => {
-    const distLexicon = resolve(process.cwd(), "dist/lexicon");
-    if (!existsSync(distLexicon)) {
-      // Hermetic unit runs without a prior build still cover the shell render above.
-      expect(true).toBe(true);
-      return;
-    }
+  test.skipIf(!hasDist)("built dist lexicon HTML keeps the etymology handler when dist/ is present", () => {
     const articleDirs = readdirSync(distLexicon, { withFileTypes: true })
       .filter((d) => d.isDirectory())
       .map((d) => d.name)


### PR DESCRIPTION
Replaces the passing tautology (`expect(true).toBe(true)` + early return) with an explicit `test.skipIf`, so a missing `dist/` shows as a skipped test instead of a false pass. Real asserts still run when dist exists. CI `test:built-output` unchanged.

Verified locally: skip when dist absent (1 passed | 1 skipped), full asserts when a minimal dist/lexicon is present (2 passed).

X-Agent: deepseek/6766-etymology-tautology