### PR TITLE
fix(atlas): publish repaired definition cards for подаватися (#6736)

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,14 +1,14 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-4e48425d010f.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-01a05ba002c9.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "9fa2634396f65e23d7822a54c5c16c3553b561965eb1cbe50bbcc9efc6983805",
+  "manifest_fingerprint": "654692bd8d5b7129705cb545dc29f497d24955ab1ca309009d0e26ff91763d85",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-08-13T22:23:58+00:00",
-  "gz_sha256": "9a12525baab0b58c10caf6b299f00396ad98b1af5a497e097bb552b9072cadf2",
-  "json_sha256": "4e48425d010ffbec5df9e0557a5335708a386092d0702417353290ac388830ae",
-  "gz_bytes": 25185489,
-  "json_bytes": 187642610,
+  "gz_sha256": "c6f0c49a7daea226b1752ce0e6b7111f5ff8b7b96c6fbfa42eac310d8688e2c9",
+  "json_sha256": "01a05ba002c96f44fa279830e048aa3c66cd437c7ed1e105d345bc4c9b5e68e4",
+  "gz_bytes": 25787129,
+  "json_bytes": 189539740,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 8902,


### PR DESCRIPTION
## Summary

- Fetched attested slovnyk.me cache for `подаватися` (primary `data/lexicon/slovnyk_cache/подаватися.json`; VTS 1112 chars, СУМ-20 5357 chars — past the retired 5000-char fetch cap).
- Ran `repair_truncated_definition_cards.py --local --write`: **chopped 2532 / repaired 809 / residual_no_cache 1723 / residual_guard_mismatch 0**.
- Published release asset `lexicon-manifest-01a05ba002c9.json.gz` and pointed the committed pointer at it so Pages hydrates.

## Before / after — подаватися ВТС

| | ВТС | СУМ-20 |
|---|---|---|
| **Before** | len 900, ends `8》 розм. Става…` | len 900, ends `намірятися щ…` |
| **After** | len 1026, continues through sense 10 (`…Пас. до подавати I 1), 3-5), 7-10), 12-14).`) | len 5289, continues through full article (`…[на печі]! (М. Стельмах).`) |

## Residual

- **1723** chopped cards still lack schema-current local cache rows (`residual_no_cache`). `подаватися` is **not** among them.
- Leaves **#6736** and **#4387** open (do not close).

## Related Issues

This PR leaves #6736 open.
This PR leaves #4387 open.

## Test plan

- [x] Cache fetch via `enrich_manifest._slovnyk_cache('подаватися')` wrote attested vts/newsum rows
- [x] Repair script residual counts quoted above
- [x] `publish_manifest` uploaded versioned + canonical gzip assets
- [ ] After merge + Pages deploy: live https://learn-ukrainian.github.io/lexicon/подаватися/ ВТС no longer ends at `Става…`


Made with [Cursor](https://cursor.com)