### PR TITLE
fix(practice): teach wrong answers and end the results dead-end (#6722)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: d5ddc1fa296505e39a0719c8e7be6a959501bf3cdc85efd4e71a0639a98455d0
+  components_sha256: 8a643e1a11774cf246f62a67592283e617da91e51790a50ac33158cc9821e66d
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1803,6 +1803,10 @@ components:
         type: ChromeLocale
         description: chromeLocale prop.
         ukrainian_text: 'false'
+      - name: showMissGloss
+        type: boolean
+        description: showMissGloss prop.
+        ukrainian_text: 'false'
       optional: []
     nested_types:
       SessionSummaryStats:
@@ -1834,9 +1838,14 @@ components:
         type: PracticeLexeme[]
         description: deferredLemmas prop.
         ukrainian_text: 'false'
+      - name: misses
+        type: SessionMissItem[]
+        description: misses prop.
+        ukrainian_text: 'false'
     example:
       stats: <SessionSummaryStats>
       chromeLocale: <ChromeLocale>
+      showMissGloss: false
     deprecated: false
     deprecation_reason: null
   PracticeStress:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -5,7 +5,7 @@ import PracticeDailyDeck from './PracticeDailyDeck';
 import PracticeErrorBoundary from './PracticeErrorBoundary';
 import PracticeFlashcard from './PracticeFlashcard';
 import PracticeFormRail, { type FormRailVerdict } from './PracticeFormRail';
-import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSessionSummary';
+import PracticeSessionSummary, { type SessionMissItem, type SessionSummaryStats } from './PracticeSessionSummary';
 import PracticeStress from './PracticeStress';
 import { ErrorCorrectionItem } from './ErrorCorrection';
 import { FillInQuestion } from './FillIn';
@@ -71,6 +71,7 @@ import {
   type PracticeSessionIdentity,
   type PracticeSessionSnapshot,
   type PracticeSessionSnapshots,
+  type PracticeStressItem,
   type ReviewLogEntry,
   type SelectionHistoryItem,
   type SessionBudget,
@@ -407,7 +408,12 @@ function heritageSeverityLabel(severity: PracticeHeritageItem['severity']): { uk
     : { uk: 'Лексичне збагачення', en: 'Vocabulary enrichment' };
 }
 
-interface ParonymFeedback {
+/**
+ * Correct/wrong teaching feedback shown under a locked drill: paronym distinctions
+ * plus the generic choice/classify/stress feedback (#6722 — those three used to lock
+ * with only a red ✗/green outline and no explanatory sentence).
+ */
+interface DrillFeedback {
   kind: 'correct' | 'wrong';
   textUk: string;
   textEn?: string;
@@ -786,7 +792,7 @@ export function isEnglishLearnerGloss(label: string): boolean {
 }
 
 function postAnswerSentenceEnglish(
-  feedback: HeritageFeedback | ParonymFeedback | ClozeFeedback | null,
+  feedback: HeritageFeedback | DrillFeedback | ClozeFeedback | null,
   raw: string | null | undefined,
 ): string | null {
   // Intentional all-level post-answer English answer key; this is not dual-chrome.
@@ -1184,10 +1190,50 @@ function choicePrompt(selection: PracticeSelection, learnerLevel: CefrLevel): { 
   };
 }
 
+/**
+ * #6722: 'choice' ('Вибір') used to lock with only a red ✗/green outline — the pair
+ * itself (word ↔ gloss) is already attested in the deck payload for both MC
+ * directions, so restate it as the teaching sentence, same bar as paronym.
+ */
+function choiceFeedbackFor(
+  selection: PracticeSelection,
+  option: ChoiceOption,
+  learnerLevel: CefrLevel,
+): DrillFeedback {
+  const lemma = displayPracticeForm(selection.lemma.lemma, learnerLevel);
+  const gloss = glossLabel(selection.lemma);
+  const pair = `«${lemma}» = ${gloss}.`;
+  return option.correct
+    ? { kind: 'correct', textUk: `Правильно! ${pair}`, textEn: 'Correct!' }
+    : { kind: 'wrong', textUk: `Неправильно. ${pair}`, textEn: 'Incorrect.' };
+}
+
 function classifySet(selection: PracticeSelection): PracticeClassifySet | null {
   const sets = selection.classify?.sets ?? [];
   if (!sets.length) return null;
   return sets.find((set) => set.setId === selection.classifySetId) ?? sets[0] ?? null;
+}
+
+/**
+ * #6722: 'classify' ('Група') teaching sentence — names the correct VESUM group
+ * (`answerLabelUk`/`answerLabelEn` are already curated deck fields, same set used
+ * to render the option list) instead of leaving the learner to infer it from color.
+ */
+function classifyFeedbackFor(
+  selection: PracticeSelection,
+  option: ChoiceOption,
+  learnerLevel: CefrLevel,
+): DrillFeedback | null {
+  const set = classifySet(selection);
+  if (!set) return null;
+  const lemma = displayPracticeForm(selection.lemma.lemma, learnerLevel);
+  const answerEn = set.answerLabelEn || translateGrammarTerm(set.answerLabelUk);
+  const setLabelEn = set.setLabelEn || translateGrammarTerm(set.setLabelUk);
+  const textUk = `«${lemma}» — ${set.answerLabelUk} (${set.setLabelUk}).`;
+  const textEn = `«${lemma}» is ${answerEn} (${setLabelEn}).`;
+  return option.correct
+    ? { kind: 'correct', textUk: `Правильно! ${textUk}`, textEn: `Correct! ${textEn}` }
+    : { kind: 'wrong', textUk: `Неправильно. ${textUk}`, textEn: `Incorrect. ${textEn}` };
 }
 
 function drillChoiceOptions(
@@ -1258,6 +1304,19 @@ function heritageFeedbackFor(item: PracticeHeritageItem, option: ChoiceOption): 
     textUk: 'Ще раз',
     textEn: 'Again',
   };
+}
+
+/**
+ * #6722: 'stress' ('Наголос') teaching sentence — restates the fully-marked form
+ * (`item.stressed` is already the attested deck field the flashcard back uses)
+ * so a wrong pick shows where the stress actually falls, not just a red ✗.
+ */
+function stressFeedbackFor(item: PracticeStressItem, correct: boolean): DrillFeedback {
+  const textUk = `Наголос: «${item.stressed}».`;
+  const textEn = `Stress: «${item.stressed}».`;
+  return correct
+    ? { kind: 'correct', textUk: `Правильно! ${textUk}`, textEn: `Correct! ${textEn}` }
+    : { kind: 'wrong', textUk: `Неправильно. ${textUk}`, textEn: `Incorrect. ${textEn}` };
 }
 
 function drillChoicePrompt(
@@ -1808,6 +1867,12 @@ function LexiconPracticeIsland({
   const [sessionCorrect, setSessionCorrect] = useState(0);
   const [sessionLapsed, setSessionLapsed] = useState(0);
   const [advancedToReview, setAdvancedToReview] = useState<string[]>([]);
+  /**
+   * #6722: every lemma missed this session (deduplicated, most-recent-last) — the
+   * results screen used to dead-end without ever surfacing which two words the
+   * learner actually got wrong.
+   */
+  const [sessionMisses, setSessionMisses] = useState<SessionMissItem[]>([]);
   const [resumeSnapshots, setResumeSnapshots] = useState<PracticeSessionSnapshots>({});
   const [learnerLevel, setLearnerLevel] = useState<CefrLevel>(() =>
     readLearnerLevel(normalizeCefrLevel(deckLevel)),
@@ -1845,7 +1910,7 @@ function LexiconPracticeIsland({
   const [clozeCaseMissCount, setClozeCaseMissCount] = useState(0);
   const clozeCaseMissOutcomeRef = useRef<CompletionOutcome | null>(null);
   const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
-  const [paronymFeedback, setParonymFeedback] = useState<ParonymFeedback | null>(null);
+  const [paronymFeedback, setParonymFeedback] = useState<DrillFeedback | null>(null);
   const [stressSelectedPosition, setStressSelectedPosition] = useState<number | null>(null);
   const [paradigmSelectedLabel, setParadigmSelectedLabel] = useState<string | null>(null);
   const [paronymSelectedLabel, setParonymSelectedLabel] = useState<string | null>(null);
@@ -1854,6 +1919,12 @@ function LexiconPracticeIsland({
    * (paronym and heritage keep their own dedicated state above — those feed
    * PracticeFormRail/slot copy, not just the option list). */
   const [choiceSelectedLabel, setChoiceSelectedLabel] = useState<string | null>(null);
+  /**
+   * #6722: explanatory correct/wrong sentence for choice ('Вибір'), classify ('Група'),
+   * and stress ('Наголос') drills — brings them up to the paronym-drill bar instead of
+   * leaving a bare red ✗ / green outline with no teaching content.
+   */
+  const [choiceFeedback, setChoiceFeedback] = useState<DrillFeedback | null>(null);
   const [customSets, setCustomSets] = useState<CustomSet[]>(() => readLocalCustomSets());
   const [selectedDeckFilter, setSelectedDeckFilter] = useState<string>('all');
   const [deckPickerOpen, setDeckPickerOpen] = useState(false);
@@ -2079,6 +2150,7 @@ function LexiconPracticeIsland({
     setParonymSelectedLabel(null);
     setHeritageSelectedLabel(null);
     setChoiceSelectedLabel(null);
+    setChoiceFeedback(null);
     setPendingOutcome(null);
     pendingOutcomeRef.current = null;
     matchedSelectedRatingRef.current = null;
@@ -3066,6 +3138,7 @@ function LexiconPracticeIsland({
     setSessionCorrect(0);
     setSessionLapsed(0);
     setAdvancedToReview([]);
+    setSessionMisses([]);
   }
 
   function buildSessionSnapshot(
@@ -3441,6 +3514,11 @@ function LexiconPracticeIsland({
       }
       if (rating === 'again') {
         setSessionLapsed((value) => value + 1);
+        // #6722: surface on the results screen — dedupe by lemma, keep the latest miss.
+        setSessionMisses((items) => [
+          ...items.filter((entry) => entry.lemmaId !== current.lemma.lemmaId),
+          { lemmaId: current.lemma.lemmaId, lemma: current.lemma.lemma, gloss: glossLabel(current.lemma) },
+        ]);
       }
       if (wasNew && rating !== 'again') {
         const daily = readNewCardsDailyState();
@@ -3557,6 +3635,7 @@ function LexiconPracticeIsland({
     const correct = position === selection.stress.stressIndex;
     const rating = correct ? 'good' : 'again';
     const outcome = recordReview(selection, rating);
+    setChoiceFeedback(stressFeedbackFor(selection.stress, correct));
     setFeedback({
       uk: `${selection.stress.unstressed}: ${correct ? 'Правильно' : 'Ще раз'}`,
       en: `${selection.stress.unstressed}: ${correct ? 'Correct' : 'Again'}`,
@@ -3576,6 +3655,14 @@ function LexiconPracticeIsland({
     const nextParonymFeedback = selection.paronym
       ? paronymFeedbackFor(selection.paronym, option)
       : null;
+    // #6722: bring 'choice' ('Вибір') and 'classify' ('Група') up to the paronym bar —
+    // a teaching sentence, not just a red ✗ / green outline.
+    const nextChoiceFeedback =
+      selection.mode === 'choice'
+        ? choiceFeedbackFor(selection, option, learnerLevel)
+        : selection.classify
+          ? classifyFeedbackFor(selection, option, learnerLevel)
+          : null;
     setAnswerLocked(true);
     setChoiceSelectedLabel(option.label);
     if (selection.paradigm) setParadigmSelectedLabel(option.label);
@@ -3583,6 +3670,7 @@ function LexiconPracticeIsland({
     if (selection.heritage) setHeritageSelectedLabel(option.label);
     setHeritageFeedback(nextHeritageFeedback);
     setParonymFeedback(nextParonymFeedback);
+    setChoiceFeedback(nextChoiceFeedback);
     setFeedback({
       uk: option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
       en: option.correct ? `${selection.lemma.lemma}: Correct` : `${selection.lemma.lemma}: Again`,
@@ -3743,6 +3831,9 @@ function LexiconPracticeIsland({
     streak: streak.current,
     nextDueLabel: formatNextDueLabel(nextDuePreviewTime()),
     deferredLemmas: deferredLemmas.filter((entry) => dailySnapshotIds.has(entry.lemmaId)),
+    // #6722: unlike advancedToReview/deferredLemmas, misses are not scoped to the
+    // daily ring — the learner missed the word in THIS session regardless of deck.
+    misses: sessionMisses,
   };
 
   function finishPractice() {
@@ -4419,6 +4510,10 @@ function LexiconPracticeIsland({
         <PracticeSessionSummary
           stats={summaryStats}
           chromeLocale={chromeLocale}
+          // #M-13 immersion: A2+ never gets English raised back up — the miss
+          // review shows the UA lemma + an Atlas link always, the gloss only
+          // where content glosses are already the level's norm (A1/EN chrome).
+          showMissGloss={showEnglishSubtitles}
           onAnotherSession={() => {
             // A fresh «another session» is never a focus session — startSession(focus=null)
             // clears any weakness so the next session is the full pool for `mode`.
@@ -4492,6 +4587,7 @@ function LexiconPracticeIsland({
                     clozeFeedback={clozeFeedback}
                     heritageFeedback={heritageFeedback}
                     paronymFeedback={paronymFeedback}
+                    choiceFeedback={choiceFeedback}
                     stressSelectedPosition={stressSelectedPosition}
                     paradigmSelectedLabel={paradigmSelectedLabel}
                     paronymSelectedLabel={paronymSelectedLabel}
@@ -4542,6 +4638,38 @@ function formatNextDueLabel(nextDue: Date | null): { uk: string; en: string } | 
   };
 }
 
+/**
+ * #6722: shared correct/wrong teaching sentence for choice ('Вибір'), classify
+ * ('Група'), and stress ('Наголос') drills — same visual language as the paronym
+ * feedback block (`.mc-feedback` mirrors `.paronym-feedback` in practice.astro).
+ */
+function DrillFeedbackPanel({
+  feedback,
+  testId,
+  showEnglishSubtitles,
+}: {
+  feedback: DrillFeedback | null;
+  testId: string;
+  showEnglishSubtitles: boolean;
+}) {
+  if (!feedback) return null;
+  return (
+    <div
+      className={`mc-feedback ${feedback.kind}`}
+      role={feedback.kind === 'wrong' ? 'alert' : 'status'}
+      aria-live="polite"
+      data-testid={testId}
+    >
+      <p>
+        <span lang="uk">{feedback.textUk}</span>
+        {showEnglishSubtitles && feedback.textEn ? (
+          <span className="btn-sub" lang="en">/ {feedback.textEn}</span>
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
 function PracticeItem({
   selection,
   deck,
@@ -4552,6 +4680,7 @@ function PracticeItem({
   clozeFeedback,
   heritageFeedback,
   paronymFeedback,
+  choiceFeedback,
   stressSelectedPosition,
   paradigmSelectedLabel,
   paronymSelectedLabel,
@@ -4579,7 +4708,8 @@ function PracticeItem({
   clozeInput: string;
   clozeFeedback: ClozeFeedback | null;
   heritageFeedback: HeritageFeedback | null;
-  paronymFeedback: ParonymFeedback | null;
+  paronymFeedback: DrillFeedback | null;
+  choiceFeedback: DrillFeedback | null;
   stressSelectedPosition: number | null;
   paradigmSelectedLabel: string | null;
   paronymSelectedLabel: string | null;
@@ -4670,6 +4800,11 @@ function PracticeItem({
           selectedPosition={stressSelectedPosition}
           answerLocked={answerLocked}
           onSelect={onStressSelect}
+        />
+        <DrillFeedbackPanel
+          feedback={choiceFeedback}
+          testId="practice-stress-feedback"
+          showEnglishSubtitles={showEnglishSubtitles}
         />
       </div>
     );
@@ -4857,6 +4992,13 @@ function PracticeItem({
             </li>
           ))}
         </ul>
+        {selection.mode === 'classify' ? (
+          <DrillFeedbackPanel
+            feedback={choiceFeedback}
+            testId="practice-classify-feedback"
+            showEnglishSubtitles={showEnglishSubtitles}
+          />
+        ) : null}
         {selection.mode === 'paradigm' && answerLocked && paradigmSelectedLabel !== null ? (
           <PracticeFormRail
             source={{
@@ -4974,6 +5116,11 @@ function PracticeItem({
           </li>
         ))}
       </ul>
+      <DrillFeedbackPanel
+        feedback={choiceFeedback}
+        testId="practice-choice-feedback"
+        showEnglishSubtitles={showEnglishSubtitles}
+      />
     </div>
   );
 }
@@ -4985,7 +5132,7 @@ function paronymOptions(item: PracticeParonymItem): ChoiceOption[] {
   }));
 }
 
-function paronymFeedbackFor(item: PracticeParonymItem, option: ChoiceOption): ParonymFeedback {
+function paronymFeedbackFor(item: PracticeParonymItem, option: ChoiceOption): DrillFeedback {
   if (option.correct) {
     return {
       kind: 'correct',
@@ -5011,7 +5158,7 @@ function PracticeParonym({
   learnerLevel,
 }: {
   item: PracticeParonymItem;
-  feedback: ParonymFeedback | null;
+  feedback: DrillFeedback | null;
   answerLocked: boolean;
   selectedLabel: string | null;
   chromeLocale: 'en' | 'uk';

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -1,5 +1,5 @@
 import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
-import type { ChromeLocale } from '../lib/i18n/chrome';
+import { CHROME_STRINGS, type ChromeLocale } from '../lib/i18n/chrome';
 import type { PracticeLexeme } from '../lib/lexicon/srs';
 
 /**
@@ -51,11 +51,10 @@ export default function PracticeSessionSummary({
   onAnotherSession,
   onDone,
 }: PracticeSessionSummaryProps) {
-  // chromeLocale is the caller's pure-locale contract; ChromeText/ChromeDual
-  // render both locales and CSS on html[data-chrome-locale] shows one.
-  void chromeLocale;
   // Score against the frozen round size, not raw rating counts: re-served lapsed
   // cards earn a second correct rating, so `correct` can exceed the round size.
+  // chromeLocale drives miss-list Atlas aria-labels (same openInAtlasTab pattern
+  // as in-session links); ChromeText/ChromeDual still dual-render for CSS locale.
   const scoreCorrect = Math.min(stats.correct, stats.roundSize);
   return (
     <div className="lexicon-session-summary" data-testid="practice-session-summary">
@@ -123,6 +122,7 @@ export default function PracticeSessionSummary({
                   href={`/lexicon/${encodeURIComponent(miss.lemmaId)}/`}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label={CHROME_STRINGS[chromeLocale]['practice.openInAtlasTab']}
                 >
                   <ChromeText k="practice.openInAtlasArrow" />
                 </a>

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -2,6 +2,17 @@ import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
 import type { ChromeLocale } from '../lib/i18n/chrome';
 import type { PracticeLexeme } from '../lib/lexicon/srs';
 
+/**
+ * #6722: one wrong answer from the session, kept for the results-screen review
+ * list — the correct pairing (attested deck gloss, never invented) plus a link
+ * onward instead of a dead end.
+ */
+export interface SessionMissItem {
+  lemmaId: string;
+  lemma: string;
+  gloss: string;
+}
+
 export interface SessionSummaryStats {
   correct: number;
   lapsed: number;
@@ -15,12 +26,20 @@ export interface SessionSummaryStats {
   streak: number;
   nextDueLabel: { uk: string; en: string } | null;
   deferredLemmas: PracticeLexeme[];
+  /** #6722: every lemma missed this session, deduplicated, most recent last. */
+  misses: SessionMissItem[];
 }
 
 interface PracticeSessionSummaryProps {
   stats: SessionSummaryStats;
   /** Pure chrome locale — summary UI never slash-duals (#5503). */
   chromeLocale: ChromeLocale;
+  /**
+   * #6722 miss review is UA lemma + Atlas link always; the English gloss only
+   * renders where the level already carries content glosses (A1, or EN chrome) —
+   * max-immersion levels never get English raised back up via the results screen.
+   */
+  showMissGloss: boolean;
   onAnotherSession(): void;
   onDone(): void;
 }
@@ -28,6 +47,7 @@ interface PracticeSessionSummaryProps {
 export default function PracticeSessionSummary({
   stats,
   chromeLocale,
+  showMissGloss,
   onAnotherSession,
   onDone,
 }: PracticeSessionSummaryProps) {
@@ -87,6 +107,30 @@ export default function PracticeSessionSummary({
           <ChromeDual uk={stats.nextDueLabel.uk} en={stats.nextDueLabel.en} />
         </p>
       ) : null}
+      {stats.misses.length > 0 ? (
+        <section className="lexicon-session-misses" data-testid="practice-session-misses">
+          <h3>
+            <ChromeText k="practice.reviewMisses" />
+          </h3>
+          <ul>
+            {stats.misses.map((miss) => (
+              <li key={miss.lemmaId}>
+                <span lang="uk">{miss.lemma}</span>
+                {showMissGloss ? (
+                  <span className="lexicon-session-miss-gloss"> — {miss.gloss}</span>
+                ) : null}
+                <a
+                  href={`/lexicon/${encodeURIComponent(miss.lemmaId)}/`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <ChromeText k="practice.openInAtlasArrow" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
       {stats.deferredLemmas.length > 0 ? (
         <section className="lexicon-session-deferred" data-testid="practice-deferred-list">
           <h3>
@@ -107,6 +151,17 @@ export default function PracticeSessionSummary({
           <ChromeText k="practice.done" />
         </button>
       </div>
+      <nav className="lexicon-session-continue" data-testid="practice-session-continue-links">
+        <span className="lexicon-session-continue-label">
+          <ChromeText k="practice.continueLearning" />
+        </span>
+        <a href="/lexicon/">
+          <ChromeText k="nav.atlas" />
+        </a>
+        <a href="/words-of-the-day/">
+          <ChromeText k="nav.dailyWords" />
+        </a>
+      </nav>
       <figure className="lexicon-session-proverb">
         <blockquote lang="uk">«Терпи, козаче — отаманом будеш.»</blockquote>
         <figcaption lang="uk">Українське прислів&apos;я</figcaption>

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -329,6 +329,10 @@ const en = {
   'practice.lapsedCount': 'Lapsed',
   'practice.advancedToReview': 'Advanced to Review',
   'practice.willRepeatNext': 'will repeat next time',
+  // #6722: results screen used to dead-end after a session — no review of the
+  // misses, no way onward besides another round or leaving.
+  'practice.reviewMisses': 'Review what you missed',
+  'practice.continueLearning': 'Keep exploring',
   'practice.retry': 'Try again',
   'practice.loadError': 'We couldn’t load practice.',
   'practice.loadErrorReload': 'We couldn’t load practice. Try reloading the page.',
@@ -657,6 +661,8 @@ const uk: Record<ChromeKey, string> = {
   'practice.lapsedCount': 'Помилки',
   'practice.advancedToReview': 'Перейшли на повторення',
   'practice.willRepeatNext': 'Повторимо наступного разу',
+  'practice.reviewMisses': 'Повторіть, що не вдалося',
+  'practice.continueLearning': 'Досліджуйте далі',
   'practice.retry': 'Спробувати ще раз',
   'practice.loadError': 'Не вдалося завантажити практику.',
   'practice.loadErrorReload': 'Не вдалося завантажити практику. Спробуйте оновити сторінку.',

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -718,6 +718,30 @@ const frontmatter = {
     color: var(--lu-state-wrong-fg);
   }
 
+  /* #6722: shared teaching-sentence panel for choice/classify/stress drills —
+     same visual language as .paronym-feedback above. */
+  :global(.mc-feedback) {
+    margin: 0.7rem 0 0;
+    padding: 0.85rem 0.95rem;
+    border-radius: 8px;
+    font-weight: 800;
+    line-height: 1.45;
+  }
+
+  :global(.mc-feedback p) {
+    margin: 0;
+  }
+
+  :global(.mc-feedback.correct) {
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.mc-feedback.wrong) {
+    background: var(--lu-state-wrong-bg);
+    color: var(--lu-state-wrong-fg);
+  }
+
   :global(.mc-q) {
     margin: 0 0 0.3rem;
     color: var(--lu-text);
@@ -1082,6 +1106,34 @@ const frontmatter = {
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
+  }
+
+  /* #6722: results screen used to dead-end at «Ще одна сесія» / «Готово» with no
+     review of the session's misses and no way onward besides another round. */
+  :global(.lexicon-session-misses li) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+
+  :global(.lexicon-session-miss-gloss) {
+    color: var(--lu-text-muted);
+  }
+
+  :global(.lexicon-session-continue) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--lu-border);
+    font-size: 0.9rem;
+  }
+
+  :global(.lexicon-session-continue-label) {
+    color: var(--lu-text-muted);
+    font-weight: 800;
   }
 
   :global(.lexicon-session-proverb) {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -4598,6 +4598,9 @@ describe('LexiconPractice', () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute('href', '/lexicon/mama/');
     expect(links[1]).toHaveAttribute('href', '/lexicon/znyshchyty/');
+    // Same openInAtlasTab aria-label as in-session Atlas links (new tab).
+    expect(links[0]).toHaveAttribute('aria-label', 'Відкрити в Атласі (нова вкладка)');
+    expect(links[1]).toHaveAttribute('aria-label', 'Відкрити в Атласі (нова вкладка)');
 
     // Dead-end fix: onward navigation is present, not just "another session"/"done".
     const continueLinks = screen.getByTestId('practice-session-continue-links');

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -4398,6 +4398,99 @@ describe('LexiconPractice', () => {
     });
   });
 
+  describe('wrong-answer teaching feedback (#6722)', () => {
+    // Before this fix, choice/classify/stress locked with only a red ✗ / green
+    // outline and no explanatory sentence — paronym already had the good pattern
+    // (a distinction sentence on both correct and wrong picks). These bring the
+    // other MC drills up to the same bar using data already in the deck payload.
+    test('choice ("Вибір"): wrong pick states the word ↔ meaning pairing', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={wordToMeaningDeck()} autoStart initialMode="choice" />);
+      const scope = within(screen.getByTestId('practice-choice'));
+
+      const promptText = screen.getByText(/^Що означає «/).textContent ?? '';
+      const promptToGloss: Record<string, string> = { сад: 'garden', дім: 'house', ліс: 'forest', річка: 'river' };
+      const promptWord = Object.keys(promptToGloss).find((word) => promptText.includes(word))!;
+      const correctGloss = promptToGloss[promptWord];
+
+      const options = scope.getAllByRole('button');
+      const correctButton = options.find((button) => button.textContent?.includes(correctGloss))!;
+      const wrongButton = options.find((button) => button !== correctButton)!;
+
+      await user.click(wrongButton);
+
+      expect(screen.getByTestId('practice-choice-feedback')).toHaveTextContent(
+        `Неправильно. «${promptWord}» = ${correctGloss}.`,
+      );
+    });
+
+    test('choice ("Вибір"): correct pick affirms the pairing', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={wordToMeaningDeck()} autoStart initialMode="choice" />);
+      const scope = within(screen.getByTestId('practice-choice'));
+
+      const promptText = screen.getByText(/^Що означає «/).textContent ?? '';
+      const promptToGloss: Record<string, string> = { сад: 'garden', дім: 'house', ліс: 'forest', річка: 'river' };
+      const promptWord = Object.keys(promptToGloss).find((word) => promptText.includes(word))!;
+      const correctGloss = promptToGloss[promptWord];
+
+      const correctButton = scope.getAllByRole('button').find((button) => button.textContent?.includes(correctGloss))!;
+      await user.click(correctButton);
+
+      expect(screen.getByTestId('practice-choice-feedback')).toHaveTextContent(
+        `Правильно! «${promptWord}» = ${correctGloss}.`,
+      );
+    });
+
+    test('classify ("Група"): wrong pick names the correct grammatical group', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={classifyDeck()} autoStart initialMode="classify" />);
+
+      await user.click(screen.getByRole('button', { name: /чоловічий/ }));
+
+      expect(screen.getByTestId('practice-classify-feedback')).toHaveTextContent(
+        'Неправильно. «кава» — жіночий (рід).',
+      );
+    });
+
+    test('classify ("Група"): correct pick affirms the group', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={classifyDeck()} autoStart initialMode="classify" />);
+
+      await user.click(screen.getByRole('button', { name: /жіночий/ }));
+
+      expect(screen.getByTestId('practice-classify-feedback')).toHaveTextContent(
+        'Правильно! «кава» — жіночий (рід).',
+      );
+    });
+
+    test('stress ("Наголос"): wrong pick shows the fully-stressed form', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={stressDeck()} autoStart initialMode="stress" />);
+
+      const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
+      const wrongTarget = buttons.find((button) => button.dataset.position === '3')!;
+      await user.click(wrongTarget);
+
+      expect(screen.getByTestId('practice-stress-feedback')).toHaveTextContent(
+        'Неправильно. Наголос: «ка́ва».',
+      );
+    });
+
+    test('stress ("Наголос"): correct pick affirms the stressed form', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={stressDeck()} autoStart initialMode="stress" />);
+
+      const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
+      const target = buttons.find((button) => button.dataset.position === '1')!;
+      await user.click(target);
+
+      expect(screen.getByTestId('practice-stress-feedback')).toHaveTextContent(
+        'Правильно! Наголос: «ка́ва».',
+      );
+    });
+  });
+
   test('heritage rail preserves source "день" and rail form "днями" while sentence keeps "Днями"', async () => {
     const item: PracticeHeritageItem = {
       ...heritagePracticeItem(),
@@ -4454,11 +4547,13 @@ describe('LexiconPractice', () => {
       streak: 5,
       nextDueLabel: null,
       deferredLemmas: [],
+      misses: [],
     };
     const { container } = render(
       <PracticeSessionSummary
         stats={stats}
         chromeLocale="uk"
+        showMissGloss={false}
         onAnotherSession={() => undefined}
         onDone={() => undefined}
       />,
@@ -4467,6 +4562,47 @@ describe('LexiconPractice', () => {
     expect(screen.getByTestId('practice-session-summary')).toHaveTextContent('18/20');
     expect(container.querySelector('blockquote')).toHaveTextContent('Терпи, козаче — отаманом будеш.');
     expect(container.querySelector('figcaption')).toHaveTextContent("Українське прислів'я");
+    expect(screen.queryByTestId('practice-session-misses')).not.toBeInTheDocument();
+  });
+
+  test('summary reviews the session misses instead of dead-ending (#6722)', () => {
+    const stats: SessionSummaryStats = {
+      correct: 8,
+      lapsed: 2,
+      roundSize: 10,
+      advancedToReview: [],
+      streak: 3,
+      nextDueLabel: null,
+      deferredLemmas: [],
+      misses: [
+        { lemmaId: 'mama', lemma: 'мама', gloss: 'mother' },
+        { lemmaId: 'znyshchyty', lemma: 'знищити', gloss: 'to destroy' },
+      ],
+    };
+    render(
+      <PracticeSessionSummary
+        stats={stats}
+        chromeLocale="uk"
+        showMissGloss
+        onAnotherSession={() => undefined}
+        onDone={() => undefined}
+      />,
+    );
+
+    const misses = screen.getByTestId('practice-session-misses');
+    expect(misses).toHaveTextContent('мама');
+    expect(misses).toHaveTextContent('mother');
+    expect(misses).toHaveTextContent('знищити');
+    expect(misses).toHaveTextContent('to destroy');
+    const links = within(misses).getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/lexicon/mama/');
+    expect(links[1]).toHaveAttribute('href', '/lexicon/znyshchyty/');
+
+    // Dead-end fix: onward navigation is present, not just "another session"/"done".
+    const continueLinks = screen.getByTestId('practice-session-continue-links');
+    expect(within(continueLinks).getByText('Атлас слів').closest('a')).toHaveAttribute('href', '/lexicon/');
+    expect(within(continueLinks).getByText('Слова дня').closest('a')).toHaveAttribute('href', '/words-of-the-day/');
   });
 
   describe('Curated Deck & Custom Sets Automated UI Selection Tests', () => {
@@ -4965,6 +5101,52 @@ describe('LexiconPractice', () => {
       const summary = await screen.findByTestId('practice-session-summary');
       // Same denominator as the badge: the score is against the frozen round size.
       expect(summary).toHaveTextContent('3/3');
+    });
+
+    test('#6722 results screen reviews the actual miss instead of dead-ending at the score', async () => {
+      // { word: [lemmaId, gloss] } — session order is seeded, not array order, so the
+      // test reads whichever card comes up first rather than assuming «книга».
+      const lemmaByWord: Record<string, [string, string]> = {
+        книга: ['knyha', 'book'],
+        робота: ['robota', 'work'],
+        місто: ['misto', 'city'],
+      };
+      const user = userEvent.setup();
+      const { container } = render(
+        <LexiconPractice initialDeck={threeFlashcardDeck()} autoStart initialMode="flashcards" />,
+      );
+      expect(await screen.findByTestId('practice-session-progress')).toHaveTextContent('0/3');
+
+      const answerCurrent = async (rating: 'again' | 'good') => {
+        const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
+        expect(flashcard).toBeInTheDocument();
+        const front = container.querySelector('.flashcard-word')?.textContent ?? '';
+        await user.click(flashcard!);
+        await user.click(container.querySelector<HTMLButtonElement>(`[data-rate="${rating}"]`)!);
+        await user.click(await screen.findByTestId('practice-advance-button'));
+        return front;
+      };
+
+      const missedWord = await answerCurrent('again'); // the miss the summary must review
+      expect(lemmaByWord[missedWord]).toBeDefined();
+      await answerCurrent('good');
+      await answerCurrent('good');
+      for (let i = 0; i < 8; i += 1) {
+        if (screen.queryByTestId('practice-session-summary')) break;
+        await answerCurrent('good');
+        if (screen.queryByTestId('practice-session-summary')) break;
+      }
+
+      const [missedLemmaId, missedGloss] = lemmaByWord[missedWord]!;
+      const summary = await screen.findByTestId('practice-session-summary');
+      const misses = within(summary).getByTestId('practice-session-misses');
+      expect(misses).toHaveTextContent(missedWord);
+      expect(misses).toHaveTextContent(missedGloss);
+      expect(within(misses).getByRole('link')).toHaveAttribute('href', `/lexicon/${missedLemmaId}/`);
+
+      // Onward navigation replaces the old dead end (proverb + two buttons only).
+      const continueLinks = within(summary).getByTestId('practice-session-continue-links');
+      expect(within(continueLinks).getAllByRole('link')).toHaveLength(2);
     });
 
     test('#6721 matching wrong pair flashes red and shows «Спробуйте ще раз» instead of silently deselecting', async () => {


### PR DESCRIPTION
## What
From issue #6722 (A1 Mix learner pass, live 2026-08-13, score 8/10):

**Wrong-answer teaching.** Choice ("Вибір"), classify ("Група"), and stress
("Наголос") drills locked with only a red ✗ / green outline — no sentence,
unlike the paronym drill's good pattern («Особистий — власне
персональний…»). Each now shows a correct/wrong teaching sentence:

- **Choice**: `«мама» = mother.` — the word ↔ gloss pair already in the deck payload.
- **Classify**: `«кава» — жіночий (рід).` — the curated VESUM group label.
- **Stress**: `Наголос: «ка́ва».` — the fully-marked form already used on the flashcard back.

No invented Ukrainian glosses — every string reuses deck/seed data already
rendered on screen elsewhere.

**Results dead end.** The summary was score + proverb + "another
session"/"done", with no review of the two misses (мама, знищити) and no
link onward. It now:
- lists every lemma missed this session (deduped) with an Atlas link — the
  UA lemma is always shown; the English gloss only renders where the level
  already carries content glosses (A1, or EN chrome), per the max-immersion
  policy (never raise English at A2+)
- adds Atlas / Words-of-the-Day links alongside the existing actions

## Out of scope
Item-quality bugs from the same learner pass (synonym data correctness,
gloss casing) are content bugs, not this fix's UI/teaching-feedback scope —
left for a separate pass. Leaves #4387 and #6722 open per dispatch.

## Tests
```
vitest run tests/unit/LexiconPractice.test.tsx tests/unit/practice-locale-purity.test.ts
Test Files  2 passed (2)
     Tests  168 passed
```
New coverage: 6 unit tests for choice/classify/stress correct+wrong feedback
text, 2 summary tests (misses list + immersion-gated gloss, continue-links),
1 end-to-end session test driving a real miss through to the results screen.

X-Agent: claude/6722-wrong-answer-teach
