### PR TITLE
fix(practice): never throw from getDeviceId on blocked localStorage (#6767)

### DIFF
--- a/site/src/lib/lexicon/custom-decks.ts
+++ b/site/src/lib/lexicon/custom-decks.ts
@@ -27,14 +27,31 @@ export interface VirtualSpecialSet extends CustomSet {
 export const CUSTOM_SETS_STORAGE_KEY = 'learn_ukrainian_custom_sets_v1';
 export const DEVICE_ID_KEY = 'learn_ukrainian_device_id';
 
+let inMemoryDeviceId: string | null = null;
+
+/**
+ * Returns one session-stable fallback id when localStorage is blocked
+ * (private browsing, SecurityError) so saves do not crash on the first write.
+ */
+function newDeviceId(): string {
+  if (!inMemoryDeviceId) {
+    inMemoryDeviceId = `dev_${Math.random().toString(36).substring(2, 11)}_${Date.now()}`;
+  }
+  return inMemoryDeviceId;
+}
+
 export function getDeviceId(): string {
   if (typeof window === 'undefined') return 'server_ssr';
-  let deviceId = localStorage.getItem(DEVICE_ID_KEY);
-  if (!deviceId) {
-    deviceId = `dev_${Math.random().toString(36).substring(2, 11)}_${Date.now()}`;
+  try {
+    const stored = localStorage.getItem(DEVICE_ID_KEY);
+    if (stored) return stored;
+    const deviceId = newDeviceId();
     localStorage.setItem(DEVICE_ID_KEY, deviceId);
+    return deviceId;
+  } catch (err) {
+    console.warn('localStorage unavailable; using in-memory device id', err);
+    return newDeviceId();
   }
-  return deviceId;
 }
 
 import teacherClozeData from '../../data/lexicon-teacher-cloze.json';

--- a/site/tests/unit/custom-decks-storage-failure.test.ts
+++ b/site/tests/unit/custom-decks-storage-failure.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  CUSTOM_SETS_STORAGE_KEY,
+  DEVICE_ID_KEY,
+  getDeviceId,
+  saveLocalCustomSet,
+} from '../../src/lib/lexicon/custom-decks';
+
+const realLocalStorage = globalThis.localStorage;
+
+/** Storage stub that mimics private-browsing / blocked localStorage. */
+function throwingLocalStorage({ onGet = false }: { onGet?: boolean } = {}): Storage {
+  const denied = () => {
+    throw new DOMException('Access is denied', 'SecurityError');
+  };
+  return {
+    get length() {
+      return 0;
+    },
+    clear: vi.fn(),
+    getItem: onGet ? denied : vi.fn(() => null),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: denied,
+  } as unknown as Storage;
+}
+
+afterEach(() => {
+  vi.stubGlobal('localStorage', realLocalStorage);
+  vi.restoreAllMocks();
+  realLocalStorage.removeItem(DEVICE_ID_KEY);
+  realLocalStorage.removeItem(CUSTOM_SETS_STORAGE_KEY);
+});
+
+describe('getDeviceId with blocked localStorage (#6767)', () => {
+  test('returns the stored id on the happy path', () => {
+    realLocalStorage.setItem(DEVICE_ID_KEY, 'dev_existing');
+    expect(getDeviceId()).toBe('dev_existing');
+  });
+
+  test('does not throw when setItem throws (private browsing / blocked storage)', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const id = getDeviceId();
+    expect(id).toMatch(/^dev_/);
+    // Session-stable fallback: a second blocked call returns the same id.
+    expect(getDeviceId()).toBe(id);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('does not throw when even getItem throws', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage({ onGet: true }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const id = getDeviceId();
+    expect(id).toMatch(/^dev_/);
+    expect(getDeviceId()).toBe(id);
+  });
+});
+
+describe('saveLocalCustomSet with blocked localStorage (#6767)', () => {
+  test('creating a custom set does not throw when storage writes fail', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let created: ReturnType<typeof saveLocalCustomSet> | undefined;
+    expect(() => {
+      created = saveLocalCustomSet({ title: 'Blocked deck', lemma_keys: ['мир'] });
+    }).not.toThrow();
+
+    expect(created?.device_id).toMatch(/^dev_/);
+    expect(created?.title).toBe('Blocked deck');
+    expect(created?.revision).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem
`getDeviceId()` read/wrote `localStorage` with no try/catch; `saveLocalCustomSet` called it before the write helper that does catch. In private browsing / blocked storage, `localStorage.setItem` threw `SecurityError`/`QuotaExceededError` as an uncaught exception on custom-deck create — crashing the Practice island from a submit handler (the error boundary only catches render errors).

## Fix
- `site/src/lib/lexicon/custom-decks.ts`: `getDeviceId()` now wraps both `getItem`/`setItem` in try/catch and falls back to one **session-stable in-memory id** (with `console.warn`, matching `writeLocalCustomSetsAllInternal`). `saveLocalCustomSet`/`deleteLocalCustomSet` therefore stay no-throw on quota/security errors.
- No schema/tombstone changes (ADR-015); Google Drive sync untouched.

## Tests
- New `site/tests/unit/custom-decks-storage-failure.test.ts`: stubs a throwing `localStorage`; `getDeviceId` and custom-set creation do not throw and yield a stable `dev_…` fallback id (covers setItem-throws and getItem-throws paths).
- Verified: `vitest run tests/unit/custom-decks-storage-failure.test.ts tests/unit/custom-decks-membership.test.ts` → 7/7 pass; `tests/unit/LexiconPractice.test.tsx` → 154/154 pass. Existing membership tests unweakened.

Closes nothing automatically beyond scope — leaves #4387 open per dispatch. No merge by the worker.

Refs #6767

X-Agent: kimi/6767-deviceid-crash