### PR TITLE
fix(site): practice drill 5xx + WotD stuck loader (#6768 #6771)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 8a643e1a11774cf246f62a67592283e617da91e51790a50ac33158cc9821e66d
+  components_sha256: 797572378449c901c327b1c9a7a9d4525317eee6e98e5d5dd1fe55eae43085bd
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -220,6 +220,12 @@ async function resolveDeckKeyMetadata(
   if (needsFullIndexFallback) {
     // Last resort only: older/static deployments can lack a manifest or a
     // relevant shard even though their legacy complete index still has the row.
+    // Last resort only: older/static deployments can lack a manifest or a
+    // relevant shard even though their legacy complete index still has the row.
+    // Soft-empty on *any* fault here: this path only resolves optional glosses
+    // for custom-deck keys. Drill shards use softSkipUnpublishedDrillShard so a
+    // 5xx cannot look like an empty deck (#6768); do not elevate this fallback
+    // into a session-killing error.
     rows = await getShardJson<SearchRow[]>('/lexicon/search-index.json', cache).catch(() => []);
   }
 
@@ -1831,6 +1837,21 @@ async function getShardJson<T>(url: string, cache: Map<string, Promise<unknown>>
   return p;
 }
 
+/**
+ * Optional drill-kind shards (and some Atlas search fallbacks) are unpublished
+ * per level/type: HTTP 404 means "not shipped", so callers may treat that as an
+ * empty payload. Network faults and 5xx must not be rewritten as empty decks
+ * (#6768) — rethrow so the Practice load-error path can surface.
+ */
+function isMissingShard(reason: unknown): boolean {
+  return (reason as { status?: number } | null)?.status === 404;
+}
+
+function softSkipUnpublishedDrillShard(reason: unknown): Record<string, never> {
+  if (isMissingShard(reason)) return {};
+  throw reason;
+}
+
 export default function LexiconPractice(props: LexiconPracticeProps) {
   return (
     <PracticeErrorBoundary>
@@ -2908,7 +2929,7 @@ function LexiconPracticeIsland({
         ];
         const drillResults = await Promise.all(
           drillUrls.map((u) =>
-            getShardJson<any>(u, shardJsonCacheRef.current).catch(() => ({})),
+            getShardJson<any>(u, shardJsonCacheRef.current).catch(softSkipUnpublishedDrillShard),
           ),
         );
         const [clozeR, stressR, classifyR, paradigmR, synonymR, paronymR, heritageR, antonymR] = drillResults;
@@ -2940,8 +2961,9 @@ function LexiconPracticeIsland({
                 ],
               };
             }
-          } catch {
-            // Degrades gracefully if teacher cloze shard is missing
+          } catch (err) {
+            // Teacher cloze is optional when unpublished (404); real faults surface.
+            if (!isMissingShard(err)) throw err;
           }
         }
 
@@ -2964,48 +2986,55 @@ function LexiconPracticeIsland({
         if (otherLevels.length > 0) {
           void (async () => {
             const bgId = deckRequestId.current;
-            const otherDrillBatches = await Promise.all(
-              otherLevels.map(async (lv) => {
-                const urls = [
-                  `${shardBaseUrl}/practice-cloze.${lv}.json`,
-                  `${shardBaseUrl}/practice-stress.${lv}.json`,
-                  `${shardBaseUrl}/practice-classify.${lv}.json`,
-                  `${shardBaseUrl}/practice-paradigm.${lv}.json`,
-                  `${shardBaseUrl}/practice-synonym.${lv}.json`,
-                  `${shardBaseUrl}/practice-paronym.${lv}.json`,
-                  `${shardBaseUrl}/practice-heritage.${lv}.json`,
-                  `${shardBaseUrl}/practice-antonym.${lv}.json`,
-                ];
-                const rs = await Promise.all(
-                  urls.map((u) => getShardJson<any>(u, shardJsonCacheRef.current).catch(() => ({}))),
-                );
+            try {
+              const otherDrillBatches = await Promise.all(
+                otherLevels.map(async (lv) => {
+                  const urls = [
+                    `${shardBaseUrl}/practice-cloze.${lv}.json`,
+                    `${shardBaseUrl}/practice-stress.${lv}.json`,
+                    `${shardBaseUrl}/practice-classify.${lv}.json`,
+                    `${shardBaseUrl}/practice-paradigm.${lv}.json`,
+                    `${shardBaseUrl}/practice-synonym.${lv}.json`,
+                    `${shardBaseUrl}/practice-paronym.${lv}.json`,
+                    `${shardBaseUrl}/practice-heritage.${lv}.json`,
+                    `${shardBaseUrl}/practice-antonym.${lv}.json`,
+                  ];
+                  const rs = await Promise.all(
+                    urls.map((u) =>
+                      getShardJson<any>(u, shardJsonCacheRef.current).catch(softSkipUnpublishedDrillShard),
+                    ),
+                  );
+                  return {
+                    cloze: (rs[0] as { cloze?: PracticeClozeItem[] }).cloze ?? [],
+                    stress: (rs[1] as { stress?: any[] }).stress ?? [],
+                    classify: (rs[2] as { classify?: any[] }).classify ?? [],
+                    paradigm: (rs[3] as { paradigm?: any[] }).paradigm ?? [],
+                    synonym: (rs[4] as { synonym?: any[] }).synonym ?? [],
+                    paronym: (rs[5] as { paronym?: any[] }).paronym ?? [],
+                    heritage: (rs[6] as { heritage?: any[] }).heritage ?? [],
+                    antonym: (rs[7] as { antonym?: any[] }).antonym ?? [],
+                  };
+                }),
+              );
+              if (deckRequestId.current !== bgId) return;
+              setDeck((prev) => {
+                if (!prev) return prev;
                 return {
-                  cloze: (rs[0] as { cloze?: PracticeClozeItem[] }).cloze ?? [],
-                  stress: (rs[1] as { stress?: any[] }).stress ?? [],
-                  classify: (rs[2] as { classify?: any[] }).classify ?? [],
-                  paradigm: (rs[3] as { paradigm?: any[] }).paradigm ?? [],
-                  synonym: (rs[4] as { synonym?: any[] }).synonym ?? [],
-                  paronym: (rs[5] as { paronym?: any[] }).paronym ?? [],
-                  heritage: (rs[6] as { heritage?: any[] }).heritage ?? [],
-                  antonym: (rs[7] as { antonym?: any[] }).antonym ?? [],
+                  ...prev,
+                  cloze: [...(prev.cloze ?? []), ...otherDrillBatches.flatMap((b) => b.cloze)],
+                  stress: [...(prev.stress ?? []), ...otherDrillBatches.flatMap((b) => b.stress)],
+                  classify: [...(prev.classify ?? []), ...otherDrillBatches.flatMap((b) => b.classify)],
+                  paradigm: [...(prev.paradigm ?? []), ...otherDrillBatches.flatMap((b) => b.paradigm)],
+                  synonym: [...(prev.synonym ?? []), ...otherDrillBatches.flatMap((b) => b.synonym)],
+                  paronym: [...(prev.paronym ?? []), ...otherDrillBatches.flatMap((b) => b.paronym)],
+                  heritage: [...(prev.heritage ?? []), ...otherDrillBatches.flatMap((b) => b.heritage)],
+                  antonym: [...(prev.antonym ?? []), ...otherDrillBatches.flatMap((b) => b.antonym)],
                 };
-              }),
-            );
-            if (deckRequestId.current !== bgId) return;
-            setDeck((prev) => {
-              if (!prev) return prev;
-              return {
-                ...prev,
-                cloze: [...(prev.cloze ?? []), ...otherDrillBatches.flatMap((b) => b.cloze)],
-                stress: [...(prev.stress ?? []), ...otherDrillBatches.flatMap((b) => b.stress)],
-                classify: [...(prev.classify ?? []), ...otherDrillBatches.flatMap((b) => b.classify)],
-                paradigm: [...(prev.paradigm ?? []), ...otherDrillBatches.flatMap((b) => b.paradigm)],
-                synonym: [...(prev.synonym ?? []), ...otherDrillBatches.flatMap((b) => b.synonym)],
-                paronym: [...(prev.paronym ?? []), ...otherDrillBatches.flatMap((b) => b.paronym)],
-                heritage: [...(prev.heritage ?? []), ...otherDrillBatches.flatMap((b) => b.heritage)],
-                antonym: [...(prev.antonym ?? []), ...otherDrillBatches.flatMap((b) => b.antonym)],
-              };
-            });
+              });
+            } catch {
+              // Selected-level drills already committed; skip broken background
+              // enrichment rather than rewriting it as empty arrays (#6768).
+            }
           })();
         }
       }

--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -49,8 +49,71 @@ const dailyCount = Math.max(1, Math.floor(count));
   )}
 
   <p class="lexicon-daily-status" data-daily-status>Завантажуємо добірку...</p>
+  <div class="lexicon-daily-fallback" data-daily-fallback hidden>
+    <p>Не вдалося завантажити добірку.</p>
+    <button type="button" data-daily-retry>Спробувати ще раз</button>
+  </div>
   <ul id="lexicon-daily-list" class="lexicon-daily-grid" aria-live="polite" data-daily-list></ul>
 </section>
+
+{/* Inline watchdog: if the processed DailyWords module never runs (CDN 503 on
+    the chunk, etc.), do not leave «Завантажуємо добірку...» as a dead end (#6771). */}
+<script is:inline>
+(() => {
+  const TIMEOUT_MS = 10000;
+  const LOADING_COPY = 'Завантажуємо добірку...';
+
+  function showSectionFallback(section) {
+    if (section.dataset.dailyReady === 'true') return;
+    const status = section.querySelector('[data-daily-status]');
+    const fallback = section.querySelector('[data-daily-fallback]');
+    const list = section.querySelector('[data-daily-list]');
+    if (list) list.innerHTML = '';
+    if (status) {
+      status.hidden = true;
+      status.textContent = '';
+    }
+    if (fallback) fallback.hidden = false;
+    section.hidden = false;
+  }
+
+  function armSection(section) {
+    const fallback = section.querySelector('[data-daily-fallback]');
+    const retry = section.querySelector('[data-daily-retry]');
+    if (retry && !retry.dataset.bound) {
+      retry.dataset.bound = '1';
+      retry.addEventListener('click', () => {
+        window.location.reload();
+      });
+    }
+    if (fallback) fallback.hidden = true;
+
+    window.setTimeout(() => {
+      if (section.dataset.dailyReady === 'true') return;
+      const status = section.querySelector('[data-daily-status]');
+      const stillLoading =
+        status &&
+        !status.hidden &&
+        (status.textContent || '').trim() === LOADING_COPY;
+      const list = section.querySelector('[data-daily-list]');
+      const emptyList = !list || list.children.length === 0;
+      if (stillLoading && emptyList) showSectionFallback(section);
+    }, TIMEOUT_MS);
+  }
+
+  function init() {
+    for (const section of document.querySelectorAll('[data-daily-words]')) {
+      armSection(section);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();
+</script>
 
 <script>
   import { dateSeed, pickDaily, type DailyWord } from "../lib/lexicon/daily";
@@ -84,6 +147,7 @@ const dailyCount = Math.max(1, Math.floor(count));
   const hydrateDailySection = (dailySection: HTMLElement) => {
     const dailyList = dailySection.querySelector<HTMLUListElement>("[data-daily-list]");
     const dailyStatus = dailySection.querySelector<HTMLElement>("[data-daily-status]");
+    const dailyFallback = dailySection.querySelector<HTMLElement>("[data-daily-fallback]");
     const levelButtons = Array.from(
       dailySection.querySelectorAll<HTMLButtonElement>("[data-daily-level]"),
     );
@@ -100,7 +164,30 @@ const dailyCount = Math.max(1, Math.floor(count));
 
     const hideDailySection = () => {
       if (dailyList) dailyList.innerHTML = "";
+      if (dailyFallback) dailyFallback.hidden = true;
       dailySection.hidden = true;
+      dailySection.dataset.dailyReady = "true";
+    };
+
+    const showLoadError = () => {
+      if (dailyList) dailyList.innerHTML = "";
+      if (dailyStatus) {
+        dailyStatus.hidden = true;
+        dailyStatus.textContent = "";
+      }
+      if (dailyFallback) dailyFallback.hidden = false;
+      dailySection.hidden = false;
+      // Mark ready so the inline watchdog does not race a second error paint.
+      dailySection.dataset.dailyReady = "true";
+    };
+
+    const clearLoadError = () => {
+      if (dailyFallback) dailyFallback.hidden = true;
+      if (dailyStatus) {
+        dailyStatus.hidden = false;
+        dailyStatus.textContent = "Завантажуємо добірку...";
+      }
+      dailySection.dataset.dailyReady = "false";
     };
 
     const syncLevelButtons = () => {
@@ -127,6 +214,8 @@ const dailyCount = Math.max(1, Math.floor(count));
           dailyStatus.hidden = false;
           dailyStatus.textContent = `Немає слів для рівня ${activeLevel}.`;
         }
+        if (dailyFallback) dailyFallback.hidden = true;
+        dailySection.dataset.dailyReady = "true";
         return;
       }
 
@@ -142,6 +231,8 @@ const dailyCount = Math.max(1, Math.floor(count));
           : "";
         dailyStatus.hidden = !useLevelSelector;
       }
+      if (dailyFallback) dailyFallback.hidden = true;
+      dailySection.dataset.dailyReady = "true";
       syncLevelButtons();
     };
 
@@ -154,7 +245,9 @@ const dailyCount = Math.max(1, Math.floor(count));
     }
 
     const loadDailyWords = async () => {
+      clearLoadError();
       try {
+        // Absolute site path — never resolve relative to /words-of-the-day/ (#6771).
         const response = await fetch("/lexicon/daily-pool.json");
         if (!response.ok) throw new Error(`Daily pool request failed: ${response.status}`);
         const data = (await response.json()) as DailyWord[];
@@ -166,7 +259,7 @@ const dailyCount = Math.max(1, Math.floor(count));
         syncLevelButtons();
         renderDailyWords();
       } catch {
-        hideDailySection();
+        showLoadError();
       }
     };
 
@@ -267,6 +360,44 @@ const dailyCount = Math.max(1, Math.floor(count));
 
   .lexicon-daily-status {
     margin: 0 auto 1rem;
+  }
+
+  .lexicon-daily-fallback {
+    max-width: 960px;
+    margin: 0 auto 1rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+  }
+
+  .lexicon-daily-fallback[hidden] {
+    display: none;
+  }
+
+  .lexicon-daily-fallback p {
+    margin: 0;
+    color: var(--lu-text);
+    line-height: 1.5;
+  }
+
+  .lexicon-daily-fallback button {
+    margin-top: 0.65rem;
+    min-height: 44px;
+    padding: 0 1rem;
+    border: 1px solid var(--lu-primary);
+    border-radius: 8px;
+    background: var(--lu-primary);
+    color: var(--lu-on-primary);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 800;
+  }
+
+  .lexicon-daily-fallback button:hover,
+  .lexicon-daily-fallback button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--lu-state-active);
   }
 
   .lexicon-daily-grid {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -59,6 +59,11 @@ function notFoundResponse(): Response {
   return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
 }
 
+/** A 5xx server error — a real load fault, distinct from a 404 "not published". */
+function serverErrorResponse(status = 503): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response;
+}
+
 /** D2: the Words-of-the-Day zone now fetches this pool directly (see `dailyPoolFixture`). */
 function dailyPoolFixture(counts: Partial<Record<CefrLevel, number>>): DailyWord[] {
   return Object.entries(counts).flatMap(([level, n]) =>
@@ -2743,6 +2748,84 @@ describe('LexiconPractice', () => {
       window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
       vi.restoreAllMocks();
     }
+  });
+
+  test('a 5xx on practice-synonym surfaces the load error instead of an empty synonym session (#6768)', async () => {
+    const deck = sampleDeck();
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, items: deck.index });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, lexemes: deck.lexemes });
+      }
+      if (url.includes('practice-synonym.A1.json')) return serverErrorResponse(500);
+      if (url.includes('practice-cloze.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, cloze: deck.cloze });
+      }
+      return notFoundResponse();
+    });
+
+    render(<LexiconPractice />);
+    await user.click(await screen.findByTestId('practice-start-session'));
+
+    expect(await screen.findByTestId('practice-fetch-error')).toHaveTextContent(
+      'Не вдалося завантажити практику.',
+    );
+    expect(screen.queryByTestId('practice-session-progress')).not.toBeInTheDocument();
+  });
+
+  test('a network failure on a drill shard surfaces the load error instead of an empty session (#6768)', async () => {
+    const deck = sampleDeck();
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, items: deck.index });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, lexemes: deck.lexemes });
+      }
+      if (url.includes('practice-cloze.A1.json')) throw new TypeError('Failed to fetch');
+      return notFoundResponse();
+    });
+
+    render(<LexiconPractice />);
+    await user.click(await screen.findByTestId('practice-start-session'));
+
+    expect(await screen.findByTestId('practice-fetch-error')).toHaveTextContent(
+      'Не вдалося завантажити практику.',
+    );
+    expect(screen.queryByTestId('practice-session-progress')).not.toBeInTheDocument();
+  });
+
+  test('a 404 on an unpublished drill shard is soft-skipped without surfacing an error (#6768)', async () => {
+    const deck = sampleDeck();
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, items: deck.index });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, lexemes: deck.lexemes });
+      }
+      if (url.includes('practice-cloze.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, cloze: deck.cloze });
+      }
+      return notFoundResponse();
+    });
+
+    render(<LexiconPractice />);
+    await user.click(await screen.findByTestId('practice-start-session'));
+
+    expect(await screen.findByTestId('practice-session-progress')).toBeInTheDocument();
+    expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
   });
 
   test('cloze wrong-case answer records one case miss and leaves blank open', async () => {

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -149,4 +149,19 @@ describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
     expect(dailyWordsSource).not.toContain("filterByCumulativeLevel");
     expect(dailyWordsSource).not.toContain("prioritizeByLearnerLevel");
   });
+
+  test("DailyWords surfaces pool/script failure with error + retry, not a stuck spinner (#6771)", () => {
+    expect(dailyWordsSource).toContain('fetch("/lexicon/daily-pool.json")');
+    expect(dailyWordsSource).not.toContain('fetch("daily-pool.json")');
+    expect(dailyWordsSource).not.toContain("words-of-the-day/daily-pool");
+    expect(dailyWordsSource).toContain("data-daily-fallback");
+    expect(dailyWordsSource).toContain("data-daily-retry");
+    expect(dailyWordsSource).toContain("Не вдалося завантажити добірку.");
+    expect(dailyWordsSource).toContain("Спробувати ще раз");
+    expect(dailyWordsSource).toContain("showLoadError");
+    expect(dailyWordsSource).toContain("script is:inline");
+    expect(dailyWordsSource).toContain("TIMEOUT_MS");
+    // Must not silently hide the section on transport/server failure.
+    expect(dailyWordsSource).toMatch(/catch\s*\{\s*showLoadError\(\);/);
+  });
 });


### PR DESCRIPTION
## Summary
- Practice drill shard loads soft-skip only HTTP 404 (unpublished kind); 5xx/network faults surface the existing Practice load-error UI instead of an empty “loaded” deck (#6768).
- Words of the Day shows error + retry when `/lexicon/daily-pool.json` fails, and an inline watchdog covers failed DailyWords script hydration so «Завантажуємо добірку...» cannot stick forever (#6771).

Related: #6768 #6771 (parent #4387). Leaves these issues open — do not auto-close.

## Test plan
- [x] `vitest run tests/unit/LexiconPractice.test.tsx tests/unit/daily-words-example.test.ts tests/unit/hydrate-practice-deck.test.ts` (181 passed)
- [ ] Smoke `/words-of-the-day/`: throttle or block DailyWords chunk / return 503 on `/lexicon/daily-pool.json` → error + «Спробувати ще раз», not stuck spinner
- [ ] Practice mixed start with mocked 500 on `practice-synonym.A1.json` → load-error UI; 404 on unpublished drill → session continues


Made with [Cursor](https://cursor.com)